### PR TITLE
Add sound preview buttons to sound alert dropdowns

### DIFF
--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -99,6 +99,54 @@ local function BuildSortedSoundOptionOrder(soundOptions)
     return order
 end
 
+local SOUND_PREVIEW_ICON_ATLAS = "chatframe-button-icon-voicechat"
+
+local function ConfigureSoundPreviewRow(item, buttonData)
+    if not (item and item.frame and item.text) then return end
+
+    local previewBtn = item._cdcSoundPreviewBtn
+    if not previewBtn then
+        previewBtn = CreateFrame("Button", nil, item.frame)
+        previewBtn:SetSize(16, 16)
+        previewBtn:SetHighlightAtlas(SOUND_PREVIEW_ICON_ATLAS)
+        if previewBtn:GetHighlightTexture() then
+            previewBtn:GetHighlightTexture():SetAlpha(0.3)
+        end
+        local icon = previewBtn:CreateTexture(nil, "ARTWORK")
+        icon:SetSize(12, 12)
+        icon:SetPoint("CENTER")
+        icon:SetAtlas(SOUND_PREVIEW_ICON_ATLAS, false)
+        previewBtn._cdcSoundPreviewIcon = icon
+        previewBtn:SetScript("OnClick", function(self)
+            local previewValue = self._cdcSoundValue
+            local previewButtonData = self._cdcButtonData
+            if previewValue and previewValue ~= SOUND_ALERT_NONE_OPTION_KEY and previewButtonData then
+                CooldownCompanion:PreviewSoundAlertSelection(previewButtonData, previewValue)
+            end
+        end)
+        item._cdcSoundPreviewBtn = previewBtn
+    end
+
+    previewBtn:SetParent(item.frame)
+    previewBtn:SetFrameLevel(item.frame:GetFrameLevel() + 1)
+    previewBtn:ClearAllPoints()
+    previewBtn:SetPoint("RIGHT", item.frame, "RIGHT", -18, 0)
+    previewBtn._cdcButtonData = buttonData
+
+    local previewValue = item.userdata and item.userdata.value
+    local hasPreview = previewValue and previewValue ~= SOUND_ALERT_NONE_OPTION_KEY
+    previewBtn._cdcSoundValue = hasPreview and previewValue or nil
+    previewBtn:SetShown(hasPreview)
+
+    item.text:ClearAllPoints()
+    item.text:SetPoint("TOPLEFT", item.frame, "TOPLEFT", 18, 0)
+    if hasPreview then
+        item.text:SetPoint("BOTTOMRIGHT", previewBtn, "LEFT", -4, 0)
+    else
+        item.text:SetPoint("BOTTOMRIGHT", item.frame, "BOTTOMRIGHT", -8, 0)
+    end
+end
+
 local function IsValidAuraUnit(unit)
     return unit == "player" or unit == "target"
 end
@@ -200,22 +248,10 @@ local function BuildSpellSoundAlertsSection(scroll, buttonData, infoButtons)
             soundDrop:SetCallback("OnOpened", function(widget)
                 if not widget.pullout then return end
 
-                -- Inline preview: click the right-side badge on a row to test that sound
+                -- Inline preview: click the sound icon on a row to test that sound
                 -- without selecting it or closing the dropdown.
                 for _, item in widget.pullout:IterateItems() do
-                    if item.SetUtilityAction then
-                        local itemValue = item and item.userdata and item.userdata.value
-                        if itemValue and itemValue ~= "None" then
-                            item:SetUtilityAction(function(itemWidget)
-                                local previewValue = itemWidget and itemWidget.userdata and itemWidget.userdata.value
-                                if previewValue and previewValue ~= "None" then
-                                    CooldownCompanion:PreviewSoundAlertSelection(buttonData, previewValue)
-                                end
-                            end)
-                        else
-                            item:SetUtilityAction(nil)
-                        end
-                    end
+                    ConfigureSoundPreviewRow(item, buttonData)
                 end
             end)
 

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -100,9 +100,40 @@ local function BuildSortedSoundOptionOrder(soundOptions)
 end
 
 local SOUND_PREVIEW_ICON_ATLAS = "chatframe-button-icon-voicechat"
+local SOUND_PREVIEW_TEXT_LEFT_OFFSET = 18
+local SOUND_PREVIEW_TEXT_RIGHT_OFFSET = -8
+local SOUND_PREVIEW_TEXT_GAP = -4
+local SOUND_PREVIEW_BUTTON_RIGHT_OFFSET = -18
+
+local function ResetSoundPreviewRow(item)
+    if not (item and item.frame and item.text) then return end
+
+    local previewBtn = item._cdcSoundPreviewBtn
+    if previewBtn then
+        previewBtn:SetShown(false)
+        previewBtn._cdcButtonData = nil
+        previewBtn._cdcSoundValue = nil
+        previewBtn:ClearAllPoints()
+    end
+
+    item.text:ClearAllPoints()
+    item.text:SetPoint("TOPLEFT", item.frame, "TOPLEFT", SOUND_PREVIEW_TEXT_LEFT_OFFSET, 0)
+    item.text:SetPoint("BOTTOMRIGHT", item.frame, "BOTTOMRIGHT", SOUND_PREVIEW_TEXT_RIGHT_OFFSET, 0)
+end
 
 local function ConfigureSoundPreviewRow(item, buttonData)
     if not (item and item.frame and item.text) then return end
+
+    if not item._cdcSoundPreviewCleanupInstalled then
+        item._cdcSoundPreviewCleanupInstalled = true
+        local prevOnRelease = item.events and item.events["OnRelease"]
+        item:SetCallback("OnRelease", function(widget, event)
+            if prevOnRelease then
+                prevOnRelease(widget, event)
+            end
+            ResetSoundPreviewRow(widget)
+        end)
+    end
 
     local previewBtn = item._cdcSoundPreviewBtn
     if not previewBtn then
@@ -130,7 +161,7 @@ local function ConfigureSoundPreviewRow(item, buttonData)
     previewBtn:SetParent(item.frame)
     previewBtn:SetFrameLevel(item.frame:GetFrameLevel() + 1)
     previewBtn:ClearAllPoints()
-    previewBtn:SetPoint("RIGHT", item.frame, "RIGHT", -18, 0)
+    previewBtn:SetPoint("RIGHT", item.frame, "RIGHT", SOUND_PREVIEW_BUTTON_RIGHT_OFFSET, 0)
     previewBtn._cdcButtonData = buttonData
 
     local previewValue = item.userdata and item.userdata.value
@@ -139,11 +170,11 @@ local function ConfigureSoundPreviewRow(item, buttonData)
     previewBtn:SetShown(hasPreview)
 
     item.text:ClearAllPoints()
-    item.text:SetPoint("TOPLEFT", item.frame, "TOPLEFT", 18, 0)
+    item.text:SetPoint("TOPLEFT", item.frame, "TOPLEFT", SOUND_PREVIEW_TEXT_LEFT_OFFSET, 0)
     if hasPreview then
-        item.text:SetPoint("BOTTOMRIGHT", previewBtn, "LEFT", -4, 0)
+        item.text:SetPoint("BOTTOMRIGHT", previewBtn, "LEFT", SOUND_PREVIEW_TEXT_GAP, 0)
     else
-        item.text:SetPoint("BOTTOMRIGHT", item.frame, "BOTTOMRIGHT", -8, 0)
+        item.text:SetPoint("BOTTOMRIGHT", item.frame, "BOTTOMRIGHT", SOUND_PREVIEW_TEXT_RIGHT_OFFSET, 0)
     end
 end
 


### PR DESCRIPTION
## Summary
- Add a clickable preview icon to each sound alert dropdown row so users can hear a sound before selecting it.
- Use the voice chat atlas for the icon and keep the hover highlight consistent with other config icons.
- Add cleanup for pooled dropdown rows so the preview control does not leak into reused menus.

## Testing
- `luac -p ConfigSettings/ButtonSettings.lua`
- Not run (not requested)