### PR TITLE
fix: show aura icon toggle for all aura-tracked spells, not just manu…

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -402,7 +402,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
 
         -- Aura icon swap: trigger icon update on _auraActive transition
-        if buttonData.auraShowAuraIcon and buttonData.auraSpellID then
+        if buttonData.auraShowAuraIcon and button._auraSpellID then
             local shouldShow = auraOverrideActive and true or false
             button._auraViewerFrame = shouldShow and viewerFrame or nil
             if shouldShow ~= (button._showingAuraIcon or false) then

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -409,7 +409,7 @@ function CooldownCompanion:UpdateButtonIcon(button)
 
     -- Aura icon swap: show the tracked aura spell's icon while aura is active
     if buttonData.type == "spell" and button._auraActive
-       and buttonData.auraShowAuraIcon and buttonData.auraSpellID and button._auraSpellID then
+       and buttonData.auraShowAuraIcon and button._auraSpellID then
         -- Read the viewer frame's Icon texture (updates per-stage for multi-stage
         -- auras like Hot Streak). GetTextureFileID may return a secret value in
         -- combat; pass it straight through — do not test or branch on it.

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -537,7 +537,7 @@ local function BuildSpellSettings(scroll, buttonData, infoButtons)
     end -- canTrackAura
 
     -- Show Aura Icon toggle (spells with aura tracking only — passive auras already show their own icon)
-    if buttonData.auraTracking and not buttonData.isPassive and buttonData.auraSpellID then
+    if buttonData.auraTracking and not buttonData.isPassive then
         local auraIconCb = AceGUI:Create("CheckBox")
         auraIconCb:SetLabel("Show Aura Icon")
         auraIconCb:SetValue(buttonData.auraShowAuraIcon == true)


### PR DESCRIPTION
…al overrides

The checkbox was gated on buttonData.auraSpellID (manual override) but ResolveAuraSpellID() auto-detects for all spell entries. Use the runtime- resolved button._auraSpellID instead.