### PR TITLE
Add config finder for groups, panels, and entries

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -33,6 +33,9 @@ local ContainersHaveForeignSpecs = ST._ContainersHaveForeignSpecs
 local FolderHasForeignSpecs = ST._FolderHasForeignSpecs
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local NotifyTutorialAction = ST._NotifyTutorialAction
+local IsConfigFinderActive = ST._IsConfigFinderActive
+local BuildConfigFinderResults = ST._BuildConfigFinderResults
+local ClearConfigFinderText = ST._ClearConfigFinderText
 
 local GenerateGroupName
 
@@ -900,6 +903,7 @@ local function RefreshColumn1(preserveDrag)
 
     local db = CooldownCompanion.db.profile
     local charKey = CooldownCompanion.db.keys.char
+    local searchResults = IsConfigFinderActive and IsConfigFinderActive() and BuildConfigFinderResults and BuildConfigFinderResults() or nil
 
     -- Ensure folders table exists
     if not db.folders then db.folders = {} end
@@ -998,7 +1002,10 @@ local function RefreshColumn1(preserveDrag)
         local folderChildContainers = {}  -- [folderId] = { containerId, ... }
         for _, cid in ipairs(sectionContainerIds) do
             local container = db.groupContainers[cid]
-            if container.folderId and validFolderIds[container.folderId] then
+            if searchResults and not searchResults.containerMatches[cid] then
+                -- Search hides non-matching groups while preserving folder context
+                -- for the groups that do match.
+            elseif container.folderId and validFolderIds[container.folderId] then
                 if not folderChildContainers[container.folderId] then
                     folderChildContainers[container.folderId] = {}
                 end
@@ -1021,7 +1028,9 @@ local function RefreshColumn1(preserveDrag)
         -- Build top-level items list: folders + loose containers
         local items = {}
         for _, fid in ipairs(sectionFolderIds) do
-            table.insert(items, { kind = "folder", id = fid, order = CooldownCompanion:GetOrderForSpec(db.folders[fid], specId, fid) })
+            if not searchResults or (folderChildContainers[fid] and #folderChildContainers[fid] > 0) then
+                table.insert(items, { kind = "folder", id = fid, order = CooldownCompanion:GetOrderForSpec(db.folders[fid], specId, fid) })
+            end
         end
         for _, cid in ipairs(looseContainerIds) do
             table.insert(items, { kind = "container", id = cid, order = CooldownCompanion:GetOrderForSpec(db.groupContainers[cid], specId, cid) })
@@ -1165,6 +1174,7 @@ local function RefreshColumn1(preserveDrag)
 
         entry:SetCallback("OnClick", function(widget, event, mouseButton)
             if mouseButton == "LeftButton"
+                and not searchResults
                 and not IsShiftKeyDown()
                 and not IsControlKeyDown()
                 and not GetCursorInfo()
@@ -1234,6 +1244,9 @@ local function RefreshColumn1(preserveDrag)
                 CS.selectedButton = nil
                 wipe(CS.selectedButtons)
                 wipe(CS.selectedPanels)
+                if searchResults and ClearConfigFinderText then
+                    ClearConfigFinderText()
+                end
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "RightButton" then
                 ShowContainerContextMenu(db, charKey, containerId, container)
@@ -1492,7 +1505,7 @@ local function RefreshColumn1(preserveDrag)
         })
 
         entry:SetCallback("OnClick", function(widget, event, mouseButton)
-            if mouseButton == "LeftButton" and not IsShiftKeyDown() and not GetCursorInfo() then
+            if mouseButton == "LeftButton" and not searchResults and not IsShiftKeyDown() and not GetCursorInfo() then
                 local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
                 CS.dragState = {
                     kind = "folder",
@@ -1812,6 +1825,16 @@ local function RefreshColumn1(preserveDrag)
         elseif container.createdBy == charKey then
             table.insert(charIds, id)
         end
+    end
+
+    if searchResults and not next(searchResults.containerMatches) then
+        local label = AceGUI:Create("Label")
+        label:SetText("|cff888888No matching groups.|r")
+        label:SetFullWidth(true)
+        CS.col1Scroll:AddChild(label)
+        CS.lastCol1RenderedRows = col1RenderedRows
+        PopulateColumn1ButtonBar()
+        return
     end
 
     if showNewUserEmptyState then

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -1538,6 +1538,9 @@ local function RefreshColumn1(preserveDrag)
         entry.frame:SetScript("OnMouseUp", function(self, button)
             if CS.dragState and CS.dragState.phase == "active" then return end
             if button == "LeftButton" then
+                if searchResults then
+                    return
+                end
                 if IsShiftKeyDown() then
                     if CS.specExpandedFolderId == folderId then
                         CS.specExpandedFolderId = nil

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -1203,6 +1203,20 @@ local function RefreshColumn1(preserveDrag)
         entry.frame:SetScript("OnMouseUp", function(self, button)
             if CS.dragState and CS.dragState.phase == "active" then return end
             if button == "LeftButton" then
+                if searchResults then
+                    CooldownCompanion:ClearAllConfigPreviews()
+                    wipe(CS.selectedGroups)
+                    wipe(CS.selectedPanels)
+                    wipe(CS.selectedButtons)
+                    CS.selectedContainer = containerId
+                    CS.selectedGroup = nil
+                    CS.selectedButton = nil
+                    if ClearConfigFinderText then
+                        ClearConfigFinderText()
+                    end
+                    CooldownCompanion:RefreshConfigPanel()
+                    return
+                end
                 if IsShiftKeyDown() then
                     if CS.specExpandedGroupId == containerId then
                         CS.specExpandedGroupId = nil
@@ -1244,9 +1258,6 @@ local function RefreshColumn1(preserveDrag)
                 CS.selectedButton = nil
                 wipe(CS.selectedButtons)
                 wipe(CS.selectedPanels)
-                if searchResults and ClearConfigFinderText then
-                    ClearConfigFinderText()
-                end
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "RightButton" then
                 ShowContainerContextMenu(db, charKey, containerId, container)
@@ -1752,7 +1763,7 @@ local function RefreshColumn1(preserveDrag)
                         RenderFolderSpecPanel(item.id, section)
                     end
                     -- If expanded, render children with accent bar
-                    if not CS.collapsedFolders[item.id] then
+                    if searchResults or not CS.collapsedFolders[item.id] then
                         local children = folderChildContainers[item.id]
                         if children and #children > 0 then
                             local firstEntry, lastEntry

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -31,6 +31,9 @@ local EncodeExportData = ST._EncodeExportData
 local GroupsHaveForeignSpecs = ST._GroupsHaveForeignSpecs
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
 local NotifyTutorialAction = ST._NotifyTutorialAction
+local IsConfigFinderActive = ST._IsConfigFinderActive
+local BuildConfigFinderResults = ST._BuildConfigFinderResults
+local SelectConfigFinderResult = ST._SelectConfigFinderResult
 
 local IsTriggerPanelGroup
 
@@ -420,6 +423,97 @@ local function RenderColumn2NoPanelsState(classColor)
         panelHelp:SetFont((GameFontNormal:GetFont()), 12, "")
         panelHelp:SetColor(0.75, 0.75, 0.75)
         CS.col2Scroll:AddChild(panelHelp)
+    end
+
+    CS.col2Scroll:DoLayout()
+end
+
+local function RenderConfigFinderResults()
+    if CS.col2ButtonBar then CS.col2ButtonBar:Hide() end
+    CS.col2Scroll.frame:SetPoint("BOTTOMRIGHT", CS.col2Scroll.frame:GetParent(), "BOTTOMRIGHT", 0, 0)
+    CS.lastCol2RenderedRows = {}
+    CS.lastCol2PanelMetas = {}
+
+    local results = BuildConfigFinderResults and BuildConfigFinderResults()
+    if not results or #results.panelResults == 0 then
+        local label = AceGUI:Create("Label")
+        label:SetText("|cff888888No matching panels or entries.|r")
+        label:SetFullWidth(true)
+        CS.col2Scroll:AddChild(label)
+        return
+    end
+
+    local cc = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
+
+    for resultIndex, result in ipairs(results.panelResults) do
+        local panel = result.panel
+        local panelId = result.panelId
+        local containerId = result.containerId
+        local container = result.container
+
+        if resultIndex > 1 then
+            AddClassAccentSpacer(CS.col2Scroll, cc)
+        end
+
+        local panelContainer = AceGUI:Create("InlineGroup")
+        panelContainer:SetTitle("")
+        panelContainer:SetLayout("List")
+        panelContainer:SetFullWidth(true)
+        CompactUntitledInlineGroupConfig(panelContainer)
+        CS.col2Scroll:AddChild(panelContainer)
+
+        local panelName = panel and panel.name or ("Panel " .. tostring(panelId))
+        local groupName = container and container.name or "Group"
+        local headerText = groupName .. "  |cff666666/|r  " .. panelName
+
+        local header = AceGUI:Create("InteractiveLabel")
+        CleanRecycledEntry(header)
+        header:SetText(headerText)
+        header:SetImage("Interface\\BUTTONS\\WHITE8X8")
+        header:SetImageSize(1, 32)
+        if header.image then header.image:SetAlpha(0) end
+        header:SetFullWidth(true)
+        header:SetFontObject(GameFontHighlight)
+        header:SetJustifyH("CENTER")
+        header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+        ConfigurePanelTypeBadge(header, panel and panel.displayMode, header.label:GetStringWidth())
+        if panel and panel.enabled == false then
+            header:SetColor(0.5, 0.5, 0.5)
+        elseif result.panelMatches then
+            header:SetColor(1.0, 0.82, 0.0)
+        end
+        header:SetCallback("OnClick", function(widget, event, mouseButton)
+            if mouseButton == "LeftButton" and SelectConfigFinderResult then
+                SelectConfigFinderResult(containerId, panelId, nil)
+            end
+        end)
+        panelContainer:AddChild(header)
+
+        for _, entryInfo in ipairs(result.entryMatches or {}) do
+            local buttonData = entryInfo.button
+            local entry = AceGUI:Create("InteractiveLabel")
+            CleanRecycledEntry(entry)
+            entry:SetText(entryInfo.text or (buttonData and buttonData.name) or "Entry")
+            entry:SetImage(buttonData and GetButtonIcon(buttonData) or 134400)
+            entry:SetImageSize(32, 32)
+            entry:SetFullWidth(true)
+            entry:SetFontObject(GameFontHighlight)
+            entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+            if buttonData and buttonData.enabled == false then
+                entry:SetColor(0.5, 0.5, 0.5)
+                if entry.image and entry.image.SetDesaturated then
+                    entry.image:SetDesaturated(true)
+                end
+            end
+
+            local buttonIndex = entryInfo.index
+            entry:SetCallback("OnClick", function(widget, event, mouseButton)
+                if mouseButton == "LeftButton" and SelectConfigFinderResult then
+                    SelectConfigFinderResult(containerId, panelId, buttonIndex)
+                end
+            end)
+            panelContainer:AddChild(entry)
+        end
     end
 
     CS.col2Scroll:DoLayout()
@@ -1375,6 +1469,11 @@ local function RefreshColumn2()
             end
         end)
         CS.col2Scroll:AddChild(copyAllBtn)
+        return
+    end
+
+    if IsConfigFinderActive and IsConfigFinderActive() then
+        RenderConfigFinderResults()
         return
     end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1317,11 +1317,23 @@ local function CreateConfigPanel()
     configFinder.frame:SetParent(colParent)
     configFinder.frame:ClearAllPoints()
     configFinder.frame:SetHeight(28)
-    if configFinder.editbox and configFinder.editbox.Instructions then
-        configFinder.editbox.Instructions:SetText("Find groups, panels, entries...")
+    local configFinderPlaceholder
+    if configFinder.editbox then
+        configFinderPlaceholder = configFinder.editbox:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+        configFinderPlaceholder:SetPoint("LEFT", configFinder.editbox, "LEFT", 6, 0)
+        configFinderPlaceholder:SetPoint("RIGHT", configFinder.editbox, "RIGHT", -6, 0)
+        configFinderPlaceholder:SetJustifyH("LEFT")
+        configFinderPlaceholder:SetText("Find groups, panels, entries...")
     end
+    local function UpdateConfigFinderPlaceholder(text)
+        if not configFinderPlaceholder then return end
+        configFinderPlaceholder:SetShown((text or "") == "")
+    end
+    configFinder._cdcUpdatePlaceholder = UpdateConfigFinderPlaceholder
+    UpdateConfigFinderPlaceholder(CS.configSearchText)
     configFinder:SetCallback("OnTextChanged", function(widget, event, text)
         if CS.configFinderSuppressTextChanged then
+            UpdateConfigFinderPlaceholder(text)
             return
         end
         if SetConfigFinderText then
@@ -1329,11 +1341,20 @@ local function CreateConfigPanel()
         else
             CS.configSearchText = text or ""
         end
+        UpdateConfigFinderPlaceholder(text)
         QueueConfigFinderRefresh()
     end)
     configFinder:SetCallback("OnEnterPressed", function(widget)
         widget:ClearFocus()
     end)
+    if configFinder.editbox then
+        configFinder.editbox:HookScript("OnEditFocusGained", function(self)
+            UpdateConfigFinderPlaceholder(self:GetText())
+        end)
+        configFinder.editbox:HookScript("OnEditFocusLost", function(self)
+            UpdateConfigFinderPlaceholder(self:GetText())
+        end)
+    end
     CS.configFinderBox = configFinder
 
     -- Column 3: Button Settings
@@ -1756,7 +1777,7 @@ local function CreateConfigPanel()
             if finderAvailable then
                 CS.configFinderBox.frame:ClearAllPoints()
                 CS.configFinderBox.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", leftInset, 0)
-                CS.configFinderBox.frame:SetSize(col1Width + pad + col2Width, 28)
+                CS.configFinderBox.frame:SetSize(col1Width, 28)
                 CS.configFinderBox.frame:Show()
             else
                 CS.configFinderBox.frame:Hide()
@@ -1776,11 +1797,11 @@ local function CreateConfigPanel()
 
         col3.frame:ClearAllPoints()
         col3.frame:SetPoint("TOPLEFT", col2.frame, "TOPRIGHT", pad, 0)
-        col3.frame:SetSize(col3Width, h)
+        col3.frame:SetSize(col3Width, col12Height)
 
         col4.frame:ClearAllPoints()
         col4.frame:SetPoint("TOPLEFT", col3.frame, "TOPRIGHT", pad, 0)
-        col4.frame:SetSize(col4Width, h)
+        col4.frame:SetSize(col4Width, col12Height)
 
         PositionPrimaryAxisUI()
     end

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -281,6 +281,14 @@ local function ClearScrollState(widget)
     state.scrollvalue = nil
 end
 
+local function ResetScrollState(widget)
+    if not widget then return end
+    ClearScrollState(widget)
+    if widget.SetScroll then
+        widget:SetScroll(0)
+    end
+end
+
 local pendingOverrideConfigRefreshToken = 0
 local pendingOverrideSpellIds = {}
 local pendingConfigFinderRefreshToken = 0
@@ -298,7 +306,24 @@ local function QueueConfigFinderRefresh()
     C_Timer.After(0.1, function()
         if pendingConfigFinderRefreshToken ~= token then return end
         if not IsConfigFrameOpenForRefresh() then return end
-        CooldownCompanion:RefreshConfigPanel()
+
+        local finderActive = IsConfigFinderActive and IsConfigFinderActive()
+        local saved1 = not finderActive and SaveScrollState(CS.col1Scroll) or nil
+        local saved2 = not finderActive and SaveScrollState(CS.col2Scroll) or nil
+        if finderActive then
+            ResetScrollState(CS.col1Scroll)
+            ResetScrollState(CS.col2Scroll)
+        end
+        RefreshColumn1()
+        RefreshColumn2()
+        ApplyConfigColumnTitles(CS.configFrame)
+        if finderActive then
+            ResetScrollState(CS.col1Scroll)
+            ResetScrollState(CS.col2Scroll)
+        else
+            RestoreScrollState(CS.col1Scroll, saved1)
+            RestoreScrollState(CS.col2Scroll, saved2)
+        end
     end)
 end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -26,6 +26,10 @@ local UpdateCol2CursorPreview = ST._UpdateCol2CursorPreview
 local ClearCol2AnimatedPreview = ST._ClearCol2AnimatedPreview
 local ClearConfigShiftTooltipHover = ST._ClearConfigShiftTooltipHover
 local GetConfigEntryDisplayName = ST._GetConfigEntryDisplayName
+local IsConfigFinderAvailable = ST._IsConfigFinderAvailable
+local IsConfigFinderActive = ST._IsConfigFinderActive
+local SetConfigFinderText = ST._SetConfigFinderText
+local ClearConfigFinderText = ST._ClearConfigFinderText
 local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
 local StartFirstIconPanelTutorial = ST._StartFirstIconPanelTutorial
 local CancelFirstIconPanelTutorial = ST._CancelFirstIconPanelTutorial
@@ -231,6 +235,9 @@ local function ApplyConfigColumnTitles(frame)
     elseif CS.browseMode then
         frame.col1:SetTitle("Browse Characters")
         frame.col2:SetTitle("Preview")
+    elseif IsConfigFinderActive and IsConfigFinderActive() then
+        frame.col1:SetTitle("Groups")
+        frame.col2:SetTitle("Search Results")
     else
         frame.col1:SetTitle("Groups")
         frame.col2:SetTitle("Panels")
@@ -276,12 +283,23 @@ end
 
 local pendingOverrideConfigRefreshToken = 0
 local pendingOverrideSpellIds = {}
+local pendingConfigFinderRefreshToken = 0
 
 local function IsConfigFrameOpenForRefresh()
     return CS.configFrame
         and CS.configFrame.frame
         and CS.configFrame.frame:IsShown()
         and not CS.talentPickerMode
+end
+
+local function QueueConfigFinderRefresh()
+    pendingConfigFinderRefreshToken = pendingConfigFinderRefreshToken + 1
+    local token = pendingConfigFinderRefreshToken
+    C_Timer.After(0.1, function()
+        if pendingConfigFinderRefreshToken ~= token then return end
+        if not IsConfigFrameOpenForRefresh() then return end
+        CooldownCompanion:RefreshConfigPanel()
+    end)
 end
 
 local function IsConfigSpellOverrideRefreshMode()
@@ -416,6 +434,9 @@ local function ResetConfigForProfileChange()
     wipe(CS.collapsedPanels)
     wipe(CS.customAuraBarSubTabs)
     wipe(CS.resourceAuraOverlayDrafts)
+    if ClearConfigFinderText then
+        ClearConfigFinderText()
+    end
     SetPrimaryMode("buttons", { skipRefresh = true })
     if ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
@@ -1287,6 +1308,34 @@ local function CreateConfigPanel()
     end)
     col2._infoBtn = infoBtn
 
+    -- Config finder searches saved groups, panels, and entries without
+    -- changing the active selection while the user types.
+    local configFinder = AceGUI:Create("EditBox")
+    configFinder:SetLabel("")
+    configFinder:SetText(CS.configSearchText or "")
+    configFinder:DisableButton(true)
+    configFinder.frame:SetParent(colParent)
+    configFinder.frame:ClearAllPoints()
+    configFinder.frame:SetHeight(28)
+    if configFinder.editbox and configFinder.editbox.Instructions then
+        configFinder.editbox.Instructions:SetText("Find groups, panels, entries...")
+    end
+    configFinder:SetCallback("OnTextChanged", function(widget, event, text)
+        if CS.configFinderSuppressTextChanged then
+            return
+        end
+        if SetConfigFinderText then
+            SetConfigFinderText(text or "", { syncWidget = false })
+        else
+            CS.configSearchText = text or ""
+        end
+        QueueConfigFinderRefresh()
+    end)
+    configFinder:SetCallback("OnEnterPressed", function(widget)
+        widget:ClearFocus()
+    end)
+    CS.configFinderBox = configFinder
+
     -- Column 3: Button Settings
     local col3 = AceGUI:Create("InlineGroup")
     col3:SetTitle("Button Settings")
@@ -1672,6 +1721,12 @@ local function CreateConfigPanel()
 
         -- Talent picker mode: 2 wide columns (col1 + col3), col2/col4 hidden
         if CS.talentPickerMode then
+            if CS.configFinderBox then
+                CS.configFinderBox.frame:Hide()
+            end
+            if ClearConfigFinderText then
+                ClearConfigFinderText()
+            end
             local wideColWidth = equalColWidth * 2 + pad
             local usedWidth = (wideColWidth * 2) + pad
             local leftInset = math.floor((w - usedWidth) * 0.5)
@@ -1693,14 +1748,31 @@ local function CreateConfigPanel()
         local col2Width = equalColWidth
         local col3Width = equalColWidth
         local col4Width = equalColWidth
+        local finderAvailable = IsConfigFinderAvailable and IsConfigFinderAvailable()
+        local finderHeight = finderAvailable and 32 or 0
+        local col12Height = math.max(1, h - finderHeight)
+
+        if CS.configFinderBox then
+            if finderAvailable then
+                CS.configFinderBox.frame:ClearAllPoints()
+                CS.configFinderBox.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", leftInset, 0)
+                CS.configFinderBox.frame:SetSize(col1Width + pad + col2Width, 28)
+                CS.configFinderBox.frame:Show()
+            else
+                CS.configFinderBox.frame:Hide()
+                if ClearConfigFinderText then
+                    ClearConfigFinderText()
+                end
+            end
+        end
 
         col1.frame:ClearAllPoints()
-        col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", leftInset, 0)
-        col1.frame:SetSize(col1Width, h)
+        col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", leftInset, -finderHeight)
+        col1.frame:SetSize(col1Width, col12Height)
 
         col2.frame:ClearAllPoints()
         col2.frame:SetPoint("TOPLEFT", col1.frame, "TOPRIGHT", pad, 0)
-        col2.frame:SetSize(col2Width, h)
+        col2.frame:SetSize(col2Width, col12Height)
 
         col3.frame:ClearAllPoints()
         col3.frame:SetPoint("TOPLEFT", col2.frame, "TOPRIGHT", pad, 0)
@@ -1760,6 +1832,11 @@ function CooldownCompanion:RefreshConfigPanel()
     if not CS.configFrame then return end
     if not CS.configFrame.frame:IsShown() then return end
     if CS.talentPickerMode then return end
+    if IsConfigFinderAvailable and not IsConfigFinderAvailable() and ClearConfigFinderText then
+        ClearConfigFinderText()
+    elseif SetConfigFinderText then
+        SetConfigFinderText(CS.configSearchText or "")
+    end
     if ClearConfigShiftTooltipHover then
         ClearConfigShiftTooltipHover()
     end
@@ -1824,6 +1901,9 @@ function CooldownCompanion:RefreshConfigPanel()
     end
     if CS.configFrame.UpdateBrowseButtonState then
         CS.configFrame.UpdateBrowseButtonState()
+    end
+    if CS.configFrame.LayoutColumns then
+        CS.configFrame.LayoutColumns()
     end
     RefreshColumn1()
     RefreshColumn2()

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -203,6 +203,11 @@ ST._configState = {
     autocompleteCache = nil,
     pendingEditBoxFocus = false,
 
+    -- Config finder state
+    configSearchText = "",
+    configFinderBox = nil,
+    configFinderSuppressTextChanged = false,
+
     -- Spec filter inline expansion
     specExpandedGroupId = nil,
     specExpandedFolderId = nil,
@@ -380,6 +385,156 @@ local function GetConfigEntryDisplayName(buttonData, opts)
     end
 
     return entryName
+end
+
+local function NormalizeConfigFinderText(text)
+    if type(text) ~= "string" then
+        return ""
+    end
+    text = text:gsub("|c%x%x%x%x%x%x%x%x", "")
+        :gsub("|r", "")
+        :gsub("|A:.-|a", "")
+        :gsub("^%s*(.-)%s*$", "%1")
+    return strlower(text)
+end
+
+local function ConfigFinderTextMatches(value, query)
+    if not query or query == "" then
+        return false
+    end
+    return NormalizeConfigFinderText(value):find(query, 1, true) ~= nil
+end
+
+local function IsConfigFinderAvailable()
+    return not CS.resourceBarPanelActive
+        and not CS.browseMode
+        and not CS.talentPickerMode
+        and not CooldownCompanion._unsupportedLegacyProfile
+end
+
+local function IsConfigFinderActive()
+    return IsConfigFinderAvailable() and NormalizeConfigFinderText(CS.configSearchText) ~= ""
+end
+
+local function SetConfigFinderText(text, opts)
+    text = type(text) == "string" and text or ""
+    CS.configSearchText = text
+
+    if opts and opts.syncWidget == false then
+        return
+    end
+
+    local searchBox = CS.configFinderBox
+    if searchBox and searchBox.GetText and searchBox:GetText() ~= text then
+        CS.configFinderSuppressTextChanged = true
+        searchBox:SetText(text)
+        CS.configFinderSuppressTextChanged = false
+    end
+end
+
+local function ClearConfigFinderText(opts)
+    SetConfigFinderText("", opts)
+end
+
+local function IsContainerVisibleInConfig(container, charKey)
+    if not container then
+        return false
+    end
+    return container.isGlobal or container.createdBy == charKey
+end
+
+local function BuildConfigFinderResults()
+    if not IsConfigFinderActive() then
+        return nil
+    end
+
+    local query = NormalizeConfigFinderText(CS.configSearchText)
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not db then
+        return nil
+    end
+
+    local charKey = CooldownCompanion.db.keys.char
+    local results = {
+        query = query,
+        containerMatches = {},
+        panelResults = {},
+        totalPanelResults = 0,
+        totalEntryResults = 0,
+    }
+
+    local function markContainer(containerId)
+        if containerId then
+            results.containerMatches[containerId] = true
+        end
+    end
+
+    for containerId, container in pairs(db.groupContainers or {}) do
+        if IsContainerVisibleInConfig(container, charKey) and ConfigFinderTextMatches(container.name, query) then
+            markContainer(containerId)
+        end
+    end
+
+    for panelId, panel in pairs(db.groups or {}) do
+        local containerId = panel.parentContainerId
+        local container = containerId and db.groupContainers and db.groupContainers[containerId]
+        if IsContainerVisibleInConfig(container, charKey) then
+            local panelMatches = ConfigFinderTextMatches(panel.name, query)
+            local entryMatches = {}
+
+            for buttonIndex, buttonData in ipairs(panel.buttons or {}) do
+                local entryName = GetConfigEntryDisplayName(buttonData, { includeDecorations = true })
+                    or buttonData.name
+                    or ("Unknown " .. tostring(buttonData.type))
+                local idText = buttonData.id and tostring(buttonData.id) or nil
+                if ConfigFinderTextMatches(entryName, query) or ConfigFinderTextMatches(idText, query) then
+                    entryMatches[#entryMatches + 1] = {
+                        index = buttonIndex,
+                        button = buttonData,
+                        text = entryName,
+                    }
+                end
+            end
+
+            if panelMatches or #entryMatches > 0 then
+                markContainer(containerId)
+                results.totalPanelResults = results.totalPanelResults + 1
+                results.totalEntryResults = results.totalEntryResults + #entryMatches
+                results.panelResults[#results.panelResults + 1] = {
+                    containerId = containerId,
+                    container = container,
+                    panelId = panelId,
+                    panel = panel,
+                    panelMatches = panelMatches,
+                    entryMatches = entryMatches,
+                }
+            end
+        end
+    end
+
+    table.sort(results.panelResults, function(a, b)
+        local orderA = a.container and CooldownCompanion:GetOrderForSpec(a.container, CooldownCompanion._currentSpecId, a.containerId) or 0
+        local orderB = b.container and CooldownCompanion:GetOrderForSpec(b.container, CooldownCompanion._currentSpecId, b.containerId) or 0
+        if orderA ~= orderB then
+            return orderA < orderB
+        end
+        return (a.panel and a.panel.order or 0) < (b.panel and b.panel.order or 0)
+    end)
+
+    return results
+end
+
+local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
+    CooldownCompanion:ClearAllConfigPreviews()
+    wipe(CS.selectedGroups)
+    wipe(CS.selectedPanels)
+    wipe(CS.selectedButtons)
+    CS.selectedContainer = containerId
+    CS.selectedGroup = panelId
+    CS.selectedButton = buttonIndex
+    CS.addingToPanelId = nil
+    ClearConfigFinderText()
+    CooldownCompanion:RefreshConfigPanel()
 end
 
 ------------------------------------------------------------------------
@@ -1790,6 +1945,13 @@ ST._ClearCol2PreviewHost = ClearCol2PreviewHost
 ST._EmbedWidget = EmbedWidget
 ST._GetButtonIcon = GetButtonIcon
 ST._GetConfigEntryDisplayName = GetConfigEntryDisplayName
+ST._NormalizeConfigFinderText = NormalizeConfigFinderText
+ST._IsConfigFinderAvailable = IsConfigFinderAvailable
+ST._IsConfigFinderActive = IsConfigFinderActive
+ST._SetConfigFinderText = SetConfigFinderText
+ST._ClearConfigFinderText = ClearConfigFinderText
+ST._BuildConfigFinderResults = BuildConfigFinderResults
+ST._SelectConfigFinderResult = SelectConfigFinderResult
 ST._GetGroupIcon = GetGroupIcon
 ST._GetContainerIcon = GetContainerIcon
 ST._GetFolderIcon = GetFolderIcon

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -430,6 +430,9 @@ local function SetConfigFinderText(text, opts)
         searchBox:SetText(text)
         CS.configFinderSuppressTextChanged = false
     end
+    if searchBox and searchBox._cdcUpdatePlaceholder then
+        searchBox._cdcUpdatePlaceholder(text)
+    end
 end
 
 local function ClearConfigFinderText(opts)


### PR DESCRIPTION
## What Players Will Notice
- The addon config now has a finder above the group column for quickly locating saved groups, panels, and entries.
- Typing narrows Column 1 to the groups where matches exist and shows matching panels or entries in Column 2.
- Clicking a search result jumps to the matching group, panel, or entry, then restores the normal config view.

## Why This Changed
- Larger setups can be hard to navigate when entries are spread across many groups and panels.
- The finder gives players a faster way to answer “where did I put this?” without manually expanding folders and scanning every panel.

## What Changed
- Added shared finder state and matching logic for group names, panel names, entry display names, and entry IDs.
- Added a compact search box above Column 1, with placeholder handling that stays visible after search result clicks.
- Added Column 1 and Column 2 search result rendering, including temporary expansion of matching folder contents without changing saved folder collapse state.
- Kept typing refreshes narrow so the search box cursor is not disturbed, and reset filtered result scroll positions so stale scroll offsets do not hide matches.

## Validation
- Ran `luac -p Config/State.lua Config/Panel.lua Config/Column1.lua Config/Column2.lua`.
- Ran `git diff --check`.
- Ran review/fix passes for search result selection, collapsed-folder behavior, stale finder scroll, and folder-click behavior during search.
- In-game validation is still needed for typing feel, result clicks, folder behavior while filtered, and combat/restricted-content safety.