### PR TITLE
Add active trigger panel effects and multiline trigger text controls

### DIFF
--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -28,6 +28,7 @@ local readyPreviewTokens = {}
 local readyButtonPreviewTokens = {}
 local kphPreviewTokens = {}
 local textureIndicatorPreviewTokens = {}
+local triggerEffectPreviewTokens = {}
 
 local function BumpButtonPreviewToken(tokenStore, groupId, buttonIndex)
     local groupTokens = tokenStore[groupId]
@@ -450,6 +451,44 @@ function CooldownCompanion:ClearAllTextureIndicatorPreviews()
             button._textureReadyPreview = nil
             button._textureUnusablePreview = nil
             button._textureIndicatorPreviewDirty = false
+            if button.UpdateCooldown then
+                button:UpdateCooldown()
+            else
+                self:UpdateAuraTextureVisual(button)
+            end
+        end
+    end
+end
+
+function CooldownCompanion:SetTriggerPanelEffectsPreview(groupId, show)
+    local frame = self.groupFrames[groupId]
+    if not frame then
+        return
+    end
+
+    if not show then
+        triggerEffectPreviewTokens[groupId] = (triggerEffectPreviewTokens[groupId] or 0) + 1
+    end
+
+    for _, button in ipairs(frame.buttons) do
+        button._triggerEffectsPreview = show or nil
+        if button.UpdateCooldown then
+            button:UpdateCooldown()
+        else
+            self:UpdateAuraTextureVisual(button)
+        end
+    end
+end
+
+function CooldownCompanion:PlayTriggerPanelEffectsPreview(groupId, durationSeconds)
+    PlayGroupPreview(self, groupId, durationSeconds, triggerEffectPreviewTokens, self.SetTriggerPanelEffectsPreview)
+end
+
+function CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+    wipe(triggerEffectPreviewTokens)
+    for _, frame in pairs(self.groupFrames) do
+        for _, button in ipairs(frame.buttons) do
+            button._triggerEffectsPreview = nil
             if button.UpdateCooldown then
                 button:UpdateCooldown()
             else

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -183,6 +183,9 @@ local function RefreshColumn4(container)
             CS.panelSettingsTab = tab
             if tab ~= "effects" then
                 CooldownCompanion:ClearAllTextureIndicatorPreviews()
+                if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
+                    CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+                end
             end
             -- Clean up raw (?) info buttons BEFORE releasing children, so they
             -- don't leak onto recycled AceGUI frames when switching tabs

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -540,6 +540,9 @@ local function CreateConfigPanel()
         CooldownCompanion:ClearAllKeyPressHighlightPreviews()
         CooldownCompanion:ClearAllBarAuraActivePreviews()
         CooldownCompanion:ClearAllTextureIndicatorPreviews()
+        if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
+            CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+        end
         CooldownCompanion:ClearAllAuraTexturePickerPreviews()
         CooldownCompanion:StopCastBarPreview()
         if ClearConfigShiftTooltipHover then

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -615,10 +615,9 @@ local function OpenConfigIconPicker(spec, context)
         pickerFrame:SetSelectedIconText()
         pickerFrame.BorderBox.OkayButton:Enable()
     else
+        pickerFrame.IconSelector:SetSelectedIndex(nil)
         pickerFrame.BorderBox.SelectedIconArea.SelectedIconButton:SetIconTexture(nil)
-        if pickerFrame.BorderBox.SelectedIconArea.SelectedIconText then
-            pickerFrame.BorderBox.SelectedIconArea.SelectedIconText:SetText("No icon selected")
-        end
+        pickerFrame:SetSelectedIconText()
         pickerFrame.BorderBox.OkayButton:Disable()
     end
 

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -728,7 +728,8 @@ end
 local function BuildTriggerTextAppearanceTab(container, group)
     local settings = CooldownCompanion:GetTriggerPanelTextSettings(group, true)
     local groupId = CS.selectedGroup
-    local maxTextLength = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH or 80
+    local maxTextLength = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH or 120
+    local maxTextLines = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LINES or 4
 
     local heading = AceGUI:Create("Heading")
     heading:SetText("Trigger Text")
@@ -751,7 +752,9 @@ local function BuildTriggerTextAppearanceTab(container, group)
 
     local previewText = textHolder:CreateFontString(nil, "OVERLAY")
     previewText:SetJustifyV("MIDDLE")
+    previewText:SetJustifyH("CENTER")
     previewText:SetWordWrap(false)
+    previewText:SetMaxLines(0)
 
     local placeholder = previewFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     placeholder:SetPoint("CENTER")
@@ -762,22 +765,27 @@ local function BuildTriggerTextAppearanceTab(container, group)
     local function RefreshTextPreview()
         local bgColor = settings.textBgColor or { 0, 0, 0, 0 }
         local fontColor = settings.textFontColor or { 1, 1, 1, 1 }
+        local textAlignment = settings.textAlignment or "CENTER"
         local hasText = CooldownCompanion.HasTriggerTextValue(settings)
         local insetX = 2
         local insetY = 1
 
         if hasText then
-            local frameWidth, frameHeight, textWidth, textHeight
-            frameWidth, frameHeight, insetX, insetY, textWidth, textHeight = CooldownCompanion.GetTriggerTextDisplayMetrics(previewText, settings)
+            local frameWidth, frameHeight, textWidth, textHeight, lineCount
+            frameWidth, frameHeight, insetX, insetY, textWidth, textHeight, lineCount = CooldownCompanion.GetTriggerTextDisplayMetrics(previewText, settings)
             textHolder:SetSize(frameWidth, frameHeight)
             textHolder:ClearAllPoints()
             textHolder:SetPoint("CENTER", previewFrame, "CENTER", 0, 0)
             previewText:SetSize(textWidth or math_max(1, frameWidth - (insetX * 2)), textHeight or math_max(1, frameHeight - (insetY * 2)))
+            previewText:SetWordWrap((lineCount or 1) > 1)
+            previewText:SetJustifyV((lineCount or 1) > 1 and "TOP" or "MIDDLE")
         else
             textHolder:SetSize(1, 1)
             textHolder:ClearAllPoints()
             textHolder:SetPoint("CENTER", previewFrame, "CENTER", 0, 0)
             previewText:SetSize(1, 1)
+            previewText:SetWordWrap(false)
+            previewText:SetJustifyV("MIDDLE")
         end
         previewBg:SetColorTexture(bgColor[1] or 0, bgColor[2] or 0, bgColor[3] or 0, bgColor[4] ~= nil and bgColor[4] or 0)
         for _, border in ipairs(previewBorders) do
@@ -785,7 +793,9 @@ local function BuildTriggerTextAppearanceTab(container, group)
         end
 
         previewText:ClearAllPoints()
-        previewText:SetPoint("CENTER", textHolder, "CENTER", 0, 0)
+        previewText:SetPoint("TOPLEFT", textHolder, "TOPLEFT", insetX, -insetY)
+        previewText:SetPoint("BOTTOMRIGHT", textHolder, "BOTTOMRIGHT", -insetX, insetY)
+        previewText:SetJustifyH(textAlignment)
         previewText:SetTextColor(fontColor[1] or 1, fontColor[2] or 1, fontColor[3] or 1, fontColor[4] ~= nil and fontColor[4] or 1)
         previewText:SetShown(hasText)
         placeholder:SetShown(not hasText)
@@ -793,19 +803,30 @@ local function BuildTriggerTextAppearanceTab(container, group)
         RefreshStandaloneTriggerDisplay(groupId)
     end
 
-    local textBox = AceGUI:Create("EditBox")
+    local textBox = AceGUI:Create("MultiLineEditBox")
     textBox:SetLabel("Display Text")
     textBox:SetFullWidth(true)
-    textBox:DisableButton(true)
-    textBox:SetMaxLetters(maxTextLength)
+    textBox:SetNumLines(maxTextLines)
+    textBox.button:Hide()
     textBox:SetText(settings.value or "")
-    local function HandleTextChanged(_, _, value)
-        settings.value = type(value) == "string" and value:sub(1, maxTextLength) or ""
+    local function HandleTextChanged(widget, _, value)
+        local sanitized = CooldownCompanion.SanitizeTriggerPanelTextValue and CooldownCompanion.SanitizeTriggerPanelTextValue(value) or (value or "")
+        settings.value = sanitized
+        if widget and widget.SetText and widget:GetText() ~= sanitized and not widget._ccSyncingText then
+            widget._ccSyncingText = true
+            widget:SetText(sanitized)
+            widget._ccSyncingText = nil
+        end
         RefreshTextPreview()
     end
     textBox:SetCallback("OnTextChanged", HandleTextChanged)
-    textBox:SetCallback("OnEnterPressed", HandleTextChanged)
     container:AddChild(textBox)
+
+    local limitLabel = AceGUI:Create("Label")
+    limitLabel:SetFullWidth(true)
+    limitLabel:SetText("Up to " .. maxTextLines .. " lines and " .. maxTextLength .. " total characters.")
+    limitLabel:SetColor(0.7, 0.7, 0.7)
+    container:AddChild(limitLabel)
 
     AddFontControls(container, settings, "text", {
         size = 12,
@@ -814,6 +835,17 @@ local function BuildTriggerTextAppearanceTab(container, group)
         font = "Friz Quadrata TT",
         outline = "OUTLINE",
     }, RefreshTextPreview)
+
+    local alignDrop = AceGUI:Create("Dropdown")
+    alignDrop:SetLabel("Alignment")
+    alignDrop:SetList({ LEFT = "Left", CENTER = "Center", RIGHT = "Right" })
+    alignDrop:SetValue(settings.textAlignment or "CENTER")
+    alignDrop:SetFullWidth(true)
+    alignDrop:SetCallback("OnValueChanged", function(_, _, value)
+        settings.textAlignment = value
+        RefreshTextPreview()
+    end)
+    container:AddChild(alignDrop)
 
     AddColorPicker(container, settings, "textFontColor", "Text Color", { 1, 1, 1, 1 }, true, RefreshTextPreview, RefreshTextPreview)
     AddColorPicker(container, settings, "textBgColor", "Background Color", { 0, 0, 0, 0 }, true, RefreshTextPreview, RefreshTextPreview)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -168,6 +168,29 @@ local function GetTextureIndicatorStore(group)
     return CooldownCompanion:GetTexturePanelIndicatorSettings(group, true)
 end
 
+local TRIGGER_PANEL_EFFECT_DEFS = {
+    pulse = {
+        label = "Pulse",
+        speedLabel = "Pulse Duration",
+    },
+    colorShift = {
+        label = "Color Shift",
+        speedLabel = "Shift Duration",
+    },
+    shrinkExpand = {
+        label = "Shrink / Expand",
+        speedLabel = "Cycle Duration",
+    },
+    bounce = {
+        label = "Bounce",
+        speedLabel = "Bounce Duration",
+    },
+}
+
+local function GetTriggerPanelEffectStore(group)
+    return CooldownCompanion:GetTriggerPanelEffectSettings(group, true)
+end
+
 local function GetTextureIndicatorUsedEffects(indicators, currentSectionKey)
     local used = {}
     if type(indicators) ~= "table" then
@@ -810,6 +833,9 @@ local function BuildLayoutTab(container)
     local style = group.style
 
     CooldownCompanion:ClearAllTextureIndicatorPreviews()
+    if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
+        CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+    end
 
     if group.displayMode == "textures" or group.displayMode == "trigger" then
         local settings = GetStandaloneTextureSettings(group, true)
@@ -1458,6 +1484,46 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
     container:AddChild(previewBtn)
 end
 
+local function BuildTriggerPanelEffectSection(container, effects, effectKey)
+    local config = effects and effects[effectKey]
+    local def = TRIGGER_PANEL_EFFECT_DEFS[effectKey]
+    if not config or not def then
+        return
+    end
+
+    local enableCb = AceGUI:Create("CheckBox")
+    enableCb:SetLabel(def.label)
+    enableCb:SetValue(config.enabled)
+    enableCb:SetFullWidth(true)
+    enableCb:SetCallback("OnValueChanged", function(_, _, value)
+        config.enabled = value == true
+        CooldownCompanion:RefreshAllAuraTextureVisuals()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(enableCb)
+
+    local advKey = "triggerEffect_" .. effectKey
+    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled)
+    if not advExpanded or not config.enabled then
+        return
+    end
+
+    if effectKey == "colorShift" then
+        AddColorPicker(
+            container,
+            config,
+            "color",
+            "Shift Color",
+            { 1, 1, 1, 1 },
+            true,
+            function() CooldownCompanion:RefreshAllAuraTextureVisuals() end,
+            function() CooldownCompanion:RefreshAllAuraTextureVisuals() end
+        )
+    end
+
+    BuildTextureIndicatorSpeedSlider(container, config, def.speedLabel)
+end
+
 local function BuildEffectsTab(container)
     for _, btn in ipairs(tabInfoButtons) do
         btn:ClearAllPoints()
@@ -1478,8 +1544,32 @@ local function BuildEffectsTab(container)
     local style = group.style
 
     CooldownCompanion:ClearAllTextureIndicatorPreviews()
+    if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
+        CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+    end
 
     if group.displayMode == "trigger" then
+        local effects = GetTriggerPanelEffectStore(group)
+        if not effects then
+            return
+        end
+
+        local anyEnabled = false
+        for _, effectKey in ipairs(TEXTURE_INDICATOR_EFFECT_ORDER) do
+            BuildTriggerPanelEffectSection(container, effects, effectKey)
+            if effects[effectKey] and effects[effectKey].enabled then
+                anyEnabled = true
+            end
+        end
+
+        local previewBtn = AceGUI:Create("Button")
+        previewBtn:SetText("Preview Effects (3s)")
+        previewBtn:SetFullWidth(true)
+        previewBtn:SetDisabled(not anyEnabled)
+        previewBtn:SetCallback("OnClick", function()
+            CooldownCompanion:PlayTriggerPanelEffectsPreview(CS.selectedGroup, 3)
+        end)
+        container:AddChild(previewBtn)
         return
     end
 
@@ -1993,6 +2083,9 @@ local function BuildAppearanceTab(container)
     local style = group.style
 
     CooldownCompanion:ClearAllTextureIndicatorPreviews()
+    if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
+        CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+    end
 
     if group.displayMode == "trigger" then
         AddTriggerDisplayTypeDropdown(container, group)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -728,6 +728,7 @@ end
 local function BuildTriggerTextAppearanceTab(container, group)
     local settings = CooldownCompanion:GetTriggerPanelTextSettings(group, true)
     local groupId = CS.selectedGroup
+    local maxTextLength = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH or 80
 
     local heading = AceGUI:Create("Heading")
     heading:SetText("Trigger Text")
@@ -766,15 +767,17 @@ local function BuildTriggerTextAppearanceTab(container, group)
         local insetY = 1
 
         if hasText then
-            local frameWidth, frameHeight
-            frameWidth, frameHeight, insetX, insetY = CooldownCompanion.GetTriggerTextDisplayMetrics(previewText, settings)
+            local frameWidth, frameHeight, textWidth, textHeight
+            frameWidth, frameHeight, insetX, insetY, textWidth, textHeight = CooldownCompanion.GetTriggerTextDisplayMetrics(previewText, settings)
             textHolder:SetSize(frameWidth, frameHeight)
             textHolder:ClearAllPoints()
             textHolder:SetPoint("CENTER", previewFrame, "CENTER", 0, 0)
+            previewText:SetSize(textWidth or math_max(1, frameWidth - (insetX * 2)), textHeight or math_max(1, frameHeight - (insetY * 2)))
         else
             textHolder:SetSize(1, 1)
             textHolder:ClearAllPoints()
             textHolder:SetPoint("CENTER", previewFrame, "CENTER", 0, 0)
+            previewText:SetSize(1, 1)
         end
         previewBg:SetColorTexture(bgColor[1] or 0, bgColor[2] or 0, bgColor[3] or 0, bgColor[4] ~= nil and bgColor[4] or 0)
         for _, border in ipairs(previewBorders) do
@@ -782,8 +785,7 @@ local function BuildTriggerTextAppearanceTab(container, group)
         end
 
         previewText:ClearAllPoints()
-        previewText:SetPoint("TOPLEFT", textHolder, "TOPLEFT", insetX, -insetY)
-        previewText:SetPoint("BOTTOMRIGHT", textHolder, "BOTTOMRIGHT", -insetX, insetY)
+        previewText:SetPoint("CENTER", textHolder, "CENTER", 0, 0)
         previewText:SetTextColor(fontColor[1] or 1, fontColor[2] or 1, fontColor[3] or 1, fontColor[4] ~= nil and fontColor[4] or 1)
         previewText:SetShown(hasText)
         placeholder:SetShown(not hasText)
@@ -791,14 +793,14 @@ local function BuildTriggerTextAppearanceTab(container, group)
         RefreshStandaloneTriggerDisplay(groupId)
     end
 
-    local textBox = AceGUI:Create("MultiLineEditBox")
+    local textBox = AceGUI:Create("EditBox")
     textBox:SetLabel("Display Text")
     textBox:SetFullWidth(true)
-    textBox:SetNumLines(4)
-    textBox.button:Hide()
+    textBox:DisableButton(true)
+    textBox:SetMaxLetters(maxTextLength)
     textBox:SetText(settings.value or "")
     local function HandleTextChanged(_, _, value)
-        settings.value = value or ""
+        settings.value = type(value) == "string" and value:sub(1, maxTextLength) or ""
         RefreshTextPreview()
     end
     textBox:SetCallback("OnTextChanged", HandleTextChanged)
@@ -1524,6 +1526,21 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
     BuildTextureIndicatorSpeedSlider(container, config, def.speedLabel)
 end
 
+local function GetTriggerPanelEffectOrderForDisplayType(group)
+    local displayType = CooldownCompanion:GetTriggerPanelDisplayType(group, true)
+    if displayType ~= "text" then
+        return TEXTURE_INDICATOR_EFFECT_ORDER
+    end
+
+    local order = {}
+    for _, effectKey in ipairs(TEXTURE_INDICATOR_EFFECT_ORDER) do
+        if effectKey ~= "shrinkExpand" then
+            order[#order + 1] = effectKey
+        end
+    end
+    return order
+end
+
 local function BuildEffectsTab(container)
     for _, btn in ipairs(tabInfoButtons) do
         btn:ClearAllPoints()
@@ -1555,7 +1572,8 @@ local function BuildEffectsTab(container)
         end
 
         local anyEnabled = false
-        for _, effectKey in ipairs(TEXTURE_INDICATOR_EFFECT_ORDER) do
+        local effectOrder = GetTriggerPanelEffectOrderForDisplayType(group)
+        for _, effectKey in ipairs(effectOrder) do
             BuildTriggerPanelEffectSection(container, effects, effectKey)
             if effects[effectKey] and effects[effectKey].enabled then
                 anyEnabled = true

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -550,6 +550,22 @@ local function CreateTriggerPreviewCanvas(container, height)
     return previewFrame
 end
 
+local function FitPreviewContentToCanvas(contentFrame, canvasFrame, contentWidth, contentHeight, padding)
+    if not contentFrame or not canvasFrame then
+        return
+    end
+
+    padding = padding or 8
+    local canvasWidth = canvasFrame:GetWidth() or TEXTURE_PREVIEW_WIDTH
+    local canvasHeight = canvasFrame:GetHeight() or 0
+    local availableWidth = math_max(1, canvasWidth - (padding * 2))
+    local availableHeight = math_max(1, canvasHeight - (padding * 2))
+    local widthScale = availableWidth / math_max(1, contentWidth or 1)
+    local heightScale = availableHeight / math_max(1, contentHeight or 1)
+    local scale = math_min(1, widthScale, heightScale)
+    contentFrame:SetScale(scale)
+end
+
 local function BuildTriggerIconAppearanceTab(container, group)
     local settings = CooldownCompanion:GetTriggerPanelIconSettings(group, true)
     local groupId = CS.selectedGroup
@@ -770,6 +786,7 @@ local function BuildTriggerTextAppearanceTab(container, group)
         local insetX = 2
         local insetY = 1
 
+        textHolder:SetScale(1)
         if hasText then
             local frameWidth, frameHeight, textWidth, textHeight, lineCount
             frameWidth, frameHeight, insetX, insetY, textWidth, textHeight, lineCount = CooldownCompanion.GetTriggerTextDisplayMetrics(previewText, settings)
@@ -779,6 +796,7 @@ local function BuildTriggerTextAppearanceTab(container, group)
             previewText:SetSize(textWidth or math_max(1, frameWidth - (insetX * 2)), textHeight or math_max(1, frameHeight - (insetY * 2)))
             previewText:SetWordWrap((lineCount or 1) > 1)
             previewText:SetJustifyV((lineCount or 1) > 1 and "TOP" or "MIDDLE")
+            FitPreviewContentToCanvas(textHolder, previewFrame, frameWidth, frameHeight, 8)
         else
             textHolder:SetSize(1, 1)
             textHolder:ClearAllPoints()

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -728,6 +728,33 @@ local TEXTURE_INDICATOR_DEFAULTS = {
     },
 }
 
+CooldownCompanion.TRIGGER_PANEL_EFFECT_ORDER = {
+    TEXTURE_INDICATOR_EFFECT_PULSE,
+    TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT,
+    TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND,
+    TEXTURE_INDICATOR_EFFECT_BOUNCE,
+}
+
+CooldownCompanion.TRIGGER_PANEL_EFFECT_DEFAULTS = {
+    pulse = {
+        enabled = false,
+        speed = DEFAULT_TEXTURE_INDICATOR_SPEED,
+    },
+    colorShift = {
+        enabled = false,
+        speed = DEFAULT_TEXTURE_INDICATOR_SPEED,
+        color = { 1, 1, 1, 1 },
+    },
+    shrinkExpand = {
+        enabled = false,
+        speed = DEFAULT_TEXTURE_INDICATOR_SPEED,
+    },
+    bounce = {
+        enabled = false,
+        speed = DEFAULT_TEXTURE_INDICATOR_SPEED,
+    },
+}
+
 local TRIGGER_CONDITION_LABELS = {
     cooldownActive = "Cooldown",
     auraActive = "Aura",
@@ -861,6 +888,46 @@ local function NormalizeTextureIndicatorStore(styleTable)
     local store = styleTable.textureIndicators
     for _, sectionKey in ipairs(TEXTURE_INDICATOR_SECTION_ORDER) do
         store[sectionKey] = NormalizeTextureIndicatorSection(sectionKey, store[sectionKey])
+    end
+
+    return store
+end
+
+function CooldownCompanion.NormalizeTriggerPanelEffectSection(effectKey, effectData)
+    local defaults = CooldownCompanion.TRIGGER_PANEL_EFFECT_DEFAULTS[effectKey]
+    if not defaults then
+        return nil
+    end
+
+    effectData = type(effectData) == "table" and effectData or {}
+    effectData.enabled = effectData.enabled == true
+    effectData.speed = Clamp(
+        tonumber(effectData.speed) or defaults.speed or DEFAULT_TEXTURE_INDICATOR_SPEED,
+        MIN_TEXTURE_INDICATOR_SPEED,
+        MAX_TEXTURE_INDICATOR_SPEED
+    )
+
+    if defaults.color ~= nil then
+        effectData.color = CopyColor(effectData.color) or CopyColor(defaults.color) or { 1, 1, 1, 1 }
+    else
+        effectData.color = nil
+    end
+
+    return effectData
+end
+
+function CooldownCompanion.NormalizeTriggerPanelEffectStore(triggerSettings)
+    if type(triggerSettings) ~= "table" then
+        return nil
+    end
+
+    if type(triggerSettings.effects) ~= "table" then
+        triggerSettings.effects = {}
+    end
+
+    local store = triggerSettings.effects
+    for _, effectKey in ipairs(CooldownCompanion.TRIGGER_PANEL_EFFECT_ORDER) do
+        store[effectKey] = CooldownCompanion.NormalizeTriggerPanelEffectSection(effectKey, store[effectKey])
     end
 
     return store
@@ -1564,6 +1631,26 @@ function CooldownCompanion:GetTriggerPanelSignalSettings(groupOrId, createIfMiss
     end
 
     return NormalizeAuraTextureSettings(group.triggerSettings.signal)
+end
+
+function CooldownCompanion:GetTriggerPanelEffectSettings(groupOrId, createIfMissing)
+    local group = ResolveGroup(groupOrId)
+    if type(group) ~= "table" then
+        return nil
+    end
+
+    if type(group.triggerSettings) ~= "table" then
+        if not createIfMissing then
+            return nil
+        end
+        group.triggerSettings = {}
+    end
+
+    if type(group.triggerSettings.effects) ~= "table" and not createIfMissing then
+        return nil
+    end
+
+    return CooldownCompanion.NormalizeTriggerPanelEffectStore(group.triggerSettings)
 end
 
 function CooldownCompanion.NormalizeTriggerDisplayType(displayType)
@@ -2915,28 +3002,47 @@ local function SetTextureIndicatorBaseVisuals(host)
         return
     end
 
-    local settings = host._activeTextureSettings
-    local geometry = host._activeTextureGeometry
-    if not settings or not geometry then
+    local displayType = host._activeDisplayType
+    if displayType == "texture" then
+        local settings = host._activeTextureSettings
+        local geometry = host._activeTextureGeometry
+        if not settings or not geometry then
+            return
+        end
+
+        local color = settings.color or { 1, 1, 1, 1 }
+        local baseAlpha = Clamp((color[4] or 1) * (settings.alpha or 1), 0.05, 1)
+        local textures = {
+            host.primaryTexture,
+            host.secondaryTexture,
+        }
+
+        for index, texture in ipairs(textures) do
+            local piece = geometry.pieces[index]
+            if texture and piece and texture:IsShown() then
+                ApplyTextureVisual(texture, settings, baseAlpha, piece.flipH, piece.flipV, geometry.rotationRadians)
+            end
+        end
+
+        host._indicatorBaseAlpha = baseAlpha
+        host._indicatorBaseColor = CopyColor(color) or { 1, 1, 1, 1 }
         return
     end
 
-    local color = settings.color or { 1, 1, 1, 1 }
-    local baseAlpha = Clamp((color[4] or 1) * (settings.alpha or 1), 0.05, 1)
-    local textures = {
-        host.primaryTexture,
-        host.secondaryTexture,
-    }
-
-    for index, texture in ipairs(textures) do
-        local piece = geometry.pieces[index]
-        if texture and piece and texture:IsShown() then
-            ApplyTextureVisual(texture, settings, baseAlpha, piece.flipH, piece.flipV, geometry.rotationRadians)
-        end
+    if displayType == "icon" and host.iconFrame and host.iconFrame.icon and host.iconFrame.icon:IsShown() then
+        local color = CopyColor(host._triggerIconBaseColor) or { 1, 1, 1, 1 }
+        host.iconFrame.icon:SetVertexColor(color[1] or 1, color[2] or 1, color[3] or 1, color[4] or 1)
+        host._indicatorBaseAlpha = Clamp(color[4] ~= nil and color[4] or 1, 0, 1)
+        host._indicatorBaseColor = color
+        return
     end
 
-    host._indicatorBaseAlpha = baseAlpha
-    host._indicatorBaseColor = CopyColor(color) or { 1, 1, 1, 1 }
+    if displayType == "text" and host.textFrame and host.textFrame.text and host.textFrame.text:IsShown() then
+        local color = CopyColor(host._triggerTextBaseColor) or { 1, 1, 1, 1 }
+        host.textFrame.text:SetTextColor(color[1] or 1, color[2] or 1, color[3] or 1, color[4] or 1)
+        host._indicatorBaseAlpha = Clamp(color[4] ~= nil and color[4] or 1, 0, 1)
+        host._indicatorBaseColor = color
+    end
 end
 
 local function ResetTextureIndicatorTransformState(host)
@@ -2962,11 +3068,20 @@ local function RefreshTextureIndicatorUpdater(host)
         return
     end
 
+    local hasDisplayVisual = false
+    if host._activeDisplayType == "texture" then
+        hasDisplayVisual = host._activeTextureSettings ~= nil and host._activeTextureGeometry ~= nil
+    elseif host._activeDisplayType == "icon" then
+        hasDisplayVisual = host.iconFrame ~= nil and host.iconFrame:IsShown()
+    elseif host._activeDisplayType == "text" then
+        hasDisplayVisual = host.textFrame ~= nil and host.textFrame:IsShown()
+    end
+
     local wantsManualUpdate = host._textureColorShiftActive
         or host._textureShrinkActive
         or host._textureBounceActive
 
-    if not wantsManualUpdate or not host._activeTextureSettings or not host._activeTextureGeometry then
+    if not wantsManualUpdate or not hasDisplayVisual then
         host:SetScript("OnUpdate", nil)
         ResetTextureIndicatorTransformState(host)
         SetTextureIndicatorBaseVisuals(host)
@@ -2978,12 +3093,11 @@ local function RefreshTextureIndicatorUpdater(host)
 end
 
 TextureIndicatorOnUpdate = function(self)
-    if not self or not self.visualRoot or not self._activeTextureSettings or not self._activeTextureGeometry then
+    if not self or not self.visualRoot or not self._activeDisplayType then
         RefreshTextureIndicatorUpdater(self)
         return
     end
 
-    local settings = self._activeTextureSettings
     local now = GetTime()
     SetTextureIndicatorBaseVisuals(self)
     local baseColor = self._indicatorBaseColor or { 1, 1, 1, 1 }
@@ -2993,22 +3107,27 @@ TextureIndicatorOnUpdate = function(self)
         local shift = self._textureColorShiftColor or { 1, 1, 1, 1 }
         local colorPhase = GetTextureIndicatorLoopPhase(now, self._textureColorShiftSpeed)
         local t = 0.5 - (0.5 * math_cos(colorPhase * 2 * math_pi))
-        local shiftAlpha = Clamp((shift[4] or 1) * (settings.alpha or 1), 0.05, 1)
+        local shiftAlpha = Clamp(shift[4] ~= nil and shift[4] or 1, 0, 1)
         local alpha = baseAlpha + ((shiftAlpha - baseAlpha) * t)
 
-        local primaryTexture = self.primaryTexture
-        if primaryTexture and primaryTexture:IsShown() then
-            primaryTexture:SetVertexColor(
-                (baseColor[1] or 1) + (((shift[1] or 1) - (baseColor[1] or 1)) * t),
-                (baseColor[2] or 1) + (((shift[2] or 1) - (baseColor[2] or 1)) * t),
-                (baseColor[3] or 1) + (((shift[3] or 1) - (baseColor[3] or 1)) * t),
-                alpha
-            )
-        end
+        local shiftedR = (baseColor[1] or 1) + (((shift[1] or 1) - (baseColor[1] or 1)) * t)
+        local shiftedG = (baseColor[2] or 1) + (((shift[2] or 1) - (baseColor[2] or 1)) * t)
+        local shiftedB = (baseColor[3] or 1) + (((shift[3] or 1) - (baseColor[3] or 1)) * t)
 
-        local secondaryTexture = self.secondaryTexture
-        if secondaryTexture and secondaryTexture:IsShown() then
-            secondaryTexture:SetVertexColor(
+        if self._activeDisplayType == "texture" then
+            local primaryTexture = self.primaryTexture
+            if primaryTexture and primaryTexture:IsShown() then
+                primaryTexture:SetVertexColor(shiftedR, shiftedG, shiftedB, alpha)
+            end
+
+            local secondaryTexture = self.secondaryTexture
+            if secondaryTexture and secondaryTexture:IsShown() then
+                secondaryTexture:SetVertexColor(shiftedR, shiftedG, shiftedB, alpha)
+            end
+        elseif self._activeDisplayType == "icon" and self.iconFrame and self.iconFrame.icon and self.iconFrame.icon:IsShown() then
+            self.iconFrame.icon:SetVertexColor(shiftedR, shiftedG, shiftedB, alpha)
+        elseif self._activeDisplayType == "text" and self.textFrame and self.textFrame.text and self.textFrame.text:IsShown() then
+            self.textFrame.text:SetTextColor(
                 (baseColor[1] or 1) + (((shift[1] or 1) - (baseColor[1] or 1)) * t),
                 (baseColor[2] or 1) + (((shift[2] or 1) - (baseColor[2] or 1)) * t),
                 (baseColor[3] or 1) + (((shift[3] or 1) - (baseColor[3] or 1)) * t),
@@ -3510,6 +3629,54 @@ local function ApplyTextureIndicatorEffects(host, button, group)
     local colorShift = effectStates[TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT]
     if colorShift then
         StartTextureColorShift(host, colorShift.color, colorShift.speed)
+    else
+        StopTextureColorShift(host)
+    end
+end
+
+function CooldownCompanion:ApplyTriggerPanelEffects(host, button, group, effectsActive)
+    if not host or not button or type(group) ~= "table" then
+        return
+    end
+
+    local effects = CooldownCompanion:GetTriggerPanelEffectSettings(group)
+    if not effects or not effectsActive then
+        StopAllTextureIndicatorEffects(host)
+        return
+    end
+
+    SetTextureIndicatorBaseVisuals(host)
+
+    local bounceAmplitude = math_max(
+        6,
+        math_min(
+            DEFAULT_TEXTURE_BOUNCE_PIXELS,
+            ((host:GetHeight() and host:GetHeight() > 0) and host:GetHeight() or DEFAULT_TEXTURE_BOUNCE_PIXELS) * 0.12
+        )
+    )
+
+    SetTextureIndicatorAnimation(
+        host,
+        TEXTURE_INDICATOR_EFFECT_PULSE,
+        effects.pulse and effects.pulse.enabled == true,
+        effects.pulse and effects.pulse.speed or nil
+    )
+    SetTextureIndicatorAnimation(
+        host,
+        TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND,
+        effects.shrinkExpand and effects.shrinkExpand.enabled == true,
+        effects.shrinkExpand and effects.shrinkExpand.speed or nil
+    )
+    SetTextureIndicatorAnimation(
+        host,
+        TEXTURE_INDICATOR_EFFECT_BOUNCE,
+        effects.bounce and effects.bounce.enabled == true,
+        effects.bounce and effects.bounce.speed or nil,
+        bounceAmplitude
+    )
+
+    if effects.colorShift and effects.colorShift.enabled == true then
+        StartTextureColorShift(host, effects.colorShift.color, effects.colorShift.speed)
     else
         StopTextureColorShift(host)
     end
@@ -4137,6 +4304,8 @@ function CooldownCompanion.ApplyTriggerIconVisual(host, settings)
     host._activeTextureSettings = nil
     host._activeTextureGeometry = nil
     host._activeDisplayType = "icon"
+    host._triggerTextBaseColor = nil
+    host._triggerIconBaseColor = CopyColor(iconTint) or { 1, 1, 1, 1 }
 
     host:SetSize(width, height)
     host.visualRoot:SetSize(width, height)
@@ -4188,6 +4357,8 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
     host._activeTextureSettings = nil
     host._activeTextureGeometry = nil
     host._activeDisplayType = "text"
+    host._triggerIconBaseColor = nil
+    host._triggerTextBaseColor = CopyColor(textColor) or { 1, 1, 1, 1 }
 
     host:SetSize(frameWidth, frameHeight)
     host.visualRoot:SetSize(frameWidth, frameHeight)
@@ -4217,80 +4388,43 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
     return true
 end
 
-function CooldownCompanion:UpdateAuraTextureVisual(button)
-    if not button or button._isText then
-        return
-    end
-
-    local group = button._groupId and ResolveGroup(button._groupId) or nil
-    if not self:IsStandaloneTexturePanelGroup(group) then
-        self:HideAuraTextureVisual(button)
-        return
-    end
-
-    local frame = button:GetParent()
-    local isTriggerPanel = self:IsTriggerPanelGroup(group)
-    local driverButton = button
-    if isTriggerPanel then
-        driverButton = frame and frame.buttons and frame.buttons[1] or nil
-        if not driverButton then
-            self:HideAuraTextureVisual(button)
-            return
-        end
-    end
-
-    local displayType, settings = CooldownCompanion.ResolveActiveStandaloneDisplay(driverButton)
-    local isEditing = IsStandaloneTextureEditingButton(driverButton)
-    local isConfigForceVisible = (not isTriggerPanel) and IsTexturePanelConfigForceVisible(driverButton)
-    local isUnlocked = group and group.locked == false
-    local hasPreviewSelection = displayType == "texture" and type(driverButton._auraTexturePreviewSelection) == "table"
-    local triggerMatched = isTriggerPanel and frame and frame:IsShown() and DoesTriggerPanelMatch(frame) or false
-    local triggerSoundVisible = false
-    local showDisplay = false
+function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
+    local state = {
+        isEditing = IsStandaloneTextureEditingButton(driverButton),
+        isConfigForceVisible = (not isTriggerPanel) and IsTexturePanelConfigForceVisible(driverButton),
+        isUnlocked = group and group.locked == false,
+        hasPreviewSelection = displayType == "texture" and type(driverButton._auraTexturePreviewSelection) == "table",
+        hasTriggerEffectPreview = isTriggerPanel and driverButton._triggerEffectsPreview == true,
+        triggerMatched = isTriggerPanel and frame and frame:IsShown() and DoesTriggerPanelMatch(frame) or false,
+        showDisplay = false,
+    }
 
     if settings then
-        if hasPreviewSelection then
-            showDisplay = true
+        if state.hasPreviewSelection then
+            state.showDisplay = true
         elseif isTriggerPanel then
-            showDisplay = triggerMatched or isEditing or isUnlocked
-        elseif isEditing then
-            showDisplay = true
-        elseif isConfigForceVisible then
-            showDisplay = true
-        elseif isUnlocked then
-            showDisplay = true
+            state.showDisplay = state.triggerMatched or state.hasTriggerEffectPreview or state.isEditing or state.isUnlocked
+        elseif state.isEditing then
+            state.showDisplay = true
+        elseif state.isConfigForceVisible then
+            state.showDisplay = true
+        elseif state.isUnlocked then
+            state.showDisplay = true
         elseif driverButton:GetParent()
             and driverButton:GetParent():IsShown()
             and not (driverButton._rawVisibilityHidden == true) then
-            showDisplay = true
+            state.showDisplay = true
         end
     end
 
-    if isTriggerPanel and self.UpdateTriggerPanelSoundAlerts then
-        triggerSoundVisible = settings ~= nil and triggerMatched and showDisplay
-        self:UpdateTriggerPanelSoundAlerts(frame, group, triggerSoundVisible)
-    end
+    state.triggerSoundVisible = settings ~= nil and state.triggerMatched and state.showDisplay
+    state.bypassModuleAlpha = state.hasPreviewSelection or state.isEditing or state.isConfigForceVisible or state.isUnlocked
+    return state
+end
 
-    if not settings or not showDisplay then
-        self:HideAuraTextureVisual(driverButton)
-        if driverButton:GetAlpha() ~= 0 then
-            driverButton:SetAlpha(0)
-            driverButton._lastVisAlpha = 0
-        end
-        return
-    end
-
-    local host = EnsureAuraTextureHost(driverButton)
-    local relativeFrame = UIParent
-    local sharedSettings = GetStandaloneTextureSettings(group) or {
-        point = "CENTER",
-        relativePoint = "CENTER",
-        x = 0,
-        y = 0,
-    }
+function CooldownCompanion:RenderStandaloneDisplay(host, driverButton, group, settings, displayType, isTriggerPanel, effectsActive)
     local hostWidth, hostHeight
     local shown = false
-    local bypassModuleAlpha = hasPreviewSelection or isEditing or isConfigForceVisible or isUnlocked
 
     host:SetFrameStrata(driverButton:GetFrameStrata())
     host:SetFrameLevel((driverButton:GetFrameLevel() or 1) + 20)
@@ -4315,10 +4449,10 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             host._activeTextureGeometry = geometry
             host._activeDisplayType = "texture"
             SetTextureIndicatorBaseVisuals(host)
-            if not isTriggerPanel then
-                ApplyTextureIndicatorEffects(host, driverButton, group)
+            if isTriggerPanel then
+                self:ApplyTriggerPanelEffects(host, driverButton, group, effectsActive)
             else
-                StopAllTextureIndicatorEffects(host)
+                ApplyTextureIndicatorEffects(host, driverButton, group)
             end
         end
     elseif displayType == "icon" then
@@ -4328,9 +4462,31 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             host.visualRoot:SetSize(hostWidth, hostHeight)
         end
         shown = CooldownCompanion.ApplyTriggerIconVisual(host, settings)
+        if shown and isTriggerPanel then
+            self:ApplyTriggerPanelEffects(host, driverButton, group, effectsActive)
+        else
+            StopAllTextureIndicatorEffects(host)
+        end
     elseif displayType == "text" then
         shown = CooldownCompanion.ApplyTriggerTextVisual(host, settings)
+        if shown and isTriggerPanel then
+            self:ApplyTriggerPanelEffects(host, driverButton, group, effectsActive)
+        else
+            StopAllTextureIndicatorEffects(host)
+        end
     end
+
+    return shown
+end
+
+function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, group, settings, displayType, isTriggerPanel, visibilityState)
+    local relativeFrame = UIParent
+    local sharedSettings = GetStandaloneTextureSettings(group) or {
+        point = "CENTER",
+        relativePoint = "CENTER",
+        x = 0,
+        y = 0,
+    }
 
     if not host._isDragging then
         host:ClearAllPoints()
@@ -4338,20 +4494,11 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
     end
     host:Show()
 
-    if not shown then
-        self:HideAuraTextureVisual(driverButton)
-        if driverButton:GetAlpha() ~= 0 then
-            driverButton:SetAlpha(0)
-            driverButton._lastVisAlpha = 0
-        end
-        return
-    end
-
     local alphaModuleId = GetTexturePanelAlphaModuleId(driverButton._groupId)
     local layoutPreviewAlpha = GetTexturePanelLayoutPreviewAlpha(driverButton)
     local visibilityAlpha = Clamp(driverButton._rawVisibilityAlphaOverride or 1, 0, 1)
     if alphaModuleId then
-        if bypassModuleAlpha then
+        if visibilityState.bypassModuleAlpha then
             self:UnregisterModuleAlpha(alphaModuleId, true)
             host:SetAlpha(layoutPreviewAlpha ~= nil and layoutPreviewAlpha or 1)
         else
@@ -4364,7 +4511,7 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             end
         end
     else
-        host:SetAlpha(bypassModuleAlpha and (layoutPreviewAlpha ~= nil and layoutPreviewAlpha or 1) or visibilityAlpha)
+        host:SetAlpha(visibilityState.bypassModuleAlpha and (layoutPreviewAlpha ~= nil and layoutPreviewAlpha or 1) or visibilityAlpha)
     end
 
     local savedSettings = isTriggerPanel and group and group.triggerSettings and group.triggerSettings.signal or group and group.textureSettings or nil
@@ -4376,7 +4523,7 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
     elseif displayType == "text" then
         hasSavedDisplay = CooldownCompanion.HasTriggerTextValue(settings)
     end
-    host._dragEnabled = isUnlocked and hasSavedDisplay
+    host._dragEnabled = visibilityState.isUnlocked and hasSavedDisplay
     host:EnableMouse(false)
     SetAuraTextureOutlineShown(host, false)
     if host.dragHandle and host.coordLabel then
@@ -4399,9 +4546,6 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
         driverButton._lastVisAlpha = 0
     end
     if ST.SetFrameClickThroughRecursive then
-        -- The visible texture host is intentionally non-interactive. Make every hidden
-        -- backing button fully click/hover-through too, so stacked trigger rows do not
-        -- leave invisible tooltip hotspots behind the visible texture.
         if isTriggerPanel and frame and type(frame.buttons) == "table" then
             for _, backingButton in ipairs(frame.buttons) do
                 ST.SetFrameClickThroughRecursive(backingButton, true, true)
@@ -4410,6 +4554,67 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             ST.SetFrameClickThroughRecursive(driverButton, true, true)
         end
     end
+end
+
+function CooldownCompanion:UpdateAuraTextureVisual(button)
+    if not button or button._isText then
+        return
+    end
+
+    local group = button._groupId and ResolveGroup(button._groupId) or nil
+    if not self:IsStandaloneTexturePanelGroup(group) then
+        self:HideAuraTextureVisual(button)
+        return
+    end
+
+    local frame = button:GetParent()
+    local isTriggerPanel = self:IsTriggerPanelGroup(group)
+    local driverButton = button
+    if isTriggerPanel then
+        driverButton = frame and frame.buttons and frame.buttons[1] or nil
+        if not driverButton then
+            self:HideAuraTextureVisual(button)
+            return
+        end
+    end
+
+    local displayType, settings = CooldownCompanion.ResolveActiveStandaloneDisplay(driverButton)
+    local visibilityState = self:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
+
+    if isTriggerPanel and self.UpdateTriggerPanelSoundAlerts then
+        self:UpdateTriggerPanelSoundAlerts(frame, group, visibilityState.triggerSoundVisible)
+    end
+
+    if not settings or not visibilityState.showDisplay then
+        self:HideAuraTextureVisual(driverButton)
+        if driverButton:GetAlpha() ~= 0 then
+            driverButton:SetAlpha(0)
+            driverButton._lastVisAlpha = 0
+        end
+        return
+    end
+
+    local host = EnsureAuraTextureHost(driverButton)
+    local shown = self:RenderStandaloneDisplay(
+        host,
+        driverButton,
+        group,
+        settings,
+        displayType,
+        isTriggerPanel,
+        visibilityState.triggerMatched or visibilityState.hasTriggerEffectPreview
+    )
+
+    if not shown then
+        self:HideAuraTextureVisual(driverButton)
+        if driverButton:GetAlpha() ~= 0 then
+            driverButton:SetAlpha(0)
+            driverButton._lastVisAlpha = 0
+        end
+        return
+    end
+
+    self:FinalizeStandaloneDisplay(host, frame, driverButton, group, settings, displayType, isTriggerPanel, visibilityState)
 end
 
 function CooldownCompanion:RefreshAllAuraTextureVisuals()

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -8,7 +8,8 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local LSM = LibStub("LibSharedMedia-3.0")
 
-CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH = 80
+CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH = 120
+CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LINES = 4
 CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X = 4
 CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y = 2
 CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_X = 6
@@ -1740,15 +1741,67 @@ function CooldownCompanion.NormalizeTriggerTextSettings(settings)
         return nil
     end
 
-    local maxLength = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH or 80
-    settings.value = type(settings.value) == "string" and settings.value:sub(1, maxLength) or ""
+    settings.value = type(settings.value) == "string" and settings.value or ""
     settings.textFont = type(settings.textFont) == "string" and settings.textFont or "Friz Quadrata TT"
     settings.textFontSize = Clamp(tonumber(settings.textFontSize) or 12, 6, 72)
     settings.textFontOutline = type(settings.textFontOutline) == "string" and settings.textFontOutline or "OUTLINE"
     settings.textFontColor = CopyColor(settings.textFontColor) or { 1, 1, 1, 1 }
     settings.textBgColor = CopyColor(settings.textBgColor) or { 0, 0, 0, 0 }
+    settings.textAlignment = (settings.textAlignment == "LEFT" or settings.textAlignment == "RIGHT") and settings.textAlignment or "CENTER"
 
     return settings
+end
+
+function CooldownCompanion.NormalizeTriggerPanelTextLineEndings(value)
+    if type(value) ~= "string" then
+        return ""
+    end
+
+    return string_gsub(string_gsub(value, "\r\n", "\n"), "\r", "\n")
+end
+
+function CooldownCompanion.SanitizeTriggerPanelTextValue(value)
+    value = CooldownCompanion.NormalizeTriggerPanelTextLineEndings(value)
+
+    local maxLength = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH or 120
+    if #value > maxLength then
+        value = value:sub(1, maxLength)
+    end
+
+    local maxLines = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LINES or 4
+    local lineCount = 1
+    local cutIndex = nil
+    for index = 1, #value do
+        if value:sub(index, index) == "\n" then
+            lineCount = lineCount + 1
+            if lineCount > maxLines then
+                cutIndex = index - 1
+                break
+            end
+        end
+    end
+
+    if cutIndex then
+        value = value:sub(1, cutIndex)
+    end
+
+    return value
+end
+
+function CooldownCompanion.CountTriggerPanelTextLines(value)
+    value = CooldownCompanion.NormalizeTriggerPanelTextLineEndings(value)
+    if value == "" then
+        return 1
+    end
+
+    local lineCount = 1
+    for index = 1, #value do
+        if value:sub(index, index) == "\n" then
+            lineCount = lineCount + 1
+        end
+    end
+
+    return lineCount
 end
 
 function CooldownCompanion:GetTriggerPanelDisplayType(groupOrId, createIfMissing)
@@ -4099,7 +4152,7 @@ function CooldownCompanion.EnsureTriggerTextVisual(host)
     frame.text:SetJustifyV("MIDDLE")
     frame.text:SetJustifyH("CENTER")
     frame.text:SetWordWrap(false)
-    frame.text:SetMaxLines(1)
+    frame.text:SetMaxLines(0)
 
     host.textFrame = frame
     return frame
@@ -4138,7 +4191,7 @@ end
 
 function CooldownCompanion.GetTriggerTextDisplayMetrics(fontString, settings)
     if not fontString or type(settings) ~= "table" then
-        return 1, 1, CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X or 4, CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y or 2, 1, 1
+        return 1, 1, CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X or 4, CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y or 2, 1, 1, 1
     end
 
     local insetX = CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X or 4
@@ -4146,22 +4199,50 @@ function CooldownCompanion.GetTriggerTextDisplayMetrics(fontString, settings)
     local overflowX = CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_X or 6
     local overflowY = CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_Y or 4
     local font = CooldownCompanion:FetchFont(settings.textFont or "Friz Quadrata TT")
+    local textValue = CooldownCompanion.NormalizeTriggerPanelTextLineEndings(settings.value)
 
     fontString:ClearAllPoints()
     fontString:SetWordWrap(false)
-    fontString:SetMaxLines(1)
+    fontString:SetMaxLines(0)
     fontString:SetJustifyV("MIDDLE")
-    fontString:SetJustifyH("CENTER")
+    fontString:SetJustifyH(settings.textAlignment or "CENTER")
     fontString:SetWidth(0)
     fontString:SetFont(font, settings.textFontSize or 12, settings.textFontOutline or "OUTLINE")
-    fontString:SetText(settings.value or "")
+    fontString:SetText(textValue)
 
-    local measuredWidth = fontString.GetUnboundedStringWidth and fontString:GetUnboundedStringWidth() or fontString:GetStringWidth()
-    local textWidth = math_max(1, math_floor((measuredWidth or 0) + 0.999))
-    local textHeight = math_max(1, math_floor((fontString:GetStringHeight() or 0) + 0.999))
+    local textWidth = 1
+    local lineCount = 1
+    local lineStart = 1
+    while true do
+        local lineBreak = string_find(textValue, "\n", lineStart, true)
+        local lineText
+        if lineBreak then
+            lineText = textValue:sub(lineStart, lineBreak - 1)
+        else
+            lineText = textValue:sub(lineStart)
+        end
+
+        if lineText ~= "" then
+            fontString:SetText(lineText)
+            local measuredWidth = fontString.GetUnboundedStringWidth and fontString:GetUnboundedStringWidth() or fontString:GetStringWidth()
+            textWidth = math_max(textWidth, math_floor((measuredWidth or 0) + 0.999))
+        end
+
+        if not lineBreak then
+            break
+        end
+        lineCount = lineCount + 1
+        lineStart = lineBreak + 1
+    end
+
+    fontString:SetText("Ag")
+    local singleLineHeight = math_max(1, math_floor((fontString:GetStringHeight() or 0) + 0.999))
+    fontString:SetText(textValue)
+    local measuredHeight = math_max(1, math_floor((fontString:GetStringHeight() or 0) + 0.999))
+    local textHeight = math_max(measuredHeight, singleLineHeight * lineCount)
     textWidth = textWidth + (overflowX * 2)
     textHeight = textHeight + (overflowY * 2)
-    return textWidth + (insetX * 2), textHeight + (insetY * 2), insetX, insetY, textWidth, textHeight
+    return textWidth + (insetX * 2), textHeight + (insetY * 2), insetX, insetY, textWidth, textHeight, lineCount
 end
 
 local function GetTexturePanelAlphaModuleId(groupId)
@@ -4403,7 +4484,7 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
     local textFrame = CooldownCompanion.EnsureTriggerTextVisual(host)
     local textColor = settings.textFontColor or { 1, 1, 1, 1 }
     local backgroundColor = settings.textBgColor or { 0, 0, 0, 0 }
-    local frameWidth, frameHeight, insetX, insetY, textWidth, textHeight = CooldownCompanion.GetTriggerTextDisplayMetrics(textFrame.text, settings)
+    local frameWidth, frameHeight, insetX, insetY, textWidth, textHeight, lineCount = CooldownCompanion.GetTriggerTextDisplayMetrics(textFrame.text, settings)
 
     CooldownCompanion:ResetTextureIndicatorRootState(host)
     CooldownCompanion.HideStandaloneDisplayVisuals(host)
@@ -4435,8 +4516,12 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
         textColor[4] ~= nil and textColor[4] or 1
     )
     textFrame.text:ClearAllPoints()
-    textFrame.text:SetPoint("CENTER", textFrame, "CENTER", 0, 0)
+    textFrame.text:SetPoint("TOPLEFT", textFrame, "TOPLEFT", insetX, -insetY)
+    textFrame.text:SetPoint("BOTTOMRIGHT", textFrame, "BOTTOMRIGHT", -insetX, insetY)
     textFrame.text:SetSize(textWidth or math_max(1, frameWidth - (insetX * 2)), textHeight or math_max(1, frameHeight - (insetY * 2)))
+    textFrame.text:SetJustifyH(settings.textAlignment or "CENTER")
+    textFrame.text:SetWordWrap((lineCount or 1) > 1)
+    textFrame.text:SetJustifyV((lineCount or 1) > 1 and "TOP" or "MIDDLE")
     textFrame:Show()
 
     return true

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -8,6 +8,12 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local LSM = LibStub("LibSharedMedia-3.0")
 
+CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH = 80
+CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X = 4
+CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y = 2
+CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_X = 6
+CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_Y = 4
+
 local C_Item_IsUsableItem = C_Item.IsUsableItem
 local C_Spell_GetSpellName = C_Spell.GetSpellName
 local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
@@ -1653,6 +1659,32 @@ function CooldownCompanion:GetTriggerPanelEffectSettings(groupOrId, createIfMiss
     return CooldownCompanion.NormalizeTriggerPanelEffectStore(group.triggerSettings)
 end
 
+function CooldownCompanion:GetTextureIndicatorTransformTarget(host)
+    if not host then
+        return nil
+    end
+
+    if host._activeDisplayType == "icon" and host.iconFrame then
+        return host.iconFrame
+    end
+
+    if host._activeDisplayType == "text" and host.textFrame then
+        return host.textFrame
+    end
+
+    return host.visualRoot
+end
+
+function CooldownCompanion:ResetTextureIndicatorRootState(host)
+    if not host or not host.visualRoot then
+        return
+    end
+
+    host.visualRoot:SetScale(1)
+    host.visualRoot:ClearAllPoints()
+    host.visualRoot:SetPoint("CENTER", host, "CENTER", 0, 0)
+end
+
 function CooldownCompanion.NormalizeTriggerDisplayType(displayType)
     if displayType == "icon" or displayType == "text" then
         return displayType
@@ -1708,7 +1740,8 @@ function CooldownCompanion.NormalizeTriggerTextSettings(settings)
         return nil
     end
 
-    settings.value = type(settings.value) == "string" and settings.value or ""
+    local maxLength = CooldownCompanion.TRIGGER_PANEL_TEXT_MAX_LENGTH or 80
+    settings.value = type(settings.value) == "string" and settings.value:sub(1, maxLength) or ""
     settings.textFont = type(settings.textFont) == "string" and settings.textFont or "Friz Quadrata TT"
     settings.textFontSize = Clamp(tonumber(settings.textFontSize) or 12, 6, 72)
     settings.textFontOutline = type(settings.textFontOutline) == "string" and settings.textFontOutline or "OUTLINE"
@@ -3046,13 +3079,24 @@ local function SetTextureIndicatorBaseVisuals(host)
 end
 
 local function ResetTextureIndicatorTransformState(host)
-    if not host or not host.visualRoot then
+    if not host then
         return
     end
 
-    host.visualRoot:SetScale(1)
-    host.visualRoot:ClearAllPoints()
-    host.visualRoot:SetPoint("CENTER", host, "CENTER", 0, 0)
+    local target = CooldownCompanion:GetTextureIndicatorTransformTarget(host)
+    if not target then
+        return
+    end
+
+    local relativeFrame = target == host.visualRoot and host or target:GetParent() or host.visualRoot
+    if not relativeFrame then
+        return
+    end
+
+    target:SetScale(1)
+    target:ClearAllPoints()
+    target:SetPoint("CENTER", relativeFrame, "CENTER", 0, 0)
+
 end
 
 local function GetTextureIndicatorLoopPhase(now, duration)
@@ -3094,6 +3138,12 @@ end
 
 TextureIndicatorOnUpdate = function(self)
     if not self or not self.visualRoot or not self._activeDisplayType then
+        RefreshTextureIndicatorUpdater(self)
+        return
+    end
+
+    local transformTarget = CooldownCompanion:GetTextureIndicatorTransformTarget(self)
+    if not transformTarget then
         RefreshTextureIndicatorUpdater(self)
         return
     end
@@ -3145,7 +3195,7 @@ TextureIndicatorOnUpdate = function(self)
         local shrinkT = 0.5 - (0.5 * math_cos(shrinkPhase * 2 * math_pi))
         scale = 1 - ((1 - DEFAULT_TEXTURE_SHRINK_SCALE) * shrinkT)
     end
-    self.visualRoot:SetScale(scale)
+    transformTarget:SetScale(scale)
 
     local bounceOffsetY = 0
     if self._textureBounceActive then
@@ -3163,8 +3213,8 @@ TextureIndicatorOnUpdate = function(self)
         end
     end
 
-    self.visualRoot:ClearAllPoints()
-    self.visualRoot:SetPoint("CENTER", self, "CENTER", 0, bounceOffsetY)
+    transformTarget:ClearAllPoints()
+    transformTarget:SetPoint("CENTER", transformTarget == self.visualRoot and self or transformTarget:GetParent() or self.visualRoot, "CENTER", 0, bounceOffsetY)
 end
 
 local function StopTextureIndicatorAnimation(host, effectType)
@@ -3654,6 +3704,7 @@ function CooldownCompanion:ApplyTriggerPanelEffects(host, button, group, effects
             ((host:GetHeight() and host:GetHeight() > 0) and host:GetHeight() or DEFAULT_TEXTURE_BOUNCE_PIXELS) * 0.12
         )
     )
+    local allowShrinkExpand = host._activeDisplayType ~= "text"
 
     SetTextureIndicatorAnimation(
         host,
@@ -3664,8 +3715,8 @@ function CooldownCompanion:ApplyTriggerPanelEffects(host, button, group, effects
     SetTextureIndicatorAnimation(
         host,
         TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND,
-        effects.shrinkExpand and effects.shrinkExpand.enabled == true,
-        effects.shrinkExpand and effects.shrinkExpand.speed or nil
+        allowShrinkExpand and effects.shrinkExpand and effects.shrinkExpand.enabled == true,
+        allowShrinkExpand and effects.shrinkExpand and effects.shrinkExpand.speed or nil
     )
     SetTextureIndicatorAnimation(
         host,
@@ -4044,10 +4095,11 @@ function CooldownCompanion.EnsureTriggerTextVisual(host)
     end
 
     frame.text = frame:CreateFontString(nil, "OVERLAY")
-    frame.text:SetPoint("TOPLEFT", 2, -1)
-    frame.text:SetPoint("BOTTOMRIGHT", -2, 1)
+    frame.text:SetPoint("CENTER", frame, "CENTER", 0, 0)
     frame.text:SetJustifyV("MIDDLE")
+    frame.text:SetJustifyH("CENTER")
     frame.text:SetWordWrap(false)
+    frame.text:SetMaxLines(1)
 
     host.textFrame = frame
     return frame
@@ -4086,24 +4138,30 @@ end
 
 function CooldownCompanion.GetTriggerTextDisplayMetrics(fontString, settings)
     if not fontString or type(settings) ~= "table" then
-        return 1, 1, 2, 1
+        return 1, 1, CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X or 4, CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y or 2, 1, 1
     end
 
-    local insetX = 2
-    local insetY = 1
+    local insetX = CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_X or 4
+    local insetY = CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y or 2
+    local overflowX = CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_X or 6
+    local overflowY = CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_Y or 4
     local font = CooldownCompanion:FetchFont(settings.textFont or "Friz Quadrata TT")
 
     fontString:ClearAllPoints()
     fontString:SetWordWrap(false)
+    fontString:SetMaxLines(1)
     fontString:SetJustifyV("MIDDLE")
     fontString:SetJustifyH("CENTER")
     fontString:SetWidth(0)
     fontString:SetFont(font, settings.textFontSize or 12, settings.textFontOutline or "OUTLINE")
     fontString:SetText(settings.value or "")
 
-    local textWidth = math_max(1, math_floor((fontString:GetStringWidth() or 0) + 0.999))
+    local measuredWidth = fontString.GetUnboundedStringWidth and fontString:GetUnboundedStringWidth() or fontString:GetStringWidth()
+    local textWidth = math_max(1, math_floor((measuredWidth or 0) + 0.999))
     local textHeight = math_max(1, math_floor((fontString:GetStringHeight() or 0) + 0.999))
-    return textWidth + (insetX * 2), textHeight + (insetY * 2), insetX, insetY
+    textWidth = textWidth + (overflowX * 2)
+    textHeight = textHeight + (overflowY * 2)
+    return textWidth + (insetX * 2), textHeight + (insetY * 2), insetX, insetY, textWidth, textHeight
 end
 
 local function GetTexturePanelAlphaModuleId(groupId)
@@ -4296,9 +4354,7 @@ function CooldownCompanion.ApplyTriggerIconVisual(host, settings)
     local backgroundColor = settings.backgroundColor or { 0, 0, 0, 0.5 }
     local borderColor = settings.borderColor or { 0, 0, 0, 1 }
 
-    ResetTextureIndicatorTransformState(host)
-    StopAllTextureIndicatorEffects(host)
-    host:SetScript("OnUpdate", nil)
+    CooldownCompanion:ResetTextureIndicatorRootState(host)
     CooldownCompanion.HideStandaloneDisplayVisuals(host)
 
     host._activeTextureSettings = nil
@@ -4347,11 +4403,9 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
     local textFrame = CooldownCompanion.EnsureTriggerTextVisual(host)
     local textColor = settings.textFontColor or { 1, 1, 1, 1 }
     local backgroundColor = settings.textBgColor or { 0, 0, 0, 0 }
-    local frameWidth, frameHeight, insetX, insetY = CooldownCompanion.GetTriggerTextDisplayMetrics(textFrame.text, settings)
+    local frameWidth, frameHeight, insetX, insetY, textWidth, textHeight = CooldownCompanion.GetTriggerTextDisplayMetrics(textFrame.text, settings)
 
-    ResetTextureIndicatorTransformState(host)
-    StopAllTextureIndicatorEffects(host)
-    host:SetScript("OnUpdate", nil)
+    CooldownCompanion:ResetTextureIndicatorRootState(host)
     CooldownCompanion.HideStandaloneDisplayVisuals(host)
 
     host._activeTextureSettings = nil
@@ -4381,8 +4435,8 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
         textColor[4] ~= nil and textColor[4] or 1
     )
     textFrame.text:ClearAllPoints()
-    textFrame.text:SetPoint("TOPLEFT", textFrame, "TOPLEFT", insetX, -insetY)
-    textFrame.text:SetPoint("BOTTOMRIGHT", textFrame, "BOTTOMRIGHT", -insetX, insetY)
+    textFrame.text:SetPoint("CENTER", textFrame, "CENTER", 0, 0)
+    textFrame.text:SetSize(textWidth or math_max(1, frameWidth - (insetX * 2)), textHeight or math_max(1, frameHeight - (insetY * 2)))
     textFrame:Show()
 
     return true

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -748,6 +748,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
                 x = 0,
                 y = 0,
             },
+            effects = {},
         }
     end
 
@@ -876,9 +877,13 @@ function CooldownCompanion:ChangePanelDisplayMode(groupId, newMode)
                 x = 0,
                 y = 0,
             },
+            effects = {},
         }
         if group.triggerSettings.displayType == nil then
             group.triggerSettings.displayType = "texture"
+        end
+        if type(group.triggerSettings.effects) ~= "table" then
+            group.triggerSettings.effects = {}
         end
         if self.NormalizeTriggerConditionRowData then
             for _, buttonData in ipairs(group.buttons or {}) do


### PR DESCRIPTION
## What Players Will Notice
- Trigger panels now have an `Indicators` tab that works as an effects tab for active displays, with `Pulse`, `Color Shift`, `Shrink / Expand`, and `Bounce` available where they fit.
- Trigger text can now use explicit line breaks, alignment controls, and a tighter preview that stays inside the config canvas.
- Trigger icon picking no longer errors when opening the chooser with no icon selected.

## Why This Changed
- Trigger panels were missing the active-display effects that texture panels already exposed, so players could not add motion or color feedback to active trigger displays.
- Trigger text editing and preview behavior needed better limits and layout handling to support real multiline labels without oversized editors or overflowing previews.
- The icon picker needed a safe empty-state path for trigger icon mode.

## What Changed
- Added a trigger-panel-specific effects store plus an `Indicators` tab UI that exposes `Pulse`, `Color Shift`, `Shrink / Expand`, and `Bounce`, with combined preview support and cleanup when leaving config.
- Extended the standalone trigger display runtime so effects only run while the trigger is actually active or during explicit preview, with texture/icon/text-specific handling and text-mode exclusion for `Shrink / Expand`.
- Reworked trigger text editing and rendering to support explicit multiline text, left/center/right alignment, bounded input, dynamic text sizing, and preview scaling inside the fixed config canvas.
- Initialized trigger-panel effect data for new and converted trigger panels and fixed the trigger icon picker empty-selection handling.

## Validation
- `luac -p` passed for `ButtonFrame/Preview.lua`, `Config/Column4.lua`, `Config/Panel.lua`, `Config/State.lua`, `ConfigSettings/GroupTabs.lua`, `Core/AuraTextures.lua`, and `Core/GroupManagement.lua`.
- `git diff --check origin/main...HEAD` passed.
- In-game validation has not been run from this environment yet, including combat and restricted-content verification.