### PR TITLE
Fix standalone Shatter auras defaulting to player instead of target

### DIFF
--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -411,6 +411,85 @@ function CooldownCompanion:InferConfirmedAuraSpellIDString(buttonData)
     return inferredAuraSpellID
 end
 
+function CooldownCompanion:ResolveStandaloneAuraDefaultSpellID(buttonData)
+    if not (buttonData and buttonData.type == "spell") then
+        return nil
+    end
+
+    local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
+
+    local function ResolveSingleSpellID(rawIDs)
+        if not rawIDs then
+            return nil
+        end
+
+        local resolvedID
+        for id in tostring(rawIDs):gmatch("%d+") do
+            local numericID = tonumber(id)
+            if numericID and numericID ~= 0 then
+                if resolvedID and resolvedID ~= numericID then
+                    return nil
+                end
+                resolvedID = numericID
+            end
+        end
+
+        return resolvedID
+    end
+
+    local explicitAuraID = ResolveSingleSpellID(buttonData.auraSpellID)
+    if explicitAuraID then
+        return explicitAuraID
+    end
+
+    local resolvedAuraID = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
+    if resolvedAuraID then
+        return resolvedAuraID
+    end
+
+    local buffViewerFrame = self:ResolveBuffViewerFrameForSpell(baseId)
+        or (baseId ~= buttonData.id and self:ResolveBuffViewerFrameForSpell(buttonData.id))
+    if not (buffViewerFrame and type(buffViewerFrame.cooldownInfo) == "table") then
+        return nil
+    end
+
+    local info = buffViewerFrame.cooldownInfo
+    local metadataCandidate
+    for _, spellID in ipairs({info.spellID, info.overrideSpellID, info.overrideTooltipSpellID}) do
+        local numericID = tonumber(spellID)
+        if numericID and numericID ~= 0 and numericID ~= buttonData.id and numericID ~= baseId then
+            if metadataCandidate and metadataCandidate ~= numericID then
+                return nil
+            end
+            metadataCandidate = numericID
+        end
+    end
+    if info.linkedSpellIDs then
+        for _, linkedSpellID in ipairs(info.linkedSpellIDs) do
+            local numericID = tonumber(linkedSpellID)
+            if numericID and numericID ~= 0 and numericID ~= buttonData.id and numericID ~= baseId then
+                if metadataCandidate and metadataCandidate ~= numericID then
+                    return nil
+                end
+                metadataCandidate = numericID
+            end
+        end
+    end
+
+    return metadataCandidate
+end
+
+function CooldownCompanion:ResolveStandaloneAuraDefaultUnit(buttonData)
+    local resolvedSpellID = self:ResolveStandaloneAuraDefaultSpellID(buttonData)
+    if resolvedSpellID then
+        return C_Spell.IsSpellHarmful(resolvedSpellID) and "target" or "player"
+    end
+    if buttonData and buttonData.id then
+        return C_Spell.IsSpellHarmful(buttonData.id) and "target" or "player"
+    end
+    return "player"
+end
+
 function CooldownCompanion:ResolveAuraTrackingAssociationData(buttonData, viewerFrame)
     local data = {
         hasAssociatedAura = false,
@@ -571,7 +650,7 @@ function CooldownCompanion:NormalizeStandaloneAuraButtonData(buttonData, sibling
     end
 
     if buttonData.auraUnit ~= "player" and buttonData.auraUnit ~= "target" then
-        buttonData.auraUnit = C_Spell.IsSpellHarmful(buttonData.id) and "target" or "player"
+        buttonData.auraUnit = self:ResolveStandaloneAuraDefaultUnit(buttonData)
         changed = true
     end
 

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1188,9 +1188,6 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
                 if overrideBuffs then
                     newButton.auraSpellID = overrideBuffs
                 end
-                if C_Spell.IsSpellHarmful(id) then
-                    newButton.auraUnit = "target"
-                end
             end
         end
     end
@@ -1199,9 +1196,18 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
         group.buttons[buttonIndex].auraTracking = false
     end
 
+    local newButton = group.buttons[buttonIndex]
+    if buttonType == "spell"
+        and newButton
+        and newButton.addedAs == "aura"
+        and newButton.auraUnit ~= "player"
+        and newButton.auraUnit ~= "target" then
+        newButton.auraUnit = self:ResolveStandaloneAuraDefaultUnit(newButton)
+    end
+
     if buttonType == "spell" and forceAura ~= false then
         self:NormalizeStandaloneAuraButtonData(
-            group.buttons[buttonIndex],
+            newButton,
             group.buttons,
             { trustExplicitAuraLabel = true }
         )


### PR DESCRIPTION
## What Players Will Notice
- Standalone Shatter aura entries now default to tracking the target debuff instead of acting like a player buff.
- When Shatter is added as its own aura entry, it now tracks the real debuff application correctly rather than requiring a workaround through another spell's aura override.

## Why This Changed
- Blizzard exposes Shatter as a specialization passive, but the actual debuff being tracked is Freezing on the target.
- Cooldown Companion was choosing the default aura unit from the added spell ID instead of the resolved tracked aura behind it, which caused standalone Shatter entries to default to `player` and fail to track the debuff.

## What Changed
- Added a resolved-aura defaulting helper for standalone aura entries.
- Standalone aura adds now choose `player` versus `target` from the resolved tracked aura spell when Blizzard exposes a different linked aura through cooldown-viewer metadata.
- Updated standalone aura normalization to use the same resolved-aura unit selection so new standalone entries and later normalization stay aligned.

## Validation
- In-game verified that standalone Shatter now saves as an aura-tracked entry with `auraUnit = target`.
- In-game verified that the Freezing debuff tracks correctly on the target, including the intended standalone add flow.
- In-game verified that a spell entry with an associated target debuff still chooses `Target` when aura tracking is enabled.
- In-game verified that a spell entry with an associated player aura still chooses `Player` when aura tracking is enabled.
- Combat / restricted-content verification has not been explicitly re-run for this change.