### PR TITLE
Flag default group and panel names in config

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -51,6 +51,70 @@ local function ClearSelection()
     wipe(CS.selectedPanels)
 end
 
+local function TrimGroupName(name)
+    if name == nil then return "" end
+    return tostring(name):match("^%s*(.-)%s*$") or ""
+end
+
+local function IsGenericGroupName(name)
+    local trimmed = TrimGroupName(name)
+    return trimmed == ""
+        or trimmed == "New Group"
+        or trimmed:match("^New Group%s+%d+$") ~= nil
+        or trimmed == "Group"
+        or trimmed:match("^Group%s+%d+$") ~= nil
+end
+
+local function EnsureGenericGroupRenameBadge(entry)
+    local badge = entry.frame._cdcGenericRenameBadge
+    if not badge then
+        badge = CreateFrame("Button", nil, entry.frame)
+        badge:SetSize(14, 14)
+        badge:SetPropagateMouseClicks(false)
+        badge:SetPropagateMouseMotion(false)
+        badge.icon = badge:CreateTexture(nil, "OVERLAY")
+        badge.icon:SetAllPoints()
+        badge:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:AddLine("Default name. Click to rename.", 1, 0.82, 0, true)
+            GameTooltip:Show()
+        end)
+        badge:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+        end)
+        entry.frame._cdcGenericRenameBadge = badge
+    end
+
+    badge:SetFrameLevel(entry.frame:GetFrameLevel() + 25)
+    return badge
+end
+
+local function ConfigureGenericGroupRenameBadge(entry, container, containerId, nameWidth)
+    local badge = EnsureGenericGroupRenameBadge(entry)
+    badge:ClearAllPoints()
+    badge:SetScript("OnClick", nil)
+
+    if not IsGenericGroupName(container and container.name) then
+        badge:Hide()
+        return
+    end
+
+    local currentName = TrimGroupName(container and container.name)
+    if currentName == "" then
+        currentName = "New Group"
+    end
+
+    badge.icon:SetAtlas("QuestLegendary", false)
+    badge.icon:SetVertexColor(1, 0.82, 0, 0.85)
+    badge:SetPoint("CENTER", entry.label, "LEFT", nameWidth + 13, 0)
+    badge:SetScript("OnClick", function(_, button)
+        if button ~= "LeftButton" then return end
+        GameTooltip:Hide()
+        ShowPopupAboveConfig("CDC_RENAME_GROUP", currentName, { containerId = containerId })
+    end)
+    badge:Show()
+end
+
 ------------------------------------------------------------------------
 -- Browse mode: class-colored name helper
 ------------------------------------------------------------------------
@@ -1134,7 +1198,12 @@ local function RefreshColumn1(preserveDrag)
 
         -- Show panel count in name when >1 panel
         local panelCount = CooldownCompanion:GetPanelCount(containerId)
-        local displayName = container.name
+        local groupName = container.name or "New Group"
+        local showGenericRenameBadge = IsGenericGroupName(groupName)
+        local displayName = groupName
+        if showGenericRenameBadge then
+            displayName = displayName .. "  |A:QuestLegendary:12:12|a"
+        end
         if panelCount > 1 then
             displayName = displayName .. "  |cff888888(" .. panelCount .. " panels)|r"
         end
@@ -1154,6 +1223,12 @@ local function RefreshColumn1(preserveDrag)
         end
         entry:SetFullWidth(true)
         entry:SetFontObject(GameFontHighlight)
+        local groupNameWidth = 0
+        if showGenericRenameBadge and entry.label then
+            entry.label:SetText(groupName)
+            groupNameWidth = entry.label:GetStringWidth()
+            entry:SetText(displayName)
+        end
         entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
 
         -- Color: blue for multi-selected, green for selected, gray for inactive
@@ -1171,6 +1246,9 @@ local function RefreshColumn1(preserveDrag)
         if entry._cdcModeBadge then entry._cdcModeBadge:Hide() end
 
         SetupGroupRowIndicators(entry, container)
+        if showGenericRenameBadge then
+            ConfigureGenericGroupRenameBadge(entry, container, containerId, groupNameWidth)
+        end
 
         entry:SetCallback("OnClick", function(widget, event, mouseButton)
             if mouseButton == "LeftButton"

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -1202,7 +1202,7 @@ local function RefreshColumn1(preserveDrag)
         local showGenericRenameBadge = IsGenericGroupName(groupName)
         local displayName = groupName
         if showGenericRenameBadge then
-            displayName = displayName .. "  |A:QuestLegendary:12:12|a"
+            displayName = displayName .. "      "
         end
         if panelCount > 1 then
             displayName = displayName .. "  |cff888888(" .. panelCount .. " panels)|r"

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -124,6 +124,68 @@ local function EnsurePanelTypeTooltipTarget(header)
     return target
 end
 
+local function TrimPanelName(name)
+    if name == nil then return "" end
+    return tostring(name):match("^%s*(.-)%s*$") or ""
+end
+
+local function IsGenericPanelName(name)
+    local trimmed = TrimPanelName(name)
+    return trimmed == "" or trimmed == "Panel" or trimmed:match("^Panel%s+%d+$") ~= nil
+end
+
+local function EnsureGenericRenameBadge(header)
+    local badge = header.frame._cdcGenericRenameBadge
+    if not badge then
+        badge = CreateFrame("Button", nil, header.frame)
+        badge:SetSize(14, 14)
+        badge:SetPropagateMouseClicks(false)
+        badge:SetPropagateMouseMotion(false)
+        badge.icon = badge:CreateTexture(nil, "OVERLAY")
+        badge.icon:SetAllPoints()
+        badge:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:AddLine("Default name. Click to rename.", 1, 0.82, 0, true)
+            GameTooltip:Show()
+        end)
+        badge:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+        end)
+        header.frame._cdcGenericRenameBadge = badge
+    end
+
+    badge:SetFrameLevel(header.frame:GetFrameLevel() + 25)
+    return badge
+end
+
+local function ConfigureGenericRenameBadge(header, panel, panelId, rightOffset)
+    local badge = EnsureGenericRenameBadge(header)
+    badge:ClearAllPoints()
+    badge:SetScript("OnClick", nil)
+
+    if not IsGenericPanelName(panel and panel.name) then
+        badge:Hide()
+        return rightOffset
+    end
+
+    local currentName = TrimPanelName(panel and panel.name)
+    if currentName == "" then
+        currentName = "Panel " .. tostring(panelId)
+    end
+
+    badge.icon:SetAtlas("QuestLegendary", false)
+    badge.icon:SetVertexColor(1, 0.82, 0, 0.85)
+    badge:SetPoint("LEFT", header.label, "CENTER", rightOffset, 0)
+    badge:SetScript("OnClick", function(_, button)
+        if button ~= "LeftButton" then return end
+        GameTooltip:Hide()
+        ShowPopupAboveConfig("CDC_RENAME_GROUP", currentName, { groupId = panelId })
+    end)
+    badge:Show()
+
+    return rightOffset + 18
+end
+
 local function ConfigurePanelTypeBadge(header, displayMode, textWidth)
     local modeBadge = header._cdcModeBadge
     if not modeBadge then
@@ -1816,6 +1878,9 @@ local function RefreshColumn2()
                 ConfigurePanelTypeBadge(header, panel.displayMode, textW)
                 header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
 
+                local rightOffset = (textW / 2) + 4
+                rightOffset = ConfigureGenericRenameBadge(header, panel, panelId, rightOffset)
+
                 -- Anchor unlock badge (shown when panel is individually unlocked)
                 local anchorBadge = header.frame._cdcAnchorBadge
                 if not anchorBadge then
@@ -1824,10 +1889,11 @@ local function RefreshColumn2()
                 end
                 anchorBadge:SetSize(16, 16)
                 anchorBadge:ClearAllPoints()
-                anchorBadge:SetPoint("LEFT", header.label, "CENTER", (textW / 2) + 4, 0)
+                anchorBadge:SetPoint("LEFT", header.label, "CENTER", rightOffset, 0)
                 if panel.locked == false then
                     anchorBadge:SetAtlas("ShipMissionIcon-Training-Map", false)
                     anchorBadge:Show()
+                    rightOffset = rightOffset + 22
                 else
                     anchorBadge:Hide()
                 end
@@ -1840,11 +1906,11 @@ local function RefreshColumn2()
                 end
                 disabledBadge:SetSize(16, 16)
                 disabledBadge:ClearAllPoints()
-                local disabledOffset = (panel.locked == false) and 22 or 0
-                disabledBadge:SetPoint("LEFT", header.label, "CENTER", (textW / 2) + 4 + disabledOffset, 0)
+                disabledBadge:SetPoint("LEFT", header.label, "CENTER", rightOffset, 0)
                 if panel.enabled == false then
                     disabledBadge:SetAtlas("GM-icon-visibleDis-pressed", false)
                     disabledBadge:Show()
+                    rightOffset = rightOffset + 22
                 else
                     disabledBadge:Hide()
                 end
@@ -1873,9 +1939,6 @@ local function RefreshColumn2()
                 end
 
                 local specBadgeIdx = 0
-                local rightOffset = (textW / 2) + 4
-                if panel.locked == false then rightOffset = rightOffset + 22 end
-                if panel.enabled == false then rightOffset = rightOffset + 22 end
 
                 if panel.specs then
                     for specId in pairs(panel.specs) do

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1105,6 +1105,7 @@ local function CleanRecycledEntry(entry)
     if entry.frame._cdcCollapseIcon then entry.frame._cdcCollapseIcon:Hide() end
     if entry.frame._cdcCollapseBtn then entry.frame._cdcCollapseBtn:Hide() end
     if entry.frame._cdcAddBtn then entry.frame._cdcAddBtn:Hide() end
+    if entry.frame._cdcGenericRenameBadge then entry.frame._cdcGenericRenameBadge:Hide() end
     if entry.frame._cdcAnchorBadge then entry.frame._cdcAnchorBadge:Hide() end
     if entry.frame._cdcHeaderDisabledBadge then entry.frame._cdcHeaderDisabledBadge:Hide() end
     if entry.frame._cdcDisabledBadge then entry.frame._cdcDisabledBadge:Hide() end


### PR DESCRIPTION
## What Players Will Notice
- Default group and panel names now show a small rename badge in the config UI.
- Clicking the badge opens the existing rename popup, making it easier to clean up generic names without changing anything automatically.

## Why This Changed
- Generic names like New Group, Panel, or Panel 1 are easy to leave behind while building a setup.
- The badge acts as a quiet cleanup signal instead of adding another settings panel or automatic naming behavior.

## What Changed
- Added rename badges beside generic group names in Column 1 and generic panel names in Column 2.
- Reused the existing rename popup for both groups and panels.
- Added pooled-widget cleanup so recycled config rows do not keep stale rename badges.

## Validation
- Ran luac -p Config\Column1.lua.
- Ran luac -p Config\Column2.lua.
- Ran luac -p Config\State.lua.
- Ran git diff --check.
- Ran a focused code review after the Column 1 click-target fix; no findings remained.
- In-game visual, click-target, combat, and restricted-content testing still need to be verified.