### PR TITLE
Fix zero-charge gating for charge state visuals

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -249,7 +249,7 @@ local function UpdateBarDisplay(button)
     -- Aura-tracked buttons always use the base bar color (aura color override handles active state).
     local wantCdColor
     if onCooldown and not button.buttonData.isPassive then
-        if button.buttonData.hasCharges and not button._mainCDShown then
+        if button.buttonData.hasCharges and not button._zeroChargesConfirmed then
             wantCdColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
         else
             wantCdColor = style.barCooldownColor
@@ -287,7 +287,7 @@ local function UpdateBarDisplay(button)
         if style.desaturateOnCooldown and button._desatCooldownActive then
             wantDesat = true
         end
-        if not wantDesat and button.buttonData.desaturateWhileZeroCharges and button._mainCDShown then
+        if not wantDesat and button.buttonData.desaturateWhileZeroCharges and button._zeroChargesConfirmed then
             wantDesat = true
         end
         if not wantDesat and button.buttonData.desaturateWhileZeroStacks and (button._itemCount or 0) == 0 then
@@ -337,7 +337,7 @@ local function UpdateBarDisplay(button)
             button._barCdColor = nil
             local resetColor
             if onCooldown then
-                if button.buttonData.hasCharges and not button._mainCDShown then
+                if button.buttonData.hasCharges and not button._zeroChargesConfirmed then
                     resetColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
                 else
                     resetColor = style.barCooldownColor
@@ -830,6 +830,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._vertexG = nil
     button._vertexB = nil
     button._chargeText = nil
+    button._chargeCountReadable = nil
+    button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._displaySpellId = nil
     button._itemCount = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -618,11 +618,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local charges
     if buttonData.hasCharges and buttonData.type == "spell" then
         charges = UpdateChargeTracking(button, buttonData, cooldownSpellId)
-    elseif not buttonData.hasCharges and button._chargeText ~= nil then
-        -- hasCharges cleared (e.g. brez pool deactivated): wipe stale charge text
-        button._chargeText = nil
+    elseif not buttonData.hasCharges then
+        -- hasCharges cleared (e.g. brez pool deactivated): wipe stale charge state.
+        if button._chargeText ~= nil then
+            button._chargeText = nil
+            button.count:SetText("")
+        end
         button._currentReadableCharges = nil
-        button.count:SetText("")
+        button._chargeCountReadable = nil
+        button._zeroChargesConfirmed = nil
     end
 
     -- Store raw GCD state for downstream display logic.
@@ -696,11 +700,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Item and readable-spell paths are always safe. Restricted-spell fallbacks
     -- that depend on button.cooldown or isGCDOnly are gated on not auraOverrideActive.
     if buttonData.hasCharges then
+        -- Default to non-zero each tick; set true only when a current probe confirms zero.
+        button._mainCDShown = false
         if buttonData.type == "item" then
             -- Items: 0 charges = on cooldown. No GCD to filter.
             local chargeCount = C_Item.GetItemCount(buttonData.id, false, true)
             button._mainCDShown = (chargeCount == 0)
-        elseif buttonData.type == "spell" and button._currentReadableCharges ~= nil then
+        elseif buttonData.type == "spell"
+           and button._chargeCountReadable == true
+           and button._currentReadableCharges ~= nil then
             -- Readable charge count is the source of truth for zero-charge state.
             -- Prevents short lockout cooldowns (e.g., dragonriding flyout abilities)
             -- from being misclassified as "zero charges".
@@ -739,13 +747,32 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
     end
 
+    -- Canonical zero-charge state for downstream visuals/visibility.
+    -- _mainCDShown is the raw "main cooldown sweep shown" signal; suppress zero
+    -- while we have explicit cast-history evidence that not all charges are spent.
+    if buttonData.hasCharges then
+        local zeroConfirmed = (button._mainCDShown == true)
+        if zeroConfirmed
+           and buttonData.type == "spell"
+           and button._chargeCountReadable ~= true then
+            local maxCharges = buttonData.maxCharges
+            local spent = button._chargesSpent
+            if maxCharges and maxCharges > 1 and spent and spent < maxCharges then
+                zeroConfirmed = false
+            end
+        end
+        button._zeroChargesConfirmed = zeroConfirmed
+    else
+        button._zeroChargesConfirmed = false
+    end
+
     -- Canonical desaturation signal:
     -- For non-charge spells, use action-slot cooldown state when spell cooldown
     -- info is unavailable (ContextuallySecret fallback). Otherwise use addon state.
     if buttonData.type == "item" then
         button._desatCooldownActive = (button._itemCdDuration and button._itemCdDuration > 0) or false
     elseif buttonData.hasCharges then
-        button._desatCooldownActive = (button._mainCDShown == true)
+        button._desatCooldownActive = (button._zeroChargesConfirmed == true)
     else
         if actionSlotCooldownShown ~= nil and spellCooldownInfo == nil then
             button._desatCooldownActive = actionSlotCooldownShown
@@ -852,7 +879,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if style.chargeFontColor or style.chargeFontColorMissing or style.chargeFontColorZero then
         local cc
         local cur = button._currentReadableCharges
-        if cur ~= nil and buttonData.maxCharges then
+        if button._chargeCountReadable == true and cur ~= nil and buttonData.maxCharges then
             if cur == 0 then
                 cc = style.chargeFontColorZero or {1, 1, 1, 1}
             elseif cur < buttonData.maxCharges then
@@ -862,11 +889,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         else
             -- Restricted mode: charges unreadable via C_Spell.
-            -- Use _mainCDShown as the canonical zero-charge signal. Blizzard only
-            -- shows main sweep at 0 charges; recharge without main sweep is partial.
+            -- Use canonical zero state derived from _mainCDShown + cast history.
             if not button._chargeRecharging then
                 cc = style.chargeFontColor or {1, 1, 1, 1}             -- FULL (max charges)
-            elseif button._mainCDShown then
+            elseif button._zeroChargesConfirmed then
                 cc = style.chargeFontColorZero or {1, 1, 1, 1}         -- ZERO (all spent)
             else
                 cc = style.chargeFontColorMissing or {1, 1, 1, 1}      -- MISSING (recharging)
@@ -911,7 +937,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if currentCharges ~= nil then
                     cooldownActive = (currentCharges == 0)
                 else
-                    cooldownActive = button._mainCDShown == true
+                    cooldownActive = button._zeroChargesConfirmed == true
                 end
             elseif auraOverrideActive then
                 -- Aura visuals can replace button.cooldown, so probe spell cooldown

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -540,7 +540,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         if style.desaturateOnCooldown and button._desatCooldownActive then
             wantDesat = true
         end
-        if not wantDesat and buttonData.desaturateWhileZeroCharges and button._mainCDShown then
+        if not wantDesat and buttonData.desaturateWhileZeroCharges and button._zeroChargesConfirmed then
             wantDesat = true
         end
         if not wantDesat and buttonData.desaturateWhileZeroStacks and (button._itemCount or 0) == 0 then
@@ -675,6 +675,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._vertexG = nil
     button._vertexB = nil
     button._chargeText = nil
+    button._chargeCountReadable = nil
+    button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._procGlowActive = nil
     button._auraGlowActive = nil

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -7,7 +7,6 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
 -- Localize frequently-used globals
-local tonumber = tonumber
 local issecretvalue = issecretvalue
 local InCombatLockdown = InCombatLockdown
 local IsItemInRange = C_Item.IsItemInRange
@@ -20,25 +19,15 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
     local spellID = chargeSpellID or buttonData.id
     local charges = C_Spell.GetSpellCharges(spellID)
 
-    -- Try to read current charges as plain number (works outside restricted).
-    -- Prefer charges.currentCharges (authoritative charge system value) over
-    -- GetSpellDisplayCount (UI-oriented, may drop to 0 during lockouts).
+    -- Read current charges only from the authoritative charge API field.
+    -- Display-count APIs are UI-oriented and can transiently read 0 during
+    -- lockout windows even when charges remain.
     local cur
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
         cur = charges.currentCharges
     end
-    if cur == nil then
-        cur = tonumber(C_Spell.GetSpellDisplayCount(spellID))
-    end
-    if cur == nil then
-        -- Tertiary fallback: cast count can reflect cast availability semantics
-        -- for some spells; for standard charge spells this still tracks charges.
-        local castCount = C_Spell.GetSpellCastCount(spellID)
-        if castCount ~= nil and not issecretvalue(castCount) then
-            cur = castCount
-        end
-    end
     button._currentReadableCharges = cur
+    button._chargeCountReadable = (cur ~= nil)
 
     -- Update persisted maxCharges when readable. Prefer API maxCharges over
     -- display count, which can reflect current charges instead of true max.
@@ -51,7 +40,7 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
     end
 
     -- Fallback: if API maxCharges is unavailable (nil/secret), keep upward-only
-    -- observed max.  The primary path above is bidirectional (tracks decreases too).
+    -- observed max from readable charge count.
     if cur and cur > persistedMax then
         buttonData.maxCharges = cur
     end
@@ -76,8 +65,7 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
                 button.count:SetText(cur)
             end
         else
-            -- Secret: pass directly to SetText (C-level renders it)
-            -- Can't compare secrets, so always call SetText
+            -- Unreadable in restricted mode: use display API for text only.
             button._chargeText = nil
             button.count:SetText(C_Spell.GetSpellDisplayCount(spellID))
         end
@@ -99,6 +87,7 @@ local function UpdateItemChargeTracking(button, buttonData)
     -- Items are always readable — feed the same field spells use so the
     -- three-state charge color block can use direct comparison.
     button._currentReadableCharges = chargeCount
+    button._chargeCountReadable = true
 
     -- Display charge text with change detection
     local showChargeText = button.style and button.style.showChargeText

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -103,7 +103,7 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
     -- Check hideWhileZeroCharges (charge-based spells and items)
     local hidReasonZeroCharges = false
     if buttonData.hideWhileZeroCharges then
-        if button._mainCDShown then
+        if button._zeroChargesConfirmed then
             shouldHide = true
             hidReasonZeroCharges = true
         end
@@ -171,7 +171,7 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
             otherHide = true
         end
         if hidReasonNoProc then otherHide = true end
-        if buttonData.hideWhileZeroCharges and button._mainCDShown then otherHide = true end
+        if buttonData.hideWhileZeroCharges and button._zeroChargesConfirmed then otherHide = true end
         if buttonData.hideWhileZeroStacks and (button._itemCount or 0) == 0 then otherHide = true end
         if buttonData.hideWhileNotEquipped and button._isEquippableNotEquipped then otherHide = true end
         if not otherHide then
@@ -211,7 +211,7 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
             otherHide = true
         end
         if hidReasonNoProc then otherHide = true end
-        if buttonData.hideWhileZeroCharges and button._mainCDShown then otherHide = true end
+        if buttonData.hideWhileZeroCharges and button._zeroChargesConfirmed then otherHide = true end
         if buttonData.hideWhileZeroStacks and (button._itemCount or 0) == 0 then otherHide = true end
         if buttonData.hideWhileNotEquipped and button._isEquippableNotEquipped then otherHide = true end
         if not otherHide then
@@ -276,7 +276,7 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
         if buttonData.hideWhileAuraNotActive and not auraOverrideActive then otherHide = true end
         if buttonData.hideWhileAuraActive and auraOverrideActive then otherHide = true end
         if hidReasonNoProc then otherHide = true end
-        if buttonData.hideWhileZeroCharges and button._mainCDShown then otherHide = true end
+        if buttonData.hideWhileZeroCharges and button._zeroChargesConfirmed then otherHide = true end
         if buttonData.hideWhileNotEquipped and button._isEquippableNotEquipped then otherHide = true end
         if not otherHide then
             local groupId = button._groupId
@@ -304,7 +304,7 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
         if buttonData.hideWhileAuraNotActive and not auraOverrideActive then otherHide = true end
         if buttonData.hideWhileAuraActive and auraOverrideActive then otherHide = true end
         if hidReasonNoProc then otherHide = true end
-        if buttonData.hideWhileZeroCharges and button._mainCDShown then otherHide = true end
+        if buttonData.hideWhileZeroCharges and button._zeroChargesConfirmed then otherHide = true end
         if buttonData.hideWhileZeroStacks and (button._itemCount or 0) == 0 then otherHide = true end
         if not otherHide then
             local groupId = button._groupId


### PR DESCRIPTION
Introduce _zeroChargesConfirmed as the canonical zero-charge signal and use it across visibility, desaturation, bar colors, and restricted-mode charge text coloring. Track charge readability explicitly and clear stale charge state when hasCharges is removed.