### PR TITLE
Add capped-charge Ready Glow for ready spells and items

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -842,6 +842,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._desaturated = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
+    button._readyGlowMaxChargesStartTime = nil
+    button._readyGlowMaxChargesActive = nil
+    button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._vertexR = nil
     button._vertexG = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1258,19 +1258,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if IsReadyGlowMaxChargeEligible(buttonData) then
         local readyGlowSpellID = cooldownSpellId or buttonData.id
-        local previousReadyGlowSpellID = button._readyGlowMaxChargesSpellID
         if button._readyGlowMaxChargesSpellID ~= readyGlowSpellID then
             button._readyGlowMaxChargesSpellID = readyGlowSpellID
             button._readyGlowMaxChargesStartTime = nil
-            if previousReadyGlowSpellID ~= nil then
-                button._readyGlowMaxChargesActive = false
-            else
-                button._readyGlowMaxChargesActive = nil
-            end
+            button._readyGlowMaxChargesActive = nil
         end
 
         local isCapped = IsReadyGlowAtMaxCharges(button, buttonData)
-        if button._readyGlowMaxChargesActive == false and isCapped then
+        if button._readyGlowMaxChargesActive ~= true and isCapped then
             button._readyGlowMaxChargesStartTime = now
         elseif not isCapped then
             button._readyGlowMaxChargesStartTime = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1257,8 +1257,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
 
     if IsReadyGlowMaxChargeEligible(buttonData) then
-        if button._readyGlowMaxChargesSpellID ~= buttonData.id then
-            button._readyGlowMaxChargesSpellID = buttonData.id
+        local readyGlowSpellID = cooldownSpellId or buttonData.id
+        if button._readyGlowMaxChargesSpellID ~= readyGlowSpellID then
+            button._readyGlowMaxChargesSpellID = readyGlowSpellID
             button._readyGlowMaxChargesStartTime = nil
             button._readyGlowMaxChargesActive = nil
         end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1258,10 +1258,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if IsReadyGlowMaxChargeEligible(buttonData) then
         local readyGlowSpellID = cooldownSpellId or buttonData.id
+        local previousReadyGlowSpellID = button._readyGlowMaxChargesSpellID
         if button._readyGlowMaxChargesSpellID ~= readyGlowSpellID then
             button._readyGlowMaxChargesSpellID = readyGlowSpellID
             button._readyGlowMaxChargesStartTime = nil
-            button._readyGlowMaxChargesActive = nil
+            if previousReadyGlowSpellID ~= nil then
+                button._readyGlowMaxChargesActive = false
+            else
+                button._readyGlowMaxChargesActive = nil
+            end
         end
 
         local isCapped = IsReadyGlowAtMaxCharges(button, buttonData)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -118,6 +118,27 @@ local function IsSpellGCDOnly(info, secrecy)
     end
 end
 
+local function IsReadyGlowMaxChargeEligible(buttonData)
+    return buttonData
+        and buttonData.type == "spell"
+        and buttonData.hasCharges == true
+        and not buttonData._hasDisplayCount
+end
+
+local function IsReadyGlowAtMaxCharges(button, buttonData)
+    if not (button and IsReadyGlowMaxChargeEligible(buttonData)) then
+        return false
+    end
+
+    local cur = button._currentReadableCharges
+    local maxCharges = buttonData.maxCharges
+    if button._chargeCountReadable == true and cur ~= nil and maxCharges ~= nil then
+        return cur == maxCharges
+    end
+
+    return not button._chargeRecharging and not button._zeroChargesConfirmed
+end
+
 -- Deferred spell cooldown detection: distinguish true held cooldowns from
 -- start-recovery / empower recovery windows. In 12.0.1, unrelated spells can
 -- transiently report isEnabled=false, isActive=false, and a positive
@@ -1233,6 +1254,26 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._chargeRecharging = (button._itemCdDuration and button._itemCdDuration > 0 and not isGCDOnly)
             or button._cooldownDeferred or false
       end
+    end
+
+    if IsReadyGlowMaxChargeEligible(buttonData) then
+        if button._readyGlowMaxChargesSpellID ~= buttonData.id then
+            button._readyGlowMaxChargesSpellID = buttonData.id
+            button._readyGlowMaxChargesStartTime = nil
+            button._readyGlowMaxChargesActive = nil
+        end
+
+        local isCapped = IsReadyGlowAtMaxCharges(button, buttonData)
+        if button._readyGlowMaxChargesActive == false and isCapped then
+            button._readyGlowMaxChargesStartTime = now
+        elseif not isCapped then
+            button._readyGlowMaxChargesStartTime = nil
+        end
+        button._readyGlowMaxChargesActive = isCapped
+    else
+        button._readyGlowMaxChargesSpellID = nil
+        button._readyGlowMaxChargesActive = nil
+        button._readyGlowMaxChargesStartTime = nil
     end
 
     -- Item count display (inventory quantity for non-equipment tracked items)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -67,7 +67,9 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
         return cur == maxCharges
     end
 
-    return not button._chargeRecharging and not button._zeroChargesConfirmed
+    -- Secret / restricted charge states do not reliably prove a spell is fully
+    -- capped, so keep capped-charge glow conservative there.
+    return false
 end
 
 local function ApplyCountTextStyle(button, style)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -52,6 +52,24 @@ local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 
+local function IsReadyGlowAtMaxCharges(button, buttonData)
+    if not (button and buttonData) then
+        return false
+    end
+
+    if buttonData.type ~= "spell" or buttonData.hasCharges ~= true then
+        return false
+    end
+
+    local cur = button._currentReadableCharges
+    local maxCharges = buttonData.maxCharges
+    if button._chargeCountReadable == true and cur ~= nil and maxCharges ~= nil then
+        return cur == maxCharges
+    end
+
+    return not button._chargeRecharging and not button._zeroChargesConfirmed
+end
+
 local function ApplyCountTextStyle(button, style)
     if not button or not button.count then return end
     local buttonData = button.buttonData
@@ -755,12 +773,43 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
                and (not style.readyGlowCombatOnly or inCombat)
                and button._desatCooldownActive == false
                and not (procOverlayActive and style.procGlowStyle ~= "none") then
-            local dur = style.readyGlowDuration or 0
-            if dur > 0 then
-                showReady = button._readyGlowStartTime ~= nil
-                    and (GetTime() - button._readyGlowStartTime) <= dur
+            if style.readyGlowOnlyAtMaxCharges and buttonData.type == "spell" and buttonData.hasCharges == true then
+                if button._readyGlowMaxChargesSpellID ~= buttonData.id then
+                    button._readyGlowMaxChargesSpellID = buttonData.id
+                    button._readyGlowMaxChargesStartTime = nil
+                    button._readyGlowMaxChargesActive = nil
+                end
+
+                local isCapped = IsReadyGlowAtMaxCharges(button, buttonData)
+                local dur = style.readyGlowDuration or 0
+
+                if isCapped then
+                    if button._readyGlowMaxChargesActive ~= true then
+                        button._readyGlowMaxChargesStartTime = GetTime()
+                    end
+
+                    if dur > 0 then
+                        showReady = button._readyGlowMaxChargesStartTime ~= nil
+                            and (GetTime() - button._readyGlowMaxChargesStartTime) <= dur
+                    else
+                        showReady = true
+                    end
+                else
+                    button._readyGlowMaxChargesStartTime = nil
+                end
+
+                button._readyGlowMaxChargesActive = isCapped
             else
-                showReady = true
+                button._readyGlowMaxChargesSpellID = nil
+                button._readyGlowMaxChargesActive = nil
+                button._readyGlowMaxChargesStartTime = nil
+                local dur = style.readyGlowDuration or 0
+                if dur > 0 then
+                    showReady = button._readyGlowStartTime ~= nil
+                        and (GetTime() - button._readyGlowStartTime) <= dur
+                else
+                    showReady = true
+                end
             end
         end
         SetReadyGlow(button, showReady)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -57,7 +57,7 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
         return false
     end
 
-    if buttonData.type ~= "spell" or buttonData.hasCharges ~= true then
+    if buttonData.type ~= "spell" or buttonData.hasCharges ~= true or buttonData._hasDisplayCount then
         return false
     end
 
@@ -773,36 +773,21 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
                and (not style.readyGlowCombatOnly or inCombat)
                and button._desatCooldownActive == false
                and not (procOverlayActive and style.procGlowStyle ~= "none") then
-            if style.readyGlowOnlyAtMaxCharges and buttonData.type == "spell" and buttonData.hasCharges == true then
-                if button._readyGlowMaxChargesSpellID ~= buttonData.id then
-                    button._readyGlowMaxChargesSpellID = buttonData.id
-                    button._readyGlowMaxChargesStartTime = nil
-                    button._readyGlowMaxChargesActive = nil
-                end
-
-                local isCapped = IsReadyGlowAtMaxCharges(button, buttonData)
+            if style.readyGlowOnlyAtMaxCharges
+               and buttonData.type == "spell"
+               and buttonData.hasCharges == true
+               and not buttonData._hasDisplayCount then
                 local dur = style.readyGlowDuration or 0
 
-                if isCapped then
-                    if button._readyGlowMaxChargesActive ~= true then
-                        button._readyGlowMaxChargesStartTime = GetTime()
-                    end
-
+                if IsReadyGlowAtMaxCharges(button, buttonData) then
                     if dur > 0 then
                         showReady = button._readyGlowMaxChargesStartTime ~= nil
                             and (GetTime() - button._readyGlowMaxChargesStartTime) <= dur
                     else
                         showReady = true
                     end
-                else
-                    button._readyGlowMaxChargesStartTime = nil
                 end
-
-                button._readyGlowMaxChargesActive = isCapped
             else
-                button._readyGlowMaxChargesSpellID = nil
-                button._readyGlowMaxChargesActive = nil
-                button._readyGlowMaxChargesStartTime = nil
                 local dur = style.readyGlowDuration or 0
                 if dur > 0 then
                     showReady = button._readyGlowStartTime ~= nil
@@ -839,6 +824,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._desaturated = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
+    button._readyGlowMaxChargesStartTime = nil
+    button._readyGlowMaxChargesActive = nil
+    button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._vertexR = nil
     button._vertexG = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -67,9 +67,7 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
         return cur == maxCharges
     end
 
-    -- Secret / restricted charge states do not reliably prove a spell is fully
-    -- capped, so keep capped-charge glow conservative there.
-    return false
+    return not button._chargeRecharging and not button._zeroChargesConfirmed
 end
 
 local function ApplyCountTextStyle(button, style)

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -134,7 +134,7 @@ local function PrimeSelectedReadyGlowNormalTransition(groupId, buttonIndex)
         return
     end
 
-    if buttonData.isPassive or button._noCooldown == true or button._desatCooldownActive ~= false then
+    if buttonData.isPassive or button._noCooldown == true or button._desatCooldownActive == true then
         return
     end
 

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1506,10 +1506,7 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                 ApplyCheckboxIndent(cappedCb, 20)
                                 CreateInfoButton(cappedCb.frame, cappedCb.checkbg, "LEFT", "RIGHT", cappedCb.text:GetStringWidth() + 6, 0, {
                                     "Glow When Charges Are Capped",
-                                    {"Only affects real multi-charge spells.", 1, 1, 1, true},
-                                    " ",
-                                    {"When enabled, charge spells only glow at max charges.", 1, 1, 1, true},
-                                    {"Auto-hide still applies.", 1, 1, 1, true},
+                                    {"When this toggle is enabled, the glow will only appear for charge based spells when at max charges.", 1, 1, 1, true},
                                 }, infoButtons)
 
                                 local durCb = AceGUI:Create("CheckBox")

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -107,6 +107,25 @@ local function GetDefaultAuraUnit(isHarmful)
     return isHarmful and "target" or "player"
 end
 
+local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex)
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
+    local button = frame and frame.buttons and frame.buttons[buttonIndex]
+    local buttonData = button and button.buttonData
+    if not (button and buttonData) then
+        return
+    end
+
+    if buttonData.type ~= "spell"
+       or buttonData.hasCharges ~= true
+       or buttonData._hasDisplayCount then
+        return
+    end
+
+    button._readyGlowMaxChargesSpellID = button._displaySpellId or buttonData.id
+    button._readyGlowMaxChargesStartTime = nil
+    button._readyGlowMaxChargesActive = false
+end
+
 local function EnsureAuraUnitChoice(buttonData, isHarmful, unit)
     if IsValidAuraUnit(unit) then
         buttonData.auraUnit = unit
@@ -1471,6 +1490,28 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                             end
 
                             if sectionId == "readyGlow" then
+                                local cappedCb = AceGUI:Create("CheckBox")
+                                cappedCb:SetLabel("Glow When Charges Are Capped")
+                                cappedCb:SetValue(overrides.readyGlowOnlyAtMaxCharges or false)
+                                cappedCb:SetFullWidth(true)
+                                cappedCb:SetCallback("OnValueChanged", function(widget, event, val)
+                                    overrides.readyGlowOnlyAtMaxCharges = val == true
+                                    CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+                                    if val and (overrides.readyGlowDuration or 0) > 0 then
+                                        PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
+                                    end
+                                    CooldownCompanion:UpdateAllCooldowns()
+                                end)
+                                cont:AddChild(cappedCb)
+                                ApplyCheckboxIndent(cappedCb, 20)
+                                CreateInfoButton(cappedCb.frame, cappedCb.checkbg, "LEFT", "RIGHT", cappedCb.text:GetStringWidth() + 6, 0, {
+                                    "Glow When Charges Are Capped",
+                                    {"Only affects real multi-charge spells.", 1, 1, 1, true},
+                                    " ",
+                                    {"Glows only at full charges.", 1, 1, 1, true},
+                                    {"Auto-hide still applies.", 1, 1, 1, true},
+                                }, infoButtons)
+
                                 local durCb = AceGUI:Create("CheckBox")
                                 durCb:SetLabel("Auto-Hide After Duration")
                                 durCb:SetValue((overrides.readyGlowDuration or 0) > 0)
@@ -1478,6 +1519,10 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                 durCb:SetCallback("OnValueChanged", function(widget, event, val)
                                     overrides.readyGlowDuration = val and 3 or 0
                                     CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+                                    if val and overrides.readyGlowOnlyAtMaxCharges then
+                                        PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
+                                    end
+                                    CooldownCompanion:UpdateAllCooldowns()
                                     CooldownCompanion:RefreshConfigPanel()
                                 end)
                                 cont:AddChild(durCb)

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1497,7 +1497,7 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                 cappedCb:SetCallback("OnValueChanged", function(widget, event, val)
                                     overrides.readyGlowOnlyAtMaxCharges = val == true
                                     CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-                                    if val and (overrides.readyGlowDuration or 0) > 0 then
+                                    if val and (GetEffectiveOverrideValue("readyGlowDuration") or 0) > 0 then
                                         PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
                                     end
                                     CooldownCompanion:UpdateAllCooldowns()
@@ -1514,12 +1514,12 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
 
                                 local durCb = AceGUI:Create("CheckBox")
                                 durCb:SetLabel("Auto-Hide After Duration")
-                                durCb:SetValue((overrides.readyGlowDuration or 0) > 0)
+                                durCb:SetValue((GetEffectiveOverrideValue("readyGlowDuration") or 0) > 0)
                                 durCb:SetFullWidth(true)
                                 durCb:SetCallback("OnValueChanged", function(widget, event, val)
                                     overrides.readyGlowDuration = val and 3 or 0
                                     CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-                                    if val and overrides.readyGlowOnlyAtMaxCharges then
+                                    if val and GetEffectiveOverrideValue("readyGlowOnlyAtMaxCharges") then
                                         PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
                                     end
                                     CooldownCompanion:UpdateAllCooldowns()

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -126,6 +126,21 @@ local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex
     button._readyGlowMaxChargesActive = false
 end
 
+local function PrimeSelectedReadyGlowNormalTransition(groupId, buttonIndex)
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
+    local button = frame and frame.buttons and frame.buttons[buttonIndex]
+    local buttonData = button and button.buttonData
+    if not (button and buttonData) then
+        return
+    end
+
+    if buttonData.isPassive or button._noCooldown == true or button._desatCooldownActive ~= false then
+        return
+    end
+
+    button._readyGlowStartTime = GetTime()
+end
+
 local function EnsureAuraUnitChoice(buttonData, isHarmful, unit)
     if IsValidAuraUnit(unit) then
         buttonData.auraUnit = unit
@@ -1497,8 +1512,12 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                 cappedCb:SetCallback("OnValueChanged", function(widget, event, val)
                                     overrides.readyGlowOnlyAtMaxCharges = val == true
                                     CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-                                    if val and (GetEffectiveOverrideValue("readyGlowDuration") or 0) > 0 then
-                                        PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
+                                    if (GetEffectiveOverrideValue("readyGlowDuration") or 0) > 0 then
+                                        if val then
+                                            PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
+                                        else
+                                            PrimeSelectedReadyGlowNormalTransition(CS.selectedGroup, CS.selectedButton)
+                                        end
                                     end
                                     CooldownCompanion:UpdateAllCooldowns()
                                 end)
@@ -1516,8 +1535,12 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                 durCb:SetCallback("OnValueChanged", function(widget, event, val)
                                     overrides.readyGlowDuration = val and 3 or 0
                                     CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-                                    if val and GetEffectiveOverrideValue("readyGlowOnlyAtMaxCharges") then
-                                        PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
+                                    if val then
+                                        if GetEffectiveOverrideValue("readyGlowOnlyAtMaxCharges") then
+                                            PrimeSelectedReadyGlowCappedChargeTransition(CS.selectedGroup, CS.selectedButton)
+                                        else
+                                            PrimeSelectedReadyGlowNormalTransition(CS.selectedGroup, CS.selectedButton)
+                                        end
                                     end
                                     CooldownCompanion:UpdateAllCooldowns()
                                     CooldownCompanion:RefreshConfigPanel()
@@ -1525,15 +1548,16 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                 cont:AddChild(durCb)
                                 ApplyCheckboxIndent(durCb, 20)
 
-                                if (overrides.readyGlowDuration or 0) > 0 then
+                                if (GetEffectiveOverrideValue("readyGlowDuration") or 0) > 0 then
                                     local durSlider = AceGUI:Create("Slider")
                                     durSlider:SetLabel("Duration (seconds)")
                                     durSlider:SetSliderValues(0.5, 5, 0.5)
-                                    durSlider:SetValue(overrides.readyGlowDuration or 3)
+                                    durSlider:SetValue(GetEffectiveOverrideValue("readyGlowDuration") or 3)
                                     durSlider:SetFullWidth(true)
                                     durSlider:SetCallback("OnValueChanged", function(widget, event, val)
                                         overrides.readyGlowDuration = val
                                         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+                                        CooldownCompanion:RefreshConfigPanel()
                                     end)
                                     cont:AddChild(durSlider)
                                 end

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1508,7 +1508,7 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                                     "Glow When Charges Are Capped",
                                     {"Only affects real multi-charge spells.", 1, 1, 1, true},
                                     " ",
-                                    {"Glows only at full charges.", 1, 1, 1, true},
+                                    {"When enabled, charge spells only glow at max charges.", 1, 1, 1, true},
                                     {"Auto-hide still applies.", 1, 1, 1, true},
                                 }, infoButtons)
 

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1556,7 +1556,7 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                         scroll:AddChild(pandemicPreviewBtn)
                     elseif sectionId == "readyGlow" and overrides.readyGlowStyle and overrides.readyGlowStyle ~= "none" then
                         local readyPreviewBtn = AceGUI:Create("Button")
-                        readyPreviewBtn:SetText("Preview Ready Glow (3s)")
+                        readyPreviewBtn:SetText("Preview Ready Glow Style (3s)")
                         readyPreviewBtn:SetFullWidth(true)
                         readyPreviewBtn:SetCallback("OnClick", function()
                             if CS.selectedGroup and CS.selectedButton then

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1492,7 +1492,7 @@ local function BuildOverridesTab(scroll, buttonData, infoButtons)
                             if sectionId == "readyGlow" then
                                 local cappedCb = AceGUI:Create("CheckBox")
                                 cappedCb:SetLabel("Glow When Charges Are Capped")
-                                cappedCb:SetValue(overrides.readyGlowOnlyAtMaxCharges or false)
+                                cappedCb:SetValue(GetEffectiveOverrideValue("readyGlowOnlyAtMaxCharges") or false)
                                 cappedCb:SetFullWidth(true)
                                 cappedCb:SetCallback("OnValueChanged", function(widget, event, val)
                                     overrides.readyGlowOnlyAtMaxCharges = val == true

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -71,6 +71,25 @@ local function PrimeReadyGlowCappedChargeTransitions(groupId)
     end
 end
 
+local function PrimeReadyGlowNormalTransitions(groupId)
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
+    if not (frame and frame.buttons) then
+        return
+    end
+
+    local now = GetTime()
+    for _, button in ipairs(frame.buttons) do
+        local buttonData = button.buttonData
+        if buttonData
+           and not buttonData.isPassive
+           and button._noCooldown ~= true
+           and button._visibilityHidden ~= true
+           and button._desatCooldownActive == false then
+            button._readyGlowStartTime = now
+        end
+    end
+end
+
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
 local KEYBIND_CUSTOM_LABEL = "Show Keybind/Custom Text"
@@ -1313,8 +1332,12 @@ local function BuildEffectsTab(container)
     readyChargesCb:SetCallback("OnValueChanged", function(widget, event, val)
         style.readyGlowOnlyAtMaxCharges = val == true
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        if val and (style.readyGlowDuration or 0) > 0 then
-            PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+        if (style.readyGlowDuration or 0) > 0 then
+            if val then
+                PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+            else
+                PrimeReadyGlowNormalTransitions(CS.selectedGroup)
+            end
         end
         CooldownCompanion:UpdateAllCooldowns()
     end)
@@ -1332,8 +1355,12 @@ local function BuildEffectsTab(container)
     readyDurCb:SetCallback("OnValueChanged", function(widget, event, val)
         style.readyGlowDuration = val and 3 or 0
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        if val and style.readyGlowOnlyAtMaxCharges then
-            PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+        if val then
+            if style.readyGlowOnlyAtMaxCharges then
+                PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+            else
+                PrimeReadyGlowNormalTransitions(CS.selectedGroup)
+            end
         end
         CooldownCompanion:UpdateAllCooldowns()
         CooldownCompanion:RefreshConfigPanel()

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -24,35 +24,6 @@ local AddOffsetSliders = ST._AddOffsetSliders
 local HookSliderEditBox = ST._HookSliderEditBox
 local BuildAlphaControls = ST._BuildAlphaControls
 
-local function ExpireCurrentCappedChargeReadyGlows(groupId, duration)
-    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
-    if not (frame and frame.buttons) then
-        return
-    end
-
-    local now = GetTime()
-    for _, button in ipairs(frame.buttons) do
-        local buttonData = button.buttonData
-        if buttonData and buttonData.type == "spell" and buttonData.hasCharges == true then
-            local cur = button._currentReadableCharges
-            local maxCharges = buttonData.maxCharges
-            local isCapped = false
-
-            if button._chargeCountReadable == true and cur ~= nil and maxCharges ~= nil then
-                isCapped = (cur == maxCharges)
-            elseif button._chargeCountReadable ~= true then
-                isCapped = not button._chargeRecharging and not button._zeroChargesConfirmed
-            end
-
-            if isCapped then
-                button._readyGlowMaxChargesSpellID = buttonData.id
-                button._readyGlowMaxChargesActive = true
-                button._readyGlowMaxChargesStartTime = now - (duration or 0) - 0.01
-            end
-        end
-    end
-end
-
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
 local BuildAuraTextControls = ST._BuildAuraTextControls
@@ -1343,9 +1314,6 @@ local function BuildEffectsTab(container)
     readyDurCb:SetCallback("OnValueChanged", function(widget, event, val)
         style.readyGlowDuration = val and 3 or 0
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        if val and style.readyGlowOnlyAtMaxCharges then
-            ExpireCurrentCappedChargeReadyGlows(CS.selectedGroup, style.readyGlowDuration or 0)
-        end
         CooldownCompanion:UpdateAllCooldowns()
         CooldownCompanion:RefreshConfigPanel()
     end)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -24,6 +24,35 @@ local AddOffsetSliders = ST._AddOffsetSliders
 local HookSliderEditBox = ST._HookSliderEditBox
 local BuildAlphaControls = ST._BuildAlphaControls
 
+local function ExpireCurrentCappedChargeReadyGlows(groupId, duration)
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
+    if not (frame and frame.buttons) then
+        return
+    end
+
+    local now = GetTime()
+    for _, button in ipairs(frame.buttons) do
+        local buttonData = button.buttonData
+        if buttonData and buttonData.type == "spell" and buttonData.hasCharges == true then
+            local cur = button._currentReadableCharges
+            local maxCharges = buttonData.maxCharges
+            local isCapped = false
+
+            if button._chargeCountReadable == true and cur ~= nil and maxCharges ~= nil then
+                isCapped = (cur == maxCharges)
+            elseif button._chargeCountReadable ~= true then
+                isCapped = not button._chargeRecharging and not button._zeroChargesConfirmed
+            end
+
+            if isCapped then
+                button._readyGlowMaxChargesSpellID = buttonData.id
+                button._readyGlowMaxChargesActive = true
+                button._readyGlowMaxChargesStartTime = now - (duration or 0) - 0.01
+            end
+        end
+    end
+end
+
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
 local BuildAuraTextControls = ST._BuildAuraTextControls
@@ -1272,7 +1301,9 @@ local function BuildEffectsTab(container)
     local readyPromoteBtn = CreateCheckboxPromoteButton(readyEnableCb, readyAdvBtn, "readyGlow", group, style)
     CreateInfoButton(readyEnableCb.frame, readyPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Ready Glow",
-        {"Adds a glow effect around buttons whose spells or items are off cooldown and ready to use.", 1, 1, 1, true},
+        {"Adds a glow to ready spells and items.", 1, 1, 1, true},
+        " ",
+        {"Optional: charge spells can glow only when fully capped.", 1, 1, 1, true},
     }, tabInfoButtons)
 
     if readyAdvExpanded and style.readyGlowStyle and style.readyGlowStyle ~= "none" then
@@ -1287,6 +1318,24 @@ local function BuildEffectsTab(container)
     container:AddChild(readyCombatCb)
     ApplyCheckboxIndent(readyCombatCb, 20)
 
+    local readyChargesCb = AceGUI:Create("CheckBox")
+    readyChargesCb:SetLabel("Glow When Charges Are Capped")
+    readyChargesCb:SetValue(style.readyGlowOnlyAtMaxCharges or false)
+    readyChargesCb:SetFullWidth(true)
+    readyChargesCb:SetCallback("OnValueChanged", function(widget, event, val)
+        style.readyGlowOnlyAtMaxCharges = val == true
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+    end)
+    container:AddChild(readyChargesCb)
+    ApplyCheckboxIndent(readyChargesCb, 20)
+    CreateInfoButton(readyChargesCb.frame, readyChargesCb.checkbg, "LEFT", "RIGHT", readyChargesCb.text:GetStringWidth() + 6, 0, {
+        "Glow When Charges Are Capped",
+        {"Only affects real multi-charge spells.", 1, 1, 1, true},
+        " ",
+        {"Glows only at full charges.", 1, 1, 1, true},
+        {"Auto-hide still applies.", 1, 1, 1, true},
+    }, tabInfoButtons)
+
     local readyDurCb = AceGUI:Create("CheckBox")
     readyDurCb:SetLabel("Auto-Hide After Duration")
     readyDurCb:SetValue((style.readyGlowDuration or 0) > 0)
@@ -1294,6 +1343,10 @@ local function BuildEffectsTab(container)
     readyDurCb:SetCallback("OnValueChanged", function(widget, event, val)
         style.readyGlowDuration = val and 3 or 0
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        if val and style.readyGlowOnlyAtMaxCharges then
+            ExpireCurrentCappedChargeReadyGlows(CS.selectedGroup, style.readyGlowDuration or 0)
+        end
+        CooldownCompanion:UpdateAllCooldowns()
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(readyDurCb)
@@ -1317,7 +1370,7 @@ local function BuildEffectsTab(container)
     end)
 
     local readyPreviewBtn = AceGUI:Create("Button")
-    readyPreviewBtn:SetText("Preview Ready Glow (3s)")
+    readyPreviewBtn:SetText("Preview Ready Glow Style (3s)")
     readyPreviewBtn:SetFullWidth(true)
     readyPreviewBtn:SetCallback("OnClick", function()
         CooldownCompanion:PlayGroupReadyGlowPreview(CS.selectedGroup, 3)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1292,8 +1292,6 @@ local function BuildEffectsTab(container)
     CreateInfoButton(readyEnableCb.frame, readyPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Ready Glow",
         {"Adds a glow to spells/items that are not on cooldown.", 1, 1, 1, true},
-        " ",
-        {"When this toggle is enabled, charge spells only glow at max charges.", 1, 1, 1, true},
     }, tabInfoButtons)
 
     if readyAdvExpanded and style.readyGlowStyle and style.readyGlowStyle ~= "none" then
@@ -1324,10 +1322,7 @@ local function BuildEffectsTab(container)
     ApplyCheckboxIndent(readyChargesCb, 20)
     CreateInfoButton(readyChargesCb.frame, readyChargesCb.checkbg, "LEFT", "RIGHT", readyChargesCb.text:GetStringWidth() + 6, 0, {
         "Glow When Charges Are Capped",
-        {"Only affects real multi-charge spells.", 1, 1, 1, true},
-        " ",
-        {"When enabled, charge spells only glow at max charges.", 1, 1, 1, true},
-        {"Auto-hide still applies.", 1, 1, 1, true},
+        {"When this toggle is enabled, the glow will only appear for charge based spells when at max charges.", 1, 1, 1, true},
     }, tabInfoButtons)
 
     local readyDurCb = AceGUI:Create("CheckBox")

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -84,7 +84,7 @@ local function PrimeReadyGlowNormalTransitions(groupId)
            and not buttonData.isPassive
            and button._noCooldown ~= true
            and button._visibilityHidden ~= true
-           and button._desatCooldownActive == false then
+           and button._desatCooldownActive ~= true then
             button._readyGlowStartTime = now
         end
     end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1337,6 +1337,9 @@ local function BuildEffectsTab(container)
     readyDurCb:SetCallback("OnValueChanged", function(widget, event, val)
         style.readyGlowDuration = val and 3 or 0
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        if val and style.readyGlowOnlyAtMaxCharges then
+            PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+        end
         CooldownCompanion:UpdateAllCooldowns()
         CooldownCompanion:RefreshConfigPanel()
     end)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -52,6 +52,25 @@ local BuildBarColorsControls = ST._BuildBarColorsControls
 local BuildBarNameTextControls = ST._BuildBarNameTextControls
 local BuildBarReadyTextControls = ST._BuildBarReadyTextControls
 
+local function PrimeReadyGlowCappedChargeTransitions(groupId)
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
+    if not (frame and frame.buttons) then
+        return
+    end
+
+    for _, button in ipairs(frame.buttons) do
+        local buttonData = button.buttonData
+        if buttonData
+           and buttonData.type == "spell"
+           and buttonData.hasCharges == true
+           and not buttonData._hasDisplayCount then
+            button._readyGlowMaxChargesSpellID = button._displaySpellId or buttonData.id
+            button._readyGlowMaxChargesStartTime = nil
+            button._readyGlowMaxChargesActive = false
+        end
+    end
+end
+
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
 local KEYBIND_CUSTOM_LABEL = "Show Keybind/Custom Text"
@@ -1296,6 +1315,10 @@ local function BuildEffectsTab(container)
     readyChargesCb:SetCallback("OnValueChanged", function(widget, event, val)
         style.readyGlowOnlyAtMaxCharges = val == true
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        if val and (style.readyGlowDuration or 0) > 0 then
+            PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+        end
+        CooldownCompanion:UpdateAllCooldowns()
     end)
     container:AddChild(readyChargesCb)
     ApplyCheckboxIndent(readyChargesCb, 20)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1291,9 +1291,9 @@ local function BuildEffectsTab(container)
     local readyPromoteBtn = CreateCheckboxPromoteButton(readyEnableCb, readyAdvBtn, "readyGlow", group, style)
     CreateInfoButton(readyEnableCb.frame, readyPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Ready Glow",
-        {"Adds a glow to ready spells and items.", 1, 1, 1, true},
+        {"Adds a glow to spells/items that are not on cooldown.", 1, 1, 1, true},
         " ",
-        {"Optional: charge spells can glow only when fully capped.", 1, 1, 1, true},
+        {"When this toggle is enabled, charge spells only glow at max charges.", 1, 1, 1, true},
     }, tabInfoButtons)
 
     if readyAdvExpanded and style.readyGlowStyle and style.readyGlowStyle ~= "none" then
@@ -1326,7 +1326,7 @@ local function BuildEffectsTab(container)
         "Glow When Charges Are Capped",
         {"Only affects real multi-charge spells.", 1, 1, 1, true},
         " ",
-        {"Glows only at full charges.", 1, 1, 1, true},
+        {"When enabled, charge spells only glow at max charges.", 1, 1, 1, true},
         {"Auto-hide still applies.", 1, 1, 1, true},
     }, tabInfoButtons)
 

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -311,6 +311,7 @@ local defaults = {
             readyGlowSpeed = 50,
             readyGlowLines = 8,
             readyGlowCombatOnly = false,
+            readyGlowOnlyAtMaxCharges = false,
             readyGlowDuration = 0,
             keyPressHighlightStyle = "none",
             keyPressHighlightColor = {1, 1, 1, 0.4},

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -652,7 +652,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     readyGlow = {
         label = "Ready Glow",
-        keys = {"readyGlowStyle", "readyGlowColor", "readyGlowSize", "readyGlowThickness", "readyGlowSpeed", "readyGlowLines", "readyGlowCombatOnly", "readyGlowDuration"},
+        keys = {"readyGlowStyle", "readyGlowColor", "readyGlowSize", "readyGlowThickness", "readyGlowSpeed", "readyGlowLines", "readyGlowCombatOnly", "readyGlowOnlyAtMaxCharges", "readyGlowDuration"},
         modes = {icons = true},
     },
     keyPressHighlight = {

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -252,6 +252,8 @@ local function ResetButtonGlowTransitionState(button)
     button._procGlowActive = nil
     button._auraGlowActive = nil
     button._readyGlowActive = nil
+    button._readyGlowMaxChargesStartTime = nil
+    button._readyGlowMaxChargesActive = false
     button._barAuraEffectActive = nil
     button._barPulseActive = nil
     button._barColorShiftActive = nil


### PR DESCRIPTION
## Summary
- Add a group-level and override-level Ready Glow option that lets charge-based spells glow only when fully capped
- Keep existing Ready Glow behavior for non-charge spells and items
- Seed and clear the capped-charge glow timer so duration-based hiding works cleanly across style refreshes and visibility changes
- Update Ready Glow copy and preview labels to make the new option read as part of the existing system

## Testing
- `luac -p` on touched Lua files
- In-game verification on a real multi-charge spell
- Verified in combat that capped-charge Ready Glow behaves correctly