### PR TITLE
Fix hidden custom aura bars appearing late on first application

### DIFF
--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -149,6 +149,10 @@ local alphaSyncFrame = nil
 local lastAppliedBarSpacing = nil
 local lastAppliedBarThickness = nil
 local layoutDirty = false
+local customAuraWakeRetryFrame = nil
+local customAuraWakeRetryQueue = {}
+local customAuraWakeRetryPending = {}
+local processingCustomAuraWakeRetryQueue = false
 local independentWrapperFrame = nil
 local customAuraBarActivePreviewTokens = {}
 local customAuraBarPandemicPreviewTokens = {}
@@ -1922,6 +1926,92 @@ local function IsEventDrivenCustomAuraBar(barInfo)
             or barInfo.barType == "custom_overlay")
 end
 
+local function StopDeferredCustomAuraWakeRetryFrame()
+    if customAuraWakeRetryFrame then
+        customAuraWakeRetryFrame:SetScript("OnUpdate", nil)
+    end
+end
+
+local function ClearDeferredCustomAuraWakeRetries()
+    wipe(customAuraWakeRetryQueue)
+    wipe(customAuraWakeRetryPending)
+    processingCustomAuraWakeRetryQueue = false
+    StopDeferredCustomAuraWakeRetryFrame()
+end
+
+local RelayoutBars
+
+local function ProcessDeferredCustomAuraWakeRetries()
+    if processingCustomAuraWakeRetryQueue then return end
+    if #customAuraWakeRetryQueue == 0 then
+        StopDeferredCustomAuraWakeRetryFrame()
+        return
+    end
+
+    processingCustomAuraWakeRetryQueue = true
+    local queue = customAuraWakeRetryQueue
+    customAuraWakeRetryQueue = {}
+    customAuraWakeRetryPending = {}
+
+    local relayoutNeeded = false
+    for _, entry in ipairs(queue) do
+        local barInfo = entry.barInfo
+        local frame = barInfo and barInfo.frame
+        local cabConfig = barInfo and barInfo.cabConfig
+        if barInfo
+            and frame
+            and cabConfig
+            and barInfo.cabConfig == entry.cabConfig
+            and IsEventDrivenCustomAuraBar(barInfo)
+            and cabConfig.hideWhenInactive == true
+            and GetHiddenCustomAuraWakeUnit(cabConfig) == entry.unit
+            and not frame:IsShown()
+        then
+            UpdateCustomAuraBar(barInfo)
+            if not barInfo._isIndependent and frame:IsShown() then
+                relayoutNeeded = true
+            end
+        end
+    end
+
+    processingCustomAuraWakeRetryQueue = false
+    StopDeferredCustomAuraWakeRetryFrame()
+
+    if relayoutNeeded then
+        layoutDirty = false
+        RelayoutBars()
+        CooldownCompanion:RepositionCastBar()
+    end
+end
+
+local function QueueDeferredCustomAuraWakeRetry(barInfo, unit)
+    if processingCustomAuraWakeRetryQueue then return end
+    if unit ~= "player" and unit ~= "target" then return end
+    if not IsEventDrivenCustomAuraBar(barInfo) then return end
+
+    local frame = barInfo and barInfo.frame
+    local cabConfig = barInfo and barInfo.cabConfig
+    if not frame or not cabConfig or cabConfig.hideWhenInactive ~= true then return end
+    if frame:IsShown() then return end
+    if GetHiddenCustomAuraWakeUnit(cabConfig) ~= unit then return end
+    if customAuraWakeRetryPending[frame] then return end
+
+    customAuraWakeRetryPending[frame] = true
+    customAuraWakeRetryQueue[#customAuraWakeRetryQueue + 1] = {
+        barInfo = barInfo,
+        cabConfig = cabConfig,
+        unit = unit,
+    }
+
+    if not customAuraWakeRetryFrame then
+        customAuraWakeRetryFrame = CreateFrame("Frame")
+    end
+    customAuraWakeRetryFrame:SetScript("OnUpdate", function(self, _elapsed)
+        self:SetScript("OnUpdate", nil)
+        ProcessDeferredCustomAuraWakeRetries()
+    end)
+end
+
 local function RefreshEventDrivenCustomAuraBarsForUnit(unit)
     if unit ~= "player" and unit ~= "target" then return end
 
@@ -1938,7 +2028,11 @@ local function RefreshEventDrivenCustomAuraBarsForUnit(unit)
                 or barInfo.barType == "custom_segmented"
                 or barInfo.barType == "custom_overlay")
             and GetHiddenCustomAuraWakeUnit(cabConfig) == unit then
+            local wasShown = frame:IsShown()
             UpdateCustomAuraBar(barInfo)
+            if not wasShown and not frame:IsShown() then
+                QueueDeferredCustomAuraWakeRetry(barInfo, unit)
+            end
         end
     end
 end
@@ -2289,7 +2383,7 @@ local function CompareBarOrder(a, b)
     return (a.powerType or 0) < (b.powerType or 0)
 end
 
-local function RelayoutBars()
+RelayoutBars = function()
     if not containerFrameAbove or not containerFrameBelow then return end
     local barSpacing = lastAppliedBarSpacing or 3.6
     local globalThickness = lastAppliedBarThickness or 12
@@ -3146,6 +3240,7 @@ function CooldownCompanion:RevertResourceBars()
     lastAppliedBarSpacing = nil
     lastAppliedBarThickness = nil
     layoutDirty = false
+    ClearDeferredCustomAuraWakeRetries()
 
     -- Stop alpha sync, unregister module alpha, restore alpha
     CooldownCompanion:UnregisterModuleAlpha("rb")

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -1941,6 +1941,25 @@ end
 
 local RelayoutBars
 
+local function ResolveDeferredCustomAuraWakeRetryBarInfo(entry)
+    if not entry or not entry.powerType or not entry.cabConfig then
+        return nil
+    end
+
+    -- ApplyResourceBars() can recreate the custom aura bar before the next-frame
+    -- retry fires, so re-resolve the active barInfo instead of trusting the
+    -- captured table/frame from queue time.
+    for _, candidate in ipairs(resourceBarFrames) do
+        if candidate
+            and candidate.powerType == entry.powerType
+            and candidate.cabConfig == entry.cabConfig then
+            return candidate
+        end
+    end
+
+    return nil
+end
+
 local function ProcessDeferredCustomAuraWakeRetries()
     if processingCustomAuraWakeRetryQueue then return end
     if #customAuraWakeRetryQueue == 0 then
@@ -1955,7 +1974,7 @@ local function ProcessDeferredCustomAuraWakeRetries()
 
     local relayoutNeeded = false
     for _, entry in ipairs(queue) do
-        local barInfo = entry.barInfo
+        local barInfo = ResolveDeferredCustomAuraWakeRetryBarInfo(entry)
         local frame = barInfo and barInfo.frame
         local cabConfig = barInfo and barInfo.cabConfig
         if barInfo
@@ -1991,15 +2010,16 @@ local function QueueDeferredCustomAuraWakeRetry(barInfo, unit)
 
     local frame = barInfo and barInfo.frame
     local cabConfig = barInfo and barInfo.cabConfig
-    if not frame or not cabConfig or cabConfig.hideWhenInactive ~= true then return end
+    local powerType = barInfo and barInfo.powerType
+    if not frame or not cabConfig or not powerType or cabConfig.hideWhenInactive ~= true then return end
     if frame:IsShown() then return end
     if GetHiddenCustomAuraWakeUnit(cabConfig) ~= unit then return end
-    if customAuraWakeRetryPending[frame] then return end
+    if customAuraWakeRetryPending[cabConfig] then return end
 
-    customAuraWakeRetryPending[frame] = true
+    customAuraWakeRetryPending[cabConfig] = true
     customAuraWakeRetryQueue[#customAuraWakeRetryQueue + 1] = {
-        barInfo = barInfo,
         cabConfig = cabConfig,
+        powerType = powerType,
         unit = unit,
     }
 


### PR DESCRIPTION
## What Players Will Notice
- Hidden segmented and overlay custom aura bars now appear immediately when an aura is first applied from 0 stacks instead of waiting for another ability or GCD update.
- The wake-up fix now survives bar reapplies, so a layout or config-driven rebuild will not leave the retry pointed at a retired hidden bar.

## Why This Changed
- Event-driven hidden custom aura bars could miss their first wake-up when the first `UNIT_AURA` refresh arrived before the bar could show itself.
- The follow-up retry path also needed to survive `ApplyResourceBars()` rebuilds, otherwise a queued retry could target the old bar object instead of the replacement bar.

## What Changed
- Added a one-shot next-frame retry for hidden `custom_segmented` and `custom_overlay` aura bars when the immediate `UNIT_AURA` wake-up still leaves the bar hidden.
- Re-layout attached bars immediately when that retry makes them visible so they do not wait for the normal 30 Hz pass.
- Re-resolve the active custom aura bar by `powerType` and `cabConfig` when the deferred retry fires, and dedupe retries by logical bar config instead of the original frame instance.
- Clear pending deferred retries during full resource bar revert.

## Validation
- In-game reproduction and retest of the first-application wake-up fix on Tip of the Spear from 0 stacks; the one-frame fallback felt immediate after the fix.
- `luac -p OtherBars/ResourceBar.lua`
- Static review of reapply paths for the stale-retry follow-up.
- Combat and restricted-content verification are still pending.
