### PR TITLE
Add player or target selection for resource aura overlays

### DIFF
--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -69,6 +69,9 @@ local SPEC_RESOURCES_CONFIG = RB.SPEC_RESOURCES_CONFIG
 local IsAstralPowerAvailableForCurrentDruidSpec = RB.IsAstralPowerAvailableForCurrentDruidSpec
 
 local ResolveSpecOverrideKey = ST._ResolveSpecOverrideKey
+local GetResolvedResourceAuraUnit = RB.GetResolvedResourceAuraUnit
+local EnsureResourceAuraUnit = RB.EnsureResourceAuraUnit
+local RefreshResourceAuraUnitForSpell = RB.RefreshResourceAuraUnitForSpell
 
 ------------------------------------------------------------------------
 -- Aura bar autocomplete cache (TrackedBuff + TrackedBar spells only)
@@ -367,6 +370,30 @@ local function GetResourceAuraEntryConfig(resource, specID)
     return nil
 end
 
+local function GetOrCreateResourceAuraEntryConfig(resource, specID)
+    if type(resource) ~= "table" or not specID then
+        return nil
+    end
+
+    if type(resource.auraOverlayEntries) ~= "table" then
+        resource.auraOverlayEntries = {}
+    end
+
+    local entry = resource.auraOverlayEntries[specID]
+    if type(entry) ~= "table" then
+        entry = resource.auraOverlayEntries[tostring(specID)]
+        if type(entry) == "table" then
+            resource.auraOverlayEntries[tostring(specID)] = nil
+            resource.auraOverlayEntries[specID] = entry
+        else
+            entry = {}
+            resource.auraOverlayEntries[specID] = entry
+        end
+    end
+
+    return entry
+end
+
 local function IsResourceAuraOverlayEnabledConfig(resource)
     if type(resource) ~= "table" then
         return false
@@ -496,6 +523,7 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
     end
 
     local spellID = tonumber(entry and entry.auraColorSpellID) or nil
+    local resolvedAuraUnit = GetResolvedResourceAuraUnit and GetResolvedResourceAuraUnit(entry, spellID) or "player"
     local spellEdit = AceGUI:Create("EditBox")
     if spellEdit.editbox.Instructions then spellEdit.editbox.Instructions:Hide() end
     spellEdit:SetLabel(resourceName .. " Aura (Spell ID or Name)")
@@ -539,6 +567,34 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
     end
 
     AddCdmAuraReadinessWarning(container, spellID)
+
+    local auraUnitDrop = AceGUI:Create("Dropdown")
+    auraUnitDrop:SetLabel("Aura Unit")
+    auraUnitDrop:SetList({
+        player = "Player",
+        target = "Target",
+    }, { "player", "target" })
+    auraUnitDrop:SetValue(resolvedAuraUnit)
+    auraUnitDrop:SetFullWidth(true)
+    auraUnitDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        if val ~= "player" and val ~= "target" then
+            return
+        end
+        if options.onAuraUnitChanged then
+            options.onAuraUnitChanged(val)
+        end
+    end)
+    container:AddChild(auraUnitDrop)
+    CreateInfoButton(auraUnitDrop.frame, auraUnitDrop.label, "LEFT", "RIGHT",
+        4, 0, {
+        "Aura Unit",
+        {"This controls where the tracked aura is expected to exist. Use Target for debuffs on your target, or Player for buffs and procs on yourself.", 1, 1, 1, true},
+    }, tabInfoButtons)
+
+    local auraUnitSpacer = AceGUI:Create("Label")
+    auraUnitSpacer:SetText(" ")
+    auraUnitSpacer:SetFullWidth(true)
+    container:AddChild(auraUnitSpacer)
 
     local _auraProxy = { auraActiveColor = GetSafeRGBConfig(entry and entry.auraActiveColor, DEFAULT_RESOURCE_AURA_ACTIVE_COLOR) }
     AddColorPicker(container, _auraProxy, "auraActiveColor", resourceName .. " Aura Active Color", DEFAULT_RESOURCE_AURA_ACTIVE_COLOR, false,
@@ -621,6 +677,8 @@ local function ClearLegacyResourceAuraFieldsConfig(resource)
     resource.auraActiveColor = nil
     resource.auraColorTrackingMode = nil
     resource.auraColorMaxStacks = nil
+    resource.auraUnit = nil
+    resource.auraUnitExplicit = nil
 end
 
 local function ClearResourceAuraEntryConfig(powerType, resource, specID)
@@ -690,41 +748,59 @@ local function AddResourceAuraOverrideControls(container, settings, powerType, r
 
     AddResourceAuraEntryFields(container, powerType, resourceName, entryForSpec, {
         onSpellChanged = function(id)
-            if not res.auraOverlayEntries then res.auraOverlayEntries = {} end
-            if not res.auraOverlayEntries[currentSpecID] then
-                res.auraOverlayEntries[currentSpecID] = {}
+            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+            if not entry then
+                return
             end
-            res.auraOverlayEntries[currentSpecID].auraColorSpellID = id
+            entry.auraColorSpellID = id
+            if RefreshResourceAuraUnitForSpell then
+                RefreshResourceAuraUnitForSpell(entry, id)
+            end
+            ClearLegacyResourceAuraFieldsConfig(res)
+            CooldownCompanion:ApplyResourceBars()
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+        onAuraUnitChanged = function(val)
+            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+            if not entry then
+                return
+            end
+            if EnsureResourceAuraUnit then
+                EnsureResourceAuraUnit(entry, entry.auraColorSpellID, val, true)
+            else
+                entry.auraUnit = val
+                entry.auraUnitExplicit = true
+            end
             ClearLegacyResourceAuraFieldsConfig(res)
             CooldownCompanion:ApplyResourceBars()
             CooldownCompanion:RefreshConfigPanel()
         end,
         onColorChanged = function(r, g, b)
-            if not res.auraOverlayEntries then res.auraOverlayEntries = {} end
-            if not res.auraOverlayEntries[currentSpecID] then
-                res.auraOverlayEntries[currentSpecID] = {}
+            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+            if not entry then
+                return
             end
-            res.auraOverlayEntries[currentSpecID].auraActiveColor = { r, g, b }
+            entry.auraActiveColor = { r, g, b }
         end,
         onColorConfirmed = function(r, g, b)
-            if not res.auraOverlayEntries then res.auraOverlayEntries = {} end
-            if not res.auraOverlayEntries[currentSpecID] then
-                res.auraOverlayEntries[currentSpecID] = {}
+            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+            if not entry then
+                return
             end
-            res.auraOverlayEntries[currentSpecID].auraActiveColor = { r, g, b }
+            entry.auraActiveColor = { r, g, b }
             ClearLegacyResourceAuraFieldsConfig(res)
             CooldownCompanion:ApplyResourceBars()
         end,
         onTrackingChanged = function(val)
-            if not res.auraOverlayEntries then res.auraOverlayEntries = {} end
-            if not res.auraOverlayEntries[currentSpecID] then
-                res.auraOverlayEntries[currentSpecID] = {}
+            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+            if not entry then
+                return
             end
-            res.auraOverlayEntries[currentSpecID].auraColorTrackingMode = val
+            entry.auraColorTrackingMode = val
             if val == "stacks" then
-                local current = tonumber(res.auraOverlayEntries[currentSpecID].auraColorMaxStacks)
+                local current = tonumber(entry.auraColorMaxStacks)
                 if not current or current < 2 then
-                    res.auraOverlayEntries[currentSpecID].auraColorMaxStacks = 2
+                    entry.auraColorMaxStacks = 2
                 end
             end
             ClearLegacyResourceAuraFieldsConfig(res)
@@ -732,11 +808,11 @@ local function AddResourceAuraOverrideControls(container, settings, powerType, r
             CooldownCompanion:RefreshConfigPanel()
         end,
         onMaxStacksChanged = function(parsed)
-            if not res.auraOverlayEntries then res.auraOverlayEntries = {} end
-            if not res.auraOverlayEntries[currentSpecID] then
-                res.auraOverlayEntries[currentSpecID] = {}
+            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+            if not entry then
+                return
             end
-            res.auraOverlayEntries[currentSpecID].auraColorMaxStacks = parsed
+            entry.auraColorMaxStacks = parsed
             ClearLegacyResourceAuraFieldsConfig(res)
             CooldownCompanion:ApplyResourceBars()
             CooldownCompanion:RefreshConfigPanel()

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -1313,6 +1313,8 @@ local function ClearLegacyResourceAuraOverlayFields(resource)
     resource.auraActiveColor = nil
     resource.auraColorTrackingMode = nil
     resource.auraColorMaxStacks = nil
+    resource.auraUnit = nil
+    resource.auraUnitExplicit = nil
 end
 
 function CooldownCompanion:MigrateResourceAuraOverlayEntries()

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -14,6 +14,17 @@ local function GetEnsureCustomAuraBarAuraUnit()
     return rb and rb.EnsureCustomAuraBarAuraUnit
 end
 
+local function BackfillLegacyResourceAuraUnit(resourceAuraEntry)
+    if type(resourceAuraEntry) ~= "table" then
+        return
+    end
+    if resourceAuraEntry.auraUnit == "player" or resourceAuraEntry.auraUnit == "target" then
+        return
+    end
+    resourceAuraEntry.auraUnit = "player"
+    resourceAuraEntry.auraUnitExplicit = nil
+end
+
 local SCOPED_BAR_SYSTEMS = {
     resourceBars = {
         storeKey = "resourceBarsByChar",
@@ -254,6 +265,8 @@ local function ClearLegacyResourceAuraOverlayFields(resource)
     resource.auraActiveColor = nil
     resource.auraColorTrackingMode = nil
     resource.auraColorMaxStacks = nil
+    resource.auraUnit = nil
+    resource.auraUnitExplicit = nil
 end
 
 local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
@@ -284,6 +297,7 @@ local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
                             filteredEntries = {}
                         end
                         filteredEntries[numericSpecID] = CopyTable(entry)
+                        BackfillLegacyResourceAuraUnit(filteredEntries[numericSpecID])
                     end
                 end
             end
@@ -303,6 +317,7 @@ local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
                         auraColorMaxStacks = resource.auraColorMaxStacks,
                     },
                 }
+                BackfillLegacyResourceAuraUnit(resource.auraOverlayEntries[currentSpecID])
                 ClearLegacyResourceAuraOverlayFields(resource)
                 hasLegacyData = false
             end

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -194,6 +194,73 @@ local function RefreshCustomAuraBarAuraUnitForSpell(cabConfig, spellID)
     return EnsureCustomAuraBarAuraUnit(cabConfig, resolvedSpellID, GetDefaultCustomAuraUnit(resolvedSpellID), false)
 end
 
+local function IsValidResourceAuraUnit(unit)
+    return unit == "player" or unit == "target"
+end
+
+local function GetDefaultResourceAuraUnit(spellID)
+    return (spellID and C_Spell.IsSpellHarmful(spellID)) and "target" or "player"
+end
+
+local function HasExplicitResourceAuraUnit(resourceAuraEntry)
+    return type(resourceAuraEntry) == "table"
+        and resourceAuraEntry.auraUnitExplicit == true
+        and IsValidResourceAuraUnit(resourceAuraEntry.auraUnit)
+end
+
+local function GetResolvedResourceAuraUnit(resourceAuraEntry, spellID)
+    local resolvedSpellID = spellID
+    if resolvedSpellID == nil and type(resourceAuraEntry) == "table" then
+        resolvedSpellID = tonumber(resourceAuraEntry.auraColorSpellID) or nil
+    end
+
+    if type(resourceAuraEntry) == "table" and IsValidResourceAuraUnit(resourceAuraEntry.auraUnit) then
+        return resourceAuraEntry.auraUnit
+    end
+
+    return GetDefaultResourceAuraUnit(resolvedSpellID)
+end
+
+local function EnsureResourceAuraUnit(resourceAuraEntry, spellID, unit, explicit)
+    local resolvedSpellID = spellID
+    if resolvedSpellID == nil and type(resourceAuraEntry) == "table" then
+        resolvedSpellID = tonumber(resourceAuraEntry.auraColorSpellID) or nil
+    end
+
+    if type(resourceAuraEntry) == "table" then
+        local wasExplicit = HasExplicitResourceAuraUnit(resourceAuraEntry)
+        local resolvedUnit = IsValidResourceAuraUnit(unit) and unit
+            or GetResolvedResourceAuraUnit(resourceAuraEntry, resolvedSpellID)
+
+        resourceAuraEntry.auraUnit = resolvedUnit
+
+        if IsValidResourceAuraUnit(unit) then
+            resourceAuraEntry.auraUnitExplicit = explicit == false and nil or true
+        elseif not wasExplicit then
+            resourceAuraEntry.auraUnitExplicit = nil
+        end
+
+        if IsValidResourceAuraUnit(resourceAuraEntry.auraUnit) then
+            return resourceAuraEntry.auraUnit
+        end
+    end
+
+    return GetDefaultResourceAuraUnit(resolvedSpellID)
+end
+
+local function RefreshResourceAuraUnitForSpell(resourceAuraEntry, spellID)
+    local resolvedSpellID = spellID
+    if resolvedSpellID == nil and type(resourceAuraEntry) == "table" then
+        resolvedSpellID = tonumber(resourceAuraEntry.auraColorSpellID) or nil
+    end
+
+    if HasExplicitResourceAuraUnit(resourceAuraEntry) then
+        return resourceAuraEntry.auraUnit
+    end
+
+    return EnsureResourceAuraUnit(resourceAuraEntry, resolvedSpellID, GetDefaultResourceAuraUnit(resolvedSpellID), false)
+end
+
 local function CreateDefaultLayoutOrder()
     return {
         resources = {},
@@ -638,6 +705,12 @@ RB.GetDefaultCustomAuraUnit = GetDefaultCustomAuraUnit
 RB.GetResolvedCustomAuraBarAuraUnit = GetResolvedCustomAuraBarAuraUnit
 RB.EnsureCustomAuraBarAuraUnit = EnsureCustomAuraBarAuraUnit
 RB.RefreshCustomAuraBarAuraUnitForSpell = RefreshCustomAuraBarAuraUnitForSpell
+RB.IsValidResourceAuraUnit = IsValidResourceAuraUnit
+RB.GetDefaultResourceAuraUnit = GetDefaultResourceAuraUnit
+RB.HasExplicitResourceAuraUnit = HasExplicitResourceAuraUnit
+RB.GetResolvedResourceAuraUnit = GetResolvedResourceAuraUnit
+RB.EnsureResourceAuraUnit = EnsureResourceAuraUnit
+RB.RefreshResourceAuraUnitForSpell = RefreshResourceAuraUnitForSpell
 RB.CreateDefaultLayoutOrder = CreateDefaultLayoutOrder
 RB.GetSpecLayoutOrder = GetSpecLayoutOrder
 RB.GetAnchorOffset = GetAnchorOffset

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -31,6 +31,7 @@ local GetResourceColors = RB.GetResourceColors
 local GetContinuousTickConfig = RB.GetContinuousTickConfig
 local GetSafeRGBColor = RB.GetSafeRGBColor
 local SupportsResourceAuraStackMode = RB.SupportsResourceAuraStackMode
+local GetResolvedResourceAuraUnit = RB.GetResolvedResourceAuraUnit
 
 ------------------------------------------------------------------------
 -- Resource Aura Overlay
@@ -158,9 +159,11 @@ local function GetResourceAuraState(powerType, settings, auraActiveCache)
         return nil, nil, false
     end
 
+    local configUnit = GetResolvedResourceAuraUnit and GetResolvedResourceAuraUnit(auraEntry, auraSpellID) or "player"
+    local cacheKey = configUnit .. ":" .. auraSpellID
     local cached
     if auraActiveCache then
-        cached = auraActiveCache[auraSpellID]
+        cached = auraActiveCache[cacheKey]
     end
 
     if not cached then
@@ -170,20 +173,23 @@ local function GetResourceAuraState(powerType, settings, auraActiveCache)
             local viewerFrame = CooldownCompanion.viewerAuraFrames and CooldownCompanion.viewerAuraFrames[auraSpellID]
             local instId = viewerFrame and viewerFrame.auraInstanceID
             if instId then
-                local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID("player", instId)
-                if auraData then
-                    cached.active = true
-                    if type(auraData.applications) == "number" then
-                        -- applications can be secret in combat for some auras.
-                        -- Keep as pass-through only (no Lua math/comparisons).
-                        cached.applications = auraData.applications
-                        cached.hasApplications = true
+                local viewerUnit = viewerFrame.auraDataUnit or configUnit
+                if viewerUnit == configUnit then
+                    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
+                    if auraData then
+                        cached.active = true
+                        if type(auraData.applications) == "number" then
+                            -- applications can be secret in combat for some auras.
+                            -- Keep as pass-through only (no Lua math/comparisons).
+                            cached.applications = auraData.applications
+                            cached.hasApplications = true
+                        end
                     end
                 end
             end
         end
 
-        if not cached.active then
+        if not cached.active and configUnit == "player" then
             -- Fallback for non-CDM spell IDs. In combat, secret aura restrictions can
             -- cause this API to return nil for some active auras.
             local auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraSpellID)
@@ -199,7 +205,7 @@ local function GetResourceAuraState(powerType, settings, auraActiveCache)
         end
 
         if auraActiveCache then
-            auraActiveCache[auraSpellID] = cached
+            auraActiveCache[cacheKey] = cached
         end
     end
 


### PR DESCRIPTION
## What Players Will Notice
- Resource Aura Overlays in Bars and Frames can now explicitly track either your own aura or your target's aura instead of relying on an inferred unit.
- Existing overlays keep their previous player-tracked behavior until you intentionally change the setting.

## Why This Changed
- Aura tracking was recently hardened so users have to choose where an aura should be read from.
- That protection already existed in button settings and Custom Aura Bars, but Resource Aura Overlays in Bars and Frames were missing the same safeguard.

## What Changed
- Added an `Aura Unit` dropdown to the Resource Aura Overlays config UI so each per-spec overlay can explicitly use `Player` or `Target`.
- Added shared resource-overlay unit resolution helpers so defaults, manual overrides, and saved state follow the same rules as the rest of the addon.
- Updated the runtime overlay lookup to honor the selected unit and separated the overlay cache by spell and unit so player and target configurations cannot bleed into each other.
- Preserved legacy overlay behavior by backfilling older saved entries to `player` during normalization instead of silently reinterpreting them as target-tracked overlays.

## Validation
- Verified Lua syntax with `luac -p` on all touched files.
- Reviewed the diff against `main` and addressed a migration/backfill regression found during review.
- In-game validation has not been run yet.
- Combat and restricted-content verification is still required before this should be considered complete.
