### PR TITLE
Make entry move menus easier to scan with nested group submenus

### DIFF
--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -192,6 +192,179 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     return true
 end
 
+local function BuildEntryMoveDestinationSections(db, sourceGroupId)
+    local containers = db and db.groupContainers or {}
+    local groupedByFolder = {}
+    local looseGroups = {}
+
+    for groupId, group in pairs(db.groups or {}) do
+        if groupId ~= sourceGroupId
+            and CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
+            and CanTexturePanelAcceptEntry(group)
+        then
+            local containerId = group.parentContainerId
+            local container = containerId and containers[containerId]
+            if container then
+                local folderId = container.folderId
+                local bucket
+                if folderId and db.folders and db.folders[folderId] then
+                    groupedByFolder[folderId] = groupedByFolder[folderId] or {}
+                    bucket = groupedByFolder[folderId]
+                else
+                    bucket = looseGroups
+                end
+
+                local entry = bucket[containerId]
+                if not entry then
+                    entry = {
+                        containerId = containerId,
+                        containerName = container.name or ("Group " .. containerId),
+                        containerOrder = CooldownCompanion:GetOrderForSpec(
+                            container,
+                            CooldownCompanion._currentSpecId,
+                            containerId
+                        ),
+                        panels = {},
+                    }
+                    bucket[containerId] = entry
+                end
+
+                entry.panels[#entry.panels + 1] = {
+                    groupId = groupId,
+                    name = group.name or ("Panel " .. groupId),
+                    order = group.order or groupId,
+                }
+            end
+        end
+    end
+
+    local function BuildSectionEntries(containerMap)
+        local entries = {}
+        for _, containerEntry in pairs(containerMap or {}) do
+            table.sort(containerEntry.panels, function(a, b)
+                if a.order ~= b.order then
+                    return a.order < b.order
+                end
+                return a.groupId < b.groupId
+            end)
+            entries[#entries + 1] = containerEntry
+        end
+
+        table.sort(entries, function(a, b)
+            if a.containerOrder ~= b.containerOrder then
+                return a.containerOrder < b.containerOrder
+            end
+            return a.containerId < b.containerId
+        end)
+
+        return entries
+    end
+
+    local sections = {}
+    local sortedFolders = {}
+    for folderId, _ in pairs(groupedByFolder) do
+        local folder = db.folders and db.folders[folderId]
+        if folder then
+            sortedFolders[#sortedFolders + 1] = {
+                id = folderId,
+                name = folder.name or ("Folder " .. folderId),
+                order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, folderId),
+            }
+        end
+    end
+
+    table.sort(sortedFolders, function(a, b)
+        if a.order ~= b.order then
+            return a.order < b.order
+        end
+        return a.id < b.id
+    end)
+
+    for _, folder in ipairs(sortedFolders) do
+        sections[#sections + 1] = {
+            title = folder.name,
+            entries = BuildSectionEntries(groupedByFolder[folder.id]),
+        }
+    end
+
+    local looseEntries = BuildSectionEntries(looseGroups)
+    if #looseEntries > 0 then
+        sections[#sections + 1] = {
+            title = (#sortedFolders > 0) and "No Folder" or nil,
+            entries = looseEntries,
+        }
+    end
+
+    return sections
+end
+
+local ENTRY_MOVE_GROUP_MENU_PREFIX = "ENTRY_MOVE_GROUP:"
+
+local function FindEntryMoveContainerEntry(sections, containerId)
+    for _, section in ipairs(sections or {}) do
+        for _, containerEntry in ipairs(section.entries or {}) do
+            if containerEntry.containerId == containerId then
+                return containerEntry
+            end
+        end
+    end
+    return nil
+end
+
+local function ParseEntryMoveContainerId(menuList)
+    if type(menuList) ~= "string" then
+        return nil
+    end
+    local idText = menuList:match("^" .. ENTRY_MOVE_GROUP_MENU_PREFIX .. "(%d+)$")
+    return idText and tonumber(idText) or nil
+end
+
+local function AddEntryMoveDestinationButtons(level, sourceGroupId, sourceIndex, entryData, menuList)
+    local db = CooldownCompanion.db.profile
+    local sections = BuildEntryMoveDestinationSections(db, sourceGroupId)
+
+    local targetContainerId = ParseEntryMoveContainerId(menuList)
+    if targetContainerId then
+        local containerEntry = FindEntryMoveContainerEntry(sections, targetContainerId)
+        if not containerEntry then
+            return
+        end
+
+        for _, panel in ipairs(containerEntry.panels) do
+            local info = UIDropDownMenu_CreateInfo()
+            info.text = panel.name
+            info.notCheckable = true
+            info.func = function()
+                if MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, panel.groupId, entryData) then
+                    CloseDropDownMenus()
+                end
+            end
+            UIDropDownMenu_AddButton(info, level)
+        end
+        return
+    end
+
+    for _, section in ipairs(sections) do
+        if section.title then
+            local header = UIDropDownMenu_CreateInfo()
+            header.text = section.title
+            header.isTitle = true
+            header.notCheckable = true
+            UIDropDownMenu_AddButton(header, level)
+        end
+
+        for _, containerEntry in ipairs(section.entries) do
+            local info = UIDropDownMenu_CreateInfo()
+            info.text = containerEntry.containerName
+            info.notCheckable = true
+            info.hasArrow = true
+            info.menuList = ENTRY_MOVE_GROUP_MENU_PREFIX .. tostring(containerEntry.containerId)
+            info.leftPadding = section.title and 10 or 0
+            UIDropDownMenu_AddButton(info, level)
+        end
+    end
+end
+
 ------------------------------------------------------------------------
 -- COLUMN 2: Panels
 ------------------------------------------------------------------------
@@ -2006,74 +2179,16 @@ local function RefreshColumn2()
                                         ShowPopupAboveConfig("CDC_DELETE_BUTTON", name, { groupId = sourceGroupId, buttonIndex = sourceIndex })
                                     end
                                     UIDropDownMenu_AddButton(removeInfo, level)
-                                elseif menuList == "MOVE_TO_GROUP" then
-                                    local db = CooldownCompanion.db.profile
-                                    local containers = db.groupContainers or {}
-                                    local folderGroups, looseGroups = {}, {}
-                                    for id, group in pairs(db.groups) do
-                                        if id ~= sourceGroupId
-                                            and CooldownCompanion:IsGroupVisibleToCurrentChar(id)
-                                            and CanTexturePanelAcceptEntry(group) then
-                                            local gName = group.name or ("Group " .. id)
-                                            local cid = group.parentContainerId
-                                            local ctr = cid and containers[cid]
-                                            local fid = ctr and ctr.folderId
-                                            if fid and db.folders[fid] then
-                                                folderGroups[fid] = folderGroups[fid] or {}
-                                                table.insert(folderGroups[fid], { id = id, name = gName })
-                                            else
-                                                table.insert(looseGroups, { id = id, name = gName })
-                                            end
-                                        end
-                                    end
-                                    local sortedFolders = {}
-                                    for fid, folder in pairs(db.folders) do
-                                        if folderGroups[fid] then
-                                            table.insert(sortedFolders, { id = fid, name = folder.name or ("Folder " .. fid), order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid) })
-                                        end
-                                    end
-                                    table.sort(sortedFolders, function(a, b) return a.order < b.order end)
-                                    local hasFolders = #sortedFolders > 0
-                                    for _, folder in ipairs(sortedFolders) do
-                                        local hdr = UIDropDownMenu_CreateInfo()
-                                        hdr.text = folder.name
-                                        hdr.isTitle = true
-                                        hdr.notCheckable = true
-                                        UIDropDownMenu_AddButton(hdr, level)
-                                        table.sort(folderGroups[folder.id], function(a, b) return a.name < b.name end)
-                                        for _, g in ipairs(folderGroups[folder.id]) do
-                                            local info = UIDropDownMenu_CreateInfo()
-                                            info.text = g.name
-                                            info.notCheckable = true
-                                            info.func = function()
-                                                if MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, g.id, entryData) then
-                                                    CloseDropDownMenus()
-                                                end
-                                            end
-                                            UIDropDownMenu_AddButton(info, level)
-                                        end
-                                    end
-                                    if #looseGroups > 0 then
-                                        if hasFolders then
-                                            local hdr = UIDropDownMenu_CreateInfo()
-                                            hdr.text = "No Folder"
-                                            hdr.isTitle = true
-                                            hdr.notCheckable = true
-                                            UIDropDownMenu_AddButton(hdr, level)
-                                        end
-                                        table.sort(looseGroups, function(a, b) return a.name < b.name end)
-                                        for _, g in ipairs(looseGroups) do
-                                            local info = UIDropDownMenu_CreateInfo()
-                                            info.text = g.name
-                                            info.notCheckable = true
-                                            info.func = function()
-                                                if MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, g.id, entryData) then
-                                                    CloseDropDownMenus()
-                                                end
-                                            end
-                                            UIDropDownMenu_AddButton(info, level)
-                                        end
-                                    end
+                                elseif menuList == "MOVE_TO_GROUP"
+                                    or ParseEntryMoveContainerId(menuList)
+                                then
+                                    AddEntryMoveDestinationButtons(
+                                        level,
+                                        sourceGroupId,
+                                        sourceIndex,
+                                        entryData,
+                                        menuList
+                                    )
                                 end
                             end, "MENU")
                             CS.buttonContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
@@ -2090,72 +2205,18 @@ local function RefreshColumn2()
                             local sourceGroupId = btnPanelId
                             local sourceIndex = btnIndex
                             local entryData = buttonData
-                            UIDropDownMenu_Initialize(CS.moveMenuFrame, function(self, level)
-                                local db = CooldownCompanion.db.profile
-                                local containers = db.groupContainers or {}
-                                local folderGroups, looseGroups = {}, {}
-                                for id, group in pairs(db.groups) do
-                                    if id ~= sourceGroupId
-                                        and CooldownCompanion:IsGroupVisibleToCurrentChar(id)
-                                        and CanTexturePanelAcceptEntry(group) then
-                                        local gName = group.name or ("Group " .. id)
-                                        local cid = group.parentContainerId
-                                        local ctr = cid and containers[cid]
-                                        local fid = ctr and ctr.folderId
-                                        if fid and db.folders[fid] then
-                                            folderGroups[fid] = folderGroups[fid] or {}
-                                            table.insert(folderGroups[fid], { id = id, name = gName })
-                                        else
-                                            table.insert(looseGroups, { id = id, name = gName })
-                                        end
-                                    end
+                            UIDropDownMenu_Initialize(CS.moveMenuFrame, function(self, level, menuList)
+                                level = level or 1
+                                if level ~= 1 and not ParseEntryMoveContainerId(menuList) then
+                                    return
                                 end
-                                local sortedFolders = {}
-                                for fid, folder in pairs(db.folders) do
-                                    if folderGroups[fid] then
-                                        table.insert(sortedFolders, { id = fid, name = folder.name or ("Folder " .. fid), order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid) })
-                                    end
-                                end
-                                table.sort(sortedFolders, function(a, b) return a.order < b.order end)
-                                local hasFolders = #sortedFolders > 0
-                                for _, folder in ipairs(sortedFolders) do
-                                    local hdr = UIDropDownMenu_CreateInfo()
-                                    hdr.text = folder.name
-                                    hdr.isTitle = true
-                                    hdr.notCheckable = true
-                                    UIDropDownMenu_AddButton(hdr, level)
-                                    table.sort(folderGroups[folder.id], function(a, b) return a.name < b.name end)
-                                    for _, g in ipairs(folderGroups[folder.id]) do
-                                        local info = UIDropDownMenu_CreateInfo()
-                                        info.text = g.name
-                                        info.func = function()
-                                            if MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, g.id, entryData) then
-                                                CloseDropDownMenus()
-                                            end
-                                        end
-                                        UIDropDownMenu_AddButton(info, level)
-                                    end
-                                end
-                                if #looseGroups > 0 then
-                                    if hasFolders then
-                                        local hdr = UIDropDownMenu_CreateInfo()
-                                        hdr.text = "No Folder"
-                                        hdr.isTitle = true
-                                        hdr.notCheckable = true
-                                        UIDropDownMenu_AddButton(hdr, level)
-                                    end
-                                    table.sort(looseGroups, function(a, b) return a.name < b.name end)
-                                    for _, g in ipairs(looseGroups) do
-                                        local info = UIDropDownMenu_CreateInfo()
-                                        info.text = g.name
-                                        info.func = function()
-                                            if MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, g.id, entryData) then
-                                                CloseDropDownMenus()
-                                            end
-                                        end
-                                        UIDropDownMenu_AddButton(info, level)
-                                    end
-                                end
+                                AddEntryMoveDestinationButtons(
+                                    level,
+                                    sourceGroupId,
+                                    sourceIndex,
+                                    entryData,
+                                    menuList
+                                )
                             end, "MENU")
                             CS.moveMenuFrame:SetFrameStrata("FULLSCREEN_DIALOG")
                             ToggleDropDownMenu(1, nil, CS.moveMenuFrame, "cursor", 0, 0)


### PR DESCRIPTION
## Summary
- consolidate folder, button, and container icon picker setup behind one shared picker flow
- keep each picker's unique validation, current-icon lookup, and apply behavior in small specs
- preserve the button picker's draggable behavior while reducing duplicated frame and selection logic

## Testing
- Not run (not requested)