### PR TITLE
Separate real cooldowns from GCD-only display state

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -840,11 +840,6 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     -- Invalidate cached state
     button._desaturated = nil
     button._desatCooldownActive = nil
-    button._cooldownApiState = nil
-    button._cooldownState = nil
-    button._cooldownPresentationState = nil
-    button._cooldownPresentationDurationObj = nil
-    button._chargeState = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -841,6 +841,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     -- Invalidate cached state
     button._desaturated = nil
     button._desatCooldownActive = nil
+    button._cooldownState = nil
+    button._chargeState = nil
+    button._baseOverrideCooldownDurationObj = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -845,8 +845,6 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._cooldownPresentationState = nil
     button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
-    button._baseOverrideCooldownDurationObj = nil
-    button._baseOverrideCooldownLastRealAt = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -273,6 +273,7 @@ local function UpdateBarDisplay(button)
     -- _durationObj may also hold aura/totem timing and must not imply cooldown.
     local isChargeButton = UsesChargeBehavior(button.buttonData)
     local chargeState = button._chargeState
+    local auraTimerActive = button._auraActive and (button._durationObj or button._viewerBar)
     local onCooldown
     if isChargeButton then
         onCooldown = chargeState == CHARGE_STATE_MISSING
@@ -282,7 +283,7 @@ local function UpdateBarDisplay(button)
     end
 
     -- Time text color: switch between cooldown and ready colors
-    local wantReadyTextColor = not onCooldown and style.showBarReadyText
+    local wantReadyTextColor = not onCooldown and not auraTimerActive and style.showBarReadyText
     if button._barReadyTextColor ~= wantReadyTextColor then
         button._barReadyTextColor = wantReadyTextColor
         if wantReadyTextColor then

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -5,6 +5,10 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
 local GetTime = GetTime
@@ -265,21 +269,16 @@ end
 local function UpdateBarDisplay(button)
     local style = button.style
 
-    -- Determine onCooldown via nil-checks (secret-safe).
-    -- _durationObj is non-nil only when UpdateButtonCooldown found an active CD/aura.
-    -- _viewerBar is non-nil when a totem/guardian viewer bar is active.
+    -- "On cooldown" for bar color/ready text follows canonical state.
+    -- _durationObj may also hold aura/totem timing and must not imply cooldown.
+    local isChargeButton = UsesChargeBehavior(button.buttonData)
+    local chargeState = button._chargeState
     local onCooldown
-    if button._cooldownDeferred then
-        onCooldown = true
-    elseif button._durationObj then
-        onCooldown = not button._barGCDSuppressed
-    elseif button._viewerBar and button._auraActive then
-        onCooldown = not button._barGCDSuppressed
-    elseif button.buttonData.type == "item" then
-        onCooldown = button._itemCdDuration and button._itemCdDuration > 0
-        if onCooldown and button._barGCDSuppressed then
-            onCooldown = false
-        end
+    if isChargeButton then
+        onCooldown = chargeState == CHARGE_STATE_MISSING
+            or chargeState == CHARGE_STATE_ZERO
+    else
+        onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     end
 
     -- Time text color: switch between cooldown and ready colors
@@ -299,7 +298,7 @@ local function UpdateBarDisplay(button)
     -- Aura-tracked buttons always use the base bar color (aura color override handles active state).
     local wantCdColor
     if onCooldown and not button.buttonData.isPassive then
-        if UsesChargeBehavior(button.buttonData) and not button._zeroChargesConfirmed then
+        if isChargeButton and chargeState == CHARGE_STATE_MISSING then
             wantCdColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
         else
             wantCdColor = style.barCooldownColor
@@ -345,7 +344,7 @@ local function UpdateBarDisplay(button)
             button._barCdColor = nil
             local resetColor
             if onCooldown then
-                if UsesChargeBehavior(button.buttonData) and not button._zeroChargesConfirmed then
+                if isChargeButton and chargeState == CHARGE_STATE_MISSING then
                     resetColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
                 else
                     resetColor = style.barCooldownColor

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -840,9 +840,13 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     -- Invalidate cached state
     button._desaturated = nil
     button._desatCooldownActive = nil
+    button._cooldownApiState = nil
     button._cooldownState = nil
+    button._cooldownPresentationState = nil
+    button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
     button._baseOverrideCooldownDurationObj = nil
+    button._baseOverrideCooldownLastRealAt = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -206,10 +206,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
                 result.realCooldownShown = slotProbe.realShown == true
                 result.durationObj = slotProbe.durationObj
                 result.realDurationObj = slotProbe.realDurationObj
-                if slotProbe.shown and slotProbe.sawUnknown then
-                    result.state = COOLDOWN_STATE_COOLDOWN
-                    result.renderDurationObj = slotProbe.realDurationObj or slotProbe.durationObj
-                elseif result.realCooldownShown and slotProbe.realDurationObj then
+                result.slotProbe = slotProbe
+                if result.realCooldownShown and slotProbe.realDurationObj then
                     result.state = COOLDOWN_STATE_COOLDOWN
                     result.renderDurationObj = slotProbe.realDurationObj
                 elseif slotProbe.shown and slotProbe.durationObj then
@@ -217,10 +215,6 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
                     result.renderDurationObj = slotProbe.durationObj
                     result.isOnGCD = true
                 end
-            elseif slotProbe.sawAnySlot and slotProbe.sawUnknown then
-                result.fetchOk = true
-                result.state = COOLDOWN_STATE_COOLDOWN
-                result.deferred = true
             end
         end
         return result
@@ -320,10 +314,23 @@ end
 -- Probe action-slot cooldown state for a spell ID pair (base + display override).
 local actionSlotSeenScratch = {}
 
+local function MergeActionSlotProbe(result, probe)
+    if probe.sawAnySlot then result.sawAnySlot = true end
+    if probe.sawUnknown then result.sawUnknown = true end
+    if probe.shown then
+        result.shown = true
+        result.durationObj = probe.durationObj
+        result.realShown = probe.realShown
+        result.realDurationObj = probe.realDurationObj
+        return true
+    end
+    return false
+end
+
 local function ProbeActionSlotsForSpellID(spellID)
     local result = {
         shown = false,
-        realShown = false,
+        realShown = nil,
         sawAnySlot = false,
         sawUnknown = false,
     }
@@ -341,18 +348,14 @@ local function ProbeActionSlotsForSpellID(spellID)
             local durationObj = C_ActionBar.GetActionCooldownDuration(slot)
             local realDurationObj = C_ActionBar.GetActionCooldownDuration(slot, true)
             local shown = false
-            local realShown = false
+            local realShown
 
             if durationObj then
                 shown = DurationObjectShowsCooldown(durationObj)
-            else
-                result.sawUnknown = true
             end
 
             if realDurationObj then
                 realShown = DurationObjectShowsCooldown(realDurationObj)
-            else
-                result.sawUnknown = true
             end
 
             if shown then
@@ -380,25 +383,12 @@ function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
 
     wipe(actionSlotSeenScratch)
 
-    local function mergeProbe(probe)
-        if probe.sawAnySlot then result.sawAnySlot = true end
-        if probe.sawUnknown then result.sawUnknown = true end
-        if probe.shown then
-            result.shown = true
-            result.durationObj = probe.durationObj
-            result.realShown = probe.realShown
-            result.realDurationObj = probe.realDurationObj
-            return true
-        end
-        return false
-    end
-
-    if mergeProbe(ProbeActionSlotsForSpellID(baseSpellID)) then
+    if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(baseSpellID)) then
         return result
     end
 
     if displaySpellID and displaySpellID ~= baseSpellID then
-        if mergeProbe(ProbeActionSlotsForSpellID(displaySpellID)) then
+        if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(displaySpellID)) then
             return result
         end
     end
@@ -1286,9 +1276,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and duration > 0).  It can report true during per-cast lockouts
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
-            local slotProbe = ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+            local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
+                or ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
             if slotProbe.shown ~= nil then
-                button._mainCDShown = slotProbe.sawUnknown or slotProbe.realShown == true
+                button._mainCDShown = slotProbe.realShown == true
             elseif not auraOverrideActive then
                 -- No action bar slot found; use the ignoreGCD-backed real cooldown state.
                 if spellCooldownResult and spellCooldownResult.fetchOk then

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -115,6 +115,10 @@ local function PlainNumber(value)
     return tonumber(value)
 end
 
+local EXECUTE_TRACE_BASE_SPELL_ID = 163201
+local EXECUTE_TRACE_OVERRIDE_SPELL_ID = 280735
+local EXECUTE_TRACE_MAX_ENTRIES = 800
+
 local BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS = {
     -- Opt-in only. Execute needs gameplay cooldown continuity when its
     -- base/override cooldown APIs briefly expose only GCD data even though the
@@ -127,6 +131,159 @@ local BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS = {
 }
 
 local EXECUTE_BRIDGE_CONTINUITY_SECONDS = 0.20
+
+local function SecretSafeValue(value)
+    if value == nil then
+        return nil
+    end
+    if issecretvalue(value) then
+        return "<secret>"
+    end
+    return value
+end
+
+local function SerializeCooldownInfo(info)
+    if not info then
+        return { present = false }
+    end
+
+    return {
+        present = true,
+        isActive = info.isActive,
+        isEnabled = info.isEnabled,
+        isOnGCD = info.isOnGCD,
+        startTime = SecretSafeValue(info.startTime),
+        startTimeSecret = info.startTime ~= nil and issecretvalue(info.startTime) or false,
+        duration = SecretSafeValue(info.duration),
+        durationSecret = info.duration ~= nil and issecretvalue(info.duration) or false,
+        modRate = SecretSafeValue(info.modRate),
+        modRateSecret = info.modRate ~= nil and issecretvalue(info.modRate) or false,
+        recovery = SecretSafeValue(info.timeUntilEndOfStartRecovery),
+        recoverySecret = info.timeUntilEndOfStartRecovery ~= nil
+            and issecretvalue(info.timeUntilEndOfStartRecovery) or false,
+    }
+end
+
+local function SerializeDurationObject(durationObj)
+    if not durationObj then
+        return { present = false }
+    end
+
+    local remaining = durationObj:GetRemainingDuration()
+    local elapsedPercent = durationObj:GetElapsedPercent()
+    local remainingPercent = durationObj:GetRemainingPercent()
+    return {
+        present = true,
+        shown = DurationObjectShowsCooldown(durationObj),
+        hasSecretValues = durationObj:HasSecretValues(),
+        remaining = SecretSafeValue(remaining),
+        remainingSecret = remaining ~= nil and issecretvalue(remaining) or false,
+        elapsedPercent = SecretSafeValue(elapsedPercent),
+        elapsedPercentSecret = elapsedPercent ~= nil and issecretvalue(elapsedPercent) or false,
+        remainingPercent = SecretSafeValue(remainingPercent),
+        remainingPercentSecret = remainingPercent ~= nil and issecretvalue(remainingPercent) or false,
+    }
+end
+
+local function SerializeCooldownLane(result)
+    if not result then
+        return nil
+    end
+
+    return {
+        spellID = result.spellID,
+        fetchOk = result.fetchOk,
+        state = result.state,
+        apiState = result.apiState,
+        presentationState = result.presentationState,
+        isOnGCD = result.isOnGCD,
+        deferred = result.deferred,
+        realCooldownShown = result.realCooldownShown,
+        normalCooldownShown = result.normalCooldownShown,
+        info = SerializeCooldownInfo(result.info),
+        durationObj = SerializeDurationObject(result.durationObj),
+        realDurationObj = SerializeDurationObject(result.realDurationObj),
+        renderDurationObj = SerializeDurationObject(result.renderDurationObj),
+        presentationDurationObj = SerializeDurationObject(result.presentationDurationObj),
+    }
+end
+
+local function ShouldTraceExecute(buttonData, cooldownSpellId)
+    local configured = PlainNumber(buttonData and buttonData.id)
+    local display = PlainNumber(cooldownSpellId)
+    return configured == EXECUTE_TRACE_BASE_SPELL_ID
+        or configured == EXECUTE_TRACE_OVERRIDE_SPELL_ID
+        or display == EXECUTE_TRACE_BASE_SPELL_ID
+        or display == EXECUTE_TRACE_OVERRIDE_SPELL_ID
+end
+
+local function GetCooldownStateTrace()
+    if type(CooldownCompanionDB) ~= "table" then
+        return nil
+    end
+
+    CooldownCompanionDB.global = CooldownCompanionDB.global or {}
+    local trace = CooldownCompanionDB.global.cooldownStateTrace
+    if type(trace) ~= "table" then
+        trace = {}
+        CooldownCompanionDB.global.cooldownStateTrace = trace
+    end
+    if trace.version ~= 3 or trace.subject ~= "execute-frame-trace" then
+        wipe(trace)
+        trace.version = 3
+        trace.subject = "execute-frame-trace"
+    end
+
+    trace.enabled = true
+    trace.maxEntries = trace.maxEntries or EXECUTE_TRACE_MAX_ENTRIES
+    if trace.maxEntries < 100 then
+        trace.maxEntries = 100
+    elseif trace.maxEntries > 1200 then
+        trace.maxEntries = 1200
+    end
+    trace.entries = trace.entries or {}
+    trace.trackedSpells = trace.trackedSpells or {
+        [EXECUTE_TRACE_BASE_SPELL_ID] = "Execute",
+        [EXECUTE_TRACE_OVERRIDE_SPELL_ID] = "Execute override",
+    }
+    trace.startedAt = trace.startedAt or GetTime()
+    trace.nextIndex = trace.nextIndex or 1
+    trace.count = trace.count or 0
+    trace.sequence = trace.sequence or 0
+    return trace
+end
+
+local function AppendCooldownStateTrace(row)
+    local trace = GetCooldownStateTrace()
+    if not trace then
+        return
+    end
+
+    trace.sequence = trace.sequence + 1
+    row.seq = trace.sequence
+    local index = trace.nextIndex
+    trace.entries[index] = row
+    trace.latestIndex = index
+    trace.nextIndex = index + 1
+    if trace.nextIndex > trace.maxEntries then
+        trace.nextIndex = 1
+    end
+    if trace.count < trace.maxEntries then
+        trace.count = trace.count + 1
+    end
+end
+
+local function SerializeSpellUsability(spellID)
+    if not spellID then
+        return nil
+    end
+    local usable, insufficientPower = C_Spell_IsSpellUsable(spellID)
+    return {
+        spellID = spellID,
+        isUsable = usable,
+        insufficientPower = insufficientPower,
+    }
+end
 
 local function GetConfiguredAuraUnit(buttonData)
     return buttonData.auraUnit or "player"
@@ -228,6 +385,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
     if info.isActive then
         result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
         result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
+        result.normalCooldownShown = DurationObjectShowsCooldown(result.durationObj)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
@@ -237,8 +395,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
         result.state = COOLDOWN_STATE_COOLDOWN
         result.renderDurationObj = result.realDurationObj
     elseif CooldownLogic.IsSpellGCDOnly(info, {
-        secrecy = secrecy,
-        gcdInfo = CooldownCompanion._gcdInfo,
+        normalCooldownShown = result.normalCooldownShown,
         realCooldownShown = result.realCooldownShown,
     }) then
         result.state = COOLDOWN_STATE_GCD
@@ -274,12 +431,17 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
     local result = displayResult
     local bridgeEligible = false
+    local traceLanes = {
+        display = displayResult,
+    }
 
     if cooldownSpellId and cooldownSpellId ~= buttonData.id then
         local displayBaseSpellID = C_Spell.GetBaseSpell(cooldownSpellId)
         if displayBaseSpellID == buttonData.id then
             bridgeEligible = ShouldApplyBaseOverrideCooldownBridge(buttonData.id, cooldownSpellId)
             local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
+            traceLanes.displayBaseSpellID = displayBaseSpellID
+            traceLanes.base = baseResult
             result = SelectSpellCooldownResult(
                 result,
                 baseResult
@@ -290,7 +452,8 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
         end
     end
 
-    return result, bridgeEligible
+    traceLanes.finalBeforeBridge = result
+    return result, bridgeEligible, traceLanes
 end
 
 local function CloneCooldownResult(result)
@@ -304,9 +467,21 @@ local function CloneCooldownResult(result)
 end
 
 local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, configuredSpellID, displaySpellID)
+    button._baseOverrideBridgeTrace = {
+        eligible = bridgeEligible == true,
+        configuredSpellID = configuredSpellID,
+        displaySpellID = displaySpellID,
+        preState = result and result.state or nil,
+        preApiState = result and result.apiState or nil,
+        applied = false,
+        cleared = false,
+    }
+
     if not bridgeEligible then
         button._baseOverrideCooldownDurationObj = nil
         button._baseOverrideCooldownLastRealAt = nil
+        button._baseOverrideBridgeTrace.cleared = true
+        button._baseOverrideBridgeTrace.reason = "not-eligible"
         return result
     end
 
@@ -319,6 +494,8 @@ local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, c
         result.apiState = result.apiState or result.state
         result.presentationState = COOLDOWN_STATE_COOLDOWN
         result.presentationDurationObj = result.renderDurationObj
+        button._baseOverrideBridgeTrace.storedDirectReal = true
+        button._baseOverrideBridgeTrace.reason = "direct-real"
         return result
     end
 
@@ -328,6 +505,9 @@ local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, c
         and (GetTime() - button._baseOverrideCooldownLastRealAt) or nil
     local bridgeWindowActive = previousRealAge ~= nil
         and previousRealAge <= EXECUTE_BRIDGE_CONTINUITY_SECONDS
+    button._baseOverrideBridgeTrace.previousRealDurationShown = previousRealDurationShown
+    button._baseOverrideBridgeTrace.previousRealAge = previousRealAge
+    button._baseOverrideBridgeTrace.bridgeWindowActive = bridgeWindowActive
     if result
             and result.state == COOLDOWN_STATE_GCD
             and previousRealDurationObj
@@ -339,11 +519,23 @@ local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, c
         bridged.renderDurationObj = previousRealDurationObj
         bridged.presentationState = COOLDOWN_STATE_COOLDOWN
         bridged.presentationDurationObj = previousRealDurationObj
+        button._baseOverrideBridgeTrace.applied = true
+        button._baseOverrideBridgeTrace.reason = "bridged-gcd"
         return bridged
     end
 
     button._baseOverrideCooldownDurationObj = nil
     button._baseOverrideCooldownLastRealAt = nil
+    button._baseOverrideBridgeTrace.cleared = true
+    if not previousRealDurationObj then
+        button._baseOverrideBridgeTrace.reason = "no-previous-real"
+    elseif not previousRealDurationShown then
+        button._baseOverrideBridgeTrace.reason = "previous-real-not-shown"
+    elseif not bridgeWindowActive then
+        button._baseOverrideBridgeTrace.reason = "bridge-window-expired"
+    else
+        button._baseOverrideBridgeTrace.reason = "state-not-gcd"
+    end
     return result
 end
 
@@ -460,6 +652,82 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
     return nil, nil
 end
 
+local function TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace, fetchOk,
+        isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive, earlyReturnReason)
+    if not ShouldTraceExecute(buttonData, cooldownSpellId) then
+        return
+    end
+
+    local actionShown, actionDurationObj, actionRealShown, actionRealDurationObj =
+        ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+    local displayBaseSpellID = cooldownSpellId and C_Spell.GetBaseSpell(cooldownSpellId) or nil
+    local overrideSpellID = buttonData.id and C_Spell.GetOverrideSpell(buttonData.id) or nil
+    local gcdInfo = CooldownCompanion._gcdInfo
+    local vertexR, vertexG, vertexB, vertexA
+    if button.icon then
+        vertexR, vertexG, vertexB, vertexA = button.icon:GetVertexColor()
+    end
+
+    AppendCooldownStateTrace({
+        t = GetTime(),
+        groupId = button._groupId,
+        index = button.index,
+        name = buttonData.name,
+        type = buttonData.type,
+        id = buttonData.id,
+        displaySpellID = cooldownSpellId,
+        displayBaseSpellID = displayBaseSpellID,
+        overrideSpellID = overrideSpellID,
+        fetchOk = fetchOk == true,
+        isOnGCD = isOnGCD == true,
+        isGCDOnly = isGCDOnly == true,
+        auraOverrideActive = auraOverrideActive == true,
+        procOverlayActive = procOverlayActive == true,
+        cooldownsDirty = CooldownCompanion._cooldownsDirty == true,
+        cooldownState = button._cooldownState,
+        cooldownApiState = button._cooldownApiState,
+        cooldownPresentationState = button._cooldownPresentationState,
+        durationObj = SerializeDurationObject(button._durationObj),
+        presentationDurationObj = SerializeDurationObject(button._cooldownPresentationDurationObj),
+        cooldownShown = button.cooldown and button.cooldown:IsShown() or false,
+        desatCooldownActive = button._desatCooldownActive == true,
+        iconDesaturated = button._desaturated == true,
+        unusableTint = button._unusableTintActive == true,
+        visibilityHidden = button._visibilityHidden == true,
+        visibilityAlphaOverride = button._visibilityAlphaOverride,
+        earlyReturnReason = earlyReturnReason,
+        bridge = button._baseOverrideBridgeTrace,
+        lanes = {
+            display = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.display),
+            base = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.base),
+            finalBeforeBridge = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.finalBeforeBridge),
+            final = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.final),
+        },
+        actionSlot = {
+            shown = actionShown,
+            durationObj = SerializeDurationObject(actionDurationObj),
+            realShown = actionRealShown,
+            realDurationObj = SerializeDurationObject(actionRealDurationObj),
+        },
+        gcd = {
+            active = CooldownCompanion._gcdActive == true,
+            info = SerializeCooldownInfo(gcdInfo),
+            durationObj = SerializeDurationObject(CooldownCompanion._gcdDurationObj),
+        },
+        usability = {
+            configured = SerializeSpellUsability(buttonData.id),
+            display = SerializeSpellUsability(cooldownSpellId),
+            override = SerializeSpellUsability(overrideSpellID),
+        },
+        vertex = {
+            r = vertexR,
+            g = vertexG,
+            b = vertexB,
+            a = vertexA,
+        },
+    })
+end
+
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
@@ -550,6 +818,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local spellCooldownDuration
     local spellRealCooldownShown = false
     local spellCooldownResult
+    local spellCooldownTrace
     local spellBaseOverrideBridgeEligible = false
     local actionSlotCooldownShown
     local actionSlotDurationObj
@@ -558,6 +827,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Aura-override probe: cached for reuse by secondary CD and sound alerts.
     local auraProbeInfo, auraProbeIsGCDOnly
     local auraProbeDuration
+    local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
@@ -1046,13 +1316,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if auraOverrideActive and buttonData.type == "spell" and not buttonData.isPassive then
         auraProbeInfo = C_Spell.GetSpellCooldown(cooldownSpellId)
         if auraProbeInfo and auraProbeInfo.isActive then
+            local auraProbeNormalDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId)
+            auraProbeNormalCooldownShown = DurationObjectShowsCooldown(auraProbeNormalDuration)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
             auraProbeRealCooldownShown = DurationObjectShowsCooldown(auraProbeDuration)
         end
         auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, {
-            secrecy = buttonData._cooldownSecrecy,
-            gcdInfo = CooldownCompanion._gcdInfo,
-            gcdActive = CooldownCompanion._gcdActive,
+            normalCooldownShown = auraProbeNormalCooldownShown,
             realCooldownShown = auraProbeRealCooldownShown,
         }) or false
     end
@@ -1102,7 +1372,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOverrideActive then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            spellCooldownResult, spellBaseOverrideBridgeEligible =
+            spellCooldownResult, spellBaseOverrideBridgeEligible, spellCooldownTrace =
                 EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
             spellCooldownResult = ApplyBaseOverrideCooldownBridge(
                 button,
@@ -1111,6 +1381,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 buttonData.id,
                 cooldownSpellId
             )
+            if spellCooldownTrace then
+                spellCooldownTrace.final = spellCooldownResult
+            end
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
@@ -1688,6 +1961,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button:SetAlpha(0)
                 button._lastVisAlpha = 0
             end
+            TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace,
+                fetchOk, isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive, "hidden")
             DispatchStandaloneTextureVisual(button)
             return  -- Skip all visual updates
         else
@@ -1704,6 +1979,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- auto-hide the CooldownFrame; without this, bar mode _mainCDShown
             -- and icon mode force-show both read stale true on next tick.
             button.cooldown:Hide()
+            TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace,
+                fetchOk, isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive, "compact-hidden")
             DispatchStandaloneTextureVisual(button)
             return  -- Skip visual updates for hidden buttons
         else
@@ -1756,4 +2033,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end
+
+    TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace,
+        fetchOk, isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive)
 end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -199,20 +199,28 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
     result.info = info
     if not info then
         if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
-            local slotShown, durationObj, realShown, realDurationObj = ProbeActionSlotCooldownForSpell(spellID)
-            if slotShown ~= nil then
+            local slotProbe = ProbeActionSlotCooldownForSpell(spellID)
+            if slotProbe.shown ~= nil then
                 result.fetchOk = true
-                result.normalCooldownShown = slotShown == true
-                result.realCooldownShown = realShown == true
-                result.durationObj = durationObj
-                result.realDurationObj = realDurationObj
-                if result.realCooldownShown and realDurationObj then
+                result.normalCooldownShown = slotProbe.shown == true
+                result.realCooldownShown = slotProbe.realShown == true
+                result.durationObj = slotProbe.durationObj
+                result.realDurationObj = slotProbe.realDurationObj
+                if slotProbe.shown and slotProbe.sawUnknown then
                     result.state = COOLDOWN_STATE_COOLDOWN
-                    result.renderDurationObj = realDurationObj
-                elseif slotShown and durationObj then
+                    result.renderDurationObj = slotProbe.realDurationObj or slotProbe.durationObj
+                elseif result.realCooldownShown and slotProbe.realDurationObj then
+                    result.state = COOLDOWN_STATE_COOLDOWN
+                    result.renderDurationObj = slotProbe.realDurationObj
+                elseif slotProbe.shown and slotProbe.durationObj then
                     result.state = COOLDOWN_STATE_GCD
-                    result.renderDurationObj = durationObj
+                    result.renderDurationObj = slotProbe.durationObj
+                    result.isOnGCD = true
                 end
+            elseif slotProbe.sawAnySlot and slotProbe.sawUnknown then
+                result.fetchOk = true
+                result.state = COOLDOWN_STATE_COOLDOWN
+                result.deferred = true
             end
         end
         return result
@@ -310,24 +318,25 @@ local function ResolveChargeState(button, buttonData)
 end
 
 -- Probe action-slot cooldown state for a spell ID pair (base + display override).
--- Returns:
---   shown      : true/false/nil (nil = no slots found or unknown from secret state)
---   durationObj: active LuaDurationObject when shown, else nil
 local actionSlotSeenScratch = {}
 
 local function ProbeActionSlotsForSpellID(spellID)
-    if not spellID then return false, nil, false, false, false, nil end
+    local result = {
+        shown = false,
+        realShown = false,
+        sawAnySlot = false,
+        sawUnknown = false,
+    }
+
+    if not spellID then return result end
 
     local slots = C_ActionBar.FindSpellActionButtons(spellID)
-    if not slots then return false, nil, false, false, false, nil end
-
-    local sawAnySlot = false
-    local sawUnknown = false
+    if not slots then return result end
 
     for _, slot in ipairs(slots) do
         if not actionSlotSeenScratch[slot] then
             actionSlotSeenScratch[slot] = true
-            sawAnySlot = true
+            result.sawAnySlot = true
 
             local durationObj = C_ActionBar.GetActionCooldownDuration(slot)
             local realDurationObj = C_ActionBar.GetActionCooldownDuration(slot, true)
@@ -337,56 +346,69 @@ local function ProbeActionSlotsForSpellID(spellID)
             if durationObj then
                 shown = DurationObjectShowsCooldown(durationObj)
             else
-                sawUnknown = true
+                result.sawUnknown = true
             end
 
             if realDurationObj then
                 realShown = DurationObjectShowsCooldown(realDurationObj)
             else
-                sawUnknown = true
+                result.sawUnknown = true
             end
 
             if shown then
-                return true, durationObj, realShown, sawAnySlot, sawUnknown, realDurationObj
+                result.shown = true
+                result.durationObj = durationObj
+                result.realShown = realShown
+                result.realDurationObj = realDurationObj
+                return result
             end
         end
     end
 
-    return false, nil, false, sawAnySlot, sawUnknown, nil
+    return result
 end
 
 function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
-    if not baseSpellID then return nil, nil, nil, nil end
+    local result = {
+        shown = nil,
+        realShown = nil,
+        sawAnySlot = false,
+        sawUnknown = false,
+    }
+
+    if not baseSpellID then return result end
 
     wipe(actionSlotSeenScratch)
 
-    local sawAnySlot = false
-    local sawUnknown = false
+    local function mergeProbe(probe)
+        if probe.sawAnySlot then result.sawAnySlot = true end
+        if probe.sawUnknown then result.sawUnknown = true end
+        if probe.shown then
+            result.shown = true
+            result.durationObj = probe.durationObj
+            result.realShown = probe.realShown
+            result.realDurationObj = probe.realDurationObj
+            return true
+        end
+        return false
+    end
 
-    local shown, durationObj, realShown, sawAny, sawUnk, realDurationObj = ProbeActionSlotsForSpellID(baseSpellID)
-    if sawAny then sawAnySlot = true end
-    if sawUnk then sawUnknown = true end
-    if shown then
-        return true, durationObj, realShown, realDurationObj
+    if mergeProbe(ProbeActionSlotsForSpellID(baseSpellID)) then
+        return result
     end
 
     if displaySpellID and displaySpellID ~= baseSpellID then
-        shown, durationObj, realShown, sawAny, sawUnk, realDurationObj = ProbeActionSlotsForSpellID(displaySpellID)
-        if sawAny then sawAnySlot = true end
-        if sawUnk then sawUnknown = true end
-        if shown then
-            return true, durationObj, realShown, realDurationObj
+        if mergeProbe(ProbeActionSlotsForSpellID(displaySpellID)) then
+            return result
         end
     end
 
-    if sawAnySlot then
-        if sawUnknown then
-            return nil, nil, nil, nil
-        end
-        return false, nil, false, nil
+    if result.sawAnySlot and not result.sawUnknown then
+        result.shown = false
+        result.realShown = false
     end
 
-    return nil, nil, nil, nil
+    return result
 end
 
 local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
@@ -1102,6 +1124,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             fetchOk = true
         end
     elseif buttonData.type == "item" then
+        -- Items keep underlying cooldown state during aura override for visibility/desaturation.
+        -- Spell aura overrides intentionally do not: the aura owns the spell visual state.
         isGCDOnly = EvaluateItemCooldown(button, buttonData, style, false)
         fetchOk = true
     end
@@ -1119,7 +1143,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         and buttonData.type == "spell"
     then
         UpdateDisplayCountTracking(button, buttonData, cooldownSpellId)
-        button._chargeRecharging = button._chargeRecharging == true
     elseif usesChargeBehavior and buttonData.type == "item" then
         UpdateItemChargeTracking(button, buttonData)
         button._chargeRecharging = button._cooldownState == COOLDOWN_STATE_COOLDOWN
@@ -1263,12 +1286,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and duration > 0).  It can report true during per-cast lockouts
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
-            local slotShown, _, slotRealShown = ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-            if slotShown ~= nil then
-                button._mainCDShown = slotRealShown
+            local slotProbe = ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+            if slotProbe.shown ~= nil then
+                button._mainCDShown = slotProbe.sawUnknown or slotProbe.realShown == true
             elseif not auraOverrideActive then
                 -- No action bar slot found; use the ignoreGCD-backed real cooldown state.
-                if spellCooldownInfo then
+                if spellCooldownResult and spellCooldownResult.fetchOk then
+                    button._mainCDShown = spellCooldownResult.state == COOLDOWN_STATE_COOLDOWN
+                elseif spellCooldownInfo then
                     button._mainCDShown = spellRealCooldownShown
                 else
                     button._mainCDShown = false

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -12,7 +12,6 @@ local GetTime = GetTime
 local tonumber = tonumber
 local tostring = tostring
 local ipairs = ipairs
-local pairs = pairs
 local wipe = wipe
 local issecretvalue = issecretvalue
 
@@ -106,175 +105,6 @@ local function DurationObjectShowsCooldown(durationObj)
     local shown = scratchCooldown:IsShown()
     scratchCooldown:SetCooldown(0, 0)
     return shown
-end
-
-local function PlainNumber(value)
-    if value == nil or issecretvalue(value) then
-        return nil
-    end
-    return tonumber(value)
-end
-
-local EXECUTE_TRACE_BASE_SPELL_ID = 163201
-local EXECUTE_TRACE_OVERRIDE_SPELL_ID = 280735
-local EXECUTE_TRACE_MAX_ENTRIES = 800
-local EXECUTE_COOLDOWN_BRIDGE_MAX_SECONDS = 0.12
-local EXECUTE_COOLDOWN_BRIDGE_SPELLS = {
-    [EXECUTE_TRACE_BASE_SPELL_ID] = true,
-    [EXECUTE_TRACE_OVERRIDE_SPELL_ID] = true,
-}
-
-local function SecretSafeValue(value)
-    if value == nil then
-        return nil
-    end
-    if issecretvalue(value) then
-        return "<secret>"
-    end
-    return value
-end
-
-local function SerializeCooldownInfo(info)
-    if not info then
-        return { present = false }
-    end
-
-    return {
-        present = true,
-        isActive = info.isActive,
-        isEnabled = info.isEnabled,
-        isOnGCD = info.isOnGCD,
-        startTime = SecretSafeValue(info.startTime),
-        startTimeSecret = info.startTime ~= nil and issecretvalue(info.startTime) or false,
-        duration = SecretSafeValue(info.duration),
-        durationSecret = info.duration ~= nil and issecretvalue(info.duration) or false,
-        modRate = SecretSafeValue(info.modRate),
-        modRateSecret = info.modRate ~= nil and issecretvalue(info.modRate) or false,
-        recovery = SecretSafeValue(info.timeUntilEndOfStartRecovery),
-        recoverySecret = info.timeUntilEndOfStartRecovery ~= nil
-            and issecretvalue(info.timeUntilEndOfStartRecovery) or false,
-    }
-end
-
-local function SerializeDurationObject(durationObj)
-    if not durationObj then
-        return { present = false }
-    end
-
-    local remaining = durationObj:GetRemainingDuration()
-    local elapsedPercent = durationObj:GetElapsedPercent()
-    local remainingPercent = durationObj:GetRemainingPercent()
-    return {
-        present = true,
-        shown = DurationObjectShowsCooldown(durationObj),
-        hasSecretValues = durationObj:HasSecretValues(),
-        remaining = SecretSafeValue(remaining),
-        remainingSecret = remaining ~= nil and issecretvalue(remaining) or false,
-        elapsedPercent = SecretSafeValue(elapsedPercent),
-        elapsedPercentSecret = elapsedPercent ~= nil and issecretvalue(elapsedPercent) or false,
-        remainingPercent = SecretSafeValue(remainingPercent),
-        remainingPercentSecret = remainingPercent ~= nil and issecretvalue(remainingPercent) or false,
-    }
-end
-
-local function SerializeCooldownLane(result)
-    if not result then
-        return nil
-    end
-
-    return {
-        spellID = result.spellID,
-        fetchOk = result.fetchOk,
-        state = result.state,
-        apiState = result.apiState,
-        presentationState = result.presentationState,
-        isOnGCD = result.isOnGCD,
-        deferred = result.deferred,
-        realCooldownShown = result.realCooldownShown,
-        normalCooldownShown = result.normalCooldownShown,
-        info = SerializeCooldownInfo(result.info),
-        durationObj = SerializeDurationObject(result.durationObj),
-        realDurationObj = SerializeDurationObject(result.realDurationObj),
-        renderDurationObj = SerializeDurationObject(result.renderDurationObj),
-        presentationDurationObj = SerializeDurationObject(result.presentationDurationObj),
-    }
-end
-
-local function ShouldTraceExecute(buttonData, cooldownSpellId)
-    local configured = PlainNumber(buttonData and buttonData.id)
-    local display = PlainNumber(cooldownSpellId)
-    return configured == EXECUTE_TRACE_BASE_SPELL_ID
-        or configured == EXECUTE_TRACE_OVERRIDE_SPELL_ID
-        or display == EXECUTE_TRACE_BASE_SPELL_ID
-        or display == EXECUTE_TRACE_OVERRIDE_SPELL_ID
-end
-
-local function GetCooldownStateTrace()
-    if type(CooldownCompanionDB) ~= "table" then
-        return nil
-    end
-
-    CooldownCompanionDB.global = CooldownCompanionDB.global or {}
-    local trace = CooldownCompanionDB.global.cooldownStateTrace
-    if type(trace) ~= "table" then
-        trace = {}
-        CooldownCompanionDB.global.cooldownStateTrace = trace
-    end
-    if trace.version ~= 5 or trace.subject ~= "execute-frame-trace" then
-        wipe(trace)
-        trace.version = 5
-        trace.subject = "execute-frame-trace"
-    end
-
-    trace.enabled = true
-    trace.maxEntries = trace.maxEntries or EXECUTE_TRACE_MAX_ENTRIES
-    if trace.maxEntries < 100 then
-        trace.maxEntries = 100
-    elseif trace.maxEntries > 1200 then
-        trace.maxEntries = 1200
-    end
-    trace.entries = trace.entries or {}
-    trace.trackedSpells = trace.trackedSpells or {
-        [EXECUTE_TRACE_BASE_SPELL_ID] = "Execute",
-        [EXECUTE_TRACE_OVERRIDE_SPELL_ID] = "Execute override",
-    }
-    trace.startedAt = trace.startedAt or GetTime()
-    trace.nextIndex = trace.nextIndex or 1
-    trace.count = trace.count or 0
-    trace.sequence = trace.sequence or 0
-    return trace
-end
-
-local function AppendCooldownStateTrace(row)
-    local trace = GetCooldownStateTrace()
-    if not trace then
-        return
-    end
-
-    trace.sequence = trace.sequence + 1
-    row.seq = trace.sequence
-    local index = trace.nextIndex
-    trace.entries[index] = row
-    trace.latestIndex = index
-    trace.nextIndex = index + 1
-    if trace.nextIndex > trace.maxEntries then
-        trace.nextIndex = 1
-    end
-    if trace.count < trace.maxEntries then
-        trace.count = trace.count + 1
-    end
-end
-
-local function SerializeSpellUsability(spellID)
-    if not spellID then
-        return nil
-    end
-    local usable, insufficientPower = C_Spell_IsSpellUsable(spellID)
-    return {
-        spellID = spellID,
-        isUsable = usable,
-        insufficientPower = insufficientPower,
-    }
 end
 
 local function GetConfiguredAuraUnit(buttonData)
@@ -408,30 +238,14 @@ local function SelectSpellCooldownResult(current, candidate)
     return CooldownLogic.SelectStrongerCooldownState(current, candidate)
 end
 
-local function IsExecuteCooldownBridgePair(configuredSpellID, displaySpellID)
-    configuredSpellID = PlainNumber(configuredSpellID)
-    displaySpellID = PlainNumber(displaySpellID)
-    return configuredSpellID == EXECUTE_TRACE_BASE_SPELL_ID
-        and displaySpellID == EXECUTE_TRACE_OVERRIDE_SPELL_ID
-        and EXECUTE_COOLDOWN_BRIDGE_SPELLS[configuredSpellID] == true
-        and EXECUTE_COOLDOWN_BRIDGE_SPELLS[displaySpellID] == true
-end
-
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
     local result = displayResult
-    local bridgeEligible = false
-    local traceLanes = {
-        display = displayResult,
-    }
 
     if cooldownSpellId and cooldownSpellId ~= buttonData.id then
         local displayBaseSpellID = C_Spell.GetBaseSpell(cooldownSpellId)
         if displayBaseSpellID == buttonData.id then
             local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
-            traceLanes.displayBaseSpellID = displayBaseSpellID
-            traceLanes.base = baseResult
-            bridgeEligible = IsExecuteCooldownBridgePair(buttonData.id, cooldownSpellId)
             result = SelectSpellCooldownResult(
                 result,
                 baseResult
@@ -442,124 +256,7 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
         end
     end
 
-    traceLanes.finalBeforeBridge = result
-    return result, bridgeEligible, traceLanes
-end
-
-local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, configuredSpellID, displaySpellID)
-    local previousDurationObj = button._baseOverrideCooldownDurationObj
-    local previousDurationShown = DurationObjectShowsCooldown(previousDurationObj)
-    local now = GetTime()
-
-    button._baseOverrideBridgeTrace = {
-        eligible = bridgeEligible == true,
-        configuredSpellID = configuredSpellID,
-        displaySpellID = displaySpellID,
-        preState = result and result.state or nil,
-        preApiState = result and result.apiState or nil,
-        applied = false,
-        cleared = false,
-        active = button._baseOverrideCooldownBridgeActive == true,
-        previousDurationShown = previousDurationShown,
-        previousLastRealWasOnGCD = button._baseOverrideCooldownLastRealWasOnGCD,
-        maxSeconds = EXECUTE_COOLDOWN_BRIDGE_MAX_SECONDS,
-    }
-
-    local function clearBridge(reason)
-        button._baseOverrideCooldownDurationObj = nil
-        button._baseOverrideCooldownLastRealAt = nil
-        button._baseOverrideCooldownLastRealWasOnGCD = nil
-        button._baseOverrideCooldownBridgeActive = nil
-        button._baseOverrideCooldownBridgeStartedAt = nil
-        button._baseOverrideBridgeTrace.cleared = true
-        button._baseOverrideBridgeTrace.reason = reason
-    end
-
-    if not bridgeEligible then
-        clearBridge("not-eligible")
-        return result
-    end
-
-    if not result or not result.fetchOk then
-        clearBridge("no-result")
-        return result
-    end
-
-    -- Execute can briefly report only GCD during a real cooldown.  This bridge is
-    -- deliberately opt-in and only carries forward a directly observed real
-    -- cooldown; it is not a normal cooldown source.
-    if result.state == COOLDOWN_STATE_COOLDOWN
-            and result.realCooldownShown == true
-            and result.renderDurationObj then
-        button._baseOverrideCooldownDurationObj = result.renderDurationObj
-        button._baseOverrideCooldownLastRealAt = now
-        button._baseOverrideCooldownLastRealWasOnGCD = result.isOnGCD == true
-        button._baseOverrideCooldownBridgeActive = nil
-        button._baseOverrideCooldownBridgeStartedAt = nil
-        button._baseOverrideBridgeTrace.reason = "direct-real-cooldown"
-        button._baseOverrideBridgeTrace.trackedRealSpellID = result.spellID
-        return result
-    end
-
-    if result.state ~= COOLDOWN_STATE_GCD then
-        clearBridge("direct-non-gcd")
-        return result
-    end
-
-    if not previousDurationShown then
-        clearBridge("no-active-previous-real")
-        return result
-    end
-
-    local bridgeAlreadyActive = button._baseOverrideCooldownBridgeActive == true
-    if not bridgeAlreadyActive then
-        if button._baseOverrideCooldownLastRealWasOnGCD == true then
-            clearBridge("previous-real-overlapped-gcd")
-            return result
-        end
-        button._baseOverrideCooldownBridgeStartedAt = now
-    elseif not button._baseOverrideCooldownBridgeStartedAt then
-        button._baseOverrideCooldownBridgeStartedAt = now
-    end
-
-    local bridgeElapsed = now - button._baseOverrideCooldownBridgeStartedAt
-    button._baseOverrideBridgeTrace.elapsed = bridgeElapsed
-    if bridgeElapsed > EXECUTE_COOLDOWN_BRIDGE_MAX_SECONDS then
-        clearBridge("debounce-expired")
-        button._baseOverrideBridgeTrace.elapsed = bridgeElapsed
-        return result
-    end
-
-    if not previousDurationObj then
-        clearBridge("no-previous-duration")
-        return result
-    end
-
-    if bridgeAlreadyActive then
-        previousDurationObj = button._baseOverrideCooldownDurationObj
-        if not previousDurationObj then
-            clearBridge("no-previous-duration")
-            return result
-        end
-    end
-
-    local bridged = {}
-    for key, value in pairs(result) do
-        bridged[key] = value
-    end
-    bridged.state = COOLDOWN_STATE_COOLDOWN
-    bridged.presentationState = COOLDOWN_STATE_COOLDOWN
-    bridged.renderDurationObj = previousDurationObj
-    bridged.presentationDurationObj = previousDurationObj
-    bridged.bridgeApplied = true
-
-    button._baseOverrideCooldownBridgeActive = true
-    button._baseOverrideBridgeTrace.applied = true
-    button._baseOverrideBridgeTrace.reason = bridgeAlreadyActive
-        and "presentation-debounce-continuing"
-        or "presentation-debounce-started"
-    button._baseOverrideBridgeTrace.postState = bridged.state
-    return bridged
+    return result
 end
 
 local function ResolveChargeState(button, buttonData)
@@ -675,82 +372,6 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
     return nil, nil
 end
 
-local function TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace, fetchOk,
-        isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive, earlyReturnReason)
-    if not ShouldTraceExecute(buttonData, cooldownSpellId) then
-        return
-    end
-
-    local actionShown, actionDurationObj, actionRealShown, actionRealDurationObj =
-        ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-    local displayBaseSpellID = cooldownSpellId and C_Spell.GetBaseSpell(cooldownSpellId) or nil
-    local overrideSpellID = buttonData.id and C_Spell.GetOverrideSpell(buttonData.id) or nil
-    local gcdInfo = CooldownCompanion._gcdInfo
-    local vertexR, vertexG, vertexB, vertexA
-    if button.icon then
-        vertexR, vertexG, vertexB, vertexA = button.icon:GetVertexColor()
-    end
-
-    AppendCooldownStateTrace({
-        t = GetTime(),
-        groupId = button._groupId,
-        index = button.index,
-        name = buttonData.name,
-        type = buttonData.type,
-        id = buttonData.id,
-        displaySpellID = cooldownSpellId,
-        displayBaseSpellID = displayBaseSpellID,
-        overrideSpellID = overrideSpellID,
-        fetchOk = fetchOk == true,
-        isOnGCD = isOnGCD == true,
-        isGCDOnly = isGCDOnly == true,
-        auraOverrideActive = auraOverrideActive == true,
-        procOverlayActive = procOverlayActive == true,
-        cooldownsDirty = CooldownCompanion._cooldownsDirty == true,
-        cooldownState = button._cooldownState,
-        cooldownApiState = button._cooldownApiState,
-        cooldownPresentationState = button._cooldownPresentationState,
-        durationObj = SerializeDurationObject(button._durationObj),
-        presentationDurationObj = SerializeDurationObject(button._cooldownPresentationDurationObj),
-        cooldownShown = button.cooldown and button.cooldown:IsShown() or false,
-        desatCooldownActive = button._desatCooldownActive == true,
-        iconDesaturated = button._desaturated == true,
-        unusableTint = button._unusableTintActive == true,
-        visibilityHidden = button._visibilityHidden == true,
-        visibilityAlphaOverride = button._visibilityAlphaOverride,
-        earlyReturnReason = earlyReturnReason,
-        bridge = button._baseOverrideBridgeTrace,
-        lanes = {
-            display = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.display),
-            base = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.base),
-            finalBeforeBridge = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.finalBeforeBridge),
-            final = SerializeCooldownLane(spellCooldownTrace and spellCooldownTrace.final),
-        },
-        actionSlot = {
-            shown = actionShown,
-            durationObj = SerializeDurationObject(actionDurationObj),
-            realShown = actionRealShown,
-            realDurationObj = SerializeDurationObject(actionRealDurationObj),
-        },
-        gcd = {
-            active = CooldownCompanion._gcdActive == true,
-            info = SerializeCooldownInfo(gcdInfo),
-            durationObj = SerializeDurationObject(CooldownCompanion._gcdDurationObj),
-        },
-        usability = {
-            configured = SerializeSpellUsability(buttonData.id),
-            display = SerializeSpellUsability(cooldownSpellId),
-            override = SerializeSpellUsability(overrideSpellID),
-        },
-        vertex = {
-            r = vertexR,
-            g = vertexG,
-            b = vertexB,
-            a = vertexA,
-        },
-    })
-end
-
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
@@ -841,8 +462,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local spellCooldownDuration
     local spellRealCooldownShown = false
     local spellCooldownResult
-    local spellCooldownTrace
-    local spellBaseOverrideBridgeEligible = false
     -- Aura-override probe: cached for reuse by secondary CD and sound alerts.
     local auraProbeInfo, auraProbeIsGCDOnly
     local auraProbeDuration
@@ -1391,18 +1010,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOverrideActive then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            spellCooldownResult, spellBaseOverrideBridgeEligible, spellCooldownTrace =
-                EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
-            spellCooldownResult = ApplyBaseOverrideCooldownBridge(
-                button,
-                spellCooldownResult,
-                spellBaseOverrideBridgeEligible,
-                buttonData.id,
-                cooldownSpellId
-            )
-            if spellCooldownTrace then
-                spellCooldownTrace.final = spellCooldownResult
-            end
+            spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
@@ -1708,10 +1316,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
     button._chargeState = ResolveChargeState(button, buttonData)
 
-    -- Cooldown desaturation follows gameplay cooldown state, not raw API state.
-    -- For normal buttons these are the same. For approved blind-gap bridges
-    -- like Execute, the gameplay state intentionally stays "cooldown" so all
-    -- cooldown visuals agree with the player-facing lockout.
+    -- Cooldown desaturation follows the canonical cooldown state, never the GCD.
     if buttonData.type == "item" then
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then
@@ -1948,8 +1553,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button:SetAlpha(0)
                 button._lastVisAlpha = 0
             end
-            TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace,
-                fetchOk, isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive, "hidden")
             DispatchStandaloneTextureVisual(button)
             return  -- Skip all visual updates
         else
@@ -1966,8 +1569,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- auto-hide the CooldownFrame; without this, bar mode _mainCDShown
             -- and icon mode force-show both read stale true on next tick.
             button.cooldown:Hide()
-            TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace,
-                fetchOk, isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive, "compact-hidden")
             DispatchStandaloneTextureVisual(button)
             return  -- Skip visual updates for hidden buttons
         else
@@ -2020,7 +1621,4 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end
-
-    TraceExecuteCooldownFrame(button, buttonData, cooldownSpellId, spellCooldownTrace,
-        fetchOk, isOnGCD, isGCDOnly, auraOverrideActive, procOverlayActive)
 end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -179,12 +179,13 @@ local function IsSpellCooldownDeferred(info)
     return recoveryTime <= 0
 end
 
+local ProbeActionSlotCooldownForSpell
+
 local function EvaluateSpellCooldownLane(spellID, secrecy)
     local result = {
         spellID = spellID,
         fetchOk = false,
         state = COOLDOWN_STATE_READY,
-        apiState = COOLDOWN_STATE_READY,
         realCooldownShown = false,
         isOnGCD = false,
         deferred = false,
@@ -197,6 +198,23 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
     local info = C_Spell.GetSpellCooldown(spellID)
     result.info = info
     if not info then
+        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
+            local slotShown, durationObj, realShown, realDurationObj = ProbeActionSlotCooldownForSpell(spellID)
+            if slotShown ~= nil then
+                result.fetchOk = true
+                result.normalCooldownShown = slotShown == true
+                result.realCooldownShown = realShown == true
+                result.durationObj = durationObj
+                result.realDurationObj = realDurationObj
+                if result.realCooldownShown and realDurationObj then
+                    result.state = COOLDOWN_STATE_COOLDOWN
+                    result.renderDurationObj = realDurationObj
+                elseif slotShown and durationObj then
+                    result.state = COOLDOWN_STATE_GCD
+                    result.renderDurationObj = durationObj
+                end
+            end
+        end
         return result
     end
 
@@ -224,7 +242,6 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
     end
 
-    result.apiState = result.state
     return result
 end
 
@@ -299,10 +316,10 @@ end
 local actionSlotSeenScratch = {}
 
 local function ProbeActionSlotsForSpellID(spellID)
-    if not spellID then return false, nil, false, false, false end
+    if not spellID then return false, nil, false, false, false, nil end
 
     local slots = C_ActionBar.FindSpellActionButtons(spellID)
-    if not slots then return false, nil, false, false, false end
+    if not slots then return false, nil, false, false, false, nil end
 
     local sawAnySlot = false
     local sawUnknown = false
@@ -335,11 +352,11 @@ local function ProbeActionSlotsForSpellID(spellID)
         end
     end
 
-    return false, nil, false, sawAnySlot, sawUnknown
+    return false, nil, false, sawAnySlot, sawUnknown, nil
 end
 
-local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
-    if not baseSpellID then return nil, nil, nil end
+function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
+    if not baseSpellID then return nil, nil, nil, nil end
 
     wipe(actionSlotSeenScratch)
 
@@ -364,12 +381,60 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
 
     if sawAnySlot then
         if sawUnknown then
-            return nil, nil
+            return nil, nil, nil, nil
         end
-        return false, nil
+        return false, nil, false, nil
     end
 
-    return nil, nil
+    return nil, nil, nil, nil
+end
+
+local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
+    button._isEquippableNotEquipped = false
+    local isEquippable = IsItemEquippable(buttonData)
+    if isEquippable and not C_Item.IsEquippedItem(buttonData.id) then
+        button._isEquippableNotEquipped = true
+        if renderCooldown then
+            button.cooldown:SetCooldown(0, 0)
+        end
+        button._itemCdStart = 0
+        button._itemCdDuration = 0
+        button._cooldownState = COOLDOWN_STATE_READY
+        return false
+    end
+
+    local cdStart, cdDuration, enableCooldownTimer = C_Item.GetItemCooldown(buttonData.id)
+    if not enableCooldownTimer and cdStart > 0 then
+        if renderCooldown then
+            button.cooldown:SetCooldown(0, 0)
+        end
+        button._itemCdStart = 0
+        button._itemCdDuration = 0
+        button._cooldownDeferred = true
+        button._cooldownState = COOLDOWN_STATE_COOLDOWN
+        return false
+    end
+
+    button._itemCdStart = cdStart
+    button._itemCdDuration = cdDuration
+    local itemGCDOnly = CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, CooldownCompanion._gcdInfo)
+    if cdDuration and cdDuration > 0 then
+        button._cooldownState = itemGCDOnly and COOLDOWN_STATE_GCD
+            or COOLDOWN_STATE_COOLDOWN
+    else
+        button._cooldownState = COOLDOWN_STATE_READY
+    end
+
+    if renderCooldown then
+        if button._cooldownState == COOLDOWN_STATE_GCD and style.showGCDSwipe ~= true then
+            button.cooldown:SetCooldown(0, 0)
+            button.cooldown:Hide()
+        else
+            button.cooldown:SetCooldown(cdStart, cdDuration)
+        end
+    end
+
+    return itemGCDOnly == true
 end
 
 function CooldownCompanion:UpdateButtonCooldown(button)
@@ -449,10 +514,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local prevAuraDurationObj = button._auraActive and button._durationObj or nil
     button._durationObj = nil
     button._cooldownDeferred = nil
-    button._cooldownApiState = COOLDOWN_STATE_READY
     button._cooldownState = COOLDOWN_STATE_READY
-    button._cooldownPresentationState = COOLDOWN_STATE_READY
-    button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
 
     -- Fetch cooldown data and update the cooldown widget.
@@ -987,14 +1049,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         elseif buttonData.type == "item" then
             local cdStart, cdDuration = C_Item.GetItemCooldown(buttonData.id)
-            local probeIsGCDOnly = false
-            if cdDuration and cdDuration > 0 then
-                local gcdInfo = CooldownCompanion._gcdInfo
-                if gcdInfo and cdStart == gcdInfo.startTime
-                        and cdDuration == gcdInfo.duration then
-                    probeIsGCDOnly = true
-                end
-            end
+            local probeIsGCDOnly = CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, CooldownCompanion._gcdInfo)
             if cdDuration and cdDuration > 0 and not probeIsGCDOnly then
                 button.secondaryCooldown:SetCooldown(cdStart, cdDuration)
                 button._secondaryCdActive = true
@@ -1016,29 +1071,21 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
-                button._cooldownApiState = spellCooldownResult.apiState
-                    or spellCooldownResult.state
-                    or COOLDOWN_STATE_READY
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
-                button._cooldownPresentationState = spellCooldownResult.presentationState
-                    or button._cooldownState
-                button._cooldownPresentationDurationObj = spellCooldownResult.presentationDurationObj
-                    or spellCooldownResult.renderDurationObj
+                local renderDurationObj = spellCooldownResult.renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
                 isGCDOnly = button._cooldownState == COOLDOWN_STATE_GCD
 
-                if button._cooldownPresentationState == COOLDOWN_STATE_COOLDOWN then
-                    if button._cooldownPresentationDurationObj then
-                        if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
-                            button._durationObj = button._cooldownPresentationDurationObj
-                        end
-                        button.cooldown:SetCooldownFromDurationObject(button._cooldownPresentationDurationObj)
+                if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
+                    if renderDurationObj then
+                        button._durationObj = renderDurationObj
+                        button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
                     else
                         button.cooldown:SetCooldown(0, 0)
                     end
-                elseif button._cooldownPresentationState == COOLDOWN_STATE_GCD then
-                    if style.showGCDSwipe == true and button._cooldownPresentationDurationObj then
-                        button.cooldown:SetCooldownFromDurationObject(button._cooldownPresentationDurationObj)
+                elseif button._cooldownState == COOLDOWN_STATE_GCD then
+                    if style.showGCDSwipe == true and renderDurationObj then
+                        button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
                     else
                         button.cooldown:SetCooldown(0, 0)
                         button.cooldown:Hide()
@@ -1051,62 +1098,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button.cooldown:SetCooldown(0, 0)
             end
         elseif buttonData.type == "item" then
-            button._isEquippableNotEquipped = false
-            local isEquippable = IsItemEquippable(buttonData)
-            if isEquippable and not C_Item.IsEquippedItem(buttonData.id) then
-                button._isEquippableNotEquipped = true
-                -- Suppress cooldown display: static desaturated icon
-                button.cooldown:SetCooldown(0, 0)
-                button._itemCdStart = 0
-                button._itemCdDuration = 0
-            else
-                button._isEquippableNotEquipped = false
-                local cdStart, cdDuration, enableCooldownTimer = C_Item.GetItemCooldown(buttonData.id)
-                if not enableCooldownTimer and cdStart > 0 then
-                    -- Deferred cooldown (e.g. Healthstone used in combat): the
-                    -- timer hasn't started yet.  Suppress the swipe to prevent
-                    -- flicker from cdStart advancing every tick with dur=0.
-                    -- Downstream code uses _cooldownDeferred for desat/visibility.
-                    button.cooldown:SetCooldown(0, 0)
-                    button._itemCdStart = 0
-                    button._itemCdDuration = 0
-                    button._cooldownDeferred = true
-                    button._cooldownApiState = COOLDOWN_STATE_COOLDOWN
-                    button._cooldownState = COOLDOWN_STATE_COOLDOWN
-                else
-                    button._itemCdStart = cdStart
-                    button._itemCdDuration = cdDuration
-                    -- GCD-only detection for items: C_Item.GetItemCooldown returns
-                    -- GCD values when the item is on GCD but has no real cooldown.
-                    -- Item cooldown values are never secret; direct comparison is safe
-                    -- (same pattern as NeverSecret spells above).
-                    if cdDuration > 0 then
-                        local gcdInfo = CooldownCompanion._gcdInfo
-                        if gcdInfo and cdStart == gcdInfo.startTime
-                                and cdDuration == gcdInfo.duration then
-                            isGCDOnly = true
-                        end
-                    end
-                    if cdDuration and cdDuration > 0 then
-                        button._cooldownApiState = isGCDOnly and COOLDOWN_STATE_GCD
-                            or COOLDOWN_STATE_COOLDOWN
-                        button._cooldownState = isGCDOnly and COOLDOWN_STATE_GCD
-                            or COOLDOWN_STATE_COOLDOWN
-                    else
-                        button._cooldownApiState = COOLDOWN_STATE_READY
-                        button._cooldownState = COOLDOWN_STATE_READY
-                    end
-
-                    if button._cooldownState == COOLDOWN_STATE_GCD and style.showGCDSwipe ~= true then
-                        button.cooldown:SetCooldown(0, 0)
-                        button.cooldown:Hide()
-                    else
-                        button.cooldown:SetCooldown(cdStart, cdDuration)
-                    end
-                end
-            end
+            isGCDOnly = EvaluateItemCooldown(button, buttonData, style, true)
             fetchOk = true
         end
+    elseif buttonData.type == "item" then
+        isGCDOnly = EvaluateItemCooldown(button, buttonData, style, false)
+        fetchOk = true
     end
 
     -- Update spell charge data before zero-charge state classification.
@@ -1122,6 +1119,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         and buttonData.type == "spell"
     then
         UpdateDisplayCountTracking(button, buttonData, cooldownSpellId)
+        button._chargeRecharging = button._chargeRecharging == true
     elseif usesChargeBehavior and buttonData.type == "item" then
         UpdateItemChargeTracking(button, buttonData)
         button._chargeRecharging = button._cooldownState == COOLDOWN_STATE_COOLDOWN
@@ -1203,8 +1201,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
 
     button._isOnGCD = isOnGCD or false
-    button._isGCDOnly = isGCDOnly
-
     -- Bar mode: suppress GCD-only display in bars (checked by UpdateBarFill OnUpdate).
     -- Skip for charge spells: their _durationObj is the recharge cycle, never the GCD.
     if button._isBar then
@@ -1585,7 +1581,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if buttonData.isPassive then
             button._isUnusable = false
         elseif buttonData.type == "spell" then
-            button._isUnusable = not C_Spell_IsSpellUsable(buttonData.id)
+            local spellID = button._displaySpellId or buttonData.id
+            button._isUnusable = not C_Spell_IsSpellUsable(spellID)
         elseif buttonData.type == "item" or buttonData.type == "equipitem" then
             local usable = IsUsableItem(buttonData.id)
             button._isUnusable = not usable

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -108,23 +108,25 @@ local function DurationObjectShowsCooldown(durationObj)
     return shown
 end
 
+local function PlainNumber(value)
+    if value == nil or issecretvalue(value) then
+        return nil
+    end
+    return tonumber(value)
+end
+
 local BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS = {
-    -- Opt-in only. Execute needs continuity when its base/override cooldown
-    -- APIs briefly expose only GCD data while the old real cooldown object
-    -- still represents lockout; Thunderblast has the same shape but should
-    -- not inherit this bridge.
+    -- Opt-in only. Execute needs gameplay cooldown continuity when its
+    -- base/override cooldown APIs briefly expose only GCD data even though the
+    -- spell is still locked out. Do not generalize this to every base/override
+    -- pair without runtime evidence; Thunderblast has shown stale behavior
+    -- when broad bridging is applied.
     [163201] = {
         [280735] = true,
     },
 }
 
-local function SpellUsabilityIsTrue(spellID)
-    if spellID == nil or issecretvalue(spellID) then
-        return false
-    end
-    local isUsable = C_Spell_IsSpellUsable(spellID)
-    return isUsable == true
-end
+local EXECUTE_BRIDGE_CONTINUITY_SECONDS = 0.20
 
 local function GetConfiguredAuraUnit(buttonData)
     return buttonData.auraUnit or "player"
@@ -203,6 +205,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
         spellID = spellID,
         fetchOk = false,
         state = COOLDOWN_STATE_READY,
+        apiState = COOLDOWN_STATE_READY,
         realCooldownShown = false,
         isOnGCD = false,
         deferred = false,
@@ -242,6 +245,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
     end
 
+    result.apiState = result.state
     return result
 end
 
@@ -260,8 +264,8 @@ local function ShouldApplyBaseOverrideCooldownBridge(configuredSpellID, displayS
             or issecretvalue(configuredSpellID) or issecretvalue(displaySpellID) then
         return false
     end
-    local configured = tonumber(configuredSpellID)
-    local display = tonumber(displaySpellID)
+    local configured = PlainNumber(configuredSpellID)
+    local display = PlainNumber(displaySpellID)
     local displayMap = configured and BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS[configured] or nil
     return displayMap ~= nil and displayMap[display] == true
 end
@@ -302,6 +306,7 @@ end
 local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, configuredSpellID, displaySpellID)
     if not bridgeEligible then
         button._baseOverrideCooldownDurationObj = nil
+        button._baseOverrideCooldownLastRealAt = nil
         return result
     end
 
@@ -310,31 +315,35 @@ local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, c
             and result.realCooldownShown
             and result.renderDurationObj then
         button._baseOverrideCooldownDurationObj = result.renderDurationObj
+        button._baseOverrideCooldownLastRealAt = GetTime()
+        result.apiState = result.apiState or result.state
+        result.presentationState = COOLDOWN_STATE_COOLDOWN
+        result.presentationDurationObj = result.renderDurationObj
         return result
     end
 
     local previousRealDurationObj = button._baseOverrideCooldownDurationObj
-    if result
-            and result.state == COOLDOWN_STATE_GCD
-            and (SpellUsabilityIsTrue(displaySpellID)
-                or SpellUsabilityIsTrue(configuredSpellID)) then
-        button._baseOverrideCooldownDurationObj = nil
-        return result
-    end
+    local previousRealDurationShown = DurationObjectShowsCooldown(previousRealDurationObj)
+    local previousRealAge = button._baseOverrideCooldownLastRealAt
+        and (GetTime() - button._baseOverrideCooldownLastRealAt) or nil
+    local bridgeWindowActive = previousRealAge ~= nil
+        and previousRealAge <= EXECUTE_BRIDGE_CONTINUITY_SECONDS
     if result
             and result.state == COOLDOWN_STATE_GCD
             and previousRealDurationObj
-            and DurationObjectShowsCooldown(previousRealDurationObj) then
+            and previousRealDurationShown
+            and bridgeWindowActive then
         local bridged = CloneCooldownResult(result)
+        bridged.apiState = result.state
         bridged.state = COOLDOWN_STATE_COOLDOWN
         bridged.renderDurationObj = previousRealDurationObj
-        bridged.realDurationObj = previousRealDurationObj
-        bridged.realCooldownShown = true
-        bridged.bridgeApplied = true
+        bridged.presentationState = COOLDOWN_STATE_COOLDOWN
+        bridged.presentationDurationObj = previousRealDurationObj
         return bridged
     end
 
     button._baseOverrideCooldownDurationObj = nil
+    button._baseOverrideCooldownLastRealAt = nil
     return result
 end
 
@@ -528,7 +537,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local prevAuraDurationObj = button._auraActive and button._durationObj or nil
     button._durationObj = nil
     button._cooldownDeferred = nil
+    button._cooldownApiState = COOLDOWN_STATE_READY
     button._cooldownState = COOLDOWN_STATE_READY
+    button._cooldownPresentationState = COOLDOWN_STATE_READY
+    button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
 
     -- Fetch cooldown data and update the cooldown widget.
@@ -1104,20 +1116,29 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
+                button._cooldownApiState = spellCooldownResult.apiState
+                    or spellCooldownResult.state
+                    or COOLDOWN_STATE_READY
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
+                button._cooldownPresentationState = spellCooldownResult.presentationState
+                    or button._cooldownState
+                button._cooldownPresentationDurationObj = spellCooldownResult.presentationDurationObj
+                    or spellCooldownResult.renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
                 isGCDOnly = button._cooldownState == COOLDOWN_STATE_GCD
 
-                if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
-                    if spellCooldownResult.renderDurationObj then
-                        button._durationObj = spellCooldownResult.renderDurationObj
-                        button.cooldown:SetCooldownFromDurationObject(spellCooldownResult.renderDurationObj)
+                if button._cooldownPresentationState == COOLDOWN_STATE_COOLDOWN then
+                    if button._cooldownPresentationDurationObj then
+                        if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
+                            button._durationObj = button._cooldownPresentationDurationObj
+                        end
+                        button.cooldown:SetCooldownFromDurationObject(button._cooldownPresentationDurationObj)
                     else
                         button.cooldown:SetCooldown(0, 0)
                     end
-                elseif button._cooldownState == COOLDOWN_STATE_GCD then
-                    if style.showGCDSwipe == true and spellCooldownResult.renderDurationObj then
-                        button.cooldown:SetCooldownFromDurationObject(spellCooldownResult.renderDurationObj)
+                elseif button._cooldownPresentationState == COOLDOWN_STATE_GCD then
+                    if style.showGCDSwipe == true and button._cooldownPresentationDurationObj then
+                        button.cooldown:SetCooldownFromDurationObject(button._cooldownPresentationDurationObj)
                     else
                         button.cooldown:SetCooldown(0, 0)
                         button.cooldown:Hide()
@@ -1136,6 +1157,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     if actionSlotDurationObj then
                         isOnGCD = actionSlotCooldownShown and not actionSlotRealCooldownShown
                         isGCDOnly = actionSlotCooldownShown and not actionSlotRealCooldownShown
+                        button._cooldownApiState = actionSlotRealCooldownShown
+                            and COOLDOWN_STATE_COOLDOWN
+                            or COOLDOWN_STATE_GCD
                         button._cooldownState = actionSlotRealCooldownShown
                             and COOLDOWN_STATE_COOLDOWN
                             or COOLDOWN_STATE_GCD
@@ -1179,6 +1203,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     button._itemCdStart = 0
                     button._itemCdDuration = 0
                     button._cooldownDeferred = true
+                    button._cooldownApiState = COOLDOWN_STATE_COOLDOWN
                     button._cooldownState = COOLDOWN_STATE_COOLDOWN
                 else
                     button._itemCdStart = cdStart
@@ -1195,9 +1220,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                         end
                     end
                     if cdDuration and cdDuration > 0 then
+                        button._cooldownApiState = isGCDOnly and COOLDOWN_STATE_GCD
+                            or COOLDOWN_STATE_COOLDOWN
                         button._cooldownState = isGCDOnly and COOLDOWN_STATE_GCD
                             or COOLDOWN_STATE_COOLDOWN
                     else
+                        button._cooldownApiState = COOLDOWN_STATE_READY
                         button._cooldownState = COOLDOWN_STATE_READY
                     end
 
@@ -1420,9 +1448,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
     button._chargeState = ResolveChargeState(button, buttonData)
 
-    -- Canonical desaturation signal:
-    -- Derived from explicit cooldown/charge state, not cooldown widget visibility.
-    -- _cooldownDeferred is represented as cooldown state for dimming/visibility.
+    -- Cooldown desaturation follows gameplay cooldown state, not raw API state.
+    -- For normal buttons these are the same. For approved blind-gap bridges
+    -- like Execute, the gameplay state intentionally stays "cooldown" so all
+    -- cooldown visuals agree with the player-facing lockout.
     if buttonData.type == "item" then
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -119,19 +119,6 @@ local EXECUTE_TRACE_BASE_SPELL_ID = 163201
 local EXECUTE_TRACE_OVERRIDE_SPELL_ID = 280735
 local EXECUTE_TRACE_MAX_ENTRIES = 800
 
-local BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS = {
-    -- Opt-in only. Execute needs gameplay cooldown continuity when its
-    -- base/override cooldown APIs briefly expose only GCD data even though the
-    -- spell is still locked out. Do not generalize this to every base/override
-    -- pair without runtime evidence; Thunderblast has shown stale behavior
-    -- when broad bridging is applied.
-    [163201] = {
-        [280735] = true,
-    },
-}
-
-local EXECUTE_BRIDGE_CONTINUITY_SECONDS = 0.20
-
 local function SecretSafeValue(value)
     if value == nil then
         return nil
@@ -416,17 +403,6 @@ local function SelectSpellCooldownResult(current, candidate)
     return CooldownLogic.SelectStrongerCooldownState(current, candidate)
 end
 
-local function ShouldApplyBaseOverrideCooldownBridge(configuredSpellID, displaySpellID)
-    if configuredSpellID == nil or displaySpellID == nil
-            or issecretvalue(configuredSpellID) or issecretvalue(displaySpellID) then
-        return false
-    end
-    local configured = PlainNumber(configuredSpellID)
-    local display = PlainNumber(displaySpellID)
-    local displayMap = configured and BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS[configured] or nil
-    return displayMap ~= nil and displayMap[display] == true
-end
-
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
     local result = displayResult
@@ -438,7 +414,6 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     if cooldownSpellId and cooldownSpellId ~= buttonData.id then
         local displayBaseSpellID = C_Spell.GetBaseSpell(cooldownSpellId)
         if displayBaseSpellID == buttonData.id then
-            bridgeEligible = ShouldApplyBaseOverrideCooldownBridge(buttonData.id, cooldownSpellId)
             local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
             traceLanes.displayBaseSpellID = displayBaseSpellID
             traceLanes.base = baseResult
@@ -456,19 +431,9 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     return result, bridgeEligible, traceLanes
 end
 
-local function CloneCooldownResult(result)
-    local clone = {}
-    if result then
-        for key, value in pairs(result) do
-            clone[key] = value
-        end
-    end
-    return clone
-end
-
 local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, configuredSpellID, displaySpellID)
     button._baseOverrideBridgeTrace = {
-        eligible = bridgeEligible == true,
+        eligible = false,
         configuredSpellID = configuredSpellID,
         displaySpellID = displaySpellID,
         preState = result and result.state or nil,
@@ -477,65 +442,10 @@ local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, c
         cleared = false,
     }
 
-    if not bridgeEligible then
-        button._baseOverrideCooldownDurationObj = nil
-        button._baseOverrideCooldownLastRealAt = nil
-        button._baseOverrideBridgeTrace.cleared = true
-        button._baseOverrideBridgeTrace.reason = "not-eligible"
-        return result
-    end
-
-    if result
-            and result.state == COOLDOWN_STATE_COOLDOWN
-            and result.realCooldownShown
-            and result.renderDurationObj then
-        button._baseOverrideCooldownDurationObj = result.renderDurationObj
-        button._baseOverrideCooldownLastRealAt = GetTime()
-        result.apiState = result.apiState or result.state
-        result.presentationState = COOLDOWN_STATE_COOLDOWN
-        result.presentationDurationObj = result.renderDurationObj
-        button._baseOverrideBridgeTrace.storedDirectReal = true
-        button._baseOverrideBridgeTrace.reason = "direct-real"
-        return result
-    end
-
-    local previousRealDurationObj = button._baseOverrideCooldownDurationObj
-    local previousRealDurationShown = DurationObjectShowsCooldown(previousRealDurationObj)
-    local previousRealAge = button._baseOverrideCooldownLastRealAt
-        and (GetTime() - button._baseOverrideCooldownLastRealAt) or nil
-    local bridgeWindowActive = previousRealAge ~= nil
-        and previousRealAge <= EXECUTE_BRIDGE_CONTINUITY_SECONDS
-    button._baseOverrideBridgeTrace.previousRealDurationShown = previousRealDurationShown
-    button._baseOverrideBridgeTrace.previousRealAge = previousRealAge
-    button._baseOverrideBridgeTrace.bridgeWindowActive = bridgeWindowActive
-    if result
-            and result.state == COOLDOWN_STATE_GCD
-            and previousRealDurationObj
-            and previousRealDurationShown
-            and bridgeWindowActive then
-        local bridged = CloneCooldownResult(result)
-        bridged.apiState = result.state
-        bridged.state = COOLDOWN_STATE_COOLDOWN
-        bridged.renderDurationObj = previousRealDurationObj
-        bridged.presentationState = COOLDOWN_STATE_COOLDOWN
-        bridged.presentationDurationObj = previousRealDurationObj
-        button._baseOverrideBridgeTrace.applied = true
-        button._baseOverrideBridgeTrace.reason = "bridged-gcd"
-        return bridged
-    end
-
     button._baseOverrideCooldownDurationObj = nil
     button._baseOverrideCooldownLastRealAt = nil
     button._baseOverrideBridgeTrace.cleared = true
-    if not previousRealDurationObj then
-        button._baseOverrideBridgeTrace.reason = "no-previous-real"
-    elseif not previousRealDurationShown then
-        button._baseOverrideBridgeTrace.reason = "previous-real-not-shown"
-    elseif not bridgeWindowActive then
-        button._baseOverrideBridgeTrace.reason = "bridge-window-expired"
-    else
-        button._baseOverrideBridgeTrace.reason = "state-not-gcd"
-    end
+    button._baseOverrideBridgeTrace.reason = "disabled"
     return result
 end
 
@@ -820,10 +730,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local spellCooldownResult
     local spellCooldownTrace
     local spellBaseOverrideBridgeEligible = false
-    local actionSlotCooldownShown
-    local actionSlotDurationObj
-    local actionSlotRealDurationObj
-    local actionSlotRealCooldownShown = false
     -- Aura-override probe: cached for reuse by secondary CD and sound alerts.
     local auraProbeInfo, auraProbeIsGCDOnly
     local auraProbeDuration
@@ -1421,39 +1327,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 end
                 fetchOk = true
             elseif not fetchOk then
-                -- GetSpellCooldown returned nil: fall back to action-slot probe.
-                -- Covers vehicle bar, override bar, and rare ContextuallySecret
-                -- spells whose spell-level API is unavailable in combat.
-                if not usesChargeBehavior and buttonData._cooldownSecrecy ~= 0 then
-                    actionSlotCooldownShown, actionSlotDurationObj, actionSlotRealCooldownShown, actionSlotRealDurationObj =
-                        ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-                    if actionSlotDurationObj then
-                        isOnGCD = actionSlotCooldownShown and not actionSlotRealCooldownShown
-                        isGCDOnly = actionSlotCooldownShown and not actionSlotRealCooldownShown
-                        button._cooldownApiState = actionSlotRealCooldownShown
-                            and COOLDOWN_STATE_COOLDOWN
-                            or COOLDOWN_STATE_GCD
-                        button._cooldownState = actionSlotRealCooldownShown
-                            and COOLDOWN_STATE_COOLDOWN
-                            or COOLDOWN_STATE_GCD
-                        local renderDurationObj = (actionSlotRealCooldownShown and actionSlotRealDurationObj)
-                            or actionSlotDurationObj
-                        if button._cooldownState == COOLDOWN_STATE_COOLDOWN and renderDurationObj then
-                            button._durationObj = renderDurationObj
-                            button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
-                        elseif style.showGCDSwipe == true and renderDurationObj then
-                            button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
-                        else
-                            button.cooldown:SetCooldown(0, 0)
-                            button.cooldown:Hide()
-                        end
-                        fetchOk = true
-                    end
-                end
-                -- Ensure widget is in a known state when all paths failed.
-                if not fetchOk then
-                    button.cooldown:SetCooldown(0, 0)
-                end
+                button.cooldown:SetCooldown(0, 0)
             end
         elseif buttonData.type == "item" then
             button._isEquippableNotEquipped = false

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -108,6 +108,24 @@ local function DurationObjectShowsCooldown(durationObj)
     return shown
 end
 
+local BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS = {
+    -- Opt-in only. Execute needs continuity when its base/override cooldown
+    -- APIs briefly expose only GCD data while the old real cooldown object
+    -- still represents lockout; Thunderblast has the same shape but should
+    -- not inherit this bridge.
+    [163201] = {
+        [280735] = true,
+    },
+}
+
+local function SpellUsabilityIsTrue(spellID)
+    if spellID == nil or issecretvalue(spellID) then
+        return false
+    end
+    local isUsable = C_Spell_IsSpellUsable(spellID)
+    return isUsable == true
+end
+
 local function GetConfiguredAuraUnit(buttonData)
     return buttonData.auraUnit or "player"
 end
@@ -237,15 +255,26 @@ local function SelectSpellCooldownResult(current, candidate)
     return CooldownLogic.SelectStrongerCooldownState(current, candidate)
 end
 
+local function ShouldApplyBaseOverrideCooldownBridge(configuredSpellID, displaySpellID)
+    if configuredSpellID == nil or displaySpellID == nil
+            or issecretvalue(configuredSpellID) or issecretvalue(displaySpellID) then
+        return false
+    end
+    local configured = tonumber(configuredSpellID)
+    local display = tonumber(displaySpellID)
+    local displayMap = configured and BASE_OVERRIDE_COOLDOWN_BRIDGE_PAIRS[configured] or nil
+    return displayMap ~= nil and displayMap[display] == true
+end
+
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
     local result = displayResult
-    local baseOverridePair = false
+    local bridgeEligible = false
 
     if cooldownSpellId and cooldownSpellId ~= buttonData.id then
         local displayBaseSpellID = C_Spell.GetBaseSpell(cooldownSpellId)
         if displayBaseSpellID == buttonData.id then
-            baseOverridePair = true
+            bridgeEligible = ShouldApplyBaseOverrideCooldownBridge(buttonData.id, cooldownSpellId)
             local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
             result = SelectSpellCooldownResult(
                 result,
@@ -257,7 +286,7 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
         end
     end
 
-    return result, baseOverridePair
+    return result, bridgeEligible
 end
 
 local function CloneCooldownResult(result)
@@ -270,8 +299,8 @@ local function CloneCooldownResult(result)
     return clone
 end
 
-local function ApplyBaseOverrideCooldownBridge(button, result, baseOverridePair)
-    if not baseOverridePair then
+local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, configuredSpellID, displaySpellID)
+    if not bridgeEligible then
         button._baseOverrideCooldownDurationObj = nil
         return result
     end
@@ -285,6 +314,13 @@ local function ApplyBaseOverrideCooldownBridge(button, result, baseOverridePair)
     end
 
     local previousRealDurationObj = button._baseOverrideCooldownDurationObj
+    if result
+            and result.state == COOLDOWN_STATE_GCD
+            and (SpellUsabilityIsTrue(displaySpellID)
+                or SpellUsabilityIsTrue(configuredSpellID)) then
+        button._baseOverrideCooldownDurationObj = nil
+        return result
+    end
     if result
             and result.state == COOLDOWN_STATE_GCD
             and previousRealDurationObj
@@ -502,7 +538,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local spellCooldownDuration
     local spellRealCooldownShown = false
     local spellCooldownResult
-    local spellBaseOverridePair = false
+    local spellBaseOverrideBridgeEligible = false
     local actionSlotCooldownShown
     local actionSlotDurationObj
     local actionSlotRealDurationObj
@@ -1054,8 +1090,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOverrideActive then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            spellCooldownResult, spellBaseOverridePair = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
-            spellCooldownResult = ApplyBaseOverrideCooldownBridge(button, spellCooldownResult, spellBaseOverridePair)
+            spellCooldownResult, spellBaseOverrideBridgeEligible =
+                EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
+            spellCooldownResult = ApplyBaseOverrideCooldownBridge(
+                button,
+                spellCooldownResult,
+                spellBaseOverrideBridgeEligible,
+                buttonData.id,
+                cooldownSpellId
+            )
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -62,6 +62,12 @@ local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
 local TARGET_SWITCH_SAFETY_CAP = 0.60
+local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
+local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 local function AuraDataHasTimer(auraData)
     if not auraData then return false end
@@ -140,13 +146,7 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
         return false
     end
 
-    local cur = button._currentReadableCharges
-    local maxCharges = buttonData.maxCharges
-    if button._chargeCountReadable == true and cur ~= nil and maxCharges ~= nil then
-        return cur == maxCharges
-    end
-
-    return not button._chargeRecharging and not button._zeroChargesConfirmed
+    return button._chargeState == CHARGE_STATE_FULL
 end
 
 -- Deferred spell cooldown detection: distinguish true held cooldowns from
@@ -178,6 +178,161 @@ local function IsSpellCooldownDeferred(info)
     end
 
     return recoveryTime <= 0
+end
+
+local function EvaluateSpellCooldownLane(spellID, secrecy)
+    local result = {
+        spellID = spellID,
+        fetchOk = false,
+        state = COOLDOWN_STATE_READY,
+        realCooldownShown = false,
+        isOnGCD = false,
+        deferred = false,
+    }
+
+    if not spellID then
+        return result
+    end
+
+    local info = C_Spell.GetSpellCooldown(spellID)
+    result.info = info
+    if not info then
+        return result
+    end
+
+    result.fetchOk = true
+    result.isOnGCD = info.isOnGCD or false
+    result.deferred = IsSpellCooldownDeferred(info)
+
+    if info.isActive then
+        result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+        result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
+        result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
+    end
+
+    if result.deferred then
+        result.state = COOLDOWN_STATE_COOLDOWN
+    elseif result.realCooldownShown and result.realDurationObj then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.renderDurationObj = result.realDurationObj
+    elseif CooldownLogic.IsSpellGCDOnly(info, {
+        secrecy = secrecy,
+        gcdInfo = CooldownCompanion._gcdInfo,
+        realCooldownShown = result.realCooldownShown,
+    }) then
+        result.state = COOLDOWN_STATE_GCD
+        result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
+    end
+
+    return result
+end
+
+local function SelectSpellCooldownResult(current, candidate)
+    if not candidate or not candidate.fetchOk then
+        return current
+    end
+    if not current or not current.fetchOk then
+        return candidate
+    end
+    return CooldownLogic.SelectStrongerCooldownState(current, candidate)
+end
+
+local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
+    local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
+    local result = displayResult
+    local baseOverridePair = false
+
+    if cooldownSpellId and cooldownSpellId ~= buttonData.id then
+        local displayBaseSpellID = C_Spell.GetBaseSpell(cooldownSpellId)
+        if displayBaseSpellID == buttonData.id then
+            baseOverridePair = true
+            local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
+            result = SelectSpellCooldownResult(
+                result,
+                baseResult
+            )
+            if result and (displayResult.isOnGCD or baseResult.isOnGCD) then
+                result.isOnGCD = true
+            end
+        end
+    end
+
+    return result, baseOverridePair
+end
+
+local function CloneCooldownResult(result)
+    local clone = {}
+    if result then
+        for key, value in pairs(result) do
+            clone[key] = value
+        end
+    end
+    return clone
+end
+
+local function ApplyBaseOverrideCooldownBridge(button, result, baseOverridePair)
+    if not baseOverridePair then
+        button._baseOverrideCooldownDurationObj = nil
+        return result
+    end
+
+    if result
+            and result.state == COOLDOWN_STATE_COOLDOWN
+            and result.realCooldownShown
+            and result.renderDurationObj then
+        button._baseOverrideCooldownDurationObj = result.renderDurationObj
+        return result
+    end
+
+    local previousRealDurationObj = button._baseOverrideCooldownDurationObj
+    if result
+            and result.state == COOLDOWN_STATE_GCD
+            and previousRealDurationObj
+            and DurationObjectShowsCooldown(previousRealDurationObj) then
+        local bridged = CloneCooldownResult(result)
+        bridged.state = COOLDOWN_STATE_COOLDOWN
+        bridged.renderDurationObj = previousRealDurationObj
+        bridged.realDurationObj = previousRealDurationObj
+        bridged.realCooldownShown = true
+        bridged.bridgeApplied = true
+        return bridged
+    end
+
+    button._baseOverrideCooldownDurationObj = nil
+    return result
+end
+
+local function ResolveChargeState(button, buttonData)
+    if not UsesChargeBehavior(buttonData) then
+        return nil
+    end
+
+    local currentCharges = button._currentReadableCharges
+    local maxCharges = buttonData.maxCharges
+    if button._chargeCountReadable == true and currentCharges ~= nil then
+        if currentCharges <= 0 then
+            return CHARGE_STATE_ZERO
+        end
+        if maxCharges and maxCharges > 0 then
+            if currentCharges >= maxCharges then
+                return CHARGE_STATE_FULL
+            end
+            return CHARGE_STATE_MISSING
+        end
+        return CHARGE_STATE_FULL
+    end
+
+    if button._zeroChargesConfirmed == true then
+        return CHARGE_STATE_ZERO
+    end
+    if button._chargeRecharging == true then
+        return CHARGE_STATE_MISSING
+    end
+    if button._chargeRecharging == false then
+        return CHARGE_STATE_FULL
+    end
+
+    return nil
 end
 
 -- Probe action-slot cooldown state for a spell ID pair (base + display override).
@@ -218,7 +373,7 @@ local function ProbeActionSlotsForSpellID(spellID)
             end
 
             if shown then
-                return true, durationObj, realShown, sawAnySlot, sawUnknown
+                return true, durationObj, realShown, sawAnySlot, sawUnknown, realDurationObj
             end
         end
     end
@@ -234,19 +389,19 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
     local sawAnySlot = false
     local sawUnknown = false
 
-    local shown, durationObj, realShown, sawAny, sawUnk = ProbeActionSlotsForSpellID(baseSpellID)
+    local shown, durationObj, realShown, sawAny, sawUnk, realDurationObj = ProbeActionSlotsForSpellID(baseSpellID)
     if sawAny then sawAnySlot = true end
     if sawUnk then sawUnknown = true end
     if shown then
-        return true, durationObj, realShown
+        return true, durationObj, realShown, realDurationObj
     end
 
     if displaySpellID and displaySpellID ~= baseSpellID then
-        shown, durationObj, realShown, sawAny, sawUnk = ProbeActionSlotsForSpellID(displaySpellID)
+        shown, durationObj, realShown, sawAny, sawUnk, realDurationObj = ProbeActionSlotsForSpellID(displaySpellID)
         if sawAny then sawAnySlot = true end
         if sawUnk then sawUnknown = true end
         if shown then
-            return true, durationObj, realShown
+            return true, durationObj, realShown, realDurationObj
         end
     end
 
@@ -337,16 +492,20 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local prevAuraDurationObj = button._auraActive and button._durationObj or nil
     button._durationObj = nil
     button._cooldownDeferred = nil
+    button._cooldownState = COOLDOWN_STATE_READY
+    button._chargeState = nil
 
     -- Fetch cooldown data and update the cooldown widget.
     -- isOnGCD is NeverSecret (always readable even during restricted combat).
     local fetchOk, isOnGCD
     local spellCooldownInfo
     local spellCooldownDuration
-    local spellRealCooldownDuration
     local spellRealCooldownShown = false
+    local spellCooldownResult
+    local spellBaseOverridePair = false
     local actionSlotCooldownShown
     local actionSlotDurationObj
+    local actionSlotRealDurationObj
     local actionSlotRealCooldownShown = false
     -- Aura-override probe: cached for reuse by secondary CD and sound alerts.
     local auraProbeInfo, auraProbeIsGCDOnly
@@ -895,48 +1054,32 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOverrideActive then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            -- isActive (NeverSecret, 12.0.1 hotfix) is authoritative for whether
-            -- the UI should render a cooldown.  Action-slot probing is deferred to
-            -- the nil-fallback below — only needed when GetSpellCooldown returns nil
-            -- (vehicle bar, override bar edge cases).
+            spellCooldownResult, spellBaseOverridePair = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
+            spellCooldownResult = ApplyBaseOverrideCooldownBridge(button, spellCooldownResult, spellBaseOverridePair)
+            if spellCooldownResult and spellCooldownResult.fetchOk then
+                spellCooldownInfo = spellCooldownResult.info
+                spellCooldownDuration = spellCooldownResult.durationObj
+                spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
+                isOnGCD = spellCooldownResult.isOnGCD or false
+                button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
+                button._cooldownDeferred = spellCooldownResult.deferred or nil
+                isGCDOnly = button._cooldownState == COOLDOWN_STATE_GCD
 
-            spellCooldownInfo = C_Spell.GetSpellCooldown(cooldownSpellId)
-            if spellCooldownInfo then
-                isOnGCD = spellCooldownInfo.isOnGCD
-
-                -- Deferred cooldown detection (e.g. Feign Death while the buff
-                -- is active): keep true hold states on the deferred path, but
-                -- exclude start-recovery / empower recovery windows. Those can
-                -- report isEnabled=false before a real cooldown begins, and
-                -- should not dim or hide unrelated spells as "on cooldown".
-                if IsSpellCooldownDeferred(spellCooldownInfo) then
-                    button._cooldownDeferred = true
-                end
-
-                -- Keep the raw cooldown widget on the default duration object so
-                -- optional GCD presentation still works in icon mode. In parallel,
-                -- fetch the ignoreGCD duration to decide whether a real cooldown
-                -- is actually active for stateful addon logic.
-                if spellCooldownInfo.isActive then
-                    spellCooldownDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId)
-                    spellRealCooldownDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
-                    spellRealCooldownShown = DurationObjectShowsCooldown(spellRealCooldownDuration)
-                end
-
-                isGCDOnly = CooldownLogic.IsSpellGCDOnly(spellCooldownInfo, {
-                    secrecy = buttonData._cooldownSecrecy,
-                    gcdInfo = CooldownCompanion._gcdInfo,
-                    gcdActive = CooldownCompanion._gcdActive,
-                    realCooldownShown = spellRealCooldownShown,
-                })
-
-                if spellRealCooldownShown and spellRealCooldownDuration then
-                    button._durationObj = spellRealCooldownDuration
-                end
-
-                if spellCooldownDuration then
-                    button.cooldown:SetCooldownFromDurationObject(spellCooldownDuration)
-                elseif not fetchOk then
+                if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
+                    if spellCooldownResult.renderDurationObj then
+                        button._durationObj = spellCooldownResult.renderDurationObj
+                        button.cooldown:SetCooldownFromDurationObject(spellCooldownResult.renderDurationObj)
+                    else
+                        button.cooldown:SetCooldown(0, 0)
+                    end
+                elseif button._cooldownState == COOLDOWN_STATE_GCD then
+                    if style.showGCDSwipe == true and spellCooldownResult.renderDurationObj then
+                        button.cooldown:SetCooldownFromDurationObject(spellCooldownResult.renderDurationObj)
+                    else
+                        button.cooldown:SetCooldown(0, 0)
+                        button.cooldown:Hide()
+                    end
+                else
                     button.cooldown:SetCooldown(0, 0)
                 end
                 fetchOk = true
@@ -945,14 +1088,24 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 -- Covers vehicle bar, override bar, and rare ContextuallySecret
                 -- spells whose spell-level API is unavailable in combat.
                 if not usesChargeBehavior and buttonData._cooldownSecrecy ~= 0 then
-                    actionSlotCooldownShown, actionSlotDurationObj, actionSlotRealCooldownShown =
+                    actionSlotCooldownShown, actionSlotDurationObj, actionSlotRealCooldownShown, actionSlotRealDurationObj =
                         ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
                     if actionSlotDurationObj then
-                        button._durationObj = actionSlotDurationObj
-                        button.cooldown:SetCooldownFromDurationObject(actionSlotDurationObj)
+                        isOnGCD = actionSlotCooldownShown and not actionSlotRealCooldownShown
                         isGCDOnly = actionSlotCooldownShown and not actionSlotRealCooldownShown
-                        if isGCDOnly then
-                            isOnGCD = true
+                        button._cooldownState = actionSlotRealCooldownShown
+                            and COOLDOWN_STATE_COOLDOWN
+                            or COOLDOWN_STATE_GCD
+                        local renderDurationObj = (actionSlotRealCooldownShown and actionSlotRealDurationObj)
+                            or actionSlotDurationObj
+                        if button._cooldownState == COOLDOWN_STATE_COOLDOWN and renderDurationObj then
+                            button._durationObj = renderDurationObj
+                            button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
+                        elseif style.showGCDSwipe == true and renderDurationObj then
+                            button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
+                        else
+                            button.cooldown:SetCooldown(0, 0)
+                            button.cooldown:Hide()
                         end
                         fetchOk = true
                     end
@@ -983,8 +1136,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     button._itemCdStart = 0
                     button._itemCdDuration = 0
                     button._cooldownDeferred = true
+                    button._cooldownState = COOLDOWN_STATE_COOLDOWN
                 else
-                    button.cooldown:SetCooldown(cdStart, cdDuration)
                     button._itemCdStart = cdStart
                     button._itemCdDuration = cdDuration
                     -- GCD-only detection for items: C_Item.GetItemCooldown returns
@@ -997,6 +1150,19 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 and cdDuration == gcdInfo.duration then
                             isGCDOnly = true
                         end
+                    end
+                    if cdDuration and cdDuration > 0 then
+                        button._cooldownState = isGCDOnly and COOLDOWN_STATE_GCD
+                            or COOLDOWN_STATE_COOLDOWN
+                    else
+                        button._cooldownState = COOLDOWN_STATE_READY
+                    end
+
+                    if button._cooldownState == COOLDOWN_STATE_GCD and style.showGCDSwipe ~= true then
+                        button.cooldown:SetCooldown(0, 0)
+                        button.cooldown:Hide()
+                    else
+                        button.cooldown:SetCooldown(cdStart, cdDuration)
                     end
                 end
             end
@@ -1011,11 +1177,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if usesChargeBehavior and buttonData.hasCharges and buttonData.type == "spell" then
         button._displayCountZeroUsabilityFallback = nil
         charges = UpdateChargeTracking(button, buttonData, cooldownSpellId)
+        button._chargeRecharging = DurationObjectShowsCooldown(button._chargeDurationObj)
     elseif usesChargeBehavior
         and (buttonData._hasDisplayCount or buttonData._displayCountFamily)
         and buttonData.type == "spell"
     then
         UpdateDisplayCountTracking(button, buttonData, cooldownSpellId)
+    elseif usesChargeBehavior and buttonData.type == "item" then
+        UpdateItemChargeTracking(button, buttonData)
+        button._chargeRecharging = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif not usesChargeBehavior then
         -- hasCharges cleared: wipe stale charge state.
         button._currentReadableCharges = nil
@@ -1205,24 +1375,19 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     else
         button._zeroChargesConfirmed = false
     end
+    button._chargeState = ResolveChargeState(button, buttonData)
 
     -- Canonical desaturation signal:
-    -- For non-charge spells, use action-slot cooldown state when spell cooldown
-    -- info is unavailable (nil-fallback probe). Otherwise use addon state.
-    -- _cooldownDeferred: timer hasn't started (e.g. Healthstone in combat, Feign
-    -- Death while buff active).  Treat as "on cooldown" for dimming/visibility.
+    -- Derived from explicit cooldown/charge state, not cooldown widget visibility.
+    -- _cooldownDeferred is represented as cooldown state for dimming/visibility.
     if buttonData.type == "item" then
-        button._desatCooldownActive = (button._itemCdDuration and button._itemCdDuration > 0 and not isGCDOnly)
-            or button._cooldownDeferred or false
+        button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then
-        button._desatCooldownActive = (button._zeroChargesConfirmed == true)
+        button._desatCooldownActive = button._chargeState == CHARGE_STATE_ZERO
+    elseif auraOverrideActive and auraProbeInfo then
+        button._desatCooldownActive = (auraProbeRealCooldownShown and not auraProbeIsGCDOnly) or false
     else
-        if actionSlotCooldownShown ~= nil and spellCooldownInfo == nil then
-            button._desatCooldownActive = actionSlotRealCooldownShown
-        else
-            button._desatCooldownActive = (button._durationObj ~= nil) and (not isGCDOnly)
-                or button._cooldownDeferred or false
-        end
+        button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     end
     -- Track on-CD → off-CD transition for ready glow duration timer.
     -- desatWasActive is true only when the previous tick had an active cooldown,
@@ -1246,15 +1411,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._durationObj = nil
         end
 
-        -- Charge recharging state: charges.isActive (NeverSecret) is false when
-        -- not recharging (at max charges, or start/duration zero) — exactly the
-        -- semantic we need.
-        if charges then
-            button._chargeRecharging = charges.isActive
-        else
-            button._chargeRecharging = false
-        end
-
         if not auraOverrideActive and button._chargeDurationObj then
             if not button._isBar and not button._isText then
                 -- Icon mode: always set _durationObj, show recharge radial
@@ -1276,12 +1432,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         end
 
-      elseif buttonData.type == "item" then
-        UpdateItemChargeTracking(button, buttonData)
-
-        -- Detect recharging via stored item cooldown values
-        button._chargeRecharging = (button._itemCdDuration and button._itemCdDuration > 0 and not isGCDOnly)
-            or button._cooldownDeferred or false
       end
     end
 
@@ -1332,28 +1482,17 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
 
     -- Charge text color: three-state (zero / partial / max).
-    -- Direct comparison when readable charges available; flag fallback in restricted mode.
+    -- Uses the canonical charge state resolved above.
     if style.chargeFontColor or style.chargeFontColorMissing or style.chargeFontColorZero then
         local cc
-        local cur = button._currentReadableCharges
-        if usesChargeBehavior and button._chargeCountReadable == true and cur ~= nil and buttonData.maxCharges then
-            if cur == 0 then
-                cc = style.chargeFontColorZero or DEFAULT_WHITE
-            elseif cur < buttonData.maxCharges then
-                cc = style.chargeFontColorMissing or DEFAULT_WHITE
-            else
-                cc = style.chargeFontColor or DEFAULT_WHITE
-            end
+        if usesChargeBehavior and button._chargeState == CHARGE_STATE_ZERO then
+            cc = style.chargeFontColorZero or DEFAULT_WHITE
+        elseif usesChargeBehavior and button._chargeState == CHARGE_STATE_MISSING then
+            cc = style.chargeFontColorMissing or DEFAULT_WHITE
+        elseif usesChargeBehavior and button._chargeState == CHARGE_STATE_FULL then
+            cc = style.chargeFontColor or DEFAULT_WHITE
         elseif usesChargeBehavior then
-            -- Restricted mode: charges unreadable via C_Spell.
-            -- Use canonical zero state derived from _mainCDShown + cast history.
-            if not button._chargeRecharging then
-                cc = style.chargeFontColor or DEFAULT_WHITE             -- FULL (max charges)
-            elseif button._zeroChargesConfirmed then
-                cc = style.chargeFontColorZero or DEFAULT_WHITE         -- ZERO (all spent)
-            else
-                cc = style.chargeFontColorMissing or DEFAULT_WHITE      -- MISSING (recharging)
-            end
+            cc = style.chargeFontColor or DEFAULT_WHITE
         elseif UsesChargeTextLane(buttonData) then
             cc = style.chargeFontColor or DEFAULT_WHITE
         end
@@ -1395,11 +1534,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local cooldownActive
             if usesChargeBehavior then
                 -- Charge spells: cooldown-active means zero available charges.
-                if currentCharges ~= nil then
-                    cooldownActive = (currentCharges == 0)
-                else
-                    cooldownActive = button._zeroChargesConfirmed == true
-                end
+                cooldownActive = button._chargeState == CHARGE_STATE_ZERO
             elseif auraOverrideActive then
                 -- Aura visuals replace button.cooldown; reuse the shared
                 -- probe computed above (same spell, same tick).
@@ -1410,11 +1545,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 end
             else
                 -- Normal path: real cooldown ignores GCD-only presentation.
-                if spellCooldownInfo then
-                    cooldownActive = spellRealCooldownShown and not isGCDOnly
-                else
-                    cooldownActive = false
-                end
+                cooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
             end
 
             self:UpdateButtonSoundAlerts(
@@ -1435,7 +1566,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Per-button visibility evaluation (after charge tracking)
     button._procOverlayActive = procOverlayActive
-    EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverrideActive, procOverlayActive)
+    EvaluateButtonVisibility(button, buttonData, auraOverrideActive, procOverlayActive)
     button._rawVisibilityHidden = button._visibilityHidden
     button._rawVisibilityAlphaOverride = button._visibilityAlphaOverride
 

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -118,6 +118,11 @@ end
 local EXECUTE_TRACE_BASE_SPELL_ID = 163201
 local EXECUTE_TRACE_OVERRIDE_SPELL_ID = 280735
 local EXECUTE_TRACE_MAX_ENTRIES = 800
+local EXECUTE_COOLDOWN_BRIDGE_MAX_SECONDS = 0.12
+local EXECUTE_COOLDOWN_BRIDGE_SPELLS = {
+    [EXECUTE_TRACE_BASE_SPELL_ID] = true,
+    [EXECUTE_TRACE_OVERRIDE_SPELL_ID] = true,
+}
 
 local function SecretSafeValue(value)
     if value == nil then
@@ -215,9 +220,9 @@ local function GetCooldownStateTrace()
         trace = {}
         CooldownCompanionDB.global.cooldownStateTrace = trace
     end
-    if trace.version ~= 3 or trace.subject ~= "execute-frame-trace" then
+    if trace.version ~= 5 or trace.subject ~= "execute-frame-trace" then
         wipe(trace)
-        trace.version = 3
+        trace.version = 5
         trace.subject = "execute-frame-trace"
     end
 
@@ -403,6 +408,15 @@ local function SelectSpellCooldownResult(current, candidate)
     return CooldownLogic.SelectStrongerCooldownState(current, candidate)
 end
 
+local function IsExecuteCooldownBridgePair(configuredSpellID, displaySpellID)
+    configuredSpellID = PlainNumber(configuredSpellID)
+    displaySpellID = PlainNumber(displaySpellID)
+    return configuredSpellID == EXECUTE_TRACE_BASE_SPELL_ID
+        and displaySpellID == EXECUTE_TRACE_OVERRIDE_SPELL_ID
+        and EXECUTE_COOLDOWN_BRIDGE_SPELLS[configuredSpellID] == true
+        and EXECUTE_COOLDOWN_BRIDGE_SPELLS[displaySpellID] == true
+end
+
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
     local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
     local result = displayResult
@@ -417,6 +431,7 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
             local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
             traceLanes.displayBaseSpellID = displayBaseSpellID
             traceLanes.base = baseResult
+            bridgeEligible = IsExecuteCooldownBridgePair(buttonData.id, cooldownSpellId)
             result = SelectSpellCooldownResult(
                 result,
                 baseResult
@@ -432,21 +447,119 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
 end
 
 local function ApplyBaseOverrideCooldownBridge(button, result, bridgeEligible, configuredSpellID, displaySpellID)
+    local previousDurationObj = button._baseOverrideCooldownDurationObj
+    local previousDurationShown = DurationObjectShowsCooldown(previousDurationObj)
+    local now = GetTime()
+
     button._baseOverrideBridgeTrace = {
-        eligible = false,
+        eligible = bridgeEligible == true,
         configuredSpellID = configuredSpellID,
         displaySpellID = displaySpellID,
         preState = result and result.state or nil,
         preApiState = result and result.apiState or nil,
         applied = false,
         cleared = false,
+        active = button._baseOverrideCooldownBridgeActive == true,
+        previousDurationShown = previousDurationShown,
+        previousLastRealWasOnGCD = button._baseOverrideCooldownLastRealWasOnGCD,
+        maxSeconds = EXECUTE_COOLDOWN_BRIDGE_MAX_SECONDS,
     }
 
-    button._baseOverrideCooldownDurationObj = nil
-    button._baseOverrideCooldownLastRealAt = nil
-    button._baseOverrideBridgeTrace.cleared = true
-    button._baseOverrideBridgeTrace.reason = "disabled"
-    return result
+    local function clearBridge(reason)
+        button._baseOverrideCooldownDurationObj = nil
+        button._baseOverrideCooldownLastRealAt = nil
+        button._baseOverrideCooldownLastRealWasOnGCD = nil
+        button._baseOverrideCooldownBridgeActive = nil
+        button._baseOverrideCooldownBridgeStartedAt = nil
+        button._baseOverrideBridgeTrace.cleared = true
+        button._baseOverrideBridgeTrace.reason = reason
+    end
+
+    if not bridgeEligible then
+        clearBridge("not-eligible")
+        return result
+    end
+
+    if not result or not result.fetchOk then
+        clearBridge("no-result")
+        return result
+    end
+
+    -- Execute can briefly report only GCD during a real cooldown.  This bridge is
+    -- deliberately opt-in and only carries forward a directly observed real
+    -- cooldown; it is not a normal cooldown source.
+    if result.state == COOLDOWN_STATE_COOLDOWN
+            and result.realCooldownShown == true
+            and result.renderDurationObj then
+        button._baseOverrideCooldownDurationObj = result.renderDurationObj
+        button._baseOverrideCooldownLastRealAt = now
+        button._baseOverrideCooldownLastRealWasOnGCD = result.isOnGCD == true
+        button._baseOverrideCooldownBridgeActive = nil
+        button._baseOverrideCooldownBridgeStartedAt = nil
+        button._baseOverrideBridgeTrace.reason = "direct-real-cooldown"
+        button._baseOverrideBridgeTrace.trackedRealSpellID = result.spellID
+        return result
+    end
+
+    if result.state ~= COOLDOWN_STATE_GCD then
+        clearBridge("direct-non-gcd")
+        return result
+    end
+
+    if not previousDurationShown then
+        clearBridge("no-active-previous-real")
+        return result
+    end
+
+    local bridgeAlreadyActive = button._baseOverrideCooldownBridgeActive == true
+    if not bridgeAlreadyActive then
+        if button._baseOverrideCooldownLastRealWasOnGCD == true then
+            clearBridge("previous-real-overlapped-gcd")
+            return result
+        end
+        button._baseOverrideCooldownBridgeStartedAt = now
+    elseif not button._baseOverrideCooldownBridgeStartedAt then
+        button._baseOverrideCooldownBridgeStartedAt = now
+    end
+
+    local bridgeElapsed = now - button._baseOverrideCooldownBridgeStartedAt
+    button._baseOverrideBridgeTrace.elapsed = bridgeElapsed
+    if bridgeElapsed > EXECUTE_COOLDOWN_BRIDGE_MAX_SECONDS then
+        clearBridge("debounce-expired")
+        button._baseOverrideBridgeTrace.elapsed = bridgeElapsed
+        return result
+    end
+
+    if not previousDurationObj then
+        clearBridge("no-previous-duration")
+        return result
+    end
+
+    if bridgeAlreadyActive then
+        previousDurationObj = button._baseOverrideCooldownDurationObj
+        if not previousDurationObj then
+            clearBridge("no-previous-duration")
+            return result
+        end
+    end
+
+    local bridged = {}
+    for key, value in pairs(result) do
+        bridged[key] = value
+    end
+    bridged.state = COOLDOWN_STATE_COOLDOWN
+    bridged.presentationState = COOLDOWN_STATE_COOLDOWN
+    bridged.renderDurationObj = previousDurationObj
+    bridged.presentationDurationObj = previousDurationObj
+    bridged.bridgeApplied = true
+
+    button._baseOverrideCooldownBridgeActive = true
+    button._baseOverrideBridgeTrace.applied = true
+    button._baseOverrideBridgeTrace.reason = bridgeAlreadyActive
+        and "presentation-debounce-continuing"
+        or "presentation-debounce-started"
+    button._baseOverrideBridgeTrace.postState = bridged.state
+    return bridged
 end
 
 local function ResolveChargeState(button, buttonData)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
@@ -555,9 +556,11 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
     -- GCD suppression (isOnGCD is NeverSecret, always readable)
     -- Passives never suppress — always show cooldown widget for aura swipe
     if fetchOk and not buttonData.isPassive then
-        -- Suppress only for GCD-only state; keep the cooldown swipe visible
-        -- when a real cooldown is active during an overlapping GCD.
-        local suppressGCD = not style.showGCDSwipe and isGCDOnly
+        -- Suppress only true GCD-only state. The extra presentation-state guard
+        -- keeps any explicit real-cooldown presentation from being hidden here.
+        local suppressGCD = not style.showGCDSwipe
+            and isGCDOnly
+            and button._cooldownPresentationState ~= COOLDOWN_STATE_COOLDOWN
 
         if suppressGCD then
             button.cooldown:Hide()
@@ -767,6 +770,7 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
                and not button._noCooldown
                and (not style.readyGlowCombatOnly or inCombat)
                and button._desatCooldownActive == false
+               and button._cooldownPresentationState ~= COOLDOWN_STATE_COOLDOWN
                and not (procOverlayActive and style.procGlowStyle ~= "none") then
             if style.readyGlowOnlyAtMaxCharges
                and buttonData.type == "spell"
@@ -818,9 +822,13 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Invalidate cached widget state so next tick reapplies everything
     button._desaturated = nil
     button._desatCooldownActive = nil
+    button._cooldownApiState = nil
     button._cooldownState = nil
+    button._cooldownPresentationState = nil
+    button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
     button._baseOverrideCooldownDurationObj = nil
+    button._baseOverrideCooldownLastRealAt = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -560,7 +560,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         -- keeps any explicit real-cooldown presentation from being hidden here.
         local suppressGCD = not style.showGCDSwipe
             and isGCDOnly
-            and button._cooldownPresentationState ~= COOLDOWN_STATE_COOLDOWN
+            and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
 
         if suppressGCD then
             button.cooldown:Hide()
@@ -770,7 +770,7 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
                and not button._noCooldown
                and (not style.readyGlowCombatOnly or inCombat)
                and button._desatCooldownActive == false
-               and button._cooldownPresentationState ~= COOLDOWN_STATE_COOLDOWN
+               and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
                and not (procOverlayActive and style.procGlowStyle ~= "none") then
             if style.readyGlowOnlyAtMaxCharges
                and buttonData.type == "spell"
@@ -822,11 +822,6 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Invalidate cached widget state so next tick reapplies everything
     button._desaturated = nil
     button._desatCooldownActive = nil
-    button._cooldownApiState = nil
-    button._cooldownState = nil
-    button._cooldownPresentationState = nil
-    button._cooldownPresentationDurationObj = nil
-    button._chargeState = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -827,8 +827,6 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._cooldownPresentationState = nil
     button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
-    button._baseOverrideCooldownDurationObj = nil
-    button._baseOverrideCooldownLastRealAt = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -5,6 +5,9 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
 local pairs = pairs
@@ -61,13 +64,7 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
         return false
     end
 
-    local cur = button._currentReadableCharges
-    local maxCharges = buttonData.maxCharges
-    if button._chargeCountReadable == true and cur ~= nil and maxCharges ~= nil then
-        return cur == maxCharges
-    end
-
-    return not button._chargeRecharging and not button._zeroChargesConfirmed
+    return button._chargeState == CHARGE_STATE_FULL
 end
 
 local function ApplyCountTextStyle(button, style)
@@ -565,16 +562,14 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         if suppressGCD then
             button.cooldown:Hide()
         else
-            if not button.cooldown:IsShown() then
-                button.cooldown:Show()
-            end
+            button.cooldown:Show()
         end
     end
 
     -- Charge-visual suppression: when toggle is active and charges remain,
     -- hide the swipe fill (dark overlay) but keep the edge visible.
     if UsesChargeBehavior(buttonData) and buttonData.hideCooldownWithCharges and not button._auraActive then
-        local hasChargesRemaining = (button._zeroChargesConfirmed == false)
+        local hasChargesRemaining = (button._chargeState ~= CHARGE_STATE_ZERO)
         if hasChargesRemaining ~= button._hideCooldownChargesActive then
             button._hideCooldownChargesActive = hasChargesRemaining
             if hasChargesRemaining then
@@ -823,6 +818,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Invalidate cached widget state so next tick reapplies everything
     button._desaturated = nil
     button._desatCooldownActive = nil
+    button._cooldownState = nil
+    button._chargeState = nil
+    button._baseOverrideCooldownDurationObj = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
     button._readyGlowMaxChargesActive = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -684,12 +684,6 @@ end
 ------------------------------------------------------------------------
 local function UpdateTextStyle(button, newStyle)
     button.style = newStyle
-    button._cooldownApiState = nil
-    button._cooldownState = nil
-    button._cooldownPresentationState = nil
-    button._cooldownPresentationDurationObj = nil
-    button._chargeState = nil
-
     -- Background
     local bgColor = newStyle.textBgColor or {0, 0, 0, 0}
     button.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -689,8 +689,6 @@ local function UpdateTextStyle(button, newStyle)
     button._cooldownPresentationState = nil
     button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
-    button._baseOverrideCooldownDurationObj = nil
-    button._baseOverrideCooldownLastRealAt = nil
 
     -- Background
     local bgColor = newStyle.textBgColor or {0, 0, 0, 0}

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -5,6 +5,11 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
 local GetTime = GetTime
@@ -266,30 +271,13 @@ local function EvaluateTokenPresence(button, tokenName, timeRemaining, timeIsSec
         return UsesChargeBehavior(button.buttonData)
     elseif tokenName == "maxcharges" then
         if not UsesChargeBehavior(button.buttonData) then return false end
-        if button._chargeCountReadable == true then
-            local cur = button._currentReadableCharges
-            local mc = button.buttonData.maxCharges
-            return cur ~= nil and mc ~= nil and cur == mc
-        else
-            return not button._chargeRecharging
-        end
+        return button._chargeState == CHARGE_STATE_FULL
     elseif tokenName == "missingcharges" then
         if not UsesChargeBehavior(button.buttonData) then return false end
-        if button._chargeCountReadable == true then
-            local cur = button._currentReadableCharges
-            local mc = button.buttonData.maxCharges
-            return cur ~= nil and mc ~= nil and cur > 0 and cur < mc
-        else
-            return button._chargeRecharging and not button._zeroChargesConfirmed
-        end
+        return button._chargeState == CHARGE_STATE_MISSING
     elseif tokenName == "zerocharges" then
         if not UsesChargeBehavior(button.buttonData) then return false end
-        if button._chargeCountReadable == true then
-            local cur = button._currentReadableCharges
-            return cur ~= nil and cur == 0
-        else
-            return button._zeroChargesConfirmed == true
-        end
+        return button._chargeState == CHARGE_STATE_ZERO
     elseif tokenName == "stacks" then
         return stackDisplayKind ~= nil
     elseif tokenName == "aura" then
@@ -354,8 +342,6 @@ local function SubstituteTokens(button, segments, style, effectState)
     local stackDisplayText, stackDisplayKind = ResolveTextModeStackDisplay(button)
     local auraActive = button._auraActive
     local auraHasTimer = button._auraHasTimer == true
-    local onCooldown = button._cooldownDeferred or (button.cooldown and button.cooldown:IsShown())
-
     -- _durationObj holds either cooldown remaining or aura remaining (when aura override is active).
     -- Determine which domain owns it this tick.
     local durationRemaining = nil
@@ -383,7 +369,7 @@ local function SubstituteTokens(button, segments, style, effectState)
     if auraActive then
         auraRemaining = durationRemaining
         auraIsSecret = durationIsSecret
-    elseif button._isGCDOnly then
+    elseif button._cooldownState == COOLDOWN_STATE_GCD then
         -- Suppress GCD-only cooldowns in text mode (not useful information)
     else
         timeRemaining = durationRemaining
@@ -698,6 +684,9 @@ end
 ------------------------------------------------------------------------
 local function UpdateTextStyle(button, newStyle)
     button.style = newStyle
+    button._cooldownState = nil
+    button._chargeState = nil
+    button._baseOverrideCooldownDurationObj = nil
 
     -- Background
     local bgColor = newStyle.textBgColor or {0, 0, 0, 0}

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -684,9 +684,13 @@ end
 ------------------------------------------------------------------------
 local function UpdateTextStyle(button, newStyle)
     button.style = newStyle
+    button._cooldownApiState = nil
     button._cooldownState = nil
+    button._cooldownPresentationState = nil
+    button._cooldownPresentationDurationObj = nil
     button._chargeState = nil
     button._baseOverrideCooldownDurationObj = nil
+    button._baseOverrideCooldownLastRealAt = nil
 
     -- Background
     local bgColor = newStyle.textBgColor or {0, 0, 0, 0}

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -49,6 +49,9 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
         buttonData.maxCharges = charges.maxCharges
         button.count:SetText("")
         button._chargeText = nil
+        button._chargeDurationObj = nil
+        button._chargeRecharging = false
+        button._chargeState = nil
         return nil
     end
 

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -5,6 +5,9 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
 local issecretvalue = issecretvalue
@@ -155,6 +158,21 @@ local function UpdateItemChargeTracking(button, buttonData)
     end
 end
 
+local function ShouldApplyUnusableTint(button, isUsable, resourceBlocked)
+    if isUsable then
+        return false
+    end
+
+    -- A GCD-only lockout is not a true unusable state for icon tinting. This
+    -- keeps icons visually ready when their real cooldown is over, while still
+    -- allowing resource failures to tint during the GCD.
+    if button._cooldownState == COOLDOWN_STATE_GCD and resourceBlocked ~= true then
+        return false
+    end
+
+    return true
+end
+
 -- Icon tinting: out-of-range red > unusable dimming > aura tint > cooldown tint > base tint.
 -- Shared by icon-mode and bar-mode display paths.
 local function UpdateIconTint(button, buttonData, style)
@@ -196,15 +214,16 @@ local function UpdateIconTint(button, buttonData, style)
     if not stateOverride and style.showUnusable then
         local uc = style.iconUnusableTintColor
         if buttonData.type == "spell" then
-            local isUsable = C_Spell.IsSpellUsable(buttonData.id)
-            if not isUsable then
+            local spellID = button._displaySpellId or buttonData.id
+            local isUsable, insufficientPower = C_Spell.IsSpellUsable(spellID)
+            if ShouldApplyUnusableTint(button, isUsable, insufficientPower) then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a
                 stateOverride = true
             end
         elseif buttonData.type == "item" then
             local usable, noMana = IsUsableItem(buttonData.id)
-            if not usable then
+            if ShouldApplyUnusableTint(button, usable, noMana) then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a
                 stateOverride = true
@@ -265,7 +284,8 @@ local function EvaluateDesaturation(button, buttonData, style)
         if style.desaturateOnCooldown and button._desatCooldownActive then
             wantDesat = true
         end
-        if not wantDesat and buttonData.desaturateWhileZeroCharges and button._zeroChargesConfirmed then
+        if not wantDesat and buttonData.desaturateWhileZeroCharges
+                and button._chargeState == CHARGE_STATE_ZERO then
             wantDesat = true
         end
         if not wantDesat and buttonData.desaturateWhileZeroStacks and (button._itemCount or 0) == 0 then

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -6,7 +6,6 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
-local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
@@ -158,24 +157,10 @@ local function UpdateItemChargeTracking(button, buttonData)
     end
 end
 
-local function ShouldApplyUnusableTint(button, isUsable, resourceBlocked)
-    if isUsable then
-        return false
-    end
-
-    -- A GCD-only lockout is not a true unusable state for icon tinting. This
-    -- keeps icons visually ready when their real cooldown is over, while still
-    -- allowing resource failures to tint during the GCD.
-    if button._cooldownState == COOLDOWN_STATE_GCD and resourceBlocked ~= true then
-        return false
-    end
-
-    return true
-end
-
 -- Icon tinting: out-of-range red > unusable dimming > aura tint > cooldown tint > base tint.
 -- Shared by icon-mode and bar-mode display paths.
 local function UpdateIconTint(button, buttonData, style)
+    button._unusableTintActive = false
     if buttonData.isPassive then
         local c
         if style.iconAuraTintEnabled and buttonData.auraTracking and button._auraActive then
@@ -215,18 +200,20 @@ local function UpdateIconTint(button, buttonData, style)
         local uc = style.iconUnusableTintColor
         if buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
-            local isUsable, insufficientPower = C_Spell.IsSpellUsable(spellID)
-            if ShouldApplyUnusableTint(button, isUsable, insufficientPower) then
+            local isUsable = C_Spell.IsSpellUsable(spellID)
+            if not isUsable then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a
                 stateOverride = true
+                button._unusableTintActive = true
             end
         elseif buttonData.type == "item" then
-            local usable, noMana = IsUsableItem(buttonData.id)
-            if ShouldApplyUnusableTint(button, usable, noMana) then
+            local usable = IsUsableItem(buttonData.id)
+            if not usable then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a
                 stateOverride = true
+                button._unusableTintActive = true
             end
         end
     end

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -5,6 +5,11 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 
 local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
@@ -47,7 +52,7 @@ local BASELINE_FALLBACKS = {
 -- Evaluate per-button visibility rules and set hidden/alpha override state.
 -- Called inside UpdateButtonCooldown after cooldown fetch and aura tracking are complete.
 -- Fast path: if no toggles are enabled, zero overhead.
-local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverrideActive, procOverlayActive)
+local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, procOverlayActive)
     -- Fast path: no visibility toggles enabled
     if not buttonData.hideWhileOnCooldown
        and not buttonData.hideWhileNotOnCooldown
@@ -73,17 +78,16 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
     -- _cooldownDeferred: treat deferred cooldowns (timer not yet started) as "on CD".
     if buttonData.hideWhileOnCooldown and not button._noCooldown then
         if UsesChargeBehavior(buttonData) then
-            if button._mainCDShown or button._chargeRecharging then
+            if button._chargeState == CHARGE_STATE_ZERO
+                    or button._chargeState == CHARGE_STATE_MISSING then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         elseif buttonData.type == "item" then
-            if (button._itemCdDuration and button._itemCdDuration > 0 and not isGCDOnly)
-                    or button._cooldownDeferred then
+            if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         else
-            if (button._durationObj and not isGCDOnly and not auraOverrideActive)
-                    or button._cooldownDeferred then
+            if button._cooldownState == COOLDOWN_STATE_COOLDOWN and not auraOverrideActive then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         end
@@ -92,17 +96,15 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
     -- Check hideWhileNotOnCooldown (skip for no-CD spells — would permanently hide)
     if buttonData.hideWhileNotOnCooldown and not button._noCooldown then
         if UsesChargeBehavior(buttonData) then
-            if not button._mainCDShown and not button._chargeRecharging then
+            if button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif buttonData.type == "item" then
-            if (not button._itemCdDuration or button._itemCdDuration == 0 or isGCDOnly)
-                    and not button._cooldownDeferred then
+            if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         else
-            if (not button._durationObj or isGCDOnly) and not auraOverrideActive
-                    and not button._cooldownDeferred then
+            if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN and not auraOverrideActive then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         end
@@ -129,7 +131,7 @@ local function EvaluateButtonVisibility(button, buttonData, isGCDOnly, auraOverr
     end
 
     -- Check hideWhileZeroCharges (charge-based spells and items)
-    if buttonData.hideWhileZeroCharges and button._zeroChargesConfirmed then
+    if buttonData.hideWhileZeroCharges and button._chargeState == CHARGE_STATE_ZERO then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_CHARGES)
     end
 

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -75,7 +75,6 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local auraTrackingReady = button._auraTrackingReady == true
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
-    -- _cooldownDeferred: treat deferred cooldowns (timer not yet started) as "on CD".
     if buttonData.hideWhileOnCooldown and not button._noCooldown then
         if UsesChargeBehavior(buttonData) then
             if button._chargeState == CHARGE_STATE_ZERO
@@ -148,7 +147,8 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     -- Check hideWhileUnusable
     if buttonData.hideWhileUnusable and not buttonData.isPassive then
         if buttonData.type == "spell" then
-            if not C_Spell_IsSpellUsable(buttonData.id) then
+            local spellID = button._displaySpellId or buttonData.id
+            if not C_Spell_IsSpellUsable(spellID) then
                 hideReasons = bit_bor(hideReasons, HIDE_UNUSABLE)
             end
         elseif buttonData.type == "item" then

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -574,7 +574,8 @@ local function IsTextureIndicatorSectionActive(button, sectionKey, config)
             return false
         end
         if buttonData.type == "spell" then
-            return not C_Spell_IsSpellUsable(buttonData.id)
+            local spellID = button._displaySpellId or buttonData.id
+            return not C_Spell_IsSpellUsable(spellID)
         end
         if buttonData.type == "item" or buttonData.type == "equipitem" then
             return not C_Item_IsUsableItem(buttonData.id)
@@ -635,7 +636,8 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
             return false
         end
         if buttonData.type == "spell" then
-            return C_Spell_IsSpellUsable(buttonData.id)
+            local spellID = button._displaySpellId or buttonData.id
+            return C_Spell_IsSpellUsable(spellID)
         end
         if buttonData.type == "item" or buttonData.type == "equipitem" then
             return C_Item_IsUsableItem(buttonData.id)

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -653,30 +653,7 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
             return nil
         end
 
-        local currentCharges = button._currentReadableCharges
-        local maxCharges = buttonData.maxCharges
-        if currentCharges ~= nil then
-            if currentCharges <= 0 then
-                return "zero"
-            end
-            if maxCharges ~= nil and maxCharges > 0 then
-                if currentCharges >= maxCharges then
-                    return "full"
-                end
-                return "missing"
-            end
-        end
-
-        if button._zeroChargesConfirmed == true then
-            return "zero"
-        end
-        if button._chargeRecharging == true then
-            return "missing"
-        end
-        if button._chargeRecharging == false then
-            return "full"
-        end
-        return nil
+        return button._chargeState
     end
 
     if conditionKey == "countTextActive" then

--- a/Core/CooldownLogic.lua
+++ b/Core/CooldownLogic.lua
@@ -56,10 +56,10 @@ function CooldownLogic.IsSpellGCDOnly(info, options)
 end
 
 function CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, gcdInfo)
-    return cdDuration and cdDuration > 0
+    return (cdDuration and cdDuration > 0
         and gcdInfo ~= nil
         and cdStart == gcdInfo.startTime
-        and cdDuration == gcdInfo.duration
+        and cdDuration == gcdInfo.duration) == true
 end
 
 ST.CooldownLogic = CooldownLogic

--- a/Core/CooldownLogic.lua
+++ b/Core/CooldownLogic.lua
@@ -55,6 +55,13 @@ function CooldownLogic.IsSpellGCDOnly(info, options)
     return info.isOnGCD == true
 end
 
+function CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, gcdInfo)
+    return cdDuration and cdDuration > 0
+        and gcdInfo ~= nil
+        and cdStart == gcdInfo.startTime
+        and cdDuration == gcdInfo.duration
+end
+
 ST.CooldownLogic = CooldownLogic
 
 return CooldownLogic

--- a/Core/CooldownLogic.lua
+++ b/Core/CooldownLogic.lua
@@ -44,20 +44,12 @@ function CooldownLogic.IsSpellGCDOnly(info, options)
     end
 
     options = options or {}
-    if options.realCooldownShown then
+    if options.realCooldownShown or not options.normalCooldownShown then
         return false
     end
 
-    local secrecy = options.secrecy or 0
-    local gcdInfo = options.gcdInfo
     if info.isActive ~= true then
         return false
-    end
-
-    if secrecy == 0 then
-        return gcdInfo ~= nil
-            and info.startTime == gcdInfo.startTime
-            and info.duration == gcdInfo.duration
     end
 
     return info.isOnGCD == true

--- a/Core/CooldownLogic.lua
+++ b/Core/CooldownLogic.lua
@@ -8,6 +8,36 @@ ST = ST or {}
 
 local CooldownLogic = ST.CooldownLogic or {}
 
+CooldownLogic.STATE_READY = "ready"
+CooldownLogic.STATE_GCD = "gcd"
+CooldownLogic.STATE_COOLDOWN = "cooldown"
+
+CooldownLogic.CHARGE_STATE_FULL = "full"
+CooldownLogic.CHARGE_STATE_MISSING = "missing"
+CooldownLogic.CHARGE_STATE_ZERO = "zero"
+
+local COOLDOWN_STATE_PRIORITY = {
+    [CooldownLogic.STATE_READY] = 1,
+    [CooldownLogic.STATE_GCD] = 2,
+    [CooldownLogic.STATE_COOLDOWN] = 3,
+}
+
+function CooldownLogic.GetCooldownStatePriority(state)
+    return COOLDOWN_STATE_PRIORITY[state] or 0
+end
+
+function CooldownLogic.SelectStrongerCooldownState(a, b)
+    if CooldownLogic.GetCooldownStatePriority(b and b.state) >
+            CooldownLogic.GetCooldownStatePriority(a and a.state) then
+        return b
+    end
+    return a
+end
+
+function CooldownLogic.IsRealCooldownState(state)
+    return state == CooldownLogic.STATE_COOLDOWN
+end
+
 function CooldownLogic.IsSpellGCDOnly(info, options)
     if not info then
         return false
@@ -20,13 +50,17 @@ function CooldownLogic.IsSpellGCDOnly(info, options)
 
     local secrecy = options.secrecy or 0
     local gcdInfo = options.gcdInfo
+    if info.isActive ~= true then
+        return false
+    end
+
     if secrecy == 0 then
         return gcdInfo ~= nil
             and info.startTime == gcdInfo.startTime
             and info.duration == gcdInfo.duration
     end
 
-    return info.isOnGCD == true and options.gcdActive == true
+    return info.isOnGCD == true
 end
 
 ST.CooldownLogic = CooldownLogic


### PR DESCRIPTION
## What Players Will Notice
- Cooldown displays now separate real cooldowns from GCD-only states more consistently, so GCD-only activity is less likely to create misleading cooldown swipes, desaturation, bar colors, text, visibility changes, or trigger behavior.
- Items that are only on the GCD no longer briefly show a cooldown swipe when GCD swipes are disabled.
- Charge text and charge-driven visuals are more reliable: full charges, missing charges, and zero charges now use one shared charge state instead of each display path guessing separately.
- Desaturation is tied to real cooldown state for spells/items and confirmed zero-charge state for charge spells, not to the GCD.

## Why This Changed
- The previous cooldown path mixed gameplay state with presentation details such as cooldown widget visibility, duration object presence, item cooldown values, and charge fallback flags.
- Adding the 12.0.5 `ignoreGCD` cooldown duration path exposed places where GCD-only state could leak into real cooldown visuals or where downstream systems reinterpreted cooldown state differently.
- Execute was investigated heavily as part of this work. Runtime traces showed its high-haste base/override cooldown data can briefly disagree with the actual gameplay lockout. The branch intentionally does not add an Execute-specific bridge or debounce because every tested workaround either allowed the flash or caused stale desaturation.

## What Changed
- Added canonical cooldown and charge states in `Core/CooldownLogic.lua`.
- Reworked normal spell cooldown evaluation so `ButtonFrame/CooldownUpdate.lua` classifies buttons as `ready`, `gcd`, or `cooldown` before rendering cooldown widgets.
- Evaluates true base/display spell pairs directly without adding an Execute-specific preservation workaround.
- Classifies item cooldowns before rendering so GCD-only item state can be suppressed cleanly when GCD swipes are disabled.
- Added `_chargeState` and updated charge text, glows, visibility, trigger conditions, and bar/text/icon consumers to read shared state instead of rebuilding charge logic.
- Updated desaturation and downstream display paths to prefer explicit cooldown/charge state over cooldown widget visibility or stale duration-object presence.
- Removed temporary Execute tracing and the failed Execute bridge/debounce experiments before publishing.

## Validation
- Lua parse checks passed for the changed cooldown/display files.
- Full addon Lua parse passed across 74 Lua files.
- `git diff --check` passed with only the normal Windows LF/CRLF warnings.
- In-game validation was reported passing for the cooldown-state rework, including GCD-only swipe suppression, item GCD suppression, charge text/color behavior, normal short cooldown behavior, and desaturation behavior.
- Execute high-haste false-ready flashing remains a known Blizzard API data-gap limitation and is not claimed as fixed by this PR.