### PR TITLE
Fix replacement spell cooldown ownership

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -915,6 +915,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._displaySpellId = nil
+    button._liveOverrideSpellId = nil
     button._itemCount = nil
     button._auraActive = nil
     button._showingAuraIcon = nil

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -905,6 +905,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._readyGlowMaxChargesActive = nil
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
+    button._noCooldownSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -406,7 +406,7 @@ end
 
 local ProbeActionSlotCooldownForSpell
 
-local function EvaluateSpellCooldownLane(spellID, secrecy)
+local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID)
     local result = {
         spellID = spellID,
         fetchOk = false,
@@ -424,7 +424,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
     result.info = info
     if not info then
         if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
-            local slotProbe = ProbeActionSlotCooldownForSpell(spellID)
+            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
             if slotProbe.shown ~= nil then
                 result.fetchOk = true
                 result.normalCooldownShown = slotProbe.shown == true
@@ -486,7 +486,7 @@ local function GetLiveOverrideSpellID(buttonData)
 end
 
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id)
 end
 
 local function ResolveChargeState(button, buttonData)
@@ -685,6 +685,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- displayed spell fresh even when the game does not fire SPELL_UPDATE_ICON.
     local cooldownSpellId = button._displaySpellId or buttonData.id
     local liveOverrideId
+    local forceBaseDisplayId = false
     if buttonData.type == "spell" and not buttonData.cdmChildSlot then
         local refreshIcon = false
         local previousLiveOverrideId = button._liveOverrideSpellId
@@ -697,6 +698,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             cooldownSpellId = liveOverrideId
         elseif previousLiveOverrideId then
             cooldownSpellId = buttonData.id
+            forceBaseDisplayId = true
             refreshIcon = true
         end
 
@@ -714,8 +716,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
 
         if refreshIcon then
+            if forceBaseDisplayId then
+                button._forceBaseDisplaySpellId = true
+            end
             CooldownCompanion:UpdateButtonIcon(button)
-            cooldownSpellId = liveOverrideId or button._displaySpellId or buttonData.id
+            button._forceBaseDisplaySpellId = nil
+            cooldownSpellId = forceBaseDisplayId and buttonData.id
+                or liveOverrideId
+                or button._displaySpellId
+                or buttonData.id
         end
     end
 

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -687,12 +687,17 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local liveOverrideId
     if buttonData.type == "spell" and not buttonData.cdmChildSlot then
         local refreshIcon = false
+        local previousLiveOverrideId = button._liveOverrideSpellId
         liveOverrideId = GetLiveOverrideSpellID(buttonData)
+        button._liveOverrideSpellId = liveOverrideId
         if liveOverrideId then
             if liveOverrideId ~= cooldownSpellId then
                 refreshIcon = true
             end
             cooldownSpellId = liveOverrideId
+        elseif previousLiveOverrideId then
+            cooldownSpellId = buttonData.id
+            refreshIcon = true
         end
 
         if button._displaySpellId ~= cooldownSpellId then

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -472,35 +472,21 @@ local function EvaluateSpellCooldownLane(spellID, secrecy)
     return result
 end
 
-local function SelectSpellCooldownResult(current, candidate)
-    if not candidate or not candidate.fetchOk then
-        return current
+local function GetLiveOverrideSpellID(buttonData)
+    if not (buttonData and buttonData.type == "spell" and not buttonData.isPassive) then
+        return nil
     end
-    if not current or not current.fetchOk then
-        return candidate
+
+    local overrideID = C_Spell.GetOverrideSpell(buttonData.id)
+    if overrideID and overrideID ~= 0 and overrideID ~= buttonData.id then
+        return overrideID
     end
-    return CooldownLogic.SelectStrongerCooldownState(current, candidate)
+
+    return nil
 end
 
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId)
-    local displayResult = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
-    local result = displayResult
-
-    if cooldownSpellId and cooldownSpellId ~= buttonData.id then
-        local displayBaseSpellID = C_Spell.GetBaseSpell(cooldownSpellId)
-        if displayBaseSpellID == buttonData.id then
-            local baseResult = EvaluateSpellCooldownLane(buttonData.id, buttonData._cooldownSecrecy)
-            result = SelectSpellCooldownResult(
-                result,
-                baseResult
-            )
-            if result and (displayResult.isOnGCD or baseResult.isOnGCD) then
-                result.isOnGCD = true
-            end
-        end
-    end
-
-    return result
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy)
 end
 
 local function ResolveChargeState(button, buttonData)
@@ -695,21 +681,38 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
     end
 
-    -- For transforming spells (e.g. Command Demon → pet ability), use the
-    -- current override spell for cooldown queries. _displaySpellId is set
-    -- by UpdateButtonIcon on SPELL_UPDATE_ICON and creation.
-    -- Lazy-cache no-cooldown detection for spells (GCD-only, no real CD).
-    -- Computed once (nil → true/false), reset in UpdateButtonStyle on respec.
-    if button._noCooldown == nil then
-        if buttonData.type == "spell" and not buttonData.isPassive and not usesChargeBehavior then
-            local baseCd = GetSpellBaseCooldown(buttonData.id)
-            button._noCooldown = (not baseCd or baseCd == 0) and not HasTooltipCooldown(buttonData.id)
-        else
-            button._noCooldown = false
+    -- For transforming spells (e.g. Void Eruption -> Void Volley), keep the
+    -- displayed spell fresh even when the game does not fire SPELL_UPDATE_ICON.
+    local cooldownSpellId = button._displaySpellId or buttonData.id
+    local liveOverrideId
+    if buttonData.type == "spell" and not buttonData.cdmChildSlot then
+        local refreshIcon = false
+        liveOverrideId = GetLiveOverrideSpellID(buttonData)
+        if liveOverrideId then
+            if liveOverrideId ~= cooldownSpellId then
+                refreshIcon = true
+            end
+            cooldownSpellId = liveOverrideId
+        end
+
+        if button._displaySpellId ~= cooldownSpellId then
+            refreshIcon = true
+        end
+
+        -- Per-tick icon staleness detection for silent transforms (e.g. Tiger's
+        -- Fury changing Rake/Rip icons). GetSpellTexture dynamically resolves
+        -- the current visual, but no event fires for these transforms.
+        local freshIcon = C_Spell.GetSpellTexture(buttonData.id)
+        if freshIcon and freshIcon ~= button._lastSpellTexture then
+            button._lastSpellTexture = freshIcon
+            refreshIcon = true
+        end
+
+        if refreshIcon then
+            CooldownCompanion:UpdateButtonIcon(button)
+            cooldownSpellId = liveOverrideId or button._displaySpellId or buttonData.id
         end
     end
-
-    local cooldownSpellId = button._displaySpellId or buttonData.id
 
     -- Deferred icon refresh for cdmChildSlot buttons (set by OnSpellUpdateIcon).
     -- One-tick delay ensures the CDM viewer's RefreshSpellTexture has already
@@ -717,21 +720,21 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if button._iconDirty then
         button._iconDirty = nil
         CooldownCompanion:UpdateButtonIcon(button)
-        cooldownSpellId = button._displaySpellId or buttonData.id
+        cooldownSpellId = liveOverrideId or button._displaySpellId or buttonData.id
     end
 
-    -- Per-tick icon staleness detection for silent transforms (e.g. Tiger's Fury
-    -- changing Rake/Rip icons). GetSpellTexture dynamically resolves the current
-    -- visual, but no event fires for these transforms. cdmChildSlot buttons
-    -- already have their own per-tick viewer-based icon re-sync.
-    -- Event-driven updates (_iconDirty) remain instant (handled above).
-    if buttonData.type == "spell" and not buttonData.cdmChildSlot then
-        local freshIcon = C_Spell.GetSpellTexture(buttonData.id)
-        if freshIcon and freshIcon ~= button._lastSpellTexture then
-            button._lastSpellTexture = freshIcon
-            CooldownCompanion:UpdateButtonIcon(button)
-            cooldownSpellId = button._displaySpellId or buttonData.id
+    -- Lazy-cache no-cooldown detection for spells (GCD-only, no real CD).
+    -- Tie the cache to the displayed spell so replacements do not inherit the
+    -- base spell's cooldown classification.
+    if buttonData.type == "spell" and not buttonData.isPassive and not usesChargeBehavior then
+        if button._noCooldown == nil or button._noCooldownSpellId ~= cooldownSpellId then
+            button._noCooldownSpellId = cooldownSpellId
+            local baseCd = GetSpellBaseCooldown(cooldownSpellId)
+            button._noCooldown = (not baseCd or baseCd == 0) and not HasTooltipCooldown(cooldownSpellId)
         end
+    else
+        button._noCooldown = false
+        button._noCooldownSpellId = nil
     end
 
     -- Proc state: event-driven table lookup (base spell + current displayed override).

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -496,10 +496,14 @@ function CooldownCompanion:UpdateButtonIcon(button)
     local icon
     local displayId = buttonData.id
     local overrideId = nil
+    local forceBaseDisplay = button._forceBaseDisplaySpellId == true
 
     if buttonData.type == "spell" then
         overrideId = C_Spell.GetOverrideSpell(buttonData.id)
         if overrideId == buttonData.id or overrideId == 0 then
+            overrideId = nil
+        end
+        if forceBaseDisplay then
             overrideId = nil
         end
         -- Look up viewer child for current override info (icon, display name).
@@ -513,7 +517,7 @@ function CooldownCompanion:UpdateButtonIcon(button)
         else
             child = CooldownCompanion.viewerAuraFrames[buttonData.id]
         end
-        if child and child.cooldownInfo then
+        if child and child.cooldownInfo and not forceBaseDisplay then
             -- For multi-slot buttons, keep the slot-specific buff viewer child —
             -- FindCooldownViewerChild is not slot-aware and would lose differentiation.
             if not buttonData.cdmChildSlot then

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -940,6 +940,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._readyGlowMaxChargesActive = nil
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
+    button._noCooldownSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -955,6 +955,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._readyGlowActive = nil
     button._keyPressHighlightActive = nil
     button._displaySpellId = nil
+    button._liveOverrideSpellId = nil
     button._spellOutOfRange = nil
     button._itemCount = nil
     button._auraActive = nil

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1352,6 +1352,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
             local buttonData = button.buttonData
             if buttonData and buttonData.type == "spell" then
                 button._noCooldown = nil
+                button._noCooldownSpellId = nil
                 button._displaySpellId = nil
                 button._lastSpellTexture = nil
                 button._iconDirty = true

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1354,6 +1354,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._noCooldown = nil
                 button._noCooldownSpellId = nil
                 button._displaySpellId = nil
+                button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil
                 button._iconDirty = true
                 button._cooldownDeferred = nil


### PR DESCRIPTION
## What Players Will Notice
- Buttons for spells that temporarily become another ability now follow the replacement ability's icon and cooldown instead of snapping back to the original spell's cooldown too early.
- For Shadow Priest, a Voidform/Void Eruption style button can now show Void Volley while that replacement is active, including when Void Volley becomes ready before the original spell's longer cooldown is done.
- When the replacement ends, the button returns to the original spell instead of keeping stale replacement state.

## Why This Changed
- Some replacement spells do not reliably trigger `SPELL_UPDATE_ICON`, so Cooldown Companion could miss that the base UI had swapped the button to a new ability.
- The cooldown code also compared the replacement spell against the original spell and picked the stronger cooldown. That made the original spell's longer cooldown win after the replacement became ready, which did not match the base UI.

## What Changed
- Cooldown updates now refresh the live replacement spell with `C_Spell.GetOverrideSpell` during the existing button update path.
- When a replacement spell is active, its cooldown state owns the button instead of being merged back with the original spell's cooldown.
- The no-cooldown cache now follows the currently displayed spell so replacement abilities do not inherit stale base-spell classification.
- The icon path can force a clean return to the base spell when a replacement ends, avoiding stale viewer override data.
- Action-slot fallback probing still checks both the stored base spell and the active replacement spell when the Spell API does not return cooldown info.

## Validation
- Ran `luac -p ButtonFrame/CooldownUpdate.lua ButtonFrame/IconMode.lua ButtonFrame/BarMode.lua Core/GroupOperations.lua`.
- Ran `git diff --check`.
- Verified in game that the reported Void Volley replacement behavior is fixed.
- Checked DevBridge after testing; it reported no Cooldown Companion Lua errors.
- Combat and restricted-content verification is still needed before this should be considered fully release-ready.
