### PR TITLE
Show hidden player aura bars as soon as the aura is active

### DIFF
--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -1732,6 +1732,24 @@ local function UpdateCustomAuraBar(barInfo)
         end
     end
 
+    if not auraPresent and configUnit == "player" then
+        local auraData = C_UnitAuras.GetPlayerAuraBySpellID(cabConfig.spellID)
+        if auraData then
+            instId = auraData.auraInstanceID
+            auraUnit = "player"
+            auraPresent = true
+            applications = auraData.applications or 0
+            if isActive then
+                stacks = 1
+            else
+                stacks = applications
+            end
+            if needsDuration and instId then
+                durationObj = C_UnitAuras.GetAuraDuration("player", instId)
+            end
+        end
+    end
+
     if indicatorPreview and not auraPresent then
         auraPresent = true
         applications = CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS


### PR DESCRIPTION
## What Players Will Notice
- Custom aura bars set to hide while inactive now appear as soon as a tracked player aura is active, including single-stack auras like Lifebloom.

## Why This Changed
- Hidden custom aura bars could stay hidden until the tracked aura reached 2+ stacks because the bar only trusted the Blizzard viewer aura path to wake itself.

## What Changed
- Added a player-aura fallback in the custom aura bar update path using `C_UnitAuras.GetPlayerAuraBySpellID` when the viewer path has not found the aura yet.
- The fallback only applies to custom aura bars resolved to the player unit. Target aura behavior, layout behavior, preview behavior, config shape, and stack math are unchanged.

## Validation
- Ran `luac -p OtherBars/ResourceBar.lua`.
- Ran `git diff --check origin/main...HEAD`.
- In-game validation is still needed for Lifebloom at 1, 2, and 3 stacks with `Hide When Inactive` enabled, plus one combat or restricted-content check before release.