### PR TITLE
Let custom aura bars track player or target auras without breaking older setups

### DIFF
--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -75,7 +75,9 @@ local DEFAULT_ARCANE_MAX_COLOR = RB.DEFAULT_ARCANE_MAX_COLOR
 local DEFAULT_ESSENCE_READY_COLOR = RB.DEFAULT_ESSENCE_READY_COLOR
 local DEFAULT_ESSENCE_RECHARGING_COLOR = RB.DEFAULT_ESSENCE_RECHARGING_COLOR
 local DEFAULT_ESSENCE_MAX_COLOR = RB.DEFAULT_ESSENCE_MAX_COLOR
+local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
+local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForSpell
 
 -- Imports from ResourceBarPanelsHelpers
 local RBP = ST._RBP
@@ -1595,7 +1597,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
     local cab = customBars[selectedSlot]
     local capturedIdx = selectedSlot
     EnsureCustomAuraIndependentConfig(cab, settings)
-    local resolvedAuraUnit = EnsureCustomAuraBarAuraUnit(cab, cab.spellID)
+    local resolvedAuraUnit = GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID)
 
     local function ClassColorText(text)
         local safeText = tostring(text or "")
@@ -1764,7 +1766,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                 local bars = CooldownCompanion:GetSpecCustomAuraBars()
                 bars[capturedIdx].spellID = entry.id
                 bars[capturedIdx].label = C_Spell.GetSpellName(entry.id) or ""
-                EnsureCustomAuraBarAuraUnit(bars[capturedIdx], entry.id)
+                RefreshCustomAuraBarAuraUnitForSpell(bars[capturedIdx], entry.id)
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:UpdateAnchorStacking()
                 CooldownCompanion:RefreshConfigPanel()
@@ -1782,7 +1784,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                 else
                     bars[capturedIdx].label = ""
                 end
-                EnsureCustomAuraBarAuraUnit(bars[capturedIdx], id)
+                RefreshCustomAuraBarAuraUnitForSpell(bars[capturedIdx], id)
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:UpdateAnchorStacking()
                 CooldownCompanion:RefreshConfigPanel()
@@ -1815,7 +1817,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                 if val ~= "player" and val ~= "target" then
                     return
                 end
-                EnsureCustomAuraBarAuraUnit(customBars[capturedIdx], customBars[capturedIdx].spellID, val)
+                EnsureCustomAuraBarAuraUnit(customBars[capturedIdx], customBars[capturedIdx].spellID, val, true)
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:UpdateAnchorStacking()
                 CooldownCompanion:RefreshConfigPanel()

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -75,6 +75,7 @@ local DEFAULT_ARCANE_MAX_COLOR = RB.DEFAULT_ARCANE_MAX_COLOR
 local DEFAULT_ESSENCE_READY_COLOR = RB.DEFAULT_ESSENCE_READY_COLOR
 local DEFAULT_ESSENCE_RECHARGING_COLOR = RB.DEFAULT_ESSENCE_RECHARGING_COLOR
 local DEFAULT_ESSENCE_MAX_COLOR = RB.DEFAULT_ESSENCE_MAX_COLOR
+local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
 
 -- Imports from ResourceBarPanelsHelpers
 local RBP = ST._RBP
@@ -1594,6 +1595,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
     local cab = customBars[selectedSlot]
     local capturedIdx = selectedSlot
     EnsureCustomAuraIndependentConfig(cab, settings)
+    local resolvedAuraUnit = EnsureCustomAuraBarAuraUnit(cab, cab.spellID)
 
     local function ClassColorText(text)
         local safeText = tostring(text or "")
@@ -1762,6 +1764,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                 local bars = CooldownCompanion:GetSpecCustomAuraBars()
                 bars[capturedIdx].spellID = entry.id
                 bars[capturedIdx].label = C_Spell.GetSpellName(entry.id) or ""
+                EnsureCustomAuraBarAuraUnit(bars[capturedIdx], entry.id)
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:UpdateAnchorStacking()
                 CooldownCompanion:RefreshConfigPanel()
@@ -1779,6 +1782,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                 else
                     bars[capturedIdx].label = ""
                 end
+                EnsureCustomAuraBarAuraUnit(bars[capturedIdx], id)
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:UpdateAnchorStacking()
                 CooldownCompanion:RefreshConfigPanel()
@@ -1798,6 +1802,35 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
             container:AddChild(spellEdit)
 
             AddCdmAuraReadinessWarning(container, cab.spellID)
+
+            local auraUnitDrop = AceGUI:Create("Dropdown")
+            auraUnitDrop:SetLabel("Aura Unit")
+            auraUnitDrop:SetList({
+                player = "Player",
+                target = "Target",
+            }, { "player", "target" })
+            auraUnitDrop:SetValue(resolvedAuraUnit)
+            auraUnitDrop:SetFullWidth(true)
+            auraUnitDrop:SetCallback("OnValueChanged", function(widget, event, val)
+                if val ~= "player" and val ~= "target" then
+                    return
+                end
+                EnsureCustomAuraBarAuraUnit(customBars[capturedIdx], customBars[capturedIdx].spellID, val)
+                CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:UpdateAnchorStacking()
+                CooldownCompanion:RefreshConfigPanel()
+            end)
+            container:AddChild(auraUnitDrop)
+            CreateInfoButton(auraUnitDrop.frame, auraUnitDrop.label, "LEFT", "RIGHT",
+                4, 0, {
+                "Aura Unit",
+                {"This controls where the tracked aura is expected to exist. Use Target for debuffs on your target, or Player for buffs and procs on yourself.", 1, 1, 1, true},
+            }, tabInfoButtons)
+
+            local auraUnitSpacer = AceGUI:Create("Label")
+            auraUnitSpacer:SetText(" ")
+            auraUnitSpacer:SetFullWidth(true)
+            container:AddChild(auraUnitSpacer)
 
             -- Tracking Mode dropdown
             local trackDrop = AceGUI:Create("Dropdown")
@@ -1946,42 +1979,44 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                         container:AddChild(activeAuraPreviewBtn)
                     end
 
-                    local pandemicEnabled = cab.showPandemicGlow == true
+                    if resolvedAuraUnit == "target" then
+                        local pandemicEnabled = cab.showPandemicGlow == true
 
-                    local pandemicCb = AceGUI:Create("CheckBox")
-                    pandemicCb:SetLabel("Show Pandemic Color/Glow")
-                    pandemicCb:SetValue(pandemicEnabled)
-                    pandemicCb:SetFullWidth(true)
-                    pandemicCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        customBars[cabIdx].showPandemicGlow = val and true or false
-                        CooldownCompanion:ApplyResourceBars()
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                    container:AddChild(pandemicCb)
-
-                    local pandemicAdvExpanded = AddAdvancedToggle(pandemicCb, "rbCabPandemic_" .. capturedIdx, tabInfoButtons, pandemicEnabled)
-                    if pandemicAdvExpanded and pandemicEnabled then
-                        local pandemicCombatCb = AceGUI:Create("CheckBox")
-                        pandemicCombatCb:SetLabel("Show Only In Combat")
-                        pandemicCombatCb:SetValue(cab.pandemicGlowCombatOnly or false)
-                        pandemicCombatCb:SetFullWidth(true)
-                        pandemicCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-                            customBars[cabIdx].pandemicGlowCombatOnly = val
+                        local pandemicCb = AceGUI:Create("CheckBox")
+                        pandemicCb:SetLabel("Show Pandemic Color/Glow")
+                        pandemicCb:SetValue(pandemicEnabled)
+                        pandemicCb:SetFullWidth(true)
+                        pandemicCb:SetCallback("OnValueChanged", function(widget, event, val)
+                            customBars[cabIdx].showPandemicGlow = val and true or false
                             CooldownCompanion:ApplyResourceBars()
+                            CooldownCompanion:RefreshConfigPanel()
                         end)
-                        container:AddChild(pandemicCombatCb)
-                        ApplyCheckboxIndent(pandemicCombatCb, 20)
+                        container:AddChild(pandemicCb)
 
-                        BuildPandemicBarControls(container, customBars[cabIdx], cabApplyBars)
-                        BuildPandemicBarPulseControls(container, customBars[cabIdx], cabApplyBars)
+                        local pandemicAdvExpanded = AddAdvancedToggle(pandemicCb, "rbCabPandemic_" .. capturedIdx, tabInfoButtons, pandemicEnabled)
+                        if pandemicAdvExpanded and pandemicEnabled then
+                            local pandemicCombatCb = AceGUI:Create("CheckBox")
+                            pandemicCombatCb:SetLabel("Show Only In Combat")
+                            pandemicCombatCb:SetValue(cab.pandemicGlowCombatOnly or false)
+                            pandemicCombatCb:SetFullWidth(true)
+                            pandemicCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+                                customBars[cabIdx].pandemicGlowCombatOnly = val
+                                CooldownCompanion:ApplyResourceBars()
+                            end)
+                            container:AddChild(pandemicCombatCb)
+                            ApplyCheckboxIndent(pandemicCombatCb, 20)
 
-                        local pandemicPreviewBtn = AceGUI:Create("Button")
-                        pandemicPreviewBtn:SetText("Preview Pandemic Effects (3s)")
-                        pandemicPreviewBtn:SetFullWidth(true)
-                        pandemicPreviewBtn:SetCallback("OnClick", function()
-                            CooldownCompanion:PlayCustomAuraBarPandemicPreview(customBars[cabIdx], 3)
-                        end)
-                        container:AddChild(pandemicPreviewBtn)
+                            BuildPandemicBarControls(container, customBars[cabIdx], cabApplyBars)
+                            BuildPandemicBarPulseControls(container, customBars[cabIdx], cabApplyBars)
+
+                            local pandemicPreviewBtn = AceGUI:Create("Button")
+                            pandemicPreviewBtn:SetText("Preview Pandemic Effects (3s)")
+                            pandemicPreviewBtn:SetFullWidth(true)
+                            pandemicPreviewBtn:SetCallback("OnClick", function()
+                                CooldownCompanion:PlayCustomAuraBarPandemicPreview(customBars[cabIdx], 3)
+                            end)
+                            container:AddChild(pandemicPreviewBtn)
+                        end
                     end
                 else
                     local thresholdCb = AceGUI:Create("CheckBox")

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -8,6 +8,8 @@ local rawget = rawget
 local tonumber = tonumber
 local type = type
 local sort = table.sort
+local RB = ST._RB
+local EnsureCustomAuraBarAuraUnit = RB and RB.EnsureCustomAuraBarAuraUnit
 
 local SCOPED_BAR_SYSTEMS = {
     resourceBars = {
@@ -430,6 +432,9 @@ local function SanitizeResourceBarAnchors(settings)
             for _, customAuraBar in pairs(specBars) do
                 if type(customAuraBar) == "table" then
                     customAuraBar.independentAnchorGroupId = SanitizeAnchorGroupID(customAuraBar.independentAnchorGroupId)
+                    if EnsureCustomAuraBarAuraUnit then
+                        EnsureCustomAuraBarAuraUnit(customAuraBar, customAuraBar.spellID)
+                    end
                 end
             end
         end

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -8,8 +8,11 @@ local rawget = rawget
 local tonumber = tonumber
 local type = type
 local sort = table.sort
-local RB = ST._RB
-local EnsureCustomAuraBarAuraUnit = RB and RB.EnsureCustomAuraBarAuraUnit
+
+local function GetEnsureCustomAuraBarAuraUnit()
+    local rb = ST and ST._RB
+    return rb and rb.EnsureCustomAuraBarAuraUnit
+end
 
 local SCOPED_BAR_SYSTEMS = {
     resourceBars = {
@@ -427,13 +430,14 @@ local function SanitizeResourceBarAnchors(settings)
         return
     end
 
+    local ensureCustomAuraBarAuraUnit = GetEnsureCustomAuraBarAuraUnit()
     for _, specBars in pairs(settings.customAuraBars) do
         if type(specBars) == "table" then
             for _, customAuraBar in pairs(specBars) do
                 if type(customAuraBar) == "table" then
                     customAuraBar.independentAnchorGroupId = SanitizeAnchorGroupID(customAuraBar.independentAnchorGroupId)
-                    if EnsureCustomAuraBarAuraUnit then
-                        EnsureCustomAuraBarAuraUnit(customAuraBar, customAuraBar.spellID)
+                    if ensureCustomAuraBarAuraUnit then
+                        ensureCustomAuraBarAuraUnit(customAuraBar, customAuraBar.spellID)
                     end
                 end
             end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -67,6 +67,7 @@ local GetVerticalSideFallback = RB.GetVerticalSideFallback
 local GetEffectiveAnchorGroupId = RB.GetEffectiveAnchorGroupId
 local GetPlayerClassID = RB.GetPlayerClassID
 local GetSpecCustomAuraBars = RB.GetSpecCustomAuraBars
+local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
 local GetSpecLayoutOrder = RB.GetSpecLayoutOrder
 local GetAnchorOffset = RB.GetAnchorOffset
 local RoundToTenths = RB.RoundToTenths
@@ -1691,21 +1692,25 @@ local function UpdateCustomAuraBar(barInfo)
     local auraPreview = bar and bar._barAuraActivePreview
     local pandemicPreview = bar and bar._pandemicPreview
     local indicatorPreview = isActive and (auraPreview or pandemicPreview)
+    local configUnit = EnsureCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
     local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(cabConfig.spellID)
-    local auraUnit = viewerFrame and viewerFrame.auraDataUnit or "player"
+    local auraUnit = configUnit
     local instId = viewerFrame and viewerFrame.auraInstanceID
     if instId then
-        local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(auraUnit, instId)
-        if auraData then
-            auraPresent = true
-            applications = auraData.applications or 0
-            if isActive then
-                stacks = 1
-            else
-                stacks = applications
-            end
-            if needsDuration then
-                durationObj = C_UnitAuras.GetAuraDuration(auraUnit, instId)
+        local viewerUnit = viewerFrame.auraDataUnit or configUnit
+        if viewerUnit == configUnit then
+            local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
+            if auraData then
+                auraPresent = true
+                applications = auraData.applications or 0
+                if isActive then
+                    stacks = 1
+                else
+                    stacks = applications
+                end
+                if needsDuration then
+                    durationObj = C_UnitAuras.GetAuraDuration(configUnit, instId)
+                end
             end
         end
     end
@@ -1728,7 +1733,7 @@ local function UpdateCustomAuraBar(barInfo)
         local inPandemic = false
         if pandemicPreview then
             inPandemic = true
-        elseif auraPresent and cabConfig.showPandemicGlow == true and viewerFrame then
+        elseif configUnit == "target" and auraPresent and cabConfig.showPandemicGlow == true and viewerFrame then
             local pi = viewerFrame.PandemicIcon
             if bar._pandemicGraceSuppressed then
                 bar._pandemicGraceSuppressed = nil
@@ -1908,14 +1913,7 @@ local function GetHiddenCustomAuraWakeUnit(cabConfig)
     if not cabConfig or not cabConfig.spellID then
         return nil
     end
-
-    local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(cabConfig.spellID)
-    local viewerUnit = viewerFrame and viewerFrame.auraDataUnit
-    if viewerUnit == "player" or viewerUnit == "target" then
-        return viewerUnit
-    end
-
-    return C_Spell.IsSpellHarmful(cabConfig.spellID) and "target" or "player"
+    return EnsureCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
 end
 
 local function IsEventDrivenCustomAuraBar(barInfo)
@@ -2539,7 +2537,7 @@ local function EnableEventFrame()
                     local cabConfig = barInfo and barInfo.cabConfig
                     if barInfo and barInfo.barType == "custom_continuous"
                         and cabConfig and cabConfig.trackingMode == "active"
-                        and bar and bar._auraUnit == "target" then
+                        and bar and EnsureCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
                         bar._auraInstanceID = nil
                         bar._inPandemic = nil
                         bar._pandemicGraceStart = nil

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -135,17 +135,42 @@ local function GetDefaultCustomAuraUnit(spellID)
     return (spellID and C_Spell.IsSpellHarmful(spellID)) and "target" or "player"
 end
 
-local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit)
+local function HasExplicitCustomAuraBarAuraUnit(cabConfig)
+    return type(cabConfig) == "table"
+        and cabConfig.auraUnitExplicit == true
+        and IsValidCustomAuraUnit(cabConfig.auraUnit)
+end
+
+local function GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
+    local resolvedSpellID = spellID
+    if resolvedSpellID == nil and type(cabConfig) == "table" then
+        resolvedSpellID = cabConfig.spellID
+    end
+
+    if type(cabConfig) == "table" and IsValidCustomAuraUnit(cabConfig.auraUnit) then
+        return cabConfig.auraUnit
+    end
+
+    return GetDefaultCustomAuraUnit(resolvedSpellID)
+end
+
+local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit, explicit)
     local resolvedSpellID = spellID
     if resolvedSpellID == nil and type(cabConfig) == "table" then
         resolvedSpellID = cabConfig.spellID
     end
 
     if type(cabConfig) == "table" then
+        local wasExplicit = HasExplicitCustomAuraBarAuraUnit(cabConfig)
+        local resolvedUnit = IsValidCustomAuraUnit(unit) and unit
+            or GetResolvedCustomAuraBarAuraUnit(cabConfig, resolvedSpellID)
+
+        cabConfig.auraUnit = resolvedUnit
+
         if IsValidCustomAuraUnit(unit) then
-            cabConfig.auraUnit = unit
-        elseif not IsValidCustomAuraUnit(cabConfig.auraUnit) and resolvedSpellID then
-            cabConfig.auraUnit = GetDefaultCustomAuraUnit(resolvedSpellID)
+            cabConfig.auraUnitExplicit = explicit == false and nil or true
+        elseif not wasExplicit then
+            cabConfig.auraUnitExplicit = nil
         end
 
         if IsValidCustomAuraUnit(cabConfig.auraUnit) then
@@ -154,6 +179,19 @@ local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit)
     end
 
     return GetDefaultCustomAuraUnit(resolvedSpellID)
+end
+
+local function RefreshCustomAuraBarAuraUnitForSpell(cabConfig, spellID)
+    local resolvedSpellID = spellID
+    if resolvedSpellID == nil and type(cabConfig) == "table" then
+        resolvedSpellID = cabConfig.spellID
+    end
+
+    if HasExplicitCustomAuraBarAuraUnit(cabConfig) then
+        return cabConfig.auraUnit
+    end
+
+    return EnsureCustomAuraBarAuraUnit(cabConfig, resolvedSpellID, GetDefaultCustomAuraUnit(resolvedSpellID), false)
 end
 
 local function CreateDefaultLayoutOrder()
@@ -597,7 +635,9 @@ RB.GetPlayerClassID = GetPlayerClassID
 RB.GetSpecCustomAuraBars = GetSpecCustomAuraBars
 RB.IsValidCustomAuraUnit = IsValidCustomAuraUnit
 RB.GetDefaultCustomAuraUnit = GetDefaultCustomAuraUnit
+RB.GetResolvedCustomAuraBarAuraUnit = GetResolvedCustomAuraBarAuraUnit
 RB.EnsureCustomAuraBarAuraUnit = EnsureCustomAuraBarAuraUnit
+RB.RefreshCustomAuraBarAuraUnitForSpell = RefreshCustomAuraBarAuraUnitForSpell
 RB.CreateDefaultLayoutOrder = CreateDefaultLayoutOrder
 RB.GetSpecLayoutOrder = GetSpecLayoutOrder
 RB.GetAnchorOffset = GetAnchorOffset

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -127,6 +127,35 @@ local function GetSpecCustomAuraBars(settings)
     return settings.customAuraBars[specID]
 end
 
+local function IsValidCustomAuraUnit(unit)
+    return unit == "player" or unit == "target"
+end
+
+local function GetDefaultCustomAuraUnit(spellID)
+    return (spellID and C_Spell.IsSpellHarmful(spellID)) and "target" or "player"
+end
+
+local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit)
+    local resolvedSpellID = spellID
+    if resolvedSpellID == nil and type(cabConfig) == "table" then
+        resolvedSpellID = cabConfig.spellID
+    end
+
+    if type(cabConfig) == "table" then
+        if IsValidCustomAuraUnit(unit) then
+            cabConfig.auraUnit = unit
+        elseif not IsValidCustomAuraUnit(cabConfig.auraUnit) and resolvedSpellID then
+            cabConfig.auraUnit = GetDefaultCustomAuraUnit(resolvedSpellID)
+        end
+
+        if IsValidCustomAuraUnit(cabConfig.auraUnit) then
+            return cabConfig.auraUnit
+        end
+    end
+
+    return GetDefaultCustomAuraUnit(resolvedSpellID)
+end
+
 local function CreateDefaultLayoutOrder()
     return {
         resources = {},
@@ -566,6 +595,9 @@ RB.GetAnchorGroupFrame = GetAnchorGroupFrame
 RB.GetCurrentSpecID = GetCurrentSpecID
 RB.GetPlayerClassID = GetPlayerClassID
 RB.GetSpecCustomAuraBars = GetSpecCustomAuraBars
+RB.IsValidCustomAuraUnit = IsValidCustomAuraUnit
+RB.GetDefaultCustomAuraUnit = GetDefaultCustomAuraUnit
+RB.EnsureCustomAuraBarAuraUnit = EnsureCustomAuraBarAuraUnit
 RB.CreateDefaultLayoutOrder = CreateDefaultLayoutOrder
 RB.GetSpecLayoutOrder = GetSpecLayoutOrder
 RB.GetAnchorOffset = GetAnchorOffset


### PR DESCRIPTION
## What Players Will Notice
- Custom aura bars can now be set to track either player buffs/procs or target debuffs.
- Older custom aura bars keep behaving correctly when you open the panel or change the tracked spell instead of getting stuck on a guessed unit.
- Pandemic options now stay hidden for player-tracking custom aura bars and remain available for target-tracking ones.

## Why This Changed
- Custom aura bars needed the same player-vs-target safety model already used by button aura entries.
- Adding an explicit aura-unit choice also needed to avoid a regression where older saved bars could silently lock in an inferred unit just by opening the config panel.
- Scoped and imported resource-bar settings also needed the same normalization so older bars behave consistently before the config panel is opened.

## What Changed
- Added shared helper logic to resolve, validate, backfill, and preserve custom aura bar `auraUnit` choices.
- Added an `Aura Unit` dropdown for custom aura bars plus an `auraUnitExplicit` flag so legacy inferred values can keep updating until the user makes a real choice.
- Hardened runtime aura reads so custom aura bars only accept viewer aura data when it matches the configured unit, and target-bar wake/cleanup paths now key off the configured unit.
- Limited pandemic UI and runtime behavior to target-tracking custom aura bars.
- Updated scoped settings sanitization to normalize custom aura bar aura units during seeded/copy flows.

## Validation
- `luac -p` passed for all touched Lua files.
- In-game checks passed for legacy inferred-unit behavior, explicit dropdown choice persistence after later spell changes, and target-bar wake/clear behavior.
- Restricted-content validation has not been done yet.