### PR TITLE
feat: add per-group Frame Strata setting with child propagation

### DIFF
--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -434,9 +434,8 @@ local function BuildLayoutTab(container)
     end -- not alphaCollapsed
 
     -- ================================================================
-    -- ADVANCED: Strata (Layer Order) — hidden for bar mode
+    -- ADVANCED: Strata — Frame Strata (all modes) + Custom Strata (icon mode only)
     -- ================================================================
-    if group.displayMode ~= "bars" then
     local strataHeading = AceGUI:Create("Heading")
     strataHeading:SetText("Strata")
     ColorHeading(strataHeading)
@@ -450,10 +449,45 @@ local function BuildLayoutTab(container)
     end)
 
     if not strataCollapsed then
+
+    -- Frame Strata dropdown (available for both icon and bar mode)
+    do
+        local frameStrataOrder = {"BACKGROUND", "LOW", "MEDIUM", "HIGH", "DIALOG"}
+        local frameStrataLabels = {
+            BACKGROUND = "Background",
+            LOW = "Low",
+            MEDIUM = "Default",
+            HIGH = "High",
+            DIALOG = "Highest",
+        }
+
+        local frameStrataDrop = AceGUI:Create("Dropdown")
+        frameStrataDrop:SetLabel("Frame Strata")
+        frameStrataDrop:SetList(frameStrataLabels, frameStrataOrder)
+        frameStrataDrop:SetValue(group.frameStrata or "MEDIUM")
+        frameStrataDrop:SetFullWidth(true)
+        frameStrataDrop:SetCallback("OnValueChanged", function(widget, event, val)
+            group.frameStrata = (val ~= "MEDIUM") and val or nil
+            CooldownCompanion:RefreshGroupFrame(CS.selectedGroup)
+        end)
+        container:AddChild(frameStrataDrop)
+
+        CreateInfoButton(frameStrataDrop.frame, frameStrataDrop.label, "LEFT", "RIGHT", 4, 0, {
+            "Frame Strata",
+            {"Sets the rendering layer for this group.", 1, 1, 1, true},
+            " ",
+            {"Higher strata groups fully overlap lower ones.", 1, 1, 1, true},
+            " ",
+            {"Only change this if you need one group to overlap another.", 1, 1, 1, true},
+        }, tabInfoButtons)
+    end
+
+    -- Custom Icon Strata (sub-element ordering) — icon mode only
+    if group.displayMode ~= "bars" then
     local customStrataEnabled = type(style.strataOrder) == "table"
 
     local strataToggle = AceGUI:Create("CheckBox")
-    strataToggle:SetLabel("Custom Strata")
+    strataToggle:SetLabel("Custom Icon Strata")
     strataToggle:SetValue(customStrataEnabled)
     strataToggle:SetFullWidth(true)
     strataToggle:SetCallback("OnValueChanged", function(widget, event, val)
@@ -474,7 +508,7 @@ local function BuildLayoutTab(container)
     container:AddChild(strataToggle)
 
     CreateInfoButton(strataToggle.frame, strataToggle.checkbg, "LEFT", "RIGHT", strataToggle.text:GetStringWidth() + 4, 0, {
-        "Custom Strata",
+        "Custom Icon Strata",
         {"Controls the draw order of overlays on each icon: Cooldown Swipe, Charge Text, Proc Glow, and Assisted Highlight.", 1, 1, 1, true},
         {"Layer 4 draws on top, Layer 1 on the bottom. When disabled, the default order is used.", 1, 1, 1, true},
     }, tabInfoButtons)
@@ -532,8 +566,9 @@ local function BuildLayoutTab(container)
             strataDropdowns[pos] = drop
         end
     end
+    end -- not bars (custom strata)
+
     end -- not strataCollapsed
-    end -- not bars (strata)
 
     -- Apply "Hide CDC Tooltips" to tab info buttons (skip advanced toggles)
     if CooldownCompanion.db.profile.hideInfoButtons then

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -137,6 +137,7 @@ local defaults = {
                     },
                     enabled = true,
                     displayMode = "icons",    -- "icons" or "bars"
+                    frameStrata = nil,        -- nil = "MEDIUM" (default), or "BACKGROUND"/"LOW"/"HIGH"/"DIALOG"
                     -- Alpha fade system
                     baselineAlpha = 1,        -- alpha when no force conditions met (0-1)
                     forceAlphaInCombat = false,

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -125,6 +125,17 @@ local NUDGE_REPEAT_INTERVAL = 0.05
 
 local CreatePixelBorders = ST.CreatePixelBorders
 
+-- Recursively set frame strata on a frame and all its child frames.
+-- Textures/FontStrings inherit from their parent frame automatically,
+-- but child Frame objects (cooldown widgets, overlay frames, glow containers)
+-- may not follow a parent strata change — so we force it explicitly.
+local function PropagateFrameStrata(frame, strata)
+    frame:SetFrameStrata(strata)
+    for _, child in pairs({frame:GetChildren()}) do
+        PropagateFrameStrata(child, strata)
+    end
+end
+
 local function CreateNudger(frame, groupId)
     local NUDGE_GAP = 2
 
@@ -233,7 +244,14 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     
     -- Set initial size (will be updated when buttons are added)
     frame:SetSize(100, 50)
-    
+
+    -- Apply per-group frame strata if configured
+    local strata = group.frameStrata
+    if strata then
+        frame:SetFrameStrata(strata)
+        frame:SetFixedFrameStrata(true)
+    end
+
     -- Position the frame
     self:AnchorGroupFrame(frame, group.anchor)
     
@@ -580,6 +598,12 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
         self:UpdateGroupLayout(groupId)
     end
 
+    -- Propagate group frame strata to all button sub-elements
+    local effectiveStrata = group.frameStrata or "MEDIUM"
+    for _, button in ipairs(frame.buttons) do
+        PropagateFrameStrata(button, effectiveStrata)
+    end
+
     -- Update event-driven range check registrations
     self:UpdateRangeCheckRegistrations()
 end
@@ -729,10 +753,20 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     if not frame then
         frame = self:CreateGroupFrame(groupId)
     else
+        -- Apply per-group frame strata before populating buttons
+        local strata = group.frameStrata
+        if strata then
+            frame:SetFrameStrata(strata)
+            frame:SetFixedFrameStrata(true)
+        else
+            frame:SetFrameStrata("MEDIUM")
+            frame:SetFixedFrameStrata(false)
+        end
+
         self:AnchorGroupFrame(frame, group.anchor)
         self:PopulateGroupButtons(groupId)
     end
-    
+
     -- Update drag handle text and lock state
     local hasButtons = #group.buttons > 0
     if frame.dragHandle then


### PR DESCRIPTION
Add a Frame Strata dropdown to group settings (both icon and bar mode) allowing groups to render at different WoW strata levels. Higher strata groups fully occlude lower ones when overlapping. Recursively propagates strata to all button child frames so borders, charge text, cooldowns, and glows all respect the chosen layer.

Rename "Custom Strata" to "Custom Icon Strata" for clarity.