### PR TITLE
Clarify main config headers for selected entries, panels, and groups

### DIFF
--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -12,6 +12,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- Imports from earlier Config/ files
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local GetButtonIcon = ST._GetButtonIcon
+local GetConfigEntryDisplayName = ST._GetConfigEntryDisplayName
 local GenerateFolderName = ST._GenerateFolderName
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
 local CompactUntitledInlineGroupConfig = ST._CompactUntitledInlineGroupConfig
@@ -1753,50 +1754,7 @@ local function RefreshColumn2()
                     CleanRecycledEntry(entry)
                     local usable = CooldownCompanion:IsButtonUsable(buttonData)
 
-                    local entryName = buttonData.name
-                    if buttonData.type == "spell" then
-                        local child
-                        if buttonData.cdmChildSlot then
-                            local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
-                            child = allChildren and allChildren[buttonData.cdmChildSlot]
-                        else
-                            child = CooldownCompanion.viewerAuraFrames[buttonData.id]
-                        end
-                        if child and child.cooldownInfo and child.cooldownInfo.overrideSpellID then
-                            local spellName = C_Spell.GetSpellName(child.cooldownInfo.overrideSpellID)
-                            if spellName then entryName = spellName end
-                        else
-                            -- Resolve through GetOverrideSpell so base-stored
-                            -- IDs display the current transform name.
-                            local raw = C_Spell.GetOverrideSpell(buttonData.id)
-                            local displayId = (raw and raw ~= 0) and raw or buttonData.id
-                            local spellName = C_Spell.GetSpellName(displayId)
-                            if spellName then entryName = spellName end
-                        end
-                        if buttonData.cdmChildSlot then
-                            entryName = entryName .. " #" .. buttonData.cdmChildSlot
-                        end
-                        local addedAs = buttonData.addedAs
-                        if addedAs ~= "spell" and addedAs ~= "aura" then
-                            addedAs = buttonData.isPassive and "aura" or "spell"
-                        end
-                        local icons = ""
-                        if addedAs ~= "aura" then
-                            icons = icons .. "|A:ui_adv_atk:15:15|a"
-                        end
-                        if addedAs == "aura" or buttonData.auraTracking then
-                            icons = icons .. "|A:ui_adv_health:15:15|a"
-                        end
-                        if icons ~= "" then
-                            entryName = entryName .. "  " .. icons
-                        end
-                    elseif buttonData.type == "item" then
-                        if C_Item.IsEquippableItem(buttonData.id) then
-                            entryName = entryName .. "  |A:Crosshair_repairnpc_32:15:15|a"
-                        else
-                            entryName = entryName .. "  |A:auctionhouse-icon-coin-gold:12:12|a"
-                        end
-                    end
+                    local entryName = GetConfigEntryDisplayName(buttonData, { includeDecorations = true })
                     entry:SetText(entryName or ("Unknown " .. buttonData.type))
                     entry:SetImage(GetButtonIcon(buttonData))
                     entry:SetImageSize(32, 32)

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -99,6 +99,55 @@ local function CountSelections(selectionSet)
     return count
 end
 
+local function GetConfigProfile()
+    return CooldownCompanion.db and CooldownCompanion.db.profile
+end
+
+local function NormalizeHeaderName(name)
+    if type(name) ~= "string" then
+        return nil
+    end
+    local trimmed = name:match("^%s*(.-)%s*$")
+    if not trimmed or trimmed == "" then
+        return nil
+    end
+    return trimmed
+end
+
+local function GetSelectedEntryHeaderName()
+    if not (CS.selectedGroup and CS.selectedButton) then
+        return nil
+    end
+    if next(CS.selectedButtons) then
+        return nil
+    end
+
+    local profile = GetConfigProfile()
+    local group = profile and profile.groups and profile.groups[CS.selectedGroup]
+    local buttonData = group and group.buttons and group.buttons[CS.selectedButton]
+    return buttonData and NormalizeHeaderName(buttonData.name)
+end
+
+local function GetSelectedPanelHeaderName(selection)
+    if not selection or selection.panelMultiCount >= 2 or not CS.selectedGroup then
+        return nil
+    end
+
+    local profile = GetConfigProfile()
+    local group = profile and profile.groups and profile.groups[CS.selectedGroup]
+    return group and NormalizeHeaderName(group.name)
+end
+
+local function GetSelectedGroupHeaderName(selection)
+    if not selection or selection.groupMultiCount >= 2 or not CS.selectedContainer or CS.selectedGroup then
+        return nil
+    end
+
+    local profile = GetConfigProfile()
+    local container = profile and profile.groupContainers and profile.groupContainers[CS.selectedContainer]
+    return container and NormalizeHeaderName(container.name)
+end
+
 local function GetConfigSelectionSummary()
     return {
         panelMultiCount = CountSelections(CS.selectedPanels),
@@ -140,6 +189,10 @@ local function GetColumn3HeaderTitle(selection)
     elseif mode == "panel_actions" then
         return "Panel Actions"
     end
+    local entryName = GetSelectedEntryHeaderName()
+    if entryName then
+        return "Entry: " .. entryName
+    end
     return "Button Settings"
 end
 
@@ -148,7 +201,15 @@ local function GetColumn4HeaderTitle(selection)
     if mode == "layout_order" then
         return GetLayoutOrderColumnTitle()
     elseif mode == "panel" then
+        local panelName = GetSelectedPanelHeaderName(selection)
+        if panelName then
+            return "Panel: " .. panelName
+        end
         return "Panel Settings"
+    end
+    local groupName = GetSelectedGroupHeaderName(selection)
+    if groupName then
+        return "Group: " .. groupName
     end
     return "Group Settings"
 end

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -25,6 +25,7 @@ local SetConfigPrimaryMode = ST._SetConfigPrimaryMode
 local UpdateCol2CursorPreview = ST._UpdateCol2CursorPreview
 local ClearCol2AnimatedPreview = ST._ClearCol2AnimatedPreview
 local ClearConfigShiftTooltipHover = ST._ClearConfigShiftTooltipHover
+local GetConfigEntryDisplayName = ST._GetConfigEntryDisplayName
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -125,7 +126,7 @@ local function GetSelectedEntryHeaderName()
     local profile = GetConfigProfile()
     local group = profile and profile.groups and profile.groups[CS.selectedGroup]
     local buttonData = group and group.buttons and group.buttons[CS.selectedButton]
-    return buttonData and NormalizeHeaderName(buttonData.name)
+    return buttonData and NormalizeHeaderName(GetConfigEntryDisplayName(buttonData))
 end
 
 local function GetSelectedPanelHeaderName(selection)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -311,6 +311,70 @@ local function GetButtonIcon(buttonData)
     return 134400
 end
 
+local function GetConfigEntryDisplayName(buttonData, opts)
+    if not buttonData then
+        return nil
+    end
+
+    opts = opts or {}
+    local includeDecorations = opts.includeDecorations == true
+    local entryName = buttonData.name
+
+    if buttonData.type == "spell" then
+        local child
+        if buttonData.cdmChildSlot then
+            local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
+            child = allChildren and allChildren[buttonData.cdmChildSlot]
+        else
+            child = CooldownCompanion.viewerAuraFrames[buttonData.id]
+        end
+
+        if child and child.cooldownInfo and child.cooldownInfo.overrideSpellID then
+            local spellName = C_Spell.GetSpellName(child.cooldownInfo.overrideSpellID)
+            if spellName then
+                entryName = spellName
+            end
+        else
+            local raw = C_Spell.GetOverrideSpell(buttonData.id)
+            local displayId = (raw and raw ~= 0) and raw or buttonData.id
+            local spellName = C_Spell.GetSpellName(displayId)
+            if spellName then
+                entryName = spellName
+            end
+        end
+
+        if buttonData.cdmChildSlot then
+            entryName = (entryName or ("Unknown " .. tostring(buttonData.type))) .. " #" .. buttonData.cdmChildSlot
+        end
+
+        if includeDecorations then
+            local addedAs = buttonData.addedAs
+            if addedAs ~= "spell" and addedAs ~= "aura" then
+                addedAs = buttonData.isPassive and "aura" or "spell"
+            end
+            local icons = ""
+            if addedAs ~= "aura" then
+                icons = icons .. "|A:ui_adv_atk:15:15|a"
+            end
+            if addedAs == "aura" or buttonData.auraTracking then
+                icons = icons .. "|A:ui_adv_health:15:15|a"
+            end
+            if icons ~= "" then
+                entryName = (entryName or ("Unknown " .. tostring(buttonData.type))) .. "  " .. icons
+            end
+        end
+    elseif buttonData.type == "item" and includeDecorations then
+        entryName = entryName or ("Unknown " .. tostring(buttonData.type))
+        if C_Item.IsEquippableItem(buttonData.id) then
+            entryName = entryName .. "  |A:Crosshair_repairnpc_32:15:15|a"
+        else
+            entryName = entryName .. "  |A:auctionhouse-icon-coin-gold:12:12|a"
+        end
+    end
+
+    return entryName
+end
+
 ------------------------------------------------------------------------
 -- Helper: Get icon for a group (from its first button)
 ------------------------------------------------------------------------
@@ -1686,6 +1750,7 @@ ST._ClearCol1PreviewHost = ClearCol1PreviewHost
 ST._ClearCol2PreviewHost = ClearCol2PreviewHost
 ST._EmbedWidget = EmbedWidget
 ST._GetButtonIcon = GetButtonIcon
+ST._GetConfigEntryDisplayName = GetConfigEntryDisplayName
 ST._GetGroupIcon = GetGroupIcon
 ST._GetContainerIcon = GetContainerIcon
 ST._GetFolderIcon = GetFolderIcon


### PR DESCRIPTION
## Summary
- show the selected entry name in column 3 instead of a generic button settings title
- show the selected panel or group name in column 4 when a single target is being configured
- reuse column 2's rendered entry-name logic so header labels stay aligned for override spells and CDM child entries

## Verification
- `luac -p Config/State.lua`
- `luac -p Config/Column2.lua`
- `luac -p Config/Panel.lua`

## Follow-up
- in-game validation still needed for normal selection, browse mode, and auto-add states
- check longer entry, panel, and group names to confirm the headers still read cleanly
