### PR TITLE
Clean up texture panel defaults and retire old recent texture data

### DIFF
--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -883,11 +883,88 @@ local function RehydrateScopedStore(store, defaultKey, formatVersion)
     return store
 end
 
+local function NormalizeTextureLibraryStore(store)
+    if type(store) ~= "table" then
+        return store
+    end
+
+    if type(CooldownCompanion.NormalizeAuraTextureLibraryStore) == "function" then
+        return CooldownCompanion:NormalizeAuraTextureLibraryStore(store)
+    end
+
+    if type(store.customTextures) ~= "table" then
+        store.customTextures = {}
+    end
+    if type(store.textureFavorites) ~= "table" then
+        store.textureFavorites = {}
+    end
+
+    local legacyFavorites = store.sharedMediaFavorites
+    if type(legacyFavorites) == "table" then
+        for storedKey, storedValue in pairs(legacyFavorites) do
+            if type(storedValue) == "string" then
+                store.textureFavorites[storedValue] = store.textureFavorites[storedValue] or storedValue
+            elseif type(storedValue) == "table" then
+                local favoriteKey = storedValue.favoriteKey
+                if type(favoriteKey) == "string" then
+                    store.textureFavorites[favoriteKey] = store.textureFavorites[favoriteKey] or CopyTable(storedValue)
+                end
+            end
+            legacyFavorites[storedKey] = nil
+        end
+    end
+
+    if type(store.textureFavorites) == "table" then
+        for favoriteKey, favoriteValue in pairs(store.textureFavorites) do
+            local storedFavoriteKey = type(favoriteValue) == "table" and favoriteValue.favoriteKey or nil
+            if (type(favoriteKey) == "string" and string.find(favoriteKey, "^favorite:legacy%-proc:"))
+                or (type(storedFavoriteKey) == "string" and string.find(storedFavoriteKey, "^favorite:legacy%-proc:")) then
+                store.textureFavorites[favoriteKey] = nil
+            end
+        end
+    end
+
+    store.sharedMediaFavorites = nil
+    store.recentProcOverlays = nil
+    return store
+end
+
+local function NormalizeTextureLibraryProfile(profile)
+    if type(profile) ~= "table" then
+        return profile
+    end
+
+    if type(profile.auraTextureLibrary) ~= "table" then
+        return profile
+    end
+
+    profile.auraTextureLibrary = NormalizeTextureLibraryStore(profile.auraTextureLibrary)
+    return profile
+end
+
+local function NormalizeTextureLibraryPayload(data)
+    if type(data) ~= "table" then
+        return data
+    end
+
+    if type(data.profile) == "table" then
+        data.profile = NormalizeTextureLibraryProfile(data.profile)
+        return data
+    end
+
+    if data.type then
+        return data
+    end
+
+    return NormalizeTextureLibraryProfile(data)
+end
+
 local function CompactProfile(profile, formatVersion)
     if type(profile) ~= "table" then
         return profile
     end
 
+    profile = NormalizeTextureLibraryProfile(CopyTable(profile))
     local profileDefaults = GetDefaultsProfile(formatVersion)
     local globalStyleDefaults = profile.globalStyle or profileDefaults.globalStyle or {}
     local compact = {}
@@ -992,7 +1069,7 @@ local function RehydrateProfile(profile, formatVersion)
         end
     end
 
-    return profile
+    return NormalizeTextureLibraryProfile(profile)
 end
 
 local function CompactEntityPayload(payload, formatVersion)
@@ -1142,14 +1219,14 @@ local function RehydrateCompactPayload(data, formatVersion)
 
     if data.profile and type(data.profile) == "table" then
         data.profile = RehydrateProfile(data.profile, formatVersion)
-        return data
+        return NormalizeTextureLibraryPayload(data)
     end
 
     if data.type then
         return RehydrateEntityPayload(data, formatVersion)
     end
 
-    return RehydrateProfile(data, formatVersion)
+    return NormalizeTextureLibraryProfile(RehydrateProfile(data, formatVersion))
 end
 
 local function EncodeSharedPayload(payload, exportKind)
@@ -1178,7 +1255,11 @@ local function DecodeSharedPayload(text)
     end
 
     if isLegacy then
-        return AceSerializer:Deserialize(trimmed)
+        local success, data = AceSerializer:Deserialize(trimmed)
+        if success and type(data) == "table" then
+            data = NormalizeTextureLibraryPayload(data)
+        end
+        return success, data
     end
 
     local decoded = LibDeflate:DecodeForPrint(normalized)
@@ -1201,7 +1282,9 @@ local function DecodeSharedPayload(text)
         or formatVersion == PREVIOUS_COMPACT_FORMAT_VALUE
         or formatVersion == CURRENT_COMPACT_FORMAT_VALUE then
         data[COMPACT_FORMAT_KEY] = nil
-        RehydrateCompactPayload(data, formatVersion)
+        data = RehydrateCompactPayload(data, formatVersion)
+    else
+        data = NormalizeTextureLibraryPayload(data)
     end
 
     return true, data

--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -121,7 +121,6 @@ local COMPACT_PROFILE_DEFAULTS = {
         },
         auraTextureLibrary = {
             textureFavorites = {},
-            recentProcOverlays = {},
         },
         globalStyle = {
             buttonSize = 36,

--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -120,6 +120,7 @@ local COMPACT_PROFILE_DEFAULTS = {
             bars = {},
         },
         auraTextureLibrary = {
+            textureFavorites = {},
             recentProcOverlays = {},
         },
         globalStyle = {

--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -11,7 +11,8 @@ local LibDeflate = LibStub("LibDeflate")
 
 local COMPRESSION_CONFIG = { level = 9 }
 local COMPACT_FORMAT_KEY = "_cdcExportFormat"
-local CURRENT_COMPACT_FORMAT_VALUE = "compact2"
+local CURRENT_COMPACT_FORMAT_VALUE = "compact3"
+local PREVIOUS_COMPACT_FORMAT_VALUE = "compact2"
 local LEGACY_COMPACT_FORMAT_VALUE = "compact1"
 
 local LOAD_CONDITIONS_DEFAULTS = {
@@ -497,11 +498,15 @@ local COMPACT_ENTITY_DEFAULTS = {
     },
 }
 
+COMPACT_PROFILE_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_PROFILE_DEFAULTS[CURRENT_COMPACT_FORMAT_VALUE])
+COMPACT_PROFILE_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE].auraTextureLibrary.recentProcOverlays = {}
+COMPACT_ENTITY_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_ENTITY_DEFAULTS[CURRENT_COMPACT_FORMAT_VALUE])
+
 -- compact1 shipped before defaults were version-pinned. Freeze it against the
 -- original baseline so older compact strings do not drift as live defaults
 -- evolve in later releases.
-COMPACT_PROFILE_DEFAULTS[LEGACY_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_PROFILE_DEFAULTS[CURRENT_COMPACT_FORMAT_VALUE])
-COMPACT_ENTITY_DEFAULTS[LEGACY_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_ENTITY_DEFAULTS[CURRENT_COMPACT_FORMAT_VALUE])
+COMPACT_PROFILE_DEFAULTS[LEGACY_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_PROFILE_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE])
+COMPACT_ENTITY_DEFAULTS[LEGACY_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_ENTITY_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE])
 
 local function CopyValue(value)
     if type(value) == "table" then
@@ -1192,7 +1197,9 @@ local function DecodeSharedPayload(text)
     end
 
     local formatVersion = data[COMPACT_FORMAT_KEY]
-    if formatVersion == LEGACY_COMPACT_FORMAT_VALUE or formatVersion == CURRENT_COMPACT_FORMAT_VALUE then
+    if formatVersion == LEGACY_COMPACT_FORMAT_VALUE
+        or formatVersion == PREVIOUS_COMPACT_FORMAT_VALUE
+        or formatVersion == CURRENT_COMPACT_FORMAT_VALUE then
         data[COMPACT_FORMAT_KEY] = nil
         RehydrateCompactPayload(data, formatVersion)
     end

--- a/Config/Pickers.lua
+++ b/Config/Pickers.lua
@@ -22,7 +22,6 @@ local pickAuraTextureOverlay = nil
 local pickAuraTextureCallback = nil
 local AURA_TEXTURE_FILTER_SYMBOLS = "symbols"
 local AURA_TEXTURE_FILTER_OTHER = "other"
-local AURA_TEXTURE_FILTER_RECENT = "recent"
 
 ------------------------------------------------------------------------
 -- Secret-safe value helpers

--- a/ConfigSettings/AuraTexturePicker.lua
+++ b/ConfigSettings/AuraTexturePicker.lua
@@ -78,13 +78,6 @@ local function FindEntryForSelection(entries, selection)
         end
     end
 
-    if CooldownCompanion.FindAuraTexturePickerEntryByAsset then
-        local matchedEntry = CooldownCompanion:FindAuraTexturePickerEntryByAsset(entries, selection)
-        if matchedEntry then
-            return matchedEntry
-        end
-    end
-
     if type(selection) ~= "table" then
         return nil
     end

--- a/ConfigSettings/AuraTexturePicker.lua
+++ b/ConfigSettings/AuraTexturePicker.lua
@@ -72,7 +72,17 @@ end
 
 local function FindEntryForSelection(entries, selection)
     if CooldownCompanion.FindAuraTexturePickerEntry then
-        return CooldownCompanion:FindAuraTexturePickerEntry(entries, selection)
+        local matchedEntry = CooldownCompanion:FindAuraTexturePickerEntry(entries, selection)
+        if matchedEntry then
+            return matchedEntry
+        end
+    end
+
+    if CooldownCompanion.FindAuraTexturePickerEntryByAsset then
+        local matchedEntry = CooldownCompanion:FindAuraTexturePickerEntryByAsset(entries, selection)
+        if matchedEntry then
+            return matchedEntry
+        end
     end
 
     if type(selection) ~= "table" then
@@ -451,7 +461,7 @@ local function OpenAuraTexturePicker(opts)
 
         if #entries == 0 then
             if IsFavoritesFilter(currentFilter) and currentSearch == "" then
-                statusLabel:SetText("No SharedMedia favorites yet. Browse SharedMedia and click + to save one here.")
+                statusLabel:SetText("No favorite textures yet. Browse any category and click + to save one here.")
             elseif IsFavoritesFilter(currentFilter) then
                 statusLabel:SetText("No favorite textures matched the current search.")
             elseif IsSharedMediaFilter(currentFilter) then
@@ -462,9 +472,9 @@ local function OpenAuraTexturePicker(opts)
         elseif IsFavoritesFilter(currentFilter) then
             statusLabel:SetText(("Showing %d favorite textures. Click the red X to remove one."):format(#entries))
         elseif IsSharedMediaFilter(currentFilter) then
-            statusLabel:SetText(("Showing %d SharedMedia textures. Click + to save a favorite."):format(#entries))
+            statusLabel:SetText(("Showing %d SharedMedia textures. Click + to favorite one, or the red X to remove it from Favorites."):format(#entries))
         else
-            statusLabel:SetText(("Showing %d textures."):format(#entries))
+            statusLabel:SetText(("Showing %d textures. Click + to favorite one, or the red X to remove it from Favorites."):format(#entries))
         end
 
         local matchedSelected = FindEntryForSelection(entries, currentSelection)
@@ -534,10 +544,10 @@ local function OpenAuraTexturePicker(opts)
                     GameTooltip:SetOwner(thumb._deleteBtn, "ANCHOR_LEFT")
                     if thumb._deleteBtn._actionMode == "addFavorite" then
                         GameTooltip:AddLine("Add To Favorites")
-                        GameTooltip:AddLine("Save this SharedMedia texture in the Favorites category.", 1, 1, 1, true)
+                        GameTooltip:AddLine("Save this texture in the Favorites category.", 1, 1, 1, true)
                     elseif thumb._deleteBtn._actionMode == "removeFavorite" then
                         GameTooltip:AddLine("Remove From Favorites")
-                        GameTooltip:AddLine("Keep the texture available in SharedMedia, but remove it from Favorites.", 1, 1, 1, true)
+                        GameTooltip:AddLine("Keep the texture in its normal category, but remove it from Favorites.", 1, 1, 1, true)
                     end
                     GameTooltip:Show()
                 end)
@@ -559,14 +569,14 @@ local function OpenAuraTexturePicker(opts)
                 end)
                 thumb._deleteBtn:SetScript("OnClick", function()
                     if thumb._deleteBtn._actionMode == "addFavorite" then
-                        local savedEntry = CooldownCompanion:SaveFavoriteAuraTexture(entry.mediaType, entry.sourceValue, entry.label)
+                        local savedEntry = CooldownCompanion:SaveFavoriteAuraTexture(entry)
                         if savedEntry then
                             statusLabel:SetText((savedEntry.label or "Texture") .. " added to Favorites.")
                         else
-                            statusLabel:SetText("That SharedMedia texture could not be added to Favorites.")
+                            statusLabel:SetText("That texture could not be added to Favorites.")
                         end
                     elseif thumb._deleteBtn._actionMode == "removeFavorite" then
-                        CooldownCompanion:RemoveFavoriteAuraTexture(entry.libraryKey or entry.key)
+                        CooldownCompanion:RemoveFavoriteAuraTexture(entry)
                         if selectedEntry == entry and IsFavoritesFilter(currentFilter) then
                             selectedEntry = nil
                         end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -240,7 +240,7 @@ local function ApplyTexturePreviewVisual(texture, settings, alpha, flipH, flipV,
 
     local color = settings.color or { 1, 1, 1, 1 }
     texture:SetVertexColor(color[1] or 1, color[2] or 1, color[3] or 1, alpha or 1)
-    texture:SetBlendMode(settings.blendMode or "ADD")
+    texture:SetBlendMode(settings.blendMode or "BLEND")
 
     local left = flipH and 1 or 0
     local right = flipH and 0 or 1
@@ -1795,10 +1795,10 @@ local function BuildAppearanceTab(container)
         local blendDrop = AceGUI:Create("Dropdown")
         blendDrop:SetLabel("Blend Mode")
         blendDrop:SetList(TEXTURE_BLEND_OPTIONS, TEXTURE_BLEND_ORDER)
-        blendDrop:SetValue(settings.blendMode or "ADD")
+        blendDrop:SetValue(settings.blendMode or "BLEND")
         blendDrop:SetFullWidth(true)
         blendDrop:SetCallback("OnValueChanged", function(_, _, value)
-            settings.blendMode = value or "ADD"
+            settings.blendMode = value or "BLEND"
             RefreshTextureVisual()
         end)
         container:AddChild(blendDrop)

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -1109,14 +1109,37 @@ local function MigrateLegacySharedMediaFavorites(store)
                 favoriteEntry.favoriteOriginCategoryKey = FILTER_SHAREDMEDIA
                 favorites[libraryKey] = favorites[libraryKey] or BuildAuraTextureFavoriteRecord(favoriteEntry)
             end
-        else
-            legacyFavorites[storedKey] = nil
         end
+
+        legacyFavorites[storedKey] = nil
     end
+
+    store.sharedMediaFavorites = nil
 end
 
 local GetAuraTextureFavoriteStore
 local AreAuraTextureFavoriteRecordsEquivalent
+local BuildBlizzardProcOverlayEntries
+local DoesAuraTextureVariantMatchRecord
+
+local function IsLegacyProcFavoriteKey(favoriteKey)
+    return type(favoriteKey) == "string" and string_find(favoriteKey, "^favorite:legacy%-proc:", 1, false) ~= nil
+end
+
+local function FindCanonicalBlizzardProcFavoriteKey(record, procEntries)
+    local matchKey = nil
+
+    for _, entry in ipairs(procEntries or {}) do
+        if DoesAuraTextureVariantMatchRecord(entry, record) then
+            if matchKey and matchKey ~= entry.key then
+                return nil
+            end
+            matchKey = entry.key
+        end
+    end
+
+    return matchKey
+end
 
 local function BuildLegacyRecentFavoriteRecord(storedKey, value)
     local sourceValue = tonumber(value and value.sourceValue)
@@ -1148,6 +1171,39 @@ local function BuildLegacyRecentFavoriteRecord(storedKey, value)
     return record
 end
 
+local function CanonicalizeLegacyProcFavoriteRecords(favorites, procEntries)
+    if type(favorites) ~= "table" then
+        return
+    end
+
+    local updates = {}
+    local removals = {}
+
+    for favoriteKey, favoriteValue in pairs(favorites) do
+        local favoriteRecord = ReadAuraTextureFavoriteRecord(favoriteValue)
+        if not favoriteRecord then
+            removals[#removals + 1] = favoriteKey
+        elseif favoriteRecord.originCategoryKey == FILTER_BLIZZARD_PROC and IsLegacyProcFavoriteKey(favoriteRecord.favoriteKey) then
+            local canonicalKey = FindCanonicalBlizzardProcFavoriteKey(favoriteRecord, procEntries)
+            if canonicalKey and canonicalKey ~= favoriteKey then
+                local existingRecord = ReadAuraTextureFavoriteRecord(favorites[canonicalKey])
+                if not existingRecord or AreAuraTextureFavoriteRecordsEquivalent(existingRecord, favoriteRecord) then
+                    favoriteRecord.favoriteKey = canonicalKey
+                    updates[canonicalKey] = favoriteRecord
+                    removals[#removals + 1] = favoriteKey
+                end
+            end
+        end
+    end
+
+    for _, favoriteKey in ipairs(removals) do
+        favorites[favoriteKey] = nil
+    end
+    for favoriteKey, favoriteRecord in pairs(updates) do
+        favorites[favoriteKey] = favoriteRecord
+    end
+end
+
 local function MigrateLegacyRecentProcOverlayFavorites(store)
     if type(store) ~= "table" or type(store.recentProcOverlays) ~= "table" then
         return
@@ -1155,14 +1211,25 @@ local function MigrateLegacyRecentProcOverlayFavorites(store)
 
     local legacyRecent = store.recentProcOverlays
     local favorites = GetAuraTextureFavoriteStore(store)
+    local procEntries = BuildBlizzardProcOverlayEntries()
     if not favorites then
         store.recentProcOverlays = nil
         return
     end
 
+    CanonicalizeLegacyProcFavoriteRecords(favorites, procEntries)
+
     for storedKey, storedValue in pairs(legacyRecent) do
         local migratedRecord = BuildLegacyRecentFavoriteRecord(storedKey, storedValue)
         if migratedRecord then
+            local canonicalKey = FindCanonicalBlizzardProcFavoriteKey(migratedRecord, procEntries)
+            if canonicalKey then
+                local existingRecord = ReadAuraTextureFavoriteRecord(favorites[canonicalKey])
+                if not existingRecord or AreAuraTextureFavoriteRecordsEquivalent(existingRecord, migratedRecord) then
+                    migratedRecord.favoriteKey = canonicalKey
+                end
+            end
+
             local alreadySaved = false
             for favoriteKey, favoriteValue in pairs(favorites) do
                 local favoriteRecord = ReadAuraTextureFavoriteRecord(favoriteValue)
@@ -1315,6 +1382,33 @@ local function AreTextureColorsEqual(a, b)
     return true
 end
 
+DoesAuraTextureVariantMatchRecord = function(entry, record)
+    if type(entry) ~= "table" or type(record) ~= "table" then
+        return false
+    end
+
+    if entry.sourceType ~= record.sourceType or entry.sourceValue ~= record.sourceValue or entry.mediaType ~= record.mediaType then
+        return false
+    end
+    if (entry.layoutAgnostic == true) ~= (record.layoutAgnostic == true) then
+        return false
+    end
+    if NormalizeTextureLayout(entry.locationType) ~= NormalizeTextureLayout(record.locationType) then
+        return false
+    end
+    if not AreTextureNumbersEqual(entry.scale or 1, record.scale or 1) then
+        return false
+    end
+    if NormalizeBlendMode(entry.blendMode) ~= NormalizeBlendMode(record.blendMode) then
+        return false
+    end
+    if not AreTextureColorsEqual(entry.color, record.color) then
+        return false
+    end
+
+    return true
+end
+
 AreAuraTextureFavoriteRecordsEquivalent = function(a, b)
     if type(a) ~= "table" or type(b) ~= "table" then
         return false
@@ -1358,10 +1452,6 @@ function CooldownCompanion:DoesAuraTexturePickerEntryMatchSelection(entry, selec
 
     if entry.sourceType == SHARED_MEDIA_SOURCE_TYPE and entry.mediaType ~= selection.mediaType then
         return false
-    end
-
-    if entry.isFavoriteRecord then
-        return true
     end
 
     if not entry.layoutAgnostic then
@@ -1430,13 +1520,17 @@ function CooldownCompanion:FindAuraTexturePickerEntryByAsset(entries, selection)
         return nil
     end
 
+    local matchedEntry = nil
     for _, entry in ipairs(entries or {}) do
         if self:DoesAuraTexturePickerEntryMatchSelectionAsset(entry, selection) then
-            return entry
+            if matchedEntry ~= nil then
+                return nil
+            end
+            matchedEntry = entry
         end
     end
 
-    return nil
+    return matchedEntry
 end
 
 function CooldownCompanion:IsAuraTextureButtonSupported(buttonData)
@@ -2029,7 +2123,7 @@ function CooldownCompanion:RemoveCustomAuraTexture(pathOrKey)
     store.customTextures[pathKey] = nil
 end
 
-local function BuildBlizzardProcOverlayEntries()
+BuildBlizzardProcOverlayEntries = function()
     local overlayLibrary = ST._spellActivationOverlayLibrary
     local rows = overlayLibrary and overlayLibrary.entries
     local entries = {}

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -54,7 +54,6 @@ local FILTER_CUSTOM = "custom"
 local FILTER_SHAREDMEDIA = "sharedMedia"
 local FILTER_FAVORITES = "favorites"
 local FILTER_OTHER = "other"
-local FILTER_RECENT = "recent"
 local MAX_RECENT_OVERLAYS = 200
 local DEFAULT_TEXTURE_SIZE = 128
 local UI_PARENT_NAME = "UIParent"
@@ -654,7 +653,6 @@ local FILTER_OPTIONS = {
     [FILTER_SHAREDMEDIA] = "SharedMedia",
     [FILTER_FAVORITES] = "Favorites",
     [FILTER_OTHER] = "Other",
-    [FILTER_RECENT] = "Recent Proc Overlays",
 }
 
 local LOCATION_ORDER = {
@@ -935,13 +933,12 @@ local function BuildSharedMediaEntry(mediaType, mediaKey, savedLabel, options)
     end
 
     local label = BuildSharedMediaLabel(mediaKey, savedLabel)
-    local isFavorite = options.isFavorite == true
-    local isSavedFavorite = options.isSavedFavorite == true
+    local isFavorited = options.isFavorited == true
     local isMissing = options.isMissing == true
-    local categoryKey = isFavorite and FILTER_FAVORITES or FILTER_SHAREDMEDIA
+    local categoryKey = options.categoryKey or FILTER_SHAREDMEDIA
     local typeLabel = SHARED_MEDIA_TYPE_LABELS[normalizedType] or normalizedType
     local stateLabel = isMissing and "Missing or unavailable"
-        or (isFavorite and "Favorite" or (isSavedFavorite and "Favorited" or "SharedMedia"))
+        or (isFavorited and "Favorited" or "SharedMedia")
     local subtitle = typeLabel .. "  |  " .. stateLabel
 
     return {
@@ -958,11 +955,10 @@ local function BuildSharedMediaEntry(mediaType, mediaKey, savedLabel, options)
         blendMode = "BLEND",
         subtitle = subtitle,
         searchText = string_lower(label .. " " .. mediaKey .. " " .. normalizedType .. " " .. stateLabel),
-        isFavorite = isFavorite,
-        isSavedFavorite = isSavedFavorite,
+        favoriteOriginCategoryKey = FILTER_SHAREDMEDIA,
         isMissingSharedMedia = isMissing,
-        canFavorite = not isFavorite and not isSavedFavorite and not isMissing,
-        canRemoveFavorite = isFavorite,
+        canFavorite = not isFavorited and not isMissing,
+        canRemoveFavorite = isFavorited,
     }
 end
 
@@ -980,6 +976,190 @@ local function ReadSharedMediaFavoriteRecord(value)
     end
 
     return mediaType, mediaKey, label
+end
+
+local function BuildAuraTextureFavoriteKey(entry)
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    local favoriteKey = entry.libraryKey or entry.key
+    if type(favoriteKey) == "string" and favoriteKey ~= "" then
+        return favoriteKey
+    end
+
+    return nil
+end
+
+local function BuildAuraTextureFavoriteRecord(entry)
+    local favoriteKey = BuildAuraTextureFavoriteKey(entry)
+    local originCategoryKey = type(entry) == "table" and entry.favoriteOriginCategoryKey or nil
+    if not favoriteKey or not FILTER_OPTIONS[originCategoryKey] or originCategoryKey == FILTER_FAVORITES then
+        return nil
+    end
+
+    return {
+        favoriteKey = favoriteKey,
+        label = type(entry.label) == "string" and entry.label or tostring(entry.sourceValue),
+        originCategoryKey = originCategoryKey,
+        sourceType = entry.sourceType,
+        sourceValue = entry.sourceValue,
+        mediaType = entry.mediaType,
+        layoutAgnostic = entry.layoutAgnostic == true,
+        locationType = entry.locationType,
+        width = tonumber(entry.width) or nil,
+        height = tonumber(entry.height) or nil,
+        color = CopyColor(entry.color) or { 1, 1, 1, 1 },
+        blendMode = NormalizeBlendMode(entry.blendMode),
+        scale = tonumber(entry.scale) or nil,
+        subtitle = type(entry.subtitle) == "string" and entry.subtitle or nil,
+        searchText = type(entry.searchText) == "string" and entry.searchText or nil,
+    }
+end
+
+local function ReadAuraTextureFavoriteRecord(value)
+    if type(value) ~= "table" then
+        return nil
+    end
+
+    local favoriteKey = value.favoriteKey or value.key or value.libraryKey
+    local originCategoryKey = FILTER_OPTIONS[value.originCategoryKey] and value.originCategoryKey or FILTER_OTHER
+    local sourceType = NormalizeAuraTextureSourceType(value.sourceType)
+    local sourceValue = value.sourceValue
+    local mediaType = sourceType == SHARED_MEDIA_SOURCE_TYPE
+        and NormalizeSharedMediaType(value.mediaType)
+        or nil
+
+    if type(favoriteKey) ~= "string" or favoriteKey == "" or not sourceType or sourceValue == nil then
+        return nil
+    end
+    if sourceType == SHARED_MEDIA_SOURCE_TYPE and not mediaType then
+        return nil
+    end
+
+    return {
+        favoriteKey = favoriteKey,
+        label = type(value.label) == "string" and value.label or tostring(sourceValue),
+        originCategoryKey = originCategoryKey,
+        sourceType = sourceType,
+        sourceValue = sourceValue,
+        mediaType = mediaType,
+        layoutAgnostic = value.layoutAgnostic ~= false,
+        locationType = value.locationType,
+        width = tonumber(value.width) or nil,
+        height = tonumber(value.height) or nil,
+        color = CopyColor(value.color) or { 1, 1, 1, 1 },
+        blendMode = NormalizeBlendMode(value.blendMode),
+        scale = tonumber(value.scale) or nil,
+        subtitle = type(value.subtitle) == "string" and value.subtitle or nil,
+        searchText = type(value.searchText) == "string" and value.searchText or nil,
+    }
+end
+
+local function BuildFavoriteAuraTextureEntry(value)
+    local record = ReadAuraTextureFavoriteRecord(value)
+    if not record then
+        return nil
+    end
+
+    local isMissingSharedMedia = false
+    local subtitle = record.subtitle
+    if record.sourceType == SHARED_MEDIA_SOURCE_TYPE then
+        local typeLabel = SHARED_MEDIA_TYPE_LABELS[record.mediaType] or record.mediaType
+        isMissingSharedMedia = LSM:Fetch(record.mediaType, record.sourceValue, true) == nil
+        local stateLabel = isMissingSharedMedia and "Missing or unavailable" or "Favorite"
+        subtitle = typeLabel .. "  |  " .. stateLabel
+    elseif subtitle and subtitle ~= "" then
+        subtitle = subtitle .. "  |  " .. (FILTER_OPTIONS[record.originCategoryKey] or FILTER_OPTIONS[FILTER_OTHER])
+    else
+        subtitle = FILTER_OPTIONS[record.originCategoryKey] or FILTER_OPTIONS[FILTER_OTHER]
+    end
+
+    return {
+        key = record.favoriteKey,
+        libraryKey = record.favoriteKey,
+        label = record.label,
+        categoryKey = FILTER_FAVORITES,
+        category = FILTER_OPTIONS[FILTER_FAVORITES],
+        favoriteOriginCategoryKey = record.originCategoryKey,
+        sourceType = record.sourceType,
+        sourceValue = record.sourceValue,
+        mediaType = record.mediaType,
+        layoutAgnostic = record.layoutAgnostic,
+        locationType = record.locationType,
+        width = record.width,
+        height = record.height,
+        color = CopyColor(record.color) or { 1, 1, 1, 1 },
+        blendMode = NormalizeBlendMode(record.blendMode),
+        scale = record.scale,
+        subtitle = subtitle,
+        searchText = record.searchText
+            or string_lower(record.label .. " " .. tostring(record.sourceValue) .. " " .. subtitle .. " favorite"),
+        canFavorite = false,
+        canRemoveFavorite = true,
+        isFavoriteRecord = true,
+        isMissingSharedMedia = isMissingSharedMedia,
+    }
+end
+
+local function MigrateLegacySharedMediaFavorites(store)
+    local favorites = store and store.textureFavorites or nil
+    local legacyFavorites = store and store.sharedMediaFavorites or nil
+    if type(favorites) ~= "table" or type(legacyFavorites) ~= "table" then
+        return
+    end
+
+    for storedKey, storedValue in pairs(legacyFavorites) do
+        local mediaType, mediaKey, savedLabel = ReadSharedMediaFavoriteRecord(storedValue)
+        local libraryKey = BuildSharedMediaLibraryKey(mediaType, mediaKey)
+        if libraryKey then
+            local favoriteEntry = BuildSharedMediaEntry(mediaType, mediaKey, savedLabel, {
+                categoryKey = FILTER_FAVORITES,
+                isFavorited = true,
+                isMissing = LSM:Fetch(mediaType, mediaKey, true) == nil,
+            })
+            if favoriteEntry then
+                favoriteEntry.favoriteOriginCategoryKey = FILTER_SHAREDMEDIA
+                favorites[libraryKey] = favorites[libraryKey] or BuildAuraTextureFavoriteRecord(favoriteEntry)
+            end
+        else
+            legacyFavorites[storedKey] = nil
+        end
+    end
+end
+
+local function GetAuraTextureFavoriteStore(store)
+    if type(store) ~= "table" then
+        return nil
+    end
+    if type(store.textureFavorites) ~= "table" then
+        store.textureFavorites = {}
+    end
+
+    MigrateLegacySharedMediaFavorites(store)
+    return store.textureFavorites
+end
+
+local function ApplyFavoriteStateToEntry(entry, favorites)
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    local favoriteKey = BuildAuraTextureFavoriteKey(entry)
+    local isFavorited = favoriteKey ~= nil and type(favorites) == "table" and favorites[favoriteKey] ~= nil
+    entry.canFavorite = not isFavorited
+    entry.canRemoveFavorite = isFavorited
+    entry.isFavoriteRecord = nil
+
+    if entry.sourceType == SHARED_MEDIA_SOURCE_TYPE then
+        local typeLabel = SHARED_MEDIA_TYPE_LABELS[entry.mediaType] or entry.mediaType
+        local stateLabel = entry.isMissingSharedMedia and "Missing or unavailable"
+            or (isFavorited and "Favorited" or "SharedMedia")
+        entry.subtitle = typeLabel .. "  |  " .. stateLabel
+        entry.searchText = string_lower(entry.label .. " " .. tostring(entry.sourceValue) .. " " .. tostring(entry.mediaType) .. " " .. stateLabel)
+    end
+
+    return entry
 end
 
 function CooldownCompanion:ResolveAuraTextureAsset(sourceType, sourceValue, mediaType)
@@ -1096,6 +1276,10 @@ function CooldownCompanion:DoesAuraTexturePickerEntryMatchSelection(entry, selec
         return false
     end
 
+    if entry.isFavoriteRecord then
+        return true
+    end
+
     if not entry.layoutAgnostic then
         local entryLocationType = NormalizeTextureLayout(entry.locationType)
         local selectionLocationType = NormalizeTextureLayout(selection.locationType)
@@ -1126,6 +1310,44 @@ function CooldownCompanion:FindAuraTexturePickerEntry(entries, selection)
 
     for _, entry in ipairs(entries or {}) do
         if self:DoesAuraTexturePickerEntryMatchSelection(entry, selection) then
+            return entry
+        end
+    end
+
+    return nil
+end
+
+function CooldownCompanion:DoesAuraTexturePickerEntryMatchSelectionAsset(entry, selection)
+    if type(entry) ~= "table" or type(selection) ~= "table" then
+        return false
+    end
+
+    if entry.sourceType ~= selection.sourceType or entry.sourceValue ~= selection.sourceValue then
+        return false
+    end
+
+    if entry.sourceType == SHARED_MEDIA_SOURCE_TYPE and entry.mediaType ~= selection.mediaType then
+        return false
+    end
+
+    if not entry.layoutAgnostic then
+        local entryLocationType = NormalizeTextureLayout(entry.locationType)
+        local selectionLocationType = NormalizeTextureLayout(selection.locationType)
+        if entryLocationType ~= selectionLocationType then
+            return false
+        end
+    end
+
+    return true
+end
+
+function CooldownCompanion:FindAuraTexturePickerEntryByAsset(entries, selection)
+    if type(selection) ~= "table" then
+        return nil
+    end
+
+    for _, entry in ipairs(entries or {}) do
+        if self:DoesAuraTexturePickerEntryMatchSelectionAsset(entry, selection) then
             return entry
         end
     end
@@ -1178,6 +1400,7 @@ function CooldownCompanion:GetTexturePanelSettings(groupOrId, createIfMissing)
             return nil
         end
         group.textureSettings = {
+            blendMode = "BLEND",
             locationType = LOCATION_CENTER,
             pairSpacing = DEFAULT_TEXTURE_PAIR_SPACING,
             rotation = 0,
@@ -1237,7 +1460,7 @@ function CooldownCompanion:ApplyTexturePanelEntry(settings, entry)
     settings.width = entry.width
     settings.height = entry.height
     settings.color = CopyColor(entry.color) or { 1, 1, 1, 1 }
-    settings.blendMode = NormalizeBlendMode(entry.blendMode or settings.blendMode)
+    settings.blendMode = NormalizeBlendMode(settings.blendMode or "BLEND")
     settings.scale = Clamp(entry.scale or settings.scale or 1, 0.25, 4)
     settings.alpha = Clamp(settings.alpha or 1, 0.05, 1)
     settings.rotation = Clamp(settings.rotation or 0, MIN_TEXTURE_ROTATION, MAX_TEXTURE_ROTATION)
@@ -1269,7 +1492,7 @@ function CooldownCompanion:CreateTexturePanelSelection(entry, baseSettings)
         label = entry.label,
         scale = entry.scale or (base and base.scale) or 1,
         alpha = base and base.alpha or 1,
-        blendMode = NormalizeBlendMode((base and base.blendMode) or entry.blendMode),
+        blendMode = NormalizeBlendMode((base and base.blendMode) or "BLEND"),
         rotation = base and base.rotation or 0,
         stretchX = base and base.stretchX or 0,
         stretchY = base and base.stretchY or 0,
@@ -1455,6 +1678,7 @@ function CooldownCompanion:EnsureAuraTextureLibraryStore()
     if type(profile.auraTextureLibrary) ~= "table" then
         profile.auraTextureLibrary = {
             customTextures = {},
+            textureFavorites = {},
             sharedMediaFavorites = {},
             recentProcOverlays = {},
         }
@@ -1462,30 +1686,36 @@ function CooldownCompanion:EnsureAuraTextureLibraryStore()
     if type(profile.auraTextureLibrary.customTextures) ~= "table" then
         profile.auraTextureLibrary.customTextures = {}
     end
+    if type(profile.auraTextureLibrary.textureFavorites) ~= "table" then
+        profile.auraTextureLibrary.textureFavorites = {}
+    end
     if type(profile.auraTextureLibrary.sharedMediaFavorites) ~= "table" then
         profile.auraTextureLibrary.sharedMediaFavorites = {}
     end
     if type(profile.auraTextureLibrary.recentProcOverlays) ~= "table" then
         profile.auraTextureLibrary.recentProcOverlays = {}
     end
+    MigrateLegacySharedMediaFavorites(profile.auraTextureLibrary)
     return profile.auraTextureLibrary
 end
 
 function CooldownCompanion:GetSharedMediaAuraTextureEntries()
     local store = self:EnsureAuraTextureLibraryStore()
-    local favorites = store and store.sharedMediaFavorites or nil
+    local favorites = GetAuraTextureFavoriteStore(store)
     local entries = {}
 
     for _, mediaType in ipairs(SHARED_MEDIA_TYPE_ORDER) do
         for _, mediaKey in ipairs(LSM:List(mediaType) or {}) do
-            local savedFavorite = favorites and favorites[BuildSharedMediaLibraryKey(mediaType, mediaKey)] or nil
-            local _, _, savedLabel = ReadSharedMediaFavoriteRecord(savedFavorite)
+            local favoriteKey = BuildSharedMediaLibraryKey(mediaType, mediaKey)
+            local savedFavorite = favoriteKey and favorites and favorites[favoriteKey] or nil
+            local savedRecord = savedFavorite and ReadAuraTextureFavoriteRecord(savedFavorite) or nil
             local entry = BuildSharedMediaEntry(
                 mediaType,
                 mediaKey,
-                savedLabel,
+                savedRecord and savedRecord.label or nil,
                 {
-                    isSavedFavorite = savedFavorite ~= nil,
+                    isFavorited = savedFavorite ~= nil,
+                    isMissing = LSM:Fetch(mediaType, mediaKey, true) == nil,
                 }
             )
             if entry then
@@ -1513,33 +1743,24 @@ end
 
 function CooldownCompanion:GetFavoriteAuraTextureEntries()
     local store = self:EnsureAuraTextureLibraryStore()
-    local favorites = store and store.sharedMediaFavorites or nil
+    local favorites = GetAuraTextureFavoriteStore(store)
     local entries = {}
 
     for storedKey, storedValue in pairs(favorites or {}) do
-        local mediaType, mediaKey, savedLabel = ReadSharedMediaFavoriteRecord(storedValue)
-        local libraryKey = BuildSharedMediaLibraryKey(mediaType, mediaKey)
-        if not libraryKey then
+        local record = ReadAuraTextureFavoriteRecord(storedValue)
+        if not record then
             favorites[storedKey] = nil
         else
-            if libraryKey ~= storedKey then
-                favorites[libraryKey] = storedValue
+            if record.favoriteKey ~= storedKey then
+                favorites[record.favoriteKey] = storedValue
                 favorites[storedKey] = nil
             end
 
-            local entry = BuildSharedMediaEntry(
-                mediaType,
-                mediaKey,
-                savedLabel,
-                {
-                    isFavorite = true,
-                    isMissing = LSM:Fetch(mediaType, mediaKey, true) == nil,
-                }
-            )
+            local entry = BuildFavoriteAuraTextureEntry(storedValue)
             if entry then
                 entries[#entries + 1] = entry
             else
-                favorites[libraryKey] = nil
+                favorites[record.favoriteKey] = nil
             end
         end
     end
@@ -1560,55 +1781,62 @@ function CooldownCompanion:GetFavoriteAuraTextureEntries()
     return entries
 end
 
-function CooldownCompanion:SaveFavoriteAuraTexture(mediaType, mediaKey, label)
-    local normalizedType = NormalizeSharedMediaType(mediaType)
-    local normalizedKey = type(mediaKey) == "string" and string_trim(mediaKey) or nil
-    local libraryKey = BuildSharedMediaLibraryKey(normalizedType, normalizedKey)
-    if not libraryKey then
+function CooldownCompanion:SaveFavoriteAuraTexture(entryOrMediaType, mediaKey, label)
+    local entry = nil
+    if type(entryOrMediaType) == "table" then
+        entry = entryOrMediaType
+    else
+        local normalizedType = NormalizeSharedMediaType(entryOrMediaType)
+        local normalizedKey = type(mediaKey) == "string" and string_trim(mediaKey) or nil
+        local libraryKey = BuildSharedMediaLibraryKey(normalizedType, normalizedKey)
+        if not libraryKey then
+            return nil
+        end
+
+        entry = BuildSharedMediaEntry(normalizedType, normalizedKey, label, {
+            isFavorited = true,
+            isMissing = LSM:Fetch(normalizedType, normalizedKey, true) == nil,
+        })
+    end
+
+    local record = BuildAuraTextureFavoriteRecord(entry)
+    if not record then
         return nil
     end
 
     local store = self:EnsureAuraTextureLibraryStore()
-    if not store then
+    local favorites = GetAuraTextureFavoriteStore(store)
+    if not favorites then
         return nil
     end
 
-    store.sharedMediaFavorites[libraryKey] = {
-        mediaType = normalizedType,
-        key = normalizedKey,
-        label = BuildSharedMediaLabel(normalizedKey, label),
-    }
+    favorites[record.favoriteKey] = record
 
-    return BuildSharedMediaEntry(
-        normalizedType,
-        normalizedKey,
-        store.sharedMediaFavorites[libraryKey].label,
-        {
-            isFavorite = true,
-            isMissing = LSM:Fetch(normalizedType, normalizedKey, true) == nil,
-        }
-    )
+    return BuildFavoriteAuraTextureEntry(record)
 end
 
-function CooldownCompanion:RemoveFavoriteAuraTexture(libraryKeyOrMediaType, mediaKey)
+function CooldownCompanion:RemoveFavoriteAuraTexture(entryOrKey, mediaKey)
     local store = self:EnsureAuraTextureLibraryStore()
-    if not store then
+    local favorites = GetAuraTextureFavoriteStore(store)
+    if not favorites then
         return
     end
 
-    local libraryKey = nil
+    local favoriteKey = nil
+    if type(entryOrKey) == "table" then
+        favoriteKey = BuildAuraTextureFavoriteKey(entryOrKey)
+    end
     if mediaKey ~= nil then
-        libraryKey = BuildSharedMediaLibraryKey(libraryKeyOrMediaType, mediaKey)
-    else
-        local mediaType, parsedKey = ParseSharedMediaLibraryKey(libraryKeyOrMediaType)
-        libraryKey = BuildSharedMediaLibraryKey(mediaType, parsedKey)
+        favoriteKey = BuildSharedMediaLibraryKey(entryOrKey, mediaKey)
+    elseif not favoriteKey and type(entryOrKey) == "string" then
+        favoriteKey = entryOrKey
     end
 
-    if not libraryKey then
+    if not favoriteKey then
         return
     end
 
-    store.sharedMediaFavorites[libraryKey] = nil
+    favorites[favoriteKey] = nil
 end
 
 function CooldownCompanion:GetCustomAuraTextureEntries()
@@ -1929,12 +2157,15 @@ end
 
 local function BuildBuiltinEntries()
     local entries = {}
+    local store = CooldownCompanion:EnsureAuraTextureLibraryStore()
+    local favorites = GetAuraTextureFavoriteStore(store)
     for _, entry in ipairs(BUILTIN_LIBRARY) do
-        entries[#entries + 1] = {
+        entries[#entries + 1] = ApplyFavoriteStateToEntry({
             key = entry.key,
             label = entry.label,
             categoryKey = entry.categoryKey or FILTER_OTHER,
             category = entry.category or FILTER_OPTIONS[entry.categoryKey] or FILTER_OPTIONS[FILTER_OTHER],
+            favoriteOriginCategoryKey = entry.categoryKey or FILTER_OTHER,
             sourceType = entry.sourceType,
             sourceValue = entry.sourceValue,
             width = entry.width,
@@ -1943,10 +2174,11 @@ local function BuildBuiltinEntries()
             blendMode = NormalizeBlendMode(entry.blendMode),
             subtitle = entry.subtitle,
             searchText = entry.searchText or string_lower(entry.label),
-        }
+        }, favorites)
     end
     for _, entry in ipairs(BuildBlizzardProcOverlayEntries()) do
-        entries[#entries + 1] = entry
+        entry.favoriteOriginCategoryKey = entry.categoryKey or FILTER_BLIZZARD_PROC
+        entries[#entries + 1] = ApplyFavoriteStateToEntry(entry, favorites)
     end
     return entries
 end
@@ -1974,15 +2206,6 @@ function CooldownCompanion:GetAuraTexturePickerEntries(searchText, filterValue)
         return entries
     end
 
-    if filter == FILTER_RECENT then
-        for _, entry in ipairs(self:GetRecentAuraTextureEntries()) do
-            if query == "" or string_find(entry.searchText, query, 1, true) then
-                entries[#entries + 1] = entry
-            end
-        end
-        return entries
-    end
-
     for _, entry in ipairs(BuildBuiltinEntries()) do
         if entry.categoryKey == filter and (query == "" or string_find(entry.searchText, query, 1, true)) then
             entries[#entries + 1] = entry
@@ -2003,7 +2226,6 @@ function CooldownCompanion:GetAuraTexturePickerFilters()
         FILTER_SHAREDMEDIA,
         FILTER_FAVORITES,
         FILTER_OTHER,
-        FILTER_RECENT,
     }
 end
 
@@ -2012,17 +2234,13 @@ function CooldownCompanion:GetAuraTexturePickerFilterForSelection(selection)
         return FILTER_SYMBOLS
     end
 
-    local recentEntry = self:FindAuraTexturePickerEntry(self:GetRecentAuraTextureEntries(), selection)
-    if recentEntry then
-        return FILTER_RECENT
-    end
-
     local favoriteEntry = self:FindAuraTexturePickerEntry(self:GetFavoriteAuraTextureEntries(), selection)
     if favoriteEntry then
         return FILTER_FAVORITES
     end
 
     local builtinEntry = self:FindAuraTexturePickerEntry(BuildBuiltinEntries(), selection)
+        or self:FindAuraTexturePickerEntryByAsset(BuildBuiltinEntries(), selection)
     if builtinEntry then
         return builtinEntry.categoryKey or FILTER_OTHER
     end
@@ -2030,10 +2248,6 @@ function CooldownCompanion:GetAuraTexturePickerFilterForSelection(selection)
     local sharedMediaEntry = self:FindAuraTexturePickerEntry(self:GetSharedMediaAuraTextureEntries(), selection)
     if sharedMediaEntry or selection.sourceType == SHARED_MEDIA_SOURCE_TYPE then
         return FILTER_SHAREDMEDIA
-    end
-
-    if selection.sourceType == "file" then
-        return FILTER_RECENT
     end
 
     return FILTER_SYMBOLS

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -1,7 +1,7 @@
 --[[
     CooldownCompanion - Core/AuraTextures.lua
-    Blizzard-first aura texture library, recent proc capture, and runtime
-    texture rendering for aura-capable buttons.
+    Blizzard-first aura texture library and runtime texture rendering
+    for aura-capable buttons.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -54,7 +54,6 @@ local FILTER_CUSTOM = "custom"
 local FILTER_SHAREDMEDIA = "sharedMedia"
 local FILTER_FAVORITES = "favorites"
 local FILTER_OTHER = "other"
-local MAX_RECENT_OVERLAYS = 200
 local DEFAULT_TEXTURE_SIZE = 128
 local UI_PARENT_NAME = "UIParent"
 local NUDGE_BTN_SIZE = 12
@@ -856,18 +855,6 @@ local function RotateOffset(x, y, radians)
     return (x * cosAngle) - (y * sinAngle), (x * sinAngle) + (y * cosAngle)
 end
 
-local function BuildRecentOverlayKey(fileDataID, locationType, scale, r, g, b)
-    return string_format(
-        "%s:%s:%s:%s:%s:%s",
-        tostring(fileDataID),
-        tostring(locationType),
-        tostring(scale),
-        tostring(r),
-        tostring(g),
-        tostring(b)
-    )
-end
-
 local function BuildLocationSubtitle(locationType)
     if LOCATION_LABELS[locationType] then
         return LOCATION_LABELS[locationType]
@@ -1128,7 +1115,77 @@ local function MigrateLegacySharedMediaFavorites(store)
     end
 end
 
-local function GetAuraTextureFavoriteStore(store)
+local GetAuraTextureFavoriteStore
+local AreAuraTextureFavoriteRecordsEquivalent
+
+local function BuildLegacyRecentFavoriteRecord(storedKey, value)
+    local sourceValue = tonumber(value and value.sourceValue)
+    if not sourceValue or sourceValue <= 0 then
+        return nil
+    end
+
+    local locationSubtitle = BuildLocationSubtitle(value.locationType)
+    local label = type(value.label) == "string" and value.label
+        or type(value.spellName) == "string" and value.spellName .. " Proc Overlay"
+        or ("File " .. tostring(sourceValue))
+    local record = ReadAuraTextureFavoriteRecord({
+        favoriteKey = "favorite:legacy-proc:" .. tostring(storedKey),
+        label = label,
+        originCategoryKey = FILTER_BLIZZARD_PROC,
+        sourceType = "file",
+        sourceValue = sourceValue,
+        layoutAgnostic = true,
+        locationType = nil,
+        color = CopyColor(value.color) or { 1, 1, 1, 1 },
+        blendMode = NormalizeBlendMode(value.blendMode or "ADD"),
+        scale = tonumber(value.scale) or 1,
+        subtitle = tostring(value.spellID or "?") .. "  |  File " .. tostring(sourceValue) .. "  |  " .. locationSubtitle,
+        searchText = string_lower(
+            label .. " " .. tostring(value.spellID or "") .. " " .. tostring(sourceValue) .. " " .. locationSubtitle
+        ),
+    })
+
+    return record
+end
+
+local function MigrateLegacyRecentProcOverlayFavorites(store)
+    if type(store) ~= "table" or type(store.recentProcOverlays) ~= "table" then
+        return
+    end
+
+    local legacyRecent = store.recentProcOverlays
+    local favorites = GetAuraTextureFavoriteStore(store)
+    if not favorites then
+        store.recentProcOverlays = nil
+        return
+    end
+
+    for storedKey, storedValue in pairs(legacyRecent) do
+        local migratedRecord = BuildLegacyRecentFavoriteRecord(storedKey, storedValue)
+        if migratedRecord then
+            local alreadySaved = false
+            for favoriteKey, favoriteValue in pairs(favorites) do
+                local favoriteRecord = ReadAuraTextureFavoriteRecord(favoriteValue)
+                if favoriteRecord then
+                    if AreAuraTextureFavoriteRecordsEquivalent(favoriteRecord, migratedRecord) then
+                        alreadySaved = true
+                        break
+                    end
+                else
+                    favorites[favoriteKey] = nil
+                end
+            end
+
+            if not alreadySaved then
+                favorites[migratedRecord.favoriteKey] = migratedRecord
+            end
+        end
+    end
+
+    store.recentProcOverlays = nil
+end
+
+GetAuraTextureFavoriteStore = function(store)
     if type(store) ~= "table" then
         return nil
     end
@@ -1255,6 +1312,33 @@ local function AreTextureColorsEqual(a, b)
             return false
         end
     end
+    return true
+end
+
+AreAuraTextureFavoriteRecordsEquivalent = function(a, b)
+    if type(a) ~= "table" or type(b) ~= "table" then
+        return false
+    end
+
+    if a.sourceType ~= b.sourceType or a.sourceValue ~= b.sourceValue or a.mediaType ~= b.mediaType then
+        return false
+    end
+    if a.layoutAgnostic ~= b.layoutAgnostic then
+        return false
+    end
+    if NormalizeTextureLayout(a.locationType) ~= NormalizeTextureLayout(b.locationType) then
+        return false
+    end
+    if not AreTextureNumbersEqual(a.scale or 1, b.scale or 1) then
+        return false
+    end
+    if NormalizeBlendMode(a.blendMode) ~= NormalizeBlendMode(b.blendMode) then
+        return false
+    end
+    if not AreTextureColorsEqual(a.color, b.color) then
+        return false
+    end
+
     return true
 end
 
@@ -1680,7 +1764,6 @@ function CooldownCompanion:EnsureAuraTextureLibraryStore()
             customTextures = {},
             textureFavorites = {},
             sharedMediaFavorites = {},
-            recentProcOverlays = {},
         }
     end
     if type(profile.auraTextureLibrary.customTextures) ~= "table" then
@@ -1692,10 +1775,8 @@ function CooldownCompanion:EnsureAuraTextureLibraryStore()
     if type(profile.auraTextureLibrary.sharedMediaFavorites) ~= "table" then
         profile.auraTextureLibrary.sharedMediaFavorites = {}
     end
-    if type(profile.auraTextureLibrary.recentProcOverlays) ~= "table" then
-        profile.auraTextureLibrary.recentProcOverlays = {}
-    end
     MigrateLegacySharedMediaFavorites(profile.auraTextureLibrary)
+    MigrateLegacyRecentProcOverlayFavorites(profile.auraTextureLibrary)
     return profile.auraTextureLibrary
 end
 
@@ -1946,101 +2027,6 @@ function CooldownCompanion:RemoveCustomAuraTexture(pathOrKey)
     end
 
     store.customTextures[pathKey] = nil
-end
-
-function CooldownCompanion:RecordRecentAuraTextureOverlay(spellID, fileDataID, locationType, scale, r, g, b)
-    if type(fileDataID) ~= "number" or fileDataID <= 0 then
-        return
-    end
-
-    local store = self:EnsureAuraTextureLibraryStore()
-    if not store then
-        return
-    end
-
-    local key = BuildRecentOverlayKey(fileDataID, locationType, scale, r, g, b)
-    local recent = store.recentProcOverlays
-    local spellName = C_Spell.GetSpellName(spellID) or ("Spell " .. tostring(spellID))
-
-    recent[key] = {
-        key = key,
-        spellID = spellID,
-        spellName = spellName,
-        label = spellName .. " Proc Overlay",
-        sourceType = "file",
-        sourceValue = fileDataID,
-        locationType = locationType,
-        color = {
-            Clamp((tonumber(r) or 255) / 255, 0, 1),
-            Clamp((tonumber(g) or 255) / 255, 0, 1),
-            Clamp((tonumber(b) or 255) / 255, 0, 1),
-            1,
-        },
-        blendMode = "ADD",
-        scale = tonumber(scale) or 1,
-        lastSeenAt = time(),
-    }
-
-    local keys = {}
-    for overlayKey in pairs(recent) do
-        keys[#keys + 1] = overlayKey
-    end
-    if #keys <= MAX_RECENT_OVERLAYS then
-        return
-    end
-
-    table_sort(keys, function(a, b)
-        local aTime = recent[a] and recent[a].lastSeenAt or 0
-        local bTime = recent[b] and recent[b].lastSeenAt or 0
-        return aTime > bTime
-    end)
-
-    for index = MAX_RECENT_OVERLAYS + 1, #keys do
-        recent[keys[index]] = nil
-    end
-end
-
-function CooldownCompanion:GetRecentAuraTextureEntries()
-    local store = self:EnsureAuraTextureLibraryStore()
-    local entries = {}
-    local recent = store and store.recentProcOverlays or nil
-
-    if recent then
-        for key, entry in pairs(recent) do
-            local label = entry.label or entry.spellName or ("File " .. tostring(entry.sourceValue))
-            local locationSubtitle = BuildLocationSubtitle(entry.locationType)
-            entries[#entries + 1] = {
-                key = "recent:" .. key,
-                label = label,
-                category = "Recent Proc Overlays",
-                sourceType = "file",
-                sourceValue = entry.sourceValue,
-                -- Recent proc captures should behave like the Blizzard proc library:
-                -- choose the art from the browser, then let the texture panel layout control
-                -- decide whether it renders as Single, Left + Right, etc. Keeping the raw
-                -- captured location here would make a recent pick silently overwrite the
-                -- panel layout with hidden right/bottom/outside values.
-                locationType = nil,
-                layoutAgnostic = true,
-                color = CopyColor(entry.color) or { 1, 1, 1, 1 },
-                blendMode = NormalizeBlendMode(entry.blendMode),
-                subtitle = tostring(entry.spellID or "?") .. "  |  File " .. tostring(entry.sourceValue) .. "  |  " .. locationSubtitle,
-                searchText = string_lower(label .. " " .. tostring(entry.spellID or "") .. " " .. tostring(entry.sourceValue) .. " " .. locationSubtitle),
-                lastSeenAt = entry.lastSeenAt or 0,
-            }
-        end
-    end
-
-    table_sort(entries, function(a, b)
-        local aTime = a.lastSeenAt or 0
-        local bTime = b.lastSeenAt or 0
-        if aTime == bTime then
-            return a.label < b.label
-        end
-        return aTime > bTime
-    end)
-
-    return entries
 end
 
 local function BuildBlizzardProcOverlayEntries()

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -1118,133 +1118,22 @@ local function MigrateLegacySharedMediaFavorites(store)
 end
 
 local GetAuraTextureFavoriteStore
-local AreAuraTextureFavoriteRecordsEquivalent
-local BuildBlizzardProcOverlayEntries
-local DoesAuraTextureVariantMatchRecord
 
 local function IsLegacyProcFavoriteKey(favoriteKey)
     return type(favoriteKey) == "string" and string_find(favoriteKey, "^favorite:legacy%-proc:", 1, false) ~= nil
 end
 
-local function FindCanonicalBlizzardProcFavoriteKey(record, procEntries)
-    local matchKey = nil
-
-    for _, entry in ipairs(procEntries or {}) do
-        if DoesAuraTextureVariantMatchRecord(entry, record) then
-            if matchKey and matchKey ~= entry.key then
-                return nil
-            end
-            matchKey = entry.key
-        end
-    end
-
-    return matchKey
-end
-
-local function BuildLegacyRecentFavoriteRecord(storedKey, value)
-    local sourceValue = tonumber(value and value.sourceValue)
-    if not sourceValue or sourceValue <= 0 then
-        return nil
-    end
-
-    local locationSubtitle = BuildLocationSubtitle(value.locationType)
-    local label = type(value.label) == "string" and value.label
-        or type(value.spellName) == "string" and value.spellName .. " Proc Overlay"
-        or ("File " .. tostring(sourceValue))
-    local record = ReadAuraTextureFavoriteRecord({
-        favoriteKey = "favorite:legacy-proc:" .. tostring(storedKey),
-        label = label,
-        originCategoryKey = FILTER_BLIZZARD_PROC,
-        sourceType = "file",
-        sourceValue = sourceValue,
-        layoutAgnostic = true,
-        locationType = nil,
-        color = CopyColor(value.color) or { 1, 1, 1, 1 },
-        blendMode = NormalizeBlendMode(value.blendMode or "ADD"),
-        scale = tonumber(value.scale) or 1,
-        subtitle = tostring(value.spellID or "?") .. "  |  File " .. tostring(sourceValue) .. "  |  " .. locationSubtitle,
-        searchText = string_lower(
-            label .. " " .. tostring(value.spellID or "") .. " " .. tostring(sourceValue) .. " " .. locationSubtitle
-        ),
-    })
-
-    return record
-end
-
-local function CanonicalizeLegacyProcFavoriteRecords(favorites, procEntries)
-    if type(favorites) ~= "table" then
+local function CleanupLegacyRecentArtifacts(store)
+    if type(store) ~= "table" then
         return
     end
 
-    local updates = {}
-    local removals = {}
-
-    for favoriteKey, favoriteValue in pairs(favorites) do
-        local favoriteRecord = ReadAuraTextureFavoriteRecord(favoriteValue)
-        if not favoriteRecord then
-            removals[#removals + 1] = favoriteKey
-        elseif favoriteRecord.originCategoryKey == FILTER_BLIZZARD_PROC and IsLegacyProcFavoriteKey(favoriteRecord.favoriteKey) then
-            local canonicalKey = FindCanonicalBlizzardProcFavoriteKey(favoriteRecord, procEntries)
-            if canonicalKey and canonicalKey ~= favoriteKey then
-                local existingRecord = ReadAuraTextureFavoriteRecord(favorites[canonicalKey])
-                if not existingRecord or AreAuraTextureFavoriteRecordsEquivalent(existingRecord, favoriteRecord) then
-                    favoriteRecord.favoriteKey = canonicalKey
-                    updates[canonicalKey] = favoriteRecord
-                    removals[#removals + 1] = favoriteKey
-                end
-            end
-        end
-    end
-
-    for _, favoriteKey in ipairs(removals) do
-        favorites[favoriteKey] = nil
-    end
-    for favoriteKey, favoriteRecord in pairs(updates) do
-        favorites[favoriteKey] = favoriteRecord
-    end
-end
-
-local function MigrateLegacyRecentProcOverlayFavorites(store)
-    if type(store) ~= "table" or type(store.recentProcOverlays) ~= "table" then
-        return
-    end
-
-    local legacyRecent = store.recentProcOverlays
-    local favorites = GetAuraTextureFavoriteStore(store)
-    local procEntries = BuildBlizzardProcOverlayEntries()
-    if not favorites then
-        store.recentProcOverlays = nil
-        return
-    end
-
-    CanonicalizeLegacyProcFavoriteRecords(favorites, procEntries)
-
-    for storedKey, storedValue in pairs(legacyRecent) do
-        local migratedRecord = BuildLegacyRecentFavoriteRecord(storedKey, storedValue)
-        if migratedRecord then
-            local canonicalKey = FindCanonicalBlizzardProcFavoriteKey(migratedRecord, procEntries)
-            if canonicalKey then
-                local existingRecord = ReadAuraTextureFavoriteRecord(favorites[canonicalKey])
-                if not existingRecord or AreAuraTextureFavoriteRecordsEquivalent(existingRecord, migratedRecord) then
-                    migratedRecord.favoriteKey = canonicalKey
-                end
-            end
-
-            local alreadySaved = false
-            for favoriteKey, favoriteValue in pairs(favorites) do
-                local favoriteRecord = ReadAuraTextureFavoriteRecord(favoriteValue)
-                if favoriteRecord then
-                    if AreAuraTextureFavoriteRecordsEquivalent(favoriteRecord, migratedRecord) then
-                        alreadySaved = true
-                        break
-                    end
-                else
-                    favorites[favoriteKey] = nil
-                end
-            end
-
-            if not alreadySaved then
-                favorites[migratedRecord.favoriteKey] = migratedRecord
+    if type(store.textureFavorites) == "table" then
+        for favoriteKey, favoriteValue in pairs(store.textureFavorites) do
+            local favoriteRecord = ReadAuraTextureFavoriteRecord(favoriteValue)
+            if IsLegacyProcFavoriteKey(favoriteKey)
+                or (favoriteRecord and IsLegacyProcFavoriteKey(favoriteRecord.favoriteKey)) then
+                store.textureFavorites[favoriteKey] = nil
             end
         end
     end
@@ -1261,6 +1150,7 @@ GetAuraTextureFavoriteStore = function(store)
     end
 
     MigrateLegacySharedMediaFavorites(store)
+    CleanupLegacyRecentArtifacts(store)
     return store.textureFavorites
 end
 
@@ -1379,60 +1269,6 @@ local function AreTextureColorsEqual(a, b)
             return false
         end
     end
-    return true
-end
-
-DoesAuraTextureVariantMatchRecord = function(entry, record)
-    if type(entry) ~= "table" or type(record) ~= "table" then
-        return false
-    end
-
-    if entry.sourceType ~= record.sourceType or entry.sourceValue ~= record.sourceValue or entry.mediaType ~= record.mediaType then
-        return false
-    end
-    if (entry.layoutAgnostic == true) ~= (record.layoutAgnostic == true) then
-        return false
-    end
-    if NormalizeTextureLayout(entry.locationType) ~= NormalizeTextureLayout(record.locationType) then
-        return false
-    end
-    if not AreTextureNumbersEqual(entry.scale or 1, record.scale or 1) then
-        return false
-    end
-    if NormalizeBlendMode(entry.blendMode) ~= NormalizeBlendMode(record.blendMode) then
-        return false
-    end
-    if not AreTextureColorsEqual(entry.color, record.color) then
-        return false
-    end
-
-    return true
-end
-
-AreAuraTextureFavoriteRecordsEquivalent = function(a, b)
-    if type(a) ~= "table" or type(b) ~= "table" then
-        return false
-    end
-
-    if a.sourceType ~= b.sourceType or a.sourceValue ~= b.sourceValue or a.mediaType ~= b.mediaType then
-        return false
-    end
-    if a.layoutAgnostic ~= b.layoutAgnostic then
-        return false
-    end
-    if NormalizeTextureLayout(a.locationType) ~= NormalizeTextureLayout(b.locationType) then
-        return false
-    end
-    if not AreTextureNumbersEqual(a.scale or 1, b.scale or 1) then
-        return false
-    end
-    if NormalizeBlendMode(a.blendMode) ~= NormalizeBlendMode(b.blendMode) then
-        return false
-    end
-    if not AreTextureColorsEqual(a.color, b.color) then
-        return false
-    end
-
     return true
 end
 
@@ -1870,7 +1706,7 @@ function CooldownCompanion:EnsureAuraTextureLibraryStore()
         profile.auraTextureLibrary.sharedMediaFavorites = {}
     end
     MigrateLegacySharedMediaFavorites(profile.auraTextureLibrary)
-    MigrateLegacyRecentProcOverlayFavorites(profile.auraTextureLibrary)
+    CleanupLegacyRecentArtifacts(profile.auraTextureLibrary)
     return profile.auraTextureLibrary
 end
 
@@ -2123,7 +1959,7 @@ function CooldownCompanion:RemoveCustomAuraTexture(pathOrKey)
     store.customTextures[pathKey] = nil
 end
 
-BuildBlizzardProcOverlayEntries = function()
+local function BuildBlizzardProcOverlayEntries()
     local overlayLibrary = ST._spellActivationOverlayLibrary
     local rows = overlayLibrary and overlayLibrary.entries
     local entries = {}

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -1141,17 +1141,27 @@ local function CleanupLegacyRecentArtifacts(store)
     store.recentProcOverlays = nil
 end
 
-GetAuraTextureFavoriteStore = function(store)
+function CooldownCompanion:NormalizeAuraTextureLibraryStore(store)
     if type(store) ~= "table" then
         return nil
     end
+
+    if type(store.customTextures) ~= "table" then
+        store.customTextures = {}
+    end
+
     if type(store.textureFavorites) ~= "table" then
         store.textureFavorites = {}
     end
 
     MigrateLegacySharedMediaFavorites(store)
     CleanupLegacyRecentArtifacts(store)
-    return store.textureFavorites
+    return store
+end
+
+GetAuraTextureFavoriteStore = function(store)
+    local normalizedStore = CooldownCompanion:NormalizeAuraTextureLibraryStore(store)
+    return normalizedStore and normalizedStore.textureFavorites or nil
 end
 
 local function ApplyFavoriteStateToEntry(entry, favorites)
@@ -1325,48 +1335,6 @@ function CooldownCompanion:FindAuraTexturePickerEntry(entries, selection)
     end
 
     return nil
-end
-
-function CooldownCompanion:DoesAuraTexturePickerEntryMatchSelectionAsset(entry, selection)
-    if type(entry) ~= "table" or type(selection) ~= "table" then
-        return false
-    end
-
-    if entry.sourceType ~= selection.sourceType or entry.sourceValue ~= selection.sourceValue then
-        return false
-    end
-
-    if entry.sourceType == SHARED_MEDIA_SOURCE_TYPE and entry.mediaType ~= selection.mediaType then
-        return false
-    end
-
-    if not entry.layoutAgnostic then
-        local entryLocationType = NormalizeTextureLayout(entry.locationType)
-        local selectionLocationType = NormalizeTextureLayout(selection.locationType)
-        if entryLocationType ~= selectionLocationType then
-            return false
-        end
-    end
-
-    return true
-end
-
-function CooldownCompanion:FindAuraTexturePickerEntryByAsset(entries, selection)
-    if type(selection) ~= "table" then
-        return nil
-    end
-
-    local matchedEntry = nil
-    for _, entry in ipairs(entries or {}) do
-        if self:DoesAuraTexturePickerEntryMatchSelectionAsset(entry, selection) then
-            if matchedEntry ~= nil then
-                return nil
-            end
-            matchedEntry = entry
-        end
-    end
-
-    return matchedEntry
 end
 
 function CooldownCompanion:IsAuraTextureButtonSupported(buttonData)
@@ -1693,21 +1661,10 @@ function CooldownCompanion:EnsureAuraTextureLibraryStore()
         profile.auraTextureLibrary = {
             customTextures = {},
             textureFavorites = {},
-            sharedMediaFavorites = {},
         }
     end
-    if type(profile.auraTextureLibrary.customTextures) ~= "table" then
-        profile.auraTextureLibrary.customTextures = {}
-    end
-    if type(profile.auraTextureLibrary.textureFavorites) ~= "table" then
-        profile.auraTextureLibrary.textureFavorites = {}
-    end
-    if type(profile.auraTextureLibrary.sharedMediaFavorites) ~= "table" then
-        profile.auraTextureLibrary.sharedMediaFavorites = {}
-    end
-    MigrateLegacySharedMediaFavorites(profile.auraTextureLibrary)
-    CleanupLegacyRecentArtifacts(profile.auraTextureLibrary)
-    return profile.auraTextureLibrary
+
+    return self:NormalizeAuraTextureLibraryStore(profile.auraTextureLibrary)
 end
 
 function CooldownCompanion:GetSharedMediaAuraTextureEntries()
@@ -2156,7 +2113,6 @@ function CooldownCompanion:GetAuraTexturePickerFilterForSelection(selection)
     end
 
     local builtinEntry = self:FindAuraTexturePickerEntry(BuildBuiltinEntries(), selection)
-        or self:FindAuraTexturePickerEntryByAsset(BuildBuiltinEntries(), selection)
     if builtinEntry then
         return builtinEntry.categoryKey or FILTER_OTHER
     end

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -32,6 +32,7 @@ local defaults = {
             bars = {},
         },
         auraTextureLibrary = {
+            textureFavorites = {},
             recentProcOverlays = {},
         },
         groups = {

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -33,7 +33,6 @@ local defaults = {
         },
         auraTextureLibrary = {
             textureFavorites = {},
-            recentProcOverlays = {},
         },
         groups = {
             --[[

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -720,6 +720,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
 
     if displayMode == "textures" then
         db.groups[groupId].textureSettings = {
+            blendMode = "BLEND",
             point = "CENTER",
             relativePoint = "CENTER",
             relativeTo = "UIParent",

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -120,7 +120,6 @@ function CooldownCompanion:OnEnable()
     -- Spell activation overlay (proc glow) events
     -- Track state via events instead of polling IsSpellOverlayed
     -- (that API is AllowedWhenUntainted — calling from addon code causes taint)
-    self:RegisterEvent("SPELL_ACTIVATION_OVERLAY_SHOW", "OnProcOverlayShow")
     self:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW", "OnProcGlowShow")
     self:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE", "OnProcGlowHide")
 
@@ -358,10 +357,6 @@ end
 function CooldownCompanion:OnProcGlowShow(event, spellID)
     self.procOverlaySpells[spellID] = true
     self:UpdateAllCooldowns()
-end
-
-function CooldownCompanion:OnProcOverlayShow(event, spellID, overlayFileDataID, locationType, scale, r, g, b)
-    self:RecordRecentAuraTextureOverlay(spellID, overlayFileDataID, locationType, scale, r, g, b)
 end
 
 function CooldownCompanion:OnProcGlowHide(event, spellID)


### PR DESCRIPTION
## Summary
- default new texture panels to Blend without copying a picked texture's authored blend mode into the panel
- replace the old recent proc overlay flow with unified texture favorites across picker categories
- clean legacy texture artifacts during import/export and bump compact exports to compact3