### PR TITLE
Add Blizzard CDM-style aura swipe for icon durations

### DIFF
--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -113,8 +113,6 @@ local function UpdateBlizzardAuraSwipe(button, style)
     local enabled = style.auraUseBlizzardSwipe == true
         and button._auraActive == true
         and button._auraHasTimer ~= false
-        and style.showCooldownSwipe ~= false
-        and style.showCooldownSwipeFill ~= false
 
     if not enabled then
         HideBlizzardAuraSwipe(button, style)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -55,6 +55,102 @@ local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
+local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
+local BLIZZARD_AURA_SWIPE_R = 1
+local BLIZZARD_AURA_SWIPE_G = 0.95
+local BLIZZARD_AURA_SWIPE_B = 0.57
+local BLIZZARD_AURA_SWIPE_A = 0.7
+local BLIZZARD_AURA_SWIPE_TEX_LOW = {x = 0.15, y = 0.15}
+local BLIZZARD_AURA_SWIPE_TEX_HIGH = {x = 0.85, y = 0.85}
+
+local function ApplyAuraBlizzardCooldownLayer(button)
+    if button and button.auraBlizzardCooldown and button.cooldown then
+        button.auraBlizzardCooldown:SetFrameLevel(button.cooldown:GetFrameLevel())
+    end
+end
+
+local function AnchorAuraBlizzardCooldown(button)
+    if not (button and button.auraBlizzardCooldown and button.icon) then
+        return
+    end
+
+    button.auraBlizzardCooldown:ClearAllPoints()
+    button.auraBlizzardCooldown:SetAllPoints(button.icon)
+    button.auraBlizzardCooldown:SetTexCoordRange(BLIZZARD_AURA_SWIPE_TEX_LOW, BLIZZARD_AURA_SWIPE_TEX_HIGH)
+end
+
+local function ApplyDefaultCooldownSwipeStyle(button, style)
+    if not (button and button.cooldown and style) then
+        return
+    end
+
+    local swipeEnabled = style.showCooldownSwipe ~= false
+    local fillEnabled = style.showCooldownSwipeFill ~= false
+    button.cooldown:SetUseAuraDisplayTime(false)
+    button.cooldown:SetDrawSwipe(swipeEnabled and fillEnabled and button._hideCooldownChargesActive ~= true)
+    button.cooldown:SetDrawEdge(swipeEnabled and style.showCooldownSwipeEdge ~= false)
+    button.cooldown:SetReverse(swipeEnabled and (style.cooldownSwipeReverse or false))
+    button.cooldown:SetSwipeColor(0, 0, 0, style.cooldownSwipeAlpha or 0.8)
+    local edgeColor = style.cooldownSwipeEdgeColor or DEFAULT_WHITE
+    button.cooldown:SetEdgeColor(edgeColor[1], edgeColor[2], edgeColor[3], edgeColor[4])
+end
+
+local function HideBlizzardAuraSwipe(button, style)
+    if button and button.auraBlizzardCooldown then
+        button.auraBlizzardCooldown:Hide()
+    end
+    if button and button._auraBlizzardSwipeActive then
+        button._auraBlizzardSwipeActive = nil
+        ApplyDefaultCooldownSwipeStyle(button, style)
+    end
+end
+
+local function UpdateBlizzardAuraSwipe(button, style)
+    if not (button and button.auraBlizzardCooldown) then
+        return
+    end
+
+    local enabled = style.auraUseBlizzardSwipe == true
+        and button._auraActive == true
+        and button._auraHasTimer ~= false
+        and style.showCooldownSwipe ~= false
+        and style.showCooldownSwipeFill ~= false
+
+    if not enabled then
+        HideBlizzardAuraSwipe(button, style)
+        return
+    end
+
+    local overlay = button.auraBlizzardCooldown
+    overlay:Show()
+    overlay:SetUseAuraDisplayTime(true)
+    overlay:SetDrawSwipe(true)
+    overlay:SetDrawEdge(false)
+    overlay:SetReverse(false)
+    overlay:SetSwipeColor(BLIZZARD_AURA_SWIPE_R, BLIZZARD_AURA_SWIPE_G, BLIZZARD_AURA_SWIPE_B, BLIZZARD_AURA_SWIPE_A)
+
+    local rendered = false
+    if button._durationObj then
+        overlay:SetCooldownFromDurationObject(button._durationObj)
+        rendered = overlay:IsShown()
+    else
+        local startMs, durMs = button.cooldown:GetCooldownTimes()
+        if startMs and durMs and not issecretvalue(startMs) and not issecretvalue(durMs) and durMs > 0 then
+            overlay:SetCooldown(startMs / 1000, durMs / 1000)
+            rendered = true
+        end
+    end
+
+    if rendered then
+        overlay:Show()
+        button._auraBlizzardSwipeActive = true
+        button.cooldown:SetUseAuraDisplayTime(true)
+        button.cooldown:SetDrawSwipe(false)
+        button.cooldown:SetDrawEdge(false)
+    else
+        HideBlizzardAuraSwipe(button, style)
+    end
+end
 
 local function IsReadyGlowAtMaxCharges(button, buttonData)
     if not (button and buttonData) then
@@ -141,17 +237,25 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Assisted highlight overlays (multiple styles, all hidden by default)
     button.assistedHighlight = CreateAssistedHighlight(button, style)
 
+    -- Blizzard-style aura duration swipe overlay. This is separate from the
+    -- normal cooldown frame so regular cooldowns keep their existing styling.
+    button.auraBlizzardCooldown = CreateFrame("Cooldown", button:GetName() .. "AuraBlizzardCooldown", button, "CooldownFrameTemplate")
+    AnchorAuraBlizzardCooldown(button)
+    button.auraBlizzardCooldown:SetDrawSwipe(true)
+    button.auraBlizzardCooldown:SetDrawEdge(false)
+    button.auraBlizzardCooldown:SetDrawBling(false)
+    button.auraBlizzardCooldown:SetReverse(false)
+    button.auraBlizzardCooldown:SetSwipeTexture(BLIZZARD_AURA_SWIPE_TEXTURE, 1, 1, 1, 1)
+    button.auraBlizzardCooldown:SetSwipeColor(BLIZZARD_AURA_SWIPE_R, BLIZZARD_AURA_SWIPE_G, BLIZZARD_AURA_SWIPE_B, BLIZZARD_AURA_SWIPE_A)
+    button.auraBlizzardCooldown:SetUseAuraDisplayTime(true)
+    button.auraBlizzardCooldown:SetHideCountdownNumbers(true)
+    button.auraBlizzardCooldown:Hide()
+    SetFrameClickThroughRecursive(button.auraBlizzardCooldown, true, true)
+
     -- Cooldown frame (standard radial swipe)
     button.cooldown = CreateFrame("Cooldown", button:GetName() .. "Cooldown", button, "CooldownFrameTemplate")
     button.cooldown:SetAllPoints(button.icon)
-    local swipeEnabled = style.showCooldownSwipe ~= false
-    local fillEnabled = style.showCooldownSwipeFill ~= false
-    button.cooldown:SetDrawSwipe(swipeEnabled and fillEnabled)
-    button.cooldown:SetDrawEdge(swipeEnabled and style.showCooldownSwipeEdge ~= false)
-    button.cooldown:SetReverse(swipeEnabled and (style.cooldownSwipeReverse or false))
-    button.cooldown:SetSwipeColor(0, 0, 0, style.cooldownSwipeAlpha or 0.8)
-    local edgeColor = style.cooldownSwipeEdgeColor or {1, 1, 1, 1}
-    button.cooldown:SetEdgeColor(edgeColor[1], edgeColor[2], edgeColor[3], edgeColor[4])
+    ApplyDefaultCooldownSwipeStyle(button, style)
     button.cooldown:SetHideCountdownNumbers(false) -- Always allow; visibility controlled via text alpha
     -- Recursively disable mouse on cooldown and all its children (CooldownFrameTemplate has children)
     -- Always fully non-interactive: disable both clicks and motion
@@ -269,6 +373,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
 
     -- Apply configurable strata ordering (LoC always on top)
     ApplyStrataOrder(button, style.strataOrder)
+    ApplyAuraBlizzardCooldownLayer(button)
 
     -- Store button data
     button.index = index
@@ -327,6 +432,9 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Re-apply full click-through on overlay frames (the recursive call above
     -- re-enables motion on them when tooltips are on, causing them to steal hover events)
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    if button.auraBlizzardCooldown then
+        SetFrameClickThroughRecursive(button.auraBlizzardCooldown, true, true)
+    end
     SetFrameClickThroughRecursive(button.locCooldown, true, true)
     if button.procGlow then
         SetFrameClickThroughRecursive(button.procGlow.solidFrame, true, true)
@@ -589,6 +697,8 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         local fillEnabled = style.showCooldownSwipeFill ~= false
         button.cooldown:SetDrawSwipe(swipeEnabled and fillEnabled)
     end
+
+    UpdateBlizzardAuraSwipe(button, style)
 
     -- When separate text positions: move primary text to aura anchor during aura, cooldown anchor otherwise
     if button._secondaryCdTextRegion and button._cdTextRegion then
@@ -887,14 +997,18 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Countdown number visibility is controlled per-tick via SetHideCountdownNumbers
     button.cooldown:SetHideCountdownNumbers(false)
-    local swipeEnabled = style.showCooldownSwipe ~= false
-    local fillEnabled = style.showCooldownSwipeFill ~= false
-    button.cooldown:SetDrawSwipe(swipeEnabled and fillEnabled)
-    button.cooldown:SetDrawEdge(swipeEnabled and style.showCooldownSwipeEdge ~= false)
-    button.cooldown:SetReverse(swipeEnabled and (style.cooldownSwipeReverse or false))
-    button.cooldown:SetSwipeColor(0, 0, 0, style.cooldownSwipeAlpha or 0.8)
-    local edgeColor = style.cooldownSwipeEdgeColor or {1, 1, 1, 1}
-    button.cooldown:SetEdgeColor(edgeColor[1], edgeColor[2], edgeColor[3], edgeColor[4])
+    ApplyDefaultCooldownSwipeStyle(button, style)
+    if button.auraBlizzardCooldown then
+        AnchorAuraBlizzardCooldown(button)
+        button.auraBlizzardCooldown:SetUseAuraDisplayTime(true)
+        button.auraBlizzardCooldown:SetDrawSwipe(true)
+        button.auraBlizzardCooldown:SetDrawEdge(false)
+        button.auraBlizzardCooldown:SetDrawBling(false)
+        button.auraBlizzardCooldown:SetReverse(false)
+        button.auraBlizzardCooldown:SetSwipeTexture(BLIZZARD_AURA_SWIPE_TEXTURE, 1, 1, 1, 1)
+        button.auraBlizzardCooldown:SetSwipeColor(BLIZZARD_AURA_SWIPE_R, BLIZZARD_AURA_SWIPE_G, BLIZZARD_AURA_SWIPE_B, BLIZZARD_AURA_SWIPE_A)
+        button.auraBlizzardCooldown:SetHideCountdownNumbers(true)
+    end
 
     -- Update cooldown font settings (default state; per-tick logic handles aura mode)
     local cooldownFont = CooldownCompanion:FetchFont(style.cooldownFont or "Friz Quadrata TT")
@@ -998,6 +1112,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Apply configurable strata ordering (LoC always on top)
     ApplyStrataOrder(button, style.strataOrder)
+    ApplyAuraBlizzardCooldownLayer(button)
     CooldownCompanion:UpdateAuraTextureVisual(button)
 
     -- Click-through is always enabled (clicks always pass through for camera movement)
@@ -1011,6 +1126,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Re-apply full click-through on overlay frames (the recursive call above
     -- re-enables motion on them when tooltips are on, causing them to steal hover events)
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    if button.auraBlizzardCooldown then
+        SetFrameClickThroughRecursive(button.auraBlizzardCooldown, true, true)
+    end
     SetFrameClickThroughRecursive(button.locCooldown, true, true)
     if button.procGlow then
         SetFrameClickThroughRecursive(button.procGlow.solidFrame, true, true)

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -327,6 +327,18 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                                     end)
                                     cont:AddChild(auraInvertCb)
                                     ApplyCheckboxIndent(auraInvertCb, 20)
+
+                                    local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
+                                    auraBlizzardSwipeCb:SetLabel("Use Blizzard Aura Swipe")
+                                    auraBlizzardSwipeCb:SetValue(GetEffectiveOverrideValue("auraUseBlizzardSwipe") == true)
+                                    auraBlizzardSwipeCb:SetFullWidth(true)
+                                    auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(_, _, val)
+                                        overrides.auraUseBlizzardSwipe = val == true
+                                        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+                                        CooldownCompanion:UpdateAllCooldowns()
+                                    end)
+                                    cont:AddChild(auraBlizzardSwipeCb)
+                                    ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
                                 end
 
                                 if sectionId == "readyGlow" then

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -328,17 +328,6 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                                     cont:AddChild(auraInvertCb)
                                     ApplyCheckboxIndent(auraInvertCb, 20)
 
-                                    local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
-                                    auraBlizzardSwipeCb:SetLabel("Use Blizzard Aura Swipe")
-                                    auraBlizzardSwipeCb:SetValue(GetEffectiveOverrideValue("auraUseBlizzardSwipe") == true)
-                                    auraBlizzardSwipeCb:SetFullWidth(true)
-                                    auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(_, _, val)
-                                        overrides.auraUseBlizzardSwipe = val == true
-                                        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-                                        CooldownCompanion:UpdateAllCooldowns()
-                                    end)
-                                    cont:AddChild(auraBlizzardSwipeCb)
-                                    ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
                                 end
 
                                 if sectionId == "readyGlow" then

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -31,6 +31,7 @@ local BuildProcGlowControls = ST._BuildProcGlowControls
 local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
+local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
 local BuildKeyPressHighlightControls = ST._BuildKeyPressHighlightControls
 local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
@@ -189,8 +190,8 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
 
     local sectionOrder = {
         "borderSettings", "cooldownText", "auraText", "auraStackText",
-        "keybindText", "chargeText", "desaturation", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
-        "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "pandemicGlow", "auraIndicator", "readyGlow", "keyPressHighlight",
+        "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
+        "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "auraIndicator", "pandemicGlow", "readyGlow", "keyPressHighlight",
         "barColors", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
         "textFont", "textColors", "textBackground",
     }
@@ -217,6 +218,12 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         procGlow = BuildProcGlowControls,
         pandemicGlow = BuildPandemicGlowControls,
         auraIndicator = BuildAuraIndicatorControls,
+        auraDurationSwipe = function(container, styleTable, onChange)
+            BuildAuraDurationSwipeControls(container, styleTable, function()
+                onChange()
+                CooldownCompanion:UpdateAllCooldowns()
+            end)
+        end,
         readyGlow = BuildReadyGlowControls,
         keyPressHighlight = BuildKeyPressHighlightControls,
         barColors = BuildBarColorsControls,

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1750,6 +1750,18 @@ local function BuildAuraGlowSection(container, group, style)
     container:AddChild(auraInvertCb)
     ApplyCheckboxIndent(auraInvertCb, 20)
 
+    local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
+    auraBlizzardSwipeCb:SetLabel("Use Blizzard Aura Swipe")
+    auraBlizzardSwipeCb:SetValue(style.auraUseBlizzardSwipe == true)
+    auraBlizzardSwipeCb:SetFullWidth(true)
+    auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(widget, event, val)
+        style.auraUseBlizzardSwipe = val == true
+        UpdateSelectedGroupStyle()
+        CooldownCompanion:UpdateAllCooldowns()
+    end)
+    container:AddChild(auraBlizzardSwipeCb)
+    ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
+
     BuildAuraIndicatorControls(container, style, UpdateSelectedGroupStyle)
 
     local auraPreviewBtn = AceGUI:Create("Button")

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1750,18 +1750,6 @@ local function BuildAuraGlowSection(container, group, style)
     container:AddChild(auraInvertCb)
     ApplyCheckboxIndent(auraInvertCb, 20)
 
-    local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
-    auraBlizzardSwipeCb:SetLabel("Use Blizzard Aura Swipe")
-    auraBlizzardSwipeCb:SetValue(style.auraUseBlizzardSwipe == true)
-    auraBlizzardSwipeCb:SetFullWidth(true)
-    auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.auraUseBlizzardSwipe = val == true
-        UpdateSelectedGroupStyle()
-        CooldownCompanion:UpdateAllCooldowns()
-    end)
-    container:AddChild(auraBlizzardSwipeCb)
-    ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
-
     BuildAuraIndicatorControls(container, style, UpdateSelectedGroupStyle)
 
     local auraPreviewBtn = AceGUI:Create("Button")
@@ -2051,6 +2039,18 @@ local function BuildEffectsTab(container)
 
         -- Swipe Fill Opacity (only when fill is visible)
         if style.showCooldownSwipeFill ~= false then
+            local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
+            auraBlizzardSwipeCb:SetLabel("Use Blizzard Swipe for Aura Durations")
+            auraBlizzardSwipeCb:SetValue(style.auraUseBlizzardSwipe == true)
+            auraBlizzardSwipeCb:SetFullWidth(true)
+            auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(widget, event, val)
+                style.auraUseBlizzardSwipe = val == true
+                CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+                CooldownCompanion:UpdateAllCooldowns()
+            end)
+            container:AddChild(auraBlizzardSwipeCb)
+            ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
+
             local alphaSlider = AceGUI:Create("Slider")
             alphaSlider:SetLabel("Swipe Fill Opacity")
             alphaSlider:SetSliderValues(0, 1, 0.05)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -48,6 +48,7 @@ local BuildProcGlowControls = ST._BuildProcGlowControls
 local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
+local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
 local BuildKeyPressHighlightControls = ST._BuildKeyPressHighlightControls
 local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
@@ -2039,18 +2040,6 @@ local function BuildEffectsTab(container)
 
         -- Swipe Fill Opacity (only when fill is visible)
         if style.showCooldownSwipeFill ~= false then
-            local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
-            auraBlizzardSwipeCb:SetLabel("Use Blizzard Swipe for Aura Durations")
-            auraBlizzardSwipeCb:SetValue(style.auraUseBlizzardSwipe == true)
-            auraBlizzardSwipeCb:SetFullWidth(true)
-            auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(widget, event, val)
-                style.auraUseBlizzardSwipe = val == true
-                CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-                CooldownCompanion:UpdateAllCooldowns()
-            end)
-            container:AddChild(auraBlizzardSwipeCb)
-            ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
-
             local alphaSlider = AceGUI:Create("Slider")
             alphaSlider:SetLabel("Swipe Fill Opacity")
             alphaSlider:SetSliderValues(0, 1, 0.05)
@@ -2688,6 +2677,22 @@ local function BuildAppearanceTab(container)
         AddAnchorDropdown(container, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
         AddOffsetSliders(container, style, "auraStackXOffset", "auraStackYOffset", { x = 2, y = 2 }, refreshStyle)
     end -- auraStackAdvExpanded + showAuraStackText
+
+    local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:UpdateAllCooldowns()
+    end)
+    local auraSwipePromoteBtn = CreateCheckboxPromoteButton(auraSwipeCb, nil, "auraDurationSwipe", group, style)
+    local auraSwipeInfoAnchor = auraSwipeCb.checkbg
+    local auraSwipeInfoXOff = auraSwipeCb.text:GetStringWidth() + 4
+    if auraSwipePromoteBtn and auraSwipePromoteBtn:IsShown() then
+        auraSwipeInfoAnchor = auraSwipePromoteBtn
+        auraSwipeInfoXOff = 4
+    end
+    CreateInfoButton(auraSwipeCb.frame, auraSwipeInfoAnchor, "LEFT", "RIGHT", auraSwipeInfoXOff, 0, {
+        "Blizzard-style Aura Duration Swipe",
+        {"While this style is shown for an active aura, the Cooldown/Duration Swipe settings do not affect that aura overlay.", 1, 1, 1, true},
+    }, tabInfoButtons)
 
     -- Show Keybind/Custom Text toggle
     local kbCb = AceGUI:Create("CheckBox")

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -334,6 +334,18 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
 
     -- Swipe Fill Opacity (only when fill is visible)
     if styleTable.showCooldownSwipeFill ~= false then
+        local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
+        auraBlizzardSwipeCb:SetLabel("Use Blizzard Swipe for Aura Durations")
+        auraBlizzardSwipeCb:SetValue(styleTable.auraUseBlizzardSwipe == true)
+        auraBlizzardSwipeCb:SetFullWidth(true)
+        auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(widget, event, val)
+            styleTable.auraUseBlizzardSwipe = val == true
+            refreshCallback()
+            CooldownCompanion:UpdateAllCooldowns()
+        end)
+        container:AddChild(auraBlizzardSwipeCb)
+        ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
+
         local alphaSlider = AceGUI:Create("Slider")
         alphaSlider:SetLabel("Swipe Fill Opacity")
         alphaSlider:SetSliderValues(0, 1, 0.05)

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -334,18 +334,6 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
 
     -- Swipe Fill Opacity (only when fill is visible)
     if styleTable.showCooldownSwipeFill ~= false then
-        local auraBlizzardSwipeCb = AceGUI:Create("CheckBox")
-        auraBlizzardSwipeCb:SetLabel("Use Blizzard Swipe for Aura Durations")
-        auraBlizzardSwipeCb:SetValue(styleTable.auraUseBlizzardSwipe == true)
-        auraBlizzardSwipeCb:SetFullWidth(true)
-        auraBlizzardSwipeCb:SetCallback("OnValueChanged", function(widget, event, val)
-            styleTable.auraUseBlizzardSwipe = val == true
-            refreshCallback()
-            CooldownCompanion:UpdateAllCooldowns()
-        end)
-        container:AddChild(auraBlizzardSwipeCb)
-        ApplyCheckboxIndent(auraBlizzardSwipeCb, 20)
-
         local alphaSlider = AceGUI:Create("Slider")
         alphaSlider:SetLabel("Swipe Fill Opacity")
         alphaSlider:SetSliderValues(0, 1, 0.05)
@@ -375,6 +363,19 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
     if styleTable.showCooldownSwipeEdge ~= false then
         AddColorPicker(container, styleTable, "cooldownSwipeEdgeColor", "Swipe Edge Color", {1, 1, 1, 1}, true, refreshCallback, refreshCallback)
     end
+end
+
+local function BuildAuraDurationSwipeControls(container, styleTable, refreshCallback)
+    local cb = AceGUI:Create("CheckBox")
+    cb:SetLabel("Blizzard CDM Aura Swipe")
+    cb:SetValue(styleTable.auraUseBlizzardSwipe == true)
+    cb:SetFullWidth(true)
+    cb:SetCallback("OnValueChanged", function(widget, event, val)
+        styleTable.auraUseBlizzardSwipe = val == true
+        refreshCallback()
+    end)
+    container:AddChild(cb)
+    return cb
 end
 
 local function BuildLossOfControlControls(container, styleTable, refreshCallback)
@@ -1086,6 +1087,7 @@ ST._BuildShowTooltipsControls = BuildShowTooltipsControls
 ST._BuildShowOutOfRangeControls = BuildShowOutOfRangeControls
 ST._BuildShowGCDSwipeControls = BuildShowGCDSwipeControls
 ST._BuildCooldownSwipeControls = BuildCooldownSwipeControls
+ST._BuildAuraDurationSwipeControls = BuildAuraDurationSwipeControls
 ST._BuildLossOfControlControls = BuildLossOfControlControls
 ST._BuildUnusableDimmingControls = BuildUnusableDimmingControls
 ST._BuildIconTintControls = BuildIconTintControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -367,7 +367,7 @@ end
 
 local function BuildAuraDurationSwipeControls(container, styleTable, refreshCallback)
     local cb = AceGUI:Create("CheckBox")
-    cb:SetLabel("Blizzard CDM Aura Swipe")
+    cb:SetLabel("Blizzard CDM Aura Swipe Style")
     cb:SetValue(styleTable.auraUseBlizzardSwipe == true)
     cb:SetFullWidth(true)
     cb:SetCallback("OnValueChanged", function(widget, event, val)

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -608,7 +608,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     cooldownSwipe = {
         label = "Cooldown Swipe",
-        keys = {"showCooldownSwipe", "showCooldownSwipeFill", "auraUseBlizzardSwipe", "cooldownSwipeReverse", "showCooldownSwipeEdge", "cooldownSwipeAlpha", "cooldownSwipeEdgeColor"},
+        keys = {"showCooldownSwipe", "showCooldownSwipeFill", "cooldownSwipeReverse", "showCooldownSwipeEdge", "cooldownSwipeAlpha", "cooldownSwipeEdgeColor"},
         modes = {icons = true},
     },
     showGCDSwipe = {
@@ -659,6 +659,11 @@ ST.OVERRIDE_SECTIONS = {
     auraIndicator = {
         label = "Show Aura Glow",
         keys = {"auraGlowStyle", "auraGlowColor", "auraGlowSize", "auraGlowThickness", "auraGlowSpeed", "auraGlowLines", "auraGlowInvert", "auraGlowCombatOnly"},
+        modes = {icons = true},
+    },
+    auraDurationSwipe = {
+        label = "Aura Duration Swipe",
+        keys = {"auraUseBlizzardSwipe"},
         modes = {icons = true},
     },
     readyGlow = {

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -147,6 +147,7 @@ local defaults = {
                         auraGlowThickness = 4,
                         auraGlowSpeed = 50,
                         auraGlowLines = 8,
+                        auraUseBlizzardSwipe = false,
                         auraGlowInvert = false,
                         auraGlowCombatOnly = false,
                         readyGlowStyle = "none",
@@ -310,6 +311,7 @@ local defaults = {
             auraGlowThickness = 4,
             auraGlowSpeed = 50,
             auraGlowLines = 8,
+            auraUseBlizzardSwipe = false,
             auraGlowInvert = false,
             auraGlowCombatOnly = false,
             readyGlowStyle = "none",
@@ -656,7 +658,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     auraIndicator = {
         label = "Show Aura Glow",
-        keys = {"auraGlowStyle", "auraGlowColor", "auraGlowSize", "auraGlowThickness", "auraGlowSpeed", "auraGlowLines", "auraGlowInvert", "auraGlowCombatOnly"},
+        keys = {"auraGlowStyle", "auraGlowColor", "auraGlowSize", "auraGlowThickness", "auraGlowSpeed", "auraGlowLines", "auraUseBlizzardSwipe", "auraGlowInvert", "auraGlowCombatOnly"},
         modes = {icons = true},
     },
     readyGlow = {

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -608,7 +608,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     cooldownSwipe = {
         label = "Cooldown Swipe",
-        keys = {"showCooldownSwipe", "showCooldownSwipeFill", "cooldownSwipeReverse", "showCooldownSwipeEdge", "cooldownSwipeAlpha", "cooldownSwipeEdgeColor"},
+        keys = {"showCooldownSwipe", "showCooldownSwipeFill", "auraUseBlizzardSwipe", "cooldownSwipeReverse", "showCooldownSwipeEdge", "cooldownSwipeAlpha", "cooldownSwipeEdgeColor"},
         modes = {icons = true},
     },
     showGCDSwipe = {
@@ -658,7 +658,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     auraIndicator = {
         label = "Show Aura Glow",
-        keys = {"auraGlowStyle", "auraGlowColor", "auraGlowSize", "auraGlowThickness", "auraGlowSpeed", "auraGlowLines", "auraUseBlizzardSwipe", "auraGlowInvert", "auraGlowCombatOnly"},
+        keys = {"auraGlowStyle", "auraGlowColor", "auraGlowSize", "auraGlowThickness", "auraGlowSpeed", "auraGlowLines", "auraGlowInvert", "auraGlowCombatOnly"},
         modes = {icons = true},
     },
     readyGlow = {

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -726,6 +726,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
     if style.showUnusable == nil then style.showUnusable = true end
     if style.showCooldownSwipe == nil then style.showCooldownSwipe = true end
     if style.showCooldownSwipeFill == nil then style.showCooldownSwipeFill = true end
+    if style.auraUseBlizzardSwipe == nil then style.auraUseBlizzardSwipe = false end
     if style.barAuraEffect == nil then style.barAuraEffect = "color" end
 
     if displayMode == "textures" then


### PR DESCRIPTION
## What Players Will Notice
- Icon-mode aura durations can now use a Blizzard Cooldown Manager-style yellow swipe overlay on top of the icon.
- The overlay is designed to sit flush with configurable icon sizes and visually match Blizzard's CDM aura duration treatment more closely.
- The style can be enabled from the icon Appearance settings as `Blizzard CDM Aura Swipe Style`, with a tooltip explaining that normal Cooldown/Duration Swipe appearance settings do not affect that active aura overlay.

## Why This Changed
- The addon already tracks aura durations, but its default aura presentation did not visually match Blizzard's built-in Cooldown Manager.
- Matching Blizzard's aura swipe appearance makes the transition from Blizzard CDM to Cooldown Companion feel more familiar and less visually jarring.
- During review, the setting placement was refined so it reads as an aura appearance style instead of an Aura Glow or generic cooldown-swipe functionality toggle.

## What Changed
- Added a separate Blizzard-style cooldown overlay for icon-mode aura durations using Blizzard's CDM swipe texture and color treatment.
- Kept the normal cooldown swipe behavior intact for regular spell and item cooldowns.
- Added a dedicated `auraUseBlizzardSwipe` style option with group defaults, new-panel initialization, and per-button override support.
- Moved the setting into the icon Appearance tab near aura text/stack appearance controls and grouped its override as `Aura Duration Swipe`.
- Preserved exact-style behavior: reverse swipe, swipe opacity, swipe edge, and swipe edge color do not modify the Blizzard-style aura overlay while it is active.

## Validation
- Ran Lua parse checks for the changed files successfully.
- Ran `git diff --check` successfully, with only normal CRLF warnings on Windows.
- Verified through in-game iteration that the overlay renders, reaches the icon edges across the tested icon sizing, and avoids the earlier secret-value taint error from size reads.
- User reported the feature appears combat-safe; restricted-content verification in instances, arenas, or battlegrounds has not been explicitly confirmed yet.