### PR TITLE
Improve config previews and protect charge cooldown swipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ nul
 agent-reference/
 .local-tools/
 scripts/
+docs/

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -94,8 +94,30 @@ local function UpdateBarFill(button)
     -- Items use stored C_Item.GetItemCooldown values (_itemCdStart/_itemCdDuration).
     local onCooldown = false
     local itemRemaining = 0
+    local previewRemaining = button._conditionalPreviewRemaining
+    local previewDuration = button._conditionalPreviewDuration
+    if previewRemaining and previewDuration and button._conditionalPreviewStartTime then
+        previewRemaining = previewDuration - (GetTime() - button._conditionalPreviewStartTime)
+        if previewRemaining < 0 then previewRemaining = 0 end
+        button._conditionalPreviewRemaining = previewRemaining
+    end
 
-    if button._durationObj and not button._barGCDSuppressed then
+    if previewRemaining and previewRemaining > 0 and not button._barGCDSuppressed then
+        onCooldown = true
+        previewDuration = previewDuration or previewRemaining
+        if previewDuration <= 0 then
+            previewDuration = previewRemaining
+        end
+        local frac
+        if button._conditionalPreviewDomain == "aura" then
+            frac = previewRemaining / previewDuration
+        else
+            frac = 1 - (previewRemaining / previewDuration)
+        end
+        if frac < 0 then frac = 0 end
+        if frac > 1 then frac = 1 end
+        button.statusBar:SetValue(frac)
+    elseif button._durationObj and not button._barGCDSuppressed then
         onCooldown = true
         -- SetValue accepts secret values; fraction animates natively in the engine
         if button._auraActive then
@@ -175,7 +197,9 @@ local function UpdateBarFill(button)
             -- Non-secret: full FormatTime formatting ("1:30:00", "1:30", "45", etc.)
             -- Secret: pass secret number to C++ SetFormattedText ("%.1f" / "%.0f" format)
             local decimal = button.style.decimalTimers
-            if button._durationObj then
+            if previewRemaining and previewRemaining > 0 then
+                button.timeText:SetText(FormatTime(previewRemaining, decimal))
+            elseif button._durationObj then
                 local remaining = button._durationObj:GetRemainingDuration()
                 if not button._durationObj:HasSecretValues() then
                     if remaining > 0 then
@@ -207,7 +231,7 @@ local function UpdateBarFill(button)
             button.statusBar:SetMinMaxValues(0, 1)
             button._viewerBar = nil
         end
-        if button._barAuraActivePreview then
+        if button._barAuraActivePreview or button._conditionalBarAuraActivePreview then
             button.statusBar:SetValue(1)
             button.timeText:SetText("")
         elseif button.buttonData.isPassive then
@@ -273,7 +297,8 @@ local function UpdateBarDisplay(button)
     -- _durationObj may also hold aura/totem timing and must not imply cooldown.
     local isChargeButton = UsesChargeBehavior(button.buttonData)
     local chargeState = button._chargeState
-    local auraTimerActive = button._auraActive and (button._durationObj or button._viewerBar)
+    local auraTimerActive = button._auraActive
+        and (button._durationObj or button._viewerBar or button._conditionalPreviewRemaining)
     local onCooldown
     if isChargeButton then
         onCooldown = chargeState == CHARGE_STATE_MISSING
@@ -325,9 +350,9 @@ local function UpdateBarDisplay(button)
 
     -- Bar aura color: override bar fill when aura is active (pandemic overrides aura color)
     local wantAuraColor
-    if button._pandemicPreview then
+    if button._pandemicPreview or button._conditionalPreviewKind == "pandemic" then
         wantAuraColor = (button.style and button.style.barPandemicColor) or DEFAULT_BAR_PANDEMIC_COLOR
-    elseif button._barAuraActivePreview then
+    elseif button._barAuraActivePreview or button._conditionalBarAuraActivePreview then
         wantAuraColor = (button.style and button.style.barAuraColor) or DEFAULT_BAR_AURA_COLOR
     elseif button._auraActive then
         if button._inPandemic and style.showPandemicGlow ~= false
@@ -361,9 +386,11 @@ local function UpdateBarDisplay(button)
 
     -- Bar aura effect (pandemic overrides effect color)
     local barAuraEffectPandemic = button._pandemicPreview
+        or button._conditionalPreviewKind == "pandemic"
         or (button._auraActive and button._inPandemic and style.showPandemicGlow ~= false
             and (not style.pandemicGlowCombatOnly or inCombat))
     local barAuraEffectShow = button._barAuraEffectPreview or button._barAuraActivePreview
+        or button._conditionalBarAuraActivePreview
         or button._pandemicPreview
         or (button._auraActive and (barAuraEffectPandemic
             or (barAuraVisualsEnabled and (not style.auraGlowCombatOnly or inCombat))))
@@ -373,6 +400,7 @@ local function UpdateBarDisplay(button)
     -- Gated behind the same master toggles as existing bar aura effects:
     -- barAuraVisualsEnabled for aura-active, showPandemicGlow for pandemic (via barAuraEffectPandemic).
     local auraActiveForPulse = button._barAuraActivePreview
+        or button._conditionalBarAuraActivePreview
         or (barAuraVisualsEnabled and button._auraActive
             and (not style.auraGlowCombatOnly or inCombat))
 

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -102,6 +102,8 @@ local function UpdateBarFill(button)
         button._conditionalPreviewRemaining = previewRemaining
     end
 
+    local auraDurationTextPreview = button._conditionalAuraDurationTextPreview == true
+
     if previewRemaining and previewRemaining > 0 and not button._barGCDSuppressed then
         onCooldown = true
         previewDuration = previewDuration or previewRemaining
@@ -109,7 +111,7 @@ local function UpdateBarFill(button)
             previewDuration = previewRemaining
         end
         local frac
-        if button._conditionalPreviewDomain == "aura" then
+        if button._conditionalPreviewDomain == "aura" or button._conditionalPreviewDomain == "aura_text" then
             frac = previewRemaining / previewDuration
         else
             frac = 1 - (previewRemaining / previewDuration)
@@ -165,16 +167,16 @@ local function UpdateBarFill(button)
     end
 
     if onCooldown then
-        local showTimeText = button._auraActive
+        local showTimeText = (button._auraActive or auraDurationTextPreview)
             and (button.style.showAuraText ~= false)
-            or (not button._auraActive and button.style.showCooldownText)
+            or (not button._auraActive and not auraDurationTextPreview and button.style.showCooldownText)
         if showTimeText then
             -- Switch font/color when mode changes
-            local mode = button._auraActive and "aura" or "cd"
+            local mode = (button._auraActive or auraDurationTextPreview) and "aura" or "cd"
             if button._barTextMode ~= mode then
                 button._barTextMode = mode
                 button._barTextColorDirty = true
-                if button._auraActive then
+                if button._auraActive or auraDurationTextPreview then
                     local f = CooldownCompanion:FetchFont(button.style.auraTextFont or "Friz Quadrata TT")
                     local s = button.style.auraTextFontSize or 12
                     local o = button.style.auraTextFontOutline or "OUTLINE"
@@ -188,7 +190,7 @@ local function UpdateBarFill(button)
             end
             if button._barTextColorDirty then
                 button._barTextColorDirty = nil
-                local cc = button._auraActive
+                local cc = (button._auraActive or auraDurationTextPreview)
                     and (button.style.auraTextFontColor or DEFAULT_AURA_TEXT_COLOR)
                     or (button.style.cooldownFontColor or DEFAULT_WHITE)
                 button.timeText:SetTextColor(cc[1], cc[2], cc[3], cc[4])

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -85,6 +85,43 @@ local function SetBarIconTooltipScripts(button, enable)
     end
 end
 
+local function ResolveConditionalPreviewRemaining(button)
+    local previewRemaining = button._conditionalPreviewRemaining
+    local previewDuration = button._conditionalPreviewDuration
+    if not (previewRemaining and previewDuration) then
+        return previewRemaining, previewDuration
+    end
+
+    if button._conditionalPreviewLoop
+        and button._conditionalPreviewLoopStartTime
+        and button._conditionalPreviewLoopDuration
+    then
+        local loopDuration = button._conditionalPreviewLoopDuration
+        if loopDuration > 0 then
+            local now = GetTime()
+            local elapsed = now - button._conditionalPreviewLoopStartTime
+            if elapsed < 0 then
+                elapsed = 0
+            end
+            local cycleElapsed = elapsed % loopDuration
+            previewRemaining = loopDuration - cycleElapsed
+            if previewRemaining > previewDuration then
+                previewRemaining = previewDuration
+            end
+            button._conditionalPreviewRemaining = previewRemaining
+            button._conditionalPreviewStartTime = now - (previewDuration - previewRemaining)
+        end
+        return previewRemaining, previewDuration
+    end
+
+    if button._conditionalPreviewStartTime then
+        previewRemaining = previewDuration - (GetTime() - button._conditionalPreviewStartTime)
+        if previewRemaining < 0 then previewRemaining = 0 end
+        button._conditionalPreviewRemaining = previewRemaining
+    end
+    return previewRemaining, previewDuration
+end
+
 -- Lightweight OnUpdate: interpolates bar fill + time text between ticker updates.
 local function UpdateBarFill(button)
     -- Single-bar path
@@ -94,13 +131,7 @@ local function UpdateBarFill(button)
     -- Items use stored C_Item.GetItemCooldown values (_itemCdStart/_itemCdDuration).
     local onCooldown = false
     local itemRemaining = 0
-    local previewRemaining = button._conditionalPreviewRemaining
-    local previewDuration = button._conditionalPreviewDuration
-    if previewRemaining and previewDuration and button._conditionalPreviewStartTime then
-        previewRemaining = previewDuration - (GetTime() - button._conditionalPreviewStartTime)
-        if previewRemaining < 0 then previewRemaining = 0 end
-        button._conditionalPreviewRemaining = previewRemaining
-    end
+    local previewRemaining, previewDuration = ResolveConditionalPreviewRemaining(button)
 
     local auraDurationTextPreview = button._conditionalAuraDurationTextPreview == true
 
@@ -735,19 +766,17 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     -- Apply count text font/anchor settings
     ApplyBarCountTextStyle(button, style)
 
-    -- Aura stack count text — separate FontString for aura stacks, independent of charge text
-    if buttonData.auraTracking or buttonData.isPassive then
-        button.auraStackCount = button.overlayFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
-        button.auraStackCount:SetText("")
-        ApplyFontStyle(button.auraStackCount, style, "auraStack")
-        local asAnchor = style.auraStackAnchor or "BOTTOMLEFT"
-        local asXOff = style.auraStackXOffset or 2
-        local asYOff = style.auraStackYOffset or 2
-        if showIcon then
-            button.auraStackCount:SetPoint(asAnchor, button.icon, asAnchor, asXOff, asYOff)
-        else
-            button.auraStackCount:SetPoint(asAnchor, button, asAnchor, asXOff, asYOff)
-        end
+    -- Aura stack count text: separate FontString for aura stacks and config previews.
+    button.auraStackCount = button.overlayFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+    button.auraStackCount:SetText("")
+    ApplyFontStyle(button.auraStackCount, style, "auraStack")
+    local asAnchor = style.auraStackAnchor or "BOTTOMLEFT"
+    local asXOff = style.auraStackXOffset or 2
+    local asYOff = style.auraStackYOffset or 2
+    if showIcon then
+        button.auraStackCount:SetPoint(asAnchor, button.icon, asAnchor, asXOff, asYOff)
+    else
+        button.auraStackCount:SetPoint(asAnchor, button, asAnchor, asXOff, asYOff)
     end
 
     -- Store button data

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -98,6 +98,9 @@ local function ClearConditionalVisualPreviewFields(button)
     button._conditionalPreviewStartTime = nil
     button._conditionalPreviewDuration = nil
     button._conditionalPreviewRemaining = nil
+    button._conditionalPreviewLoop = nil
+    button._conditionalPreviewLoopStartTime = nil
+    button._conditionalPreviewLoopDuration = nil
     button._conditionalPreviewDomain = nil
     button._conditionalAuraPreview = nil
     button._conditionalAuraDurationTextPreview = nil
@@ -142,11 +145,42 @@ local function GetConditionalPreviewTiming(preview, now)
         startTime = now
     end
 
+    local loopDuration = tonumber(preview and preview.loopDuration)
+    local loopStartTime = tonumber(preview and preview.loopStartTime)
+    if preview and preview.loop == true and loopDuration and loopDuration > 0 then
+        if loopDuration > duration then
+            loopDuration = duration
+        end
+        if not loopStartTime then
+            loopStartTime = startTime + (duration - loopDuration)
+        end
+        local elapsed = now - loopStartTime
+        if elapsed < 0 then
+            elapsed = 0
+        end
+        local cycleElapsed = elapsed % loopDuration
+        local remaining = loopDuration - cycleElapsed
+        if remaining > duration then
+            remaining = duration
+        end
+        startTime = now - (duration - remaining)
+        return startTime, duration, remaining, loopStartTime, loopDuration
+    end
+
     local remaining = duration - (now - startTime)
     if remaining < 0 then
         remaining = 0
     end
     return startTime, duration, remaining
+end
+
+local function SetConditionalPreviewTimingFields(button, startTime, duration, remaining, loopStartTime, loopDuration)
+    button._conditionalPreviewStartTime = startTime
+    button._conditionalPreviewDuration = duration
+    button._conditionalPreviewRemaining = remaining
+    button._conditionalPreviewLoop = (loopStartTime and loopDuration) and true or nil
+    button._conditionalPreviewLoopStartTime = loopStartTime
+    button._conditionalPreviewLoopDuration = loopDuration
 end
 
 local function ApplyConditionalVisualPreview(button, buttonData, style, preview, now, usesChargeBehavior)
@@ -158,15 +192,13 @@ local function ApplyConditionalVisualPreview(button, buttonData, style, preview,
     button._conditionalPreviewKind = kind
 
     if kind == "cooldown" then
-        local startTime, duration, remaining = GetConditionalPreviewTiming(preview, now)
+        local startTime, duration, remaining, loopStartTime, loopDuration = GetConditionalPreviewTiming(preview, now)
         if not startTime then return end
         button._cooldownState = COOLDOWN_STATE_COOLDOWN
         button._desatCooldownActive = true
         button._cooldownDeferred = nil
         button._conditionalPreviewDomain = "cooldown"
-        button._conditionalPreviewStartTime = startTime
-        button._conditionalPreviewDuration = duration
-        button._conditionalPreviewRemaining = remaining
+        SetConditionalPreviewTimingFields(button, startTime, duration, remaining, loopStartTime, loopDuration)
         if button.cooldown then
             button.cooldown:SetCooldown(startTime, duration)
         end
@@ -174,7 +206,7 @@ local function ApplyConditionalVisualPreview(button, buttonData, style, preview,
     end
 
     if kind == "aura" or kind == "pandemic" then
-        local startTime, duration, remaining = GetConditionalPreviewTiming(preview, now)
+        local startTime, duration, remaining, loopStartTime, loopDuration = GetConditionalPreviewTiming(preview, now)
         if not startTime then return end
         button._auraActive = true
         button._auraHasTimer = true
@@ -184,9 +216,7 @@ local function ApplyConditionalVisualPreview(button, buttonData, style, preview,
         button._conditionalPandemicPreview = kind == "pandemic" or nil
         button._conditionalBarAuraActivePreview = true
         button._conditionalPreviewDomain = "aura"
-        button._conditionalPreviewStartTime = startTime
-        button._conditionalPreviewDuration = duration
-        button._conditionalPreviewRemaining = remaining
+        SetConditionalPreviewTimingFields(button, startTime, duration, remaining, loopStartTime, loopDuration)
         if button.cooldown then
             button.cooldown:SetCooldown(startTime, duration)
         end
@@ -197,13 +227,11 @@ local function ApplyConditionalVisualPreview(button, buttonData, style, preview,
     end
 
     if kind == "aura_duration_text" then
-        local startTime, duration, remaining = GetConditionalPreviewTiming(preview, now)
+        local startTime, duration, remaining, loopStartTime, loopDuration = GetConditionalPreviewTiming(preview, now)
         if not startTime then return end
         button._conditionalAuraDurationTextPreview = true
         button._conditionalPreviewDomain = "aura_text"
-        button._conditionalPreviewStartTime = startTime
-        button._conditionalPreviewDuration = duration
-        button._conditionalPreviewRemaining = remaining
+        SetConditionalPreviewTimingFields(button, startTime, duration, remaining, loopStartTime, loopDuration)
         if button.cooldown then
             button.cooldown:SetCooldown(startTime, duration)
         end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -14,6 +14,7 @@ local tostring = tostring
 local ipairs = ipairs
 local wipe = wipe
 local issecretvalue = issecretvalue
+local math_max = math.max
 
 -- Imports from Glows
 local GetViewerAuraStackText = ST._GetViewerAuraStackText
@@ -34,6 +35,9 @@ local UnitCanAttack = UnitCanAttack
 
 -- Imports from Utils
 local HasTooltipCooldown = ST.HasTooltipCooldown
+
+-- Imports from Preview
+local GetConditionalVisualPreview = ST._GetConditionalVisualPreview
 
 -- Imports from Tracking
 local UpdateChargeTracking = ST._UpdateChargeTracking
@@ -67,6 +71,168 @@ local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+
+local function ClearConditionalVisualPreviewFields(button)
+    if button._conditionalAuraPreview then
+        local buttonData = button.buttonData
+        if not (buttonData and (buttonData.auraTracking or buttonData.isPassive)) then
+            button._auraActive = false
+            button._auraHasTimer = false
+            button._auraStackText = ""
+        end
+    end
+    if button._conditionalPandemicPreview then
+        local buttonData = button.buttonData
+        if not (buttonData and buttonData.auraTracking) then
+            button._inPandemic = false
+            button._pandemicGraceStart = nil
+        end
+    end
+    button._conditionalPreviewKind = nil
+    button._conditionalPreviewStartTime = nil
+    button._conditionalPreviewDuration = nil
+    button._conditionalPreviewRemaining = nil
+    button._conditionalPreviewDomain = nil
+    button._conditionalAuraPreview = nil
+    button._conditionalPandemicPreview = nil
+    button._conditionalUnusablePreview = nil
+    button._conditionalOutOfRangePreview = nil
+    button._conditionalReadyPreview = nil
+    button._conditionalBarAuraActivePreview = nil
+end
+
+local function ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)
+    if not (button and button.count and (style.chargeFontColor or style.chargeFontColorMissing or style.chargeFontColorZero)) then
+        return
+    end
+
+    local cc
+    if usesChargeBehavior and button._chargeState == CHARGE_STATE_ZERO then
+        cc = style.chargeFontColorZero or DEFAULT_WHITE
+    elseif usesChargeBehavior and button._chargeState == CHARGE_STATE_MISSING then
+        cc = style.chargeFontColorMissing or DEFAULT_WHITE
+    elseif usesChargeBehavior and button._chargeState == CHARGE_STATE_FULL then
+        cc = style.chargeFontColor or DEFAULT_WHITE
+    elseif usesChargeBehavior then
+        cc = style.chargeFontColor or DEFAULT_WHITE
+    elseif UsesChargeTextLane(buttonData) then
+        cc = style.chargeFontColor or DEFAULT_WHITE
+    end
+
+    if cc then
+        button.count:SetTextColor(cc[1], cc[2], cc[3], cc[4])
+    end
+end
+
+local function GetConditionalPreviewTiming(preview, now)
+    local duration = tonumber(preview and preview.duration)
+    local startTime = tonumber(preview and preview.startTime)
+    if not duration or duration <= 0 then
+        return nil, nil, nil
+    end
+    if not startTime then
+        startTime = now
+    end
+
+    local remaining = duration - (now - startTime)
+    if remaining < 0 then
+        remaining = 0
+    end
+    return startTime, duration, remaining
+end
+
+local function ApplyConditionalVisualPreview(button, buttonData, style, preview, now, usesChargeBehavior)
+    if not preview then
+        return
+    end
+
+    local kind = preview.kind
+    button._conditionalPreviewKind = kind
+
+    if kind == "cooldown" then
+        local startTime, duration, remaining = GetConditionalPreviewTiming(preview, now)
+        if not startTime then return end
+        button._cooldownState = COOLDOWN_STATE_COOLDOWN
+        button._desatCooldownActive = true
+        button._cooldownDeferred = nil
+        button._conditionalPreviewDomain = "cooldown"
+        button._conditionalPreviewStartTime = startTime
+        button._conditionalPreviewDuration = duration
+        button._conditionalPreviewRemaining = remaining
+        if button.cooldown then
+            button.cooldown:SetCooldown(startTime, duration)
+        end
+        return
+    end
+
+    if kind == "aura" or kind == "pandemic" then
+        local startTime, duration, remaining = GetConditionalPreviewTiming(preview, now)
+        if not startTime then return end
+        button._auraActive = true
+        button._auraHasTimer = true
+        button._auraStackText = preview.stackText or "3"
+        button._inPandemic = kind == "pandemic"
+        button._conditionalAuraPreview = true
+        button._conditionalPandemicPreview = kind == "pandemic" or nil
+        button._conditionalBarAuraActivePreview = true
+        button._conditionalPreviewDomain = "aura"
+        button._conditionalPreviewStartTime = startTime
+        button._conditionalPreviewDuration = duration
+        button._conditionalPreviewRemaining = remaining
+        if button.cooldown then
+            button.cooldown:SetCooldown(startTime, duration)
+        end
+        if button.auraStackCount and style.showAuraStackText ~= false then
+            button.auraStackCount:SetText(button._auraStackText or "")
+        end
+        return
+    end
+
+    if kind == "charge_full" or kind == "charge_missing" or kind == "charge_zero" then
+        if not usesChargeBehavior then
+            return
+        end
+        local maxCharges = buttonData.maxCharges or 2
+        if maxCharges < 2 then
+            maxCharges = 2
+        end
+
+        local currentCharges = maxCharges
+        if kind == "charge_missing" then
+            currentCharges = math_max(1, maxCharges - 1)
+            button._chargeState = CHARGE_STATE_MISSING
+            button._zeroChargesConfirmed = false
+        elseif kind == "charge_zero" then
+            currentCharges = 0
+            button._chargeState = CHARGE_STATE_ZERO
+            button._zeroChargesConfirmed = true
+            button._desatCooldownActive = true
+        else
+            button._chargeState = CHARGE_STATE_FULL
+            button._zeroChargesConfirmed = false
+            button._desatCooldownActive = false
+        end
+
+        button._chargeCountReadable = true
+        button._currentReadableCharges = currentCharges
+        button._chargeText = currentCharges
+        if button.count and style.showChargeText ~= false then
+            button.count:SetText(currentCharges)
+        end
+        return
+    end
+
+    if kind == "unusable" then
+        button._isUnusable = true
+        button._conditionalUnusablePreview = true
+        return
+    end
+
+    if kind == "out_of_range" then
+        button._isOutOfRange = true
+        button._conditionalOutOfRangePreview = true
+    end
+end
 
 local function AuraDataHasTimer(auraData)
     if not auraData then return false end
@@ -457,6 +623,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local now = GetTime()
     local isGCDOnly = false
     local desatWasActive = button._desatCooldownActive == true
+    ClearConditionalVisualPreviewFields(button)
 
     if button.count and button._countTextLaneStyled ~= useChargeTextLane then
         if button._isBar then
@@ -1347,10 +1514,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._readyGlowStartTime = nil
     end
 
-    if not button._isBar and not button._isText then
-        UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
-    end
-
     if usesChargeBehavior then
       if buttonData.type == "spell" and buttonData.hasCharges then
         -- Bar/text mode: charge bars are driven by the recharge DurationObject, not
@@ -1432,23 +1595,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Charge text color: three-state (zero / partial / max).
     -- Uses the canonical charge state resolved above.
-    if style.chargeFontColor or style.chargeFontColorMissing or style.chargeFontColorZero then
-        local cc
-        if usesChargeBehavior and button._chargeState == CHARGE_STATE_ZERO then
-            cc = style.chargeFontColorZero or DEFAULT_WHITE
-        elseif usesChargeBehavior and button._chargeState == CHARGE_STATE_MISSING then
-            cc = style.chargeFontColorMissing or DEFAULT_WHITE
-        elseif usesChargeBehavior and button._chargeState == CHARGE_STATE_FULL then
-            cc = style.chargeFontColor or DEFAULT_WHITE
-        elseif usesChargeBehavior then
-            cc = style.chargeFontColor or DEFAULT_WHITE
-        elseif UsesChargeTextLane(buttonData) then
-            cc = style.chargeFontColor or DEFAULT_WHITE
-        end
-        if cc then
-            button.count:SetTextColor(cc[1], cc[2], cc[3], cc[4])
-        end
-    end
+    ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)
 
     -- Per-button sound alerts (Blizzard-scoped events, CDM-valid only).
     if buttonData.type == "spell" then
@@ -1624,6 +1771,16 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._isOutOfRange = false
     end
 
+    ApplyConditionalVisualPreview(
+        button,
+        buttonData,
+        style,
+        GetConditionalVisualPreview and GetConditionalVisualPreview(button),
+        now,
+        usesChargeBehavior
+    )
+    ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)
+
     -- Mode-specific visual dispatch
     if button._isText then
         UpdateTextDisplay(button)
@@ -1631,6 +1788,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateBarDisplay(button)
         DispatchStandaloneTextureVisual(button)
     else
+        UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -81,6 +81,12 @@ local function ClearConditionalVisualPreviewFields(button)
             button._auraStackText = ""
         end
     end
+    if button._conditionalAuraStackTextPreview then
+        button._auraStackText = ""
+        if button.auraStackCount then
+            button.auraStackCount:SetText("")
+        end
+    end
     if button._conditionalPandemicPreview then
         local buttonData = button.buttonData
         if not (buttonData and buttonData.auraTracking) then
@@ -94,6 +100,8 @@ local function ClearConditionalVisualPreviewFields(button)
     button._conditionalPreviewRemaining = nil
     button._conditionalPreviewDomain = nil
     button._conditionalAuraPreview = nil
+    button._conditionalAuraDurationTextPreview = nil
+    button._conditionalAuraStackTextPreview = nil
     button._conditionalPandemicPreview = nil
     button._conditionalUnusablePreview = nil
     button._conditionalOutOfRangePreview = nil
@@ -182,6 +190,29 @@ local function ApplyConditionalVisualPreview(button, buttonData, style, preview,
         if button.cooldown then
             button.cooldown:SetCooldown(startTime, duration)
         end
+        if button.auraStackCount and style.showAuraStackText ~= false then
+            button.auraStackCount:SetText(button._auraStackText or "")
+        end
+        return
+    end
+
+    if kind == "aura_duration_text" then
+        local startTime, duration, remaining = GetConditionalPreviewTiming(preview, now)
+        if not startTime then return end
+        button._conditionalAuraDurationTextPreview = true
+        button._conditionalPreviewDomain = "aura_text"
+        button._conditionalPreviewStartTime = startTime
+        button._conditionalPreviewDuration = duration
+        button._conditionalPreviewRemaining = remaining
+        if button.cooldown then
+            button.cooldown:SetCooldown(startTime, duration)
+        end
+        return
+    end
+
+    if kind == "aura_stack_text" then
+        button._auraStackText = preview.stackText or "3"
+        button._conditionalAuraStackTextPreview = true
         if button.auraStackCount and style.showAuraStackText ~= false then
             button.auraStackCount:SetText(button._auraStackText or "")
         end
@@ -623,6 +654,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local now = GetTime()
     local isGCDOnly = false
     local desatWasActive = button._desatCooldownActive == true
+    local conditionalPreview = GetConditionalVisualPreview and GetConditionalVisualPreview(button)
     ClearConditionalVisualPreviewFields(button)
 
     if button.count and button._countTextLaneStyled ~= useChargeTextLane then
@@ -1584,9 +1616,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Aura stack count display (aura-tracking spells with stackable auras)
     -- Text is a secret value in combat — pass through directly to SetText.
     -- Blizzard sets it to "" when stacks <= 1 and the count string when > 1.
-    if button.auraStackCount and (button._auraTrackingReady or buttonData.isPassive)
+    if button.auraStackCount and (button._auraTrackingReady or buttonData.isPassive or button._conditionalAuraStackTextPreview)
        and (style.showAuraStackText ~= false) then
-        if button._auraActive then
+        if button._auraActive or button._conditionalAuraStackTextPreview then
             button.auraStackCount:SetText(button._auraStackText or "")
         else
             button.auraStackCount:SetText("")
@@ -1680,14 +1712,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Config panel QOL: selected buttons in column 2 are always fully visible.
     local forceVisibleByConfig = IsConfigButtonForceVisible(button)
-    if forceVisibleByUnlockPreview then
+    local forceVisibleByPreview = conditionalPreview ~= nil and not isTriggerPanel
+    if forceVisibleByUnlockPreview or forceVisibleByPreview then
         button._visibilityHidden = false
         button._visibilityAlphaOverride = 1
     elseif forceVisibleByConfig and not isTriggerPanel then
         button._visibilityHidden = false
         button._visibilityAlphaOverride = 1
     end
-    button._forceVisibleByConfig = ((forceVisibleByConfig or forceVisibleByUnlockPreview) and not isTriggerPanel) or nil
+    button._forceVisibleByConfig = ((forceVisibleByConfig or forceVisibleByUnlockPreview or forceVisibleByPreview) and not isTriggerPanel) or nil
 
     -- Track visibility/force-visible state changes for compact layout reflow.
     local visibilityChanged = button._visibilityHidden ~= button._prevVisibilityHidden
@@ -1775,7 +1808,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button,
         buttonData,
         style,
-        GetConditionalVisualPreview and GetConditionalVisualPreview(button),
+        conditionalPreview,
         now,
         usesChargeBehavior
     )

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -755,6 +755,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._cooldownDeferred = nil
     button._cooldownState = COOLDOWN_STATE_READY
     button._chargeState = nil
+    button._chargeCooldownVisualActive = nil
 
     -- Fetch cooldown data and update the cooldown widget.
     -- isOnGCD is NeverSecret (always readable even during restricted combat).
@@ -1354,7 +1355,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if usesChargeBehavior and buttonData.hasCharges and buttonData.type == "spell" then
         button._displayCountZeroUsabilityFallback = nil
         charges = UpdateChargeTracking(button, buttonData, cooldownSpellId)
-        button._chargeRecharging = DurationObjectShowsCooldown(button._chargeDurationObj)
+        button._chargeCooldownVisualActive = DurationObjectShowsCooldown(button._chargeDurationObj)
+        button._chargeRecharging = button._chargeCooldownVisualActive
     elseif usesChargeBehavior
         and (buttonData._hasDisplayCount or buttonData._displayCountFamily)
         and buttonData.type == "spell"
@@ -1583,23 +1585,33 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._durationObj = nil
         end
 
+        local normalCooldownDisplayActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+            or (button._cooldownState == COOLDOWN_STATE_GCD and style.showGCDSwipe == true)
         if not auraOverrideActive and button._chargeDurationObj then
             if not button._isBar and not button._isText then
-                -- Icon mode: always set _durationObj, show recharge radial
-                button._durationObj = button._chargeDurationObj
-                button.cooldown:SetCooldownFromDurationObject(button._chargeDurationObj)
+                if button._chargeCooldownVisualActive then
+                    -- Icon mode: active recharge owns the shared cooldown frame.
+                    button._durationObj = button._chargeDurationObj
+                    button.cooldown:SetCooldownFromDurationObject(button._chargeDurationObj)
+                elseif not normalCooldownDisplayActive then
+                    button.cooldown:SetCooldown(0, 0)
+                end
             elseif button._chargeRecharging then
                 -- Bar/text mode: only set _durationObj if actually recharging
                 button._durationObj = button._chargeDurationObj
             end
         elseif not button._isBar and not button._isText and not auraOverrideActive then
             -- Icon mode fallback: no chargeDurationObj, try fetching one.
-            -- Clear if unavailable to prevent stale cooldown widget state.
+            -- Only an active charge DurationObject may replace an existing GCD display.
             local chargeSpellID = cooldownSpellId or buttonData.id
             local fallbackDuration = C_Spell.GetSpellChargeDuration(chargeSpellID)
-            if fallbackDuration then
+            local fallbackActive = DurationObjectShowsCooldown(fallbackDuration)
+            button._chargeCooldownVisualActive = fallbackActive or nil
+            if fallbackActive then
+                button._chargeRecharging = true
+                button._durationObj = fallbackDuration
                 button.cooldown:SetCooldownFromDurationObject(fallbackDuration)
-            else
+            elseif not normalCooldownDisplayActive then
                 button.cooldown:SetCooldown(0, 0)
             end
         end

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -112,7 +112,7 @@ local function UpdateBlizzardAuraSwipe(button, style)
 
     local enabled = style.auraUseBlizzardSwipe == true
         and (button._auraActive == true or button._conditionalAuraDurationTextPreview == true)
-        and button._auraHasTimer ~= false
+        and (button._conditionalAuraDurationTextPreview == true or button._auraHasTimer ~= false)
 
     if not enabled then
         HideBlizzardAuraSwipe(button, style)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -700,7 +700,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
 
     -- When separate text positions: move primary text to aura anchor during aura, cooldown anchor otherwise
     if button._secondaryCdTextRegion and button._cdTextRegion then
-        local wantAuraPos = button._auraActive == true
+        local wantAuraPos = button._auraActive == true or button._conditionalAuraDurationTextPreview == true
         if button._cdTextAtAuraPos ~= wantAuraPos then
             button._cdTextAtAuraPos = wantAuraPos
             button._cdTextRegion:ClearAllPoints()
@@ -722,7 +722,8 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
     -- Color is reapplied each tick because WoW's CooldownFrame may reset it.
     if button._cdTextRegion then
         local showText, fontColor, wantFont, wantSize, wantOutline
-        if button._auraActive then
+        local auraTextPreview = button._conditionalAuraDurationTextPreview == true
+        if button._auraActive or auraTextPreview then
             showText = style.showAuraText ~= false
             fontColor = style.auraTextFontColor or DEFAULT_AURA_TEXT_COLOR
             wantFont = CooldownCompanion:FetchFont(style.auraTextFont or "Friz Quadrata TT")
@@ -745,7 +746,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
             local cc = fontColor
             button._cdTextRegion:SetTextColor(cc[1], cc[2], cc[3], cc[4])
             -- Only call SetFont when mode changes to avoid per-tick overhead
-            local mode = button._auraActive and "aura" or "cd"
+            local mode = (button._auraActive or auraTextPreview) and "aura" or "cd"
             if button._cdTextMode ~= mode then
                 button._cdTextMode = mode
                 button._cdTextRegion:SetFont(wantFont, wantSize, wantOutline)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -128,7 +128,12 @@ local function UpdateBlizzardAuraSwipe(button, style)
     overlay:SetSwipeColor(BLIZZARD_AURA_SWIPE_R, BLIZZARD_AURA_SWIPE_G, BLIZZARD_AURA_SWIPE_B, BLIZZARD_AURA_SWIPE_A)
 
     local rendered = false
-    if button._durationObj then
+    if button._conditionalAuraDurationTextPreview == true
+        and button._conditionalPreviewStartTime
+        and button._conditionalPreviewDuration then
+        overlay:SetCooldown(button._conditionalPreviewStartTime, button._conditionalPreviewDuration)
+        rendered = true
+    elseif button._durationObj then
         overlay:SetCooldownFromDurationObject(button._durationObj)
         rendered = overlay:IsShown()
     else
@@ -664,6 +669,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         -- keeps any explicit real-cooldown presentation from being hidden here.
         local suppressGCD = not style.showGCDSwipe
             and isGCDOnly
+            and button._chargeCooldownVisualActive ~= true
             and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
 
         if suppressGCD then

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -345,16 +345,14 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
 
     ApplyCountTextStyle(button, style)
 
-    -- Aura stack count text — separate FontString for aura stacks, independent of charge text
-    if buttonData.auraTracking or buttonData.isPassive then
-        button.auraStackCount = button.overlayFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
-        button.auraStackCount:SetText("")
-        ApplyFontStyle(button.auraStackCount, style, "auraStack")
-        local asAnchor = style.auraStackAnchor or "BOTTOMLEFT"
-        local asXOff = style.auraStackXOffset or 2
-        local asYOff = style.auraStackYOffset or 2
-        button.auraStackCount:SetPoint(asAnchor, asXOff, asYOff)
-    end
+    -- Aura stack count text: separate FontString for aura stacks and config previews.
+    button.auraStackCount = button.overlayFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+    button.auraStackCount:SetText("")
+    ApplyFontStyle(button.auraStackCount, style, "auraStack")
+    local asAnchor = style.auraStackAnchor or "BOTTOMLEFT"
+    local asXOff = style.auraStackXOffset or 2
+    local asYOff = style.auraStackYOffset or 2
+    button.auraStackCount:SetPoint(asAnchor, asXOff, asYOff)
 
     -- Keybind text overlay
     button.keybindText = button.overlayFrame:CreateFontString(nil, "OVERLAY")

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -111,7 +111,7 @@ local function UpdateBlizzardAuraSwipe(button, style)
     end
 
     local enabled = style.auraUseBlizzardSwipe == true
-        and button._auraActive == true
+        and (button._auraActive == true or button._conditionalAuraDurationTextPreview == true)
         and button._auraHasTimer ~= false
 
     if not enabled then

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -805,3 +805,45 @@ function CooldownCompanion:ClearAllAuraTexturePickerPreviews()
         end
     end
 end
+
+function CooldownCompanion:ClearAllConfigPreviews()
+    if self.ClearAllProcGlowPreviews then
+        self:ClearAllProcGlowPreviews()
+    end
+    if self.ClearAllAuraGlowPreviews then
+        self:ClearAllAuraGlowPreviews()
+    end
+    if self.ClearAllPandemicPreviews then
+        self:ClearAllPandemicPreviews()
+    end
+    if self.ClearAllReadyGlowPreviews then
+        self:ClearAllReadyGlowPreviews()
+    end
+    if self.ClearAllKeyPressHighlightPreviews then
+        self:ClearAllKeyPressHighlightPreviews()
+    end
+    if self.ClearAllBarAuraActivePreviews then
+        self:ClearAllBarAuraActivePreviews()
+    end
+    if self.ClearAllConditionalVisualPreviews then
+        self:ClearAllConditionalVisualPreviews()
+    end
+    if self.ClearAllTextureIndicatorPreviews then
+        self:ClearAllTextureIndicatorPreviews()
+    end
+    if self.ClearAllTriggerPanelEffectPreviews then
+        self:ClearAllTriggerPanelEffectPreviews()
+    end
+    if self.ClearAllCustomAuraBarPreviews then
+        self:ClearAllCustomAuraBarPreviews()
+    end
+    if self.ClearAllAuraTexturePickerPreviews then
+        self:ClearAllAuraTexturePickerPreviews()
+    end
+    if self.StopCastBarPreview then
+        self:StopCastBarPreview()
+    end
+    if self.StopResourceBarPreview then
+        self:StopResourceBarPreview()
+    end
+end

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -15,6 +15,7 @@ local pairs = pairs
 local ipairs = ipairs
 local tonumber = tonumber
 local wipe = wipe
+local GetTime = GetTime
 local C_Timer_After = C_Timer.After
 
 -- Token stores for each glow type (used to invalidate stale timed callbacks)
@@ -29,6 +30,8 @@ local readyButtonPreviewTokens = {}
 local kphPreviewTokens = {}
 local textureIndicatorPreviewTokens = {}
 local triggerEffectPreviewTokens = {}
+local conditionalVisualGroupTokens = {}
+local conditionalVisualButtonTokens = {}
 
 local function BumpButtonPreviewToken(tokenStore, groupId, buttonIndex)
     local groupTokens = tokenStore[groupId]
@@ -126,6 +129,151 @@ local function ClearAllPreviews(self, previewFlag, cacheFlag, cacheValue, groupT
             if onClear then onClear(button) end
             if updateCooldown and button.UpdateCooldown then
                 button:UpdateCooldown()
+            end
+        end
+    end
+end
+
+local CONDITIONAL_VISUAL_PREVIEW_DEFAULTS = {
+    cooldown = { kind = "cooldown", duration = 12, remaining = 8 },
+    aura = { kind = "aura", duration = 12, remaining = 8, stackText = "3" },
+    pandemic = { kind = "pandemic", duration = 12, remaining = 3, stackText = "3" },
+    charge_full = { kind = "charge_full" },
+    charge_missing = { kind = "charge_missing" },
+    charge_zero = { kind = "charge_zero" },
+    unusable = { kind = "unusable" },
+    out_of_range = { kind = "out_of_range" },
+}
+
+local function BuildConditionalVisualPreviewState(previewKind, sampleState)
+    local base = CONDITIONAL_VISUAL_PREVIEW_DEFAULTS[previewKind] or CONDITIONAL_VISUAL_PREVIEW_DEFAULTS.cooldown
+    local state = {}
+    for key, value in pairs(base) do
+        state[key] = value
+    end
+    if sampleState then
+        for key, value in pairs(sampleState) do
+            state[key] = value
+        end
+    end
+
+    local duration = tonumber(state.duration)
+    local remaining = tonumber(state.remaining)
+    if duration and duration > 0 then
+        if not remaining or remaining <= 0 or remaining > duration then
+            remaining = duration
+        end
+        state.duration = duration
+        state.remaining = remaining
+        state.startTime = GetTime() - (duration - remaining)
+    end
+    return state
+end
+
+local function ClearConditionalVisualPreviewDerivedFields(button)
+    if button._conditionalAuraPreview then
+        button._auraActive = false
+        button._auraHasTimer = false
+        button._auraStackText = ""
+    end
+    if button._conditionalPandemicPreview then
+        button._inPandemic = false
+        button._pandemicGraceStart = nil
+    end
+    button._conditionalPreviewKind = nil
+    button._conditionalPreviewStartTime = nil
+    button._conditionalPreviewDuration = nil
+    button._conditionalPreviewRemaining = nil
+    button._conditionalPreviewDomain = nil
+    button._conditionalAuraPreview = nil
+    button._conditionalPandemicPreview = nil
+    button._conditionalUnusablePreview = nil
+    button._conditionalOutOfRangePreview = nil
+    button._conditionalReadyPreview = nil
+    button._conditionalBarAuraActivePreview = nil
+end
+
+local function RefreshConditionalVisualPreviewButton(self, button)
+    if button.UpdateCooldown then
+        button:UpdateCooldown()
+    elseif type(self.UpdateAuraTextureVisual) == "function" then
+        self:UpdateAuraTextureVisual(button)
+    end
+end
+
+local function SetConditionalVisualPreviewOnButton(self, button, state)
+    button._conditionalVisualPreview = state
+    if not state then
+        ClearConditionalVisualPreviewDerivedFields(button)
+    end
+    RefreshConditionalVisualPreviewButton(self, button)
+end
+
+local function SetConditionalVisualPreview(self, groupId, buttonIndex, state)
+    if not self.groupFrames then return end
+    local frame = self.groupFrames[groupId]
+    if not frame then return end
+    for _, button in ipairs(frame.buttons) do
+        if button.index == buttonIndex then
+            SetConditionalVisualPreviewOnButton(self, button, state)
+            return
+        end
+    end
+end
+
+local function SetGroupConditionalVisualPreview(self, groupId, state)
+    if not self.groupFrames then return end
+    local frame = self.groupFrames[groupId]
+    if not frame then return end
+    for _, button in ipairs(frame.buttons) do
+        SetConditionalVisualPreviewOnButton(self, button, state)
+    end
+end
+
+local function GetConditionalVisualPreview(button)
+    return button and button._conditionalVisualPreview or nil
+end
+
+ST._GetConditionalVisualPreview = GetConditionalVisualPreview
+
+function CooldownCompanion:PlayConditionalVisualPreview(groupId, buttonIndex, previewKind, durationSeconds, sampleState)
+    local duration = tonumber(durationSeconds) or 3
+    if duration <= 0 then duration = 3 end
+
+    local state = BuildConditionalVisualPreviewState(previewKind, sampleState)
+    if buttonIndex then
+        local token = BumpButtonPreviewToken(conditionalVisualButtonTokens, groupId, buttonIndex)
+        SetConditionalVisualPreview(self, groupId, buttonIndex, state)
+
+        C_Timer_After(duration, function()
+            local groupTokens = conditionalVisualButtonTokens[groupId]
+            if not groupTokens or groupTokens[buttonIndex] ~= token then return end
+            SetConditionalVisualPreview(self, groupId, buttonIndex, nil)
+        end)
+        return
+    end
+
+    conditionalVisualButtonTokens[groupId] = nil
+    local token = (conditionalVisualGroupTokens[groupId] or 0) + 1
+    conditionalVisualGroupTokens[groupId] = token
+    SetGroupConditionalVisualPreview(self, groupId, state)
+
+    C_Timer_After(duration, function()
+        if conditionalVisualGroupTokens[groupId] ~= token then return end
+        SetGroupConditionalVisualPreview(self, groupId, nil)
+    end)
+end
+
+function CooldownCompanion:ClearAllConditionalVisualPreviews()
+    wipe(conditionalVisualGroupTokens)
+    wipe(conditionalVisualButtonTokens)
+    if not self.groupFrames then return end
+    for _, frame in pairs(self.groupFrames) do
+        for _, button in ipairs(frame.buttons) do
+            if button._conditionalVisualPreview then
+                SetConditionalVisualPreviewOnButton(self, button, nil)
+            else
+                ClearConditionalVisualPreviewDerivedFields(button)
             end
         end
     end

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -137,6 +137,8 @@ end
 local CONDITIONAL_VISUAL_PREVIEW_DEFAULTS = {
     cooldown = { kind = "cooldown", duration = 12, remaining = 8 },
     aura = { kind = "aura", duration = 12, remaining = 8, stackText = "3" },
+    aura_duration_text = { kind = "aura_duration_text", duration = 12, remaining = 8 },
+    aura_stack_text = { kind = "aura_stack_text", stackText = "3" },
     pandemic = { kind = "pandemic", duration = 12, remaining = 3, stackText = "3" },
     charge_full = { kind = "charge_full" },
     charge_missing = { kind = "charge_missing" },
@@ -176,6 +178,12 @@ local function ClearConditionalVisualPreviewDerivedFields(button)
         button._auraHasTimer = false
         button._auraStackText = ""
     end
+    if button._conditionalAuraStackTextPreview then
+        button._auraStackText = ""
+        if button.auraStackCount then
+            button.auraStackCount:SetText("")
+        end
+    end
     if button._conditionalPandemicPreview then
         button._inPandemic = false
         button._pandemicGraceStart = nil
@@ -186,6 +194,8 @@ local function ClearConditionalVisualPreviewDerivedFields(button)
     button._conditionalPreviewRemaining = nil
     button._conditionalPreviewDomain = nil
     button._conditionalAuraPreview = nil
+    button._conditionalAuraDurationTextPreview = nil
+    button._conditionalAuraStackTextPreview = nil
     button._conditionalPandemicPreview = nil
     button._conditionalUnusablePreview = nil
     button._conditionalOutOfRangePreview = nil
@@ -230,11 +240,66 @@ local function SetGroupConditionalVisualPreview(self, groupId, state)
     end
 end
 
+local function IsGroupButtonPreviewActive(self, groupId, buttonIndex, predicate)
+    if not (self.groupFrames and groupId and predicate) then
+        return false
+    end
+    local frame = self.groupFrames[groupId]
+    if not frame then
+        return false
+    end
+
+    for _, button in ipairs(frame.buttons) do
+        if not buttonIndex or button.index == buttonIndex then
+            if predicate(button) then
+                return true
+            end
+            if buttonIndex then
+                return false
+            end
+        end
+    end
+    return false
+end
+
 local function GetConditionalVisualPreview(button)
     return button and button._conditionalVisualPreview or nil
 end
 
 ST._GetConditionalVisualPreview = GetConditionalVisualPreview
+
+function CooldownCompanion:IsPreviewFlagActive(groupId, buttonIndex, previewFlag)
+    if not previewFlag then
+        return false
+    end
+    return IsGroupButtonPreviewActive(self, groupId, buttonIndex, function(button)
+        return button[previewFlag] == true
+    end)
+end
+
+function CooldownCompanion:IsConditionalVisualPreviewActive(groupId, buttonIndex, previewKind)
+    return IsGroupButtonPreviewActive(self, groupId, buttonIndex, function(button)
+        local state = GetConditionalVisualPreview(button)
+        return state and state.kind == previewKind
+    end)
+end
+
+function CooldownCompanion:SetConditionalVisualPreviewActive(groupId, buttonIndex, previewKind, show, sampleState)
+    if not groupId then
+        return
+    end
+
+    local state = show and BuildConditionalVisualPreviewState(previewKind, sampleState) or nil
+    if buttonIndex then
+        BumpButtonPreviewToken(conditionalVisualButtonTokens, groupId, buttonIndex)
+        SetConditionalVisualPreview(self, groupId, buttonIndex, state)
+        return
+    end
+
+    conditionalVisualButtonTokens[groupId] = nil
+    conditionalVisualGroupTokens[groupId] = (conditionalVisualGroupTokens[groupId] or 0) + 1
+    SetGroupConditionalVisualPreview(self, groupId, state)
+end
 
 function CooldownCompanion:PlayConditionalVisualPreview(groupId, buttonIndex, previewKind, durationSeconds, sampleState)
     local duration = tonumber(durationSeconds) or 3
@@ -411,6 +476,29 @@ end
 local barAuraActiveGroupTokens = {}
 local barAuraActiveButtonTokens = {}
 
+function CooldownCompanion:SetBarAuraActivePreview(groupId, buttonIndex, show)
+    if not groupId then return end
+    if buttonIndex then
+        BumpButtonPreviewToken(barAuraActiveButtonTokens, groupId, buttonIndex)
+    else
+        barAuraActiveButtonTokens[groupId] = nil
+        barAuraActiveGroupTokens[groupId] = (barAuraActiveGroupTokens[groupId] or 0) + 1
+    end
+
+    local frame = self.groupFrames[groupId]
+    if not frame then return end
+    for _, button in ipairs(frame.buttons) do
+        if not buttonIndex or button.index == buttonIndex then
+            button._barAuraActivePreview = show or nil
+            if button.UpdateCooldown then button:UpdateCooldown() end
+        end
+    end
+end
+
+function CooldownCompanion:IsBarAuraActivePreviewActive(groupId, buttonIndex)
+    return self:IsPreviewFlagActive(groupId, buttonIndex, "_barAuraActivePreview")
+end
+
 function CooldownCompanion:PlayBarAuraActivePreview(groupId, buttonIndex, durationSeconds)
     local duration = tonumber(durationSeconds) or 3
     if duration <= 0 then duration = 3 end
@@ -569,6 +657,11 @@ function CooldownCompanion:SetGroupTextureIndicatorPreview(groupId, indicatorKey
     )
 end
 
+function CooldownCompanion:IsGroupTextureIndicatorPreviewActive(groupId, indicatorKey)
+    local previewFlag = TEXTURE_INDICATOR_PREVIEW_FLAGS[indicatorKey]
+    return previewFlag and self:IsPreviewFlagActive(groupId, nil, previewFlag) or false
+end
+
 function CooldownCompanion:PlayGroupTextureIndicatorPreview(groupId, indicatorKey, durationSeconds)
     local previewFlag = TEXTURE_INDICATOR_PREVIEW_FLAGS[indicatorKey]
     if not previewFlag then
@@ -626,6 +719,10 @@ function CooldownCompanion:SetTriggerPanelEffectsPreview(groupId, show)
             self:UpdateAuraTextureVisual(button)
         end
     end
+end
+
+function CooldownCompanion:IsTriggerPanelEffectsPreviewActive(groupId)
+    return self:IsPreviewFlagActive(groupId, nil, "_triggerEffectsPreview")
 end
 
 function CooldownCompanion:PlayTriggerPanelEffectsPreview(groupId, durationSeconds)

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -32,6 +32,11 @@ local textureIndicatorPreviewTokens = {}
 local triggerEffectPreviewTokens = {}
 local conditionalVisualGroupTokens = {}
 local conditionalVisualButtonTokens = {}
+local activeGroupPreviewFlags = {}
+local activeButtonPreviewFlags = {}
+local activeTriggerPanelEffectPreviews = {}
+local activeConditionalGroupPreviews = {}
+local activeConditionalButtonPreviews = {}
 
 local function BumpButtonPreviewToken(tokenStore, groupId, buttonIndex)
     local groupTokens = tokenStore[groupId]
@@ -48,12 +53,113 @@ end
 -- Shared Helpers
 --------------------------------------------------------------------------------
 
+local function CopyPreviewState(state)
+    if not state then
+        return nil
+    end
+    local copy = {}
+    for key, value in pairs(state) do
+        copy[key] = value
+    end
+    return copy
+end
+
+local function SetActiveGroupPreviewFlag(groupId, previewFlag, show)
+    if not (groupId and previewFlag) then return end
+    local groupFlags = activeGroupPreviewFlags[groupId]
+    if show then
+        if not groupFlags then
+            groupFlags = {}
+            activeGroupPreviewFlags[groupId] = groupFlags
+        end
+        groupFlags[previewFlag] = true
+    elseif groupFlags then
+        groupFlags[previewFlag] = nil
+        if not next(groupFlags) then
+            activeGroupPreviewFlags[groupId] = nil
+        end
+    end
+end
+
+local function SetActiveButtonPreviewFlag(groupId, buttonIndex, previewFlag, show)
+    if not (groupId and buttonIndex and previewFlag) then return end
+    local groupButtons = activeButtonPreviewFlags[groupId]
+    local buttonFlags = groupButtons and groupButtons[buttonIndex]
+    if show then
+        if not groupButtons then
+            groupButtons = {}
+            activeButtonPreviewFlags[groupId] = groupButtons
+        end
+        if not buttonFlags then
+            buttonFlags = {}
+            groupButtons[buttonIndex] = buttonFlags
+        end
+        buttonFlags[previewFlag] = true
+    elseif buttonFlags then
+        buttonFlags[previewFlag] = nil
+        if not next(buttonFlags) then
+            groupButtons[buttonIndex] = nil
+            if not next(groupButtons) then
+                activeButtonPreviewFlags[groupId] = nil
+            end
+        end
+    end
+end
+
+local function ClearActiveButtonPreviewFlagForGroup(groupId, previewFlag)
+    local groupButtons = activeButtonPreviewFlags[groupId]
+    if not (groupButtons and previewFlag) then return end
+    for buttonIndex, buttonFlags in pairs(groupButtons) do
+        buttonFlags[previewFlag] = nil
+        if not next(buttonFlags) then
+            groupButtons[buttonIndex] = nil
+        end
+    end
+    if not next(groupButtons) then
+        activeButtonPreviewFlags[groupId] = nil
+    end
+end
+
+local function ClearActivePreviewFlag(previewFlag)
+    for groupId in pairs(activeGroupPreviewFlags) do
+        SetActiveGroupPreviewFlag(groupId, previewFlag, false)
+    end
+    for groupId in pairs(activeButtonPreviewFlags) do
+        ClearActiveButtonPreviewFlagForGroup(groupId, previewFlag)
+    end
+end
+
+local function IsActivePreviewFlagStored(groupId, buttonIndex, previewFlag)
+    if not (groupId and previewFlag) then
+        return false
+    end
+    local groupFlags = activeGroupPreviewFlags[groupId]
+    if groupFlags and groupFlags[previewFlag] then
+        return true
+    end
+    local groupButtons = activeButtonPreviewFlags[groupId]
+    if not groupButtons then
+        return false
+    end
+    if buttonIndex then
+        local buttonFlags = groupButtons[buttonIndex]
+        return buttonFlags and buttonFlags[previewFlag] == true or false
+    end
+    for _, buttonFlags in pairs(groupButtons) do
+        if buttonFlags[previewFlag] then
+            return true
+        end
+    end
+    return false
+end
+
 -- Set preview on a single button.
 -- cacheValue: false forces cache miss on next tick; nil forces re-evaluate.
 local function SetButtonPreview(self, groupId, buttonIndex, show, previewFlag, cacheFlag, cacheValue, buttonTokenStore, onToggle, updateCooldown)
     if buttonTokenStore and not show then
         BumpButtonPreviewToken(buttonTokenStore, groupId, buttonIndex)
     end
+    SetActiveButtonPreviewFlag(groupId, buttonIndex, previewFlag, show)
     local frame = self.groupFrames[groupId]
     if not frame then return end
     for _, button in ipairs(frame.buttons) do
@@ -72,6 +178,8 @@ end
 -- Set preview on all buttons in a group.
 local function SetGroupPreview(self, groupId, show, previewFlag, cacheFlag, cacheValue, groupTokenStore, buttonTokenStore, onToggle, updateCooldown)
     if buttonTokenStore then buttonTokenStore[groupId] = nil end
+    SetActiveGroupPreviewFlag(groupId, previewFlag, show)
+    ClearActiveButtonPreviewFlagForGroup(groupId, previewFlag)
     if not show then
         groupTokenStore[groupId] = (groupTokenStore[groupId] or 0) + 1
     end
@@ -122,6 +230,7 @@ end
 local function ClearAllPreviews(self, previewFlag, cacheFlag, cacheValue, groupTokenStore, buttonTokenStore, onClear, updateCooldown)
     wipe(groupTokenStore)
     if buttonTokenStore then wipe(buttonTokenStore) end
+    ClearActivePreviewFlag(previewFlag)
     for _, frame in pairs(self.groupFrames) do
         for _, button in ipairs(frame.buttons) do
             button[previewFlag] = nil
@@ -280,12 +389,31 @@ function CooldownCompanion:IsPreviewFlagActive(groupId, buttonIndex, previewFlag
     if not previewFlag then
         return false
     end
+    if IsActivePreviewFlagStored(groupId, buttonIndex, previewFlag) then
+        return true
+    end
     return IsGroupButtonPreviewActive(self, groupId, buttonIndex, function(button)
         return button[previewFlag] == true
     end)
 end
 
 function CooldownCompanion:IsConditionalVisualPreviewActive(groupId, buttonIndex, previewKind)
+    local groupState = activeConditionalGroupPreviews[groupId]
+    if groupState and groupState.kind == previewKind then
+        return true
+    end
+    local groupButtons = activeConditionalButtonPreviews[groupId]
+    if groupButtons then
+        if buttonIndex then
+            local buttonState = groupButtons[buttonIndex]
+            return buttonState and buttonState.kind == previewKind or false
+        end
+        for _, buttonState in pairs(groupButtons) do
+            if buttonState and buttonState.kind == previewKind then
+                return true
+            end
+        end
+    end
     return IsGroupButtonPreviewActive(self, groupId, buttonIndex, function(button)
         local state = GetConditionalVisualPreview(button)
         return state and state.kind == previewKind
@@ -300,11 +428,25 @@ function CooldownCompanion:SetConditionalVisualPreviewActive(groupId, buttonInde
     local state = show and BuildConditionalVisualPreviewState(previewKind, sampleState) or nil
     if buttonIndex then
         BumpButtonPreviewToken(conditionalVisualButtonTokens, groupId, buttonIndex)
+        activeConditionalGroupPreviews[groupId] = nil
+        if state then
+            if not activeConditionalButtonPreviews[groupId] then
+                activeConditionalButtonPreviews[groupId] = {}
+            end
+            activeConditionalButtonPreviews[groupId][buttonIndex] = CopyPreviewState(state)
+        elseif activeConditionalButtonPreviews[groupId] then
+            activeConditionalButtonPreviews[groupId][buttonIndex] = nil
+            if not next(activeConditionalButtonPreviews[groupId]) then
+                activeConditionalButtonPreviews[groupId] = nil
+            end
+        end
         SetConditionalVisualPreview(self, groupId, buttonIndex, state)
         return
     end
 
     conditionalVisualButtonTokens[groupId] = nil
+    activeConditionalButtonPreviews[groupId] = nil
+    activeConditionalGroupPreviews[groupId] = CopyPreviewState(state)
     conditionalVisualGroupTokens[groupId] = (conditionalVisualGroupTokens[groupId] or 0) + 1
     SetGroupConditionalVisualPreview(self, groupId, state)
 end
@@ -340,6 +482,8 @@ end
 function CooldownCompanion:ClearAllConditionalVisualPreviews()
     wipe(conditionalVisualGroupTokens)
     wipe(conditionalVisualButtonTokens)
+    wipe(activeConditionalGroupPreviews)
+    wipe(activeConditionalButtonPreviews)
     if not self.groupFrames then return end
     for _, frame in pairs(self.groupFrames) do
         for _, button in ipairs(frame.buttons) do
@@ -488,9 +632,12 @@ function CooldownCompanion:SetBarAuraActivePreview(groupId, buttonIndex, show)
     if not groupId then return end
     if buttonIndex then
         BumpButtonPreviewToken(barAuraActiveButtonTokens, groupId, buttonIndex)
+        SetActiveButtonPreviewFlag(groupId, buttonIndex, "_barAuraActivePreview", show)
     else
         barAuraActiveButtonTokens[groupId] = nil
         barAuraActiveGroupTokens[groupId] = (barAuraActiveGroupTokens[groupId] or 0) + 1
+        SetActiveGroupPreviewFlag(groupId, "_barAuraActivePreview", show)
+        ClearActiveButtonPreviewFlagForGroup(groupId, "_barAuraActivePreview")
     end
 
     local frame = self.groupFrames[groupId]
@@ -550,6 +697,7 @@ end
 function CooldownCompanion:ClearAllBarAuraActivePreviews()
     wipe(barAuraActiveGroupTokens)
     wipe(barAuraActiveButtonTokens)
+    ClearActivePreviewFlag("_barAuraActivePreview")
     for _, frame in pairs(self.groupFrames) do
         for _, button in ipairs(frame.buttons) do
             if button._barAuraActivePreview then
@@ -710,7 +858,11 @@ function CooldownCompanion:ClearAllTextureIndicatorPreviews()
 end
 
 function CooldownCompanion:SetTriggerPanelEffectsPreview(groupId, show)
+    if not groupId then
+        return
+    end
     local frame = self.groupFrames[groupId]
+    activeTriggerPanelEffectPreviews[groupId] = show or nil
     if not frame then
         return
     end
@@ -730,6 +882,9 @@ function CooldownCompanion:SetTriggerPanelEffectsPreview(groupId, show)
 end
 
 function CooldownCompanion:IsTriggerPanelEffectsPreviewActive(groupId)
+    if activeTriggerPanelEffectPreviews[groupId] then
+        return true
+    end
     return self:IsPreviewFlagActive(groupId, nil, "_triggerEffectsPreview")
 end
 
@@ -739,6 +894,7 @@ end
 
 function CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
     wipe(triggerEffectPreviewTokens)
+    wipe(activeTriggerPanelEffectPreviews)
     for _, frame in pairs(self.groupFrames) do
         for _, button in ipairs(frame.buttons) do
             button._triggerEffectsPreview = nil
@@ -801,6 +957,82 @@ function CooldownCompanion:ClearAllAuraTexturePickerPreviews()
                 button:UpdateCooldown()
             else
                 self:UpdateAuraTextureVisual(button)
+            end
+        end
+    end
+end
+
+local function ApplyPreviewFlagToButton(button, previewFlag)
+    button[previewFlag] = true
+    if previewFlag == "_procGlowPreview" then
+        button._procGlowActive = false
+    elseif previewFlag == "_auraGlowPreview" or previewFlag == "_pandemicPreview" then
+        button._auraGlowActive = false
+        if previewFlag == "_pandemicPreview" then
+            pandemicOnToggle(button, true)
+        end
+    elseif previewFlag == "_readyGlowPreview" then
+        button._readyGlowActive = false
+    elseif previewFlag == "_keyPressHighlightPreview" then
+        button._keyPressHighlightActive = nil
+    elseif previewFlag == "_textureProcPreview"
+        or previewFlag == "_textureAuraPreview"
+        or previewFlag == "_texturePandemicPreview"
+        or previewFlag == "_textureReadyPreview"
+        or previewFlag == "_textureUnusablePreview" then
+        button._textureIndicatorPreviewDirty = false
+    end
+end
+
+function CooldownCompanion:ApplyConfigPreviewsToGroup(groupId)
+    if not (self.groupFrames and groupId) then
+        return
+    end
+    local frame = self.groupFrames[groupId]
+    if not frame then
+        return
+    end
+
+    local groupFlags = activeGroupPreviewFlags[groupId]
+    if groupFlags then
+        for _, button in ipairs(frame.buttons) do
+            for previewFlag in pairs(groupFlags) do
+                ApplyPreviewFlagToButton(button, previewFlag)
+            end
+        end
+    end
+
+    local buttonFlagsByIndex = activeButtonPreviewFlags[groupId]
+    if buttonFlagsByIndex then
+        for _, button in ipairs(frame.buttons) do
+            local buttonFlags = buttonFlagsByIndex[button.index]
+            if buttonFlags then
+                for previewFlag in pairs(buttonFlags) do
+                    ApplyPreviewFlagToButton(button, previewFlag)
+                end
+            end
+        end
+    end
+
+    if activeTriggerPanelEffectPreviews[groupId] then
+        for _, button in ipairs(frame.buttons) do
+            button._triggerEffectsPreview = true
+        end
+    end
+
+    local groupConditionalPreview = activeConditionalGroupPreviews[groupId]
+    if groupConditionalPreview then
+        for _, button in ipairs(frame.buttons) do
+            SetConditionalVisualPreviewOnButton(self, button, CopyPreviewState(groupConditionalPreview))
+        end
+    end
+
+    local conditionalButtons = activeConditionalButtonPreviews[groupId]
+    if conditionalButtons then
+        for _, button in ipairs(frame.buttons) do
+            local preview = conditionalButtons[button.index]
+            if preview then
+                SetConditionalVisualPreviewOnButton(self, button, CopyPreviewState(preview))
             end
         end
     end

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -837,6 +837,7 @@ end
 
 function CooldownCompanion:ClearAllTextureIndicatorPreviews()
     for indicatorKey in pairs(TEXTURE_INDICATOR_PREVIEW_FLAGS) do
+        ClearActivePreviewFlag(TEXTURE_INDICATOR_PREVIEW_FLAGS[indicatorKey])
         wipe(GetTextureIndicatorTokenStore(indicatorKey))
     end
 

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -135,9 +135,9 @@ local function ClearAllPreviews(self, previewFlag, cacheFlag, cacheValue, groupT
 end
 
 local CONDITIONAL_VISUAL_PREVIEW_DEFAULTS = {
-    cooldown = { kind = "cooldown", duration = 12, remaining = 8 },
+    cooldown = { kind = "cooldown", duration = 12, remaining = 8, loop = true },
     aura = { kind = "aura", duration = 12, remaining = 8, stackText = "3" },
-    aura_duration_text = { kind = "aura_duration_text", duration = 12, remaining = 8 },
+    aura_duration_text = { kind = "aura_duration_text", duration = 12, remaining = 8, loop = true },
     aura_stack_text = { kind = "aura_stack_text", stackText = "3" },
     pandemic = { kind = "pandemic", duration = 12, remaining = 3, stackText = "3" },
     charge_full = { kind = "charge_full" },
@@ -161,13 +161,18 @@ local function BuildConditionalVisualPreviewState(previewKind, sampleState)
 
     local duration = tonumber(state.duration)
     local remaining = tonumber(state.remaining)
+    local now = GetTime()
     if duration and duration > 0 then
         if not remaining or remaining <= 0 or remaining > duration then
             remaining = duration
         end
         state.duration = duration
         state.remaining = remaining
-        state.startTime = GetTime() - (duration - remaining)
+        state.startTime = now - (duration - remaining)
+        if state.loop == true then
+            state.loopDuration = remaining
+            state.loopStartTime = now
+        end
     end
     return state
 end
@@ -192,6 +197,9 @@ local function ClearConditionalVisualPreviewDerivedFields(button)
     button._conditionalPreviewStartTime = nil
     button._conditionalPreviewDuration = nil
     button._conditionalPreviewRemaining = nil
+    button._conditionalPreviewLoop = nil
+    button._conditionalPreviewLoopStartTime = nil
+    button._conditionalPreviewLoopDuration = nil
     button._conditionalPreviewDomain = nil
     button._conditionalAuraPreview = nil
     button._conditionalAuraDurationTextPreview = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -346,7 +346,9 @@ local function SubstituteTokens(button, segments, style, effectState)
     -- Determine which domain owns it this tick.
     local durationRemaining = nil
     local durationIsSecret = false
-    if button._durationObj then
+    if button._conditionalPreviewRemaining and button._conditionalPreviewRemaining > 0 then
+        durationRemaining = button._conditionalPreviewRemaining
+    elseif button._durationObj then
         local rem = button._durationObj:GetRemainingDuration()
         if button._durationObj:HasSecretValues() then
             durationIsSecret = true

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -340,8 +340,9 @@ local function SubstituteTokens(button, segments, style, effectState)
     local currentCharges = button._currentReadableCharges
     local maxCharges = button.buttonData.maxCharges
     local stackDisplayText, stackDisplayKind = ResolveTextModeStackDisplay(button)
-    local auraActive = button._auraActive
-    local auraHasTimer = button._auraHasTimer == true
+    local auraDurationTextPreview = button._conditionalAuraDurationTextPreview == true
+    local auraActive = button._auraActive or auraDurationTextPreview
+    local auraHasTimer = button._auraHasTimer == true or auraDurationTextPreview
     -- _durationObj holds either cooldown remaining or aura remaining (when aura override is active).
     -- Determine which domain owns it this tick.
     local durationRemaining = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -237,6 +237,13 @@ local function WrapColor(text, color)
 end
 
 local function ResolveTextModeStackDisplay(button)
+    if button._conditionalAuraStackTextPreview then
+        local previewStackText = button._auraStackText
+        if previewStackText and (issecretvalue(previewStackText) or previewStackText ~= "") then
+            return previewStackText, "aura"
+        end
+    end
+
     local auraUnit = button._auraUnit
     local auraInstanceID = button._auraInstanceID
     if auraUnit and auraInstanceID then

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -178,7 +178,10 @@ local function UpdateIconTint(button, buttonData, style)
     local r, g, b, a = 1, 1, 1, bc and bc[4] or 1
     local stateOverride = false
     if style.showOutOfRange then
-        if buttonData.type == "spell" then
+        if button._conditionalOutOfRangePreview then
+            r, g, b = 1, 0.2, 0.2
+            stateOverride = true
+        elseif buttonData.type == "spell" then
             if button._spellOutOfRange then
                 r, g, b = 1, 0.2, 0.2
                 stateOverride = true
@@ -198,7 +201,12 @@ local function UpdateIconTint(button, buttonData, style)
     end
     if not stateOverride and style.showUnusable then
         local uc = style.iconUnusableTintColor
-        if buttonData.type == "spell" then
+        if button._conditionalUnusablePreview then
+            r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
+            a = uc and uc[4] or a
+            stateOverride = true
+            button._unusableTintActive = true
+        elseif buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
             local isUsable = C_Spell.IsSpellUsable(spellID)
             if not isUsable then

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -40,6 +40,7 @@ local GenerateGroupName
 -- Clear all selection state (container, panel, button, multi-select)
 ------------------------------------------------------------------------
 local function ClearSelection()
+    CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedContainer = nil
     CS.selectedGroup = nil
     CS.selectedButton = nil
@@ -208,6 +209,7 @@ local function RenderBrowseMode()
             -- Left-click: select for preview; Right-click: copy context menu
             entry.frame:SetScript("OnMouseUp", function(self, button)
                 if button == "LeftButton" then
+                    CooldownCompanion:ClearAllConfigPreviews()
                     if CS.browseContainerId == containerId then
                         CS.browseContainerId = nil
                         CS.selectedContainer = nil
@@ -235,6 +237,7 @@ local function RenderBrowseMode()
                             if not db.groupContainers[containerId] then return end
                             local newId = CooldownCompanion:CopyContainerFromBrowse(containerId)
                             if newId then
+                                CooldownCompanion:ClearAllConfigPreviews()
                                 CS.browseMode = false
                                 CS.browseCharKey = nil
                                 CS.browseContainerId = nil
@@ -394,6 +397,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                 CloseDropDownMenus()
                 local newContainerId = CooldownCompanion:DuplicateGroup(containerId)
                 if newContainerId then
+                    CooldownCompanion:ClearAllConfigPreviews()
                     CS.selectedContainer = newContainerId
                     CS.selectedGroup = nil
                     CooldownCompanion:RefreshConfigPanel()
@@ -543,6 +547,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                     CloseDropDownMenus()
                     local newPanelId = CooldownCompanion:CreatePanel(containerId, targetMode)
                     if newPanelId then
+                        CooldownCompanion:ClearAllConfigPreviews()
                         CS.selectedContainer = containerId
                         CS.selectedGroup = newPanelId
                         CS.addingToPanelId = newPanelId
@@ -581,6 +586,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
             CloseDropDownMenus()
             local containerId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
             CooldownCompanion:MoveGroupToFolder(containerId, folderId)
+            CooldownCompanion:ClearAllConfigPreviews()
             CS.selectedContainer = containerId
             CS.selectedGroup = nil
             CS.selectedButton = nil
@@ -745,6 +751,7 @@ local function PopulateColumn1ButtonBar()
     newGroupBtn:SetText("New Group")
     newGroupBtn:SetCallback("OnClick", function()
         local containerId, groupId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
+        CooldownCompanion:ClearAllConfigPreviews()
         CS.selectedContainer = containerId
         CS.selectedGroup = nil
         CS.selectedButton = nil
@@ -1210,6 +1217,7 @@ local function RefreshColumn1(preserveDrag)
                     return
                 end
                 -- Normal click: toggle-through selection, clear multi-select
+                CooldownCompanion:ClearAllConfigPreviews()
                 wipe(CS.selectedGroups)
                 if CS.selectedContainer == containerId then
                     if CS.selectedGroup then

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -198,6 +198,7 @@ local function FinalizeCreatedPanel(newPanelId, displayMode, opts)
         CooldownCompanion:RefreshGroupFrame(newPanelId)
     end
 
+    CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedGroup = newPanelId
     if opts and opts.clearSelection then
         CS.selectedButton = nil
@@ -731,6 +732,7 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     table.remove(db.groups[sourceGroupId].buttons, sourceIndex)
     CooldownCompanion:RefreshGroupFrame(targetGroupId)
     CooldownCompanion:RefreshGroupFrame(sourceGroupId)
+    CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedButton = nil
     wipe(CS.selectedButtons)
     CooldownCompanion:RefreshConfigPanel()
@@ -2016,6 +2018,7 @@ local function RefreshColumn2()
                                 CloseDropDownMenus()
                                 local newPanelId = CooldownCompanion:DuplicatePanel(ctxContainerId, ctxPanelId)
                                 if newPanelId then
+                                    CooldownCompanion:ClearAllConfigPreviews()
                                     CS.selectedGroup = newPanelId
                                     CooldownCompanion:RefreshConfigPanel()
                                 end
@@ -2108,6 +2111,7 @@ local function RefreshColumn2()
                                     info.func = function()
                                         CloseDropDownMenus()
                                         local _, sourceDeleted = CooldownCompanion:MovePanel(ctxPanelId, c.id)
+                                        CooldownCompanion:ClearAllConfigPreviews()
                                         if sourceDeleted then
                                             CS.selectedContainer = c.id
                                         end
@@ -2135,6 +2139,7 @@ local function RefreshColumn2()
                                     info.func = function()
                                         CloseDropDownMenus()
                                         local _, sourceDeleted = CooldownCompanion:MovePanel(ctxPanelId, c.id)
+                                        CooldownCompanion:ClearAllConfigPreviews()
                                         if sourceDeleted then
                                             CS.selectedContainer = c.id
                                         end
@@ -2178,6 +2183,7 @@ local function RefreshColumn2()
                         CS.addingToPanelId = nil
                     else
                         CS.addingToPanelId = addBtnPanelId
+                        CooldownCompanion:ClearAllConfigPreviews()
                         CS.selectedGroup = addBtnPanelId
                         CS.selectedButton = nil
                         wipe(CS.selectedButtons)
@@ -2486,6 +2492,7 @@ local function RefreshColumn2()
                             ToggleDropDownMenu(1, nil, CS.buttonContextMenu, "cursor", 0, 0)
                         elseif mouseButton == "MiddleButton" then
                             if CS.selectedGroup ~= btnPanelId then
+                                CooldownCompanion:ClearAllConfigPreviews()
                                 CS.selectedGroup = btnPanelId
                                 CS.selectedButton = nil
                                 wipe(CS.selectedButtons)

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -1200,7 +1200,7 @@ local function RefreshColumn2()
             end
             header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
             header:SetCallback("OnClick", function()
-                CooldownCompanion:ClearAllConditionalVisualPreviews()
+                CooldownCompanion:ClearAllConfigPreviews()
                 CS.selectedContainer = CS.browseContainerId
                 CS.selectedGroup = panelGroupId
                 CS.selectedButton = nil
@@ -1238,7 +1238,7 @@ local function RefreshColumn2()
                     end
                     local capturedIndex = buttonIndex
                     entry:SetCallback("OnClick", function()
-                        CooldownCompanion:ClearAllConditionalVisualPreviews()
+                        CooldownCompanion:ClearAllConfigPreviews()
                         CS.selectedContainer = CS.browseContainerId
                         CS.selectedGroup = panelGroupId
                         CS.selectedButton = capturedIndex
@@ -2380,7 +2380,7 @@ local function RefreshColumn2()
                                     CS.selectedButton = btnIndex
                                 end
                             end
-                            CooldownCompanion:ClearAllConditionalVisualPreviews()
+                            CooldownCompanion:ClearAllConfigPreviews()
                             CooldownCompanion:RefreshConfigPanel()
                         elseif mouseButton == "RightButton" then
                             -- Auto-select panel on right-click too

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -1200,6 +1200,7 @@ local function RefreshColumn2()
             end
             header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
             header:SetCallback("OnClick", function()
+                CooldownCompanion:ClearAllConditionalVisualPreviews()
                 CS.selectedContainer = CS.browseContainerId
                 CS.selectedGroup = panelGroupId
                 CS.selectedButton = nil
@@ -1237,6 +1238,7 @@ local function RefreshColumn2()
                     end
                     local capturedIndex = buttonIndex
                     entry:SetCallback("OnClick", function()
+                        CooldownCompanion:ClearAllConditionalVisualPreviews()
                         CS.selectedContainer = CS.browseContainerId
                         CS.selectedGroup = panelGroupId
                         CS.selectedButton = capturedIndex
@@ -2378,6 +2380,7 @@ local function RefreshColumn2()
                                     CS.selectedButton = btnIndex
                                 end
                             end
+                            CooldownCompanion:ClearAllConditionalVisualPreviews()
                             CooldownCompanion:RefreshConfigPanel()
                         elseif mouseButton == "RightButton" then
                             -- Auto-select panel on right-click too

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -1892,6 +1892,7 @@ local function RefreshColumn2()
                         end
 
                         if IsControlKeyDown() then
+                            CooldownCompanion:ClearAllConfigPreviews()
                             if CS.selectedPanels[panelId] then
                                 CS.selectedPanels[panelId] = nil
                             else
@@ -1909,6 +1910,7 @@ local function RefreshColumn2()
                         end
 
                         wipe(CS.selectedPanels)
+                        CooldownCompanion:ClearAllConfigPreviews()
                         if CS.selectedGroup == panelId and not CS.selectedButton then
                             CS.selectedGroup = nil
                         else
@@ -2385,6 +2387,7 @@ local function RefreshColumn2()
                         elseif mouseButton == "RightButton" then
                             -- Auto-select panel on right-click too
                             if CS.selectedGroup ~= btnPanelId then
+                                CooldownCompanion:ClearAllConfigPreviews()
                                 CS.selectedGroup = btnPanelId
                                 CS.selectedButton = nil
                                 wipe(CS.selectedButtons)

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -181,8 +181,11 @@ local function RefreshColumn4(container)
         tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
             CS.selectedTab = tab
             CS.panelSettingsTab = tab
-            CooldownCompanion:ClearAllConditionalVisualPreviews()
-            if tab ~= "effects" then
+            local preservePreviews = CS.previewToggleRefreshActive == true
+            if not preservePreviews then
+                CooldownCompanion:ClearAllConditionalVisualPreviews()
+            end
+            if tab ~= "effects" and not preservePreviews then
                 CooldownCompanion:ClearAllTextureIndicatorPreviews()
                 if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
                     CooldownCompanion:ClearAllTriggerPanelEffectPreviews()

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -183,13 +183,7 @@ local function RefreshColumn4(container)
             CS.panelSettingsTab = tab
             local preservePreviews = CS.previewToggleRefreshActive == true
             if not preservePreviews then
-                CooldownCompanion:ClearAllConditionalVisualPreviews()
-            end
-            if tab ~= "effects" and not preservePreviews then
-                CooldownCompanion:ClearAllTextureIndicatorPreviews()
-                if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
-                    CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
-                end
+                CooldownCompanion:ClearAllConfigPreviews()
             end
             -- Clean up raw (?) info buttons BEFORE releasing children, so they
             -- don't leak onto recycled AceGUI frames when switching tabs

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -302,6 +302,7 @@ local function RefreshProfileBar(bar)
     profileDrop:SetValue(currentProfile)
     profileDrop:SetWidth(150)
     profileDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        CooldownCompanion:ClearAllConfigPreviews()
         db:SetProfile(val)
         CS.selectedContainer = nil
         CS.selectedGroup = nil

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -181,6 +181,7 @@ local function RefreshColumn4(container)
         tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
             CS.selectedTab = tab
             CS.panelSettingsTab = tab
+            CooldownCompanion:ClearAllConditionalVisualPreviews()
             if tab ~= "effects" then
                 CooldownCompanion:ClearAllTextureIndicatorPreviews()
                 if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -179,10 +179,13 @@ local function RefreshColumn4(container)
         tabGroup:SetLayout("Fill")
 
         tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
+            local previousTab = container._activePanelSettingsTab
+            local tabChanged = previousTab ~= nil and previousTab ~= tab
+            container._activePanelSettingsTab = tab
             CS.selectedTab = tab
             CS.panelSettingsTab = tab
             local preservePreviews = CS.previewToggleRefreshActive == true
-            if not preservePreviews then
+            if tabChanged and not preservePreviews then
                 CooldownCompanion:ClearAllConfigPreviews()
             end
             -- Clean up raw (?) info buttons BEFORE releasing children, so they

--- a/Config/DragReorder.lua
+++ b/Config/DragReorder.lua
@@ -3777,6 +3777,7 @@ local function FinishPanelDrag(state)
     local dropTarget = state.dropTarget
     local changed = dropTarget and not IsPanelReorderNoOp(state.sourcePanelId, dropTarget.targetIndex, state.panelDropTargets)
     if changed then
+        CooldownCompanion:ClearAllConfigPreviews()
         wipe(CS.selectedPanels)
         CS.selectedGroup = state.sourcePanelId
         CS.selectedButton = nil
@@ -3820,6 +3821,7 @@ local function FinishButtonDrag(state)
         PerformButtonReorder(state.groupId, state.sourceIndex, state.dropIndex or state.sourceIndex)
         CooldownCompanion:RefreshGroupFrame(state.groupId)
     end
+    CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedButton = nil
     wipe(CS.selectedButtons)
     CooldownCompanion:RefreshConfigPanel()

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1456,6 +1456,9 @@ local function CreateConfigPanel()
     bsTabGroup:SetLayout("Fill")
 
     bsTabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
+        local previousTab = col3._activeButtonSettingsTab
+        local tabChanged = previousTab ~= nil and previousTab ~= tab
+        col3._activeButtonSettingsTab = tab
         CS.buttonSettingsTab = tab
         -- Clean up info/collapse buttons before releasing
         for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
@@ -1465,7 +1468,7 @@ local function CreateConfigPanel()
         end
         wipe(CS.buttonSettingsInfoButtons)
 
-        if not CS.previewToggleRefreshActive then
+        if tabChanged and not CS.previewToggleRefreshActive then
             CooldownCompanion:ClearAllConfigPreviews()
         end
         widget:ReleaseChildren()

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -828,6 +828,7 @@ local function CreateConfigPanel()
         if CS.resourceBarPanelActive then
             SetPrimaryMode("buttons", { skipRefresh = true })
         end
+        CooldownCompanion:ClearAllConfigPreviews()
         CS.browseMode = true
         CS.browseCharKey = nil
         CS.browseContainerId = nil

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -422,6 +422,7 @@ local function ResetConfigForProfileChange()
     end
     CooldownCompanion:StopCastBarPreview()
     CooldownCompanion:StopResourceBarPreview()
+    CooldownCompanion:ClearAllConditionalVisualPreviews()
 end
 
 local function MaybeAutoOpenChangelog()
@@ -540,6 +541,7 @@ local function CreateConfigPanel()
         CooldownCompanion:ClearAllReadyGlowPreviews()
         CooldownCompanion:ClearAllKeyPressHighlightPreviews()
         CooldownCompanion:ClearAllBarAuraActivePreviews()
+        CooldownCompanion:ClearAllConditionalVisualPreviews()
         CooldownCompanion:ClearAllTextureIndicatorPreviews()
         if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
             CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
@@ -1482,6 +1484,7 @@ local function CreateConfigPanel()
         CooldownCompanion:ClearAllReadyGlowPreviews()
         CooldownCompanion:ClearAllKeyPressHighlightPreviews()
         CooldownCompanion:ClearAllBarAuraActivePreviews()
+        CooldownCompanion:ClearAllConditionalVisualPreviews()
         widget:ReleaseChildren()
 
         local scroll = AceGUI:Create("ScrollFrame")

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1483,13 +1483,15 @@ local function CreateConfigPanel()
         end
         wipe(CS.buttonSettingsInfoButtons)
 
-        CooldownCompanion:ClearAllProcGlowPreviews()
-        CooldownCompanion:ClearAllAuraGlowPreviews()
-        CooldownCompanion:ClearAllPandemicPreviews()
-        CooldownCompanion:ClearAllReadyGlowPreviews()
-        CooldownCompanion:ClearAllKeyPressHighlightPreviews()
-        CooldownCompanion:ClearAllBarAuraActivePreviews()
-        CooldownCompanion:ClearAllConditionalVisualPreviews()
+        if not CS.previewToggleRefreshActive then
+            CooldownCompanion:ClearAllProcGlowPreviews()
+            CooldownCompanion:ClearAllAuraGlowPreviews()
+            CooldownCompanion:ClearAllPandemicPreviews()
+            CooldownCompanion:ClearAllReadyGlowPreviews()
+            CooldownCompanion:ClearAllKeyPressHighlightPreviews()
+            CooldownCompanion:ClearAllBarAuraActivePreviews()
+            CooldownCompanion:ClearAllConditionalVisualPreviews()
+        end
         widget:ReleaseChildren()
 
         local scroll = AceGUI:Create("ScrollFrame")

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -535,16 +535,21 @@ local function CreateConfigPanel()
         if CS.CancelPickAuraTexture then
             CS.CancelPickAuraTexture()
         end
-        CooldownCompanion:ClearAllProcGlowPreviews()
-        CooldownCompanion:ClearAllAuraGlowPreviews()
-        CooldownCompanion:ClearAllPandemicPreviews()
-        CooldownCompanion:ClearAllReadyGlowPreviews()
-        CooldownCompanion:ClearAllKeyPressHighlightPreviews()
-        CooldownCompanion:ClearAllBarAuraActivePreviews()
-        CooldownCompanion:ClearAllConditionalVisualPreviews()
+        if not CS.previewToggleRefreshActive then
+            CooldownCompanion:ClearAllProcGlowPreviews()
+            CooldownCompanion:ClearAllAuraGlowPreviews()
+            CooldownCompanion:ClearAllPandemicPreviews()
+            CooldownCompanion:ClearAllReadyGlowPreviews()
+            CooldownCompanion:ClearAllKeyPressHighlightPreviews()
+            CooldownCompanion:ClearAllBarAuraActivePreviews()
+            CooldownCompanion:ClearAllConditionalVisualPreviews()
+        end
         CooldownCompanion:ClearAllTextureIndicatorPreviews()
         if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
             CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
+        end
+        if CooldownCompanion.ClearAllCustomAuraBarPreviews then
+            CooldownCompanion:ClearAllCustomAuraBarPreviews()
         end
         CooldownCompanion:ClearAllAuraTexturePickerPreviews()
         CooldownCompanion:StopCastBarPreview()

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -420,9 +420,6 @@ local function ResetConfigForProfileChange()
     if ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
     end
-    CooldownCompanion:StopCastBarPreview()
-    CooldownCompanion:StopResourceBarPreview()
-    CooldownCompanion:ClearAllConditionalVisualPreviews()
 end
 
 local function MaybeAutoOpenChangelog()
@@ -536,23 +533,8 @@ local function CreateConfigPanel()
             CS.CancelPickAuraTexture()
         end
         if not CS.previewToggleRefreshActive then
-            CooldownCompanion:ClearAllProcGlowPreviews()
-            CooldownCompanion:ClearAllAuraGlowPreviews()
-            CooldownCompanion:ClearAllPandemicPreviews()
-            CooldownCompanion:ClearAllReadyGlowPreviews()
-            CooldownCompanion:ClearAllKeyPressHighlightPreviews()
-            CooldownCompanion:ClearAllBarAuraActivePreviews()
-            CooldownCompanion:ClearAllConditionalVisualPreviews()
+            CooldownCompanion:ClearAllConfigPreviews()
         end
-        CooldownCompanion:ClearAllTextureIndicatorPreviews()
-        if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
-            CooldownCompanion:ClearAllTriggerPanelEffectPreviews()
-        end
-        if CooldownCompanion.ClearAllCustomAuraBarPreviews then
-            CooldownCompanion:ClearAllCustomAuraBarPreviews()
-        end
-        CooldownCompanion:ClearAllAuraTexturePickerPreviews()
-        CooldownCompanion:StopCastBarPreview()
         if ClearConfigShiftTooltipHover then
             ClearConfigShiftTooltipHover()
         end
@@ -1484,13 +1466,7 @@ local function CreateConfigPanel()
         wipe(CS.buttonSettingsInfoButtons)
 
         if not CS.previewToggleRefreshActive then
-            CooldownCompanion:ClearAllProcGlowPreviews()
-            CooldownCompanion:ClearAllAuraGlowPreviews()
-            CooldownCompanion:ClearAllPandemicPreviews()
-            CooldownCompanion:ClearAllReadyGlowPreviews()
-            CooldownCompanion:ClearAllKeyPressHighlightPreviews()
-            CooldownCompanion:ClearAllBarAuraActivePreviews()
-            CooldownCompanion:ClearAllConditionalVisualPreviews()
+            CooldownCompanion:ClearAllConfigPreviews()
         end
         widget:ReleaseChildren()
 

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -68,6 +68,7 @@ StaticPopupDialogs["CDC_DELETE_GROUP"] = {
         if not data then return end
         local id = data.containerId or data.groupId
         if id then
+            CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:DeleteGroup(id)
             if data.containerId then
                 if CS.selectedContainer == id then
@@ -99,6 +100,7 @@ StaticPopupDialogs["CDC_DELETE_PANEL"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if not data then return end
+        CooldownCompanion:ClearAllConfigPreviews()
         CooldownCompanion:DeletePanel(data.containerId, data.panelId)
         if CS.selectedGroup == data.panelId then
             CS.selectedGroup = nil
@@ -206,6 +208,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_PANELS"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.panelIds and data.containerId then
+            CooldownCompanion:ClearAllConfigPreviews()
             for _, pid in ipairs(data.panelIds) do
                 CooldownCompanion:DeletePanel(data.containerId, pid)
             end
@@ -690,6 +693,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
             data.targetPanelId, data.targetIndex
         )
         if buttonData then
+            CooldownCompanion:ClearAllConfigPreviews()
             ST._StripButtonOverrides(buttonData)
             CooldownCompanion:RefreshGroupFrame(data.sourcePanelId)
             CooldownCompanion:RefreshGroupFrame(data.targetPanelId)
@@ -828,6 +832,7 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.folderId then
+            CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:DeleteFolder(data.folderId)
             if CS.selectedGroup then
                 local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -22,6 +22,8 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 -- Precondition: CS.selectedContainer is already set by the caller's
 -- panel/container selection flow.
 local function SelectNewButton(panelId, buttonIndex)
+    CooldownCompanion:ClearAllConfigPreviews()
+
     local group = panelId and CooldownCompanion.db
         and CooldownCompanion.db.profile
         and CooldownCompanion.db.profile.groups

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1605,7 +1605,7 @@ local function ResetConfigSelection(full)
     if full and ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
     end
-    CooldownCompanion:ClearAllConditionalVisualPreviews()
+    CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedButton = nil
     wipe(CS.selectedButtons)
     wipe(CS.selectedPanels)
@@ -1634,13 +1634,10 @@ local function SetConfigPrimaryMode(mode, opts)
     local wasBars = CS.resourceBarPanelActive == true
     if toBars and not wasBars then
         -- Preserve existing behavior when entering Bars & Frames mode.
-        CooldownCompanion:ClearAllConditionalVisualPreviews()
         ResetConfigSelection(true)
     elseif (not toBars) and wasBars then
         -- Stop preview loops when returning to button settings mode.
-        CooldownCompanion:StopCastBarPreview()
-        CooldownCompanion:StopResourceBarPreview()
-        CooldownCompanion:ClearAllConditionalVisualPreviews()
+        CooldownCompanion:ClearAllConfigPreviews()
     end
 
     CS.resourceBarPanelActive = toBars

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1605,6 +1605,7 @@ local function ResetConfigSelection(full)
     if full and ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
     end
+    CooldownCompanion:ClearAllConditionalVisualPreviews()
     CS.selectedButton = nil
     wipe(CS.selectedButtons)
     wipe(CS.selectedPanels)
@@ -1633,11 +1634,13 @@ local function SetConfigPrimaryMode(mode, opts)
     local wasBars = CS.resourceBarPanelActive == true
     if toBars and not wasBars then
         -- Preserve existing behavior when entering Bars & Frames mode.
+        CooldownCompanion:ClearAllConditionalVisualPreviews()
         ResetConfigSelection(true)
     elseif (not toBars) and wasBars then
         -- Stop preview loops when returning to button settings mode.
         CooldownCompanion:StopCastBarPreview()
         CooldownCompanion:StopResourceBarPreview()
+        CooldownCompanion:ClearAllConditionalVisualPreviews()
     end
 
     CS.resourceBarPanelActive = toBars

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -30,6 +30,7 @@ local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
 local BuildLossOfControlControls = ST._BuildLossOfControlControls
 local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildShowTooltipsControls = ST._BuildShowTooltipsControls
+local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -255,6 +256,9 @@ local function BuildBarAppearanceTab(container, group, style)
 
     local timeAdvExpanded, timeAdvBtn = AddAdvancedToggle(showTimeCbBasic, "barCooldownText", tabInfoButtons, style.showCooldownText)
     CreateCheckboxPromoteButton(showTimeCbBasic, timeAdvBtn, "cooldownText", group, style)
+    if style.showCooldownText and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Cooldown State (3s)", "cooldown")
+    end
 
     if timeAdvExpanded and style.showCooldownText then
         local flipTimeCheck = AceGUI:Create("CheckBox")
@@ -292,6 +296,10 @@ local function BuildBarAppearanceTab(container, group, style)
 
     local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false)
     CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
+    if style.showChargeText ~= false and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Missing Charges (3s)", "charge_missing")
+        AddConditionalPreviewButton(container, "Preview Zero Charges (3s)", "charge_zero")
+    end
 
     if chargeAdvExpanded and style.showChargeText ~= false then
         AddFontControls(container, style, "charge", {}, refreshStyle)
@@ -318,6 +326,9 @@ local function BuildBarAppearanceTab(container, group, style)
 
     local barAuraTextAdvExpanded, barAuraTextAdvBtn = AddAdvancedToggle(auraTextCb, "barAuraText", tabInfoButtons, style.showAuraText ~= false)
     CreateCheckboxPromoteButton(auraTextCb, barAuraTextAdvBtn, "auraText", group, style)
+    if style.showAuraText ~= false and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Aura State (3s)", "aura")
+    end
 
     if barAuraTextAdvExpanded and style.showAuraText ~= false then
         AddFontControls(container, style, "auraText", {sizeMin = 6, sizeMax = 24}, refreshStyle)
@@ -549,6 +560,9 @@ local function BuildBarEffectsTab(container, group, style)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
         CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
+        if style.showUnusable and AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Unusable State (3s)", "unusable")
+        end
 
         -- Show Tooltips
         local tooltipCb = BuildShowTooltipsControls(container, style, function()

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -30,6 +30,7 @@ local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
 local BuildLossOfControlControls = ST._BuildLossOfControlControls
 local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildShowTooltipsControls = ST._BuildShowTooltipsControls
+local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
 local tabInfoButtons = CS.tabInfoButtons
@@ -256,9 +257,6 @@ local function BuildBarAppearanceTab(container, group, style)
 
     local timeAdvExpanded, timeAdvBtn = AddAdvancedToggle(showTimeCbBasic, "barCooldownText", tabInfoButtons, style.showCooldownText)
     CreateCheckboxPromoteButton(showTimeCbBasic, timeAdvBtn, "cooldownText", group, style)
-    if style.showCooldownText and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Cooldown State (3s)", "cooldown")
-    end
 
     if timeAdvExpanded and style.showCooldownText then
         local flipTimeCheck = AceGUI:Create("CheckBox")
@@ -280,6 +278,10 @@ local function BuildBarAppearanceTab(container, group, style)
         AddFontControls(container, style, "cooldown", {sizeMin = 6, sizeMax = 24}, refreshStyle)
         AddColorPicker(container, style, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshStyle, refreshStyle)
         AddOffsetSliders(container, style, "barCdTextOffsetX", "barCdTextOffsetY", {range = 50}, refreshStyle)
+
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Cooldown Text", "cooldown")
+        end
     end
 
     -- Show Charge Text toggle
@@ -296,10 +298,6 @@ local function BuildBarAppearanceTab(container, group, style)
 
     local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false)
     CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
-    if style.showChargeText ~= false and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Missing Charges (3s)", "charge_missing")
-        AddConditionalPreviewButton(container, "Preview Zero Charges (3s)", "charge_zero")
-    end
 
     if chargeAdvExpanded and style.showChargeText ~= false then
         AddFontControls(container, style, "charge", {}, refreshStyle)
@@ -326,13 +324,14 @@ local function BuildBarAppearanceTab(container, group, style)
 
     local barAuraTextAdvExpanded, barAuraTextAdvBtn = AddAdvancedToggle(auraTextCb, "barAuraText", tabInfoButtons, style.showAuraText ~= false)
     CreateCheckboxPromoteButton(auraTextCb, barAuraTextAdvBtn, "auraText", group, style)
-    if style.showAuraText ~= false and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Aura State (3s)", "aura")
-    end
 
     if barAuraTextAdvExpanded and style.showAuraText ~= false then
         AddFontControls(container, style, "auraText", {sizeMin = 6, sizeMax = 24}, refreshStyle)
         AddColorPicker(container, style, "auraTextFontColor", "Font Color", {0, 0.925, 1, 1}, false, refreshStyle, refreshStyle)
+
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Aura Duration Text", "aura_duration_text")
+        end
     end -- barAuraTextAdvExpanded
 
     -- ================================================================
@@ -357,6 +356,10 @@ local function BuildBarAppearanceTab(container, group, style)
         AddColorPicker(container, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
         AddAnchorDropdown(container, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
         AddOffsetSliders(container, style, "auraStackXOffset", "auraStackYOffset", {x = 2, y = 2}, refreshStyle)
+
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
+        end
     end -- barAuraStackAdvExpanded
 
     -- Show Ready Text toggle
@@ -460,15 +463,17 @@ local function BuildBarEffectsTab(container, group, style)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
     end)
 
-    local auraActivePreviewBtn = AceGUI:Create("Button")
-    auraActivePreviewBtn:SetText("Preview Active Aura Effects (3s)")
-    auraActivePreviewBtn:SetFullWidth(true)
-    auraActivePreviewBtn:SetCallback("OnClick", function()
-        if CS.selectedGroup then
-            CooldownCompanion:PlayBarAuraActivePreview(CS.selectedGroup, nil, 3)
-        end
-    end)
-    container:AddChild(auraActivePreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Active Aura Effects", function()
+            return CS.selectedGroup and CooldownCompanion:IsBarAuraActivePreviewActive(CS.selectedGroup, nil)
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, show)
+            end
+        end)
+    end
+    elseif CS.selectedGroup then
+        CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, false)
     end -- barAuraAdvExpanded
 
     -- ================================================================
@@ -508,15 +513,17 @@ local function BuildBarEffectsTab(container, group, style)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
     end)
 
-    local pandemicPreviewBtn = AceGUI:Create("Button")
-    pandemicPreviewBtn:SetText("Preview Pandemic Effects (3s)")
-    pandemicPreviewBtn:SetFullWidth(true)
-    pandemicPreviewBtn:SetCallback("OnClick", function()
-        if CS.selectedGroup then
-            CooldownCompanion:PlayGroupPandemicPreview(CS.selectedGroup, 3)
-        end
-    end)
-    container:AddChild(pandemicPreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Pandemic Effects", function()
+            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
+            end
+        end)
+    end
+    elseif CS.selectedGroup then
+        CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, false)
     end -- barPandemicAdvExpanded
 
     -- ================================================================
@@ -558,10 +565,12 @@ local function BuildBarEffectsTab(container, group, style)
         -- ================================================================
         local unusableCb = BuildUnusableDimmingControls(container, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            CooldownCompanion:RefreshConfigPanel()
         end)
-        CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
-        if style.showUnusable and AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Unusable State (3s)", "unusable")
+        local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "barUnusableDimming", tabInfoButtons, style.showUnusable)
+        CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
+        if unusableAdvExpanded and style.showUnusable and AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
         end
 
         -- Show Tooltips

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -5,6 +5,7 @@ local CS = ST._configState
 
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
+local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateRevertButton = ST._CreateRevertButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
@@ -43,6 +44,7 @@ local BuildBarReadyTextControls = ST._BuildBarReadyTextControls
 local BuildTextFontControls = ST._BuildTextFontControls
 local BuildTextColorsControls = ST._BuildTextColorsControls
 local BuildTextBackgroundControls = ST._BuildTextBackgroundControls
+local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
 local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex)
@@ -73,6 +75,56 @@ local function PrimeSelectedReadyGlowNormalTransition(groupId, buttonIndex)
     button._readyGlowStartTime = GetTime()
 end
 
+local PREVIEWABLE_OVERRIDE_SECTIONS = {
+    cooldownText = true,
+    cooldownSwipe = true,
+    desaturation = true,
+    auraText = true,
+    auraStackText = true,
+    auraDurationSwipe = true,
+    showOutOfRange = true,
+    unusableDimming = true,
+    iconTint = true,
+    procGlow = true,
+    auraIndicator = true,
+    pandemicGlow = true,
+    barActiveAura = true,
+    pandemicBar = true,
+    readyGlow = true,
+}
+
+local function AddSelectedButtonPreviewToggle(container, label, previewFlag, setPreviewFn)
+    if not AddPreviewToggleButton then
+        return
+    end
+
+    AddPreviewToggleButton(container, label, function()
+        return CS.selectedGroup
+            and CS.selectedButton
+            and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, CS.selectedButton, previewFlag)
+    end, function(show)
+        if CS.selectedGroup and CS.selectedButton then
+            setPreviewFn(CooldownCompanion, CS.selectedGroup, CS.selectedButton, show)
+        end
+    end)
+end
+
+local function AddSelectedBarAuraActivePreviewToggle(container, label)
+    if not AddPreviewToggleButton then
+        return
+    end
+
+    AddPreviewToggleButton(container, label, function()
+        return CS.selectedGroup
+            and CS.selectedButton
+            and CooldownCompanion:IsBarAuraActivePreviewActive(CS.selectedGroup, CS.selectedButton)
+    end, function(show)
+        if CS.selectedGroup and CS.selectedButton then
+            CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, CS.selectedButton, show)
+        end
+    end)
+end
+
 local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
     local fmtHeading = AceGUI:Create("Heading")
     fmtHeading:SetText("Format Override")
@@ -80,7 +132,10 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
     fmtHeading:SetFullWidth(true)
     scroll:AddChild(fmtHeading)
 
-    local fmtInfo = CreateInfoButton(fmtHeading.frame, fmtHeading.label, "LEFT", "RIGHT", 4, 0, {
+    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons)
+    fmtPreviewAdvBtn:SetPoint("LEFT", fmtHeading.label, "RIGHT", 4, 0)
+
+    local fmtInfo = CreateInfoButton(fmtHeading.frame, fmtPreviewAdvBtn, "LEFT", "RIGHT", 4, 0, {
         {"Per-Button Format Override", 1, 0.82, 0, true},
         " ",
         {"Overrides the group format string for this button only.", 1, 1, 1},
@@ -154,15 +209,14 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
         scroll:AddChild(clearBtn)
     end
 
-    if AddConditionalPreviewButton then
+    if fmtPreviewAdvExpanded and AddConditionalPreviewButton then
         local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
-        AddConditionalPreviewButton(scroll, "Preview Cooldown State (3s)", "cooldown", target)
-        AddConditionalPreviewButton(scroll, "Preview Aura State (3s)", "aura", target)
-        AddConditionalPreviewButton(scroll, "Preview Pandemic State (3s)", "pandemic", target)
-        AddConditionalPreviewButton(scroll, "Preview Missing Charges (3s)", "charge_missing", target)
-        AddConditionalPreviewButton(scroll, "Preview Zero Charges (3s)", "charge_zero", target)
-        AddConditionalPreviewButton(scroll, "Preview Unusable State (3s)", "unusable", target)
-        AddConditionalPreviewButton(scroll, "Preview Out of Range State (3s)", "out_of_range", target)
+        AddConditionalPreviewButton(scroll, "Preview Cooldown State", "cooldown", target)
+        AddConditionalPreviewButton(scroll, "Preview Aura Duration Text", "aura_duration_text", target)
+        AddConditionalPreviewButton(scroll, "Preview Aura Stack Text", "aura_stack_text", target)
+        AddConditionalPreviewButton(scroll, "Preview Pandemic State", "pandemic", target)
+        AddConditionalPreviewButton(scroll, "Preview Unusable State", "unusable", target)
+        AddConditionalPreviewButton(scroll, "Preview Out of Range State", "out_of_range", target)
     end
 end
 
@@ -289,7 +343,19 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                     CooldownCompanion:RefreshConfigPanel()
                 end)
 
-                table.insert(infoButtons, CreateRevertButton(heading, buttonData, sectionId))
+                local revertBtn = CreateRevertButton(heading, buttonData, sectionId)
+                table.insert(infoButtons, revertBtn)
+
+                local previewAdvExpanded
+                if PREVIEWABLE_OVERRIDE_SECTIONS[sectionId] then
+                    local previewAdvBtn
+                    previewAdvExpanded, previewAdvBtn = AddAdvancedToggle(heading, "overridePreview_" .. sectionId, infoButtons)
+                    previewAdvBtn:SetPoint("LEFT", revertBtn, "RIGHT", 4, 0)
+                    heading.right:ClearAllPoints()
+                    heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)
+                    heading.right:SetPoint("LEFT", previewAdvBtn, "RIGHT", 4, 0)
+                end
+
                 if not overrideCollapsed then
                     local builder = sectionBuilders[sectionId]
                     if builder then
@@ -416,86 +482,37 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                             afterEnableCallback = afterEnableCallback,
                         })
 
-                        if sectionId == "procGlow" and overrides.procGlowStyle ~= "none" then
-                            local btn = AceGUI:Create("Button")
-                            btn:SetText("Preview Proc Glow (3s)")
-                            btn:SetFullWidth(true)
-                            btn:SetCallback("OnClick", function()
-                                if CS.selectedGroup and CS.selectedButton then
-                                    CooldownCompanion:PlayProcGlowPreview(CS.selectedGroup, CS.selectedButton, 3)
-                                end
-                            end)
-                            scroll:AddChild(btn)
-                        elseif sectionId == "auraIndicator" and overrides.auraGlowStyle ~= "none" then
-                            local btn = AceGUI:Create("Button")
-                            btn:SetText("Preview Aura Glow (3s)")
-                            btn:SetFullWidth(true)
-                            btn:SetCallback("OnClick", function()
-                                if CS.selectedGroup and CS.selectedButton then
-                                    CooldownCompanion:PlayAuraGlowPreview(CS.selectedGroup, CS.selectedButton, 3)
-                                end
-                            end)
-                            scroll:AddChild(btn)
-                        elseif sectionId == "pandemicGlow" and GetEffectiveOverrideValue("showPandemicGlow") ~= false then
-                            local btn = AceGUI:Create("Button")
-                            btn:SetText("Preview Pandemic Glow (3s)")
-                            btn:SetFullWidth(true)
-                            btn:SetCallback("OnClick", function()
-                                if CS.selectedGroup and CS.selectedButton then
-                                    CooldownCompanion:PlayPandemicPreview(CS.selectedGroup, CS.selectedButton, 3)
-                                end
-                            end)
-                            scroll:AddChild(btn)
-                        elseif sectionId == "barActiveAura" then
-                            local btn = AceGUI:Create("Button")
-                            btn:SetText("Preview Active Aura Effects (3s)")
-                            btn:SetFullWidth(true)
-                            btn:SetCallback("OnClick", function()
-                                if CS.selectedGroup and CS.selectedButton then
-                                    CooldownCompanion:PlayBarAuraActivePreview(CS.selectedGroup, CS.selectedButton, 3)
-                                end
-                            end)
-                            scroll:AddChild(btn)
-                        elseif sectionId == "pandemicBar" then
-                            local btn = AceGUI:Create("Button")
-                            btn:SetText("Preview Pandemic Effects (3s)")
-                            btn:SetFullWidth(true)
-                            btn:SetCallback("OnClick", function()
-                                if CS.selectedGroup and CS.selectedButton then
-                                    CooldownCompanion:PlayPandemicPreview(CS.selectedGroup, CS.selectedButton, 3)
-                                end
-                            end)
-                            scroll:AddChild(btn)
-                        elseif sectionId == "readyGlow" and overrides.readyGlowStyle and overrides.readyGlowStyle ~= "none" then
-                            local btn = AceGUI:Create("Button")
-                            btn:SetText("Preview Ready Glow Style (3s)")
-                            btn:SetFullWidth(true)
-                            btn:SetCallback("OnClick", function()
-                                if CS.selectedGroup and CS.selectedButton then
-                                    CooldownCompanion:PlayReadyGlowPreview(CS.selectedGroup, CS.selectedButton, 3)
-                                end
-                            end)
-                            scroll:AddChild(btn)
+                        if previewAdvExpanded and sectionId == "procGlow" and overrides.procGlowStyle ~= "none" then
+                            AddSelectedButtonPreviewToggle(scroll, "Preview Proc Glow", "_procGlowPreview", CooldownCompanion.SetProcGlowPreview)
+                        elseif previewAdvExpanded and sectionId == "auraIndicator" and overrides.auraGlowStyle ~= "none" then
+                            AddSelectedButtonPreviewToggle(scroll, "Preview Aura Glow", "_auraGlowPreview", CooldownCompanion.SetAuraGlowPreview)
+                        elseif previewAdvExpanded and sectionId == "pandemicGlow" and GetEffectiveOverrideValue("showPandemicGlow") ~= false then
+                            AddSelectedButtonPreviewToggle(scroll, "Preview Pandemic Glow", "_pandemicPreview", CooldownCompanion.SetPandemicPreview)
+                        elseif previewAdvExpanded and sectionId == "barActiveAura" then
+                            AddSelectedBarAuraActivePreviewToggle(scroll, "Preview Active Aura Effects")
+                        elseif previewAdvExpanded and sectionId == "pandemicBar" then
+                            AddSelectedButtonPreviewToggle(scroll, "Preview Pandemic Effects", "_pandemicPreview", CooldownCompanion.SetPandemicPreview)
+                        elseif previewAdvExpanded and sectionId == "readyGlow" and overrides.readyGlowStyle and overrides.readyGlowStyle ~= "none" then
+                            AddSelectedButtonPreviewToggle(scroll, "Preview Ready Glow Style", "_readyGlowPreview", CooldownCompanion.SetReadyGlowPreview)
                         end
 
-                        if AddConditionalPreviewButton then
+                        if previewAdvExpanded and AddConditionalPreviewButton then
                             local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
                             if sectionId == "cooldownText" or sectionId == "cooldownSwipe" or sectionId == "desaturation" then
-                                AddConditionalPreviewButton(scroll, "Preview Cooldown State (3s)", "cooldown", target)
-                            elseif sectionId == "auraText" or sectionId == "auraStackText" or sectionId == "auraDurationSwipe" then
-                                AddConditionalPreviewButton(scroll, "Preview Aura State (3s)", "aura", target)
-                            elseif sectionId == "chargeText" then
-                                AddConditionalPreviewButton(scroll, "Preview Missing Charges (3s)", "charge_missing", target)
-                                AddConditionalPreviewButton(scroll, "Preview Zero Charges (3s)", "charge_zero", target)
+                                AddConditionalPreviewButton(scroll, "Preview Cooldown State", "cooldown", target)
+                            elseif sectionId == "auraText" or sectionId == "auraDurationSwipe" then
+                                AddConditionalPreviewButton(scroll, "Preview Aura Duration Text", "aura_duration_text", target)
+                            elseif sectionId == "auraStackText" then
+                                AddConditionalPreviewButton(scroll, "Preview Aura Stack Text", "aura_stack_text", target)
                             elseif sectionId == "showOutOfRange" then
-                                AddConditionalPreviewButton(scroll, "Preview Out of Range State (3s)", "out_of_range", target)
+                                AddConditionalPreviewButton(scroll, "Preview Out of Range State", "out_of_range", target)
                             elseif sectionId == "unusableDimming" then
-                                AddConditionalPreviewButton(scroll, "Preview Unusable State (3s)", "unusable", target)
+                                AddConditionalPreviewButton(scroll, "Preview Unusable State", "unusable", target)
                             elseif sectionId == "iconTint" then
-                                AddConditionalPreviewButton(scroll, "Preview Cooldown Tint (3s)", "cooldown", target)
-                                AddConditionalPreviewButton(scroll, "Preview Aura Tint (3s)", "aura", target)
-                                AddConditionalPreviewButton(scroll, "Preview Unusable Tint (3s)", "unusable", target)
-                                AddConditionalPreviewButton(scroll, "Preview Out of Range Tint (3s)", "out_of_range", target)
+                                AddConditionalPreviewButton(scroll, "Preview Cooldown Tint", "cooldown", target)
+                                AddConditionalPreviewButton(scroll, "Preview Aura Tint", "aura", target)
+                                AddConditionalPreviewButton(scroll, "Preview Unusable Tint", "unusable", target)
+                                AddConditionalPreviewButton(scroll, "Preview Out of Range Tint", "out_of_range", target)
                             end
                         end
                     end

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -43,6 +43,7 @@ local BuildBarReadyTextControls = ST._BuildBarReadyTextControls
 local BuildTextFontControls = ST._BuildTextFontControls
 local BuildTextColorsControls = ST._BuildTextColorsControls
 local BuildTextBackgroundControls = ST._BuildTextBackgroundControls
+local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
 local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex)
     local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
@@ -151,6 +152,17 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
             CooldownCompanion:RefreshConfigPanel()
         end)
         scroll:AddChild(clearBtn)
+    end
+
+    if AddConditionalPreviewButton then
+        local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
+        AddConditionalPreviewButton(scroll, "Preview Cooldown State (3s)", "cooldown", target)
+        AddConditionalPreviewButton(scroll, "Preview Aura State (3s)", "aura", target)
+        AddConditionalPreviewButton(scroll, "Preview Pandemic State (3s)", "pandemic", target)
+        AddConditionalPreviewButton(scroll, "Preview Missing Charges (3s)", "charge_missing", target)
+        AddConditionalPreviewButton(scroll, "Preview Zero Charges (3s)", "charge_zero", target)
+        AddConditionalPreviewButton(scroll, "Preview Unusable State (3s)", "unusable", target)
+        AddConditionalPreviewButton(scroll, "Preview Out of Range State (3s)", "out_of_range", target)
     end
 end
 
@@ -464,6 +476,27 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                                 end
                             end)
                             scroll:AddChild(btn)
+                        end
+
+                        if AddConditionalPreviewButton then
+                            local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
+                            if sectionId == "cooldownText" or sectionId == "cooldownSwipe" or sectionId == "desaturation" then
+                                AddConditionalPreviewButton(scroll, "Preview Cooldown State (3s)", "cooldown", target)
+                            elseif sectionId == "auraText" or sectionId == "auraStackText" or sectionId == "auraDurationSwipe" then
+                                AddConditionalPreviewButton(scroll, "Preview Aura State (3s)", "aura", target)
+                            elseif sectionId == "chargeText" then
+                                AddConditionalPreviewButton(scroll, "Preview Missing Charges (3s)", "charge_missing", target)
+                                AddConditionalPreviewButton(scroll, "Preview Zero Charges (3s)", "charge_zero", target)
+                            elseif sectionId == "showOutOfRange" then
+                                AddConditionalPreviewButton(scroll, "Preview Out of Range State (3s)", "out_of_range", target)
+                            elseif sectionId == "unusableDimming" then
+                                AddConditionalPreviewButton(scroll, "Preview Unusable State (3s)", "unusable", target)
+                            elseif sectionId == "iconTint" then
+                                AddConditionalPreviewButton(scroll, "Preview Cooldown Tint (3s)", "cooldown", target)
+                                AddConditionalPreviewButton(scroll, "Preview Aura Tint (3s)", "aura", target)
+                                AddConditionalPreviewButton(scroll, "Preview Unusable Tint (3s)", "unusable", target)
+                                AddConditionalPreviewButton(scroll, "Preview Out of Range Tint (3s)", "out_of_range", target)
+                            end
                         end
                     end
                 end

--- a/ConfigSettings/CastBarPanels.lua
+++ b/ConfigSettings/CastBarPanels.lua
@@ -13,6 +13,7 @@ local AddColorPicker = ST._AddColorPicker
 local AddAnchorDropdown = ST._AddAnchorDropdown
 local HookSliderEditBox = ST._HookSliderEditBox
 local BuildIndependentAnchorTargetRow = ST._BuildIndependentAnchorTargetRow
+local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 
 ------------------------------------------------------------------------
 -- CAST BAR SETTINGS PANEL
@@ -118,9 +119,13 @@ local function BuildCastBarAnchoringPanel(container)
     previewCb:SetFullWidth(true)
     previewCb:SetCallback("OnValueChanged", function(widget, event, val)
         if val then
+            CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:StartCastBarPreview()
         else
             CooldownCompanion:StopCastBarPreview()
+        end
+        if RefreshConfigPanelForPreviewToggle then
+            RefreshConfigPanelForPreviewToggle()
         end
     end)
     container:AddChild(previewCb)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -48,6 +48,7 @@ local BuildProcGlowControls = ST._BuildProcGlowControls
 local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
+local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
@@ -146,23 +147,23 @@ local TEXTURE_INDICATOR_EFFECT_ORDER = {
 local TEXTURE_INDICATOR_SECTION_DEFS = {
     proc = {
         label = "Show Proc Effect",
-        previewText = "Preview Proc Effect (3s)",
+        previewText = "Preview Proc Effect",
     },
     aura = {
         label = "Show Aura Effect",
-        previewText = "Preview Aura Effect (3s)",
+        previewText = "Preview Aura Effect",
     },
     pandemic = {
         label = "Show Pandemic Effect",
-        previewText = "Preview Pandemic Effect (3s)",
+        previewText = "Preview Pandemic Effect",
     },
     ready = {
         label = "Show Ready Effect",
-        previewText = "Preview Ready Effect (3s)",
+        previewText = "Preview Ready Effect",
     },
     unusable = {
         label = "Show Unusable Effect",
-        previewText = "Preview Unusable Effect (3s)",
+        previewText = "Preview Unusable Effect",
     },
 }
 
@@ -1477,6 +1478,9 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
     local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled)
 
     if not advExpanded or not config.enabled then
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, false)
+        end
         return
     end
 
@@ -1529,13 +1533,16 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
         BuildTextureIndicatorSpeedSlider(container, config, "Bounce Duration")
     end
 
-    local previewBtn = AceGUI:Create("Button")
-    previewBtn:SetText(sectionDef.previewText)
-    previewBtn:SetFullWidth(true)
-    previewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, 3)
-    end)
-    container:AddChild(previewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, sectionDef.previewText, function()
+            return CS.selectedGroup
+                and CooldownCompanion:IsGroupTextureIndicatorPreviewActive(CS.selectedGroup, sectionKey)
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, show)
+            end
+        end)
+    end
 end
 
 local function BuildTriggerPanelEffectSection(container, effects, effectKey)
@@ -1559,7 +1566,7 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
     local advKey = "triggerEffect_" .. effectKey
     local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled)
     if not advExpanded or not config.enabled then
-        return
+        return false
     end
 
     if effectKey == "colorShift" then
@@ -1576,6 +1583,7 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
     end
 
     BuildTextureIndicatorSpeedSlider(container, config, def.speedLabel)
+    return true
 end
 
 local function GetTriggerPanelEffectOrderForDisplayType(group)
@@ -1629,22 +1637,31 @@ local function BuildTriggerEffectsTab(container, group)
     end
 
     local anyEnabled = false
+    local anyAdvancedExpanded = false
     local effectOrder = GetTriggerPanelEffectOrderForDisplayType(group)
     for _, effectKey in ipairs(effectOrder) do
-        BuildTriggerPanelEffectSection(container, effects, effectKey)
+        local sectionAdvancedExpanded = BuildTriggerPanelEffectSection(container, effects, effectKey)
         if effects[effectKey] and effects[effectKey].enabled then
             anyEnabled = true
         end
+        if sectionAdvancedExpanded then
+            anyAdvancedExpanded = true
+        end
     end
 
-    local previewBtn = AceGUI:Create("Button")
-    previewBtn:SetText("Preview Effects (3s)")
-    previewBtn:SetFullWidth(true)
-    previewBtn:SetDisabled(not anyEnabled)
-    previewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayTriggerPanelEffectsPreview(CS.selectedGroup, 3)
-    end)
-    container:AddChild(previewBtn)
+    if anyEnabled and anyAdvancedExpanded then
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(container, "Preview Effects", function()
+                return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    elseif CS.selectedGroup then
+        CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, false)
+    end
 end
 
 local function BuildTextureEffectsTab(container, group)
@@ -1659,11 +1676,12 @@ local function BuildTextureEffectsTab(container, group)
 end
 
 local function BuildBarModeEffects(container, group, style)
-    CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, false)
-    CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, false)
-    CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, false)
-    CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, false)
-    CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, false)
+    if not CS.previewToggleRefreshActive then
+        CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, false)
+        CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, false)
+        CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, false)
+        CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, false)
+    end
     BuildBarEffectsTab(container, group, style)
 end
 
@@ -1702,13 +1720,15 @@ local function BuildProcGlowSection(container, group, style)
 
     BuildProcGlowControls(container, style, UpdateSelectedGroupStyle)
 
-    local procPreviewBtn = AceGUI:Create("Button")
-    procPreviewBtn:SetText("Preview Proc Glow (3s)")
-    procPreviewBtn:SetFullWidth(true)
-    procPreviewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayGroupProcGlowPreview(CS.selectedGroup, 3)
-    end)
-    container:AddChild(procPreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Proc Glow", function()
+            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_procGlowPreview")
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, show)
+            end
+        end)
+    end
 end
 
 local function BuildAuraGlowSection(container, group, style)
@@ -1754,13 +1774,15 @@ local function BuildAuraGlowSection(container, group, style)
 
     BuildAuraIndicatorControls(container, style, UpdateSelectedGroupStyle)
 
-    local auraPreviewBtn = AceGUI:Create("Button")
-    auraPreviewBtn:SetText("Preview Aura Glow (3s)")
-    auraPreviewBtn:SetFullWidth(true)
-    auraPreviewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayGroupAuraGlowPreview(CS.selectedGroup, 3)
-    end)
-    container:AddChild(auraPreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Aura Glow", function()
+            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_auraGlowPreview")
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, show)
+            end
+        end)
+    end
 end
 
 local function BuildPandemicGlowSection(container, group, style)
@@ -1795,13 +1817,15 @@ local function BuildPandemicGlowSection(container, group, style)
 
     BuildPandemicGlowControls(container, style, UpdateSelectedGroupStyle)
 
-    local pandemicPreviewBtn = AceGUI:Create("Button")
-    pandemicPreviewBtn:SetText("Preview Pandemic Glow (3s)")
-    pandemicPreviewBtn:SetFullWidth(true)
-    pandemicPreviewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayGroupPandemicPreview(CS.selectedGroup, 3)
-    end)
-    container:AddChild(pandemicPreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Pandemic Glow", function()
+            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
+            end
+        end)
+    end
 end
 
 local function BuildReadyGlowSection(container, group, style)
@@ -1896,13 +1920,15 @@ local function BuildReadyGlowSection(container, group, style)
 
     BuildReadyGlowControls(container, style, UpdateSelectedGroupStyle)
 
-    local readyPreviewBtn = AceGUI:Create("Button")
-    readyPreviewBtn:SetText("Preview Ready Glow Style (3s)")
-    readyPreviewBtn:SetFullWidth(true)
-    readyPreviewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayGroupReadyGlowPreview(CS.selectedGroup, 3)
-    end)
-    container:AddChild(readyPreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Ready Glow Style", function()
+            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_readyGlowPreview")
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, show)
+            end
+        end)
+    end
 end
 
 local function BuildKeyPressHighlightSection(container, group, style)
@@ -1941,13 +1967,15 @@ local function BuildKeyPressHighlightSection(container, group, style)
 
     BuildKeyPressHighlightControls(container, style, UpdateSelectedGroupStyle)
 
-    local kphPreviewBtn = AceGUI:Create("Button")
-    kphPreviewBtn:SetText("Preview Key Press Highlight (3s)")
-    kphPreviewBtn:SetFullWidth(true)
-    kphPreviewBtn:SetCallback("OnClick", function()
-        CooldownCompanion:PlayGroupKeyPressHighlightPreview(CS.selectedGroup, 3)
-    end)
-    container:AddChild(kphPreviewBtn)
+    if AddPreviewToggleButton then
+        AddPreviewToggleButton(container, "Preview Key Press Highlight", function()
+            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_keyPressHighlightPreview")
+        end, function(show)
+            if CS.selectedGroup then
+                CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, show)
+            end
+        end)
+    end
 end
 
 local function BuildEffectsTab(container)
@@ -1958,19 +1986,25 @@ local function BuildEffectsTab(container)
     if not group then return end
     local style = group.style
 
-    ResetEffectsTabPreviews()
+    local displayMode = group.displayMode
+    if not CS.previewToggleRefreshActive
+        and (CS.lastEffectsPreviewGroup ~= CS.selectedGroup or CS.lastEffectsPreviewMode ~= displayMode) then
+        ResetEffectsTabPreviews()
+        CS.lastEffectsPreviewGroup = CS.selectedGroup
+        CS.lastEffectsPreviewMode = displayMode
+    end
 
-    if group.displayMode == "trigger" then
+    if displayMode == "trigger" then
         BuildTriggerEffectsTab(container, group)
         return
     end
 
-    if group.displayMode == "textures" then
+    if displayMode == "textures" then
         BuildTextureEffectsTab(container, group)
         return
     end
 
-    if group.displayMode == "bars" then
+    if displayMode == "bars" then
         BuildBarModeEffects(container, group, style)
         return
     end
@@ -2091,10 +2125,12 @@ local function BuildEffectsTab(container)
     -- Out of Range
     local oorCb = BuildShowOutOfRangeControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    CreateCheckboxPromoteButton(oorCb, nil, "showOutOfRange", group, style)
-    if style.showOutOfRange and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Out of Range State (3s)", "out_of_range")
+    local oorAdvExpanded, oorAdvBtn = AddAdvancedToggle(oorCb, "showOutOfRange", tabInfoButtons, style.showOutOfRange)
+    CreateCheckboxPromoteButton(oorCb, oorAdvBtn, "showOutOfRange", group, style)
+    if oorAdvExpanded and style.showOutOfRange and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Out of Range State", "out_of_range")
     end
 
     -- Loss of Control
@@ -2106,10 +2142,12 @@ local function BuildEffectsTab(container)
     -- Unusable Dimming
     local unusableCb = BuildUnusableDimmingControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
-    if style.showUnusable and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Unusable State (3s)", "unusable")
+    local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "unusableDimming", tabInfoButtons, style.showUnusable)
+    CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
+    if unusableAdvExpanded and style.showUnusable and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
     end
 
     -- Show Tooltips
@@ -2573,9 +2611,6 @@ local function BuildAppearanceTab(container)
 
     local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText)
     CreateCheckboxPromoteButton(cdTextCb, cdTextAdvBtn, "cooldownText", group, style)
-    if style.showCooldownText and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Cooldown State (3s)", "cooldown")
-    end
 
     if cdTextAdvExpanded and style.showCooldownText then
         AddFontControls(container, style, "cooldown", { size = 12 }, refreshStyle)
@@ -2591,6 +2626,9 @@ local function BuildAppearanceTab(container)
 
         AddOffsetSliders(container, style, "cooldownTextXOffset", "cooldownTextYOffset", { x = 0, y = 0 }, refreshStyle)
 
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Cooldown Text", "cooldown")
+        end
     end -- cdTextAdvExpanded + showCooldownText
 
     -- Show Charge Text toggle
@@ -2607,10 +2645,6 @@ local function BuildAppearanceTab(container)
 
     local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false)
     CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
-    if style.showChargeText ~= false and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Missing Charges (3s)", "charge_missing")
-        AddConditionalPreviewButton(container, "Preview Zero Charges (3s)", "charge_zero")
-    end
 
     if chargeAdvExpanded and style.showChargeText ~= false then
         AddFontControls(container, style, "charge", { size = 12 }, refreshStyle)
@@ -2635,9 +2669,6 @@ local function BuildAppearanceTab(container)
 
     local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false)
     local auraTextPromoteBtn = CreateCheckboxPromoteButton(auraTextCb, auraTextAdvBtn, "auraText", group, style)
-    if style.showAuraText ~= false and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Aura State (3s)", "aura")
-    end
 
     local auraPosInfo = CreateInfoButton(auraTextCb.frame, auraTextPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Shared Position",
@@ -2671,6 +2702,10 @@ local function BuildAppearanceTab(container)
             AddAnchorDropdown(container, style, "auraTextAnchor", "TOPLEFT", refreshStyle)
             AddOffsetSliders(container, style, "auraTextXOffset", "auraTextYOffset", { x = 2, y = -2 }, refreshStyle)
         end
+
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Aura Duration Text", "aura_duration_text")
+        end
     end -- auraTextAdvExpanded + showAuraText
 
     -- Show Aura Stack Text toggle
@@ -2693,6 +2728,10 @@ local function BuildAppearanceTab(container)
         AddColorPicker(container, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
         AddAnchorDropdown(container, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
         AddOffsetSliders(container, style, "auraStackXOffset", "auraStackYOffset", { x = 2, y = 2 }, refreshStyle)
+
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
+        end
     end -- auraStackAdvExpanded + showAuraStackText
 
     local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -48,6 +48,7 @@ local BuildProcGlowControls = ST._BuildProcGlowControls
 local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
+local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
 local BuildKeyPressHighlightControls = ST._BuildKeyPressHighlightControls
@@ -2092,6 +2093,9 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
     end)
     CreateCheckboxPromoteButton(oorCb, nil, "showOutOfRange", group, style)
+    if style.showOutOfRange and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Out of Range State (3s)", "out_of_range")
+    end
 
     -- Loss of Control
     local locCb = BuildLossOfControlControls(container, style, function()
@@ -2104,6 +2108,9 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
     end)
     CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
+    if style.showUnusable and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Unusable State (3s)", "unusable")
+    end
 
     -- Show Tooltips
     local tooltipCb = BuildShowTooltipsControls(container, style, function()
@@ -2566,6 +2573,9 @@ local function BuildAppearanceTab(container)
 
     local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText)
     CreateCheckboxPromoteButton(cdTextCb, cdTextAdvBtn, "cooldownText", group, style)
+    if style.showCooldownText and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Cooldown State (3s)", "cooldown")
+    end
 
     if cdTextAdvExpanded and style.showCooldownText then
         AddFontControls(container, style, "cooldown", { size = 12 }, refreshStyle)
@@ -2597,6 +2607,10 @@ local function BuildAppearanceTab(container)
 
     local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false)
     CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
+    if style.showChargeText ~= false and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Missing Charges (3s)", "charge_missing")
+        AddConditionalPreviewButton(container, "Preview Zero Charges (3s)", "charge_zero")
+    end
 
     if chargeAdvExpanded and style.showChargeText ~= false then
         AddFontControls(container, style, "charge", { size = 12 }, refreshStyle)
@@ -2621,6 +2635,9 @@ local function BuildAppearanceTab(container)
 
     local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false)
     local auraTextPromoteBtn = CreateCheckboxPromoteButton(auraTextCb, auraTextAdvBtn, "auraText", group, style)
+    if style.showAuraText ~= false and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Aura State (3s)", "aura")
+    end
 
     local auraPosInfo = CreateInfoButton(auraTextCb.frame, auraTextPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Shared Position",

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -27,6 +27,7 @@ local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
 local BuildBarAuraPulseControls = ST._BuildBarAuraPulseControls
 local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
+local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 local tabInfoButtons = CS.tabInfoButtons
 
 local function RefreshLayoutOrderPreview()
@@ -184,9 +185,13 @@ local function BuildResourceBarAnchoringPanel(container)
     previewCb:SetFullWidth(true)
     previewCb:SetCallback("OnValueChanged", function(widget, event, val)
         if val then
+            CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:StartResourceBarPreview()
         else
             CooldownCompanion:StopResourceBarPreview()
+        end
+        if RefreshConfigPanelForPreviewToggle then
+            RefreshConfigPanelForPreviewToggle()
         end
     end)
     container:AddChild(previewCb)
@@ -2049,9 +2054,13 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                         previewCb:SetFullWidth(true)
                         previewCb:SetCallback("OnValueChanged", function(widget, event, val)
                             if val then
+                                CooldownCompanion:ClearAllConfigPreviews()
                                 CooldownCompanion:StartResourceBarPreview()
                             else
                                 CooldownCompanion:StopResourceBarPreview()
+                            end
+                            if RefreshConfigPanelForPreviewToggle then
+                                RefreshConfigPanelForPreviewToggle()
                             end
                         end)
                         container:AddChild(previewCb)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -26,6 +26,7 @@ local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
 local BuildBarAuraPulseControls = ST._BuildBarAuraPulseControls
 local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
+local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local tabInfoButtons = CS.tabInfoButtons
 
 local function RefreshLayoutOrderPreview()
@@ -1938,13 +1939,15 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                         })
                         BuildBarAuraPulseControls(container, customBars[cabIdx], cabApplyBars)
 
-                        local activeAuraPreviewBtn = AceGUI:Create("Button")
-                        activeAuraPreviewBtn:SetText("Preview Active Aura Effects (3s)")
-                        activeAuraPreviewBtn:SetFullWidth(true)
-                        activeAuraPreviewBtn:SetCallback("OnClick", function()
-                            CooldownCompanion:PlayCustomAuraBarActivePreview(customBars[cabIdx], 3)
-                        end)
-                        container:AddChild(activeAuraPreviewBtn)
+                        if AddPreviewToggleButton then
+                            AddPreviewToggleButton(container, "Preview Active Aura Effects", function()
+                                return CooldownCompanion:IsCustomAuraBarActivePreviewActive(customBars[cabIdx])
+                            end, function(show)
+                                CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], show)
+                            end)
+                        end
+                    else
+                        CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], false)
                     end
 
                     if resolvedAuraUnit == "target" then
@@ -1977,14 +1980,18 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                             BuildPandemicBarControls(container, customBars[cabIdx], cabApplyBars)
                             BuildPandemicBarPulseControls(container, customBars[cabIdx], cabApplyBars)
 
-                            local pandemicPreviewBtn = AceGUI:Create("Button")
-                            pandemicPreviewBtn:SetText("Preview Pandemic Effects (3s)")
-                            pandemicPreviewBtn:SetFullWidth(true)
-                            pandemicPreviewBtn:SetCallback("OnClick", function()
-                                CooldownCompanion:PlayCustomAuraBarPandemicPreview(customBars[cabIdx], 3)
-                            end)
-                            container:AddChild(pandemicPreviewBtn)
+                            if AddPreviewToggleButton then
+                                AddPreviewToggleButton(container, "Preview Pandemic Effects", function()
+                                    return CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(customBars[cabIdx])
+                                end, function(show)
+                                    CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], show)
+                                end)
+                            end
+                        else
+                            CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
                         end
+                    else
+                        CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
                     end
                 else
                     local thresholdCb = AceGUI:Create("CheckBox")

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -35,6 +35,40 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
 
+local function AddConditionalPreviewButton(container, label, previewKind, opts)
+    if not (container and CooldownCompanion.PlayConditionalVisualPreview) then
+        return nil
+    end
+
+    local btn = AceGUI:Create("Button")
+    btn:SetText(label)
+    btn:SetFullWidth(true)
+    btn:SetCallback("OnClick", function()
+        local groupId = opts and opts.groupId or CS.selectedGroup
+        local buttonIndex = opts and opts.buttonIndex
+        if type(groupId) == "function" then
+            groupId = groupId()
+        end
+        if type(buttonIndex) == "function" then
+            buttonIndex = buttonIndex()
+        end
+        if opts and opts.requireButton and not buttonIndex then
+            return
+        end
+        if groupId then
+            CooldownCompanion:PlayConditionalVisualPreview(
+                groupId,
+                buttonIndex,
+                previewKind,
+                opts and opts.durationSeconds or 3,
+                opts and opts.sampleState
+            )
+        end
+    end)
+    container:AddChild(btn)
+    return btn
+end
+
 local function BuildCooldownTextControls(container, styleTable, refreshCallback)
     local cdTextCb = AceGUI:Create("CheckBox")
     cdTextCb:SetLabel("Show Cooldown Text")
@@ -1076,6 +1110,7 @@ end
 -- EXPORTS
 ------------------------------------------------------------------------
 ST._BuildCooldownTextControls = BuildCooldownTextControls
+ST._AddConditionalPreviewButton = AddConditionalPreviewButton
 ST._BuildAuraTextControls = BuildAuraTextControls
 ST._BuildAuraStackTextControls = BuildAuraStackTextControls
 ST._BuildKeybindTextControls = BuildKeybindTextControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -35,38 +35,68 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
 
-local function AddConditionalPreviewButton(container, label, previewKind, opts)
-    if not (container and CooldownCompanion.PlayConditionalVisualPreview) then
+local function ResolvePreviewOption(value)
+    if type(value) == "function" then
+        return value()
+    end
+    return value
+end
+
+local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActiveFn)
+    if not (container and isActiveFn and setActiveFn) then
         return nil
     end
 
     local btn = AceGUI:Create("Button")
-    btn:SetText(label)
+    btn:SetText(isActiveFn() and "Preview: ON" or offLabel)
     btn:SetFullWidth(true)
     btn:SetCallback("OnClick", function()
-        local groupId = opts and opts.groupId or CS.selectedGroup
-        local buttonIndex = opts and opts.buttonIndex
-        if type(groupId) == "function" then
-            groupId = groupId()
-        end
-        if type(buttonIndex) == "function" then
-            buttonIndex = buttonIndex()
-        end
-        if opts and opts.requireButton and not buttonIndex then
-            return
-        end
-        if groupId then
-            CooldownCompanion:PlayConditionalVisualPreview(
-                groupId,
-                buttonIndex,
-                previewKind,
-                opts and opts.durationSeconds or 3,
-                opts and opts.sampleState
-            )
+        setActiveFn(not isActiveFn())
+        if CooldownCompanion.RefreshConfigPanel then
+            local wasPreviewRefresh = CS.previewToggleRefreshActive
+            CS.previewToggleRefreshActive = true
+            CooldownCompanion:RefreshConfigPanel()
+            CS.previewToggleRefreshActive = wasPreviewRefresh
+        else
+            btn:SetText(isActiveFn() and "Preview: ON" or offLabel)
         end
     end)
     container:AddChild(btn)
     return btn
+end
+
+local function AddConditionalPreviewButton(container, label, previewKind, opts)
+    if not (container and CooldownCompanion.SetConditionalVisualPreviewActive and CooldownCompanion.IsConditionalVisualPreviewActive) then
+        return nil
+    end
+
+    local function ResolveTarget()
+        local groupId = ResolvePreviewOption(opts and opts.groupId) or CS.selectedGroup
+        local buttonIndex = ResolvePreviewOption(opts and opts.buttonIndex)
+        if opts and opts.requireButton and not buttonIndex then
+            return nil, nil
+        end
+        return groupId, buttonIndex
+    end
+
+    return AddPreviewToggleButton(container, label, function()
+        local groupId, buttonIndex = ResolveTarget()
+        if not groupId then
+            return false
+        end
+        return CooldownCompanion:IsConditionalVisualPreviewActive(groupId, buttonIndex, previewKind)
+    end, function(show)
+        local groupId, buttonIndex = ResolveTarget()
+        if groupId then
+            CooldownCompanion:SetConditionalVisualPreviewActive(
+                groupId,
+                buttonIndex,
+                previewKind,
+                show,
+                opts and opts.sampleState
+            )
+        end
+    end)
 end
 
 local function BuildCooldownTextControls(container, styleTable, refreshCallback)
@@ -1110,6 +1140,7 @@ end
 -- EXPORTS
 ------------------------------------------------------------------------
 ST._BuildCooldownTextControls = BuildCooldownTextControls
+ST._AddPreviewToggleButton = AddPreviewToggleButton
 ST._AddConditionalPreviewButton = AddConditionalPreviewButton
 ST._BuildAuraTextControls = BuildAuraTextControls
 ST._BuildAuraStackTextControls = BuildAuraStackTextControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -42,6 +42,18 @@ local function ResolvePreviewOption(value)
     return value
 end
 
+local function RefreshConfigPanelForPreviewToggle()
+    if not CooldownCompanion.RefreshConfigPanel then
+        return false
+    end
+
+    local wasPreviewRefresh = CS.previewToggleRefreshActive
+    CS.previewToggleRefreshActive = true
+    CooldownCompanion:RefreshConfigPanel()
+    CS.previewToggleRefreshActive = wasPreviewRefresh
+    return true
+end
+
 local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActiveFn)
     if not (container and isActiveFn and setActiveFn) then
         return nil
@@ -51,13 +63,12 @@ local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActive
     btn:SetText(isActiveFn() and "Preview: ON" or offLabel)
     btn:SetFullWidth(true)
     btn:SetCallback("OnClick", function()
-        setActiveFn(not isActiveFn())
-        if CooldownCompanion.RefreshConfigPanel then
-            local wasPreviewRefresh = CS.previewToggleRefreshActive
-            CS.previewToggleRefreshActive = true
-            CooldownCompanion:RefreshConfigPanel()
-            CS.previewToggleRefreshActive = wasPreviewRefresh
-        else
+        local showPreview = not isActiveFn()
+        if showPreview and CooldownCompanion.ClearAllConfigPreviews then
+            CooldownCompanion:ClearAllConfigPreviews()
+        end
+        setActiveFn(showPreview)
+        if not RefreshConfigPanelForPreviewToggle() then
             btn:SetText(isActiveFn() and "Preview: ON" or offLabel)
         end
     end)
@@ -1141,6 +1152,7 @@ end
 ------------------------------------------------------------------------
 ST._BuildCooldownTextControls = BuildCooldownTextControls
 ST._AddPreviewToggleButton = AddPreviewToggleButton
+ST._RefreshConfigPanelForPreviewToggle = RefreshConfigPanelForPreviewToggle
 ST._AddConditionalPreviewButton = AddConditionalPreviewButton
 ST._BuildAuraTextControls = BuildAuraTextControls
 ST._BuildAuraStackTextControls = BuildAuraStackTextControls

--- a/ConfigSettings/TextModeTabs.lua
+++ b/ConfigSettings/TextModeTabs.lua
@@ -19,6 +19,7 @@ local OpenFormatEditor = ST._OpenFormatEditor
 local AddColorPicker = ST._AddColorPicker
 local RenderFormatPreview = ST._RenderFormatPreview
 local ParseFormatString = ST._ParseFormatString
+local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -285,6 +286,16 @@ local function BuildTextAppearanceTab(container, group, style)
         OpenFormatEditor(style, CS.selectedGroup)
     end)
     container:AddChild(editBtn)
+
+    if AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Cooldown State (3s)", "cooldown")
+        AddConditionalPreviewButton(container, "Preview Aura State (3s)", "aura")
+        AddConditionalPreviewButton(container, "Preview Pandemic State (3s)", "pandemic")
+        AddConditionalPreviewButton(container, "Preview Missing Charges (3s)", "charge_missing")
+        AddConditionalPreviewButton(container, "Preview Zero Charges (3s)", "charge_zero")
+        AddConditionalPreviewButton(container, "Preview Unusable State (3s)", "unusable")
+        AddConditionalPreviewButton(container, "Preview Out of Range State (3s)", "out_of_range")
+    end
     end -- not fmtCollapsed
 
     -- ================================================================

--- a/ConfigSettings/TextModeTabs.lua
+++ b/ConfigSettings/TextModeTabs.lua
@@ -10,6 +10,7 @@ local CS = ST._configState
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
+local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateInfoButton = ST._CreateInfoButton
 local BuildCompactModeControls = ST._BuildCompactModeControls
 local BuildGroupSettingPresetControls = ST._BuildGroupSettingPresetControls
@@ -220,9 +221,11 @@ local function BuildTextAppearanceTab(container, group, style)
         CS.collapsedSections["textappearance_format"] = not CS.collapsedSections["textappearance_format"]
         CooldownCompanion:RefreshConfigPanel()
     end)
+    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons)
+    fmtPreviewAdvBtn:SetPoint("LEFT", fmtCollapseBtn, "RIGHT", 4, 0)
 
     -- Token reference info button
-    local fmtInfo = CreateInfoButton(fmtHeading.frame, fmtCollapseBtn, "LEFT", "RIGHT", 4, 0, {
+    local fmtInfo = CreateInfoButton(fmtHeading.frame, fmtPreviewAdvBtn, "LEFT", "RIGHT", 4, 0, {
         {"Format String", 1, 0.82, 0, true},
         " ",
         {"Controls what each button displays using", 1, 1, 1, true},
@@ -287,14 +290,13 @@ local function BuildTextAppearanceTab(container, group, style)
     end)
     container:AddChild(editBtn)
 
-    if AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Cooldown State (3s)", "cooldown")
-        AddConditionalPreviewButton(container, "Preview Aura State (3s)", "aura")
-        AddConditionalPreviewButton(container, "Preview Pandemic State (3s)", "pandemic")
-        AddConditionalPreviewButton(container, "Preview Missing Charges (3s)", "charge_missing")
-        AddConditionalPreviewButton(container, "Preview Zero Charges (3s)", "charge_zero")
-        AddConditionalPreviewButton(container, "Preview Unusable State (3s)", "unusable")
-        AddConditionalPreviewButton(container, "Preview Out of Range State (3s)", "out_of_range")
+    if fmtPreviewAdvExpanded and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Cooldown State", "cooldown")
+        AddConditionalPreviewButton(container, "Preview Aura Duration Text", "aura_duration_text")
+        AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
+        AddConditionalPreviewButton(container, "Preview Pandemic State", "pandemic")
+        AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
+        AddConditionalPreviewButton(container, "Preview Out of Range State", "out_of_range")
     end
     end -- not fmtCollapsed
 

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1015,6 +1015,10 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     -- Update clickthrough state
     self:UpdateGroupClickthrough(groupId)
 
+    if self.ApplyConfigPreviewsToGroup then
+        self:ApplyConfigPreviewsToGroup(groupId)
+    end
+
     -- Initial cooldown update
     frame:UpdateCooldowns()
 

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -3339,6 +3339,63 @@ local function RefreshCustomAuraBarPreviewState(cabConfig, previewKey, show)
     end
 end
 
+local function IsCustomAuraBarPreviewStateActive(cabConfig, previewKey)
+    if not (cabConfig and previewKey) then
+        return false
+    end
+    for _, barInfo in ipairs(resourceBarFrames) do
+        if barInfo.cabConfig == cabConfig and barInfo.frame and barInfo.frame[previewKey] then
+            return true
+        end
+    end
+    return false
+end
+
+function CooldownCompanion:SetCustomAuraBarActivePreview(cabConfig, show)
+    if not cabConfig then return end
+    customAuraBarActivePreviewTokens[cabConfig] = (customAuraBarActivePreviewTokens[cabConfig] or 0) + 1
+    RefreshCustomAuraBarPreviewState(cabConfig, "_barAuraActivePreview", show)
+end
+
+function CooldownCompanion:IsCustomAuraBarActivePreviewActive(cabConfig)
+    return IsCustomAuraBarPreviewStateActive(cabConfig, "_barAuraActivePreview")
+end
+
+function CooldownCompanion:SetCustomAuraBarPandemicPreview(cabConfig, show)
+    if not cabConfig then return end
+    customAuraBarPandemicPreviewTokens[cabConfig] = (customAuraBarPandemicPreviewTokens[cabConfig] or 0) + 1
+    RefreshCustomAuraBarPreviewState(cabConfig, "_pandemicPreview", show)
+end
+
+function CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(cabConfig)
+    return IsCustomAuraBarPreviewStateActive(cabConfig, "_pandemicPreview")
+end
+
+function CooldownCompanion:ClearAllCustomAuraBarPreviews()
+    wipe(customAuraBarActivePreviewTokens)
+    wipe(customAuraBarPandemicPreviewTokens)
+
+    local anyUpdated = false
+    for _, barInfo in ipairs(resourceBarFrames) do
+        local frame = barInfo.frame
+        if frame and (frame._barAuraActivePreview or frame._pandemicPreview) then
+            frame._barAuraActivePreview = nil
+            frame._pandemicPreview = nil
+            UpdateCustomAuraBar(barInfo)
+            if barInfo.barType == "custom_continuous" then
+                AnimateCustomAuraBarIndicator(frame)
+            end
+            anyUpdated = true
+        end
+    end
+
+    if anyUpdated and layoutDirty then
+        layoutDirty = false
+        RelayoutBars()
+        CooldownCompanion:RepositionCastBar()
+    end
+end
+
 function CooldownCompanion:PlayCustomAuraBarActivePreview(cabConfig, durationSeconds)
     if not cabConfig then return end
 

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -156,6 +156,8 @@ local processingCustomAuraWakeRetryQueue = false
 local independentWrapperFrame = nil
 local customAuraBarActivePreviewTokens = {}
 local customAuraBarPandemicPreviewTokens = {}
+local activeCustomAuraBarActivePreviews = {}
+local activeCustomAuraBarPandemicPreviews = {}
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL = 0.65
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS = 3
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION = 12.3
@@ -427,6 +429,17 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     end
 
     ResetCustomAuraBarIndicatorVisuals(bar, barInfo.cabConfig)
+end
+
+local function ApplyCustomAuraBarPreviewState(barInfo)
+    local bar = barInfo and barInfo.frame
+    local cabConfig = barInfo and barInfo.cabConfig
+    if not (bar and cabConfig) then
+        return
+    end
+
+    bar._barAuraActivePreview = activeCustomAuraBarActivePreviews[cabConfig] and true or nil
+    bar._pandemicPreview = activeCustomAuraBarPandemicPreviews[cabConfig] and true or nil
 end
 
 local function AnimateCustomAuraBarIndicator(bar)
@@ -2294,6 +2307,7 @@ local function PrepareCustomAuraBar(
 
     barInfo.cabConfig = cabConfig
     barInfo.powerType = powerType
+    ApplyCustomAuraBarPreviewState(barInfo)
     barInfo.frame:SetSize(customWidth, customHeight)
     barInfo.frame._isVertical = customIsVertical
     barInfo.frame._reverseFill = customReverseFill
@@ -3303,6 +3317,8 @@ function CooldownCompanion:RevertResourceBars()
     isPreviewActive = false
     wipe(customAuraBarActivePreviewTokens)
     wipe(customAuraBarPandemicPreviewTokens)
+    wipe(activeCustomAuraBarActivePreviews)
+    wipe(activeCustomAuraBarPandemicPreviews)
     activeResources = {}
 end
 
@@ -3354,26 +3370,32 @@ end
 function CooldownCompanion:SetCustomAuraBarActivePreview(cabConfig, show)
     if not cabConfig then return end
     customAuraBarActivePreviewTokens[cabConfig] = (customAuraBarActivePreviewTokens[cabConfig] or 0) + 1
+    activeCustomAuraBarActivePreviews[cabConfig] = show or nil
     RefreshCustomAuraBarPreviewState(cabConfig, "_barAuraActivePreview", show)
 end
 
 function CooldownCompanion:IsCustomAuraBarActivePreviewActive(cabConfig)
-    return IsCustomAuraBarPreviewStateActive(cabConfig, "_barAuraActivePreview")
+    return activeCustomAuraBarActivePreviews[cabConfig] == true
+        or IsCustomAuraBarPreviewStateActive(cabConfig, "_barAuraActivePreview")
 end
 
 function CooldownCompanion:SetCustomAuraBarPandemicPreview(cabConfig, show)
     if not cabConfig then return end
     customAuraBarPandemicPreviewTokens[cabConfig] = (customAuraBarPandemicPreviewTokens[cabConfig] or 0) + 1
+    activeCustomAuraBarPandemicPreviews[cabConfig] = show or nil
     RefreshCustomAuraBarPreviewState(cabConfig, "_pandemicPreview", show)
 end
 
 function CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(cabConfig)
-    return IsCustomAuraBarPreviewStateActive(cabConfig, "_pandemicPreview")
+    return activeCustomAuraBarPandemicPreviews[cabConfig] == true
+        or IsCustomAuraBarPreviewStateActive(cabConfig, "_pandemicPreview")
 end
 
 function CooldownCompanion:ClearAllCustomAuraBarPreviews()
     wipe(customAuraBarActivePreviewTokens)
     wipe(customAuraBarPandemicPreviewTokens)
+    wipe(activeCustomAuraBarActivePreviews)
+    wipe(activeCustomAuraBarPandemicPreviews)
 
     local anyUpdated = false
     for _, barInfo in ipairs(resourceBarFrames) do
@@ -3405,10 +3427,12 @@ function CooldownCompanion:PlayCustomAuraBarActivePreview(cabConfig, durationSec
     local token = (customAuraBarActivePreviewTokens[cabConfig] or 0) + 1
     customAuraBarActivePreviewTokens[cabConfig] = token
 
+    activeCustomAuraBarActivePreviews[cabConfig] = true
     RefreshCustomAuraBarPreviewState(cabConfig, "_barAuraActivePreview", true)
 
     C_Timer.After(duration, function()
         if customAuraBarActivePreviewTokens[cabConfig] ~= token then return end
+        activeCustomAuraBarActivePreviews[cabConfig] = nil
         RefreshCustomAuraBarPreviewState(cabConfig, "_barAuraActivePreview", false)
     end)
 end
@@ -3422,10 +3446,12 @@ function CooldownCompanion:PlayCustomAuraBarPandemicPreview(cabConfig, durationS
     local token = (customAuraBarPandemicPreviewTokens[cabConfig] or 0) + 1
     customAuraBarPandemicPreviewTokens[cabConfig] = token
 
+    activeCustomAuraBarPandemicPreviews[cabConfig] = true
     RefreshCustomAuraBarPreviewState(cabConfig, "_pandemicPreview", true)
 
     C_Timer.After(duration, function()
         if customAuraBarPandemicPreviewTokens[cabConfig] ~= token then return end
+        activeCustomAuraBarPandemicPreviews[cabConfig] = nil
         RefreshCustomAuraBarPreviewState(cabConfig, "_pandemicPreview", false)
     end)
 end


### PR DESCRIPTION
## What Players Will Notice
- Preview buttons in the settings UI now behave like persistent toggles instead of short 3-second flashes, so players can turn a preview on, adjust settings, and keep seeing the result while tuning it.
- Only one config preview can be active at a time, and previews now clear when changing selections, switching modes, adding entries, deleting/moving panels, changing profiles, or closing the config.
- Cooldown text and aura duration text previews now loop while active, and aura stack previews can appear on every icon in the panel instead of only on spells with live stack state.
- Charge-based cooldown swipes should stay visible during overlapping GCD windows instead of being hidden when GCD swipes are disabled.

## Why This Changed
- The preview system was easier to use when previews could stay on during tuning, but persistent previews exposed cleanup gaps where a preview could remain active after the visible ON button disappeared.
- The forced preview states needed to be independent from live aura/cooldown state so each preview shows the exact setting being configured.
- Charge recharge and GCD display shared the same icon cooldown frame; when the GCD suppressor ran after charge tracking, it could hide the active charge recharge swipe.

## What Changed
- Added shared preview toggle helpers and a central `ClearAllConfigPreviews()` cleanup path for config preview families.
- Added runtime preview registries so active previews survive button/resource-frame rebuilds during style edits, then reapply to the rebuilt frames.
- Reworked conditional visual previews so cooldown, aura duration, aura stack, unusable, and out-of-range previews force their own display state without requiring live aura or cooldown state.
- Updated selection, deletion, drag/reorder, profile, mode-switch, inline-add, and config-close paths to clear persistent previews when the editing context changes.
- Added charge-recharge ownership tracking so icon-mode GCD suppression does not hide an active charge recharge swipe.
- Kept custom aura bar preview state keyed by bar config instead of recycled frame identity, so previews survive layout/order/display changes.
- Ignored generated development planning docs under `docs/` so local planning artifacts do not enter addon releases.

## Validation
- Ran Lua syntax validation with `luac -p` across the branch-touched addon Lua files.
- Ran `git diff --check origin/main...HEAD`.
- Checked CC DevBridge for recent addon Lua errors before publishing; no errors were captured in the latest available snapshot.
- Not yet verified in game after the final edits. Charge swipe behavior, preview cleanup, and combat/restricted-content behavior still need targeted in-game testing before this should be considered ready to merge.