### PR TITLE
Fix Masque settings staying enabled after reloads

### DIFF
--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -192,8 +192,8 @@ local function FinalizeCreatedPanel(newPanelId, displayMode, opts)
     local group = CooldownCompanion.db.profile.groups[newPanelId]
     if opts and opts.verticalStyle and group then
         group.style.orientation = "vertical"
-        if group.masqueEnabled then
-            CooldownCompanion:ToggleGroupMasque(newPanelId, false)
+        if group.masqueEnabled and CooldownCompanion.DeactivateGroupMasqueRuntime then
+            CooldownCompanion:DeactivateGroupMasqueRuntime(newPanelId)
         end
         CooldownCompanion:RefreshGroupFrame(newPanelId)
     end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2452,6 +2452,8 @@ local function BuildAppearanceTab(container)
     -- ================================================================
     -- Icon Settings (size, spacing)
     -- ================================================================
+    local masqueActive = CooldownCompanion:IsGroupMasqueActive(CS.selectedGroup, group)
+
     local iconHeading = AceGUI:Create("Heading")
     iconHeading:SetText("Icon Settings")
     ColorHeading(iconHeading)
@@ -2469,7 +2471,7 @@ local function BuildAppearanceTab(container)
     squareCb:SetLabel("Square Icons")
     squareCb:SetValue(style.maintainAspectRatio or false)
     squareCb:SetFullWidth(true)
-    if group.masqueEnabled then
+    if masqueActive then
         squareCb:SetDisabled(true)
         local masqueLabel = squareCb.frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
         masqueLabel:SetPoint("LEFT", squareCb.checkbg, "RIGHT", squareCb.text:GetStringWidth() + 8, 0)
@@ -2529,7 +2531,7 @@ local function BuildAppearanceTab(container)
     borderSlider:SetSliderValues(0, 5, 0.1)
     borderSlider:SetValue(style.borderSize or ST.DEFAULT_BORDER_SIZE)
     borderSlider:SetFullWidth(true)
-    if group.masqueEnabled then
+    if masqueActive then
         borderSlider:SetDisabled(true)
     end
     borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
@@ -2761,7 +2763,7 @@ local function BuildAppearanceTab(container)
 
     if not borderCollapsed then
     local borderColor = AddColorPicker(container, style, "borderColor", "Border Color", {0, 0, 0, 1}, true, refreshStyle, refreshStyle)
-    if group.masqueEnabled then
+    if masqueActive then
         borderColor:SetDisabled(true)
     end
     end -- not borderCollapsed
@@ -2825,20 +2827,19 @@ local function BuildAppearanceTab(container)
     end -- not iconTintCollapsed
 
     -- Masque skinning (icon-only)
-    if CooldownCompanion.Masque then
-        local masqueHeading = AceGUI:Create("Heading")
-        masqueHeading:SetText("Masque")
-        ColorHeading(masqueHeading)
-        masqueHeading:SetFullWidth(true)
-        container:AddChild(masqueHeading)
+    local masqueHeading = AceGUI:Create("Heading")
+    masqueHeading:SetText("Masque")
+    ColorHeading(masqueHeading)
+    masqueHeading:SetFullWidth(true)
+    container:AddChild(masqueHeading)
 
-        local masqueCollapsed = CS.collapsedSections["appearance_masque"]
-        AttachCollapseButton(masqueHeading, masqueCollapsed, function()
-            CS.collapsedSections["appearance_masque"] = not CS.collapsedSections["appearance_masque"]
-            CooldownCompanion:RefreshConfigPanel()
-        end)
+    local masqueCollapsed = CS.collapsedSections["appearance_masque"]
+    AttachCollapseButton(masqueHeading, masqueCollapsed, function()
+        CS.collapsedSections["appearance_masque"] = not CS.collapsedSections["appearance_masque"]
+        CooldownCompanion:RefreshConfigPanel()
+    end)
 
-        if not masqueCollapsed then
+    if not masqueCollapsed then
         local masqueCb = AceGUI:Create("CheckBox")
         masqueCb:SetLabel("Enable Masque Skinning")
         masqueCb:SetValue(group.masqueEnabled or false)
@@ -2856,8 +2857,14 @@ local function BuildAppearanceTab(container)
             {"Overridden Settings:", 1, 0.82, 0},
             {"Border Size, Border Color, Square Icons (forced on)", 0.7, 0.7, 0.7, true},
         }, tabInfoButtons)
-        end -- not masqueCollapsed
-    end
+
+        if not CooldownCompanion.Masque and group.masqueEnabled then
+            local missingMasqueLabel = AceGUI:Create("Label")
+            missingMasqueLabel:SetText("|cffffcc00Masque is not loaded. This preference is saved and will apply on the next /reload after Masque is enabled.|r")
+            missingMasqueLabel:SetFullWidth(true)
+            container:AddChild(missingMasqueLabel)
+        end
+    end -- not masqueCollapsed
 
     BuildGroupSettingPresetControls(container, group, "icons", tabInfoButtons)
 

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -620,8 +620,8 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     -- Store the frame
     self.groupFrames[groupId] = frame
 
-    -- Create Masque group if enabled
-    if group.masqueEnabled and self.Masque then
+    -- Create Masque group if active
+    if self:IsGroupMasqueActive(groupId, group) then
         self:CreateMasqueGroup(groupId)
     end
 
@@ -900,12 +900,12 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     local buttonsPerRow = style.buttonsPerRow or 12
     local isTriggerMode = group.displayMode == "trigger"
 
-    -- Clear existing buttons (remove from Masque first if enabled)
+    -- Clear existing buttons, including buttons left registered from an earlier Masque-active state.
     for _, button in ipairs(frame.buttons) do
         if CooldownCompanion.ReleaseAuraTextureVisual then
             CooldownCompanion:ReleaseAuraTextureVisual(button)
         end
-        if group.masqueEnabled then
+        if self:IsGroupMasqueActive(groupId, group) or button._masqueStaticId then
             self:RemoveButtonFromMasque(groupId, button)
         end
         button:Hide()
@@ -993,7 +993,7 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
             table_insert(frame.buttons, button)
 
             -- Add to Masque if enabled (after button is shown and in the list, icons only)
-            if group.displayMode == "icons" and group.masqueEnabled then
+            if self:IsGroupMasqueActive(groupId, group) then
                 self:AddButtonToMasque(groupId, button)
             end
         end
@@ -1218,9 +1218,11 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
 
         self:AnchorGroupFrame(frame, group.anchor)
 
-        -- Recreate Masque group if it was deleted during unload
-        if group.masqueEnabled and self.Masque and not self.MasqueGroups[groupId] then
+        -- Keep Masque runtime state aligned without changing the saved user preference.
+        if self:IsGroupMasqueActive(groupId, group) and not self.MasqueGroups[self:GetMasqueStaticId(groupId)] then
             self:CreateMasqueGroup(groupId)
+        elseif self.Masque and self._masqueGroupKeys and self._masqueGroupKeys[groupId] then
+            self:DeactivateGroupMasqueRuntime(groupId)
         end
 
         self:PopulateGroupButtons(groupId)

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1219,9 +1219,10 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
         self:AnchorGroupFrame(frame, group.anchor)
 
         -- Keep Masque runtime state aligned without changing the saved user preference.
-        if self:IsGroupMasqueActive(groupId, group) and not self.MasqueGroups[self:GetMasqueStaticId(groupId)] then
+        local masqueActive = self:IsGroupMasqueActive(groupId, group)
+        if masqueActive and not self.MasqueGroups[self:GetMasqueStaticId(groupId)] then
             self:CreateMasqueGroup(groupId)
-        elseif self.Masque and self._masqueGroupKeys and self._masqueGroupKeys[groupId] then
+        elseif not masqueActive and self.Masque and self._masqueGroupKeys and self._masqueGroupKeys[groupId] then
             self:DeactivateGroupMasqueRuntime(groupId)
         end
 

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -479,14 +479,6 @@ function CooldownCompanion:ApplyGroupSettingPreset(mode, presetName, groupId)
     ApplyGroupSettingPresetData(self.db.profile, group, mode, presetData)
     local newMasqueEnabled = group.masqueEnabled and true or false
 
-    -- Presets can be imported from clients with Masque enabled.
-    -- If Masque is unavailable on this client, do not leave groups flagged
-    -- as Masque-enabled because that disables icon controls in config.
-    if mode == "icons" and not self.Masque and newMasqueEnabled then
-        group.masqueEnabled = false
-        newMasqueEnabled = false
-    end
-
     -- Keep Masque's internal group/button lifecycle in sync when preset apply
     -- flips skinning state for icon groups.
     if mode == "icons" and self.Masque and oldMasqueEnabled ~= newMasqueEnabled then
@@ -859,8 +851,8 @@ function CooldownCompanion:ChangePanelDisplayMode(groupId, newMode)
     if newMode == "bars" or newMode == "text" then
         group.style.orientation = "vertical"
     end
-    if newMode ~= "icons" and group.masqueEnabled and self.ToggleGroupMasque then
-        self:ToggleGroupMasque(groupId, false)
+    if newMode ~= "icons" and group.masqueEnabled and self.DeactivateGroupMasqueRuntime then
+        self:DeactivateGroupMasqueRuntime(groupId)
     end
     if newMode == "textures" or newMode == "trigger" then
         -- Entering texture mode switches from group.anchor to textureSettings,

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -579,6 +579,7 @@ function CooldownCompanion:DeleteContainer(containerId)
         end
     end
     for _, groupId in ipairs(panelIds) do
+        self:DeleteMasqueGroup(groupId)
         self:UnloadGroup(groupId)
         self:DiscardDormantFrame(groupId)
         db.groups[groupId] = nil
@@ -754,6 +755,7 @@ function CooldownCompanion:DeletePanel(containerId, groupId)
     local group = db.groups[groupId]
     if not group or group.parentContainerId ~= containerId then return false end
 
+    self:DeleteMasqueGroup(groupId)
     self:UnloadGroup(groupId)
     self:DiscardDormantFrame(groupId)
     db.groups[groupId] = nil
@@ -916,6 +918,7 @@ function CooldownCompanion:DeleteGroup(id)
 
     local parentId = group.parentContainerId
 
+    self:DeleteMasqueGroup(id)
     self:UnloadGroup(id)
     self:DiscardDormantFrame(id)
     self.db.profile.groups[id] = nil

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -482,7 +482,7 @@ function CooldownCompanion:ApplyGroupSettingPreset(mode, presetName, groupId)
     -- Keep Masque's internal group/button lifecycle in sync when preset apply
     -- flips skinning state for icon groups.
     if mode == "icons" and self.Masque and oldMasqueEnabled ~= newMasqueEnabled then
-        self:ToggleGroupMasque(groupId, newMasqueEnabled)
+        self:ToggleGroupMasque(groupId, newMasqueEnabled, oldMasqueEnabled)
     end
 
     self:RefreshGroupFrame(groupId)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1350,6 +1350,7 @@ function CooldownCompanion:RefreshAllGroups()
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
             self:UnloadGroup(groupId)
+            self:DeleteMasqueGroup(groupId, true)
             self:DiscardDormantFrame(groupId)
         end
     end
@@ -1397,6 +1398,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
             self:UnloadGroup(groupId)
+            self:DeleteMasqueGroup(groupId, true)
             self:DiscardDormantFrame(groupId)
         end
     end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1349,6 +1349,7 @@ function CooldownCompanion:RefreshAllGroups()
     -- (e.g. after a profile switch).
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
+            self:DeleteMasqueGroup(groupId, true)
             self:UnloadGroup(groupId)
             self:DiscardDormantFrame(groupId)
         end
@@ -1396,6 +1397,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     -- Fully unload frames for groups not in the current profile
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
+            self:DeleteMasqueGroup(groupId, true)
             self:UnloadGroup(groupId)
             self:DiscardDormantFrame(groupId)
         end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1564,7 +1564,7 @@ function CooldownCompanion:RecoverDormantFrame(groupId)
 
     -- Recreate Masque group and re-add buttons
     local group = self.db.profile.groups[groupId]
-    if group and group.masqueEnabled and self.Masque then
+    if group and self:IsGroupMasqueActive(groupId, group) then
         self:CreateMasqueGroup(groupId)
         for _, button in ipairs(frame.buttons) do
             self:AddButtonToMasque(groupId, button)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1513,8 +1513,8 @@ function CooldownCompanion:UnloadGroup(groupId)
         end
     end
 
-    -- Delete Masque group
-    self:DeleteMasqueGroup(groupId)
+    -- Drop the runtime Masque reference without deleting the user's saved skin choice.
+    self:UnregisterMasqueGroup(groupId)
 
     -- Clear alpha fade state
     if self.alphaState then

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1349,7 +1349,6 @@ function CooldownCompanion:RefreshAllGroups()
     -- (e.g. after a profile switch).
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
-            self:DeleteMasqueGroup(groupId, true)
             self:UnloadGroup(groupId)
             self:DiscardDormantFrame(groupId)
         end
@@ -1397,7 +1396,6 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     -- Fully unload frames for groups not in the current profile
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
-            self:DeleteMasqueGroup(groupId, true)
             self:UnloadGroup(groupId)
             self:DiscardDormantFrame(groupId)
         end

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -46,7 +46,7 @@ local LSM = LibStub("LibSharedMedia-3.0")
 
 -- Masque skinning support (optional)
 local Masque = LibStub("Masque", true)
-local MasqueGroups = {} -- Maps groupId -> Masque Group object
+local MasqueGroups = {} -- Maps Masque static ID -> Masque Group object
 
 CooldownCompanion.Masque = Masque
 CooldownCompanion.MasqueGroups = MasqueGroups

--- a/Core/Masque.lua
+++ b/Core/Masque.lua
@@ -161,11 +161,14 @@ function CooldownCompanion:SetButtonBorderVisible(button, visible)
     end
 end
 
-function CooldownCompanion:ToggleGroupMasque(groupId, enable)
+function CooldownCompanion:ToggleGroupMasque(groupId, enable, previousMasqueEnabled)
     local group = self.db.profile.groups[groupId]
     if not group then return end
 
-    local wasMasqueEnabled = group.masqueEnabled == true
+    local wasMasqueEnabled = previousMasqueEnabled
+    if wasMasqueEnabled == nil then
+        wasMasqueEnabled = group.masqueEnabled == true
+    end
     group.masqueEnabled = enable
 
     if not self.Masque then return end

--- a/Core/Masque.lua
+++ b/Core/Masque.lua
@@ -48,10 +48,16 @@ function CooldownCompanion:CreateMasqueGroup(groupId)
     return masqueGroup
 end
 
-function CooldownCompanion:DeleteMasqueGroup(groupId)
+function CooldownCompanion:DeleteMasqueGroup(groupId, forceReacquire)
     if not self.Masque then return end
+    local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId]
     local staticId = self:GetMasqueStaticId(groupId)
     local oldStaticId = self._masqueGroupKeys and self._masqueGroupKeys[groupId]
+
+    if not MasqueGroups[staticId] and (forceReacquire or (group and group.masqueEnabled == true)) then
+        local groupName = group and group.name or ("Group " .. groupId)
+        MasqueGroups[staticId] = self.Masque:Group(ADDON_NAME, groupName, staticId)
+    end
 
     DeleteMasqueGroupByStaticId(staticId)
     if oldStaticId and oldStaticId ~= staticId then
@@ -159,6 +165,7 @@ function CooldownCompanion:ToggleGroupMasque(groupId, enable)
     local group = self.db.profile.groups[groupId]
     if not group then return end
 
+    local wasMasqueEnabled = group.masqueEnabled == true
     group.masqueEnabled = enable
 
     if not self.Masque then return end
@@ -191,6 +198,6 @@ function CooldownCompanion:ToggleGroupMasque(groupId, enable)
             end
         end
         -- Delete the Masque group
-        self:DeleteMasqueGroup(groupId)
+        self:DeleteMasqueGroup(groupId, wasMasqueEnabled)
     end
 end

--- a/Core/Masque.lua
+++ b/Core/Masque.lua
@@ -5,31 +5,90 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
-local Masque = CooldownCompanion.Masque
 local MasqueGroups = CooldownCompanion.MasqueGroups
 
 local ipairs = ipairs
 local tostring = tostring
 
+local function DeleteMasqueGroupByStaticId(staticId)
+    local masqueGroup = MasqueGroups[staticId]
+    if masqueGroup then
+        masqueGroup:Delete()
+        MasqueGroups[staticId] = nil
+    end
+end
+
 -- Masque Helper Functions
+function CooldownCompanion:GetMasqueStaticId(groupId)
+    -- Keep the legacy panel ID so existing Masque settings continue to apply.
+    return tostring(groupId)
+end
+
+function CooldownCompanion:IsGroupMasqueActive(groupId, group)
+    if not self.Masque then return false end
+
+    group = group or (self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[groupId])
+    return group and group.masqueEnabled == true and group.displayMode == "icons"
+end
+
 function CooldownCompanion:CreateMasqueGroup(groupId)
-    if not Masque then return end
+    if not self.Masque then return end
     local group = self.db.profile.groups[groupId]
     if not group then return end
+    if group.style then
+        group.style.maintainAspectRatio = true
+    end
 
-    -- Use groupId as the static ID so Masque settings persist across sessions
-    local masqueGroup = Masque:Group(ADDON_NAME, group.name or ("Group " .. groupId), tostring(groupId))
-    MasqueGroups[groupId] = masqueGroup
+    local staticId = self:GetMasqueStaticId(groupId)
+    self._masqueGroupKeys = self._masqueGroupKeys or {}
+
+    local masqueGroup = self.Masque:Group(ADDON_NAME, group.name or ("Group " .. groupId), staticId)
+    MasqueGroups[staticId] = masqueGroup
+    self._masqueGroupKeys[groupId] = staticId
     return masqueGroup
 end
 
 function CooldownCompanion:DeleteMasqueGroup(groupId)
-    if not Masque then return end
-    local masqueGroup = MasqueGroups[groupId]
-    if masqueGroup then
-        masqueGroup:Delete()
-        MasqueGroups[groupId] = nil
+    if not self.Masque then return end
+    local staticId = self:GetMasqueStaticId(groupId)
+    local oldStaticId = self._masqueGroupKeys and self._masqueGroupKeys[groupId]
+
+    DeleteMasqueGroupByStaticId(staticId)
+    if oldStaticId and oldStaticId ~= staticId then
+        DeleteMasqueGroupByStaticId(oldStaticId)
     end
+
+    if self._masqueGroupKeys then
+        self._masqueGroupKeys[groupId] = nil
+    end
+end
+
+function CooldownCompanion:UnregisterMasqueGroup(groupId)
+    if not self.Masque then return end
+    local staticId = self:GetMasqueStaticId(groupId)
+    local oldStaticId = self._masqueGroupKeys and self._masqueGroupKeys[groupId]
+
+    MasqueGroups[staticId] = nil
+    if oldStaticId and oldStaticId ~= staticId then
+        MasqueGroups[oldStaticId] = nil
+    end
+
+    if self._masqueGroupKeys then
+        self._masqueGroupKeys[groupId] = nil
+    end
+end
+
+function CooldownCompanion:DeactivateGroupMasqueRuntime(groupId)
+    if not self.Masque then return end
+    local frame = self.groupFrames and self.groupFrames[groupId]
+    if frame and frame.buttons then
+        for _, button in ipairs(frame.buttons) do
+            if button._masqueStaticId then
+                self:RemoveButtonFromMasque(groupId, button)
+            end
+        end
+    end
+    self:UnregisterMasqueGroup(groupId)
 end
 
 function CooldownCompanion:GetMasqueRegions(button)
@@ -43,25 +102,30 @@ function CooldownCompanion:GetMasqueRegions(button)
 end
 
 function CooldownCompanion:AddButtonToMasque(groupId, button)
-    if not Masque then return end
-    local masqueGroup = MasqueGroups[groupId]
+    if not self:IsGroupMasqueActive(groupId) then return end
+    local staticId = self:GetMasqueStaticId(groupId)
+    local masqueGroup = MasqueGroups[staticId]
     if not masqueGroup then return end
 
     local regions = self:GetMasqueRegions(button)
     -- Type "Action" is standard for action-bar-like buttons
     -- Strict=true tells Masque to only use the regions we provide
     masqueGroup:AddButton(button, regions, "Action", true)
+    button._masqueStaticId = staticId
 
     -- Hide CC's custom border/bg when Masque is active
     self:SetButtonBorderVisible(button, false)
 end
 
 function CooldownCompanion:RemoveButtonFromMasque(groupId, button)
-    if not Masque then return end
-    local masqueGroup = MasqueGroups[groupId]
-    if not masqueGroup then return end
+    if not self.Masque or not button then return end
+    local staticId = button._masqueStaticId or self:GetMasqueStaticId(groupId)
+    local masqueGroup = MasqueGroups[staticId]
 
-    masqueGroup:RemoveButton(button)
+    if masqueGroup then
+        masqueGroup:RemoveButton(button)
+    end
+    button._masqueStaticId = nil
 
     -- Restore CC's custom border/bg
     self:SetButtonBorderVisible(button, true)
@@ -92,19 +156,23 @@ function CooldownCompanion:SetButtonBorderVisible(button, visible)
 end
 
 function CooldownCompanion:ToggleGroupMasque(groupId, enable)
-    if not Masque then return end
-
     local group = self.db.profile.groups[groupId]
     if not group then return end
 
     group.masqueEnabled = enable
 
+    if not self.Masque then return end
+
     if enable then
-        -- Force square icons when Masque is enabled (non-square causes stretching)
-        group.style.maintainAspectRatio = true
+        if not self:IsGroupMasqueActive(groupId, group) then return end
+
+        -- Masque skins assume square icon regions; non-square regions can stretch skin art.
+        if group.style then
+            group.style.maintainAspectRatio = true
+        end
 
         -- Create Masque group if it doesn't exist
-        if not MasqueGroups[groupId] then
+        if not MasqueGroups[self:GetMasqueStaticId(groupId)] then
             self:CreateMasqueGroup(groupId)
         end
         -- Add all existing buttons to Masque

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -5,8 +5,6 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
-local Masque = CooldownCompanion.Masque
-
 local pairs = pairs
 local ipairs = ipairs
 local type = type
@@ -300,10 +298,6 @@ end
 function CooldownCompanion:MigrateMasqueField()
     for groupId, group in pairs(self.db.profile.groups) do
         if group.masqueEnabled == nil then
-            group.masqueEnabled = false
-        end
-        -- If Masque addon is not available but group had it enabled, disable it
-        if group.masqueEnabled and not Masque then
             group.masqueEnabled = false
         end
     end


### PR DESCRIPTION
## What Players Will Notice
- The "Enable Masque Skinning" checkbox should stay enabled for icon panels after reloads, even if Masque was unavailable during a previous load.
- Panels that were saved with Masque enabled will keep that preference and apply it again once Masque is available after a reload.
- Existing Masque skin selections continue using the same panel IDs as before, so this fix should not reset skins for players using named Cooldown Companion profiles.
- Icon size, border, and square-icon controls remain editable when Masque is not currently loaded instead of being locked by a saved preference that cannot actively skin the panel.

## Why This Changed
- A user reported that Masque skinning kept turning itself off after relogs across every panel.
- The root cause was that Cooldown Companion treated `masqueEnabled` as proof that Masque was currently loaded, so some load and preset paths could save the setting back to disabled when the optional Masque addon was missing.

## What Changed
- `masqueEnabled` now represents the player's saved preference: whether they want Masque enabled for that panel.
- Runtime checks now separately ask whether Masque is actually active, meaning Masque is loaded, the panel is an icon panel, and the saved preference is enabled.
- Presets and migrations no longer erase saved Masque-enabled preferences just because Masque is unavailable.
- Cooldown Companion keeps the existing Masque static ID format for all profiles to avoid resetting current Masque skin choices.
- Automatic mode changes, profile switches, and temporary panel unloads now detach only Cooldown Companion's runtime Masque references without saving the player's preference as disabled or deleting their Masque skin choice.
- Ordinary panel refreshes no longer deactivate an already-active Masque group.
- Actual panel/container deletion, explicit Masque disable, and presets that turn Masque off still use destructive Masque cleanup, including after a panel was temporarily unloaded.
- The config UI now explains when Masque is not loaded but the preference is still saved, including that Masque needs to be enabled before the next `/reload`.

## Validation
- Ran Lua syntax validation across 74 addon Lua files in `Core`, `ButtonFrame`, `Config`, `ConfigSettings`, and `OtherBars`.
- Ran `git diff --check` with no whitespace errors reported.
- Reviewed the Masque persistence, refresh, mode-change, profile-switch, preset apply, unload/recover, toggle-off, and delete paths so saved Masque preferences are not disabled solely because Masque is unavailable or a panel temporarily unloads.
- In-game verification is still needed for reloads with Masque unavailable/available, display mode switching, existing skin compatibility, profile switches, spec/load-condition unloads, dormant panel deletion/toggle-off/preset-off cleanup, and combat or restricted-content refresh behavior.