### PR TITLE
Add a first-run tutorial for creating your first icon panel

### DIFF
--- a/Config/AutoImport.lua
+++ b/Config/AutoImport.lua
@@ -16,6 +16,8 @@ local IsSpellInCDMCooldown = ST._IsSpellInCDMCooldown
 local IsNeverTrackableSpell = ST._IsNeverTrackableSpell
 local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
+local NotifyTutorialAction = ST._NotifyTutorialAction
+local ConsumeTutorialAutoAddSeed = ST._ConsumeTutorialAutoAddSeed
 
 local ICON_FALLBACK = 134400
 local ACTION_BAR_COUNT = 6
@@ -626,6 +628,7 @@ local function ApplyPreviewToGroup(groupID, preview, selectedEntries, suppressRe
 
     local addedSpells, addedAuras, addedItems = 0, 0, 0
     local applySkipped = 0
+    local addedButtonIndexes = {}
 
     for _, entry in ipairs(preview.spells) do
         if selectedEntries[entry.importKey] then
@@ -635,8 +638,13 @@ local function ApplyPreviewToGroup(groupID, preview, selectedEntries, suppressRe
                 if IsSpellInCDMCooldown(entry.id) and IsSpellInCDMBuffBar(entry.id) then
                     forceAura = false
                 end
-                CooldownCompanion:AddButtonToGroup(groupID, "spell", entry.id, spellInfo.name, nil, nil, forceAura)
-                addedSpells = addedSpells + 1
+                local buttonIndex = CooldownCompanion:AddButtonToGroup(groupID, "spell", entry.id, spellInfo.name, nil, nil, forceAura)
+                if buttonIndex then
+                    addedSpells = addedSpells + 1
+                    addedButtonIndexes[#addedButtonIndexes + 1] = buttonIndex
+                else
+                    applySkipped = applySkipped + 1
+                end
             else
                 applySkipped = applySkipped + 1
             end
@@ -648,8 +656,13 @@ local function ApplyPreviewToGroup(groupID, preview, selectedEntries, suppressRe
             local spellInfo = C_Spell.GetSpellInfo(entry.id)
             if spellInfo and spellInfo.name then
                 local isPassive = IsPassiveOrProc(entry.id) and true or nil
-                CooldownCompanion:AddButtonToGroup(groupID, "spell", entry.id, spellInfo.name, nil, isPassive, true)
-                addedAuras = addedAuras + 1
+                local buttonIndex = CooldownCompanion:AddButtonToGroup(groupID, "spell", entry.id, spellInfo.name, nil, isPassive, true)
+                if buttonIndex then
+                    addedAuras = addedAuras + 1
+                    addedButtonIndexes[#addedButtonIndexes + 1] = buttonIndex
+                else
+                    applySkipped = applySkipped + 1
+                end
             else
                 applySkipped = applySkipped + 1
             end
@@ -660,8 +673,13 @@ local function ApplyPreviewToGroup(groupID, preview, selectedEntries, suppressRe
         if selectedEntries[entry.importKey] then
             if C_Item.GetItemSpell(entry.id) then
                 local itemName = C_Item.GetItemNameByID(entry.id) or entry.name or ("Item " .. entry.id)
-                CooldownCompanion:AddButtonToGroup(groupID, "item", entry.id, itemName)
-                addedItems = addedItems + 1
+                local buttonIndex = CooldownCompanion:AddButtonToGroup(groupID, "item", entry.id, itemName)
+                if buttonIndex then
+                    addedItems = addedItems + 1
+                    addedButtonIndexes[#addedButtonIndexes + 1] = buttonIndex
+                else
+                    applySkipped = applySkipped + 1
+                end
             else
                 applySkipped = applySkipped + 1
             end
@@ -680,7 +698,16 @@ local function ApplyPreviewToGroup(groupID, preview, selectedEntries, suppressRe
         .. addedItems .. " items). "
         .. applySkipped .. " skipped during apply."
     )
-    return true
+    return {
+        applied = true,
+        totalAdded = totalAdded,
+        addedSpells = addedSpells,
+        addedAuras = addedAuras,
+        addedItems = addedItems,
+        applySkipped = applySkipped,
+        addedButtonIndexes = addedButtonIndexes,
+        firstAddedButtonIndex = addedButtonIndexes[1],
+    }
 end
 
 local function CountSelectedBars(selectedBars)
@@ -1027,8 +1054,17 @@ local function RenderStep3(container, state)
             return
         end
 
-        if ApplyPreviewToGroup(state.groupID, preview, state.selectedEntries, true) then
+        local applyResult = ApplyPreviewToGroup(state.groupID, preview, state.selectedEntries, true)
+        if applyResult and applyResult.applied then
             PersistAutoAddPrefs(state)
+            if NotifyTutorialAction then
+                NotifyTutorialAction("auto_add_applied", {
+                    groupId = state.groupID,
+                    firstAddedButtonIndex = applyResult.firstAddedButtonIndex,
+                    addedButtonIndexes = applyResult.addedButtonIndexes,
+                    totalAdded = applyResult.totalAdded,
+                })
+            end
             CancelAutoAddFlow()
             RefreshFlowUI()
         end
@@ -1061,13 +1097,14 @@ local function OpenAutoAddFlow()
     end
 
     local prefs = EnsureAutoAddPrefs()
+    local tutorialSeed = ConsumeTutorialAutoAddSeed and ConsumeTutorialAutoAddSeed(groupID)
     CS.autoAddFlowSerial = (tonumber(CS.autoAddFlowSerial) or 0) + 1
     CS.autoAddFlowActive = true
     CS.autoAddFlowState = {
         groupID = groupID,
         step = AUTO_ADD_STEP_SOURCE,
-        source = NormalizeSource(prefs.lastSource),
-        selectedBars = NormalizeBarSelection(prefs.selectedBars),
+        source = NormalizeSource((tutorialSeed and tutorialSeed.source) or prefs.lastSource),
+        selectedBars = NormalizeBarSelection((tutorialSeed and tutorialSeed.selectedBars) or prefs.selectedBars),
         selectedEntries = {},
         preview = nil,
         hasInteractedStep2 = false,

--- a/Config/AutoImport.lua
+++ b/Config/AutoImport.lua
@@ -16,8 +16,6 @@ local IsSpellInCDMCooldown = ST._IsSpellInCDMCooldown
 local IsNeverTrackableSpell = ST._IsNeverTrackableSpell
 local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
-local NotifyTutorialAction = ST._NotifyTutorialAction
-local ConsumeTutorialAutoAddSeed = ST._ConsumeTutorialAutoAddSeed
 
 local ICON_FALLBACK = 134400
 local ACTION_BAR_COUNT = 6
@@ -1057,14 +1055,6 @@ local function RenderStep3(container, state)
         local applyResult = ApplyPreviewToGroup(state.groupID, preview, state.selectedEntries, true)
         if applyResult and applyResult.applied then
             PersistAutoAddPrefs(state)
-            if NotifyTutorialAction then
-                NotifyTutorialAction("auto_add_applied", {
-                    groupId = state.groupID,
-                    firstAddedButtonIndex = applyResult.firstAddedButtonIndex,
-                    addedButtonIndexes = applyResult.addedButtonIndexes,
-                    totalAdded = applyResult.totalAdded,
-                })
-            end
             CancelAutoAddFlow()
             RefreshFlowUI()
         end
@@ -1097,14 +1087,13 @@ local function OpenAutoAddFlow()
     end
 
     local prefs = EnsureAutoAddPrefs()
-    local tutorialSeed = ConsumeTutorialAutoAddSeed and ConsumeTutorialAutoAddSeed(groupID)
     CS.autoAddFlowSerial = (tonumber(CS.autoAddFlowSerial) or 0) + 1
     CS.autoAddFlowActive = true
     CS.autoAddFlowState = {
         groupID = groupID,
         step = AUTO_ADD_STEP_SOURCE,
-        source = NormalizeSource((tutorialSeed and tutorialSeed.source) or prefs.lastSource),
-        selectedBars = NormalizeBarSelection((tutorialSeed and tutorialSeed.selectedBars) or prefs.selectedBars),
+        source = NormalizeSource(prefs.lastSource),
+        selectedBars = NormalizeBarSelection(prefs.selectedBars),
         selectedEntries = {},
         preview = nil,
         hasInteractedStep2 = false,

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -32,6 +32,7 @@ local EncodeExportData = ST._EncodeExportData
 local ContainersHaveForeignSpecs = ST._ContainersHaveForeignSpecs
 local FolderHasForeignSpecs = ST._FolderHasForeignSpecs
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
+local NotifyTutorialAction = ST._NotifyTutorialAction
 
 ------------------------------------------------------------------------
 -- Clear all selection state (container, panel, button, multi-select)
@@ -1828,6 +1829,12 @@ local function RefreshColumn1(preserveDrag)
             CS.selectedButton = nil
             wipe(CS.selectedButtons)
             CooldownCompanion:RefreshConfigPanel()
+            if NotifyTutorialAction then
+                NotifyTutorialAction("group_created", {
+                    containerId = containerId,
+                    groupId = groupId,
+                })
+            end
         end)
         newGroupBtn.frame:SetParent(CS.col1ButtonBar)
         newGroupBtn.frame:ClearAllPoints()
@@ -1835,6 +1842,9 @@ local function RefreshColumn1(preserveDrag)
         newGroupBtn.frame:SetWidth(thirdW)
         newGroupBtn.frame:SetHeight(28)
         newGroupBtn.frame:Show()
+        if CS.tutorialAnchors then
+            CS.tutorialAnchors.new_group_button = newGroupBtn.frame
+        end
         table.insert(CS.col1BarWidgets, newGroupBtn)
 
         local newFolderBtn = AceGUI:Create("Button")

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -2362,11 +2362,6 @@ local function RefreshColumn2()
                         autoAddBtn:SetCallback("OnClick", function()
                             CS.selectedGroup = CS.addingToPanelId
                             OpenAutoAddFlow()
-                            if NotifyTutorialAction then
-                                NotifyTutorialAction("auto_add_opened", {
-                                    groupId = CS.addingToPanelId,
-                                })
-                            end
                         end)
                         autoAddBtn:SetCallback("OnEnter", function(widget)
                             GameTooltip:SetOwner(widget.frame, "ANCHOR_TOP")

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -2359,6 +2359,10 @@ local function RefreshColumn2()
                         local autoAddBtn = AceGUI:Create("Button")
                         autoAddBtn:SetText("Auto Add")
                         autoAddBtn:SetRelativeWidth(0.49)
+                        local tutorialRuntime = CS.tutorialRuntime
+                        local deemphasizeAutoAdd = tutorialRuntime
+                            and tutorialRuntime.active
+                            and (tutorialRuntime.step == "add_box_intro" or tutorialRuntime.step == "add_one_spell")
                         autoAddBtn:SetCallback("OnClick", function()
                             CS.selectedGroup = CS.addingToPanelId
                             OpenAutoAddFlow()
@@ -2367,11 +2371,17 @@ local function RefreshColumn2()
                             GameTooltip:SetOwner(widget.frame, "ANCHOR_TOP")
                             GameTooltip:AddLine("Auto Add")
                             GameTooltip:AddLine("Auto-add from Action Bars, Spellbook, or CDM Auras.", 1, 1, 1, true)
+                            if deemphasizeAutoAdd then
+                                GameTooltip:AddLine("Optional during the tutorial. The guided path uses the add box above.", 0.8, 0.8, 0.8, true)
+                            end
                             GameTooltip:Show()
                         end)
                         autoAddBtn:SetCallback("OnLeave", function()
                             GameTooltip:Hide()
                         end)
+                        if autoAddBtn.frame then
+                            autoAddBtn.frame:SetAlpha(deemphasizeAutoAdd and 0.62 or 1)
+                        end
                         panelMeta.autoAddButtonFrame = autoAddBtn.frame
                         addRow:AddChild(autoAddBtn)
                     end

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -30,6 +30,7 @@ local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
 local GroupsHaveForeignSpecs = ST._GroupsHaveForeignSpecs
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
+local NotifyTutorialAction = ST._NotifyTutorialAction
 
 local function HideAllBarWidgets(col2)
     if col2._barsStylingScroll then col2._barsStylingScroll.frame:Hide() end
@@ -1051,9 +1052,18 @@ local function RefreshColumn2()
                 local newPanelId = CooldownCompanion:CreatePanel(CS.selectedContainer, "icons")
                 if newPanelId then
                     CS.selectedGroup = newPanelId
+                    CS.selectedButton = nil
+                    wipe(CS.selectedButtons)
                     CS.addingToPanelId = newPanelId
                     CS.pendingEditBoxFocus = true
                     CooldownCompanion:RefreshConfigPanel()
+                    if NotifyTutorialAction then
+                        NotifyTutorialAction("panel_created", {
+                            containerId = CS.selectedContainer,
+                            panelId = newPanelId,
+                            displayMode = "icons",
+                        })
+                    end
                 end
             end
 
@@ -1114,6 +1124,9 @@ local function RefreshColumn2()
             iconPanelBtn.frame:SetWidth(panelBtnWidth)
             iconPanelBtn.frame:SetHeight(28)
             iconPanelBtn.frame:Show()
+            if CS.tutorialAnchors then
+                CS.tutorialAnchors.icon_panel_button = iconPanelBtn.frame
+            end
             table.insert(CS.col2BarWidgets, iconPanelBtn)
 
             local barPanelBtn = AceGUI:Create("Button")
@@ -1307,6 +1320,10 @@ local function RefreshColumn2()
                 isCollapsed = isCollapsed and true or false,
                 displayMode = panel.displayMode,
                 buttonRows = {},
+                addRowFrame = nil,
+                addInputFrame = nil,
+                manualAddButtonFrame = nil,
+                autoAddButtonFrame = nil,
             }
 
             -- Class-colored accent separator between panels
@@ -2250,6 +2267,22 @@ local function RefreshColumn2()
                     inputBox:SetText(CS.newInput)
                     inputBox:DisableButton(true)
                     inputBox:SetFullWidth(true)
+                    panelMeta.addInputFrame = inputBox.frame
+
+                    local function NotifyTutorialInlineAddSuccess(addTargetGroupId, rawInput)
+                        if not NotifyTutorialAction then
+                            return
+                        end
+                        local selectedButton = CS.selectedButton
+                        if addTargetGroupId and selectedButton then
+                            NotifyTutorialAction("inline_add_succeeded", {
+                                groupId = addTargetGroupId,
+                                buttonIndex = selectedButton,
+                                rawInput = rawInput,
+                            })
+                        end
+                    end
+
                     inputBox:SetCallback("OnEnterPressed", function(widget, event, text)
                         if CS.ConsumeAutocompleteEnter() then return end
                         CS.HideAutocomplete()
@@ -2258,6 +2291,7 @@ local function RefreshColumn2()
                             local addTargetGroupId = CS.addingToPanelId
                             CS.selectedGroup = addTargetGroupId
                             if TryAdd(CS.newInput) then
+                                NotifyTutorialInlineAddSuccess(addTargetGroupId, CS.newInput)
                                 CS.newInput = ""
                                 local targetGroup = CooldownCompanion.db.profile.groups[addTargetGroupId]
                                 if not (targetGroup and targetGroup.displayMode == "textures") then
@@ -2298,15 +2332,18 @@ local function RefreshColumn2()
                     local addRow = AceGUI:Create("SimpleGroup")
                     addRow:SetFullWidth(true)
                     addRow:SetLayout("Flow")
+                    panelMeta.addRowFrame = addRow.frame
 
                     local manualAddBtn = AceGUI:Create("Button")
                     manualAddBtn:SetText("Manual Add")
                     manualAddBtn:SetRelativeWidth(panel.displayMode == "textures" and 1 or 0.49)
+                    panelMeta.manualAddButtonFrame = manualAddBtn.frame
                     manualAddBtn:SetCallback("OnClick", function()
                         if CS.newInput ~= "" and CS.addingToPanelId then
                             local addTargetGroupId = CS.addingToPanelId
                             CS.selectedGroup = addTargetGroupId
                             if TryAdd(CS.newInput) then
+                                NotifyTutorialInlineAddSuccess(addTargetGroupId, CS.newInput)
                                 CS.newInput = ""
                                 local targetGroup = CooldownCompanion.db.profile.groups[addTargetGroupId]
                                 if not (targetGroup and targetGroup.displayMode == "textures") then
@@ -2325,6 +2362,11 @@ local function RefreshColumn2()
                         autoAddBtn:SetCallback("OnClick", function()
                             CS.selectedGroup = CS.addingToPanelId
                             OpenAutoAddFlow()
+                            if NotifyTutorialAction then
+                                NotifyTutorialAction("auto_add_opened", {
+                                    groupId = CS.addingToPanelId,
+                                })
+                            end
                         end)
                         autoAddBtn:SetCallback("OnEnter", function(widget)
                             GameTooltip:SetOwner(widget.frame, "ANCHOR_TOP")
@@ -2335,6 +2377,7 @@ local function RefreshColumn2()
                         autoAddBtn:SetCallback("OnLeave", function()
                             GameTooltip:Hide()
                         end)
+                        panelMeta.autoAddButtonFrame = autoAddBtn.frame
                         addRow:AddChild(autoAddBtn)
                     end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -860,30 +860,6 @@ local function CreateConfigPanel()
     end)
     browseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
-    local tutorialBtn = CreateFrame("Button", nil, content, "MainHelpPlateButton")
-    tutorialBtn:SetScale(0.5)
-    tutorialBtn:SetFrameLevel(content:GetFrameLevel() + 5)
-    if tutorialBtn.BigIPulse then
-        tutorialBtn.BigIPulse:Hide()
-    end
-    if tutorialBtn.RingPulse then
-        tutorialBtn.RingPulse:Hide()
-    end
-    tutorialBtn:SetScript("OnClick", function()
-        CloseDropDownMenus()
-        if StartFirstIconPanelTutorial then
-            StartFirstIconPanelTutorial(true)
-        end
-    end)
-    tutorialBtn:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
-        GameTooltip:AddLine("Tutorial")
-        GameTooltip:AddLine("Replay the first icon panel tutorial.", 1, 1, 1, true)
-        GameTooltip:Show()
-    end)
-    tutorialBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
-    CS.tutorialButton = tutorialBtn
-
     local changelogOverlay
     local changelogBtn
     local changelogBtnBorder = nil
@@ -931,12 +907,12 @@ local function CreateConfigPanel()
     cdmBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
     browseBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
     cdmDisplayBtn:SetPoint("RIGHT", browseBtn, "LEFT", -4, 0)
-    tutorialBtn:SetPoint("RIGHT", cdmDisplayBtn, "LEFT", 4, 1)
     local gearIcon = gearBtn:CreateTexture(nil, "ARTWORK")
     gearIcon:SetTexture("Interface\\WorldMap\\GEAR_64GREY")
     gearIcon:SetAllPoints()
     gearBtn:SetHighlightTexture("Interface\\WorldMap\\GEAR_64GREY")
     gearBtn:GetHighlightTexture():SetAlpha(0.3)
+    CS.gearButton = gearBtn
 
     -- Gear dropdown menu
     gearBtn:SetScript("OnClick", function()
@@ -984,13 +960,24 @@ local function CreateConfigPanel()
             UIDropDownMenu_AddButton(info3, level)
 
             local info4 = UIDropDownMenu_CreateInfo()
-            info4.text = "  Join Discord"
+            info4.text = "  Replay Tutorial"
             info4.notCheckable = true
             info4.func = function()
                 CloseDropDownMenus()
-                ShowPopupAboveConfig("CDC_DISCORD_INVITE")
+                if StartFirstIconPanelTutorial then
+                    StartFirstIconPanelTutorial(true)
+                end
             end
             UIDropDownMenu_AddButton(info4, level)
+
+            local info5 = UIDropDownMenu_CreateInfo()
+            info5.text = "  Join Discord"
+            info5.notCheckable = true
+            info5.func = function()
+                CloseDropDownMenus()
+                ShowPopupAboveConfig("CDC_DISCORD_INVITE")
+            end
+            UIDropDownMenu_AddButton(info5, level)
         end, "MENU")
         CS.gearDropdownFrame:SetFrameStrata("FULLSCREEN_DIALOG")
         ToggleDropDownMenu(1, nil, CS.gearDropdownFrame, gearBtn, 0, 0)

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -407,6 +407,9 @@ end
 
 -- Shared reset for profile change/copy/reset callbacks
 local function ResetConfigForProfileChange()
+    if CancelFirstIconPanelTutorial then
+        CancelFirstIconPanelTutorial("profile_changed")
+    end
     ResetConfigSelection(true)
     wipe(CS.collapsedFolders)
     wipe(CS.collapsedPanels)

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -26,6 +26,11 @@ local UpdateCol2CursorPreview = ST._UpdateCol2CursorPreview
 local ClearCol2AnimatedPreview = ST._ClearCol2AnimatedPreview
 local ClearConfigShiftTooltipHover = ST._ClearConfigShiftTooltipHover
 local GetConfigEntryDisplayName = ST._GetConfigEntryDisplayName
+local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
+local StartFirstIconPanelTutorial = ST._StartFirstIconPanelTutorial
+local CancelFirstIconPanelTutorial = ST._CancelFirstIconPanelTutorial
+local RebuildTutorialAnchors = ST._RebuildTutorialAnchors
+local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -510,6 +515,9 @@ local function CreateConfigPanel()
     -- isCollapsing flag prevents cleanup when collapsing (vs truly closing)
     local isCollapsing = false
     content:HookScript("OnHide", function()
+        if CancelFirstIconPanelTutorial then
+            CancelFirstIconPanelTutorial(isCollapsing and "config_collapsed" or "config_hidden")
+        end
         if isCollapsing then return end
         if frame.HideChangelogOverlay then
             frame.HideChangelogOverlay()
@@ -849,6 +857,30 @@ local function CreateConfigPanel()
     end)
     browseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
+    local tutorialBtn = CreateFrame("Button", nil, content, "MainHelpPlateButton")
+    tutorialBtn:SetScale(0.5)
+    tutorialBtn:SetFrameLevel(content:GetFrameLevel() + 5)
+    if tutorialBtn.BigIPulse then
+        tutorialBtn.BigIPulse:Hide()
+    end
+    if tutorialBtn.RingPulse then
+        tutorialBtn.RingPulse:Hide()
+    end
+    tutorialBtn:SetScript("OnClick", function()
+        CloseDropDownMenus()
+        if StartFirstIconPanelTutorial then
+            StartFirstIconPanelTutorial(true)
+        end
+    end)
+    tutorialBtn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
+        GameTooltip:AddLine("Tutorial")
+        GameTooltip:AddLine("Replay the first icon panel tutorial.", 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    tutorialBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
+    CS.tutorialButton = tutorialBtn
+
     local changelogOverlay
     local changelogBtn
     local changelogBtnBorder = nil
@@ -896,6 +928,7 @@ local function CreateConfigPanel()
     cdmBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
     browseBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
     cdmDisplayBtn:SetPoint("RIGHT", browseBtn, "LEFT", -4, 0)
+    tutorialBtn:SetPoint("RIGHT", cdmDisplayBtn, "LEFT", 4, 1)
     local gearIcon = gearBtn:CreateTexture(nil, "ARTWORK")
     gearIcon:SetTexture("Interface\\WorldMap\\GEAR_64GREY")
     gearIcon:SetAllPoints()
@@ -2248,6 +2281,13 @@ function CooldownCompanion:RefreshConfigPanel()
     end
     RestoreScrollState(buttonSettingsScroll, savedBtn)
 
+    if RebuildTutorialAnchors then
+        RebuildTutorialAnchors()
+    end
+    if RefreshTutorialPlacement then
+        RefreshTutorialPlacement()
+    end
+
 end
 
 ------------------------------------------------------------------------
@@ -2270,6 +2310,9 @@ function CooldownCompanion:ToggleConfig()
             end
             CooldownCompanion:RefreshConfigPanel()
             MaybeAutoOpenChangelog()
+            if MaybeAutoStartFirstIconPanelTutorial then
+                MaybeAutoStartFirstIconPanelTutorial()
+            end
         end)
         return -- AceGUI Frame is already shown on creation
     end
@@ -2290,6 +2333,9 @@ function CooldownCompanion:ToggleConfig()
         CS.configFrame.frame:Show()
         self:RefreshConfigPanel()
         MaybeAutoOpenChangelog()
+        if MaybeAutoStartFirstIconPanelTutorial then
+            MaybeAutoStartFirstIconPanelTutorial()
+        end
     end
 end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1143,6 +1143,7 @@ local function CreateConfigPanel()
     profileBar:SetPoint("LEFT", profileGear, "RIGHT", 8, 0)
     profileBar:SetPoint("RIGHT", content, "RIGHT", -20, 0)
     profileBar:Hide()
+    CS.profileBar = profileBar
 
     local function SyncModeToggleWithProfileBar()
         if not modeStatusRow then return end
@@ -1182,6 +1183,7 @@ local function CreateConfigPanel()
     modeToggleButton.frame:ClearAllPoints()
     modeToggleButton.frame:SetPoint("LEFT", modeStatusRow, "LEFT", 0, 0)
     modeToggleButton.frame:Show()
+    CS.modeToggleButton = modeToggleButton.frame
 
     modeValueText = modeToggleButton.text
 

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -15,6 +15,7 @@ local IsNeverTrackableSpell = ST._IsNeverTrackableSpell
 local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local GetButtonIcon = ST._GetButtonIcon
 local CDM_VIEWER_NAMES = ST._CDM_VIEWER_NAMES
+local NotifyTutorialAction = ST._NotifyTutorialAction
 
 -- After a successful add, set selection state to the new button so the
 -- next RefreshConfigPanel shows its settings in Column 3.
@@ -697,6 +698,13 @@ local function OnAutocompleteSelect(entry)
         added = TryAddSpell(tostring(entry.id), entry.isPetSpell, entry.forceAura)
     end
     if added then
+        if NotifyTutorialAction and CS.selectedGroup and CS.selectedButton then
+            NotifyTutorialAction("inline_add_succeeded", {
+                groupId = CS.selectedGroup,
+                buttonIndex = CS.selectedButton,
+                rawInput = entry.name,
+            })
+        end
         CS.newInput = ""
         CS.pendingEditBoxFocus = true
         CooldownCompanion:RefreshConfigPanel()

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -130,6 +130,12 @@ ST._configState = {
     buttonSettingsTab = "settings",
     panelSettingsTab = "appearance",
     newInput = "",
+    tutorialAnchors = {},
+    tutorialFrame = nil,
+    tutorialHighlight = nil,
+    tutorialArrow = nil,
+    tutorialRuntime = nil,
+    tutorialButton = nil,
 
     -- Main frame reference
     configFrame = nil,
@@ -204,6 +210,7 @@ ST._configState = {
     -- Auto Add flow state (Column 3 wizard mode)
     autoAddFlowActive = false,
     autoAddFlowState = nil,
+    autoAddFlowSerial = 0,
     configShiftTooltipActive = nil,
 
     -- Tab UI state (populated by ConfigSettings, cleaned by both files)

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -700,28 +700,9 @@ local function NotifyTutorialAction(action, payload)
     end
 end
 
-local function ConsumeTutorialAutoAddSeed(groupID)
-    local runtime = GetRuntime()
-    if not (runtime and runtime.active) then
-        return nil
-    end
-    if runtime.step ~= "open_auto_add" then
-        return nil
-    end
-    if groupID ~= CS.selectedGroup then
-        return nil
-    end
-
-    return {
-        source = "actionbars",
-        selectedBars = { true, true, true, true, true, true },
-    }
-end
-
 ST._MaybeAutoStartFirstIconPanelTutorial = MaybeAutoStartFirstIconPanelTutorial
 ST._StartFirstIconPanelTutorial = StartFirstIconPanelTutorial
 ST._CancelFirstIconPanelTutorial = CancelFirstIconPanelTutorial
 ST._NotifyTutorialAction = NotifyTutorialAction
 ST._RebuildTutorialAnchors = RebuildTutorialAnchors
 ST._RefreshTutorialPlacement = RefreshTutorialPlacement
-ST._ConsumeTutorialAutoAddSeed = ConsumeTutorialAutoAddSeed

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -587,7 +587,7 @@ end
 local function PositionFrame(frame, anchor, placement)
     frame:ClearAllPoints()
 
-    if not anchor and placement == "center" then
+    if not anchor then
         local parent = (CS.configFrame and CS.configFrame.frame) or UIParent
         frame:SetPoint("CENTER", parent, "CENTER", 0, 0)
         if frame.arrow then
@@ -785,14 +785,14 @@ local function NotifyTutorialAction(action, payload)
         return
     end
 
-    if action == "group_created" and runtime.step == "create_group" then
+    if action == "group_created" and (runtime.step == "groups_column_intro" or runtime.step == "create_group") then
         runtime.createdGroup = true
         CS.selectedButton = nil
         wipe(CS.selectedButtons)
         wipe(CS.selectedPanels)
         wipe(CS.selectedGroups)
         AdvanceStep("panels_column_intro")
-    elseif action == "panel_created" and runtime.step == "create_panel" then
+    elseif action == "panel_created" and (runtime.step == "panels_column_intro" or runtime.step == "create_panel") then
         if payload and payload.displayMode == "icons" then
             runtime.createdPanel = true
             CS.selectedButton = nil
@@ -801,7 +801,7 @@ local function NotifyTutorialAction(action, payload)
             wipe(CS.selectedGroups)
             AdvanceStep("panel_area_intro")
         end
-    elseif action == "inline_add_succeeded" and runtime.step == "add_one_spell" then
+    elseif action == "inline_add_succeeded" and (runtime.step == "panel_area_intro" or runtime.step == "add_one_spell") then
         if payload and payload.groupId and payload.buttonIndex then
             runtime.addedEntry = true
             CS.selectedGroup = payload.groupId

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -23,15 +23,25 @@ local format = string.format
 
 local TUTORIAL_ID = "firstIconPanel"
 local TUTORIAL_SOLID_GLOW_COLOR = { 1, 0.9, 0.18, 1 }
+local TUTORIAL_SIDE_PLACEMENT_OFFSET = 44
+local TUTORIAL_FRAME_WIDTH = 316
+local TUTORIAL_FRAME_MIN_HEIGHT = 142
+local TUTORIAL_FRAME_MAX_HEIGHT = 320
+local TUTORIAL_TEXT_WIDTH = 266
+local TUTORIAL_TOP_CONTENT_PADDING = 52
+local TUTORIAL_BOTTOM_CONTENT_PADDING = 48
 local STEP_ORDER = {
     "welcome",
+    "groups_column_intro",
     "create_group",
+    "panels_column_intro",
     "create_panel",
-    "panel_area",
-    "inline_add_area",
-    "add_one_ability",
-    "edit_one_entry",
-    "panel_wide_settings",
+    "panel_area_intro",
+    "add_one_spell",
+    "entry_settings_intro",
+    "panel_settings_intro",
+    "view_modes_intro",
+    "help_tooltips_intro",
     "finish",
 }
 
@@ -43,54 +53,73 @@ end
 local STEP_DATA = {
     welcome = {
         title = "First Icon Panel",
-        text = "Groups hold one or more panels. This tutorial helps you build your first real icon panel and add one real ability to it.",
+        text = "This tutorial will walk you through adding a single spell to track and explain some basics about the add-on along the way.",
         placement = "center",
+    },
+    groups_column_intro = {
+        title = "Groups",
+        text = "Groups are containers for panels. By default, groups belong to the character they are created on.",
+        anchor = "groups_column_area",
+        placement = "right",
     },
     create_group = {
         title = "Create a Group",
-        text = "A group is the top-level container that holds your panels. Click New Group to create your first group.",
+        text = "Click New Group to create a group.",
         anchor = "new_group_button",
         placement = "above",
     },
+    panels_column_intro = {
+        title = "Panels",
+        text = "Panels are containers for the things you want to track, like spells, auras, and items. The type of panel you choose determines how tracked entries are displayed.\n\nRead the descriptions of each type of panel in the column to become familiar with available panel types.",
+        anchor = "panels_column_area",
+        placement = "right",
+    },
     create_panel = {
         title = "Create an Icon Panel",
-        text = "Panels live inside a group and hold the abilities you want to track. Click Icon Panel to create your first real panel.",
+        text = "Click Icon Panel to create a new icon panel.",
         anchor = "icon_panel_button",
         placement = "above",
     },
-    panel_area = {
+    panel_area_intro = {
         title = "This Is the Panel",
-        text = "This panel is where the abilities in this group will appear.",
+        text = "This is an empty icon panel. Let's add something to track.",
         anchor = "selected_panel_area",
         placement = "right",
     },
-    inline_add_area = {
-        title = "This Is the Add Box",
-        text = "This add box searches as you type so you can pick a matching spell or item from the dropdown.",
-        anchor = "selected_panel_add_input",
-        placement = "right",
-    },
-    add_one_ability = {
+    add_one_spell = {
         title = "Add Your First Ability",
-        text = "Begin typing an ability name, then choose it from the dropdown by clicking it or highlighting it with the arrow keys and pressing Enter.",
+        text = "Type the name of a spell your character can use in the edit box.\n\nAs you type, the addon will attempt to help you narrow down what you're looking for. Add the spell by clicking on it in the dropdown or using arrow keys + Enter.",
         anchor = "selected_panel_add_input",
         placement = "right",
     },
-    edit_one_entry = {
-        title = "Edit One Entry",
-        text = "Each ability can be adjusted without changing the rest of the panel. Your new entry is selected, and Column 3 changes only this entry.",
+    entry_settings_intro = {
+        title = "Entry Settings",
+        text = "This column is dedicated to editing and styling single, specific entries. Aura tracking settings, per-button visibility rules, sound alerts, and more is configured in this column.",
         anchor = "col3_area",
         placement = "right",
     },
-    panel_wide_settings = {
-        title = "Panel-Wide Settings",
-        text = "Panels also have settings that affect every entry they contain. Column 4 changes the whole panel, not just the selected entry.",
+    panel_settings_intro = {
+        title = "Panel Settings",
+        text = "This column is dedicated to editing and styling all entries in a panel. Panel layout, text elements, and indicators are all found here.\n\nImportant:\n\n|A:Crosshair_VehichleCursor_32:14:14|a: Whenever you see the |A:Crosshair_VehichleCursor_32:14:14|a next to a setting, that means you can override a panel-wide setting for a specific entry.\n\n|A:QuestLog-icon-setting:14:14|a: Whenever you see the |A:QuestLog-icon-setting:14:14|a next to a setting, that means you can expand advanced settings for it.",
         anchor = "col4_area",
         placement = "left",
     },
+    view_modes_intro = {
+        title = "Bars And Frames",
+        text = "This button switches between the main Buttons view and optional extras like resource bars, cast bar anchoring and styling, and unit frame anchoring.",
+        anchor = "mode_toggle_button",
+        placement = "above",
+    },
+    help_tooltips_intro = {
+        title = "More Help",
+        text = "Tooltips are spread throughout the config in order to help explain some of the less obvious aspects of the addon. Be sure to read them as you're exploring.",
+        anchor = "panels_info_button",
+        highlightAnchor = "column_info_buttons_area",
+        placement = "below",
+    },
     finish = {
         title = "Tutorial Complete",
-        text = "This panel is part of your real profile now. You can keep adding abilities here one at a time, use Auto Add later for bulk setup, or replay this later from the Tutorial button.",
+        text = "You can watch this tutorial again later by clicking the Tutorial button in the top-right corner.",
         anchor = "tutorial_button",
         placement = "below",
     },
@@ -105,6 +134,14 @@ end
 
 local function GetStepNumber(step)
     return tonumber(STEP_INDEX[step]) or 1
+end
+
+local function GetPreviousStep(step)
+    local index = STEP_INDEX[step]
+    if not index or index <= 1 then
+        return nil
+    end
+    return STEP_ORDER[index - 1]
 end
 
 local function GetTutorialState()
@@ -164,20 +201,31 @@ local function SetStep(step)
 end
 
 local function GetAnchor(name)
-    local frame = CS.tutorialAnchors and CS.tutorialAnchors[name]
-    if frame and frame.IsShown and frame:IsShown() then
-        return frame
+    local anchor = CS.tutorialAnchors and CS.tutorialAnchors[name]
+    if type(anchor) == "table" and anchor[1] then
+        for _, frame in ipairs(anchor) do
+            if frame and frame.IsShown and frame:IsShown() then
+                return anchor
+            end
+        end
+        return nil
+    end
+    if anchor and anchor.IsShown and anchor:IsShown() then
+        return anchor
     end
     return nil
 end
 
 local function HideHighlight()
-    if CS.tutorialHighlight then
-        if CS.tutorialHighlight._cdcGlow and HideGlowStyles then
-            HideGlowStyles(CS.tutorialHighlight._cdcGlow)
+    local highlights = CS.tutorialHighlights
+    if highlights then
+        for _, highlight in ipairs(highlights) do
+            if highlight._cdcGlow and HideGlowStyles then
+                HideGlowStyles(highlight._cdcGlow)
+            end
+            highlight:ClearAllPoints()
+            highlight:Hide()
         end
-        CS.tutorialHighlight:ClearAllPoints()
-        CS.tutorialHighlight:Hide()
     end
 end
 
@@ -204,7 +252,7 @@ local function EnsureTutorialFrame()
 
     local parent = (CS.configFrame and CS.configFrame.frame) or UIParent
     local frame = CreateFrame("Frame", nil, parent, "GlowBoxTemplate")
-    frame:SetSize(316, 170)
+    frame:SetSize(TUTORIAL_FRAME_WIDTH, TUTORIAL_FRAME_MIN_HEIGHT)
     frame:SetFrameStrata("FULLSCREEN_DIALOG")
     frame:SetFrameLevel(parent:GetFrameLevel() + 40)
     frame:SetClampedToScreen(true)
@@ -229,7 +277,7 @@ local function EnsureTutorialFrame()
     bodyText:SetJustifyV("TOP")
     bodyText:SetSpacing(2)
     bodyText:SetPoint("TOPLEFT", frame, "TOPLEFT", 16, -33)
-    bodyText:SetWidth(266)
+    bodyText:SetWidth(TUTORIAL_TEXT_WIDTH)
     frame.bodyText = bodyText
 
     local arrow = CreateFrame("Frame", nil, frame, "GlowBoxArrowTemplate")
@@ -270,24 +318,7 @@ local function EnsureTutorialFrame()
     closeButton:GetHighlightTexture():SetAlpha(0.3)
     frame.CloseButton = closeButton
 
-    local highlight = CreateFrame("Frame", nil, UIParent)
-    highlight:SetFrameStrata("TOOLTIP")
-    highlight:SetFrameLevel(2000)
-    highlight:SetToplevel(true)
-    highlight:EnableMouse(false)
-    highlight:Hide()
-    if CreateGlowContainer then
-        highlight._cdcGlow = CreateGlowContainer(highlight, 48, false)
-        if highlight._cdcGlow.solidFrame then
-            highlight._cdcGlow.solidFrame:SetFrameStrata("TOOLTIP")
-            highlight._cdcGlow.solidFrame:SetFrameLevel(highlight:GetFrameLevel() + 1)
-        end
-        if highlight._cdcGlow.procFrame then
-            highlight._cdcGlow.procFrame:SetFrameStrata("TOOLTIP")
-            highlight._cdcGlow.procFrame:SetFrameLevel(highlight:GetFrameLevel() + 2)
-        end
-    end
-    CS.tutorialHighlight = highlight
+    CS.tutorialHighlights = CS.tutorialHighlights or {}
 
     frame:SetScript("OnHide", function()
         HideHighlight()
@@ -308,6 +339,49 @@ local function EnsureTutorialFrame()
 
     CS.tutorialFrame = frame
     return frame
+end
+
+local function GetOrCreateHighlight(index)
+    CS.tutorialHighlights = CS.tutorialHighlights or {}
+    local highlight = CS.tutorialHighlights[index]
+    if highlight then
+        return highlight
+    end
+
+    highlight = CreateFrame("Frame", nil, UIParent)
+    highlight:SetFrameStrata("TOOLTIP")
+    highlight:SetFrameLevel(2000)
+    highlight:SetToplevel(true)
+    highlight:EnableMouse(false)
+    highlight:Hide()
+    if CreateGlowContainer then
+        highlight._cdcGlow = CreateGlowContainer(highlight, 48, false)
+        if highlight._cdcGlow.solidFrame then
+            highlight._cdcGlow.solidFrame:SetFrameStrata("TOOLTIP")
+            highlight._cdcGlow.solidFrame:SetFrameLevel(highlight:GetFrameLevel() + 1)
+        end
+        if highlight._cdcGlow.procFrame then
+            highlight._cdcGlow.procFrame:SetFrameStrata("TOOLTIP")
+            highlight._cdcGlow.procFrame:SetFrameLevel(highlight:GetFrameLevel() + 2)
+        end
+    end
+    CS.tutorialHighlights[index] = highlight
+    return highlight
+end
+
+local function ResizeTutorialFrame(frame)
+    if not frame or not frame.bodyText then
+        return
+    end
+
+    local bodyText = frame.bodyText
+    bodyText:SetWidth(TUTORIAL_TEXT_WIDTH)
+
+    local textHeight = math.ceil(bodyText:GetStringHeight() or 0)
+    local desiredHeight = TUTORIAL_TOP_CONTENT_PADDING + textHeight + TUTORIAL_BOTTOM_CONTENT_PADDING
+    local clampedHeight = math.min(TUTORIAL_FRAME_MAX_HEIGHT, math.max(TUTORIAL_FRAME_MIN_HEIGHT, desiredHeight))
+
+    frame:SetHeight(clampedHeight)
 end
 
 local function ResetTutorialButton(button)
@@ -358,6 +432,17 @@ local function AdvanceStep(nextStep)
     end
 end
 
+local function GoToPreviousStep()
+    local runtime = GetRuntime()
+    if not runtime then
+        return
+    end
+    local previousStep = GetPreviousStep(runtime.step)
+    if previousStep then
+        AdvanceStep(previousStep)
+    end
+end
+
 local function NormalizeTutorialContext()
     if not IsConfigVisible() then
         return
@@ -366,6 +451,9 @@ local function NormalizeTutorialContext()
     local configFrame = CS.configFrame
     if configFrame and configFrame.HideChangelogOverlay then
         configFrame.HideChangelogOverlay()
+    end
+    if CS.profileBar and CS.profileBar:IsShown() then
+        CS.profileBar:Hide()
     end
 
     if CS.talentPickerMode and CooldownCompanion.CloseTalentPicker then
@@ -409,34 +497,70 @@ local function ConfigureButtonsForStep(frame, step)
 
     if step == "welcome" then
         SetTutorialButton(frame.leftButton, "Skip", DismissTutorial)
-        SetTutorialButton(frame.rightButton, "Start Tutorial", function()
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("groups_column_intro")
+        end)
+    elseif step == "groups_column_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
+        SetTutorialButton(frame.rightButton, "Next", function()
             AdvanceStep("create_group")
         end)
-    elseif step == "panel_area" then
-        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+    elseif step == "create_group" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
+        if GetRuntime() and GetRuntime().createdGroup then
+            SetTutorialButton(frame.rightButton, "Next", function()
+                AdvanceStep("panels_column_intro")
+            end)
+        end
+    elseif step == "panels_column_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
         SetTutorialButton(frame.rightButton, "Next", function()
-            AdvanceStep("inline_add_area")
+            AdvanceStep("create_panel")
         end)
-    elseif step == "inline_add_area" then
-        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+    elseif step == "create_panel" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
+        if GetRuntime() and GetRuntime().createdPanel then
+            SetTutorialButton(frame.rightButton, "Next", function()
+                AdvanceStep("panel_area_intro")
+            end)
+        end
+    elseif step == "panel_area_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
         SetTutorialButton(frame.rightButton, "Next", function()
-            AdvanceStep("add_one_ability")
+            AdvanceStep("add_one_spell")
         end)
-    elseif step == "edit_one_entry" then
-        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+    elseif step == "add_one_spell" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
+        if GetRuntime() and GetRuntime().addedEntry then
+            SetTutorialButton(frame.rightButton, "Next", function()
+                AdvanceStep("entry_settings_intro")
+            end)
+        end
+    elseif step == "entry_settings_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
         SetTutorialButton(frame.rightButton, "Next", function()
-            AdvanceStep("panel_wide_settings")
+            AdvanceStep("panel_settings_intro")
         end)
-    elseif step == "panel_wide_settings" then
-        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+    elseif step == "panel_settings_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("view_modes_intro")
+        end)
+    elseif step == "view_modes_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("help_tooltips_intro")
+        end)
+    elseif step == "help_tooltips_intro" then
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
         SetTutorialButton(frame.rightButton, "Next", function()
             AdvanceStep("finish")
         end)
     elseif step == "finish" then
-        SetTutorialButton(frame.leftButton, "Replay Later", CompleteTutorial)
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
         SetTutorialButton(frame.rightButton, "Finish", CompleteTutorial)
     else
-        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
     end
 end
 
@@ -446,11 +570,41 @@ local function UpdateHighlight(anchor)
         return
     end
 
-    local highlight = CS.tutorialHighlight
-    if not highlight then
+    if type(anchor) == "table" and anchor[1] then
+        HideHighlight()
+        local used = 0
+        for _, frame in ipairs(anchor) do
+            if frame and frame.IsShown and frame:IsShown() then
+                used = used + 1
+                local highlight = GetOrCreateHighlight(used)
+                highlight:ClearAllPoints()
+                highlight:SetParent(UIParent)
+                highlight:SetPoint("TOPLEFT", frame, "TOPLEFT", -1, 1)
+                highlight:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 1, -1)
+                highlight:Show()
+                if highlight._cdcGlow and ShowGlowStyle then
+                    ShowGlowStyle(highlight._cdcGlow, "solid", highlight, TUTORIAL_SOLID_GLOW_COLOR, {
+                        size = 3,
+                        defaultAlpha = 1,
+                    })
+                end
+            end
+        end
+        local highlights = CS.tutorialHighlights or {}
+        for index = used + 1, #highlights do
+            local extra = highlights[index]
+            if extra then
+                if extra._cdcGlow and HideGlowStyles then
+                    HideGlowStyles(extra._cdcGlow)
+                end
+                extra:ClearAllPoints()
+                extra:Hide()
+            end
+        end
         return
     end
 
+    local highlight = GetOrCreateHighlight(1)
     highlight:ClearAllPoints()
     highlight:SetParent(UIParent)
     highlight:SetPoint("TOPLEFT", anchor, "TOPLEFT", -1, 1)
@@ -461,6 +615,17 @@ local function UpdateHighlight(anchor)
             size = 3,
             defaultAlpha = 1,
         })
+    end
+    local highlights = CS.tutorialHighlights or {}
+    for index = 2, #highlights do
+        local extra = highlights[index]
+        if extra then
+            if extra._cdcGlow and HideGlowStyles then
+                HideGlowStyles(extra._cdcGlow)
+            end
+            extra:ClearAllPoints()
+            extra:Hide()
+        end
     end
 end
 
@@ -499,7 +664,7 @@ end
 local function PositionFrame(frame, anchor, placement)
     frame:ClearAllPoints()
 
-    if not anchor or placement == "center" then
+    if not anchor and placement == "center" then
         local parent = (CS.configFrame and CS.configFrame.frame) or UIParent
         frame:SetPoint("CENTER", parent, "CENTER", 0, 0)
         if frame.arrow then
@@ -509,14 +674,17 @@ local function PositionFrame(frame, anchor, placement)
         return
     end
 
-    if placement == "above" then
+    if placement == "center" then
+        local parent = (CS.configFrame and CS.configFrame.frame) or UIParent
+        frame:SetPoint("CENTER", parent, "CENTER", 0, 0)
+    elseif placement == "above" then
         frame:SetPoint("BOTTOM", anchor, "TOP", 0, 18)
     elseif placement == "below" then
         frame:SetPoint("TOP", anchor, "BOTTOM", 0, -18)
     elseif placement == "left" then
-        frame:SetPoint("RIGHT", anchor, "LEFT", -20, 0)
+        frame:SetPoint("RIGHT", anchor, "LEFT", -TUTORIAL_SIDE_PLACEMENT_OFFSET, 0)
     elseif placement == "right" then
-        frame:SetPoint("LEFT", anchor, "RIGHT", 20, 0)
+        frame:SetPoint("LEFT", anchor, "RIGHT", TUTORIAL_SIDE_PLACEMENT_OFFSET, 0)
     else
         frame:SetPoint("CENTER", anchor, "CENTER", 0, 0)
     end
@@ -555,6 +723,12 @@ local function RefreshTutorialPlacement()
     frame:SetFrameLevel(CS.configFrame.frame:GetFrameLevel() + 40)
 
     local step = runtime.step or "welcome"
+    if step == "view_modes_intro" and CS.profileBar and CS.profileBar:IsShown() then
+        CS.profileBar:Hide()
+        if ST._RebuildTutorialAnchors then
+            ST._RebuildTutorialAnchors()
+        end
+    end
     local data = STEP_DATA[step] or STEP_DATA.welcome
     local titleText = frame.titleText
     if titleText then
@@ -563,9 +737,14 @@ local function RefreshTutorialPlacement()
     frame.stepLabel:SetText(format("%d of %d", GetStepNumber(step), #STEP_ORDER))
     frame.bodyText:SetText(data.text or "")
     ConfigureButtonsForStep(frame, step)
+    ResizeTutorialFrame(frame)
 
-    local anchor = data.anchor and GetAnchor(data.anchor) or nil
-    PositionFrame(frame, anchor, data.placement)
+    local placementAnchor = data.anchor and GetAnchor(data.anchor) or nil
+    local highlightAnchor = data.highlightAnchor and GetAnchor(data.highlightAnchor) or placementAnchor
+    PositionFrame(frame, placementAnchor, data.placement)
+    if highlightAnchor ~= placementAnchor then
+        UpdateHighlight(highlightAnchor)
+    end
     frame:Show()
 end
 
@@ -590,8 +769,34 @@ local function RebuildTutorialAnchors()
     end
     wipe(anchors)
 
+    local infoButtons = CS.columnInfoButtons
+    if infoButtons and #infoButtons > 0 then
+        local shownButtons = {}
+        for _, button in ipairs(infoButtons) do
+            if button and button.IsShown and button:IsShown() then
+                table.insert(shownButtons, button)
+            end
+        end
+        if #shownButtons > 0 then
+            anchors.column_info_buttons_area = shownButtons
+        end
+    end
+
     if CS.tutorialButton then
         anchors.tutorial_button = CS.tutorialButton
+    end
+    if CS.modeToggleButton and CS.modeToggleButton:IsShown() then
+        anchors.mode_toggle_button = CS.modeToggleButton
+    end
+
+    if CS.configFrame and CS.configFrame.col1 and CS.configFrame.col1.frame then
+        anchors.groups_column_area = CS.configFrame.col1.frame
+    end
+    if CS.configFrame and CS.configFrame.col2 and CS.configFrame.col2.frame then
+        anchors.panels_column_area = CS.configFrame.col2.frame
+        if CS.configFrame.col2._infoBtn and CS.configFrame.col2._infoBtn:IsShown() then
+            anchors.panels_info_button = CS.configFrame.col2._infoBtn
+        end
     end
 
     local col1Widgets = CS.col1BarWidgets or {}
@@ -641,6 +846,9 @@ local function StartFirstIconPanelTutorial(isReplay)
         active = true,
         isReplay = isReplay == true,
         step = "welcome",
+        createdGroup = false,
+        createdPanel = false,
+        addedEntry = false,
     }
 
     RebuildTutorialAnchors()
@@ -675,27 +883,30 @@ local function NotifyTutorialAction(action, payload)
     end
 
     if action == "group_created" and runtime.step == "create_group" then
+        runtime.createdGroup = true
         CS.selectedButton = nil
         wipe(CS.selectedButtons)
         wipe(CS.selectedPanels)
         wipe(CS.selectedGroups)
-        AdvanceStep("create_panel")
+        AdvanceStep("panels_column_intro")
     elseif action == "panel_created" and runtime.step == "create_panel" then
         if payload and payload.displayMode == "icons" then
+            runtime.createdPanel = true
             CS.selectedButton = nil
             wipe(CS.selectedButtons)
             wipe(CS.selectedPanels)
             wipe(CS.selectedGroups)
-            AdvanceStep("panel_area")
+            AdvanceStep("panel_area_intro")
         end
-    elseif action == "inline_add_succeeded" and (runtime.step == "panel_area" or runtime.step == "inline_add_area" or runtime.step == "add_one_ability") then
+    elseif action == "inline_add_succeeded" and runtime.step == "add_one_spell" then
         if payload and payload.groupId and payload.buttonIndex then
+            runtime.addedEntry = true
             CS.selectedGroup = payload.groupId
             CS.selectedButton = payload.buttonIndex
             wipe(CS.selectedButtons)
             wipe(CS.selectedPanels)
             wipe(CS.selectedGroups)
-            AdvanceStep("edit_one_entry")
+            AdvanceStep("entry_settings_intro")
         end
     end
 end

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -1,0 +1,727 @@
+--[[
+    CooldownCompanion - Config/Tutorial
+    First-run icon-panel onboarding using a standalone raw frame and semantic anchors.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+local CS = ST._configState
+local CreateGlowContainer = ST._CreateGlowContainer
+local ShowGlowStyle = ST._ShowGlowStyle
+local HideGlowStyles = ST._HideGlowStyles
+
+local pairs = pairs
+local next = next
+local wipe = wipe
+local tonumber = tonumber
+local tostring = tostring
+local math_deg = math.deg
+local math_floor = math.floor
+local math_fmod = math.fmod
+local math_pi = math.pi
+local format = string.format
+
+local TUTORIAL_ID = "firstIconPanel"
+local TUTORIAL_SOLID_GLOW_COLOR = { 1, 0.9, 0.18, 1 }
+local STEP_ORDER = {
+    "welcome",
+    "create_group",
+    "create_panel",
+    "panel_area",
+    "inline_add_area",
+    "add_one_ability",
+    "edit_one_entry",
+    "panel_wide_settings",
+    "finish",
+}
+
+local STEP_INDEX = {}
+for index, step in ipairs(STEP_ORDER) do
+    STEP_INDEX[step] = index
+end
+
+local STEP_DATA = {
+    welcome = {
+        title = "First Icon Panel",
+        text = "Groups hold one or more panels. This tutorial helps you build your first real icon panel and add one real ability to it.",
+        placement = "center",
+    },
+    create_group = {
+        title = "Create a Group",
+        text = "A group is the top-level container that holds your panels. Click New Group to create your first group.",
+        anchor = "new_group_button",
+        placement = "above",
+    },
+    create_panel = {
+        title = "Create an Icon Panel",
+        text = "Panels live inside a group and hold the abilities you want to track. Click Icon Panel to create your first real panel.",
+        anchor = "icon_panel_button",
+        placement = "above",
+    },
+    panel_area = {
+        title = "This Is the Panel",
+        text = "This panel is where the abilities in this group will appear.",
+        anchor = "selected_panel_area",
+        placement = "right",
+    },
+    inline_add_area = {
+        title = "This Is the Add Box",
+        text = "This add box searches as you type so you can pick a matching spell or item from the dropdown.",
+        anchor = "selected_panel_add_input",
+        placement = "right",
+    },
+    add_one_ability = {
+        title = "Add Your First Ability",
+        text = "Begin typing an ability name, then choose it from the dropdown by clicking it or highlighting it with the arrow keys and pressing Enter.",
+        anchor = "selected_panel_add_input",
+        placement = "right",
+    },
+    edit_one_entry = {
+        title = "Edit One Entry",
+        text = "Each ability can be adjusted without changing the rest of the panel. Your new entry is selected, and Column 3 changes only this entry.",
+        anchor = "col3_area",
+        placement = "right",
+    },
+    panel_wide_settings = {
+        title = "Panel-Wide Settings",
+        text = "Panels also have settings that affect every entry they contain. Column 4 changes the whole panel, not just the selected entry.",
+        anchor = "col4_area",
+        placement = "left",
+    },
+    finish = {
+        title = "Tutorial Complete",
+        text = "This panel is part of your real profile now. You can keep adding abilities here one at a time, use Auto Add later for bulk setup, or replay this later from the Tutorial button.",
+        anchor = "tutorial_button",
+        placement = "below",
+    },
+}
+
+local function GetAddonVersion()
+    if ST._GetAddonVersion then
+        return tostring(ST._GetAddonVersion() or "unknown")
+    end
+    return "unknown"
+end
+
+local function GetStepNumber(step)
+    return tonumber(STEP_INDEX[step]) or 1
+end
+
+local function GetTutorialState()
+    if not (CooldownCompanion and CooldownCompanion.db and CooldownCompanion.db.global) then
+        return nil
+    end
+
+    local global = CooldownCompanion.db.global
+    if type(global.tutorials) ~= "table" then
+        global.tutorials = {}
+    end
+    if type(global.tutorials[TUTORIAL_ID]) ~= "table" then
+        global.tutorials[TUTORIAL_ID] = {}
+    end
+
+    local state = global.tutorials[TUTORIAL_ID]
+    if state.completed ~= true then
+        state.completed = false
+    end
+    if state.dismissed ~= true then
+        state.dismissed = false
+    end
+    if state.lastVersionSeen ~= nil then
+        state.lastVersionSeen = tostring(state.lastVersionSeen)
+    end
+
+    return state
+end
+
+local function ProfileHasExistingSetup()
+    local profile = CooldownCompanion and CooldownCompanion.db and CooldownCompanion.db.profile
+    if not profile then
+        return false
+    end
+    return next(profile.groupContainers or {}) ~= nil or next(profile.groups or {}) ~= nil
+end
+
+local function IsConfigVisible()
+    return CS.configFrame and CS.configFrame.frame and CS.configFrame.frame:IsShown()
+end
+
+local function GetRuntime()
+    return CS.tutorialRuntime
+end
+
+local function IsTutorialActive()
+    local runtime = GetRuntime()
+    return runtime and runtime.active == true
+end
+
+local function SetStep(step)
+    local runtime = GetRuntime()
+    if not runtime then
+        return
+    end
+    runtime.step = step
+end
+
+local function GetAnchor(name)
+    local frame = CS.tutorialAnchors and CS.tutorialAnchors[name]
+    if frame and frame.IsShown and frame:IsShown() then
+        return frame
+    end
+    return nil
+end
+
+local function HideHighlight()
+    if CS.tutorialHighlight then
+        if CS.tutorialHighlight._cdcGlow and HideGlowStyles then
+            HideGlowStyles(CS.tutorialHighlight._cdcGlow)
+        end
+        CS.tutorialHighlight:ClearAllPoints()
+        CS.tutorialHighlight:Hide()
+    end
+end
+
+local function RotateTexture(texture, rotation)
+    if not texture then
+        return
+    end
+    if SetClampedTextureRotation then
+        local degrees = math_fmod(math_deg(rotation), 360)
+        if degrees < 0 then
+            degrees = degrees + 360
+        end
+        degrees = (math_floor((degrees / 90) + 0.5) % 4) * 90
+        SetClampedTextureRotation(texture, degrees)
+    else
+        texture:SetRotation(rotation)
+    end
+end
+
+local function EnsureTutorialFrame()
+    if CS.tutorialFrame then
+        return CS.tutorialFrame
+    end
+
+    local parent = (CS.configFrame and CS.configFrame.frame) or UIParent
+    local frame = CreateFrame("Frame", nil, parent, "GlowBoxTemplate")
+    frame:SetSize(316, 170)
+    frame:SetFrameStrata("FULLSCREEN_DIALOG")
+    frame:SetFrameLevel(parent:GetFrameLevel() + 40)
+    frame:SetClampedToScreen(true)
+    frame:EnableMouse(true)
+    frame:SetMovable(false)
+    frame:Hide()
+
+    local titleText = frame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    titleText:SetPoint("TOP", frame, "TOP", 0, -11)
+    titleText:SetTextColor(1, 0.82, 0)
+    titleText:SetText("First Icon Panel")
+    frame.titleText = titleText
+
+    local stepLabel = frame:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
+    stepLabel:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -30, -14)
+    stepLabel:SetTextColor(1, 0.82, 0, 0.85)
+    stepLabel:SetJustifyH("RIGHT")
+    frame.stepLabel = stepLabel
+
+    local bodyText = frame:CreateFontString(nil, "ARTWORK", "GameFontHighlightLeft")
+    bodyText:SetJustifyH("LEFT")
+    bodyText:SetJustifyV("TOP")
+    bodyText:SetSpacing(2)
+    bodyText:SetPoint("TOPLEFT", frame, "TOPLEFT", 16, -33)
+    bodyText:SetWidth(266)
+    frame.bodyText = bodyText
+
+    local arrow = CreateFrame("Frame", nil, frame, "GlowBoxArrowTemplate")
+    arrow:SetSize(45, 18)
+    if arrow.Arrow then
+        arrow.Arrow:SetAlpha(0.9)
+    end
+    if arrow.Glow then
+        arrow.Glow:SetAlpha(0.28)
+    end
+    arrow:Hide()
+    frame.arrow = arrow
+
+    local function CreateActionButton(width)
+        local button = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+        button:SetSize(width or 110, 22)
+        button:Hide()
+        return button
+    end
+
+    local leftButton = CreateActionButton(110)
+    local middleButton = CreateActionButton(110)
+    local rightButton = CreateActionButton(110)
+    leftButton:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 14, 10)
+    middleButton:SetPoint("BOTTOM", frame, "BOTTOM", 0, 10)
+    rightButton:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -14, 10)
+    frame.leftButton = leftButton
+    frame.middleButton = middleButton
+    frame.rightButton = rightButton
+
+    local closeButton = CreateFrame("Button", nil, frame)
+    closeButton:SetSize(18, 18)
+    closeButton:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -3, -3)
+    local closeIcon = closeButton:CreateTexture(nil, "ARTWORK")
+    closeIcon:SetAtlas("common-icon-redx")
+    closeIcon:SetAllPoints()
+    closeButton:SetHighlightAtlas("common-icon-redx")
+    closeButton:GetHighlightTexture():SetAlpha(0.3)
+    frame.CloseButton = closeButton
+
+    local highlight = CreateFrame("Frame", nil, UIParent)
+    highlight:SetFrameStrata("TOOLTIP")
+    highlight:SetFrameLevel(2000)
+    highlight:SetToplevel(true)
+    highlight:EnableMouse(false)
+    highlight:Hide()
+    if CreateGlowContainer then
+        highlight._cdcGlow = CreateGlowContainer(highlight, 48, false)
+        if highlight._cdcGlow.solidFrame then
+            highlight._cdcGlow.solidFrame:SetFrameStrata("TOOLTIP")
+            highlight._cdcGlow.solidFrame:SetFrameLevel(highlight:GetFrameLevel() + 1)
+        end
+        if highlight._cdcGlow.procFrame then
+            highlight._cdcGlow.procFrame:SetFrameStrata("TOOLTIP")
+            highlight._cdcGlow.procFrame:SetFrameLevel(highlight:GetFrameLevel() + 2)
+        end
+    end
+    CS.tutorialHighlight = highlight
+
+    frame:SetScript("OnHide", function()
+        HideHighlight()
+        if frame.arrow then
+            frame.arrow:Hide()
+        end
+    end)
+
+    if closeButton then
+        closeButton:SetScript("OnClick", function()
+            if ST._CancelFirstIconPanelTutorial then
+                ST._CancelFirstIconPanelTutorial("close_button")
+            else
+                frame:Hide()
+            end
+        end)
+    end
+
+    CS.tutorialFrame = frame
+    return frame
+end
+
+local function ResetTutorialButton(button)
+    button:Hide()
+    button:SetEnabled(true)
+    button:SetScript("OnClick", nil)
+    button:SetText("")
+end
+
+local function SetTutorialButton(button, text, onClick, enabled)
+    if not button then
+        return
+    end
+    button:SetText(text or "")
+    button:SetEnabled(enabled ~= false)
+    button:SetScript("OnClick", onClick)
+    button:Show()
+end
+
+local function DismissTutorial()
+    local state = GetTutorialState()
+    if state then
+        state.completed = false
+        state.dismissed = true
+        state.lastVersionSeen = GetAddonVersion()
+    end
+    if ST._CancelFirstIconPanelTutorial then
+        ST._CancelFirstIconPanelTutorial("dismissed")
+    end
+end
+
+local function CompleteTutorial()
+    local state = GetTutorialState()
+    if state then
+        state.completed = true
+        state.dismissed = false
+        state.lastVersionSeen = GetAddonVersion()
+    end
+    if ST._CancelFirstIconPanelTutorial then
+        ST._CancelFirstIconPanelTutorial("completed")
+    end
+end
+
+local function AdvanceStep(nextStep)
+    SetStep(nextStep)
+    if ST._RefreshTutorialPlacement then
+        ST._RefreshTutorialPlacement()
+    end
+end
+
+local function NormalizeTutorialContext()
+    if not IsConfigVisible() then
+        return
+    end
+
+    local configFrame = CS.configFrame
+    if configFrame and configFrame.HideChangelogOverlay then
+        configFrame.HideChangelogOverlay()
+    end
+
+    if CS.talentPickerMode and CooldownCompanion.CloseTalentPicker then
+        CooldownCompanion:CloseTalentPicker()
+    end
+    if ST._CancelAutoAddFlow then
+        ST._CancelAutoAddFlow()
+    end
+
+    CloseDropDownMenus()
+    if CS.HideAutocomplete then
+        CS.HideAutocomplete()
+    end
+
+    CS.browseMode = false
+    CS.browseCharKey = nil
+    CS.browseContainerId = nil
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    CS.selectedButton = nil
+    wipe(CS.selectedButtons)
+    wipe(CS.selectedPanels)
+    wipe(CS.selectedGroups)
+    CS.addingToPanelId = nil
+    CS.newInput = ""
+    CS.pendingEditBoxFocus = false
+
+    if ST._SetConfigPrimaryMode then
+        ST._SetConfigPrimaryMode("buttons", { skipRefresh = true })
+    else
+        CS.resourceBarPanelActive = false
+    end
+
+    CooldownCompanion:RefreshConfigPanel()
+end
+
+local function ConfigureButtonsForStep(frame, step)
+    ResetTutorialButton(frame.leftButton)
+    ResetTutorialButton(frame.middleButton)
+    ResetTutorialButton(frame.rightButton)
+
+    if step == "welcome" then
+        SetTutorialButton(frame.leftButton, "Skip", DismissTutorial)
+        SetTutorialButton(frame.rightButton, "Start Tutorial", function()
+            AdvanceStep("create_group")
+        end)
+    elseif step == "panel_area" then
+        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("inline_add_area")
+        end)
+    elseif step == "inline_add_area" then
+        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("add_one_ability")
+        end)
+    elseif step == "edit_one_entry" then
+        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("panel_wide_settings")
+        end)
+    elseif step == "panel_wide_settings" then
+        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+        SetTutorialButton(frame.rightButton, "Next", function()
+            AdvanceStep("finish")
+        end)
+    elseif step == "finish" then
+        SetTutorialButton(frame.leftButton, "Replay Later", CompleteTutorial)
+        SetTutorialButton(frame.rightButton, "Finish", CompleteTutorial)
+    else
+        SetTutorialButton(frame.leftButton, "Skip Tutorial", DismissTutorial)
+    end
+end
+
+local function UpdateHighlight(anchor)
+    if not anchor then
+        HideHighlight()
+        return
+    end
+
+    local highlight = CS.tutorialHighlight
+    if not highlight then
+        return
+    end
+
+    highlight:ClearAllPoints()
+    highlight:SetParent(UIParent)
+    highlight:SetPoint("TOPLEFT", anchor, "TOPLEFT", -1, 1)
+    highlight:SetPoint("BOTTOMRIGHT", anchor, "BOTTOMRIGHT", 1, -1)
+    highlight:Show()
+    if highlight._cdcGlow and ShowGlowStyle then
+        ShowGlowStyle(highlight._cdcGlow, "solid", highlight, TUTORIAL_SOLID_GLOW_COLOR, {
+            size = 3,
+            defaultAlpha = 1,
+        })
+    end
+end
+
+local function PositionArrow(frame, placement)
+    local arrow = frame and frame.arrow
+    if not arrow then
+        return
+    end
+
+    arrow:ClearAllPoints()
+    RotateTexture(arrow.Arrow, 0)
+    RotateTexture(arrow.Glow, 0)
+
+    if placement == "above" then
+        arrow:SetPoint("TOP", frame, "BOTTOM", 0, 3)
+    elseif placement == "below" then
+        arrow:SetPoint("BOTTOM", frame, "TOP", 0, -3)
+        RotateTexture(arrow.Arrow, math_pi)
+        RotateTexture(arrow.Glow, math_pi)
+    elseif placement == "left" then
+        arrow:SetPoint("LEFT", frame, "RIGHT", -3, 0)
+        RotateTexture(arrow.Arrow, -math_pi / 2)
+        RotateTexture(arrow.Glow, -math_pi / 2)
+    elseif placement == "right" then
+        arrow:SetPoint("RIGHT", frame, "LEFT", 3, 0)
+        RotateTexture(arrow.Arrow, math_pi / 2)
+        RotateTexture(arrow.Glow, math_pi / 2)
+    else
+        arrow:Hide()
+        return
+    end
+
+    arrow:Show()
+end
+
+local function PositionFrame(frame, anchor, placement)
+    frame:ClearAllPoints()
+
+    if not anchor or placement == "center" then
+        local parent = (CS.configFrame and CS.configFrame.frame) or UIParent
+        frame:SetPoint("CENTER", parent, "CENTER", 0, 0)
+        if frame.arrow then
+            frame.arrow:Hide()
+        end
+        HideHighlight()
+        return
+    end
+
+    if placement == "above" then
+        frame:SetPoint("BOTTOM", anchor, "TOP", 0, 18)
+    elseif placement == "below" then
+        frame:SetPoint("TOP", anchor, "BOTTOM", 0, -18)
+    elseif placement == "left" then
+        frame:SetPoint("RIGHT", anchor, "LEFT", -20, 0)
+    elseif placement == "right" then
+        frame:SetPoint("LEFT", anchor, "RIGHT", 20, 0)
+    else
+        frame:SetPoint("CENTER", anchor, "CENTER", 0, 0)
+    end
+
+    PositionArrow(frame, placement)
+    UpdateHighlight(anchor)
+end
+
+local function ValidateRuntimeState()
+    local runtime = GetRuntime()
+    if not runtime then
+        return
+    end
+end
+
+local function RefreshTutorialPlacement()
+    local runtime = GetRuntime()
+    if not (runtime and runtime.active and IsConfigVisible()) then
+        if CS.tutorialFrame then
+            CS.tutorialFrame:Hide()
+        end
+        HideHighlight()
+        return
+    end
+
+    ValidateRuntimeState()
+    runtime = GetRuntime()
+    if not runtime then
+        return
+    end
+
+    local frame = EnsureTutorialFrame()
+    if frame:GetParent() ~= CS.configFrame.frame then
+        frame:SetParent(CS.configFrame.frame)
+    end
+    frame:SetFrameLevel(CS.configFrame.frame:GetFrameLevel() + 40)
+
+    local step = runtime.step or "welcome"
+    local data = STEP_DATA[step] or STEP_DATA.welcome
+    local titleText = frame.titleText
+    if titleText then
+        titleText:SetText(data.title or "Tutorial")
+    end
+    frame.stepLabel:SetText(format("%d of %d", GetStepNumber(step), #STEP_ORDER))
+    frame.bodyText:SetText(data.text or "")
+    ConfigureButtonsForStep(frame, step)
+
+    local anchor = data.anchor and GetAnchor(data.anchor) or nil
+    PositionFrame(frame, anchor, data.placement)
+    frame:Show()
+end
+
+local function CancelFirstIconPanelTutorial(reason)
+    local runtime = GetRuntime()
+    if not runtime then
+        return
+    end
+
+    CS.tutorialRuntime = nil
+    if CS.tutorialFrame then
+        CS.tutorialFrame:Hide()
+    end
+    HideHighlight()
+end
+
+local function RebuildTutorialAnchors()
+    local anchors = CS.tutorialAnchors
+    if not anchors then
+        anchors = {}
+        CS.tutorialAnchors = anchors
+    end
+    wipe(anchors)
+
+    if CS.tutorialButton then
+        anchors.tutorial_button = CS.tutorialButton
+    end
+
+    local col1Widgets = CS.col1BarWidgets or {}
+    local firstCol1Button = col1Widgets[1]
+    if firstCol1Button and firstCol1Button.frame then
+        anchors.new_group_button = firstCol1Button.frame
+    end
+
+    local col2Widgets = CS.col2BarWidgets or {}
+    local firstCol2Button = col2Widgets[1]
+    if firstCol2Button and firstCol2Button.frame and CS.col2ButtonBar and CS.col2ButtonBar:IsShown() then
+        anchors.icon_panel_button = firstCol2Button.frame
+    end
+
+    local selectedPanelId = CS.selectedGroup
+    local selectedPanelMeta
+    for _, panelMeta in ipairs(CS.lastCol2PanelMetas or {}) do
+        if panelMeta.panelId == selectedPanelId then
+            selectedPanelMeta = panelMeta
+            break
+        end
+    end
+
+    if selectedPanelMeta then
+        anchors.selected_panel_area = selectedPanelMeta.panelFrame or selectedPanelMeta.headerFrame
+        anchors.selected_panel_add_row = selectedPanelMeta.addRowFrame
+        anchors.selected_panel_add_input = selectedPanelMeta.addInputFrame
+        anchors.selected_panel_manual_add_button = selectedPanelMeta.manualAddButtonFrame
+    end
+
+    if CS.configFrame and CS.configFrame.col3 and CS.configFrame.col3.frame then
+        anchors.col3_area = CS.configFrame.col3.frame
+    end
+    if CS.configFrame and CS.configFrame.col4 and CS.configFrame.col4.frame then
+        anchors.col4_area = CS.configFrame.col4.frame
+    end
+end
+
+local function StartFirstIconPanelTutorial(isReplay)
+    if not IsConfigVisible() then
+        return false
+    end
+
+    NormalizeTutorialContext()
+
+    CS.tutorialRuntime = {
+        active = true,
+        isReplay = isReplay == true,
+        step = "welcome",
+    }
+
+    RebuildTutorialAnchors()
+    RefreshTutorialPlacement()
+    return true
+end
+
+local function MaybeAutoStartFirstIconPanelTutorial()
+    if not IsConfigVisible() or IsTutorialActive() then
+        return false
+    end
+
+    local state = GetTutorialState()
+    if not state then
+        return false
+    end
+    if state.completed or state.dismissed or state.lastVersionSeen ~= nil then
+        return false
+    end
+    if ProfileHasExistingSetup() then
+        return false
+    end
+
+    state.lastVersionSeen = GetAddonVersion()
+    return StartFirstIconPanelTutorial(false)
+end
+
+local function NotifyTutorialAction(action, payload)
+    local runtime = GetRuntime()
+    if not (runtime and runtime.active) then
+        return
+    end
+
+    if action == "group_created" and runtime.step == "create_group" then
+        CS.selectedButton = nil
+        wipe(CS.selectedButtons)
+        wipe(CS.selectedPanels)
+        wipe(CS.selectedGroups)
+        AdvanceStep("create_panel")
+    elseif action == "panel_created" and runtime.step == "create_panel" then
+        if payload and payload.displayMode == "icons" then
+            CS.selectedButton = nil
+            wipe(CS.selectedButtons)
+            wipe(CS.selectedPanels)
+            wipe(CS.selectedGroups)
+            AdvanceStep("panel_area")
+        end
+    elseif action == "inline_add_succeeded" and (runtime.step == "panel_area" or runtime.step == "inline_add_area" or runtime.step == "add_one_ability") then
+        if payload and payload.groupId and payload.buttonIndex then
+            CS.selectedGroup = payload.groupId
+            CS.selectedButton = payload.buttonIndex
+            wipe(CS.selectedButtons)
+            wipe(CS.selectedPanels)
+            wipe(CS.selectedGroups)
+            AdvanceStep("edit_one_entry")
+        end
+    end
+end
+
+local function ConsumeTutorialAutoAddSeed(groupID)
+    local runtime = GetRuntime()
+    if not (runtime and runtime.active) then
+        return nil
+    end
+    if runtime.step ~= "open_auto_add" then
+        return nil
+    end
+    if groupID ~= CS.selectedGroup then
+        return nil
+    end
+
+    return {
+        source = "actionbars",
+        selectedBars = { true, true, true, true, true, true },
+    }
+end
+
+ST._MaybeAutoStartFirstIconPanelTutorial = MaybeAutoStartFirstIconPanelTutorial
+ST._StartFirstIconPanelTutorial = StartFirstIconPanelTutorial
+ST._CancelFirstIconPanelTutorial = CancelFirstIconPanelTutorial
+ST._NotifyTutorialAction = NotifyTutorialAction
+ST._RebuildTutorialAnchors = RebuildTutorialAnchors
+ST._RefreshTutorialPlacement = RefreshTutorialPlacement
+ST._ConsumeTutorialAutoAddSeed = ConsumeTutorialAutoAddSeed

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -785,7 +785,7 @@ local function NotifyTutorialAction(action, payload)
         return
     end
 
-    if action == "group_created" and (runtime.step == "groups_column_intro" or runtime.step == "create_group") then
+    if action == "group_created" and (runtime.step == "welcome" or runtime.step == "groups_column_intro" or runtime.step == "create_group") then
         runtime.createdGroup = true
         CS.selectedButton = nil
         wipe(CS.selectedButtons)

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -25,11 +25,11 @@ local TUTORIAL_ID = "firstIconPanel"
 local TUTORIAL_SOLID_GLOW_COLOR = { 1, 0.9, 0.18, 1 }
 local TUTORIAL_SIDE_PLACEMENT_OFFSET = 44
 local TUTORIAL_FRAME_WIDTH = 316
-local TUTORIAL_FRAME_MIN_HEIGHT = 142
+local TUTORIAL_FRAME_MIN_HEIGHT = 90
 local TUTORIAL_FRAME_MAX_HEIGHT = 320
 local TUTORIAL_TEXT_WIDTH = 266
-local TUTORIAL_TOP_CONTENT_PADDING = 52
-local TUTORIAL_BOTTOM_CONTENT_PADDING = 48
+local TUTORIAL_TOP_CONTENT_PADDING = 48
+local TUTORIAL_BOTTOM_CONTENT_PADDING = 42
 local STEP_ORDER = {
     "welcome",
     "groups_column_intro",
@@ -41,7 +41,6 @@ local STEP_ORDER = {
     "entry_settings_intro",
     "panel_settings_intro",
     "view_modes_intro",
-    "help_tooltips_intro",
     "finish",
 }
 
@@ -110,17 +109,10 @@ local STEP_DATA = {
         anchor = "mode_toggle_button",
         placement = "above",
     },
-    help_tooltips_intro = {
-        title = "More Help",
-        text = "Tooltips are spread throughout the config in order to help explain some of the less obvious aspects of the addon. Be sure to read them as you're exploring.",
-        anchor = "panels_info_button",
-        highlightAnchor = "column_info_buttons_area",
-        placement = "below",
-    },
     finish = {
         title = "Tutorial Complete",
-        text = "You can watch this tutorial again later by clicking the Tutorial button in the top-right corner.",
-        anchor = "tutorial_button",
+        text = "You can watch this tutorial again later from the gear menu in the top-right corner.",
+        anchor = "gear_button",
         placement = "below",
     },
 }
@@ -201,31 +193,20 @@ local function SetStep(step)
 end
 
 local function GetAnchor(name)
-    local anchor = CS.tutorialAnchors and CS.tutorialAnchors[name]
-    if type(anchor) == "table" and anchor[1] then
-        for _, frame in ipairs(anchor) do
-            if frame and frame.IsShown and frame:IsShown() then
-                return anchor
-            end
-        end
-        return nil
-    end
-    if anchor and anchor.IsShown and anchor:IsShown() then
-        return anchor
+    local frame = CS.tutorialAnchors and CS.tutorialAnchors[name]
+    if frame and frame.IsShown and frame:IsShown() then
+        return frame
     end
     return nil
 end
 
 local function HideHighlight()
-    local highlights = CS.tutorialHighlights
-    if highlights then
-        for _, highlight in ipairs(highlights) do
-            if highlight._cdcGlow and HideGlowStyles then
-                HideGlowStyles(highlight._cdcGlow)
-            end
-            highlight:ClearAllPoints()
-            highlight:Hide()
+    if CS.tutorialHighlight then
+        if CS.tutorialHighlight._cdcGlow and HideGlowStyles then
+            HideGlowStyles(CS.tutorialHighlight._cdcGlow)
         end
+        CS.tutorialHighlight:ClearAllPoints()
+        CS.tutorialHighlight:Hide()
     end
 end
 
@@ -318,7 +299,24 @@ local function EnsureTutorialFrame()
     closeButton:GetHighlightTexture():SetAlpha(0.3)
     frame.CloseButton = closeButton
 
-    CS.tutorialHighlights = CS.tutorialHighlights or {}
+    local highlight = CreateFrame("Frame", nil, UIParent)
+    highlight:SetFrameStrata("TOOLTIP")
+    highlight:SetFrameLevel(2000)
+    highlight:SetToplevel(true)
+    highlight:EnableMouse(false)
+    highlight:Hide()
+    if CreateGlowContainer then
+        highlight._cdcGlow = CreateGlowContainer(highlight, 48, false)
+        if highlight._cdcGlow.solidFrame then
+            highlight._cdcGlow.solidFrame:SetFrameStrata("TOOLTIP")
+            highlight._cdcGlow.solidFrame:SetFrameLevel(highlight:GetFrameLevel() + 1)
+        end
+        if highlight._cdcGlow.procFrame then
+            highlight._cdcGlow.procFrame:SetFrameStrata("TOOLTIP")
+            highlight._cdcGlow.procFrame:SetFrameLevel(highlight:GetFrameLevel() + 2)
+        end
+    end
+    CS.tutorialHighlight = highlight
 
     frame:SetScript("OnHide", function()
         HideHighlight()
@@ -339,34 +337,6 @@ local function EnsureTutorialFrame()
 
     CS.tutorialFrame = frame
     return frame
-end
-
-local function GetOrCreateHighlight(index)
-    CS.tutorialHighlights = CS.tutorialHighlights or {}
-    local highlight = CS.tutorialHighlights[index]
-    if highlight then
-        return highlight
-    end
-
-    highlight = CreateFrame("Frame", nil, UIParent)
-    highlight:SetFrameStrata("TOOLTIP")
-    highlight:SetFrameLevel(2000)
-    highlight:SetToplevel(true)
-    highlight:EnableMouse(false)
-    highlight:Hide()
-    if CreateGlowContainer then
-        highlight._cdcGlow = CreateGlowContainer(highlight, 48, false)
-        if highlight._cdcGlow.solidFrame then
-            highlight._cdcGlow.solidFrame:SetFrameStrata("TOOLTIP")
-            highlight._cdcGlow.solidFrame:SetFrameLevel(highlight:GetFrameLevel() + 1)
-        end
-        if highlight._cdcGlow.procFrame then
-            highlight._cdcGlow.procFrame:SetFrameStrata("TOOLTIP")
-            highlight._cdcGlow.procFrame:SetFrameLevel(highlight:GetFrameLevel() + 2)
-        end
-    end
-    CS.tutorialHighlights[index] = highlight
-    return highlight
 end
 
 local function ResizeTutorialFrame(frame)
@@ -549,11 +519,6 @@ local function ConfigureButtonsForStep(frame, step)
     elseif step == "view_modes_intro" then
         SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
         SetTutorialButton(frame.rightButton, "Next", function()
-            AdvanceStep("help_tooltips_intro")
-        end)
-    elseif step == "help_tooltips_intro" then
-        SetTutorialButton(frame.leftButton, "Previous", GoToPreviousStep)
-        SetTutorialButton(frame.rightButton, "Next", function()
             AdvanceStep("finish")
         end)
     elseif step == "finish" then
@@ -570,41 +535,10 @@ local function UpdateHighlight(anchor)
         return
     end
 
-    if type(anchor) == "table" and anchor[1] then
-        HideHighlight()
-        local used = 0
-        for _, frame in ipairs(anchor) do
-            if frame and frame.IsShown and frame:IsShown() then
-                used = used + 1
-                local highlight = GetOrCreateHighlight(used)
-                highlight:ClearAllPoints()
-                highlight:SetParent(UIParent)
-                highlight:SetPoint("TOPLEFT", frame, "TOPLEFT", -1, 1)
-                highlight:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 1, -1)
-                highlight:Show()
-                if highlight._cdcGlow and ShowGlowStyle then
-                    ShowGlowStyle(highlight._cdcGlow, "solid", highlight, TUTORIAL_SOLID_GLOW_COLOR, {
-                        size = 3,
-                        defaultAlpha = 1,
-                    })
-                end
-            end
-        end
-        local highlights = CS.tutorialHighlights or {}
-        for index = used + 1, #highlights do
-            local extra = highlights[index]
-            if extra then
-                if extra._cdcGlow and HideGlowStyles then
-                    HideGlowStyles(extra._cdcGlow)
-                end
-                extra:ClearAllPoints()
-                extra:Hide()
-            end
-        end
+    local highlight = CS.tutorialHighlight
+    if not highlight then
         return
     end
-
-    local highlight = GetOrCreateHighlight(1)
     highlight:ClearAllPoints()
     highlight:SetParent(UIParent)
     highlight:SetPoint("TOPLEFT", anchor, "TOPLEFT", -1, 1)
@@ -615,17 +549,6 @@ local function UpdateHighlight(anchor)
             size = 3,
             defaultAlpha = 1,
         })
-    end
-    local highlights = CS.tutorialHighlights or {}
-    for index = 2, #highlights do
-        local extra = highlights[index]
-        if extra then
-            if extra._cdcGlow and HideGlowStyles then
-                HideGlowStyles(extra._cdcGlow)
-            end
-            extra:ClearAllPoints()
-            extra:Hide()
-        end
     end
 end
 
@@ -739,12 +662,8 @@ local function RefreshTutorialPlacement()
     ConfigureButtonsForStep(frame, step)
     ResizeTutorialFrame(frame)
 
-    local placementAnchor = data.anchor and GetAnchor(data.anchor) or nil
-    local highlightAnchor = data.highlightAnchor and GetAnchor(data.highlightAnchor) or placementAnchor
-    PositionFrame(frame, placementAnchor, data.placement)
-    if highlightAnchor ~= placementAnchor then
-        UpdateHighlight(highlightAnchor)
-    end
+    local anchor = data.anchor and GetAnchor(data.anchor) or nil
+    PositionFrame(frame, anchor, data.placement)
     frame:Show()
 end
 
@@ -769,21 +688,8 @@ local function RebuildTutorialAnchors()
     end
     wipe(anchors)
 
-    local infoButtons = CS.columnInfoButtons
-    if infoButtons and #infoButtons > 0 then
-        local shownButtons = {}
-        for _, button in ipairs(infoButtons) do
-            if button and button.IsShown and button:IsShown() then
-                table.insert(shownButtons, button)
-            end
-        end
-        if #shownButtons > 0 then
-            anchors.column_info_buttons_area = shownButtons
-        end
-    end
-
-    if CS.tutorialButton then
-        anchors.tutorial_button = CS.tutorialButton
+    if CS.gearButton and CS.gearButton:IsShown() then
+        anchors.gear_button = CS.gearButton
     end
     if CS.modeToggleButton and CS.modeToggleButton:IsShown() then
         anchors.mode_toggle_button = CS.modeToggleButton
@@ -794,9 +700,6 @@ local function RebuildTutorialAnchors()
     end
     if CS.configFrame and CS.configFrame.col2 and CS.configFrame.col2.frame then
         anchors.panels_column_area = CS.configFrame.col2.frame
-        if CS.configFrame.col2._infoBtn and CS.configFrame.col2._infoBtn:IsShown() then
-            anchors.panels_info_button = CS.configFrame.col2._infoBtn
-        end
     end
 
     local col1Widgets = CS.col1BarWidgets or {}

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -79,6 +79,7 @@ OtherBars\ResourceBarVisuals.lua
 OtherBars\ResourceBar.lua
 Core\FrameAnchoring.lua
 Config\State.lua
+Config\Tutorial.lua
 Config\ExportCodec.lua
 Config\Popups.lua
 Config\Diagnostics.lua

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -12,6 +12,13 @@ local defaults = {
             lastSeenVersion = nil,
             fontSize = 13,
         },
+        tutorials = {
+            firstIconPanel = {
+                completed = false,
+                dismissed = false,
+                lastVersionSeen = nil,
+            },
+        },
     },
     profile = {
         minimap = {


### PR DESCRIPTION
## What Players Will Notice
- A first-run tutorial now walks new users through creating a real icon panel, adding a real spell, and understanding where single-entry settings versus panel-wide settings live.
- The tutorial highlights the live config controls as you go, supports stepping backward, and can be replayed later from the gear menu.
- The tutorial window is more polished and easier to read, with dynamic sizing and clearer guidance around groups, panels, entries, and advanced panel-setting badges.

## Why This Changed
- New users were landing in a dense config with very little direction on what a group, panel, or entry actually is, or where to add their first tracked spell.
- The onboarding flow needed to teach the real config using the user's actual profile instead of a disconnected help overlay.

## What Changed
- Added a standalone tutorial system in `Config/Tutorial.lua` with account-wide completion state and runtime-only step tracking.
- Wired the tutorial into the real config actions for creating groups, creating icon panels, and adding a spell through the inline autocomplete flow.
- Added semantic tutorial anchors across the config so the callout can survive config rebuilds and keep pointing at the right controls.
- Moved tutorial replay into the top-right gear menu and updated the finish step to point users there.
- Improved tutorial resilience so early real actions are accepted, missing anchors fall back safely, profile changes tear the tutorial down cleanly, and short tutorial panels no longer waste vertical space.
- Kept `Auto Add` available but out of the guided path, while making it visually secondary during the tutorial's add step.

## Validation
- Verified syntax with `luac -p` for the touched config files during implementation.
- Reviewed and fixed tutorial state-machine edge cases around early clicks and missing anchors.
- In-game combat and restricted-content behavior have not been verified yet.
