### PR TITLE
Added a custom anchor option for bar cooldown text

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -498,20 +498,27 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     local cdOffX = style.barCdTextOffsetX or 0
     local cdOffY = style.barCdTextOffsetY or 0
     local timeReverse = style.barTimeTextReverse
-    if isVertical then
-        if timeReverse then
-            button.timeText:SetPoint("BOTTOM", cdOffX, 3 + cdOffY)
-        else
-            button.timeText:SetPoint("TOP", cdOffX, -3 + cdOffY)
-        end
+    local customCdAnchor = style.customCdAnchor or false
+    if customCdAnchor then
+        local cdAnchor = style.barCdTextAnchor or "CENTER"
+        button.timeText:SetPoint(cdAnchor, cdOffX, cdOffY)
         button.timeText:SetJustifyH("CENTER")
     else
-        if timeReverse then
-            button.timeText:SetPoint("LEFT", 3 + cdOffX, cdOffY)
-            button.timeText:SetJustifyH("LEFT")
+        if isVertical then
+            if timeReverse then
+                button.timeText:SetPoint("BOTTOM", cdOffX, 3 + cdOffY)
+            else
+                button.timeText:SetPoint("TOP", cdOffX, -3 + cdOffY)
+            end
+            button.timeText:SetJustifyH("CENTER")
         else
-            button.timeText:SetPoint("RIGHT", -3 + cdOffX, cdOffY)
-            button.timeText:SetJustifyH("RIGHT")
+            if timeReverse then
+                button.timeText:SetPoint("LEFT", 3 + cdOffX, cdOffY)
+                button.timeText:SetJustifyH("LEFT")
+            else
+                button.timeText:SetPoint("RIGHT", -3 + cdOffX, cdOffY)
+                button.timeText:SetJustifyH("RIGHT")
+            end
         end
     end
 

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -451,6 +451,33 @@ local function BuildBarAppearanceTab(container, group, style)
         end)
         container:AddChild(cdFontColor)
 
+        local cdCustomAnchorToggle = AceGUI:Create("CheckBox")
+        cdCustomAnchorToggle:SetLabel("Use Custom Anchor")
+        cdCustomAnchorToggle:SetValue(style.customCdAnchor or false)
+        cdCustomAnchorToggle:SetFullWidth(true)
+        cdCustomAnchorToggle:SetCallback("OnValueChanged", function(widget, event, val)
+            style.customCdAnchor = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        container:AddChild(cdCustomAnchorToggle)
+
+        local cdAnchorValues = {}
+        for _, pt in ipairs(CS.anchorPoints) do
+            cdAnchorValues[pt] = CS.anchorPointLabels[pt]
+        end
+        local cdAnchorDrop = AceGUI:Create("Dropdown")
+        cdAnchorDrop:SetLabel("Anchor")
+        cdAnchorDrop:SetList(cdAnchorValues, CS.anchorPoints)
+        cdAnchorDrop:SetValue(style.barCdTextAnchor or "CENTER")
+        cdAnchorDrop:SetFullWidth(true)
+        cdAnchorDrop:SetDisabled(not (style.customCdAnchor or false))
+        cdAnchorDrop:SetCallback("OnValueChanged", function(widget, event, val)
+            style.barCdTextAnchor = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        container:AddChild(cdAnchorDrop)
+
         local cdOffXSlider = AceGUI:Create("Slider")
         cdOffXSlider:SetLabel("X Offset")
         cdOffXSlider:SetSliderValues(-50, 50, 0.1)


### PR DESCRIPTION
Added an anchor option for Cooldown/Duration text on bars. 
My personal need was to have the text centred on the bar. The 'dynamic' anchoring behaviour stays default, custom anchor has to be enabled with a new checkbox.