### PR TITLE
Fix load conditions for outdoor delves

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -241,9 +241,18 @@ end
 
 function CooldownCompanion:CachePlayerState()
     local inInstance, instanceType = IsInInstance()
-    if inInstance and instanceType == "scenario" then
-        local _, _, difficultyID = GetInstanceInfo()
-        self._currentInstanceType = (difficultyID == 208) and "delve" or "scenario"
+    local _, reportedInstanceType, difficultyID = GetInstanceInfo()
+    local mapID = C_Map.GetBestMapForUnit("player")
+    -- Outdoor delves can disagree across APIs, so treat any verified delve signal
+    -- as authoritative before falling back to the generic instance classification.
+    local isDelve = C_PartyInfo.IsDelveInProgress()
+        or (reportedInstanceType == "scenario" and difficultyID == 208)
+        or (mapID and C_DelvesUI.HasActiveDelve(mapID))
+        or C_DelvesUI.HasActiveDelve()
+    if isDelve then
+        self._currentInstanceType = "delve"
+    elseif inInstance and instanceType == "scenario" then
+        self._currentInstanceType = "scenario"
     else
         self._currentInstanceType = inInstance and instanceType or "none"
     end


### PR DESCRIPTION
## What Players Will Notice
- Panels and groups set to not load in Delves now unload correctly in outdoor delves.
- Open World load conditions no longer treat those outdoor delves as open world.

## Why This Changed
- Some outdoor delves report conflicting environment APIs. Cooldown Companion only trusted `IsInInstance()` before classifying delve state, so those delves could fall through to open world instead of being treated as delves.

## What Changed
- Updated player environment caching to resolve delve state before the generic instance fallback.
- Added a composite delve check using `C_PartyInfo.IsDelveInProgress()`, scenario difficulty `208`, and active delve API signals so outdoor delves are classified more consistently.

## Validation
- Verified in game by walking into and back out of an outdoor delve with delve-based load conditions enabled; the panel unloaded inside and reloaded outside.
- Verified the post-exit API state returned `false false false` for `C_PartyInfo.IsDelveInProgress()`, `C_DelvesUI.HasActiveDelve(mapID)`, and `C_DelvesUI.HasActiveDelve()`.
- Normal dungeon/open-world smoke checks and combat/restricted-content validation are still pending.