### PR TITLE
Add hero spec filters to talent picker conditions

### DIFF
--- a/Config/TalentPicker.lua
+++ b/Config/TalentPicker.lua
@@ -1171,6 +1171,26 @@ local function BuildNodeRecord(configID, nodeID, nodeInfo)
     }
 end
 
+local function BuildHeroSpecNodeRecord(configID, treeID, heroSubTreeID)
+    if not configID or not treeID or not heroSubTreeID then
+        return nil
+    end
+
+    local nodeID, nodeInfo = CooldownCompanion:GetHeroSubTreeRootNode(configID, treeID, heroSubTreeID)
+    if not nodeID or not nodeInfo then
+        return nil
+    end
+
+    local record = BuildNodeRecord(configID, nodeID, nodeInfo)
+    if not record then
+        return nil
+    end
+
+    record.scopeType = "hero"
+    record.displayName = GetHeroDisplayName(configID, heroSubTreeID)
+    return record
+end
+
 local function ComputeBounds(nodeSet)
     local mnX, mxX, mnY, mxY = math.huge, -math.huge, math.huge, -math.huge
     for _, n in ipairs(nodeSet) do
@@ -1284,6 +1304,7 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
         local primaryEntry = node.isChoice
             and GetPrimaryDisplayEntry(node.entries, node.nodeID)
             or node.entries[1]
+        local displayName = node.displayName or (primaryEntry and primaryEntry.name) or nil
 
         btn.icon:SetTexture(primaryEntry.icon)
         btn.icon:SetDesaturated(false)
@@ -1294,7 +1315,7 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
         btn._entryID = nil  -- regular nodes use nil; choice entries set per-entry
         btn._isChoiceNode = node.isChoice
         btn._entries = node.entries
-        btn._talentName = primaryEntry.name
+        btn._talentName = displayName
         btn._spellID = primaryEntry.spellID
         btn._rankText = nil
 
@@ -1311,7 +1332,7 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
                 end
             else
                 HideChoiceFrame()
-                CyclePendingState(nodeRef.nodeID, nil, primaryEntry.spellID, primaryEntry.name, BuildConditionContext(nodeRef.scopeType, nodeRef.subTreeID))
+                CyclePendingState(nodeRef.nodeID, nil, primaryEntry.spellID, displayName, BuildConditionContext(nodeRef.scopeType, nodeRef.subTreeID))
                 RefreshPickerBorders()
             end
         end)
@@ -1392,12 +1413,12 @@ local function RenderNodePanel(panelFrame, nodeSet, nodeIDToBtn, edgePool, btnIn
     return btnIndex
 end
 
-local function RenderHeroChoiceList(panelFrame, nodeSet, nodeIDToBtn, btnIndex)
+local function RenderHeroChoiceList(panelFrame, nodeSet, nodeIDToBtn, btnIndex, leadingNode)
     for _, line in ipairs(heroEdgeLines) do
         line:Hide()
     end
 
-    if not panelFrame or #nodeSet == 0 then
+    if not panelFrame or (#nodeSet == 0 and not leadingNode) then
         return btnIndex
     end
 
@@ -1415,6 +1436,12 @@ local function RenderHeroChoiceList(panelFrame, nodeSet, nodeIDToBtn, btnIndex)
 
     local centeredX = math_max(NODE_PADDING, math_floor((panelFrame:GetWidth() - NODE_SIZE) * 0.5))
     local nextY = HERO_HEADER_HEIGHT + 8
+
+    if leadingNode then
+        btnIndex = PlaceNodesInPanel(panelFrame, { leadingNode }, centeredX - NODE_PADDING, nextY - NODE_PADDING,
+            leadingNode.px, leadingNode.py, leadingNode.px, leadingNode.py, 0, btnIndex, nodeIDToBtn)
+        nextY = nextY + NODE_SIZE + 10
+    end
 
     for _, node in ipairs(orderedNodes) do
         btnIndex = PlaceNodesInPanel(panelFrame, { node }, centeredX - NODE_PADDING, nextY - NODE_PADDING,
@@ -1512,6 +1539,7 @@ PopulateTree = function()
     end
 
     local selectedHeroSubTreeID = pickerSelectedHeroSubTreeID
+    local heroSpecNode = BuildHeroSpecNodeRecord(configID, treeID, selectedHeroSubTreeID)
 
     -- Get tree currencies for class/spec split
     local treeCurrencyInfo = C_Traits.GetTreeCurrencyInfo(configID, treeID, false)
@@ -1568,7 +1596,7 @@ PopulateTree = function()
         end
     end
 
-    local hasHeroChoices = #heroNodes > 0
+    local hasHeroChoices = heroSpecNode ~= nil or #heroNodes > 0
 
     local dualPanel = (#classNodes > 0 and #specNodes > 0)
     local nodeIDToBtn = {}
@@ -1587,7 +1615,7 @@ PopulateTree = function()
     end
 
     if hasHeroChoices then
-        btnIndex = RenderHeroChoiceList(heroTreeFrame, heroNodes, nodeIDToBtn, btnIndex)
+        btnIndex = RenderHeroChoiceList(heroTreeFrame, heroNodes, nodeIDToBtn, btnIndex, heroSpecNode)
     end
 end
 

--- a/Config/TalentPicker.lua
+++ b/Config/TalentPicker.lua
@@ -245,6 +245,13 @@ end
 
 local function CyclePendingState(nodeID, entryID, spellID, name, context)
     local existing = GetPendingState(nodeID, entryID)
+    local isHeroSpecProxy = entryID == nil
+        and context
+        and context.heroSubTreeID ~= nil
+        and type(name) == "string"
+        and type(context.heroName) == "string"
+        and name == context.heroName
+
     if not existing then
         if context and context.specID then
             ClearConflictingPendingScopes(context.specID, context.heroSubTreeID)
@@ -255,6 +262,19 @@ local function CyclePendingState(nodeID, entryID, spellID, name, context)
             ClearConflictingPendingScopes(context.specID, context.heroSubTreeID)
         end
         SetPendingState(nodeID, entryID, spellID, name, "not_taken", context)
+        if isHeroSpecProxy then
+            for key, cond in pairs(pendingConditions) do
+                if cond.heroSubTreeID == context.heroSubTreeID
+                    and not (cond.nodeID ~= nil
+                        and cond.entryID == nil
+                        and type(cond.name) == "string"
+                        and type(cond.heroName) == "string"
+                        and cond.name == cond.heroName)
+                    and cond.nodeID ~= nodeID then
+                    pendingConditions[key] = nil
+                end
+            end
+        end
     else
         -- not_taken → clear
         SetPendingState(nodeID, entryID, nil, nil, nil)
@@ -861,7 +881,8 @@ local function EnsureButtons()
         clearBtn:SetWidth(80)
         clearBtn:SetCallback("OnClick", function()
             wipe(pendingConditions)
-            RefreshPickerBorders()
+            HideChoiceFrame()
+            PopulateTree()
         end)
     end
 

--- a/Config/TalentPicker.lua
+++ b/Config/TalentPicker.lua
@@ -325,6 +325,21 @@ local function GetConditionState(nodeID, entryID)
     return GetPendingStateForNode(nodeID)
 end
 
+local function IsHeroSpecProxyCondition(cond)
+    return type(cond) == "table"
+        and cond.nodeID ~= nil
+        and cond.heroSubTreeID ~= nil
+        and cond.entryID == nil
+        and type(cond.name) == "string"
+        and type(cond.heroName) == "string"
+        and cond.name == cond.heroName
+end
+
+local function IsHeroSpecProxyNodeDisabled(nodeID)
+    local pending = GetPendingStateForNode(nodeID)
+    return pending and pending.show == "not_taken" and IsHeroSpecProxyCondition(pending)
+end
+
 local function AddPendingTooltipLine(pending, isChoiceNode)
     if not pending then return end
 
@@ -409,7 +424,9 @@ local function CreateNodeButton(parent, index)
             and GetPendingState(self._nodeID, self._entryID)
             or  GetPendingStateForNode(self._nodeID)
         AddPendingTooltipLine(pending, self._isChoiceNode)
-        if self._isChoiceNode then
+        if self._disabledReason then
+            GameTooltip:AddLine(self._disabledReason, 1, 0.82, 0.2, true)
+        elseif self._isChoiceNode then
             GameTooltip:AddLine("Left-click to show or hide choices", 0.5, 0.8, 1)
         else
             GameTooltip:AddLine("Click to cycle condition", 0.5, 0.8, 1)
@@ -459,7 +476,11 @@ local function CreateChoiceButton(parent)
             local pending = GetPendingState(self._nodeID, self._entryID)
             AddPendingTooltipLine(pending, true)
         end
-        GameTooltip:AddLine("Click to cycle a specific choice", 0.5, 0.8, 1)
+        if self._disabledReason then
+            GameTooltip:AddLine(self._disabledReason, 1, 0.82, 0.2, true)
+        else
+            GameTooltip:AddLine("Click to cycle a specific choice", 0.5, 0.8, 1)
+        end
         GameTooltip:Show()
     end)
     btn:SetScript("OnLeave", function() GameTooltip:Hide() end)
@@ -1318,14 +1339,26 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
         btn._talentName = displayName
         btn._spellID = primaryEntry.spellID
         btn._rankText = nil
+        btn._disabledReason = node.disabledReason
 
         local borderColor, borderSize = GetNodeBorderStyle(node.nodeID, nil)
         SetNodeBorderThickness(btn, borderSize)
         SetNodeBorderColor(btn, borderColor)
+        btn.icon:SetDesaturated(node.disabledInteraction and true or false)
+        if node.disabledInteraction then
+            btn.icon:SetVertexColor(0.5, 0.5, 0.5)
+            btn.highlight:Hide()
+        else
+            btn.icon:SetVertexColor(1, 1, 1)
+            btn.highlight:Show()
+        end
 
         -- Click handler
         local nodeRef = node
         btn:SetScript("OnClick", function(self, mouseButton)
+            if nodeRef.disabledInteraction then
+                return
+            end
             if nodeRef.isChoice and #nodeRef.entries > 1 then
                 if mouseButton == "LeftButton" or mouseButton == nil then
                     ToggleChoiceFrame(self, nodeRef.entries, nodeRef.nodeID, nodeRef.scopeType, nodeRef.subTreeID)
@@ -1333,7 +1366,11 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
             else
                 HideChoiceFrame()
                 CyclePendingState(nodeRef.nodeID, nil, primaryEntry.spellID, displayName, BuildConditionContext(nodeRef.scopeType, nodeRef.subTreeID))
-                RefreshPickerBorders()
+                if nodeRef.scopeType == "hero" and nodeRef.displayName then
+                    PopulateTree()
+                else
+                    RefreshPickerBorders()
+                end
             end
         end)
 
@@ -1436,6 +1473,7 @@ local function RenderHeroChoiceList(panelFrame, nodeSet, nodeIDToBtn, btnIndex, 
 
     local centeredX = math_max(NODE_PADDING, math_floor((panelFrame:GetWidth() - NODE_SIZE) * 0.5))
     local nextY = HERO_HEADER_HEIGHT + 8
+    local disableHeroSubTreeRows = leadingNode and IsHeroSpecProxyNodeDisabled(leadingNode.nodeID)
 
     if leadingNode then
         btnIndex = PlaceNodesInPanel(panelFrame, { leadingNode }, centeredX - NODE_PADDING, nextY - NODE_PADDING,
@@ -1444,6 +1482,13 @@ local function RenderHeroChoiceList(panelFrame, nodeSet, nodeIDToBtn, btnIndex, 
     end
 
     for _, node in ipairs(orderedNodes) do
+        if disableHeroSubTreeRows then
+            node.disabledInteraction = true
+            node.disabledReason = "Clear the top hero-spec condition first to edit hero-tree talents."
+        else
+            node.disabledInteraction = nil
+            node.disabledReason = nil
+        end
         btnIndex = PlaceNodesInPanel(panelFrame, { node }, centeredX - NODE_PADDING, nextY - NODE_PADDING,
             node.px, node.py, node.px, node.py, 0, btnIndex, nodeIDToBtn)
         nextY = nextY + NODE_SIZE + 10

--- a/Config/TalentPicker.lua
+++ b/Config/TalentPicker.lua
@@ -1230,6 +1230,7 @@ local function BuildHeroSpecNodeRecord(configID, treeID, heroSubTreeID)
 
     record.scopeType = "hero"
     record.displayName = GetHeroDisplayName(configID, heroSubTreeID)
+    record.isHeroSpecProxy = true
     return record
 end
 
@@ -1347,6 +1348,7 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
             and GetPrimaryDisplayEntry(node.entries, node.nodeID)
             or node.entries[1]
         local displayName = node.displayName or (primaryEntry and primaryEntry.name) or nil
+        local displaySpellID = node.isHeroSpecProxy and nil or primaryEntry.spellID
 
         btn.icon:SetTexture(primaryEntry.icon)
         btn.icon:SetDesaturated(false)
@@ -1358,7 +1360,7 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
         btn._isChoiceNode = node.isChoice
         btn._entries = node.entries
         btn._talentName = displayName
-        btn._spellID = primaryEntry.spellID
+        btn._spellID = displaySpellID
         btn._rankText = nil
         btn._disabledReason = node.disabledReason
 
@@ -1386,7 +1388,7 @@ local function PlaceNodesInPanel(scrollChild, nodeSet, panelOffsetX, yOffset,
                 end
             else
                 HideChoiceFrame()
-                CyclePendingState(nodeRef.nodeID, nil, primaryEntry.spellID, displayName, BuildConditionContext(nodeRef.scopeType, nodeRef.subTreeID))
+                CyclePendingState(nodeRef.nodeID, nil, displaySpellID, displayName, BuildConditionContext(nodeRef.scopeType, nodeRef.subTreeID))
                 if nodeRef.scopeType == "hero" and nodeRef.displayName then
                     PopulateTree()
                 else

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -262,6 +262,16 @@ local function ResolveConditionHeroName(cond)
     return nil
 end
 
+local function IsHeroSpecProxyCondition(cond)
+    return type(cond) == "table"
+        and cond.nodeID ~= nil
+        and cond.heroSubTreeID ~= nil
+        and cond.entryID == nil
+        and type(cond.name) == "string"
+        and type(cond.heroName) == "string"
+        and cond.name == cond.heroName
+end
+
 local function GetConditionContextSuffix(cond)
     local parts = {}
     local className = ResolveConditionClassName(cond)
@@ -1188,7 +1198,9 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
             summaryLabel:SetText("|cff888888Multiple conditions|r")
         elseif hasTalent and condCount > 0 then
             local firstCond = conditions[1]
-            local displayIcon = firstCond.spellID and C_Spell.GetSpellTexture(firstCond.spellID)
+            local displayIcon = not IsHeroSpecProxyCondition(firstCond)
+                and firstCond.spellID
+                and C_Spell.GetSpellTexture(firstCond.spellID)
             if displayIcon then
                 summaryLabel:SetImage(displayIcon, 0.08, 0.92, 0.08, 0.92)
                 summaryLabel:SetImageSize(16, 16)
@@ -1220,7 +1232,9 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         local currentHeroSubTreeID = CooldownCompanion._currentHeroSpecId
         for _, cond in ipairs(conditions) do
             local condLabel = AceGUI:Create("Label")
-            local displayIcon = cond.spellID and C_Spell.GetSpellTexture(cond.spellID)
+            local displayIcon = not IsHeroSpecProxyCondition(cond)
+                and cond.spellID
+                and C_Spell.GetSpellTexture(cond.spellID)
             if displayIcon then
                 condLabel:SetImage(displayIcon, 0.08, 0.92, 0.08, 0.92)
                 condLabel:SetImageSize(16, 16)

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -267,6 +267,7 @@ local function GetConditionContextSuffix(cond)
     local className = ResolveConditionClassName(cond)
     local specName = ResolveConditionSpecName(cond)
     local heroName = ResolveConditionHeroName(cond)
+    local conditionName = cond and cond.name or nil
 
     if className then
         parts[#parts + 1] = className
@@ -274,7 +275,7 @@ local function GetConditionContextSuffix(cond)
     if specName then
         parts[#parts + 1] = specName
     end
-    if heroName then
+    if heroName and heroName ~= conditionName then
         parts[#parts + 1] = heroName
     end
 

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -78,6 +78,16 @@ local DEFAULT_ESSENCE_RECHARGING_COLOR = RB.DEFAULT_ESSENCE_RECHARGING_COLOR
 local DEFAULT_ESSENCE_MAX_COLOR = RB.DEFAULT_ESSENCE_MAX_COLOR
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
+
+local function IsHeroSpecProxyCondition(cond)
+    return type(cond) == "table"
+        and cond.nodeID ~= nil
+        and cond.heroSubTreeID ~= nil
+        and cond.entryID == nil
+        and type(cond.name) == "string"
+        and type(cond.heroName) == "string"
+        and cond.name == cond.heroName
+end
 local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForSpell
 
 -- Imports from ResourceBarPanelsHelpers
@@ -2328,7 +2338,9 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                     local summaryLabel = AceGUI:Create("Label")
                     if condCount > 0 then
                         local firstCond = conditions[1]
-                        local displayIcon = firstCond.spellID and C_Spell.GetSpellTexture(firstCond.spellID)
+                        local displayIcon = not IsHeroSpecProxyCondition(firstCond)
+                            and firstCond.spellID
+                            and C_Spell.GetSpellTexture(firstCond.spellID)
                         if displayIcon then
                             summaryLabel:SetImage(displayIcon, 0.08, 0.92, 0.08, 0.92)
                             summaryLabel:SetImageSize(16, 16)
@@ -2355,7 +2367,9 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                     local currentHeroSubTreeID = CooldownCompanion._currentHeroSpecId
                     for _, cond in ipairs(conditions) do
                         local condLabel = AceGUI:Create("Label")
-                        local displayIcon = cond.spellID and C_Spell.GetSpellTexture(cond.spellID)
+                        local displayIcon = not IsHeroSpecProxyCondition(cond)
+                            and cond.spellID
+                            and C_Spell.GetSpellTexture(cond.spellID)
                         if displayIcon then
                             condLabel:SetImage(displayIcon, 0.08, 0.92, 0.08, 0.92)
                             condLabel:SetImageSize(16, 16)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1560,7 +1560,9 @@ function CooldownCompanion:IsTalentConditionMet(buttonData)
             if cond.heroSubTreeID ~= activeHeroSubTreeID then
                 return false
             end
-        else
+        end
+
+        if not IsHeroSpecProxyCondition(cond) then
             local entry = cache and cache[cond.nodeID] or nil
             local isTaken = entry and entry.activeRank > 0 or false
 

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1413,7 +1413,6 @@ function CooldownCompanion:UnlockAllFrames()
     end
 end
 
-------------------------------------------------------------------------
 -- TALENT NODE CACHE (for per-button talent conditions)
 ------------------------------------------------------------------------
 
@@ -1520,6 +1519,16 @@ function CooldownCompanion:IsTalentConditionMet(buttonData)
         cache = self._talentNodeCache
     end
 
+    local function IsHeroSpecProxyCondition(cond)
+        return type(cond) == "table"
+            and cond.nodeID ~= nil
+            and cond.heroSubTreeID ~= nil
+            and cond.entryID == nil
+            and type(cond.name) == "string"
+            and type(cond.heroName) == "string"
+            and cond.name == cond.heroName
+    end
+
     for _, cond in ipairs(conditions) do
         if cond.classID and self._playerClassID and cond.classID ~= self._playerClassID then
             return false
@@ -1529,26 +1538,43 @@ function CooldownCompanion:IsTalentConditionMet(buttonData)
             return false
         end
 
+        local activeHeroSubTreeID = nil
         if cond.heroSubTreeID then
-            local activeHeroSubTreeID = self._currentHeroSpecId or C_ClassTalents.GetActiveHeroTalentSpec()
+            activeHeroSubTreeID = self._currentHeroSpecId or C_ClassTalents.GetActiveHeroTalentSpec()
+        end
+
+        if IsHeroSpecProxyCondition(cond) then
+            local show = cond.show or "taken"
+            local heroIsActive = activeHeroSubTreeID ~= nil and cond.heroSubTreeID == activeHeroSubTreeID
+            local otherHeroIsActive = activeHeroSubTreeID ~= nil and cond.heroSubTreeID ~= activeHeroSubTreeID
+            if show == "not_taken" then
+                if not otherHeroIsActive then
+                    return false
+                end
+            else
+                if not heroIsActive then
+                    return false
+                end
+            end
+        elseif cond.heroSubTreeID then
             if cond.heroSubTreeID ~= activeHeroSubTreeID then
                 return false
             end
-        end
-
-        local entry = cache and cache[cond.nodeID] or nil
-        local isTaken = entry and entry.activeRank > 0 or false
-
-        -- For choice nodes: if a specific entryID is required, verify it matches
-        if isTaken and cond.entryID then
-            isTaken = (entry.activeEntryID == cond.entryID)
-        end
-
-        local show = cond.show or "taken"
-        if show == "not_taken" then
-            if isTaken then return false end
         else
-            if not isTaken then return false end
+            local entry = cache and cache[cond.nodeID] or nil
+            local isTaken = entry and entry.activeRank > 0 or false
+
+            -- For choice nodes: if a specific entryID is required, verify it matches
+            if isTaken and cond.entryID then
+                isTaken = (entry.activeEntryID == cond.entryID)
+            end
+
+            local show = cond.show or "taken"
+            if show == "not_taken" then
+                if isTaken then return false end
+            else
+                if not isTaken then return false end
+            end
         end
     end
 

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1546,9 +1546,8 @@ function CooldownCompanion:IsTalentConditionMet(buttonData)
         if IsHeroSpecProxyCondition(cond) then
             local show = cond.show or "taken"
             local heroIsActive = activeHeroSubTreeID ~= nil and cond.heroSubTreeID == activeHeroSubTreeID
-            local otherHeroIsActive = activeHeroSubTreeID ~= nil and cond.heroSubTreeID ~= activeHeroSubTreeID
             if show == "not_taken" then
-                if not otherHeroIsActive then
+                if heroIsActive then
                     return false
                 end
             else

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1417,6 +1417,34 @@ end
 -- TALENT NODE CACHE (for per-button talent conditions)
 ------------------------------------------------------------------------
 
+function CooldownCompanion:GetHeroSubTreeRootNode(configID, treeID, heroSubTreeID)
+    if not configID or not treeID or not heroSubTreeID then
+        return nil, nil
+    end
+
+    local nodeIDs = C_Traits.GetTreeNodes(treeID)
+    if not nodeIDs then
+        return nil, nil
+    end
+
+    local bestNodeID, bestNodeInfo = nil, nil
+    for _, nodeID in ipairs(nodeIDs) do
+        local nodeInfo = C_Traits.GetNodeInfo(configID, nodeID)
+        if nodeInfo
+            and nodeInfo.subTreeID == heroSubTreeID
+            and nodeInfo.type ~= Enum.TraitNodeType.SubTreeSelection then
+            if not bestNodeInfo
+                or nodeInfo.posY < bestNodeInfo.posY
+                or (nodeInfo.posY == bestNodeInfo.posY and nodeInfo.posX < bestNodeInfo.posX) then
+                bestNodeID = nodeID
+                bestNodeInfo = nodeInfo
+            end
+        end
+    end
+
+    return bestNodeID, bestNodeInfo
+end
+
 -- Rebuild the runtime talent node cache from the active talent config.
 -- Called on TRAIT_CONFIG_UPDATED, PLAYER_ENTERING_WORLD, spec changes.
 function CooldownCompanion:RebuildTalentNodeCache()
@@ -1435,9 +1463,14 @@ function CooldownCompanion:RebuildTalentNodeCache()
     local treeID = C_ClassTalents.GetTraitTreeForSpec(specID)
     if not treeID then return end
 
+    local activeHeroSubTreeID = self._currentHeroSpecId or C_ClassTalents.GetActiveHeroTalentSpec()
+    local heroRootNodeID = nil
+    if activeHeroSubTreeID then
+        heroRootNodeID = self:GetHeroSubTreeRootNode(configID, treeID, activeHeroSubTreeID)
+    end
+
     local nodeIDs = C_Traits.GetTreeNodes(treeID)
     if not nodeIDs then return end
-    local activeHeroSubTreeID = self._currentHeroSpecId or C_ClassTalents.GetActiveHeroTalentSpec()
 
     for _, nodeID in ipairs(nodeIDs) do
         local nodeInfo = C_Traits.GetNodeInfo(configID, nodeID)
@@ -1449,7 +1482,10 @@ function CooldownCompanion:RebuildTalentNodeCache()
                 or (
                     activeHeroSubTreeID
                     and nodeInfo.subTreeID == activeHeroSubTreeID
-                    and nodeInfo.type == Enum.TraitNodeType.Selection
+                    and (
+                        nodeInfo.type == Enum.TraitNodeType.Selection
+                        or nodeID == heroRootNodeID
+                    )
                 )
             )
         if includeNode then


### PR DESCRIPTION
## What Players Will Notice
- Talent-condition picking can now target a hero spec directly from the hero section of the talent picker.
- The selected hero spec appears as a dedicated top row above that tree's hero talent choices.
- That top row supports both `taken` and `not taken`, so entries can load only for a chosen hero spec or stay hidden while that hero spec is active.
- When the top hero-spec row is set to `not taken`, the lower hero-tree rows are disabled to prevent contradictory conditions.

## Why This Changed
- Button and entry conditions could already filter by regular talents, but there was no direct way to say "only load for this hero spec" at the same level.
- Reusing the hero tree's top node keeps the interaction inside the existing picker instead of adding a separate filter control.
- Follow-up fixes were needed so the new hero-spec row would not conflict with ordinary hero talents, leave impossible condition combinations behind, or show misleading root-talent tooltips and icons.

## What Changed
- Added a derived hero-spec proxy row at the top of the hero picker by resolving the top visible non-selector node for the selected hero subtree.
- Extended runtime talent evaluation so the proxy row is handled separately from ordinary hero-tree talents, while normal hero talent and hero choice conditions still verify the actual node or selected choice entry.
- Cached the active hero tree's proxy root node so the runtime can evaluate the new top-row condition alongside existing hero choice rows.
- Updated picker behavior so flipping the top hero row to `not taken` clears same-subtree child conditions, disables lower hero rows, and re-enables them correctly after `Clear`.
- Stopped the proxy row from inheriting the root talent's spell tooltip and saved-summary icon so it reads as a hero-spec filter instead of a specific starter talent.
- Updated condition labels to avoid repeating the hero name when the proxy row already uses the hero spec name as its display text.

## Validation
- `luac -p Config/TalentPicker.lua`
- `luac -p ConfigSettings/ButtonConditions.lua`
- `luac -p ConfigSettings/ResourceBarPanels.lua`
- `luac -p Core/GroupOperations.lua`
- In-game validation is still required before merge.
- Combat and restricted-content behavior have not been verified yet.