### PR TITLE
Add direct panel style copying

### DIFF
--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -2187,6 +2187,26 @@ local function RefreshColumn2()
                             end
                             UIDropDownMenu_AddButton(info, level)
 
+                            local copyStyleMode
+                            if ctxPanel.displayMode == "bars" then
+                                copyStyleMode = "bars"
+                            elseif ctxPanel.displayMode == nil or ctxPanel.displayMode == "icons" then
+                                copyStyleMode = "icons"
+                            end
+                            if copyStyleMode then
+                                local _, copyPanelOrder = CooldownCompanion:GetDirectStyleCopyPanelList(copyStyleMode, ctxPanelId)
+                                info = UIDropDownMenu_CreateInfo()
+                                info.text = "Copy Style From"
+                                info.notCheckable = true
+                                if #copyPanelOrder > 0 then
+                                    info.hasArrow = true
+                                    info.menuList = "COPY_STYLE_FROM_PANEL"
+                                else
+                                    info.disabled = true
+                                end
+                                UIDropDownMenu_AddButton(info, level)
+                            end
+
                             -- Export single panel
                             info = UIDropDownMenu_CreateInfo()
                             info.text = "Export"
@@ -2234,6 +2254,38 @@ local function RefreshColumn2()
                                 ShowPopupAboveConfig("CDC_DELETE_PANEL", ctxPanel.name or "Panel", { containerId = ctxContainerId, panelId = ctxPanelId })
                             end
                             UIDropDownMenu_AddButton(info, level)
+
+                        elseif menuList == "COPY_STYLE_FROM_PANEL" then
+                            local copyStyleMode
+                            if ctxPanel.displayMode == "bars" then
+                                copyStyleMode = "bars"
+                            elseif ctxPanel.displayMode == nil or ctxPanel.displayMode == "icons" then
+                                copyStyleMode = "icons"
+                            end
+                            local copyPanelList, copyPanelOrder = CooldownCompanion:GetDirectStyleCopyPanelList(copyStyleMode, ctxPanelId)
+                            if #copyPanelOrder == 0 then
+                                local emptyInfo = UIDropDownMenu_CreateInfo()
+                                emptyInfo.text = "No same-type panels available"
+                                emptyInfo.notCheckable = true
+                                emptyInfo.disabled = true
+                                UIDropDownMenu_AddButton(emptyInfo, level)
+                            else
+                                for _, sourceGroupId in ipairs(copyPanelOrder) do
+                                    local sourceName = copyPanelList[sourceGroupId] or ("Panel " .. tostring(sourceGroupId))
+                                    local copyInfo = UIDropDownMenu_CreateInfo()
+                                    copyInfo.text = sourceName
+                                    copyInfo.notCheckable = true
+                                    copyInfo.func = function()
+                                        CloseDropDownMenus()
+                                        ShowPopupAboveConfig("CDC_CONFIRM_PANEL_STYLE_COPY", sourceName, {
+                                            mode = copyStyleMode,
+                                            sourceGroupId = sourceGroupId,
+                                            targetGroupId = ctxPanelId,
+                                        })
+                                    end
+                                    UIDropDownMenu_AddButton(copyInfo, level)
+                                end
+                            end
 
                         elseif menuList == "MOVE_TO_GROUP" then
                             local db = CooldownCompanion.db.profile

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -2207,6 +2207,24 @@ local function RefreshColumn2()
                                 UIDropDownMenu_AddButton(info, level)
                             end
 
+                            -- "Move to Group" submenu (only when other visible containers exist)
+                            local db = CooldownCompanion.db.profile
+                            local hasOtherContainer = false
+                            for cid, _ in pairs(db.groupContainers) do
+                                if cid ~= ctxContainerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                                    hasOtherContainer = true
+                                    break
+                                end
+                            end
+                            if hasOtherContainer then
+                                info = UIDropDownMenu_CreateInfo()
+                                info.text = "Move to Group"
+                                info.notCheckable = true
+                                info.hasArrow = true
+                                info.menuList = "MOVE_TO_GROUP"
+                                UIDropDownMenu_AddButton(info, level)
+                            end
+
                             -- Export single panel
                             info = UIDropDownMenu_CreateInfo()
                             info.text = "Export"
@@ -2227,24 +2245,6 @@ local function RefreshColumn2()
                                 ShowPopupAboveConfig("CDC_EXPORT_GROUP", nil, { exportString = exportString })
                             end
                             UIDropDownMenu_AddButton(info, level)
-
-                            -- "Move to Group" submenu (only when other visible containers exist)
-                            local db = CooldownCompanion.db.profile
-                            local hasOtherContainer = false
-                            for cid, _ in pairs(db.groupContainers) do
-                                if cid ~= ctxContainerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
-                                    hasOtherContainer = true
-                                    break
-                                end
-                            end
-                            if hasOtherContainer then
-                                info = UIDropDownMenu_CreateInfo()
-                                info.text = "Move to Group"
-                                info.notCheckable = true
-                                info.hasArrow = true
-                                info.menuList = "MOVE_TO_GROUP"
-                                UIDropDownMenu_AddButton(info, level)
-                            end
 
                             info = UIDropDownMenu_CreateInfo()
                             info.text = "|cffff4444Delete|r"

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -1331,7 +1331,7 @@ StaticPopupDialogs["CDC_DELETE_GROUP_SETTINGS_PRESET"] = {
 }
 
 StaticPopupDialogs["CDC_CONFIRM_PANEL_STYLE_COPY"] = {
-    text = "Copy visual settings from '%s' to this panel? This replaces the current panel's style settings.",
+    text = "Copy style from '%s' to this panel?\n\nThis copies Appearance, Indicators, and layout style. Positioning, Load Conditions, and panel contents stay unchanged.",
     button1 = "Copy",
     button2 = "Cancel",
     OnAccept = function(self, data)

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -1330,6 +1330,30 @@ StaticPopupDialogs["CDC_DELETE_GROUP_SETTINGS_PRESET"] = {
     preferredIndex = 3,
 }
 
+StaticPopupDialogs["CDC_CONFIRM_PANEL_STYLE_COPY"] = {
+    text = "Copy visual settings from '%s' to this panel? This replaces the current panel's style settings.",
+    button1 = "Copy",
+    button2 = "Cancel",
+    OnAccept = function(self, data)
+        if not (data and data.mode and data.sourceGroupId and data.targetGroupId) then
+            CooldownCompanion:Print("Style copy failed: missing context.")
+            return
+        end
+
+        local ok = CooldownCompanion:CopyDirectStyleFromPanel(data.mode, data.sourceGroupId, data.targetGroupId)
+        if not ok then
+            CooldownCompanion:Print("Style copy failed.")
+            return
+        end
+
+        CooldownCompanion:RefreshConfigPanel()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
 StaticPopupDialogs["CDC_CONFIRM_CHARACTER_SCOPED_COPY"] = {
     text = "Copy selected %s settings from the chosen character to this character?",
     button1 = "Copy",

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -604,12 +604,8 @@ local function BuildGroupSettingPresetControls(container, group, mode, tabInfoBu
     end
 
     local presetList, presetOrder = CooldownCompanion:GetGroupSettingPresetList(mode)
-    local copyPanelList, copyPanelOrder = CooldownCompanion:GetDirectStyleCopyPanelList(mode, CS.selectedGroup)
     if not CS.groupPresetSelection then
         CS.groupPresetSelection = { icons = nil, bars = nil }
-    end
-    if not CS.groupStyleCopySelection then
-        CS.groupStyleCopySelection = { icons = nil, bars = nil }
     end
 
     local selectedPreset = CS.groupPresetSelection[mode]
@@ -617,30 +613,25 @@ local function BuildGroupSettingPresetControls(container, group, mode, tabInfoBu
         selectedPreset = nil
         CS.groupPresetSelection[mode] = nil
     end
-    local selectedCopyPanel = CS.groupStyleCopySelection[mode]
-    if selectedCopyPanel and not copyPanelList[selectedCopyPanel] then
-        selectedCopyPanel = nil
-        CS.groupStyleCopySelection[mode] = nil
-    end
 
     local heading = AceGUI:Create("Heading")
-    heading:SetText(mode == "bars" and "Bar Panel Style" or "Icon Panel Style")
+    heading:SetText(mode == "bars" and "Bar Panel Preset" or "Icon Panel Preset")
     ColorHeading(heading)
     heading:SetFullWidth(true)
     container:AddChild(heading)
 
-    local presetModeLabel = mode == "bars" and "Bar Panel Style" or "Icon Panel Style"
+    local presetModeLabel = mode == "bars" and "Bar Panel Presets" or "Icon Panel Presets"
     local modeSpecificLine = mode == "bars"
-        and "Copy and presets only work on bar panels."
-        or "Copy and presets only work on icon panels."
+        and "Bar presets only work on bar panels."
+        or "Icon presets only work on icon panels."
     local headingInfoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, {
         presetModeLabel,
-        {"Copy From Panel applies another same-type panel's visual settings directly.", 1, 1, 1},
-        " ",
         {"Click Save to store this panel's settings as a preset.", 1, 1, 1},
         " ",
-        {"Copy and presets include appearance, indicator, and text settings.", 1, 1, 1},
-        {"They do not change entries, load rules, anchors, or placement.", 1, 1, 1},
+        {"Presets save appearance, indicator, and text settings.", 1, 1, 1},
+        {"Load Conditions (including Spec/Hero filters) are not saved or changed.", 1, 1, 1},
+        {"Presets do not include Columns 1, 2, or 3.", 1, 1, 1},
+        {"Anchors are not saved or changed.", 1, 1, 1},
         " ",
         {"Apply resets preset settings first, then applies the preset.", 1, 1, 1},
         " ",
@@ -741,52 +732,6 @@ local function BuildGroupSettingPresetControls(container, group, mode, tabInfoBu
     -- compute scroll height correctly on first render.
     container:AddChild(buttonRow)
 
-    local copyDrop = AceGUI:Create("Dropdown")
-    copyDrop:SetLabel("Copy From Panel")
-    copyDrop:SetList(copyPanelList, copyPanelOrder)
-    copyDrop:SetValue(selectedCopyPanel)
-    copyDrop:SetFullWidth(true)
-    local copyBtn
-    copyDrop:SetCallback("OnValueChanged", function(widget, event, value)
-        CS.groupStyleCopySelection[mode] = value
-        if copyBtn then
-            copyBtn:SetDisabled(value == nil)
-        end
-    end)
-    container:AddChild(copyDrop)
-
-    if #copyPanelOrder == 0 then
-        local copyHint = AceGUI:Create("Label")
-        copyHint:SetText("|cff888888No other " .. (mode == "bars" and "bar" or "icon") .. " panels available to copy from.|r")
-        copyHint:SetFullWidth(true)
-        container:AddChild(copyHint)
-    end
-
-    local copyButtonRow = AceGUI:Create("SimpleGroup")
-    copyButtonRow:SetFullWidth(true)
-    copyButtonRow:SetLayout("Flow")
-
-    copyBtn = AceGUI:Create("Button")
-    copyBtn:SetText("Copy Style")
-    copyBtn:SetRelativeWidth(1)
-    copyBtn:SetDisabled(selectedCopyPanel == nil)
-    copyBtn:SetCallback("OnClick", function()
-        local sourceGroupId = CS.groupStyleCopySelection and CS.groupStyleCopySelection[mode]
-        if not sourceGroupId then return end
-        if not ShowPopupAboveConfig then
-            CooldownCompanion:Print("Style copy confirmation is unavailable.")
-            return
-        end
-
-        local sourceName = copyPanelList[sourceGroupId] or "the selected panel"
-        ShowPopupAboveConfig("CDC_CONFIRM_PANEL_STYLE_COPY", sourceName, {
-            mode = mode,
-            sourceGroupId = sourceGroupId,
-            targetGroupId = CS.selectedGroup,
-        })
-    end)
-    copyButtonRow:AddChild(copyBtn)
-    container:AddChild(copyButtonRow)
 end
 
 local charCopyButtons = {}

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -604,8 +604,12 @@ local function BuildGroupSettingPresetControls(container, group, mode, tabInfoBu
     end
 
     local presetList, presetOrder = CooldownCompanion:GetGroupSettingPresetList(mode)
+    local copyPanelList, copyPanelOrder = CooldownCompanion:GetDirectStyleCopyPanelList(mode, CS.selectedGroup)
     if not CS.groupPresetSelection then
         CS.groupPresetSelection = { icons = nil, bars = nil }
+    end
+    if not CS.groupStyleCopySelection then
+        CS.groupStyleCopySelection = { icons = nil, bars = nil }
     end
 
     local selectedPreset = CS.groupPresetSelection[mode]
@@ -613,25 +617,30 @@ local function BuildGroupSettingPresetControls(container, group, mode, tabInfoBu
         selectedPreset = nil
         CS.groupPresetSelection[mode] = nil
     end
+    local selectedCopyPanel = CS.groupStyleCopySelection[mode]
+    if selectedCopyPanel and not copyPanelList[selectedCopyPanel] then
+        selectedCopyPanel = nil
+        CS.groupStyleCopySelection[mode] = nil
+    end
 
     local heading = AceGUI:Create("Heading")
-    heading:SetText(mode == "bars" and "Bar Panel Preset" or "Icon Panel Preset")
+    heading:SetText(mode == "bars" and "Bar Panel Style" or "Icon Panel Style")
     ColorHeading(heading)
     heading:SetFullWidth(true)
     container:AddChild(heading)
 
-    local presetModeLabel = mode == "bars" and "Bar Panel Presets" or "Icon Panel Presets"
+    local presetModeLabel = mode == "bars" and "Bar Panel Style" or "Icon Panel Style"
     local modeSpecificLine = mode == "bars"
-        and "Bar presets only work on bar panels."
-        or "Icon presets only work on icon panels."
+        and "Copy and presets only work on bar panels."
+        or "Copy and presets only work on icon panels."
     local headingInfoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, {
         presetModeLabel,
+        {"Copy From Panel applies another same-type panel's visual settings directly.", 1, 1, 1},
+        " ",
         {"Click Save to store this panel's settings as a preset.", 1, 1, 1},
         " ",
-        {"Presets save appearance, indicator, and text settings.", 1, 1, 1},
-        {"Load Conditions (including Spec/Hero filters) are not saved or changed.", 1, 1, 1},
-        {"Presets do not include Columns 1, 2, or 3.", 1, 1, 1},
-        {"Anchors are not saved or changed.", 1, 1, 1},
+        {"Copy and presets include appearance, indicator, and text settings.", 1, 1, 1},
+        {"They do not change entries, load rules, anchors, or placement.", 1, 1, 1},
         " ",
         {"Apply resets preset settings first, then applies the preset.", 1, 1, 1},
         " ",
@@ -731,6 +740,53 @@ local function BuildGroupSettingPresetControls(container, group, mode, tabInfoBu
     -- Add the row after children are populated so List-layout parent containers
     -- compute scroll height correctly on first render.
     container:AddChild(buttonRow)
+
+    local copyDrop = AceGUI:Create("Dropdown")
+    copyDrop:SetLabel("Copy From Panel")
+    copyDrop:SetList(copyPanelList, copyPanelOrder)
+    copyDrop:SetValue(selectedCopyPanel)
+    copyDrop:SetFullWidth(true)
+    local copyBtn
+    copyDrop:SetCallback("OnValueChanged", function(widget, event, value)
+        CS.groupStyleCopySelection[mode] = value
+        if copyBtn then
+            copyBtn:SetDisabled(value == nil)
+        end
+    end)
+    container:AddChild(copyDrop)
+
+    if #copyPanelOrder == 0 then
+        local copyHint = AceGUI:Create("Label")
+        copyHint:SetText("|cff888888No other " .. (mode == "bars" and "bar" or "icon") .. " panels available to copy from.|r")
+        copyHint:SetFullWidth(true)
+        container:AddChild(copyHint)
+    end
+
+    local copyButtonRow = AceGUI:Create("SimpleGroup")
+    copyButtonRow:SetFullWidth(true)
+    copyButtonRow:SetLayout("Flow")
+
+    copyBtn = AceGUI:Create("Button")
+    copyBtn:SetText("Copy Style")
+    copyBtn:SetRelativeWidth(1)
+    copyBtn:SetDisabled(selectedCopyPanel == nil)
+    copyBtn:SetCallback("OnClick", function()
+        local sourceGroupId = CS.groupStyleCopySelection and CS.groupStyleCopySelection[mode]
+        if not sourceGroupId then return end
+        if not ShowPopupAboveConfig then
+            CooldownCompanion:Print("Style copy confirmation is unavailable.")
+            return
+        end
+
+        local sourceName = copyPanelList[sourceGroupId] or "the selected panel"
+        ShowPopupAboveConfig("CDC_CONFIRM_PANEL_STYLE_COPY", sourceName, {
+            mode = mode,
+            sourceGroupId = sourceGroupId,
+            targetGroupId = CS.selectedGroup,
+        })
+    end)
+    copyButtonRow:AddChild(copyBtn)
+    container:AddChild(copyButtonRow)
 end
 
 local charCopyButtons = {}

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1222,9 +1222,21 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
 
         self:AnchorGroupFrame(frame, group.anchor)
 
-        -- Recreate Masque group if it was deleted during unload
-        if group.masqueEnabled and self.Masque and not self.MasqueGroups[groupId] then
-            self:CreateMasqueGroup(groupId)
+        -- Keep runtime Masque state aligned with saved group settings. This
+        -- also resolves style-copy changes that were deferred during combat.
+        if self.Masque then
+            if (group.displayMode == nil or group.displayMode == "icons") and group.masqueEnabled then
+                if not self.MasqueGroups[groupId] then
+                    self:CreateMasqueGroup(groupId)
+                end
+            elseif self.MasqueGroups[groupId] then
+                if frame.buttons then
+                    for _, button in ipairs(frame.buttons) do
+                        self:RemoveButtonFromMasque(groupId, button)
+                    end
+                end
+                self:DeleteMasqueGroup(groupId)
+            end
         end
 
         self:PopulateGroupButtons(groupId)

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -9,6 +9,7 @@ local CooldownCompanion = ST.Addon
 local pairs = pairs
 local ipairs = ipairs
 local tonumber = tonumber
+local InCombatLockdown = InCombatLockdown
 local math_floor = math.floor
 local table_sort = table.sort
 local table_remove = table.remove
@@ -628,6 +629,15 @@ function CooldownCompanion:CopyDirectStyleFromPanel(mode, sourceGroupId, targetG
         newMasqueEnabled = false
     end
 
+    local frame = self.groupFrames and self.groupFrames[targetGroupId]
+    if InCombatLockdown() and (not frame or frame:IsProtected()) then
+        if frame then
+            frame._layoutDirty = true
+        end
+        self._pendingFullRefresh = true
+        return true
+    end
+
     if mode == "icons" and self.Masque and oldMasqueEnabled ~= newMasqueEnabled then
         self:ToggleGroupMasque(targetGroupId, newMasqueEnabled)
     end
@@ -635,7 +645,6 @@ function CooldownCompanion:CopyDirectStyleFromPanel(mode, sourceGroupId, targetG
     if self.PopulateGroupButtons then
         self:PopulateGroupButtons(targetGroupId)
     end
-    local frame = self.groupFrames and self.groupFrames[targetGroupId]
     if frame then
         frame._layoutDirty = true
     end

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -18,8 +18,17 @@ local GROUP_SETTING_PRESET_MODES = {
     text = true,
 }
 
+local DIRECT_STYLE_COPY_MODES = {
+    icons = true,
+    bars = true,
+}
+
 local function IsValidGroupSettingPresetMode(mode)
     return GROUP_SETTING_PRESET_MODES[mode] == true
+end
+
+local function IsValidDirectStyleCopyMode(mode)
+    return DIRECT_STYLE_COPY_MODES[mode] == true
 end
 
 local function GetAnchorOffset(point, width, height)
@@ -284,6 +293,32 @@ local function GetGroupDisplayMode(group)
     return "icons"
 end
 
+local function GroupMatchesDirectStyleCopyMode(group, mode)
+    if not group or not IsValidDirectStyleCopyMode(mode) then
+        return false
+    end
+    if mode == "bars" then
+        return group.displayMode == "bars"
+    end
+    return group.displayMode == nil or group.displayMode == "icons"
+end
+
+local function CopyCompactLayoutSettings(sourceGroup, targetGroup)
+    targetGroup.compactLayout = sourceGroup.compactLayout == true
+    targetGroup.compactGrowthDirection = sourceGroup.compactGrowthDirection or "center"
+
+    local sourceMaxVisible = tonumber(sourceGroup.maxVisibleButtons) or 0
+    local targetButtonCount = targetGroup.buttons and #targetGroup.buttons or 0
+    if sourceMaxVisible > 0 and targetButtonCount > 0 then
+        targetGroup.maxVisibleButtons = math.min(sourceMaxVisible, targetButtonCount)
+        if targetGroup.maxVisibleButtons >= targetButtonCount then
+            targetGroup.maxVisibleButtons = 0
+        end
+    else
+        targetGroup.maxVisibleButtons = 0
+    end
+end
+
 local function BuildGroupSettingPresetBaseline(profile, mode)
     local style = CopyTable(profile.globalStyle or {})
     if mode == "bars" then
@@ -494,6 +529,117 @@ function CooldownCompanion:ApplyGroupSettingPreset(mode, presetName, groupId)
     end
 
     self:RefreshGroupFrame(groupId)
+    return true
+end
+
+function CooldownCompanion:GetDirectStyleCopyPanelList(mode, targetGroupId)
+    targetGroupId = tonumber(targetGroupId)
+    if not IsValidDirectStyleCopyMode(mode) then
+        return {}, {}
+    end
+
+    local db = self.db and self.db.profile
+    if not db then
+        return {}, {}
+    end
+
+    local targetGroup = db.groups and db.groups[targetGroupId]
+    if not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
+        return {}, {}
+    end
+
+    local list = {}
+    local order = {}
+    local sortData = {}
+    for groupId, group in pairs(db.groups or {}) do
+        if groupId ~= targetGroupId
+            and GroupMatchesDirectStyleCopyMode(group, mode)
+            and self:IsGroupVisibleToCurrentChar(groupId) then
+            local parentContainer = self:GetParentContainer(group)
+            local containerName = parentContainer and parentContainer.name
+                or group.name
+                or ("Panel " .. tostring(groupId))
+            local panelName = group.name or ("Panel " .. tostring(groupId))
+            local label = containerName
+            if parentContainer and panelName ~= containerName then
+                label = containerName .. " - " .. panelName
+            end
+            local orderValue = parentContainer
+                and self:GetOrderForSpec(parentContainer, self._currentSpecId, group.parentContainerId)
+                or (group.order or groupId)
+
+            list[groupId] = label
+            order[#order + 1] = groupId
+            sortData[groupId] = {
+                order = orderValue or groupId,
+                panelOrder = group.order or groupId,
+                label = label,
+            }
+        end
+    end
+
+    table_sort(order, function(a, b)
+        local left = sortData[a]
+        local right = sortData[b]
+        if left.order ~= right.order then
+            return left.order < right.order
+        end
+        if left.panelOrder ~= right.panelOrder then
+            return left.panelOrder < right.panelOrder
+        end
+        return left.label < right.label
+    end)
+
+    return list, order
+end
+
+function CooldownCompanion:CopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
+    sourceGroupId = tonumber(sourceGroupId)
+    targetGroupId = tonumber(targetGroupId)
+    if not IsValidDirectStyleCopyMode(mode) then
+        return false, "invalid_mode"
+    end
+
+    local db = self.db and self.db.profile
+    local sourceGroup = db and db.groups and db.groups[sourceGroupId]
+    local targetGroup = db and db.groups and db.groups[targetGroupId]
+    if not sourceGroup or not targetGroup then
+        return false, "missing_group"
+    end
+    if sourceGroupId == targetGroupId then
+        return false, "same_group"
+    end
+    if not GroupMatchesDirectStyleCopyMode(sourceGroup, mode)
+        or not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
+        return false, "mode_mismatch"
+    end
+    if not self:IsGroupVisibleToCurrentChar(sourceGroupId) then
+        return false, "source_unavailable"
+    end
+
+    local oldMasqueEnabled = targetGroup.masqueEnabled and true or false
+    local presetData = CaptureGroupSettingPresetData(db, mode, sourceGroup)
+    ApplyGroupSettingPresetData(db, targetGroup, mode, presetData)
+    CopyCompactLayoutSettings(sourceGroup, targetGroup)
+    local newMasqueEnabled = targetGroup.masqueEnabled and true or false
+
+    if mode == "icons" and not self.Masque and newMasqueEnabled then
+        targetGroup.masqueEnabled = false
+        newMasqueEnabled = false
+    end
+
+    if mode == "icons" and self.Masque and oldMasqueEnabled ~= newMasqueEnabled then
+        self:ToggleGroupMasque(targetGroupId, newMasqueEnabled)
+    end
+
+    if self.PopulateGroupButtons then
+        self:PopulateGroupButtons(targetGroupId)
+    end
+    local frame = self.groupFrames and self.groupFrames[targetGroupId]
+    if frame then
+        frame._layoutDirty = true
+    end
+    self:RefreshGroupFrame(targetGroupId)
     return true
 end
 


### PR DESCRIPTION
## What Players Will Notice
- Icon and bar panels can copy their visual setup from another same-type panel directly from the panel header right-click menu.
- The copy action asks for confirmation and keeps the target panel's entries, positioning, and Load Conditions unchanged.
- Compact panel layouts are copied with the style, so compact icon/bar panels can be matched more accurately.

## Why This Changed
- Reusing a panel's visual setup was awkward without saving a preset or exporting/importing a group.
- The copy action belongs with panel-level actions like Duplicate, Move, and Export, not inside preset management.
- Review feedback also caught that direct copy needed to preserve compact layout and avoid protected-frame refresh work during combat.

## What Changed
- Added same-type source-panel discovery for direct style copy, limited to current-character visible icon/bar panels.
- Added `Copy Style From` to the panel header context menu and removed the direct copy controls from the preset section.
- Added a confirmation popup that explains the copy boundary in terms of Appearance, Indicators, layout style, Positioning, Load Conditions, and panel contents.
- Reused the existing preset capture/apply path for visual style data, then copied compact layout settings separately.
- Deferred protected-frame refresh work during combat and reconciled Masque state during the normal refresh path.

## Validation
- Ran targeted `luac -p` for the touched Lua files.
- Ran a full Lua syntax sweep: 121 files checked.
- Ran `git diff --check origin/main...HEAD`.
- Ran code review and review-intake passes; follow-up findings for compact layout and combat-safe refresh were addressed.
- In-game menu/copy validation is still needed.
- Combat and restricted-content behavior has not yet been verified in-game.