### PR TITLE
Improve unlocked group editing with visible wrappers and panel selection

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1456,6 +1456,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     local group = button._groupId and CooldownCompanion.db.profile.groups[button._groupId]
     local isTriggerPanel = group and group.displayMode == "trigger"
+    local forceVisibleByUnlockPreview = group
+        and group.parentContainerId
+        and CooldownCompanion.IsContainerUnlockPreviewActive
+        and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
+        and not isTriggerPanel
     if isTriggerPanel then
         button._visibilityHidden = true
         button._visibilityAlphaOverride = 0
@@ -1463,11 +1468,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Config panel QOL: selected buttons in column 2 are always fully visible.
     local forceVisibleByConfig = IsConfigButtonForceVisible(button)
-    if forceVisibleByConfig and not isTriggerPanel then
+    if forceVisibleByUnlockPreview then
+        button._visibilityHidden = false
+        button._visibilityAlphaOverride = 1
+    elseif forceVisibleByConfig and not isTriggerPanel then
         button._visibilityHidden = false
         button._visibilityAlphaOverride = 1
     end
-    button._forceVisibleByConfig = (forceVisibleByConfig and not isTriggerPanel) or nil
+    button._forceVisibleByConfig = ((forceVisibleByConfig or forceVisibleByUnlockPreview) and not isTriggerPanel) or nil
 
     -- Track visibility/force-visible state changes for compact layout reflow.
     local visibilityChanged = button._visibilityHidden ~= button._prevVisibilityHidden

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2907,6 +2907,29 @@ local function BuildContainerGeneralTab(scroll, containerId)
 
     if not layoutCollapsed then
         container.anchor = CooldownCompanion:NormalizeContainerAnchor(container.anchor)
+        local function ApplyContainerOffset(axis, value)
+            local oldValue = tonumber(container.anchor[axis]) or 0
+            container.anchor[axis] = value
+
+            local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
+            if containerFrame then
+                CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
+            end
+
+            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                local deltaX, deltaY = 0, 0
+                if axis == "x" then
+                    deltaX = value - oldValue
+                else
+                    deltaY = value - oldValue
+                end
+                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, deltaX, deltaY)
+            end
+
+            if containerFrame and CooldownCompanion.RefreshContainerWrapper then
+                CooldownCompanion:RefreshContainerWrapper(containerId)
+            end
+        end
 
         -- X Offset
         local xSlider = AceGUI:Create("Slider")
@@ -2914,21 +2937,8 @@ local function BuildContainerGeneralTab(scroll, containerId)
         xSlider:SetSliderValues(-2000, 2000, 0.1)
         xSlider:SetValue(container.anchor.x or 0)
         xSlider:SetFullWidth(true)
-        xSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            local oldX = tonumber(container.anchor.x) or 0
-            container.anchor.x = val
-            local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
-            if containerFrame then
-                CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
-            end
-            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
-                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, val - oldX, 0)
-            end
-            if containerFrame then
-                if CooldownCompanion.RefreshContainerWrapper then
-                    CooldownCompanion:RefreshContainerWrapper(containerId)
-                end
-            end
+        xSlider:SetCallback("OnValueChanged", function(_, _, val)
+            ApplyContainerOffset("x", val)
         end)
         HookSliderEditBox(xSlider)
         scroll:AddChild(xSlider)
@@ -2939,21 +2949,8 @@ local function BuildContainerGeneralTab(scroll, containerId)
         ySlider:SetSliderValues(-2000, 2000, 0.1)
         ySlider:SetValue(container.anchor.y or 0)
         ySlider:SetFullWidth(true)
-        ySlider:SetCallback("OnValueChanged", function(widget, event, val)
-            local oldY = tonumber(container.anchor.y) or 0
-            container.anchor.y = val
-            local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
-            if containerFrame then
-                CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
-            end
-            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
-                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, 0, val - oldY)
-            end
-            if containerFrame then
-                if CooldownCompanion.RefreshContainerWrapper then
-                    CooldownCompanion:RefreshContainerWrapper(containerId)
-                end
-            end
+        ySlider:SetCallback("OnValueChanged", function(_, _, val)
+            ApplyContainerOffset("y", val)
         end)
         HookSliderEditBox(ySlider)
         scroll:AddChild(ySlider)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2915,10 +2915,17 @@ local function BuildContainerGeneralTab(scroll, containerId)
         xSlider:SetValue(container.anchor.x or 0)
         xSlider:SetFullWidth(true)
         xSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            local oldX = tonumber(container.anchor.x) or 0
             container.anchor.x = val
+            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, val - oldX, 0)
+            end
             local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
             if containerFrame then
                 CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
+                if CooldownCompanion.RefreshContainerWrapper then
+                    CooldownCompanion:RefreshContainerWrapper(containerId)
+                end
             end
         end)
         HookSliderEditBox(xSlider)
@@ -2931,10 +2938,17 @@ local function BuildContainerGeneralTab(scroll, containerId)
         ySlider:SetValue(container.anchor.y or 0)
         ySlider:SetFullWidth(true)
         ySlider:SetCallback("OnValueChanged", function(widget, event, val)
+            local oldY = tonumber(container.anchor.y) or 0
             container.anchor.y = val
+            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, 0, val - oldY)
+            end
             local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
             if containerFrame then
                 CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
+                if CooldownCompanion.RefreshContainerWrapper then
+                    CooldownCompanion:RefreshContainerWrapper(containerId)
+                end
             end
         end)
         HookSliderEditBox(ySlider)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2917,12 +2917,14 @@ local function BuildContainerGeneralTab(scroll, containerId)
         xSlider:SetCallback("OnValueChanged", function(widget, event, val)
             local oldX = tonumber(container.anchor.x) or 0
             container.anchor.x = val
-            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
-                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, val - oldX, 0)
-            end
             local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
             if containerFrame then
                 CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
+            end
+            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, val - oldX, 0)
+            end
+            if containerFrame then
                 if CooldownCompanion.RefreshContainerWrapper then
                     CooldownCompanion:RefreshContainerWrapper(containerId)
                 end
@@ -2940,12 +2942,14 @@ local function BuildContainerGeneralTab(scroll, containerId)
         ySlider:SetCallback("OnValueChanged", function(widget, event, val)
             local oldY = tonumber(container.anchor.y) or 0
             container.anchor.y = val
-            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
-                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, 0, val - oldY)
-            end
             local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[containerId]
             if containerFrame then
                 CooldownCompanion:AnchorContainerFrame(containerFrame, container.anchor)
+            end
+            if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, 0, val - oldY)
+            end
+            if containerFrame then
                 if CooldownCompanion.RefreshContainerWrapper then
                     CooldownCompanion:RefreshContainerWrapper(containerId)
                 end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -128,34 +128,63 @@ local function GetStandaloneScreenAnchorPoint(settings)
     return uiCenterX + relOffsetX + x, uiCenterY + relOffsetY + y, point, relativePoint
 end
 
-local function SaveGroupedStandalonePreviewSettings(host, group, settings)
-    local containerFrame = GetGroupedPreviewContainerFrame(group)
-    if not (host and containerFrame and settings and host.GetPoint) then
-        return false
+local function GetTextureHostDisplayCoords(host, point, relativePoint)
+    if not (host and host.GetCenter and host.GetSize) then
+        return nil, nil, nil, nil
     end
 
-    local containerX, containerY = containerFrame:GetCenter()
     local uiCenterX, uiCenterY = UIParent:GetCenter()
     local uiWidth, uiHeight = UIParent:GetSize()
-    local point, relativeFrame, _, x, y = host:GetPoint(1)
-    if not (containerX and containerY and uiCenterX and uiCenterY and uiWidth and uiHeight) then
+    local hostCenterX, hostCenterY = host:GetCenter()
+    local hostWidth, hostHeight = host:GetSize()
+    if not (uiCenterX and uiCenterY and uiWidth and uiHeight and hostCenterX and hostCenterY and hostWidth and hostHeight) then
+        return nil, nil, nil, nil
+    end
+
+    local normalizedPoint = NormalizeAnchorPoint(point or "CENTER")
+    local normalizedRelativePoint = NormalizeAnchorPoint(relativePoint or "CENTER")
+    local pointOffsetX, pointOffsetY = GetAnchorOffset(normalizedPoint, hostWidth, hostHeight)
+    local refOffsetX, refOffsetY = GetAnchorOffset(normalizedRelativePoint, uiWidth, uiHeight)
+    if pointOffsetX == nil or pointOffsetY == nil or refOffsetX == nil or refOffsetY == nil then
+        return nil, nil, normalizedPoint, normalizedRelativePoint
+    end
+
+    local screenAnchorX = hostCenterX + pointOffsetX
+    local screenAnchorY = hostCenterY + pointOffsetY
+    local x = math_floor(((screenAnchorX - (uiCenterX + refOffsetX)) * 10) + 0.5) / 10
+    local y = math_floor(((screenAnchorY - (uiCenterY + refOffsetY)) * 10) + 0.5) / 10
+    return x, y, normalizedPoint, normalizedRelativePoint
+end
+
+local function SaveGroupedStandalonePreviewSettings(host, group, settings)
+    local containerFrame = GetGroupedPreviewContainerFrame(group)
+    if not (host and containerFrame and settings and host.GetPoint and host.GetCenter and host.GetSize) then
         return false
     end
 
-    if relativeFrame ~= containerFrame and not host._wrapperManaged then
+    local point = host:GetPoint(1)
+
+    if not host._wrapperManaged then
+        local _, relativeFrame = host:GetPoint(1)
+        if relativeFrame ~= containerFrame then
+            return false
+        end
+    end
+
+    local x, y, normalizedPoint, normalizedRelativePoint = GetTextureHostDisplayCoords(
+        host,
+        point or settings.point or "CENTER",
+        settings.relativePoint or "CENTER"
+    )
+    if x == nil or y == nil then
         return false
     end
 
-    local relativePoint = settings.relativePoint or "CENTER"
-    local refOffsetX, refOffsetY = GetAnchorOffset(relativePoint, uiWidth, uiHeight)
-    local screenAnchorX = containerX + (x or 0)
-    local screenAnchorY = containerY + (y or 0)
-
-    settings.point = NormalizeAnchorPoint(point or settings.point or "CENTER")
-    settings.relativePoint = NormalizeAnchorPoint(relativePoint)
+    settings.point = normalizedPoint
+    settings.relativePoint = normalizedRelativePoint
     settings.relativeTo = UI_PARENT_NAME
-    settings.x = math_floor(((screenAnchorX - (uiCenterX + refOffsetX)) * 10) + 0.5) / 10
-    settings.y = math_floor(((screenAnchorY - (uiCenterY + refOffsetY)) * 10) + 0.5) / 10
+    settings.x = x
+    settings.y = y
     return true
 end
 
@@ -228,7 +257,7 @@ local function EnsureAuraTextureNudger(host)
 
     local function DoNudge(dx, dy)
         host:AdjustPointsOffset(dx, dy)
-        local _, _, _, x, y = host:GetPoint()
+        local point, _, relativePoint, x, y = host:GetPoint()
         local owner = host._ownerButton
         local group = owner and owner._groupId and ResolveGroup(owner._groupId) or nil
         local settings
@@ -237,11 +266,26 @@ local function EnsureAuraTextureNudger(host)
         else
             settings = group and CooldownCompanion:GetTexturePanelSettings(group)
         end
-        if settings then
-            settings.x = math_floor((x or 0) * 10 + 0.5) / 10
-            settings.y = math_floor((y or 0) * 10 + 0.5) / 10
+        local displayX, displayY
+        if settings and group and group.parentContainerId
+            and CooldownCompanion.IsContainerUnlockPreviewActive
+            and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
+        then
+            displayX, displayY = GetTextureHostDisplayCoords(
+                host,
+                point or settings.point or "CENTER",
+                settings.relativePoint or "CENTER"
+            )
         end
-        UpdateTextureHostCoordLabel(host, x, y)
+        if displayX == nil or displayY == nil then
+            displayX = math_floor((x or 0) * 10 + 0.5) / 10
+            displayY = math_floor((y or 0) * 10 + 0.5) / 10
+        end
+        if settings then
+            settings.x = displayX
+            settings.y = displayY
+        end
+        UpdateTextureHostCoordLabel(host, displayX, displayY)
         if group and group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
             CooldownCompanion:RefreshContainerWrapper(group.parentContainerId)
         end
@@ -1051,7 +1095,25 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     SetAuraTextureOutlineShown(host, visibilityState.isGroupedPreview and (isGroupedPreviewSelected or isGroupedPreviewHovered) or false)
     if host.dragHandle and host.coordLabel then
         host.dragHandle.text:SetText(group and group.name or "Texture Panel")
-        if host._isDragging then
+        if visibilityState.isGroupedPreview then
+            local point = host:GetPoint(1)
+            local displayX, displayY = GetTextureHostDisplayCoords(
+                host,
+                point or sharedSettings.point or "CENTER",
+                sharedSettings.relativePoint or "CENTER"
+            )
+            if displayX == nil or displayY == nil then
+                if host._isDragging then
+                    local _, _, _, currentX, currentY = host:GetPoint()
+                    displayX = currentX
+                    displayY = currentY
+                else
+                    displayX = sharedSettings.x
+                    displayY = sharedSettings.y
+                end
+            end
+            UpdateTextureHostCoordLabel(host, displayX, displayY)
+        elseif host._isDragging then
             local _, _, _, currentX, currentY = host:GetPoint()
             UpdateTextureHostCoordLabel(host, currentX, currentY)
         else

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -8,6 +8,7 @@ local CooldownCompanion = ST.Addon
 local AT = ST._AT
 
 local CreateFrame = CreateFrame
+local InCombatLockdown = InCombatLockdown
 local UIParent = UIParent
 local ipairs = ipairs
 local math_floor = math.floor
@@ -241,6 +242,9 @@ local function EnsureAuraTextureNudger(host)
             settings.y = math_floor((y or 0) * 10 + 0.5) / 10
         end
         UpdateTextureHostCoordLabel(host, x, y)
+        if group and group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
+            CooldownCompanion:RefreshContainerWrapper(group.parentContainerId)
+        end
     end
 
     for _, dir in ipairs(directions) do
@@ -350,6 +354,12 @@ local function EnsureAuraTextureDragHandle(host)
         if not group then
             return
         end
+        if group.parentContainerId
+            and CooldownCompanion.IsContainerUnlockPreviewActive
+            and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
+        then
+            return
+        end
 
         group.locked = nil
         CooldownCompanion:RefreshGroupFrame(owner._groupId)
@@ -365,13 +375,13 @@ local function EnsureAuraTextureDragHandle(host)
     EnsureAuraTextureNudger(host)
 end
 
-local function SyncAuraTextureControlLevels(host)
+local function SyncAuraTextureControlLevels(host, raiseAboveWrapper)
     if not host then
         return
     end
 
-    local strata = host:GetFrameStrata()
-    local baseLevel = host:GetFrameLevel() or 1
+    local strata = raiseAboveWrapper and "FULLSCREEN_DIALOG" or host:GetFrameStrata()
+    local baseLevel = raiseAboveWrapper and 90 or (host:GetFrameLevel() or 1)
 
     if host.dragHandle then
         host.dragHandle:SetFrameStrata(strata)
@@ -906,7 +916,7 @@ function CooldownCompanion:RenderStandaloneDisplay(host, driverButton, group, se
 
     host:SetFrameStrata(driverButton:GetFrameStrata())
     host:SetFrameLevel((driverButton:GetFrameLevel() or 1) + 20)
-    SyncAuraTextureControlLevels(host)
+    SyncAuraTextureControlLevels(host, false)
 
     if displayType == "texture" then
         local baseAlpha = Clamp((settings.color and settings.color[4] or 1) * settings.alpha, 0.05, 1)
@@ -1020,10 +1030,25 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     elseif displayType == "text" then
         hasSavedDisplay = CooldownCompanion.HasTriggerTextValue(settings)
     end
-    host._dragEnabled = visibilityState.isUnlocked and hasSavedDisplay and not visibilityState.isGroupedPreview
+    local containerId = group and group.parentContainerId or nil
+    local isGroupedPreviewSelected = visibilityState.isGroupedPreview
+        and containerId
+        and self.IsContainerPanelSelected
+        and self:IsContainerPanelSelected(containerId, driverButton._groupId)
+        or false
+    local isGroupedPreviewHovered = visibilityState.isGroupedPreview
+        and containerId
+        and self.IsContainerPanelHovered
+        and self:IsContainerPanelHovered(containerId, driverButton._groupId)
+        or false
+    host._hasSavedDisplay = hasSavedDisplay
+    host._groupedPreviewContainerId = containerId
+    host._dragEnabled = visibilityState.isUnlocked
+        and hasSavedDisplay
+        and (not visibilityState.isGroupedPreview or isGroupedPreviewSelected)
     host._wrapperManaged = visibilityState.isGroupedPreview or nil
     host:EnableMouse(false)
-    SetAuraTextureOutlineShown(host, false)
+    SetAuraTextureOutlineShown(host, visibilityState.isGroupedPreview and (isGroupedPreviewSelected or isGroupedPreviewHovered) or false)
     if host.dragHandle and host.coordLabel then
         host.dragHandle.text:SetText(group and group.name or "Texture Panel")
         if host._isDragging then
@@ -1032,7 +1057,8 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
         else
             UpdateTextureHostCoordLabel(host, sharedSettings.x, sharedSettings.y)
         end
-        local showHeader = host._dragEnabled == true and not visibilityState.isGroupedPreview
+        local showHeader = host._dragEnabled == true and (not visibilityState.isGroupedPreview or isGroupedPreviewSelected)
+        SyncAuraTextureControlLevels(host, visibilityState.isGroupedPreview and isGroupedPreviewSelected)
         host.dragHandle:SetShown(showHeader)
         host.coordLabel:SetShown(showHeader)
         if host.nudger then
@@ -1056,6 +1082,83 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     if visibilityState.isGroupedPreview and group and group.parentContainerId and self.RefreshContainerWrapper then
         self:RefreshContainerWrapper(group.parentContainerId)
     end
+end
+
+function CooldownCompanion:UpdateGroupedStandalonePreviewSelection(groupId)
+    local group = groupId and ResolveGroup(groupId) or nil
+    if not (group and group.parentContainerId and (group.displayMode == "textures" or group.displayMode == "trigger")) then
+        return
+    end
+
+    if not (self.IsContainerUnlockPreviewActive and self:IsContainerUnlockPreviewActive(group.parentContainerId)) then
+        return
+    end
+
+    local groupFrame = self.groupFrames and self.groupFrames[groupId] or nil
+    local driverButton = groupFrame and groupFrame.buttons and groupFrame.buttons[1] or nil
+    local host = driverButton and driverButton.auraTextureHost or nil
+    if not host then
+        return
+    end
+
+    local isSelected = self.IsContainerPanelSelected and self:IsContainerPanelSelected(group.parentContainerId, groupId) or false
+    local isHovered = self.IsContainerPanelHovered and self:IsContainerPanelHovered(group.parentContainerId, groupId) or false
+    local showControls = isSelected and host._hasSavedDisplay == true
+
+    host._dragEnabled = showControls
+    SyncAuraTextureControlLevels(host, showControls)
+    SetAuraTextureOutlineShown(host, isSelected or isHovered)
+
+    if host.dragHandle then
+        host.dragHandle:SetShown(showControls)
+    end
+    if host.coordLabel then
+        host.coordLabel:SetShown(showControls)
+    end
+    if host.nudger then
+        host.nudger:SetShown(showControls)
+    end
+end
+
+function CooldownCompanion:StartGroupedStandalonePreviewHostDrag(groupId, containerId)
+    local group = groupId and ResolveGroup(groupId) or nil
+    if not (group and group.parentContainerId == containerId) then
+        return false
+    end
+
+    local groupFrame = self.groupFrames and self.groupFrames[groupId] or nil
+    local driverButton = groupFrame and groupFrame.buttons and groupFrame.buttons[1] or nil
+    local host = driverButton and driverButton.auraTextureHost or nil
+    if not (host and host:IsShown()) then
+        return false
+    end
+    if InCombatLockdown() and host:IsProtected() then
+        return false
+    end
+
+    host._isDragging = true
+    host:StartMoving()
+    return true
+end
+
+function CooldownCompanion:StopGroupedStandalonePreviewHostDrag(groupId, containerId)
+    local group = groupId and ResolveGroup(groupId) or nil
+    if not (group and group.parentContainerId == containerId) then
+        return
+    end
+
+    local groupFrame = self.groupFrames and self.groupFrames[groupId] or nil
+    local driverButton = groupFrame and groupFrame.buttons and groupFrame.buttons[1] or nil
+    local host = driverButton and driverButton.auraTextureHost or nil
+    if not host then
+        return
+    end
+
+    host._isDragging = nil
+    if not (InCombatLockdown() and host:IsProtected()) then
+        host:StopMovingOrSizing()
+    end
+    SaveTextureHostPosition(host)
 end
 
 function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId)

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -17,6 +17,7 @@ local pairs = pairs
 local string_find = string.find
 local string_trim = strtrim
 local tostring = tostring
+local tonumber = tonumber
 local type = type
 
 local DEFAULT_TEXTURE_SIZE = AT.DEFAULT_TEXTURE_SIZE
@@ -88,6 +89,75 @@ local function UpdateTextureHostCoordLabel(host, x, y)
     end
 end
 
+local function GetAnchorOffset(point, width, height)
+    if point == "TOPLEFT" then return -(width or 0) / 2, (height or 0) / 2 end
+    if point == "TOP" then return 0, (height or 0) / 2 end
+    if point == "TOPRIGHT" then return (width or 0) / 2, (height or 0) / 2 end
+    if point == "LEFT" then return -(width or 0) / 2, 0 end
+    if point == "CENTER" then return 0, 0 end
+    if point == "RIGHT" then return (width or 0) / 2, 0 end
+    if point == "BOTTOMLEFT" then return -(width or 0) / 2, -(height or 0) / 2 end
+    if point == "BOTTOM" then return 0, -(height or 0) / 2 end
+    if point == "BOTTOMRIGHT" then return (width or 0) / 2, -(height or 0) / 2 end
+    return 0, 0
+end
+
+local function GetGroupedPreviewContainerFrame(group)
+    if not (group and group.parentContainerId) then
+        return nil
+    end
+    if not (CooldownCompanion.IsContainerUnlockPreviewActive and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)) then
+        return nil
+    end
+    return CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[group.parentContainerId] or nil
+end
+
+local function GetStandaloneScreenAnchorPoint(settings)
+    local point = settings and settings.point or "CENTER"
+    local relativePoint = settings and settings.relativePoint or "CENTER"
+    local x = tonumber(settings and settings.x) or 0
+    local y = tonumber(settings and settings.y) or 0
+    local uiCenterX, uiCenterY = UIParent:GetCenter()
+    local uiWidth, uiHeight = UIParent:GetSize()
+    if not (uiCenterX and uiCenterY and uiWidth and uiHeight) then
+        return nil, nil, point, relativePoint
+    end
+
+    local relOffsetX, relOffsetY = GetAnchorOffset(relativePoint, uiWidth, uiHeight)
+    return uiCenterX + relOffsetX + x, uiCenterY + relOffsetY + y, point, relativePoint
+end
+
+local function SaveGroupedStandalonePreviewSettings(host, group, settings)
+    local containerFrame = GetGroupedPreviewContainerFrame(group)
+    if not (host and containerFrame and settings and host.GetPoint) then
+        return false
+    end
+
+    local containerX, containerY = containerFrame:GetCenter()
+    local uiCenterX, uiCenterY = UIParent:GetCenter()
+    local uiWidth, uiHeight = UIParent:GetSize()
+    local point, relativeFrame, _, x, y = host:GetPoint(1)
+    if not (containerX and containerY and uiCenterX and uiCenterY and uiWidth and uiHeight) then
+        return false
+    end
+
+    if relativeFrame ~= containerFrame and not host._wrapperManaged then
+        return false
+    end
+
+    local relativePoint = settings.relativePoint or "CENTER"
+    local refOffsetX, refOffsetY = GetAnchorOffset(relativePoint, uiWidth, uiHeight)
+    local screenAnchorX = containerX + (x or 0)
+    local screenAnchorY = containerY + (y or 0)
+
+    settings.point = NormalizeAnchorPoint(point or settings.point or "CENTER")
+    settings.relativePoint = NormalizeAnchorPoint(relativePoint)
+    settings.relativeTo = UI_PARENT_NAME
+    settings.x = math_floor(((screenAnchorX - (uiCenterX + refOffsetX)) * 10) + 0.5) / 10
+    settings.y = math_floor(((screenAnchorY - (uiCenterY + refOffsetY)) * 10) + 0.5) / 10
+    return true
+end
+
 local function SaveTextureHostPosition(host)
     if not host then
         return
@@ -107,6 +177,15 @@ local function SaveTextureHostPosition(host)
         return
     end
     if requiresConfiguredTexture and not settings.sourceType then
+        return
+    end
+
+    if SaveGroupedStandalonePreviewSettings(host, group, settings) then
+        UpdateTextureHostCoordLabel(host, settings.x, settings.y)
+        CooldownCompanion:UpdateAuraTextureVisual(owner)
+        if ST._configState and ST._configState.configFrame and ST._configState.configFrame.frame and ST._configState.configFrame.frame:IsShown() then
+            CooldownCompanion:RefreshConfigPanel()
+        end
         return
     end
 
@@ -538,6 +617,7 @@ function CooldownCompanion:HideAuraTextureVisual(button)
     host._activeTextureSettings = nil
     host._activeTextureGeometry = nil
     host._dragEnabled = nil
+    host._wrapperManaged = nil
     host:EnableMouse(false)
     host:SetAlpha(1)
     SetAuraTextureOutlineShown(host, false)
@@ -561,6 +641,11 @@ function CooldownCompanion:HideAuraTextureVisual(button)
         host.nudger:Hide()
     end
     host:Hide()
+
+    local group = button and button._groupId and ResolveGroup(button._groupId) or nil
+    if group and group.parentContainerId and self.RefreshContainerWrapper then
+        self:RefreshContainerWrapper(group.parentContainerId)
+    end
 end
 
 function CooldownCompanion:ReleaseAuraTextureVisual(button)
@@ -779,10 +864,13 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
 end
 
 function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
+    local groupedPreviewFrame = GetGroupedPreviewContainerFrame(group)
     local state = {
         isEditing = IsStandaloneTextureEditingButton(driverButton),
         isConfigForceVisible = (not isTriggerPanel) and IsTexturePanelConfigForceVisible(driverButton),
-        isUnlocked = group and group.locked == false,
+        isGroupedPreview = groupedPreviewFrame ~= nil,
+        groupedPreviewFrame = groupedPreviewFrame,
+        isUnlocked = group and (group.locked == false or groupedPreviewFrame ~= nil),
         hasPreviewSelection = displayType == "texture" and type(driverButton._auraTexturePreviewSelection) == "table",
         hasTriggerEffectPreview = isTriggerPanel and driverButton._triggerEffectsPreview == true,
         triggerMatched = isTriggerPanel and frame and frame:IsShown() and DoesTriggerPanelMatch(frame) or false,
@@ -870,7 +958,6 @@ function CooldownCompanion:RenderStandaloneDisplay(host, driverButton, group, se
 end
 
 function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, group, settings, displayType, isTriggerPanel, visibilityState)
-    local relativeFrame = UIParent
     local sharedSettings = GetStandaloneTextureSettings(group) or {
         point = "CENTER",
         relativePoint = "CENTER",
@@ -879,8 +966,28 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     }
 
     if not host._isDragging then
+        local currentPoint, currentRelativeFrame, _, currentX, currentY = host:GetPoint(1)
         host:ClearAllPoints()
-        host:SetPoint(sharedSettings.point, relativeFrame, sharedSettings.relativePoint, sharedSettings.x, sharedSettings.y)
+        local groupedPreviewFrame = visibilityState and visibilityState.groupedPreviewFrame or nil
+        if groupedPreviewFrame then
+            local preserveRelativeOffset = host._wrapperManaged
+                and currentRelativeFrame == groupedPreviewFrame
+                and currentX ~= nil
+                and currentY ~= nil
+            if preserveRelativeOffset then
+                host:SetPoint(currentPoint or sharedSettings.point or "CENTER", groupedPreviewFrame, "CENTER", currentX, currentY)
+            else
+                local screenAnchorX, screenAnchorY, point = GetStandaloneScreenAnchorPoint(sharedSettings)
+                local containerX, containerY = groupedPreviewFrame:GetCenter()
+                if screenAnchorX and screenAnchorY and containerX and containerY then
+                    host:SetPoint(point or sharedSettings.point or "CENTER", groupedPreviewFrame, "CENTER", screenAnchorX - containerX, screenAnchorY - containerY)
+                else
+                    host:SetPoint(sharedSettings.point, UIParent, sharedSettings.relativePoint, sharedSettings.x, sharedSettings.y)
+                end
+            end
+        else
+            host:SetPoint(sharedSettings.point, UIParent, sharedSettings.relativePoint, sharedSettings.x, sharedSettings.y)
+        end
     end
     host:Show()
 
@@ -913,7 +1020,8 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     elseif displayType == "text" then
         hasSavedDisplay = CooldownCompanion.HasTriggerTextValue(settings)
     end
-    host._dragEnabled = visibilityState.isUnlocked and hasSavedDisplay
+    host._dragEnabled = visibilityState.isUnlocked and hasSavedDisplay and not visibilityState.isGroupedPreview
+    host._wrapperManaged = visibilityState.isGroupedPreview or nil
     host:EnableMouse(false)
     SetAuraTextureOutlineShown(host, false)
     if host.dragHandle and host.coordLabel then
@@ -924,7 +1032,7 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
         else
             UpdateTextureHostCoordLabel(host, sharedSettings.x, sharedSettings.y)
         end
-        local showHeader = host._dragEnabled == true
+        local showHeader = host._dragEnabled == true and not visibilityState.isGroupedPreview
         host.dragHandle:SetShown(showHeader)
         host.coordLabel:SetShown(showHeader)
         if host.nudger then
@@ -942,6 +1050,36 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
             end
         else
             ST.SetFrameClickThroughRecursive(driverButton, true, true)
+        end
+    end
+
+    if visibilityState.isGroupedPreview and group and group.parentContainerId and self.RefreshContainerWrapper then
+        self:RefreshContainerWrapper(group.parentContainerId)
+    end
+end
+
+function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId)
+    if not (containerId and self.GetContainerUnlockPreviewPanels) then
+        return
+    end
+
+    local previewPanels = self:GetContainerUnlockPreviewPanels(containerId)
+    for _, panelInfo in ipairs(previewPanels) do
+        local group = panelInfo.group
+        if group and (group.displayMode == "textures" or group.displayMode == "trigger") then
+            local groupFrame = self.groupFrames and self.groupFrames[panelInfo.groupId] or nil
+            local driverButton = groupFrame and groupFrame.buttons and groupFrame.buttons[1] or nil
+            local host = driverButton and driverButton.auraTextureHost or nil
+            local settings = nil
+            if group.displayMode == "trigger" then
+                settings = self:GetTriggerPanelSignalSettings(group)
+            else
+                settings = self:GetTexturePanelSettings(group)
+            end
+
+            if host and settings and SaveGroupedStandalonePreviewSettings(host, group, settings) then
+                UpdateTextureHostCoordLabel(host, settings.x, settings.y)
+            end
         end
     end
 end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -391,13 +391,21 @@ local function EnsureAuraTextureDragHandle(host)
             return
         end
         if host._dragEnabled then
+            host._dragCancelPending = nil
             host._isDragging = true
             host:StartMoving()
         end
     end)
     dragHandle:SetScript("OnDragStop", function()
+        local cancelSave = host._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        host._dragCancelPending = nil
         host._isDragging = nil
-        host:StopMovingOrSizing()
+        if not (InCombatLockdown() and host:IsProtected()) then
+            host:StopMovingOrSizing()
+        end
+        if cancelSave then
+            return
+        end
         SaveTextureHostPosition(host)
     end)
     dragHandle:SetScript("OnMouseUp", function(_, button)
@@ -485,13 +493,21 @@ local function EnsureAuraTextureHost(button)
         if CooldownCompanion._combatForcedLock or not self._dragEnabled then
             return
         end
+        self._dragCancelPending = nil
         self._isDragging = true
         self:StartMoving()
     end)
 
     host:SetScript("OnDragStop", function(self)
+        local cancelSave = self._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        self._dragCancelPending = nil
         self._isDragging = nil
-        self:StopMovingOrSizing()
+        if not (InCombatLockdown() and self:IsProtected()) then
+            self:StopMovingOrSizing()
+        end
+        if cancelSave then
+            return
+        end
         SaveTextureHostPosition(self)
     end)
 
@@ -1213,6 +1229,7 @@ function CooldownCompanion:StartGroupedStandalonePreviewHostDrag(groupId, contai
         return false
     end
 
+    host._dragCancelPending = nil
     host._isDragging = true
     host:StartMoving()
     return true
@@ -1231,9 +1248,14 @@ function CooldownCompanion:StopGroupedStandalonePreviewHostDrag(groupId, contain
         return
     end
 
+    local cancelSave = host._dragCancelPending == true or self._combatForcedLock
+    host._dragCancelPending = nil
     host._isDragging = nil
     if not (InCombatLockdown() and host:IsProtected()) then
         host:StopMovingOrSizing()
+    end
+    if cancelSave then
+        return
     end
     SaveTextureHostPosition(host)
 end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -162,7 +162,7 @@ local function SaveGroupedStandalonePreviewSettings(host, group, settings)
         return false
     end
 
-    local point = host:GetPoint(1)
+    local point = settings.point or host:GetPoint(1)
 
     if not host._wrapperManaged then
         local _, relativeFrame = host:GetPoint(1)
@@ -273,7 +273,7 @@ local function EnsureAuraTextureNudger(host)
         then
             displayX, displayY = GetTextureHostDisplayCoords(
                 host,
-                point or settings.point or "CENTER",
+                settings.point or point or "CENTER",
                 settings.relativePoint or "CENTER"
             )
         end
@@ -378,6 +378,9 @@ local function EnsureAuraTextureDragHandle(host)
     coordLabel.text:SetTextColor(1, 1, 1, 1)
 
     dragHandle:SetScript("OnDragStart", function()
+        if CooldownCompanion._combatForcedLock then
+            return
+        end
         if host._dragEnabled then
             host._isDragging = true
             host:StartMoving()
@@ -470,7 +473,7 @@ local function EnsureAuraTextureHost(button)
     host.secondaryTexture = secondary
 
     host:SetScript("OnDragStart", function(self)
-        if not self._dragEnabled then
+        if CooldownCompanion._combatForcedLock or not self._dragEnabled then
             return
         end
         self._isDragging = true
@@ -919,12 +922,13 @@ end
 
 function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
     local groupedPreviewFrame = GetGroupedPreviewContainerFrame(group)
+    local combatForcedLock = self._combatForcedLock == true
     local state = {
         isEditing = IsStandaloneTextureEditingButton(driverButton),
         isConfigForceVisible = (not isTriggerPanel) and IsTexturePanelConfigForceVisible(driverButton),
         isGroupedPreview = groupedPreviewFrame ~= nil,
         groupedPreviewFrame = groupedPreviewFrame,
-        isUnlocked = group and (group.locked == false or groupedPreviewFrame ~= nil),
+        isUnlocked = not combatForcedLock and group and (group.locked == false or groupedPreviewFrame ~= nil),
         hasPreviewSelection = displayType == "texture" and type(driverButton._auraTexturePreviewSelection) == "table",
         hasTriggerEffectPreview = isTriggerPanel and driverButton._triggerEffectsPreview == true,
         triggerMatched = isTriggerPanel and frame and frame:IsShown() and DoesTriggerPanelMatch(frame) or false,
@@ -1096,10 +1100,9 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     if host.dragHandle and host.coordLabel then
         host.dragHandle.text:SetText(group and group.name or "Texture Panel")
         if visibilityState.isGroupedPreview then
-            local point = host:GetPoint(1)
             local displayX, displayY = GetTextureHostDisplayCoords(
                 host,
-                point or sharedSettings.point or "CENTER",
+                sharedSettings.point or "CENTER",
                 sharedSettings.relativePoint or "CENTER"
             )
             if displayX == nil or displayY == nil then
@@ -1184,7 +1187,7 @@ end
 
 function CooldownCompanion:StartGroupedStandalonePreviewHostDrag(groupId, containerId)
     local group = groupId and ResolveGroup(groupId) or nil
-    if not (group and group.parentContainerId == containerId) then
+    if self._combatForcedLock or not (group and group.parentContainerId == containerId) then
         return false
     end
 
@@ -1192,6 +1195,9 @@ function CooldownCompanion:StartGroupedStandalonePreviewHostDrag(groupId, contai
     local driverButton = groupFrame and groupFrame.buttons and groupFrame.buttons[1] or nil
     local host = driverButton and driverButton.auraTextureHost or nil
     if not (host and host:IsShown()) then
+        return false
+    end
+    if host._dragEnabled ~= true or host._hasSavedDisplay ~= true then
         return false
     end
     if InCombatLockdown() and host:IsProtected() then

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -219,24 +219,14 @@ local function SaveTextureHostPosition(host)
         return
     end
 
-    if SaveGroupedStandalonePreviewSettings(host, group, settings, owner and owner._groupId) then
-        UpdateTextureHostCoordLabel(host, settings.x, settings.y)
-        CooldownCompanion:UpdateAuraTextureVisual(owner)
-        if group and group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
-            CooldownCompanion:RefreshContainerWrapper(group.parentContainerId)
-        end
-        if ST._configState and ST._configState.configFrame and ST._configState.configFrame.frame and ST._configState.configFrame.frame:IsShown() then
-            CooldownCompanion:RefreshConfigPanel()
-        end
-        return
+    if not SaveGroupedStandalonePreviewSettings(host, group, settings, owner and owner._groupId) then
+        local point, _, relPoint, x, y = host:GetPoint(1)
+        settings.point = NormalizeAnchorPoint(point)
+        settings.relativePoint = NormalizeAnchorPoint(relPoint)
+        settings.relativeTo = UI_PARENT_NAME
+        settings.x = math_floor(((x or 0) * 10) + 0.5) / 10
+        settings.y = math_floor(((y or 0) * 10) + 0.5) / 10
     end
-
-    local point, _, relPoint, x, y = host:GetPoint(1)
-    settings.point = NormalizeAnchorPoint(point)
-    settings.relativePoint = NormalizeAnchorPoint(relPoint)
-    settings.relativeTo = UI_PARENT_NAME
-    settings.x = math_floor(((x or 0) * 10) + 0.5) / 10
-    settings.y = math_floor(((y or 0) * 10) + 0.5) / 10
 
     UpdateTextureHostCoordLabel(host, settings.x, settings.y)
     CooldownCompanion:UpdateAuraTextureVisual(owner)
@@ -264,6 +254,38 @@ local function StopGroupedStandaloneWrapperTracking(host)
     if containerId and CooldownCompanion.StopContainerMemberPreviewTracking then
         CooldownCompanion:StopContainerMemberPreviewTracking(containerId)
     end
+end
+
+local function BeginTextureHostDrag(host)
+    if CooldownCompanion._combatForcedLock or not (host and host._dragEnabled) then
+        return false
+    end
+
+    host._dragCancelPending = nil
+    host._isDragging = true
+    StartGroupedStandaloneWrapperTracking(host)
+    host:StartMoving()
+    return true
+end
+
+local function FinishTextureHostDrag(host)
+    if not host then
+        return false
+    end
+
+    local cancelSave = host._dragCancelPending == true or CooldownCompanion._combatForcedLock
+    host._dragCancelPending = nil
+    host._isDragging = nil
+    if not (InCombatLockdown() and host:IsProtected()) then
+        host:StopMovingOrSizing()
+    end
+    StopGroupedStandaloneWrapperTracking(host)
+    if cancelSave then
+        return false
+    end
+
+    SaveTextureHostPosition(host)
+    return true
 end
 
 local function EnsureAuraTextureNudger(host)
@@ -411,28 +433,10 @@ local function EnsureAuraTextureDragHandle(host)
     coordLabel.text:SetTextColor(1, 1, 1, 1)
 
     dragHandle:SetScript("OnDragStart", function()
-        if CooldownCompanion._combatForcedLock then
-            return
-        end
-        if host._dragEnabled then
-            host._dragCancelPending = nil
-            host._isDragging = true
-            StartGroupedStandaloneWrapperTracking(host)
-            host:StartMoving()
-        end
+        BeginTextureHostDrag(host)
     end)
     dragHandle:SetScript("OnDragStop", function()
-        local cancelSave = host._dragCancelPending == true or CooldownCompanion._combatForcedLock
-        host._dragCancelPending = nil
-        host._isDragging = nil
-        if not (InCombatLockdown() and host:IsProtected()) then
-            host:StopMovingOrSizing()
-        end
-        StopGroupedStandaloneWrapperTracking(host)
-        if cancelSave then
-            return
-        end
-        SaveTextureHostPosition(host)
+        FinishTextureHostDrag(host)
     end)
     dragHandle:SetScript("OnMouseUp", function(_, button)
         if button ~= "MiddleButton" then
@@ -516,27 +520,11 @@ local function EnsureAuraTextureHost(button)
     host.secondaryTexture = secondary
 
     host:SetScript("OnDragStart", function(self)
-        if CooldownCompanion._combatForcedLock or not self._dragEnabled then
-            return
-        end
-        self._dragCancelPending = nil
-        self._isDragging = true
-        StartGroupedStandaloneWrapperTracking(self)
-        self:StartMoving()
+        BeginTextureHostDrag(self)
     end)
 
     host:SetScript("OnDragStop", function(self)
-        local cancelSave = self._dragCancelPending == true or CooldownCompanion._combatForcedLock
-        self._dragCancelPending = nil
-        self._isDragging = nil
-        if not (InCombatLockdown() and self:IsProtected()) then
-            self:StopMovingOrSizing()
-        end
-        StopGroupedStandaloneWrapperTracking(self)
-        if cancelSave then
-            return
-        end
-        SaveTextureHostPosition(self)
+        FinishTextureHostDrag(self)
     end)
 
     CreateAuraTextureOutline(host)
@@ -1256,11 +1244,7 @@ function CooldownCompanion:StartGroupedStandalonePreviewHostDrag(groupId, contai
         return false
     end
 
-    host._dragCancelPending = nil
-    host._isDragging = true
-    StartGroupedStandaloneWrapperTracking(host)
-    host:StartMoving()
-    return true
+    return BeginTextureHostDrag(host)
 end
 
 function CooldownCompanion:StopGroupedStandalonePreviewHostDrag(groupId, containerId)
@@ -1276,17 +1260,7 @@ function CooldownCompanion:StopGroupedStandalonePreviewHostDrag(groupId, contain
         return
     end
 
-    local cancelSave = host._dragCancelPending == true or self._combatForcedLock
-    host._dragCancelPending = nil
-    host._isDragging = nil
-    if not (InCombatLockdown() and host:IsProtected()) then
-        host:StopMovingOrSizing()
-    end
-    StopGroupedStandaloneWrapperTracking(host)
-    if cancelSave then
-        return
-    end
-    SaveTextureHostPosition(host)
+    FinishTextureHostDrag(host)
 end
 
 local function RoundGroupedStandaloneOffset(value)

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -222,6 +222,9 @@ local function SaveTextureHostPosition(host)
     if SaveGroupedStandalonePreviewSettings(host, group, settings, owner and owner._groupId) then
         UpdateTextureHostCoordLabel(host, settings.x, settings.y)
         CooldownCompanion:UpdateAuraTextureVisual(owner)
+        if group and group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
+            CooldownCompanion:RefreshContainerWrapper(group.parentContainerId)
+        end
         if ST._configState and ST._configState.configFrame and ST._configState.configFrame.frame and ST._configState.configFrame.frame:IsShown() then
             CooldownCompanion:RefreshConfigPanel()
         end
@@ -237,8 +240,29 @@ local function SaveTextureHostPosition(host)
 
     UpdateTextureHostCoordLabel(host, settings.x, settings.y)
     CooldownCompanion:UpdateAuraTextureVisual(owner)
+    if group and group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
+        CooldownCompanion:RefreshContainerWrapper(group.parentContainerId)
+    end
     if ST._configState and ST._configState.configFrame and ST._configState.configFrame.frame and ST._configState.configFrame.frame:IsShown() then
         CooldownCompanion:RefreshConfigPanel()
+    end
+end
+
+local function StartGroupedStandaloneWrapperTracking(host)
+    local owner = host and host._ownerButton or nil
+    local group = owner and owner._groupId and ResolveGroup(owner._groupId) or nil
+    local containerId = group and group.parentContainerId or nil
+    if containerId and CooldownCompanion.StartContainerMemberPreviewTracking then
+        CooldownCompanion:StartContainerMemberPreviewTracking(containerId, owner._groupId)
+    end
+end
+
+local function StopGroupedStandaloneWrapperTracking(host)
+    local owner = host and host._ownerButton or nil
+    local group = owner and owner._groupId and ResolveGroup(owner._groupId) or nil
+    local containerId = group and group.parentContainerId or nil
+    if containerId and CooldownCompanion.StopContainerMemberPreviewTracking then
+        CooldownCompanion:StopContainerMemberPreviewTracking(containerId)
     end
 end
 
@@ -393,6 +417,7 @@ local function EnsureAuraTextureDragHandle(host)
         if host._dragEnabled then
             host._dragCancelPending = nil
             host._isDragging = true
+            StartGroupedStandaloneWrapperTracking(host)
             host:StartMoving()
         end
     end)
@@ -403,6 +428,7 @@ local function EnsureAuraTextureDragHandle(host)
         if not (InCombatLockdown() and host:IsProtected()) then
             host:StopMovingOrSizing()
         end
+        StopGroupedStandaloneWrapperTracking(host)
         if cancelSave then
             return
         end
@@ -495,6 +521,7 @@ local function EnsureAuraTextureHost(button)
         end
         self._dragCancelPending = nil
         self._isDragging = true
+        StartGroupedStandaloneWrapperTracking(self)
         self:StartMoving()
     end)
 
@@ -505,6 +532,7 @@ local function EnsureAuraTextureHost(button)
         if not (InCombatLockdown() and self:IsProtected()) then
             self:StopMovingOrSizing()
         end
+        StopGroupedStandaloneWrapperTracking(self)
         if cancelSave then
             return
         end
@@ -973,6 +1001,7 @@ function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, dri
             state.showDisplay = true
         elseif driverButton:GetParent()
             and driverButton:GetParent():IsShown()
+            and not driverButton:GetParent()._combatForcedHidden
             and not (driverButton._rawVisibilityHidden == true) then
             state.showDisplay = true
         end
@@ -1057,6 +1086,7 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
                 and currentRelativeFrame == groupedPreviewFrame
                 and currentX ~= nil
                 and currentY ~= nil
+                and groupedPreviewFrame._dragInProgress == true
             if preserveRelativeOffset then
                 host:SetPoint(currentPoint or sharedSettings.point or "CENTER", groupedPreviewFrame, "CENTER", currentX, currentY)
             else
@@ -1169,9 +1199,6 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
         end
     end
 
-    if visibilityState.isGroupedPreview and group and group.parentContainerId and self.RefreshContainerWrapper then
-        self:RefreshContainerWrapper(group.parentContainerId)
-    end
 end
 
 function CooldownCompanion:UpdateGroupedStandalonePreviewSelection(groupId)
@@ -1231,6 +1258,7 @@ function CooldownCompanion:StartGroupedStandalonePreviewHostDrag(groupId, contai
 
     host._dragCancelPending = nil
     host._isDragging = true
+    StartGroupedStandaloneWrapperTracking(host)
     host:StartMoving()
     return true
 end
@@ -1254,6 +1282,7 @@ function CooldownCompanion:StopGroupedStandalonePreviewHostDrag(groupId, contain
     if not (InCombatLockdown() and host:IsProtected()) then
         host:StopMovingOrSizing()
     end
+    StopGroupedStandaloneWrapperTracking(host)
     if cancelSave then
         return
     end
@@ -1385,5 +1414,8 @@ function CooldownCompanion:RefreshAllAuraTextureVisuals()
         for _, button in ipairs(frame.buttons or {}) do
             self:UpdateAuraTextureVisual(button)
         end
+    end
+    if self.RefreshAllContainerWrappers then
+        self:RefreshAllContainerWrappers()
     end
 end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -103,11 +103,20 @@ local function GetAnchorOffset(point, width, height)
     return 0, 0
 end
 
-local function GetGroupedPreviewContainerFrame(group)
+local function GetGroupedPreviewContainerFrame(group, groupId)
     if not (group and group.parentContainerId) then
         return nil
     end
     if not (CooldownCompanion.IsContainerUnlockPreviewActive and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)) then
+        return nil
+    end
+    if groupId
+        and CooldownCompanion.IsGroupVisibleInUnlockPreview
+        and not CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, {
+            group = group,
+            checkCharVisibility = true,
+        })
+    then
         return nil
     end
     return CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[group.parentContainerId] or nil
@@ -156,8 +165,8 @@ local function GetTextureHostDisplayCoords(host, point, relativePoint)
     return x, y, normalizedPoint, normalizedRelativePoint
 end
 
-local function SaveGroupedStandalonePreviewSettings(host, group, settings)
-    local containerFrame = GetGroupedPreviewContainerFrame(group)
+local function SaveGroupedStandalonePreviewSettings(host, group, settings, groupId)
+    local containerFrame = GetGroupedPreviewContainerFrame(group, groupId)
     if not (host and containerFrame and settings and host.GetPoint and host.GetCenter and host.GetSize) then
         return false
     end
@@ -210,7 +219,7 @@ local function SaveTextureHostPosition(host)
         return
     end
 
-    if SaveGroupedStandalonePreviewSettings(host, group, settings) then
+    if SaveGroupedStandalonePreviewSettings(host, group, settings, owner and owner._groupId) then
         UpdateTextureHostCoordLabel(host, settings.x, settings.y)
         CooldownCompanion:UpdateAuraTextureVisual(owner)
         if ST._configState and ST._configState.configFrame and ST._configState.configFrame.frame and ST._configState.configFrame.frame:IsShown() then
@@ -921,7 +930,7 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
 end
 
 function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
-    local groupedPreviewFrame = GetGroupedPreviewContainerFrame(group)
+    local groupedPreviewFrame = GetGroupedPreviewContainerFrame(group, driverButton and driverButton._groupId)
     local combatForcedLock = self._combatForcedLock == true
     local state = {
         isEditing = IsStandaloneTextureEditingButton(driverButton),
@@ -1229,13 +1238,30 @@ function CooldownCompanion:StopGroupedStandalonePreviewHostDrag(groupId, contain
     SaveTextureHostPosition(host)
 end
 
-function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId)
-    if not (containerId and self.GetContainerUnlockPreviewPanels) then
+local function RoundGroupedStandaloneOffset(value)
+    return math_floor(((tonumber(value) or 0) * 10) + 0.5) / 10
+end
+
+local function ApplyGroupedStandaloneSettingsDelta(settings, deltaX, deltaY)
+    if not settings then
+        return false
+    end
+    if deltaX == nil and deltaY == nil then
+        return false
+    end
+
+    settings.x = RoundGroupedStandaloneOffset((tonumber(settings.x) or 0) + (tonumber(deltaX) or 0))
+    settings.y = RoundGroupedStandaloneOffset((tonumber(settings.y) or 0) + (tonumber(deltaY) or 0))
+    return true
+end
+
+function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, deltaX, deltaY)
+    if not (containerId and self.GetPanels) then
         return
     end
 
-    local previewPanels = self:GetContainerUnlockPreviewPanels(containerId)
-    for _, panelInfo in ipairs(previewPanels) do
+    local panels = self:GetPanels(containerId)
+    for _, panelInfo in ipairs(panels) do
         local group = panelInfo.group
         if group and (group.displayMode == "textures" or group.displayMode == "trigger") then
             local groupFrame = self.groupFrames and self.groupFrames[panelInfo.groupId] or nil
@@ -1248,8 +1274,24 @@ function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId)
                 settings = self:GetTexturePanelSettings(group)
             end
 
-            if host and settings and SaveGroupedStandalonePreviewSettings(host, group, settings) then
+            local didSync = false
+            if host
+                and settings
+                and self.IsGroupVisibleInUnlockPreview
+                and self:IsGroupVisibleInUnlockPreview(panelInfo.groupId, {
+                    group = group,
+                    groupFrame = groupFrame,
+                    checkCharVisibility = true,
+                })
+                and SaveGroupedStandalonePreviewSettings(host, group, settings, panelInfo.groupId)
+            then
+                didSync = true
                 UpdateTextureHostCoordLabel(host, settings.x, settings.y)
+            end
+            if not didSync and ApplyGroupedStandaloneSettingsDelta(settings, deltaX, deltaY) then
+                if host and host.coordLabel and host:IsShown() then
+                    UpdateTextureHostCoordLabel(host, settings.x, settings.y)
+                end
             end
         end
     end

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1977,16 +1977,20 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
     UpdateContainerWrapperLevels(frame)
 
     if self._combatForcedLock or container.locked ~= false or not self:IsContainerVisibleToCurrentChar(containerId) then
-        self:ClearContainerUnlockState(containerId)
-        wrapper:Hide()
-        if header then
-            header:Hide()
-        end
-        if frame.coordLabel then
-            frame.coordLabel:Hide()
-        end
-        if frame.nudger then
-            frame.nudger:Hide()
+        if self.UpdateContainerDragHandle then
+            self:UpdateContainerDragHandle(containerId, true)
+        else
+            self:ClearContainerUnlockState(containerId)
+            wrapper:Hide()
+            if header then
+                header:Hide()
+            end
+            if frame.coordLabel then
+                frame.coordLabel:Hide()
+            end
+            if frame.nudger then
+                frame.nudger:Hide()
+            end
         end
         frame._isRefreshingContainerWrapper = nil
         return

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -41,6 +41,9 @@ local function GetContainerState(groupId)
     if not profile then return true, 1 end
     local group = profile.groups[groupId]
     if not group then return true, 1 end
+    if CooldownCompanion._combatForcedLock then
+        return true, group.baselineAlpha or 1
+    end
 
     if group.parentContainerId then
         -- Panel: own lock state (nil/true = locked, false = unlocked), panel's own alpha
@@ -333,6 +336,7 @@ local function CreateNudger(frame, groupId)
     local NUDGE_GAP = 2
 
     local nudger = CreateFrame("Frame", nil, frame.dragHandle, "BackdropTemplate")
+    nudger.buttons = {}
     nudger:SetSize(NUDGE_BTN_SIZE * 2 + NUDGE_GAP, NUDGE_BTN_SIZE * 2 + NUDGE_GAP)
     nudger:SetPoint("BOTTOM", frame.dragHandle, "TOP", 0, 2)
     nudger:SetFrameStrata(frame.dragHandle:GetFrameStrata())
@@ -350,6 +354,7 @@ local function CreateNudger(frame, groupId)
 
     for _, dir in ipairs(directions) do
         local btn = CreateFrame("Button", nil, nudger)
+        nudger.buttons[#nudger.buttons + 1] = btn
         btn:SetSize(NUDGE_BTN_SIZE, NUDGE_BTN_SIZE)
         btn:SetPoint(dir.anchor, nudger, "CENTER", dir.ox, dir.oy)
         btn:EnableMouse(true)
@@ -524,7 +529,9 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     frame:SetScript("OnDragStart", function(self)
         local locked = GetContainerState(self.groupId)
         local previewActive, selectedInContainer, containerId = GetContainerPreviewSelectionState(self.groupId)
-        if previewActive then
+        if CooldownCompanion._combatForcedLock then
+            return
+        elseif previewActive then
             if not selectedInContainer then
                 return
             end
@@ -552,7 +559,9 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     frame.dragHandle:SetScript("OnDragStart", function()
         local locked = GetContainerState(groupId)
         local previewActive, selectedInContainer, containerId = GetContainerPreviewSelectionState(groupId)
-        if previewActive then
+        if CooldownCompanion._combatForcedLock then
+            return
+        elseif previewActive then
             if not selectedInContainer then
                 return
             end
@@ -1506,6 +1515,8 @@ local CONTAINER_WRAPPER_HEADER_HEIGHT = 18
 local CONTAINER_PANEL_LABEL_HEIGHT = 15
 local CONTAINER_PANEL_LABEL_MIN_WIDTH = 70
 local CONTAINER_MEMBER_DRAG_REFRESH_INTERVAL = 0.05
+local CONTAINER_WRAPPER_FALLBACK_WIDTH = 120
+local CONTAINER_WRAPPER_FALLBACK_HEIGHT = 18
 
 local function GetRelativeFrameRect(referenceFrame, targetFrame)
     if not (referenceFrame and targetFrame and referenceFrame.GetCenter and targetFrame.GetCenter) then
@@ -1794,7 +1805,7 @@ end
 
 function CooldownCompanion:StartContainerPreviewMemberDrag(containerId, groupId)
     local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId]
-    if not (containerId and group and group.parentContainerId == containerId) then
+    if self._combatForcedLock or not (containerId and group and group.parentContainerId == containerId) then
         return false
     end
 
@@ -1927,7 +1938,7 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
     HideContainerPanelLabels(frame)
     UpdateContainerWrapperLevels(frame)
 
-    if container.locked ~= false or not self:IsContainerVisibleToCurrentChar(containerId) then
+    if self._combatForcedLock or container.locked ~= false or not self:IsContainerVisibleToCurrentChar(containerId) then
         self:ClearContainerUnlockState(containerId)
         wrapper:Hide()
         if header then
@@ -1970,18 +1981,35 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
 
     local selectedGroupId = frame._containerSelectedGroupId
     local hoveredGroupId = frame._containerHoveredGroupId
+    local headerWidth = 96
+
+    if header then
+        local titleText = header.text or wrapper.text
+        if titleText then
+            titleText:SetText(container.name or "Group")
+            headerWidth = math_max(96, math_floor((titleText:GetStringWidth() or 0) + 24.5))
+        end
+    end
 
     if #previewRects == 0 then
         HideContainerMemberOverlays(frame)
-        wrapper:Hide()
+        local fallbackWidth = math_max(headerWidth, CONTAINER_WRAPPER_FALLBACK_WIDTH)
+        local fallbackHalfWidth = RoundPreviewOffset(fallbackWidth / 2)
+        local fallbackHalfHeight = RoundPreviewOffset(CONTAINER_WRAPPER_FALLBACK_HEIGHT / 2)
+
+        wrapper:ClearAllPoints()
+        wrapper:SetPoint("BOTTOMLEFT", frame, "CENTER", -fallbackHalfWidth, -fallbackHalfHeight)
+        wrapper:SetPoint("TOPRIGHT", frame, "CENTER", fallbackHalfWidth, fallbackHalfHeight)
+        wrapper:SetShown(true)
         if header then
-            header:Hide()
+            header:SetWidth(headerWidth)
+            header:Show()
         end
         if frame.coordLabel then
-            frame.coordLabel:Hide()
+            frame.coordLabel:SetShown(true)
         end
         if frame.nudger then
-            frame.nudger:Hide()
+            frame.nudger:SetShown(true)
         end
         frame._isRefreshingContainerWrapper = nil
         return
@@ -1994,13 +2022,7 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
     wrapper:SetShown(true)
 
     if header then
-        local titleText = header.text or wrapper.text
-        if titleText then
-            titleText:SetText(container.name or "Group")
-            header:SetWidth(math_max(96, math_floor((titleText:GetStringWidth() or 0) + 24.5)))
-        else
-            header:SetWidth(96)
-        end
+        header:SetWidth(headerWidth)
         header:Show()
     end
 
@@ -2040,7 +2062,9 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
         overlay:SetBackdropColor(0.15, 0.45, 0.65, fillAlpha)
         EnsureContainerWrapperBorder(overlay, 0.2, 0.8, 1, borderAlpha)
 
-        if not isSelected then
+        local showLabel = hoveredGroupId ~= nil and isHovered and not isSelected
+
+        if showLabel then
             local labelFrame = EnsureContainerPanelLabel(frame, labelIndex)
             labelFrame.text:SetText(rect.label)
             labelFrame:SetWidth(math_max(CONTAINER_PANEL_LABEL_MIN_WIDTH, math_floor((labelFrame.text:GetStringWidth() or 0) + 16.5)))
@@ -2262,7 +2286,7 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     -- Drag scripts
     frame:SetScript("OnDragStart", function(self)
         local c = CooldownCompanion.db.profile.groupContainers[self.containerId]
-        if c and not c.locked then
+        if c and not CooldownCompanion._combatForcedLock and CooldownCompanion:IsContainerUnlockPreviewActive(self.containerId) then
             CooldownCompanion:SelectContainerWrapper(self.containerId)
             self:StartMoving()
         end
@@ -2276,7 +2300,7 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     frame.dragHandle:RegisterForDrag("LeftButton")
     frame.dragHandle:SetScript("OnDragStart", function()
         local c = CooldownCompanion.db.profile.groupContainers[containerId]
-        if c and not c.locked then
+        if c and not CooldownCompanion._combatForcedLock and CooldownCompanion:IsContainerUnlockPreviewActive(containerId) then
             frame.dragHandle._suppressClick = true
             CooldownCompanion:SelectContainerWrapper(containerId)
             frame:StartMoving()
@@ -2301,7 +2325,7 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     frame.dragHandle.header:RegisterForDrag("LeftButton")
     frame.dragHandle.header:SetScript("OnDragStart", function()
         local c = CooldownCompanion.db.profile.groupContainers[containerId]
-        if c and not c.locked then
+        if c and not CooldownCompanion._combatForcedLock and CooldownCompanion:IsContainerUnlockPreviewActive(containerId) then
             frame.dragHandle.header._suppressClick = true
             CooldownCompanion:SelectContainerWrapper(containerId)
             frame:StartMoving()

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -538,17 +538,29 @@ function CooldownCompanion:CreateGroupFrame(groupId)
             if containerId and CooldownCompanion.StartContainerMemberPreviewTracking then
                 CooldownCompanion:StartContainerMemberPreviewTracking(containerId, self.groupId)
             end
+            self._dragCancelPending = nil
+            self._dragInProgress = true
             self:StartMoving()
         elseif not locked then
+            self._dragCancelPending = nil
+            self._dragInProgress = true
             self:StartMoving()
         end
     end)
 
     frame:SetScript("OnDragStop", function(self)
         local _, selectedInContainer, containerId = GetContainerPreviewSelectionState(self.groupId)
-        self:StopMovingOrSizing()
+        local cancelSave = self._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        self._dragCancelPending = nil
+        self._dragInProgress = nil
+        if not (InCombatLockdown() and self:IsProtected()) then
+            self:StopMovingOrSizing()
+        end
         if selectedInContainer and containerId and CooldownCompanion.StopContainerMemberPreviewTracking then
             CooldownCompanion:StopContainerMemberPreviewTracking(containerId, self.groupId)
+        end
+        if cancelSave then
+            return
         end
         CooldownCompanion:SaveGroupPosition(self.groupId)
     end)
@@ -568,16 +580,28 @@ function CooldownCompanion:CreateGroupFrame(groupId)
             if containerId and CooldownCompanion.StartContainerMemberPreviewTracking then
                 CooldownCompanion:StartContainerMemberPreviewTracking(containerId, groupId)
             end
+            frame._dragCancelPending = nil
+            frame._dragInProgress = true
             frame:StartMoving()
         elseif not locked then
+            frame._dragCancelPending = nil
+            frame._dragInProgress = true
             frame:StartMoving()
         end
     end)
     frame.dragHandle:SetScript("OnDragStop", function()
         local _, selectedInContainer, containerId = GetContainerPreviewSelectionState(groupId)
-        frame:StopMovingOrSizing()
+        local cancelSave = frame._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        frame._dragCancelPending = nil
+        frame._dragInProgress = nil
+        if not (InCombatLockdown() and frame:IsProtected()) then
+            frame:StopMovingOrSizing()
+        end
         if selectedInContainer and containerId and CooldownCompanion.StopContainerMemberPreviewTracking then
             CooldownCompanion:StopContainerMemberPreviewTracking(containerId, groupId)
+        end
+        if cancelSave then
+            return
         end
         CooldownCompanion:SaveGroupPosition(groupId)
     end)
@@ -1244,7 +1268,7 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
             frame:Show()
         end
         -- Force 100% alpha while unlocked for easier positioning
-        if not isLocked then
+        if containerPreviewActive or not isLocked then
             frame:SetAlpha(1)
         -- Apply current alpha from the alpha fade system so frame doesn't flash at 1.0
         else
@@ -1830,6 +1854,8 @@ function CooldownCompanion:StartContainerPreviewMemberDrag(containerId, groupId)
         return false
     end
 
+    groupFrame._dragCancelPending = nil
+    groupFrame._dragInProgress = true
     groupFrame:StartMoving()
     return true
 end
@@ -1850,10 +1876,18 @@ function CooldownCompanion:StopContainerPreviewMemberDrag(containerId, groupId)
     end
 
     local groupFrame = self.groupFrames and self.groupFrames[groupId]
+    local cancelSave = (groupFrame and groupFrame._dragCancelPending == true) or self._combatForcedLock
     if groupFrame and not (InCombatLockdown() and groupFrame:IsProtected()) then
         groupFrame:StopMovingOrSizing()
     end
+    if groupFrame then
+        groupFrame._dragCancelPending = nil
+        groupFrame._dragInProgress = nil
+    end
     self:StopContainerMemberPreviewTracking(containerId)
+    if cancelSave then
+        return
+    end
     self:SaveGroupPosition(groupId)
 end
 
@@ -2307,11 +2341,21 @@ function CooldownCompanion:CreateContainerFrame(containerId)
         local c = CooldownCompanion.db.profile.groupContainers[self.containerId]
         if c and not CooldownCompanion._combatForcedLock and CooldownCompanion:IsContainerUnlockPreviewActive(self.containerId) then
             CooldownCompanion:SelectContainerWrapper(self.containerId)
+            self._dragCancelPending = nil
+            self._dragInProgress = true
             self:StartMoving()
         end
     end)
     frame:SetScript("OnDragStop", function(self)
-        self:StopMovingOrSizing()
+        local cancelSave = self._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        self._dragCancelPending = nil
+        self._dragInProgress = nil
+        if not (InCombatLockdown() and self:IsProtected()) then
+            self:StopMovingOrSizing()
+        end
+        if cancelSave then
+            return
+        end
         CooldownCompanion:SaveContainerPosition(self.containerId)
     end)
 
@@ -2322,11 +2366,21 @@ function CooldownCompanion:CreateContainerFrame(containerId)
         if c and not CooldownCompanion._combatForcedLock and CooldownCompanion:IsContainerUnlockPreviewActive(containerId) then
             frame.dragHandle._suppressClick = true
             CooldownCompanion:SelectContainerWrapper(containerId)
+            frame._dragCancelPending = nil
+            frame._dragInProgress = true
             frame:StartMoving()
         end
     end)
     frame.dragHandle:SetScript("OnDragStop", function()
-        frame:StopMovingOrSizing()
+        local cancelSave = frame._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        frame._dragCancelPending = nil
+        frame._dragInProgress = nil
+        if not (InCombatLockdown() and frame:IsProtected()) then
+            frame:StopMovingOrSizing()
+        end
+        if cancelSave then
+            return
+        end
         CooldownCompanion:SaveContainerPosition(containerId)
     end)
     frame.dragHandle:SetScript("OnMouseUp", function(_, button)
@@ -2347,11 +2401,21 @@ function CooldownCompanion:CreateContainerFrame(containerId)
         if c and not CooldownCompanion._combatForcedLock and CooldownCompanion:IsContainerUnlockPreviewActive(containerId) then
             frame.dragHandle.header._suppressClick = true
             CooldownCompanion:SelectContainerWrapper(containerId)
+            frame._dragCancelPending = nil
+            frame._dragInProgress = true
             frame:StartMoving()
         end
     end)
     frame.dragHandle.header:SetScript("OnDragStop", function()
-        frame:StopMovingOrSizing()
+        local cancelSave = frame._dragCancelPending == true or CooldownCompanion._combatForcedLock
+        frame._dragCancelPending = nil
+        frame._dragInProgress = nil
+        if not (InCombatLockdown() and frame:IsProtected()) then
+            frame:StopMovingOrSizing()
+        end
+        if cancelSave then
+            return
+        end
         CooldownCompanion:SaveContainerPosition(containerId)
     end)
 

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -9,6 +9,7 @@ local CooldownCompanion = ST.Addon
 -- Localize frequently-used globals for faster access
 local pairs = pairs
 local ipairs = ipairs
+local math_abs = math.abs
 local math_floor = math.floor
 local math_min = math.min
 local math_max = math.max
@@ -67,6 +68,31 @@ local function GetAnchorOffset(point, width, height)
     if point == "BOTTOM" then return 0, -height / 2 end
     if point == "BOTTOMRIGHT" then return width / 2, -height / 2 end
     return 0, 0
+end
+
+local function GetFrameSizeInUIParentSpace(frame)
+    if not (frame and frame.GetSize) then
+        return nil, nil
+    end
+
+    local width, height = frame:GetSize()
+    if not (width and height) then
+        return nil, nil
+    end
+
+    local frameScale = frame.GetEffectiveScale and frame:GetEffectiveScale() or nil
+    local uiScale = UIParent and UIParent.GetEffectiveScale and UIParent:GetEffectiveScale() or nil
+    if frameScale and uiScale and uiScale > 0 then
+        local scaleRatio = frameScale / uiScale
+        width = width * scaleRatio
+        height = height * scaleRatio
+    end
+
+    return width, height
+end
+
+local function RoundPreviewOffset(value)
+    return math_floor(((value or 0) * 10) + 0.5) / 10
 end
 
 local function ApplyUnsafeAnchorVisualFallback(frame, anchor, relativeFrame)
@@ -706,6 +732,10 @@ function CooldownCompanion:SaveGroupPosition(groupId)
 
     UpdateCoordLabel(frame, newX, newY)
     self:RefreshConfigPanel()
+    local containerId = group.parentContainerId
+    if containerId and self.RefreshContainerWrapper then
+        self:RefreshContainerWrapper(containerId)
+    end
 end
 
 -- Compute button width/height from group style (bar mode vs square vs non-square).
@@ -1132,6 +1162,18 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     else
         self:UnloadGroup(groupId)
     end
+
+    if (group.displayMode == "textures" or group.displayMode == "trigger")
+        and self.UpdateAuraTextureVisual
+        and frame
+        and frame.buttons
+        and frame.buttons[1] then
+        self:UpdateAuraTextureVisual(frame.buttons[1])
+    end
+
+    if group.parentContainerId and self.RefreshContainerWrapper then
+        self:RefreshContainerWrapper(group.parentContainerId)
+    end
 end
 
 function CooldownCompanion:WouldCreateCircularAnchor(sourceId, targetId, targetKind, sourceKind)
@@ -1346,14 +1388,297 @@ end
 -- Container Frames (invisible anchor frames for the Group → Panel hierarchy)
 ------------------------------------------------------------------------
 
+local CONTAINER_WRAPPER_PADDING = 10
+local CONTAINER_WRAPPER_BORDER_SIZE = 2
+local CONTAINER_WRAPPER_LABEL_OFFSET = 2
+local CONTAINER_WRAPPER_HEADER_HEIGHT = 18
+local CONTAINER_PANEL_LABEL_HEIGHT = 15
+local CONTAINER_PANEL_LABEL_MIN_WIDTH = 70
+
+local function GetRelativeFrameRect(referenceFrame, targetFrame)
+    if not (referenceFrame and targetFrame and referenceFrame.GetCenter and targetFrame.GetCenter) then
+        return nil
+    end
+
+    local refX, refY = referenceFrame:GetCenter()
+    local targetX, targetY = targetFrame:GetCenter()
+    local width, height = GetFrameSizeInUIParentSpace(targetFrame)
+    if not (refX and refY and targetX and targetY and width and height) then
+        return nil
+    end
+
+    return {
+        left = targetX - (width / 2) - refX,
+        right = targetX + (width / 2) - refX,
+        bottom = targetY - (height / 2) - refY,
+        top = targetY + (height / 2) - refY,
+        centerX = targetX - refX,
+        centerY = targetY - refY,
+        width = width,
+        height = height,
+    }
+end
+
+local function EnsureContainerPanelLabel(frame, index)
+    frame._containerPanelLabels = frame._containerPanelLabels or {}
+    local labelFrame = frame._containerPanelLabels[index]
+    if labelFrame then
+        return labelFrame
+    end
+
+    labelFrame = CreateFrame("Frame", nil, frame.dragHandle, "BackdropTemplate")
+    labelFrame:SetHeight(CONTAINER_PANEL_LABEL_HEIGHT)
+    labelFrame:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
+    labelFrame:SetBackdropColor(0.2, 0.2, 0.2, 0.9)
+    labelFrame:EnableMouse(false)
+    CreatePixelBorders(labelFrame, 0, 0, 0, 1)
+
+    labelFrame.text = labelFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    labelFrame.text:SetPoint("CENTER")
+    labelFrame.text:SetTextColor(1, 1, 1, 1)
+
+    frame._containerPanelLabels[index] = labelFrame
+    return labelFrame
+end
+
+local function HideContainerPanelLabels(frame)
+    if not frame or not frame._containerPanelLabels then
+        return
+    end
+
+    for _, labelFrame in pairs(frame._containerPanelLabels) do
+        labelFrame:Hide()
+    end
+end
+
+local function EnsureContainerWrapperBorder(wrapper, r, g, b, a)
+    if not wrapper then
+        return
+    end
+
+    local borderTextures = wrapper._containerWrapperBorderTextures
+    if not borderTextures then
+        borderTextures = {}
+        for i = 1, 4 do
+            borderTextures[i] = wrapper:CreateTexture(nil, "BORDER")
+        end
+        wrapper._containerWrapperBorderTextures = borderTextures
+    end
+
+    if wrapper.borderTextures then
+        for _, texture in ipairs(wrapper.borderTextures) do
+            texture:Hide()
+        end
+    end
+
+    local size = CONTAINER_WRAPPER_BORDER_SIZE
+    local top = borderTextures[1]
+    local bottom = borderTextures[2]
+    local left = borderTextures[3]
+    local right = borderTextures[4]
+
+    for _, texture in ipairs(borderTextures) do
+        texture:SetColorTexture(r, g, b, a)
+        texture:Show()
+    end
+
+    PixelUtil.SetPoint(top, "BOTTOMLEFT", wrapper, "TOPLEFT", -size, 0)
+    PixelUtil.SetPoint(top, "BOTTOMRIGHT", wrapper, "TOPRIGHT", size, 0)
+    PixelUtil.SetHeight(top, size, 1)
+
+    PixelUtil.SetPoint(bottom, "TOPLEFT", wrapper, "BOTTOMLEFT", -size, 0)
+    PixelUtil.SetPoint(bottom, "TOPRIGHT", wrapper, "BOTTOMRIGHT", size, 0)
+    PixelUtil.SetHeight(bottom, size, 1)
+
+    PixelUtil.SetPoint(left, "TOPRIGHT", wrapper, "TOPLEFT", 0, size)
+    PixelUtil.SetPoint(left, "BOTTOMRIGHT", wrapper, "BOTTOMLEFT", 0, -size)
+    PixelUtil.SetWidth(left, size, 1)
+
+    PixelUtil.SetPoint(right, "TOPLEFT", wrapper, "TOPRIGHT", 0, size)
+    PixelUtil.SetPoint(right, "BOTTOMLEFT", wrapper, "BOTTOMRIGHT", 0, -size)
+    PixelUtil.SetWidth(right, size, 1)
+end
+
+local function UpdateContainerWrapperLevels(frame)
+    if not (frame and frame.dragHandle) then
+        return
+    end
+
+    local wrapper = frame.dragHandle
+    local strata = "FULLSCREEN_DIALOG"
+    local baseLevel = 60
+
+    wrapper:SetFrameStrata(strata)
+    wrapper:SetFrameLevel(baseLevel)
+
+    if wrapper.header then
+        wrapper.header:SetFrameStrata(strata)
+        wrapper.header:SetFrameLevel(baseLevel + 1)
+    end
+
+    if frame.coordLabel then
+        frame.coordLabel:SetFrameStrata(strata)
+        frame.coordLabel:SetFrameLevel(baseLevel + 2)
+    end
+
+    if frame._containerPanelLabels then
+        for _, labelFrame in pairs(frame._containerPanelLabels) do
+            labelFrame:SetFrameStrata(strata)
+            labelFrame:SetFrameLevel(baseLevel + 3)
+        end
+    end
+
+    if frame.nudger then
+        frame.nudger:SetFrameStrata(strata)
+        frame.nudger:SetFrameLevel(baseLevel + 4)
+        for buttonIndex, btn in ipairs(frame.nudger.buttons or {}) do
+            btn:SetFrameStrata(strata)
+            btn:SetFrameLevel(baseLevel + 5 + buttonIndex)
+        end
+    end
+end
+
+local function GetContainerMemberDisplayRect(self, containerFrame, groupId, group)
+    local groupFrame = self.groupFrames and self.groupFrames[groupId]
+    local rect = nil
+    local isStandaloneDisplay = group and (group.displayMode == "textures" or group.displayMode == "trigger")
+
+    if isStandaloneDisplay then
+        local driverButton = groupFrame and groupFrame.buttons and groupFrame.buttons[1] or nil
+        local host = driverButton and driverButton.auraTextureHost or nil
+        if host and host:IsShown() then
+            rect = GetRelativeFrameRect(containerFrame, host)
+        end
+    end
+
+    if not rect and not isStandaloneDisplay and groupFrame and groupFrame:IsShown() then
+        rect = GetRelativeFrameRect(containerFrame, groupFrame)
+    end
+
+    if rect then
+        rect.groupId = groupId
+        rect.group = group
+        rect.label = group.name or ("Panel " .. groupId)
+    end
+
+    return rect
+end
+
+function CooldownCompanion:RefreshContainerWrapper(containerId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    local container = self.db and self.db.profile and self.db.profile.groupContainers and self.db.profile.groupContainers[containerId]
+    if not (frame and container and frame.dragHandle) then
+        return
+    end
+
+    local wrapper = frame.dragHandle
+    local header = wrapper.header
+    HideContainerPanelLabels(frame)
+    UpdateContainerWrapperLevels(frame)
+
+    if container.locked ~= false or not self:IsContainerVisibleToCurrentChar(containerId) then
+        wrapper:Hide()
+        if header then
+            header:Hide()
+        end
+        if frame.coordLabel then
+            frame.coordLabel:Hide()
+        end
+        if frame.nudger then
+            frame.nudger:Hide()
+        end
+        return
+    end
+
+    local previewPanels = self.GetContainerUnlockPreviewPanels and self:GetContainerUnlockPreviewPanels(containerId) or {}
+    local previewRects = {}
+    local minLeft, maxRight, minBottom, maxTop = nil, nil, nil, nil
+
+    for _, panelInfo in ipairs(previewPanels) do
+        local rect = GetContainerMemberDisplayRect(self, frame, panelInfo.groupId, panelInfo.group)
+        if rect then
+            previewRects[#previewRects + 1] = rect
+            minLeft = minLeft and math_min(minLeft, rect.left) or rect.left
+            maxRight = maxRight and math_max(maxRight, rect.right) or rect.right
+            minBottom = minBottom and math_min(minBottom, rect.bottom) or rect.bottom
+            maxTop = maxTop and math_max(maxTop, rect.top) or rect.top
+        end
+    end
+
+    if #previewRects == 0 then
+        wrapper:Hide()
+        if header then
+            header:Hide()
+        end
+        if frame.coordLabel then
+            frame.coordLabel:Hide()
+        end
+        if frame.nudger then
+            frame.nudger:Hide()
+        end
+        return
+    end
+
+    local padding = CONTAINER_WRAPPER_PADDING
+    wrapper:ClearAllPoints()
+    wrapper:SetPoint("BOTTOMLEFT", frame, "CENTER", RoundPreviewOffset(minLeft - padding), RoundPreviewOffset(minBottom - padding))
+    wrapper:SetPoint("TOPRIGHT", frame, "CENTER", RoundPreviewOffset(maxRight + padding), RoundPreviewOffset(maxTop + padding))
+    wrapper:SetShown(true)
+
+    if header then
+        local titleText = header.text or wrapper.text
+        if titleText then
+            titleText:SetText(container.name or "Group")
+            header:SetWidth(math_max(96, math_floor((titleText:GetStringWidth() or 0) + 24.5)))
+        else
+            header:SetWidth(96)
+        end
+        header:Show()
+    end
+
+    if frame.coordLabel then
+        frame.coordLabel:SetShown(true)
+    end
+    if frame.nudger then
+        frame.nudger:SetShown(true)
+    end
+
+    for labelIndex, rect in ipairs(previewRects) do
+        local labelFrame = EnsureContainerPanelLabel(frame, labelIndex)
+        labelFrame.text:SetText(rect.label)
+        labelFrame:SetWidth(math_max(CONTAINER_PANEL_LABEL_MIN_WIDTH, math_floor((labelFrame.text:GetStringWidth() or 0) + 16.5)))
+        labelFrame:ClearAllPoints()
+        labelFrame:SetPoint(
+            "BOTTOM",
+            wrapper,
+            "BOTTOMLEFT",
+            RoundPreviewOffset(rect.centerX - minLeft + padding),
+            RoundPreviewOffset(rect.top - minBottom + padding + CONTAINER_WRAPPER_LABEL_OFFSET)
+        )
+        labelFrame:Show()
+    end
+end
+
+function CooldownCompanion:RefreshAllContainerWrappers()
+    if not self.containerFrames then
+        return
+    end
+
+    for containerId in pairs(self.containerFrames) do
+        self:RefreshContainerWrapper(containerId)
+    end
+end
+
 local function CreateContainerNudger(frame, containerId)
     local NUDGE_GAP = 2
 
-    local nudger = CreateFrame("Frame", nil, frame.dragHandle, "BackdropTemplate")
+    local nudgerAnchor = frame.dragHandle.header or frame.dragHandle
+    local nudger = CreateFrame("Frame", nil, nudgerAnchor, "BackdropTemplate")
+    nudger.buttons = {}
     nudger:SetSize(NUDGE_BTN_SIZE * 2 + NUDGE_GAP, NUDGE_BTN_SIZE * 2 + NUDGE_GAP)
-    nudger:SetPoint("BOTTOM", frame.dragHandle, "TOP", 0, 2)
-    nudger:SetFrameStrata(frame.dragHandle:GetFrameStrata())
-    nudger:SetFrameLevel(frame.dragHandle:GetFrameLevel() + 5)
+    nudger:SetPoint("BOTTOM", nudgerAnchor, "TOP", 0, 2)
+    nudger:SetFrameStrata(nudgerAnchor:GetFrameStrata())
+    nudger:SetFrameLevel(nudgerAnchor:GetFrameLevel() + 5)
     nudger:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
     nudger:SetBackdropColor(0.2, 0.2, 0.2, 0.8)
     CreatePixelBorders(nudger)
@@ -1367,6 +1692,7 @@ local function CreateContainerNudger(frame, containerId)
 
     for _, dir in ipairs(directions) do
         local btn = CreateFrame("Button", nil, nudger)
+        nudger.buttons[#nudger.buttons + 1] = btn
         btn:SetSize(NUDGE_BTN_SIZE, NUDGE_BTN_SIZE)
         btn:SetPoint(dir.anchor, nudger, "CENTER", dir.ox, dir.oy)
         btn:EnableMouse(true)
@@ -1459,24 +1785,32 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     frame:EnableMouse(not container.locked)
     frame:RegisterForDrag("LeftButton")
 
-    -- Drag handle (visible when unlocked)
+    -- Wrapper outline (visible when unlocked)
     frame.dragHandle = CreateFrame("Frame", nil, frame, "BackdropTemplate")
-    frame.dragHandle:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", -40, 2)
-    frame.dragHandle:SetSize(80, 15)
+    frame.dragHandle:SetPoint("CENTER", frame, "CENTER", 0, 0)
+    frame.dragHandle:SetSize(1, 1)
     frame.dragHandle:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
-    frame.dragHandle:SetBackdropColor(0.15, 0.35, 0.55, 0.9)
-    CreatePixelBorders(frame.dragHandle)
+    frame.dragHandle:SetBackdropColor(0.15, 0.35, 0.55, 0.08)
+    EnsureContainerWrapperBorder(frame.dragHandle, 0.2, 0.8, 1, 0.95)
 
-    frame.dragHandle.text = frame.dragHandle:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    frame.dragHandle.header = CreateFrame("Frame", nil, frame.dragHandle, "BackdropTemplate")
+    frame.dragHandle.header:SetHeight(CONTAINER_WRAPPER_HEADER_HEIGHT)
+    frame.dragHandle.header:SetPoint("BOTTOM", frame.dragHandle, "TOP", 0, 2)
+    frame.dragHandle.header:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
+    frame.dragHandle.header:SetBackdropColor(0.15, 0.35, 0.55, 0.92)
+    CreatePixelBorders(frame.dragHandle.header)
+
+    frame.dragHandle.text = frame.dragHandle.header:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     frame.dragHandle.text:SetPoint("CENTER")
     frame.dragHandle.text:SetText(container.name)
     frame.dragHandle.text:SetTextColor(1, 1, 1, 1)
+    frame.dragHandle.header.text = frame.dragHandle.text
 
     -- Pixel nudger
     frame.nudger = CreateContainerNudger(frame, containerId)
 
     -- Coordinate label
-    frame.coordLabel = CreateFrame("Frame", nil, frame.dragHandle, "BackdropTemplate")
+    frame.coordLabel = CreateFrame("Frame", nil, frame, "BackdropTemplate")
     frame.coordLabel:SetHeight(15)
     frame.coordLabel:SetPoint("TOPLEFT", frame.dragHandle, "BOTTOMLEFT", 0, -2)
     frame.coordLabel:SetPoint("TOPRIGHT", frame.dragHandle, "BOTTOMRIGHT", 0, -2)
@@ -1517,13 +1851,30 @@ function CooldownCompanion:CreateContainerFrame(containerId)
         CooldownCompanion:SaveContainerPosition(containerId)
     end)
 
+    frame.dragHandle.header:EnableMouse(true)
+    frame.dragHandle.header:RegisterForDrag("LeftButton")
+    frame.dragHandle.header:SetScript("OnDragStart", function()
+        local c = CooldownCompanion.db.profile.groupContainers[containerId]
+        if c and not c.locked then
+            frame:StartMoving()
+        end
+    end)
+    frame.dragHandle.header:SetScript("OnDragStop", function()
+        frame:StopMovingOrSizing()
+        CooldownCompanion:SaveContainerPosition(containerId)
+    end)
+
     -- Middle-click to lock
-    frame.dragHandle:SetScript("OnMouseUp", function(_, btn)
+    frame.dragHandle.header:SetScript("OnMouseUp", function(_, btn)
         if btn == "MiddleButton" then
             local c = CooldownCompanion.db.profile.groupContainers[containerId]
             if c then
+                if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                    CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId)
+                end
                 c.locked = true
-                frame.dragHandle:Hide()
+                CooldownCompanion:UpdateContainerDragHandle(containerId, true)
+                CooldownCompanion:RefreshContainerPanels(containerId)
                 CooldownCompanion:RefreshConfigPanel()
                 CooldownCompanion:Print(c.name .. " locked.")
             end
@@ -1531,6 +1882,8 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     end)
 
     self.containerFrames[containerId] = frame
+    UpdateContainerWrapperLevels(frame)
+    self:RefreshContainerWrapper(containerId)
     frame:Show()
     return frame
 end
@@ -1601,7 +1954,13 @@ function CooldownCompanion:SaveContainerPosition(containerId)
     frame:ClearAllPoints()
     frame:SetPoint("CENTER", UIParent, "CENTER", newX, newY)
 
+    if self.SyncGroupedStandalonePreviewSettings then
+        self:SyncGroupedStandalonePreviewSettings(containerId)
+    end
     UpdateCoordLabel(frame, newX, newY)
+    if self.RefreshContainerWrapper then
+        self:RefreshContainerWrapper(containerId)
+    end
     self:RefreshConfigPanel()
 end
 

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -51,6 +51,27 @@ local function GetContainerState(groupId)
     return group.locked or false, group.baselineAlpha or 1
 end
 
+local function GetContainerPreviewSelectionState(groupId)
+    local profile = CooldownCompanion.db and CooldownCompanion.db.profile
+    local group = profile and profile.groups and profile.groups[groupId]
+    local containerId = group and group.parentContainerId or nil
+    if not containerId then
+        return false, false, nil
+    end
+
+    local previewActive = CooldownCompanion.IsContainerUnlockPreviewActive
+        and CooldownCompanion:IsContainerUnlockPreviewActive(containerId)
+        or false
+    if not previewActive then
+        return false, false, containerId
+    end
+
+    local selected = CooldownCompanion.IsContainerPanelSelected
+        and CooldownCompanion:IsContainerPanelSelected(containerId, groupId)
+        or false
+    return true, selected, containerId
+end
+
 local function UpdateCoordLabel(frame, x, y)
     if frame.coordLabel then
         frame.coordLabel.text:SetText(("x:%.1f, y:%.1f"):format(x, y))
@@ -369,6 +390,9 @@ local function CreateNudger(frame, groupId)
                 group.anchor.x = math_floor(x * 10 + 0.5) / 10
                 group.anchor.y = math_floor(y * 10 + 0.5) / 10
                 UpdateCoordLabel(gFrame, x, y)
+                if group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
+                    CooldownCompanion:RefreshContainerWrapper(group.parentContainerId)
+                end
             end
         end
 
@@ -396,6 +420,32 @@ local function CreateNudger(frame, groupId)
     end
 
     return nudger
+end
+
+local function SyncGroupControlLevels(frame, raiseAboveWrapper)
+    if not frame then
+        return
+    end
+
+    local strata = raiseAboveWrapper and "FULLSCREEN_DIALOG" or frame:GetFrameStrata()
+    local baseLevel = raiseAboveWrapper and 90 or ((frame:GetFrameLevel() or 1) + 5)
+
+    if frame.dragHandle then
+        frame.dragHandle:SetFrameStrata(strata)
+        frame.dragHandle:SetFrameLevel(baseLevel)
+    end
+    if frame.coordLabel then
+        frame.coordLabel:SetFrameStrata(strata)
+        frame.coordLabel:SetFrameLevel(baseLevel + 1)
+    end
+    if frame.nudger then
+        frame.nudger:SetFrameStrata(strata)
+        frame.nudger:SetFrameLevel(baseLevel + 5)
+        for buttonIndex, btn in ipairs(frame.nudger.buttons or {}) do
+            btn:SetFrameStrata(strata)
+            btn:SetFrameLevel(baseLevel + 6 + buttonIndex)
+        end
+    end
 end
 
 function CooldownCompanion:CreateGroupFrame(groupId)
@@ -473,13 +523,26 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     -- Drag scripts (check lock state at drag time)
     frame:SetScript("OnDragStart", function(self)
         local locked = GetContainerState(self.groupId)
-        if not locked then
+        local previewActive, selectedInContainer, containerId = GetContainerPreviewSelectionState(self.groupId)
+        if previewActive then
+            if not selectedInContainer then
+                return
+            end
+            if containerId and CooldownCompanion.StartContainerMemberPreviewTracking then
+                CooldownCompanion:StartContainerMemberPreviewTracking(containerId, self.groupId)
+            end
+            self:StartMoving()
+        elseif not locked then
             self:StartMoving()
         end
     end)
 
     frame:SetScript("OnDragStop", function(self)
+        local _, selectedInContainer, containerId = GetContainerPreviewSelectionState(self.groupId)
         self:StopMovingOrSizing()
+        if selectedInContainer and containerId and CooldownCompanion.StopContainerMemberPreviewTracking then
+            CooldownCompanion:StopContainerMemberPreviewTracking(containerId, self.groupId)
+        end
         CooldownCompanion:SaveGroupPosition(self.groupId)
     end)
 
@@ -488,12 +551,25 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     frame.dragHandle:RegisterForDrag("LeftButton")
     frame.dragHandle:SetScript("OnDragStart", function()
         local locked = GetContainerState(groupId)
-        if not locked then
+        local previewActive, selectedInContainer, containerId = GetContainerPreviewSelectionState(groupId)
+        if previewActive then
+            if not selectedInContainer then
+                return
+            end
+            if containerId and CooldownCompanion.StartContainerMemberPreviewTracking then
+                CooldownCompanion:StartContainerMemberPreviewTracking(containerId, groupId)
+            end
+            frame:StartMoving()
+        elseif not locked then
             frame:StartMoving()
         end
     end)
     frame.dragHandle:SetScript("OnDragStop", function()
+        local _, selectedInContainer, containerId = GetContainerPreviewSelectionState(groupId)
         frame:StopMovingOrSizing()
+        if selectedInContainer and containerId and CooldownCompanion.StopContainerMemberPreviewTracking then
+            CooldownCompanion:StopContainerMemberPreviewTracking(containerId, groupId)
+        end
         CooldownCompanion:SaveGroupPosition(groupId)
     end)
 
@@ -1123,11 +1199,19 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     -- Update drag handle text and lock state
     local hasButtons = #group.buttons > 0
     local isTextureMode = group.displayMode == "textures" or group.displayMode == "trigger"
+    local containerPreviewActive = group.parentContainerId and self:IsContainerUnlockPreviewActive(group.parentContainerId)
+    local selectedInContainer = containerPreviewActive and self:IsContainerPanelSelected(group.parentContainerId, groupId)
     if frame.dragHandle then
         if frame.dragHandle.text then
             frame.dragHandle.text:SetText(group.name)
         end
-        if isLocked or not hasButtons or isTextureMode then
+        if containerPreviewActive then
+            if selectedInContainer and hasButtons and not isTextureMode then
+                frame.dragHandle:Show()
+            else
+                frame.dragHandle:Hide()
+            end
+        elseif isLocked or not hasButtons or isTextureMode then
             frame.dragHandle:Hide()
         else
             frame.dragHandle:Show()
@@ -1344,6 +1428,33 @@ function CooldownCompanion:UpdateGroupClickthrough(groupId)
 
     local isLocked = GetContainerState(groupId)
     local isTextureMode = group.displayMode == "textures" or group.displayMode == "trigger"
+    local containerPreviewActive = group.parentContainerId and self:IsContainerUnlockPreviewActive(group.parentContainerId)
+    local isSelectedInContainer = containerPreviewActive and self:IsContainerPanelSelected(group.parentContainerId, groupId)
+
+    SyncGroupControlLevels(frame, isSelectedInContainer and not isTextureMode)
+
+    if containerPreviewActive then
+        SetFrameClickThrough(frame, true, true)
+        if frame.dragHandle then
+            if isSelectedInContainer and not isTextureMode then
+                SetFrameClickThrough(frame.dragHandle, false, false)
+                frame.dragHandle:EnableMouse(true)
+                frame.dragHandle:RegisterForDrag("LeftButton")
+                frame.dragHandle:SetScript("OnMouseUp", nil)
+            else
+                SetFrameClickThrough(frame.dragHandle, true, true)
+            end
+        end
+        if frame.nudger then
+            if isSelectedInContainer and not isTextureMode then
+                SetFrameClickThrough(frame.nudger, false, false)
+                frame.nudger:EnableMouse(true)
+            else
+                SetFrameClickThrough(frame.nudger, true, true)
+            end
+        end
+        return
+    end
 
     -- When locked: group container is always fully non-interactive
     -- Texture panels also keep the backing group frame non-interactive while
@@ -1394,6 +1505,7 @@ local CONTAINER_WRAPPER_LABEL_OFFSET = 2
 local CONTAINER_WRAPPER_HEADER_HEIGHT = 18
 local CONTAINER_PANEL_LABEL_HEIGHT = 15
 local CONTAINER_PANEL_LABEL_MIN_WIDTH = 70
+local CONTAINER_MEMBER_DRAG_REFRESH_INTERVAL = 0.05
 
 local function GetRelativeFrameRect(referenceFrame, targetFrame)
     if not (referenceFrame and targetFrame and referenceFrame.GetCenter and targetFrame.GetCenter) then
@@ -1451,6 +1563,84 @@ local function HideContainerPanelLabels(frame)
     end
 end
 
+local function EnsureContainerMemberOverlay(frame, index)
+    frame._containerMemberOverlays = frame._containerMemberOverlays or {}
+    local overlay = frame._containerMemberOverlays[index]
+    if overlay then
+        return overlay
+    end
+
+    overlay = CreateFrame("Frame", nil, frame, "BackdropTemplate")
+    overlay:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
+    overlay:SetBackdropColor(0.2, 0.8, 1, 0)
+    overlay:RegisterForDrag("LeftButton")
+    overlay:EnableMouse(true)
+
+    overlay:SetScript("OnEnter", function(self)
+        local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[self.containerId]
+        if not (self.containerId and self.groupId and containerFrame) then
+            return
+        end
+        if containerFrame._containerHoveredGroupId ~= self.groupId then
+            containerFrame._containerHoveredGroupId = self.groupId
+            CooldownCompanion:RefreshContainerWrapper(self.containerId)
+        end
+    end)
+
+    overlay:SetScript("OnLeave", function(self)
+        if self._dragging then
+            return
+        end
+        local containerFrame = CooldownCompanion.containerFrames and CooldownCompanion.containerFrames[self.containerId]
+        if not containerFrame then
+            return
+        end
+        if containerFrame._containerHoveredGroupId == self.groupId then
+            containerFrame._containerHoveredGroupId = nil
+            CooldownCompanion:RefreshContainerWrapper(self.containerId)
+        end
+    end)
+
+    overlay:SetScript("OnDragStart", function(self)
+        self._suppressClick = true
+        self._dragging = CooldownCompanion:StartContainerPreviewMemberDrag(self.containerId, self.groupId) or nil
+    end)
+
+    overlay:SetScript("OnDragStop", function(self)
+        if self._dragging then
+            CooldownCompanion:StopContainerPreviewMemberDrag(self.containerId, self.groupId)
+        end
+        self._dragging = nil
+    end)
+
+    overlay:SetScript("OnMouseUp", function(self, button)
+        if button ~= "LeftButton" then
+            return
+        end
+        if self._suppressClick then
+            self._suppressClick = nil
+            return
+        end
+        CooldownCompanion:SelectContainerPanel(self.containerId, self.groupId)
+    end)
+
+    frame._containerMemberOverlays[index] = overlay
+    return overlay
+end
+
+local function HideContainerMemberOverlays(frame)
+    if not frame or not frame._containerMemberOverlays then
+        return
+    end
+
+    for _, overlay in pairs(frame._containerMemberOverlays) do
+        overlay._dragging = nil
+        overlay._suppressClick = nil
+        overlay.groupId = nil
+        overlay:Hide()
+    end
+end
+
 local function EnsureContainerWrapperBorder(wrapper, r, g, b, a)
     if not wrapper then
         return
@@ -1499,6 +1689,159 @@ local function EnsureContainerWrapperBorder(wrapper, r, g, b, a)
     PixelUtil.SetWidth(right, size, 1)
 end
 
+function CooldownCompanion:GetContainerSelectedGroupId(containerId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    return frame and frame._containerSelectedGroupId or nil
+end
+
+function CooldownCompanion:IsContainerPanelSelected(containerId, groupId)
+    return groupId ~= nil and self:GetContainerSelectedGroupId(containerId) == groupId
+end
+
+function CooldownCompanion:IsContainerPanelHovered(containerId, groupId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    return groupId ~= nil and frame and frame._containerHoveredGroupId == groupId or false
+end
+
+function CooldownCompanion:StartContainerMemberPreviewTracking(containerId, groupId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    if not frame then
+        return
+    end
+
+    local tracker = frame._containerMemberDragTracker
+    if not tracker then
+        tracker = CreateFrame("Frame", nil, frame)
+        frame._containerMemberDragTracker = tracker
+    end
+
+    frame._containerDraggingGroupId = groupId
+    tracker._elapsed = 0
+    tracker:SetScript("OnUpdate", function(self, elapsed)
+        self._elapsed = (self._elapsed or 0) + elapsed
+        if self._elapsed < CONTAINER_MEMBER_DRAG_REFRESH_INTERVAL then
+            return
+        end
+
+        self._elapsed = 0
+        CooldownCompanion:RefreshContainerWrapper(containerId)
+    end)
+end
+
+function CooldownCompanion:StopContainerMemberPreviewTracking(containerId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    if not frame then
+        return
+    end
+
+    frame._containerDraggingGroupId = nil
+    local tracker = frame._containerMemberDragTracker
+    if tracker then
+        tracker._elapsed = 0
+        tracker:SetScript("OnUpdate", nil)
+    end
+end
+
+function CooldownCompanion:ClearContainerUnlockState(containerId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    if not frame then
+        return
+    end
+
+    frame._containerSelectedGroupId = nil
+    frame._containerHoveredGroupId = nil
+    self:StopContainerMemberPreviewTracking(containerId)
+    HideContainerMemberOverlays(frame)
+end
+
+function CooldownCompanion:SelectContainerWrapper(containerId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    if not frame then
+        return
+    end
+
+    if frame._containerSelectedGroupId == nil then
+        return
+    end
+
+    frame._containerSelectedGroupId = nil
+    self:RefreshContainerWrapper(containerId)
+end
+
+function CooldownCompanion:SelectContainerPanel(containerId, groupId)
+    local frame = self.containerFrames and self.containerFrames[containerId]
+    local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId]
+    if not (frame and group and group.parentContainerId == containerId) then
+        return
+    end
+
+    if not self:IsGroupVisibleInUnlockPreview(groupId, {
+        group = group,
+        checkCharVisibility = true,
+    }) then
+        self:SelectContainerWrapper(containerId)
+        return
+    end
+
+    if frame._containerSelectedGroupId == groupId and frame._containerHoveredGroupId == groupId then
+        return
+    end
+
+    frame._containerSelectedGroupId = groupId
+    frame._containerHoveredGroupId = groupId
+    self:RefreshContainerWrapper(containerId)
+end
+
+function CooldownCompanion:StartContainerPreviewMemberDrag(containerId, groupId)
+    local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId]
+    if not (containerId and group and group.parentContainerId == containerId) then
+        return false
+    end
+
+    self:SelectContainerPanel(containerId, groupId)
+    self:StartContainerMemberPreviewTracking(containerId, groupId)
+
+    if group.displayMode == "textures" or group.displayMode == "trigger" then
+        if self.StartGroupedStandalonePreviewHostDrag and self:StartGroupedStandalonePreviewHostDrag(groupId, containerId) then
+            return true
+        end
+        self:StopContainerMemberPreviewTracking(containerId)
+        return false
+    end
+
+    local groupFrame = self.groupFrames and self.groupFrames[groupId]
+    if not groupFrame or (InCombatLockdown() and groupFrame:IsProtected()) then
+        self:StopContainerMemberPreviewTracking(containerId)
+        return false
+    end
+
+    groupFrame:StartMoving()
+    return true
+end
+
+function CooldownCompanion:StopContainerPreviewMemberDrag(containerId, groupId)
+    local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId]
+    if not (containerId and group and group.parentContainerId == containerId) then
+        self:StopContainerMemberPreviewTracking(containerId)
+        return
+    end
+
+    if group.displayMode == "textures" or group.displayMode == "trigger" then
+        if self.StopGroupedStandalonePreviewHostDrag then
+            self:StopGroupedStandalonePreviewHostDrag(groupId, containerId)
+        end
+        self:StopContainerMemberPreviewTracking(containerId)
+        return
+    end
+
+    local groupFrame = self.groupFrames and self.groupFrames[groupId]
+    if groupFrame and not (InCombatLockdown() and groupFrame:IsProtected()) then
+        groupFrame:StopMovingOrSizing()
+    end
+    self:StopContainerMemberPreviewTracking(containerId)
+    self:SaveGroupPosition(groupId)
+end
+
 local function UpdateContainerWrapperLevels(frame)
     if not (frame and frame.dragHandle) then
         return
@@ -1525,6 +1868,13 @@ local function UpdateContainerWrapperLevels(frame)
         for _, labelFrame in pairs(frame._containerPanelLabels) do
             labelFrame:SetFrameStrata(strata)
             labelFrame:SetFrameLevel(baseLevel + 3)
+        end
+    end
+
+    if frame._containerMemberOverlays then
+        for overlayIndex, overlay in pairs(frame._containerMemberOverlays) do
+            overlay:SetFrameStrata(strata)
+            overlay:SetFrameLevel(baseLevel + 10 + overlayIndex)
         end
     end
 
@@ -1567,16 +1917,18 @@ end
 function CooldownCompanion:RefreshContainerWrapper(containerId)
     local frame = self.containerFrames and self.containerFrames[containerId]
     local container = self.db and self.db.profile and self.db.profile.groupContainers and self.db.profile.groupContainers[containerId]
-    if not (frame and container and frame.dragHandle) then
+    if not (frame and container and frame.dragHandle) or frame._isRefreshingContainerWrapper then
         return
     end
 
+    frame._isRefreshingContainerWrapper = true
     local wrapper = frame.dragHandle
     local header = wrapper.header
     HideContainerPanelLabels(frame)
     UpdateContainerWrapperLevels(frame)
 
     if container.locked ~= false or not self:IsContainerVisibleToCurrentChar(containerId) then
+        self:ClearContainerUnlockState(containerId)
         wrapper:Hide()
         if header then
             header:Hide()
@@ -1587,17 +1939,21 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
         if frame.nudger then
             frame.nudger:Hide()
         end
+        frame._isRefreshingContainerWrapper = nil
         return
     end
 
     local previewPanels = self.GetContainerUnlockPreviewPanels and self:GetContainerUnlockPreviewPanels(containerId) or {}
+    local allPanels = self.GetPanels and self:GetPanels(containerId) or previewPanels
     local previewRects = {}
+    local previewedGroupIds = {}
     local minLeft, maxRight, minBottom, maxTop = nil, nil, nil, nil
 
     for _, panelInfo in ipairs(previewPanels) do
         local rect = GetContainerMemberDisplayRect(self, frame, panelInfo.groupId, panelInfo.group)
         if rect then
             previewRects[#previewRects + 1] = rect
+            previewedGroupIds[rect.groupId] = true
             minLeft = minLeft and math_min(minLeft, rect.left) or rect.left
             maxRight = maxRight and math_max(maxRight, rect.right) or rect.right
             minBottom = minBottom and math_min(minBottom, rect.bottom) or rect.bottom
@@ -1605,7 +1961,18 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
         end
     end
 
+    if frame._containerSelectedGroupId and not previewedGroupIds[frame._containerSelectedGroupId] then
+        frame._containerSelectedGroupId = nil
+    end
+    if frame._containerHoveredGroupId and not previewedGroupIds[frame._containerHoveredGroupId] then
+        frame._containerHoveredGroupId = nil
+    end
+
+    local selectedGroupId = frame._containerSelectedGroupId
+    local hoveredGroupId = frame._containerHoveredGroupId
+
     if #previewRects == 0 then
+        HideContainerMemberOverlays(frame)
         wrapper:Hide()
         if header then
             header:Hide()
@@ -1616,6 +1983,7 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
         if frame.nudger then
             frame.nudger:Hide()
         end
+        frame._isRefreshingContainerWrapper = nil
         return
     end
 
@@ -1637,26 +2005,91 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
     end
 
     if frame.coordLabel then
-        frame.coordLabel:SetShown(true)
+        frame.coordLabel:SetShown(selectedGroupId == nil)
     end
     if frame.nudger then
-        frame.nudger:SetShown(true)
+        frame.nudger:SetShown(selectedGroupId == nil)
     end
 
+    local usedOverlayIndices = {}
     for labelIndex, rect in ipairs(previewRects) do
-        local labelFrame = EnsureContainerPanelLabel(frame, labelIndex)
-        labelFrame.text:SetText(rect.label)
-        labelFrame:SetWidth(math_max(CONTAINER_PANEL_LABEL_MIN_WIDTH, math_floor((labelFrame.text:GetStringWidth() or 0) + 16.5)))
-        labelFrame:ClearAllPoints()
-        labelFrame:SetPoint(
-            "BOTTOM",
-            wrapper,
-            "BOTTOMLEFT",
-            RoundPreviewOffset(rect.centerX - minLeft + padding),
-            RoundPreviewOffset(rect.top - minBottom + padding + CONTAINER_WRAPPER_LABEL_OFFSET)
-        )
-        labelFrame:Show()
+        local isSelected = selectedGroupId == rect.groupId
+        local isHovered = hoveredGroupId == rect.groupId
+        local isStandaloneDisplay = rect.group and (rect.group.displayMode == "textures" or rect.group.displayMode == "trigger")
+
+        local overlay = EnsureContainerMemberOverlay(frame, labelIndex)
+        usedOverlayIndices[labelIndex] = true
+        overlay.containerId = containerId
+        overlay.groupId = rect.groupId
+        overlay:ClearAllPoints()
+        overlay:SetPoint("BOTTOMLEFT", frame, "CENTER", RoundPreviewOffset(rect.left), RoundPreviewOffset(rect.bottom))
+        overlay:SetPoint("TOPRIGHT", frame, "CENTER", RoundPreviewOffset(rect.right), RoundPreviewOffset(rect.top))
+        overlay:SetShown(true)
+
+        local fillAlpha = 0
+        local borderAlpha = 0
+        if not isStandaloneDisplay then
+            if isSelected then
+                fillAlpha = 0.12
+                borderAlpha = 0.95
+            elseif isHovered then
+                fillAlpha = 0.08
+                borderAlpha = 0.75
+            end
+        end
+        overlay:SetBackdropColor(0.15, 0.45, 0.65, fillAlpha)
+        EnsureContainerWrapperBorder(overlay, 0.2, 0.8, 1, borderAlpha)
+
+        if not isSelected then
+            local labelFrame = EnsureContainerPanelLabel(frame, labelIndex)
+            labelFrame.text:SetText(rect.label)
+            labelFrame:SetWidth(math_max(CONTAINER_PANEL_LABEL_MIN_WIDTH, math_floor((labelFrame.text:GetStringWidth() or 0) + 16.5)))
+            labelFrame:ClearAllPoints()
+            labelFrame:SetPoint(
+                "BOTTOM",
+                wrapper,
+                "BOTTOMLEFT",
+                RoundPreviewOffset(rect.centerX - minLeft + padding),
+                RoundPreviewOffset(rect.top - minBottom + padding + CONTAINER_WRAPPER_LABEL_OFFSET)
+            )
+            labelFrame:Show()
+        end
     end
+
+    if frame._containerMemberOverlays then
+        for overlayIndex, overlay in pairs(frame._containerMemberOverlays) do
+            if not usedOverlayIndices[overlayIndex] then
+                overlay._dragging = nil
+                overlay._suppressClick = nil
+                overlay.groupId = nil
+                overlay:Hide()
+            end
+        end
+    end
+
+    for _, panelInfo in ipairs(allPanels) do
+        local group = panelInfo.group
+        local groupId = panelInfo.groupId
+        local groupFrame = self.groupFrames and self.groupFrames[groupId] or nil
+        local isSelected = selectedGroupId == groupId and previewedGroupIds[groupId]
+        local isStandaloneDisplay = group and (group.displayMode == "textures" or group.displayMode == "trigger")
+
+        if groupFrame and not isStandaloneDisplay then
+            SyncGroupControlLevels(groupFrame, isSelected)
+            if groupFrame.dragHandle then
+                if isSelected then
+                    groupFrame.dragHandle:Show()
+                elseif self:IsContainerUnlockPreviewActive(containerId) then
+                    groupFrame.dragHandle:Hide()
+                end
+            end
+            self:UpdateGroupClickthrough(groupId)
+        elseif isStandaloneDisplay and self.UpdateGroupedStandalonePreviewSelection then
+            self:UpdateGroupedStandalonePreviewSelection(groupId)
+        end
+    end
+
+    frame._isRefreshingContainerWrapper = nil
 end
 
 function CooldownCompanion:RefreshAllContainerWrappers()
@@ -1830,6 +2263,7 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     frame:SetScript("OnDragStart", function(self)
         local c = CooldownCompanion.db.profile.groupContainers[self.containerId]
         if c and not c.locked then
+            CooldownCompanion:SelectContainerWrapper(self.containerId)
             self:StartMoving()
         end
     end)
@@ -1843,6 +2277,8 @@ function CooldownCompanion:CreateContainerFrame(containerId)
     frame.dragHandle:SetScript("OnDragStart", function()
         local c = CooldownCompanion.db.profile.groupContainers[containerId]
         if c and not c.locked then
+            frame.dragHandle._suppressClick = true
+            CooldownCompanion:SelectContainerWrapper(containerId)
             frame:StartMoving()
         end
     end)
@@ -1850,12 +2286,24 @@ function CooldownCompanion:CreateContainerFrame(containerId)
         frame:StopMovingOrSizing()
         CooldownCompanion:SaveContainerPosition(containerId)
     end)
+    frame.dragHandle:SetScript("OnMouseUp", function(_, button)
+        if button ~= "LeftButton" then
+            return
+        end
+        if frame.dragHandle._suppressClick then
+            frame.dragHandle._suppressClick = nil
+            return
+        end
+        CooldownCompanion:SelectContainerWrapper(containerId)
+    end)
 
     frame.dragHandle.header:EnableMouse(true)
     frame.dragHandle.header:RegisterForDrag("LeftButton")
     frame.dragHandle.header:SetScript("OnDragStart", function()
         local c = CooldownCompanion.db.profile.groupContainers[containerId]
         if c and not c.locked then
+            frame.dragHandle.header._suppressClick = true
+            CooldownCompanion:SelectContainerWrapper(containerId)
             frame:StartMoving()
         end
     end)
@@ -1878,6 +2326,15 @@ function CooldownCompanion:CreateContainerFrame(containerId)
                 CooldownCompanion:RefreshConfigPanel()
                 CooldownCompanion:Print(c.name .. " locked.")
             end
+            return
+        end
+
+        if btn == "LeftButton" then
+            if frame.dragHandle.header._suppressClick then
+                frame.dragHandle.header._suppressClick = nil
+                return
+            end
+            CooldownCompanion:SelectContainerWrapper(containerId)
         end
     end)
 

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1511,7 +1511,9 @@ end
 local CONTAINER_WRAPPER_PADDING = 10
 local CONTAINER_WRAPPER_BORDER_SIZE = 2
 local CONTAINER_WRAPPER_LABEL_OFFSET = 2
-local CONTAINER_WRAPPER_HEADER_HEIGHT = 18
+local CONTAINER_WRAPPER_HEADER_HEIGHT = 27
+local CONTAINER_WRAPPER_HEADER_FONT_SIZE = 14
+local CONTAINER_WRAPPER_HEADER_GAP = 4
 local CONTAINER_PANEL_LABEL_HEIGHT = 15
 local CONTAINER_PANEL_LABEL_MIN_WIDTH = 70
 local CONTAINER_MEMBER_DRAG_REFRESH_INTERVAL = 0.05
@@ -2252,13 +2254,19 @@ function CooldownCompanion:CreateContainerFrame(containerId)
 
     frame.dragHandle.header = CreateFrame("Frame", nil, frame.dragHandle, "BackdropTemplate")
     frame.dragHandle.header:SetHeight(CONTAINER_WRAPPER_HEADER_HEIGHT)
-    frame.dragHandle.header:SetPoint("BOTTOM", frame.dragHandle, "TOP", 0, 2)
+    frame.dragHandle.header:SetPoint("BOTTOM", frame.dragHandle, "TOP", 0, CONTAINER_WRAPPER_HEADER_GAP)
     frame.dragHandle.header:SetBackdrop({ bgFile = "Interface\\Buttons\\WHITE8X8" })
     frame.dragHandle.header:SetBackdropColor(0.15, 0.35, 0.55, 0.92)
     CreatePixelBorders(frame.dragHandle.header)
 
     frame.dragHandle.text = frame.dragHandle.header:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     frame.dragHandle.text:SetPoint("CENTER")
+    do
+        local fontPath, _, fontFlags = frame.dragHandle.text:GetFont()
+        if fontPath then
+            frame.dragHandle.text:SetFont(fontPath, CONTAINER_WRAPPER_HEADER_FONT_SIZE, fontFlags)
+        end
+    end
     frame.dragHandle.text:SetText(container.name)
     frame.dragHandle.text:SetTextColor(1, 1, 1, 1)
     frame.dragHandle.header.text = frame.dragHandle.text

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1229,12 +1229,13 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     self:UpdateGroupClickthrough(groupId)
 
     -- Update visibility — unload if disabled, no buttons, wrong spec/hero, wrong character, or load conditions
-    if CooldownCompanion:IsGroupActive(groupId, {
+    local isActive = CooldownCompanion:IsGroupActive(groupId, {
         group = group,
         checkCharVisibility = true,
         checkLoadConditions = true,
         requireButtons = true,
-    }) then
+    })
+    if isActive then
         if InCombatLockdown() and frame:IsProtected() then
             if not frame:IsShown() then
                 self._pendingVisibilityRefresh = true
@@ -1256,7 +1257,8 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
         self:UnloadGroup(groupId)
     end
 
-    if (group.displayMode == "textures" or group.displayMode == "trigger")
+    if isActive
+        and (group.displayMode == "textures" or group.displayMode == "trigger")
         and self.UpdateAuraTextureVisual
         and frame
         and frame.buttons
@@ -2185,10 +2187,19 @@ local function CreateContainerNudger(frame, containerId)
             container.anchor = CooldownCompanion:NormalizeContainerAnchor(container.anchor)
             local cFrame = CooldownCompanion.containerFrames[containerId]
             if cFrame then
+                local oldX = tonumber(container.anchor.x) or 0
+                local oldY = tonumber(container.anchor.y) or 0
                 cFrame:AdjustPointsOffset(dir.dx, dir.dy)
                 local _, _, _, x, y = cFrame:GetPoint()
                 container.anchor.x = math_floor(x * 10 + 0.5) / 10
                 container.anchor.y = math_floor(y * 10 + 0.5) / 10
+                if CooldownCompanion.SyncGroupedStandalonePreviewSettings then
+                    CooldownCompanion:SyncGroupedStandalonePreviewSettings(
+                        containerId,
+                        container.anchor.x - oldX,
+                        container.anchor.y - oldY
+                    )
+                end
                 UpdateCoordLabel(cFrame, x, y)
             end
         end
@@ -2425,6 +2436,8 @@ function CooldownCompanion:SaveContainerPosition(containerId)
     local container = self.db.profile.groupContainers[containerId]
     if not frame or not container then return end
     container.anchor = self:NormalizeContainerAnchor(container.anchor)
+    local oldX = tonumber(container.anchor.x) or 0
+    local oldY = tonumber(container.anchor.y) or 0
 
     local cx, cy = frame:GetCenter()
     if not cx then return end
@@ -2444,7 +2457,7 @@ function CooldownCompanion:SaveContainerPosition(containerId)
     frame:SetPoint("CENTER", UIParent, "CENTER", newX, newY)
 
     if self.SyncGroupedStandalonePreviewSettings then
-        self:SyncGroupedStandalonePreviewSettings(containerId)
+        self:SyncGroupedStandalonePreviewSettings(containerId, newX - oldX, newY - oldY)
     end
     UpdateCoordLabel(frame, newX, newY)
     if self.RefreshContainerWrapper then

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -174,6 +174,48 @@ local function ForceCombatMouseLock(frame)
     end
 end
 
+local function CanSafelyChangeFrameVisibility(frame)
+    if not frame then
+        return false
+    end
+    if not InCombatLockdown() then
+        return true
+    end
+    if frame.CanChangeProtectedState then
+        return frame:CanChangeProtectedState()
+    end
+    return not (frame.IsProtected and frame:IsProtected())
+end
+
+local function SuppressFrameVisibilityForCombat(frame)
+    if not frame then
+        return
+    end
+
+    if CanSafelyChangeFrameVisibility(frame) then
+        frame:Hide()
+        return
+    end
+
+    if frame.GetAlpha and frame._combatForcedAlpha == nil then
+        frame._combatForcedAlpha = frame:GetAlpha()
+    end
+    if frame.SetAlpha then
+        frame:SetAlpha(0)
+    end
+end
+
+local function RestoreFrameVisibilityAfterCombat(frame)
+    if not frame then
+        return
+    end
+
+    if frame._combatForcedAlpha ~= nil and frame.SetAlpha then
+        frame:SetAlpha(frame._combatForcedAlpha)
+    end
+    frame._combatForcedAlpha = nil
+end
+
 function CooldownCompanion:BeginCombatForcedLock()
     if self._combatForcedLock then
         return false
@@ -224,15 +266,10 @@ function CooldownCompanion:BeginCombatForcedLock()
             end
             frame._dragInProgress = nil
         end
-        if frame.dragHandle then
-            frame.dragHandle:Hide()
-        end
-        if frame.coordLabel then
-            frame.coordLabel:Hide()
-        end
-        if frame.nudger then
-            frame.nudger:Hide()
-        end
+        frame._combatForcedHidden = not active or nil
+        SuppressFrameVisibilityForCombat(frame.dragHandle)
+        SuppressFrameVisibilityForCombat(frame.coordLabel)
+        SuppressFrameVisibilityForCombat(frame.nudger)
         ForceCombatMouseLock(frame)
         ForceCombatMouseLock(frame.dragHandle)
         ForceCombatMouseLock(frame.nudger)
@@ -248,15 +285,9 @@ function CooldownCompanion:BeginCombatForcedLock()
                     host._isDragging = nil
                 end
                 host._dragEnabled = false
-                if host.dragHandle then
-                    host.dragHandle:Hide()
-                end
-                if host.coordLabel then
-                    host.coordLabel:Hide()
-                end
-                if host.nudger then
-                    host.nudger:Hide()
-                end
+                SuppressFrameVisibilityForCombat(host.dragHandle)
+                SuppressFrameVisibilityForCombat(host.coordLabel)
+                SuppressFrameVisibilityForCombat(host.nudger)
                 if host.auraTextureOutlineFill then
                     host.auraTextureOutlineFill:Hide()
                 end
@@ -307,6 +338,30 @@ function CooldownCompanion:EndCombatForcedLock()
     local snapshot = self._combatForcedLockSnapshot
     self._combatForcedLock = nil
     self._combatForcedLockSnapshot = nil
+
+    for _, frame in pairs(self.groupFrames or {}) do
+        frame._combatForcedHidden = nil
+        RestoreFrameVisibilityAfterCombat(frame.dragHandle)
+        RestoreFrameVisibilityAfterCombat(frame.coordLabel)
+        RestoreFrameVisibilityAfterCombat(frame.nudger)
+        for _, button in ipairs(frame.buttons or {}) do
+            local host = button and button.auraTextureHost or nil
+            RestoreFrameVisibilityAfterCombat(host and host.dragHandle or nil)
+            RestoreFrameVisibilityAfterCombat(host and host.coordLabel or nil)
+            RestoreFrameVisibilityAfterCombat(host and host.nudger or nil)
+        end
+    end
+
+    for _, frame in pairs(self.containerFrames or {}) do
+        RestoreFrameVisibilityAfterCombat(frame.dragHandle)
+        RestoreFrameVisibilityAfterCombat(frame.dragHandle and frame.dragHandle.header or nil)
+        RestoreFrameVisibilityAfterCombat(frame.coordLabel)
+        RestoreFrameVisibilityAfterCombat(frame.nudger)
+        for _, label in pairs(frame._containerPanelLabels or {}) do
+            RestoreFrameVisibilityAfterCombat(label)
+        end
+    end
+
     return snapshot
 end
 
@@ -1621,16 +1676,13 @@ function CooldownCompanion:UpdateContainerDragHandle(containerId, locked)
             if self.ClearContainerUnlockState then
                 self:ClearContainerUnlockState(containerId)
             end
-            cFrame.dragHandle:Hide()
-            if cFrame.coordLabel then
-                cFrame.coordLabel:Hide()
-            end
-            if cFrame.nudger then
-                cFrame.nudger:Hide()
-            end
+            SuppressFrameVisibilityForCombat(cFrame.dragHandle)
+            SuppressFrameVisibilityForCombat(cFrame.dragHandle and cFrame.dragHandle.header or nil)
+            SuppressFrameVisibilityForCombat(cFrame.coordLabel)
+            SuppressFrameVisibilityForCombat(cFrame.nudger)
             if cFrame._containerPanelLabels then
                 for _, label in pairs(cFrame._containerPanelLabels) do
-                    label:Hide()
+                    SuppressFrameVisibilityForCombat(label)
                 end
             end
         elseif self.RefreshContainerWrapper then

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -128,6 +128,10 @@ function CooldownCompanion:IsContainerUnlockPreviewActive(containerOrContainerId
     local container = containerOrContainerId
     local containerId = nil
 
+    if self._combatForcedLock then
+        return false
+    end
+
     if type(containerOrContainerId) == "number" then
         containerId = containerOrContainerId
         container = self.db.profile.groupContainers and self.db.profile.groupContainers[containerId]
@@ -151,6 +155,94 @@ function CooldownCompanion:IsContainerUnlockPreviewActive(containerOrContainerId
     end
 
     return true
+end
+
+function CooldownCompanion:BeginCombatForcedLock()
+    if self._combatForcedLock then
+        return false
+    end
+
+    local snapshot = {
+        containers = {},
+        groups = {},
+        hadUnlocked = false,
+    }
+
+    for containerId, container in pairs(self.db.profile.groupContainers or {}) do
+        if container
+            and container.locked == false
+            and self:IsContainerVisibleToCurrentChar(containerId)
+        then
+            snapshot.containers[containerId] = true
+            snapshot.hadUnlocked = true
+        end
+    end
+
+    for groupId, group in pairs(self.db.profile.groups or {}) do
+        if group
+            and group.locked == false
+            and self:IsGroupVisibleToCurrentChar(groupId)
+        then
+            snapshot.groups[groupId] = true
+            snapshot.hadUnlocked = true
+        end
+    end
+
+    self._combatForcedLock = true
+    self._combatForcedLockSnapshot = snapshot
+
+    for _, frame in pairs(self.groupFrames or {}) do
+        if frame.dragHandle then
+            frame.dragHandle:Hide()
+        end
+        if frame.coordLabel then
+            frame.coordLabel:Hide()
+        end
+        if frame.nudger then
+            frame.nudger:Hide()
+        end
+        for _, button in ipairs(frame.buttons or {}) do
+            local host = button and button.auraTextureHost or nil
+            if host then
+                host._dragEnabled = false
+                if host.dragHandle then
+                    host.dragHandle:Hide()
+                end
+                if host.coordLabel then
+                    host.coordLabel:Hide()
+                end
+                if host.nudger then
+                    host.nudger:Hide()
+                end
+                if host.auraTextureOutlineFill then
+                    host.auraTextureOutlineFill:Hide()
+                end
+                for _, edge in ipairs(host.auraTextureOutlineEdges or {}) do
+                    edge:Hide()
+                end
+            end
+        end
+    end
+
+    if self.containerFrames then
+        for containerId in pairs(self.containerFrames) do
+            self:UpdateContainerDragHandle(containerId, true)
+        end
+    end
+
+    self:RefreshAllGroups()
+    return snapshot.hadUnlocked
+end
+
+function CooldownCompanion:EndCombatForcedLock()
+    if not self._combatForcedLock then
+        return nil
+    end
+
+    local snapshot = self._combatForcedLockSnapshot
+    self._combatForcedLock = nil
+    self._combatForcedLockSnapshot = nil
+    return snapshot
 end
 
 function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
@@ -1451,7 +1543,8 @@ end
 function CooldownCompanion:UpdateContainerDragHandle(containerId, locked)
     local cFrame = self.containerFrames and self.containerFrames[containerId]
     if cFrame and cFrame.dragHandle then
-        if locked then
+        local effectiveLocked = locked or self._combatForcedLock
+        if effectiveLocked then
             if self.ClearContainerUnlockState then
                 self:ClearContainerUnlockState(containerId)
             end
@@ -1505,7 +1598,7 @@ function CooldownCompanion:UnlockAllFrames()
         if frame then
             self:UpdateGroupClickthrough(groupId)
             local group = self.db.profile.groups[groupId]
-            local panelUnlocked = group and group.locked == false
+            local panelUnlocked = group and group.locked == false and not self._combatForcedLock
             if frame.dragHandle then
                 if panelUnlocked then
                     frame.dragHandle:Show()

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -124,6 +124,84 @@ function CooldownCompanion:GetParentContainer(groupOrGroupId)
     return containers and containers[group.parentContainerId]
 end
 
+function CooldownCompanion:IsContainerUnlockPreviewActive(containerOrContainerId)
+    local container = containerOrContainerId
+    local containerId = nil
+
+    if type(containerOrContainerId) == "number" then
+        containerId = containerOrContainerId
+        container = self.db.profile.groupContainers and self.db.profile.groupContainers[containerId]
+    elseif type(containerOrContainerId) == "table" then
+        for id, candidate in pairs(self.db.profile.groupContainers or {}) do
+            if candidate == containerOrContainerId then
+                containerId = id
+                break
+            end
+        end
+    end
+
+    if not container then
+        return false
+    end
+    if container.locked ~= false then
+        return false
+    end
+    if containerId and not self:IsContainerVisibleToCurrentChar(containerId) then
+        return false
+    end
+
+    return true
+end
+
+function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
+    opts = opts or {}
+
+    local group = opts.group or self.db.profile.groups[groupId]
+    if not (group and group.parentContainerId) then
+        return false
+    end
+
+    local container = opts.container or self:GetParentContainer(group)
+    if not self:IsContainerUnlockPreviewActive(container) then
+        return false
+    end
+
+    if not (group.buttons and #group.buttons > 0) then
+        return false
+    end
+
+    local checkCharVisibility = opts.checkCharVisibility
+    if checkCharVisibility == nil then
+        checkCharVisibility = true
+    end
+    if checkCharVisibility and groupId and not self:IsGroupVisibleToCurrentChar(groupId) then
+        return false
+    end
+
+    local effectiveSpecs = self:GetEffectiveSpecs(group)
+    if effectiveSpecs and next(effectiveSpecs) then
+        if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
+            return false
+        end
+    end
+
+    return true
+end
+
+function CooldownCompanion:GetContainerUnlockPreviewPanels(containerId)
+    local previewPanels = {}
+    local panels = self:GetPanels(containerId)
+    for _, panelInfo in ipairs(panels) do
+        if self:IsGroupVisibleInUnlockPreview(panelInfo.groupId, {
+            group = panelInfo.group,
+            checkCharVisibility = true,
+        }) then
+            previewPanels[#previewPanels + 1] = panelInfo
+        end
+    end
+    return previewPanels
+end
+
 function CooldownCompanion:GetEffectiveSpecs(group)
     if not group then return nil, false end
 
@@ -480,6 +558,13 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
 
     -- If this panel has a parent container, check container-level state first
     local container = self:GetParentContainer(group)
+    if container and self:IsContainerUnlockPreviewActive(container) then
+        return self:IsGroupVisibleInUnlockPreview(groupId, {
+            group = group,
+            container = container,
+            checkCharVisibility = opts.checkCharVisibility,
+        })
+    end
     if container then
         if container.enabled == false then return false end
         if group.enabled == false then return false end
@@ -1075,6 +1160,9 @@ function CooldownCompanion:RefreshAllGroups()
     end
 
     self:FinalizeContainerAnchorsToScreenOffsets()
+    if self.RefreshAllContainerWrappers then
+        self:RefreshAllContainerWrappers()
+    end
 end
 
 -- Refresh only frame-level visibility/load-state without rebuilding buttons.
@@ -1175,6 +1263,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     end
 
     self:FinalizeContainerAnchorsToScreenOffsets()
+    if self.RefreshAllContainerWrappers then
+        self:RefreshAllContainerWrappers()
+    end
 end
 
 -- Fully unload a group: save/clear button OnUpdate scripts, remove from
@@ -1360,7 +1451,24 @@ end
 function CooldownCompanion:UpdateContainerDragHandle(containerId, locked)
     local cFrame = self.containerFrames and self.containerFrames[containerId]
     if cFrame and cFrame.dragHandle then
-        cFrame.dragHandle:SetShown(not locked)
+        if locked then
+            cFrame.dragHandle:Hide()
+            if cFrame.coordLabel then
+                cFrame.coordLabel:Hide()
+            end
+            if cFrame.nudger then
+                cFrame.nudger:Hide()
+            end
+            if cFrame._containerPanelLabels then
+                for _, label in pairs(cFrame._containerPanelLabels) do
+                    label:Hide()
+                end
+            end
+        elseif self.RefreshContainerWrapper then
+            self:RefreshContainerWrapper(containerId)
+        else
+            cFrame.dragHandle:Show()
+        end
     end
 end
 
@@ -1385,6 +1493,7 @@ function CooldownCompanion:LockAllFrames()
             self:UpdateContainerDragHandle(containerId, true)
         end
     end
+    self:RefreshAllGroups()
 end
 
 function CooldownCompanion:UnlockAllFrames()
@@ -1411,6 +1520,7 @@ function CooldownCompanion:UnlockAllFrames()
             self:UpdateContainerDragHandle(containerId, not container or container.locked)
         end
     end
+    self:RefreshAllGroups()
 end
 
 -- TALENT NODE CACHE (for per-button talent conditions)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1452,6 +1452,9 @@ function CooldownCompanion:UpdateContainerDragHandle(containerId, locked)
     local cFrame = self.containerFrames and self.containerFrames[containerId]
     if cFrame and cFrame.dragHandle then
         if locked then
+            if self.ClearContainerUnlockState then
+                self:ClearContainerUnlockState(containerId)
+            end
             cFrame.dragHandle:Hide()
             if cFrame.coordLabel then
                 cFrame.coordLabel:Hide()

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -275,7 +275,6 @@ function CooldownCompanion:BeginCombatForcedLock()
         ForceCombatMouseLock(frame.nudger)
         for _, button in ipairs(frame.buttons or {}) do
             local host = button and button.auraTextureHost or nil
-            ForceCombatMouseLock(button)
             if host then
                 if host._isDragging then
                     host._dragCancelPending = true

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -191,7 +191,22 @@ function CooldownCompanion:BeginCombatForcedLock()
     self._combatForcedLock = true
     self._combatForcedLockSnapshot = snapshot
 
-    for _, frame in pairs(self.groupFrames or {}) do
+    for groupId, frame in pairs(self.groupFrames or {}) do
+        local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId]
+        local active = group and self:IsGroupActive(groupId, {
+            group = group,
+            checkCharVisibility = true,
+            checkLoadConditions = true,
+            requireButtons = true,
+        }) or false
+
+        if frame._dragInProgress then
+            frame._dragCancelPending = true
+            if not frame:IsProtected() then
+                frame:StopMovingOrSizing()
+            end
+            frame._dragInProgress = nil
+        end
         if frame.dragHandle then
             frame.dragHandle:Hide()
         end
@@ -204,6 +219,13 @@ function CooldownCompanion:BeginCombatForcedLock()
         for _, button in ipairs(frame.buttons or {}) do
             local host = button and button.auraTextureHost or nil
             if host then
+                if host._isDragging then
+                    host._dragCancelPending = true
+                    if not host:IsProtected() then
+                        host:StopMovingOrSizing()
+                    end
+                    host._isDragging = nil
+                end
                 host._dragEnabled = false
                 if host.dragHandle then
                     host.dragHandle:Hide()
@@ -221,11 +243,30 @@ function CooldownCompanion:BeginCombatForcedLock()
                     edge:Hide()
                 end
             end
+            if not active and self.HideAuraTextureVisual then
+                self:HideAuraTextureVisual(button)
+            end
+        end
+
+        if active then
+            local alphaState = self.alphaState and self.alphaState[groupId]
+            frame:SetAlpha(alphaState and alphaState.currentAlpha or (group and group.baselineAlpha) or 1)
+        elseif frame:IsProtected() then
+            frame:SetAlpha(0)
+        else
+            frame:Hide()
         end
     end
 
     if self.containerFrames then
-        for containerId in pairs(self.containerFrames) do
+        for containerId, frame in pairs(self.containerFrames) do
+            if frame._dragInProgress then
+                frame._dragCancelPending = true
+                if not frame:IsProtected() then
+                    frame:StopMovingOrSizing()
+                end
+                frame._dragInProgress = nil
+            end
             self:UpdateContainerDragHandle(containerId, true)
         end
     end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -230,7 +230,6 @@ function CooldownCompanion:BeginCombatForcedLock()
         end
     end
 
-    self:RefreshAllGroups()
     return snapshot.hadUnlocked
 end
 
@@ -259,6 +258,14 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
     end
 
     if not (group.buttons and #group.buttons > 0) then
+        return false
+    end
+
+    local groupFrame = opts.groupFrame
+    if groupFrame == nil and groupId then
+        groupFrame = self.groupFrames and self.groupFrames[groupId] or nil
+    end
+    if groupFrame and (not groupFrame.buttons or #groupFrame.buttons == 0) then
         return false
     end
 

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -157,6 +157,23 @@ function CooldownCompanion:IsContainerUnlockPreviewActive(containerOrContainerId
     return true
 end
 
+local function ForceCombatMouseLock(frame)
+    if not frame then
+        return
+    end
+
+    local canChangeProtectedState = not frame.CanChangeProtectedState or frame:CanChangeProtectedState()
+    if frame.EnableMouse and canChangeProtectedState then
+        frame:EnableMouse(false)
+    end
+    if frame.SetMouseClickEnabled and canChangeProtectedState then
+        frame:SetMouseClickEnabled(false)
+    end
+    if frame.SetMouseMotionEnabled and canChangeProtectedState then
+        frame:SetMouseMotionEnabled(false)
+    end
+end
+
 function CooldownCompanion:BeginCombatForcedLock()
     if self._combatForcedLock then
         return false
@@ -216,8 +233,12 @@ function CooldownCompanion:BeginCombatForcedLock()
         if frame.nudger then
             frame.nudger:Hide()
         end
+        ForceCombatMouseLock(frame)
+        ForceCombatMouseLock(frame.dragHandle)
+        ForceCombatMouseLock(frame.nudger)
         for _, button in ipairs(frame.buttons or {}) do
             local host = button and button.auraTextureHost or nil
+            ForceCombatMouseLock(button)
             if host then
                 if host._isDragging then
                     host._dragCancelPending = true
@@ -250,7 +271,11 @@ function CooldownCompanion:BeginCombatForcedLock()
 
         if active then
             local alphaState = self.alphaState and self.alphaState[groupId]
-            frame:SetAlpha(alphaState and alphaState.currentAlpha or (group and group.baselineAlpha) or 1)
+            local frameAlpha = (group and group.baselineAlpha) or 1
+            if alphaState and alphaState.currentAlpha ~= nil then
+                frameAlpha = alphaState.currentAlpha
+            end
+            frame:SetAlpha(frameAlpha)
         elseif frame:IsProtected() then
             frame:SetAlpha(0)
         else

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -408,6 +408,7 @@ end
 
 
 function CooldownCompanion:OnCombatStart()
+    self:BeginCombatForcedLock()
     self:UpdateAllCooldowns()
     -- Close spellbook during combat to avoid Blizzard secret value errors
     if PlayerSpellsFrame and PlayerSpellsFrame:IsShown() then
@@ -426,6 +427,7 @@ function CooldownCompanion:OnCombatStart()
 end
 
 function CooldownCompanion:OnCombatEnd()
+    local combatLockSnapshot = self:EndCombatForcedLock()
     self:UpdateAllCooldowns()
     self:ApplyCdmAlpha()
     if self._pendingUnsupportedLegacyHide or self._unsupportedLegacyProfile then
@@ -441,7 +443,19 @@ function CooldownCompanion:OnCombatEnd()
         self:RefreshAllGroups()
     elseif self._pendingVisibilityRefresh then
         self._pendingVisibilityRefresh = nil
-        self:RefreshAllGroupsVisibilityOnly()
+        if combatLockSnapshot and combatLockSnapshot.hadUnlocked then
+            self:RefreshAllGroups()
+        else
+            self:RefreshAllGroupsVisibilityOnly()
+        end
+    elseif combatLockSnapshot and combatLockSnapshot.hadUnlocked then
+        self:RefreshAllGroups()
+    end
+    if combatLockSnapshot and combatLockSnapshot.hadUnlocked and self.containerFrames then
+        for containerId in pairs(self.containerFrames) do
+            local container = self.db.profile.groupContainers and self.db.profile.groupContainers[containerId]
+            self:UpdateContainerDragHandle(containerId, not container or container.locked)
+        end
     end
     -- Reopen config panel if it was open before combat
     if self._configWasOpen then


### PR DESCRIPTION
## What Players Will Notice
- Unlocked groups now show a clear visible wrapper around the panels they contain instead of a tiny shared handle.
- You can hover panels inside an unlocked group to highlight them, then select and drag individual panels into place without locking the whole group first.
- Grouped texture and trigger panels now follow the same unlocked editing flow, including live dragging, nudging, and wrapper tracking.
- Group headers are larger and clearer, and idle panel labels stay out of the way until you hover or select something.
- Entering combat temporarily hides the unlock editing UI and restores the previous unlocked state afterward instead of leaving edit chrome active during combat.

## Why This Changed
- The old unlocked group handle did not make it obvious which panels belonged to the group or what would move together.
- Editing grouped layouts was harder than it needed to be because individual panels inside a group could not be selected and repositioned directly.
- Grouped texture and trigger panels had several drag, sync, and combat cleanup edge cases that made the new wrapper flow unreliable until they were handled explicitly.

## What Changed
- Replaced the old tiny unlocked group handle with a full wrapper frame that shows group bounds, supports wrapper dragging, and provides clearer group headers.
- Added panel hover and selection inside unlocked groups so normal grouped panels can reuse their existing header, coordinate, and nudger controls when selected.
- Integrated grouped texture and trigger panels into the same unlock-preview model, including grouped preview geometry, live coordinate display, save paths, and hidden-member sync when containers move.
- Added unlock-preview visibility rules that force grouped panels visible for editing while still respecting current character and current spec filtering.
- Added temporary combat forced-lock handling so unlock chrome is suppressed during combat and the prior unlocked state is restored afterward.
- Tightened follow-up behavior around config slider moves, grouped standalone save/sync logic, wrapper refresh timing, and combat-safe wrapper suppression.

## Validation
- `luac -p` passed on the edited Lua files.
- Multiple in-game editing checks passed during development, including panel hover/selection, grouped texture dragging, grouped texture coordinate stability, first-hover overlay behavior, geometry-effect dragging, and wrapper tracking during standalone header drags.
- Full end-to-end combat verification should be re-run after the latest combat-lock follow-up changes.
- Restricted-content verification (instances, arenas, battlegrounds) has not been completed yet.
