### PR TITLE
Fix cooldown panels after PvP talents become unavailable

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -15,6 +15,7 @@ local wipe = wipe
 -- Some talent swaps briefly report pre-final spell charge state. Coalesce a
 -- delayed second pass so charge flags settle without duplicate refresh storms.
 local pendingTalentChargeRefreshToken = 0
+local pendingSpellAvailabilityRefreshToken = 0
 
 -- Coalesce rapid-fire ACTIONBAR_SLOT_CHANGED events (e.g. modifier-reactive
 -- macros changing many slots simultaneously) into a single rebuild pass.
@@ -31,6 +32,61 @@ local function QueueTalentChargeRefresh(addon)
         addon:RefreshAllGroups()
         addon:RefreshConfigPanel()
     end)
+end
+
+local function QueueSpellAvailabilitySettlingRefresh(addon)
+    pendingSpellAvailabilityRefreshToken = pendingSpellAvailabilityRefreshToken + 1
+    local token = pendingSpellAvailabilityRefreshToken
+    C_Timer.After(0.2, function()
+        if pendingSpellAvailabilityRefreshToken ~= token then return end
+        addon:RefreshSpellAvailabilityState({ skipSettlingRefresh = true })
+    end)
+end
+
+function CooldownCompanion:RefreshSpellAvailabilityState(opts)
+    opts = opts or {}
+    self:CachePlayerState()
+    self:CacheCurrentSpec()
+    self._currentHeroSpecId = C_ClassTalents.GetActiveHeroTalentSpec()
+    self:RebuildTalentNodeCache()
+    if opts.refreshAllChargeTypes then
+        self:RefreshChargeFlags()
+    else
+        self:RefreshChargeFlags("spell")
+    end
+    self:RefreshAllGroupsForSpellAvailability()
+    self:RefreshConfigPanel()
+
+    if opts.applyResourceBars then
+        self:ApplyResourceBars()
+        self:UpdateAnchorStacking()
+    elseif opts.evaluateResourceBars then
+        self:EvaluateResourceBars()
+    end
+
+    if opts.rebuildViewerMap then
+        C_Timer.After(1, function()
+            self:BuildViewerAuraMap()
+        end)
+    end
+
+    if not opts.skipSettlingRefresh then
+        QueueSpellAvailabilitySettlingRefresh(self)
+    end
+end
+
+function CooldownCompanion:OnSpellAvailabilityChanged()
+    self:RefreshSpellAvailabilityState()
+end
+
+function CooldownCompanion:OnPlayerSpecializationChanged(event, unit)
+    if unit and unit ~= "player" then return end
+    self:OnSpecChanged()
+end
+
+function CooldownCompanion:OnSpellsChanged()
+    self:OnSpellUpdateIcon()
+    self:RefreshSpellAvailabilityState()
 end
 
 function CooldownCompanion:OnSpellUpdateIcon()
@@ -86,13 +142,10 @@ function CooldownCompanion:OnBagChanged()
 end
 
 function CooldownCompanion:OnTalentsChanged()
-    self._currentHeroSpecId = C_ClassTalents.GetActiveHeroTalentSpec()
-    self:RebuildTalentNodeCache()
-    self:RefreshChargeFlags("spell")
-    self:RefreshAllGroups()
-    self:ApplyResourceBars()
-    self:UpdateAnchorStacking()
-    self:RefreshConfigPanel()
+    self:RefreshSpellAvailabilityState({
+        applyResourceBars = true,
+        skipSettlingRefresh = true,
+    })
     QueueTalentChargeRefresh(self)
 end
 
@@ -227,16 +280,11 @@ function CooldownCompanion:CacheCurrentSpec()
 end
 
 function CooldownCompanion:OnSpecChanged()
-    self:CacheCurrentSpec()
-    self:RebuildTalentNodeCache()
-    self:RefreshChargeFlags()
-    self:RefreshAllGroups()
-    self:EvaluateResourceBars()
-    self:RefreshConfigPanel()
-    -- Rebuild viewer map after a short delay to let the viewer re-populate
-    C_Timer.After(1, function()
-        self:BuildViewerAuraMap()
-    end)
+    self:RefreshSpellAvailabilityState({
+        evaluateResourceBars = true,
+        refreshAllChargeTypes = true,
+        rebuildViewerMap = true,
+    })
 end
 
 function CooldownCompanion:CachePlayerState()
@@ -264,9 +312,7 @@ function CooldownCompanion:CachePlayerState()
 end
 
 function CooldownCompanion:OnZoneChanged()
-    self:CachePlayerState()
-    self:RefreshAllGroupsVisibilityOnly()
-    self:RefreshConfigPanel()
+    self:RefreshSpellAvailabilityState()
 end
 
 function CooldownCompanion:OnRestingChanged()
@@ -305,13 +351,10 @@ function CooldownCompanion:OnVehicleUIChanged(event, unit)
 end
 
 function CooldownCompanion:OnHeroTalentChanged()
-    self._currentHeroSpecId = C_ClassTalents.GetActiveHeroTalentSpec()
-    self:RebuildTalentNodeCache()
-    self:RefreshChargeFlags("spell")
-    self:RefreshAllGroups()
-    self:ApplyResourceBars()
-    self:UpdateAnchorStacking()
-    self:RefreshConfigPanel()
+    self:RefreshSpellAvailabilityState({
+        applyResourceBars = true,
+        skipSettlingRefresh = true,
+    })
     QueueTalentChargeRefresh(self)
 end
 
@@ -327,7 +370,7 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
         if isFullInit then
             self:RefreshAllGroups()
         else
-            self:RefreshAllGroupsVisibilityOnly()
+            self:RefreshAllGroupsForSpellAvailability()
         end
         self:ApplyCdmAlpha()
         if isFullInit then
@@ -338,10 +381,12 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
         -- Delayed second pass: talent-dependent charge data (e.g. Hover,
         -- Keg Smash) may not be resolved when RefreshChargeFlags runs
         -- above.  A coalesced recheck catches late-loading talent state.
-        -- Only on full init — zone transitions use the visibility-only
-        -- fast path and must not schedule a full button repopulation.
+        -- Full init keeps the talent charge queue. Zone transitions get a
+        -- lighter settling pass that rebuilds only if button availability changed.
         if isFullInit then
             QueueTalentChargeRefresh(self)
+        else
+            QueueSpellAvailabilitySettlingRefresh(self)
         end
     end)
     -- Post-login sweep: clear buttons falsely stuck as aura-active from stale

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1285,6 +1285,116 @@ function CooldownCompanion:IsButtonUsable(buttonData)
     return true
 end
 
+local function GetFrameForButtonSetComparison(addon, groupId)
+    local frame = addon.groupFrames and addon.groupFrames[groupId]
+    if frame then return frame end
+    return addon._dormantFrames and addon._dormantFrames[groupId] or nil
+end
+
+function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
+    local frame = GetFrameForButtonSetComparison(self, groupId)
+    if not frame or not frame.buttons then
+        return false
+    end
+    if not group.buttons then
+        return #frame.buttons > 0
+    end
+
+    local usableButtons = {}
+    local usableCount = 0
+    for _, buttonData in ipairs(group.buttons) do
+        if self:IsButtonUsable(buttonData) then
+            usableCount = usableCount + 1
+            usableButtons[usableCount] = buttonData
+        end
+    end
+
+    if #frame.buttons ~= usableCount then
+        return true
+    end
+
+    for i = 1, usableCount do
+        local button = frame.buttons[i]
+        if not button or button.buttonData ~= usableButtons[i] then
+            return true
+        end
+    end
+
+    return false
+end
+
+function CooldownCompanion:AnyGroupButtonSetNeedsRebuild()
+    if not self.db or not self.db.profile or not self.db.profile.groups then
+        return false
+    end
+
+    for groupId, group in pairs(self.db.profile.groups) do
+        if self:IsGroupVisibleToCurrentChar(groupId)
+            and self:IsGroupActive(groupId, {
+                group = group,
+                checkCharVisibility = false,
+                checkLoadConditions = true,
+                requireButtons = false,
+            })
+            and self:GroupButtonSetNeedsRebuild(groupId, group)
+        then
+            return true
+        end
+    end
+
+    return false
+end
+
+function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
+    local function resetFrameButtons(frame)
+        if not frame or not frame.buttons then return end
+        for _, button in ipairs(frame.buttons) do
+            local buttonData = button.buttonData
+            if buttonData and buttonData.type == "spell" then
+                button._noCooldown = nil
+                button._displaySpellId = nil
+                button._lastSpellTexture = nil
+                button._iconDirty = true
+                button._cooldownDeferred = nil
+                button._durationObj = nil
+                button._chargeDurationObj = nil
+                button._chargeRecharging = nil
+                button._chargeState = nil
+                button._currentReadableCharges = nil
+                button._chargeCountReadable = nil
+                button._zeroChargesConfirmed = nil
+                button._displayCountZeroUsabilityFallback = nil
+            end
+        end
+    end
+
+    if self.groupFrames then
+        for _, frame in pairs(self.groupFrames) do
+            resetFrameButtons(frame)
+        end
+    end
+    if self._dormantFrames then
+        for _, frame in pairs(self._dormantFrames) do
+            resetFrameButtons(frame)
+        end
+    end
+
+    self._cooldownsDirty = true
+end
+
+function CooldownCompanion:RefreshAllGroupsForSpellAvailability()
+    local needsFullRefresh = self:AnyGroupButtonSetNeedsRebuild()
+    self:ResetSpellAvailabilityButtonRuntime()
+
+    if needsFullRefresh then
+        self:RefreshAllGroups()
+    else
+        self:RefreshAllGroupsVisibilityOnly()
+    end
+
+    self:UpdateAllCooldowns()
+end
+
 function CooldownCompanion:CreateAllGroupFrames()
     for groupId, _ in pairs(self.db.profile.groups) do
         if self:IsGroupVisibleToCurrentChar(groupId) then
@@ -1425,6 +1535,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
             else
                 local frame = self.groupFrames[groupId]
                 if not frame then
+                    if self:GroupButtonSetNeedsRebuild(groupId, group) then
+                        self:DiscardDormantFrame(groupId)
+                    end
                     -- Recover dormant frame with buttons intact (no repopulation needed)
                     frame = self:RecoverDormantFrame(groupId)
                 end

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -146,7 +146,7 @@ function CooldownCompanion:OnEnable()
     self:RegisterEvent("SPELL_UPDATE_ICON", "OnSpellUpdateIcon")
     -- Spellbook rebuild — catches always-on talent transforms that resolve
     -- after init without firing SPELL_UPDATE_ICON (e.g. hero talent icon swaps).
-    self:RegisterEvent("SPELLS_CHANGED", "OnSpellUpdateIcon")
+    self:RegisterEvent("SPELLS_CHANGED", "OnSpellsChanged")
 
     -- Event-driven range checking (replaces per-tick IsSpellInRange polling)
     self:RegisterEvent("SPELL_RANGE_CHECK_UPDATE", "OnSpellRangeCheckUpdate")
@@ -156,12 +156,15 @@ function CooldownCompanion:OnEnable()
 
     -- Talent change events — refresh group frames and config panel
     self:RegisterEvent("TRAIT_CONFIG_UPDATED", "OnTalentsChanged")
+    self:RegisterEvent("PLAYER_PVP_TALENT_UPDATE", "OnSpellAvailabilityChanged")
+    self:RegisterEvent("WAR_MODE_STATUS_UPDATE", "OnSpellAvailabilityChanged")
 
     -- Pet summon/dismiss — show/hide pet spell buttons dynamically
     self:RegisterEvent("UNIT_PET", "OnPetChanged")
 
     -- Specialization change events — show/hide groups based on spec filter
     self:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED", "OnSpecChanged")
+    self:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED", "OnPlayerSpecializationChanged")
     self:RegisterEvent("TRAIT_SUB_TREE_CHANGED", "OnHeroTalentChanged")
 
     -- Zone/instance change events — load condition evaluation


### PR DESCRIPTION
## What Players Will Notice
- PvP talent abilities should disappear from cooldown panels when the current environment disables them, such as entering a delve, without needing a `/reload`.
- Normal cooldowns on the same panels, such as Adrenaline Rush, get their spell-derived cooldown and icon state refreshed during the same transition so they are less likely to show stale cooldown information.
- Saved panel configuration is preserved. Temporarily unavailable PvP talent buttons are hidden from the live panel instead of being deleted from settings.

## Why This Changed
- Entering some content can change the active spellbook while the panel itself remains loaded.
- Cooldown Companion previously treated these transitions as visibility-only updates, so existing live buttons could be reused even when a PvP talent was no longer usable.
- DevBridge evidence showed Death from Above remaining on a panel after a scenario/delve-style transition where PvP talents should no longer have been available.

## What Changed
- Added refresh handling for PvP talent, War Mode, player specialization, spellbook, zone, and non-reload world-entry availability changes.
- Added a shared spell-availability refresh path that compares live panel buttons against the current `IsButtonUsable()` result and rebuilds only when the visible button set is stale.
- Cleared derived spell cooldown/icon runtime state during availability refreshes so existing non-PvP buttons are re-evaluated with current spellbook/environment data.
- Preserved charge cast-history state during that reset so restricted/secret charge cooldown handling does not regress.

## Validation
- Verified all Lua files parse with `luac -p`.
- Verified `git diff --check origin/main...HEAD` is clean.
- Ran a focused code review pass and fixed one charge-state regression risk before publishing.
- Checked DevBridge error buffers; no Cooldown Companion errors were captured in the available snapshot.
- In-game `/reload`, delve/PvP talent transition, and combat/restricted-content verification are still needed before treating the behavior as fully runtime-validated.