### PR TITLE
Fix trigger panel unlock header and coordinate bar framing

### DIFF
--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -3707,6 +3707,7 @@ local function ApplyTextureIndicatorEffects(host, button, group)
         end
     end
 
+    local freezeGeometryWhileUnlocked = group.locked == false
     local bounceAmplitude = math_max(6, math_min(DEFAULT_TEXTURE_BOUNCE_PIXELS, (host._activeTextureGeometry and host._activeTextureGeometry.boundsHeight or DEFAULT_TEXTURE_BOUNCE_PIXELS) * 0.12))
 
     SetTextureIndicatorAnimation(
@@ -3718,13 +3719,13 @@ local function ApplyTextureIndicatorEffects(host, button, group)
     SetTextureIndicatorAnimation(
         host,
         TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND,
-        effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND] ~= nil,
+        (not freezeGeometryWhileUnlocked) and effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND] ~= nil,
         effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND] and effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND].speed or nil
     )
     SetTextureIndicatorAnimation(
         host,
         TEXTURE_INDICATOR_EFFECT_BOUNCE,
-        effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE] ~= nil,
+        (not freezeGeometryWhileUnlocked) and effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE] ~= nil,
         effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE] and effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE].speed or nil,
         bounceAmplitude
     )
@@ -3750,6 +3751,7 @@ function CooldownCompanion:ApplyTriggerPanelEffects(host, button, group, effects
 
     SetTextureIndicatorBaseVisuals(host)
 
+    local freezeGeometryWhileUnlocked = group.locked == false
     local bounceAmplitude = math_max(
         6,
         math_min(
@@ -3757,7 +3759,7 @@ function CooldownCompanion:ApplyTriggerPanelEffects(host, button, group, effects
             ((host:GetHeight() and host:GetHeight() > 0) and host:GetHeight() or DEFAULT_TEXTURE_BOUNCE_PIXELS) * 0.12
         )
     )
-    local allowShrinkExpand = host._activeDisplayType ~= "text"
+    local allowShrinkExpand = host._activeDisplayType ~= "text" and not freezeGeometryWhileUnlocked
 
     SetTextureIndicatorAnimation(
         host,
@@ -3774,7 +3776,7 @@ function CooldownCompanion:ApplyTriggerPanelEffects(host, button, group, effects
     SetTextureIndicatorAnimation(
         host,
         TEXTURE_INDICATOR_EFFECT_BOUNCE,
-        effects.bounce and effects.bounce.enabled == true,
+        (not freezeGeometryWhileUnlocked) and effects.bounce and effects.bounce.enabled == true,
         effects.bounce and effects.bounce.speed or nil,
         bounceAmplitude
     )
@@ -3990,8 +3992,8 @@ local function EnsureAuraTextureDragHandle(host)
 
     local coordLabel = CreateFrame("Frame", nil, dragHandle, "BackdropTemplate")
     coordLabel:SetHeight(15)
-    coordLabel:SetPoint("TOPLEFT", dragHandle, "BOTTOMLEFT", 0, -2)
-    coordLabel:SetPoint("TOPRIGHT", dragHandle, "BOTTOMRIGHT", 0, -2)
+    coordLabel:SetPoint("TOPLEFT", host, "BOTTOMLEFT", 0, -2)
+    coordLabel:SetPoint("TOPRIGHT", host, "BOTTOMRIGHT", 0, -2)
     coordLabel:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
     coordLabel:SetBackdropColor(0.2, 0.2, 0.2, 0.8)
     ST.CreatePixelBorders(coordLabel)


### PR DESCRIPTION
## What Players Will Notice
- Trigger panels now keep their unlock header and `x/y` coordinate bar framed to the display correctly instead of leaving the coordinate bar in the wrong spot while positioning.
- Unlock-mode trigger displays also stay visually stable while dragging because the geometry-changing bounce and shrink effects are suppressed during unlock.

## Why This Changed
- The standalone trigger-panel unlock chrome was anchoring the coordinate bar to the drag handle instead of the panel bounds, which made the panel look misframed during unlock.
- Trigger-panel unlock visuals also allowed bounce and shrink effects to distort the apparent framed area while positioning.

## What Changed
- Reanchored the standalone trigger-panel coordinate bar to the display host bounds in `Core/AuraTextures.lua` so the top header and bottom coordinate bar frame the trigger display like normal panels do.
- Gated unlock-time bounce and shrink effects in the shared standalone display path so trigger-panel framing stays stable while unlocked.
- Left the normal icon-panel path untouched.

## Validation
- Local Lua syntax check passed.
- In-game screenshot-driven validation confirmed the anchor fix resolved the reported trigger-panel framing issue.
- Combat and restricted-content verification have not been completed yet.