### PR TITLE
Fix specific CDM aura selection for Eclipse and Starweaver

### DIFF
--- a/Config/AutoImport.lua
+++ b/Config/AutoImport.lua
@@ -33,6 +33,26 @@ local SOURCE_GROUP_ORDER_SPEC = 2000
 local SOURCE_GROUP_ORDER_PET = 3000
 local SOURCE_GROUP_ORDER_GENERAL = 4000
 
+local function IsConcreteSpellID(spellID)
+    return type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID)
+end
+
+local function ResolveCDMAuraSpellID(cooldownInfo)
+    if type(cooldownInfo) ~= "table" then
+        return nil
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
+        return cooldownInfo.overrideTooltipSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideSpellID) then
+        return cooldownInfo.overrideSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.spellID) then
+        return cooldownInfo.spellID
+    end
+    return nil
+end
+
 local function CreateAutoAddPrefDefaults()
     local selectedBars = {}
     for i = 1, ACTION_BAR_COUNT do
@@ -344,13 +364,14 @@ local function BuildCDMAuraPreview()
                 elseif not cooldownInfo.isKnown then
                     -- Known/current-spec only; omit unknown entries silently.
                 else
-                    local spellInfo = C_Spell.GetSpellInfo(cooldownInfo.spellID)
+                    local auraSpellID = ResolveCDMAuraSpellID(cooldownInfo)
+                    local spellInfo = auraSpellID and C_Spell.GetSpellInfo(auraSpellID)
                     if not spellInfo or not spellInfo.name then
-                        AddSkipped(result, catInfo.label, "Spell data is unavailable.", "Spell " .. cooldownInfo.spellID)
+                        AddSkipped(result, catInfo.label, "Spell data is unavailable.", "Spell " .. tostring(auraSpellID or cooldownInfo.spellID))
                     else
                         TryAddEntry(result, seen, "auras", {
                             type = "spell",
-                            id = cooldownInfo.spellID,
+                            id = auraSpellID,
                             name = spellInfo.name,
                             icon = spellInfo.iconID or ICON_FALLBACK,
                             source = catInfo.label,
@@ -653,8 +674,7 @@ local function ApplyPreviewToGroup(groupID, preview, selectedEntries, suppressRe
         if selectedEntries[entry.importKey] then
             local spellInfo = C_Spell.GetSpellInfo(entry.id)
             if spellInfo and spellInfo.name then
-                local isPassive = IsPassiveOrProc(entry.id) and true or nil
-                local buttonIndex = CooldownCompanion:AddButtonToGroup(groupID, "spell", entry.id, spellInfo.name, nil, isPassive, true)
+                local buttonIndex = CooldownCompanion:AddButtonToGroup(groupID, "spell", entry.id, spellInfo.name, nil, true, true)
                 if buttonIndex then
                     addedAuras = addedAuras + 1
                     addedButtonIndexes[#addedButtonIndexes + 1] = buttonIndex

--- a/Config/AutoImport.lua
+++ b/Config/AutoImport.lua
@@ -175,15 +175,13 @@ local function TryAddEntry(result, seen, bucketKey, entry, sourceLabel)
     local dedupeKey
     if bucketKey == "items" then
         dedupeKey = "item:" .. tostring(entry.id)
+    elseif bucketKey == "auras" then
+        dedupeKey = "spell:" .. tostring(entry.id) .. ":aura"
     else
         -- Resolve spell ID to base form for dedup so that variant transforms
         -- (e.g. Raze and Maul) share a single key and don't double-add.
         local resolvedId = ST.ResolveToBaseSpell(entry.id)
-        if bucketKey == "auras" then
-            dedupeKey = "spell:" .. tostring(resolvedId) .. ":aura"
-        else
-            dedupeKey = "spell:" .. tostring(resolvedId) .. ":spell"
-        end
+        dedupeKey = "spell:" .. tostring(resolvedId) .. ":spell"
     end
 
     if seen[dedupeKey] then

--- a/Config/AutoImport.lua
+++ b/Config/AutoImport.lua
@@ -53,6 +53,44 @@ local function ResolveCDMAuraSpellID(cooldownInfo)
     return nil
 end
 
+local function CooldownInfoReferencesSpellID(cooldownInfo, spellID)
+    if type(cooldownInfo) ~= "table" or not IsConcreteSpellID(spellID) then
+        return false
+    end
+    return cooldownInfo.spellID == spellID
+        or cooldownInfo.overrideSpellID == spellID
+        or cooldownInfo.overrideTooltipSpellID == spellID
+end
+
+local function ResolveTrackedCDMAuraSpellIDForSpell(spellID)
+    if not IsConcreteSpellID(spellID) then
+        return nil, false, false
+    end
+
+    local resolvedAuraID
+    local found = false
+    for _, cat in ipairs({Enum.CooldownViewerCategory.TrackedBuff, Enum.CooldownViewerCategory.TrackedBar}) do
+        local cooldownIDs = C_CooldownViewer.GetCooldownViewerCategorySet(cat, true)
+        if cooldownIDs then
+            for _, cooldownID in ipairs(cooldownIDs) do
+                local cooldownInfo = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
+                if CooldownInfoReferencesSpellID(cooldownInfo, spellID) then
+                    found = true
+                    local auraID = ResolveCDMAuraSpellID(cooldownInfo)
+                    if auraID then
+                        if resolvedAuraID and resolvedAuraID ~= auraID then
+                            return nil, true, true
+                        end
+                        resolvedAuraID = auraID
+                    end
+                end
+            end
+        end
+    end
+
+    return resolvedAuraID, false, found
+end
+
 local function CreateAutoAddPrefDefaults()
     local selectedBars = {}
     for i = 1, ACTION_BAR_COUNT do
@@ -242,20 +280,31 @@ local function BuildActionBarPreview(selectedBars)
                             elseif IsNeverTrackableSpell(spellID) then
                                 -- Omit known non-trackable spells from preview.
                             else
-                                local isAura = IsPassiveOrProc(spellID)
-                                if isAura and not IsSpellInCDMBuffBar(spellID) then
+                                local cdmAuraSpellID, ambiguousCDMAuras, hasTrackedCDMAura = ResolveTrackedCDMAuraSpellIDForSpell(spellID)
+                                local isBuffOnlyCDMSpell = hasTrackedCDMAura and not IsSpellInCDMCooldown(spellID)
+                                local isAura = IsPassiveOrProc(spellID) or isBuffOnlyCDMSpell
+                                if ambiguousCDMAuras then
+                                    AddSkipped(result, sourceLabel, "Choose a specific CDM aura.", spellName)
+                                elseif isAura and not cdmAuraSpellID then
                                     AddSkipped(result, sourceLabel, "Passive/proc spell is not tracked in CDM.", spellName)
                                 else
                                     local bucketKey = isAura and "auras" or "spells"
-                                    TryAddEntry(result, seen, bucketKey, {
-                                        type = "spell",
-                                        id = spellID,
-                                        name = spellName,
-                                        icon = spellInfo.iconID or C_ActionBar.GetActionTexture(slot) or ICON_FALLBACK,
-                                        source = sourceLabel,
-                                        sourceGroup = barSourceGroup,
-                                        sourceOrder = barIndex,
-                                    }, sourceLabel)
+                                    local entryID = isAura and cdmAuraSpellID or spellID
+                                    local entrySpellInfo = isAura and C_Spell.GetSpellInfo(entryID) or spellInfo
+                                    local entryName = entrySpellInfo and entrySpellInfo.name
+                                    if not entryName then
+                                        AddSkipped(result, sourceLabel, "Spell data is unavailable.", "Spell " .. tostring(entryID))
+                                    else
+                                        TryAddEntry(result, seen, bucketKey, {
+                                            type = "spell",
+                                            id = entryID,
+                                            name = entryName,
+                                            icon = entrySpellInfo.iconID or C_ActionBar.GetActionTexture(slot) or ICON_FALLBACK,
+                                            source = sourceLabel,
+                                            sourceGroup = barSourceGroup,
+                                            sourceOrder = barIndex,
+                                        }, sourceLabel)
+                                    end
                                 end
                             end
                         else

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -58,6 +58,40 @@ local function IsTriggerPanelTarget(groupId)
     return group and group.displayMode == "trigger"
 end
 
+local function IsConcreteSpellID(spellID)
+    return type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID)
+end
+
+local function ResolveCDMAuraSpellID(cooldownInfo)
+    if type(cooldownInfo) ~= "table" then
+        return nil
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
+        return cooldownInfo.overrideTooltipSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideSpellID) then
+        return cooldownInfo.overrideSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.spellID) then
+        return cooldownInfo.spellID
+    end
+    return nil
+end
+
+local function CDMAuraChildrenShareResolvedSpellID(children)
+    local resolvedID
+    for _, child in ipairs(children or {}) do
+        local childID = child and ResolveCDMAuraSpellID(child.cooldownInfo)
+        if childID then
+            if resolvedID and resolvedID ~= childID then
+                return false
+            end
+            resolvedID = childID
+        end
+    end
+    return resolvedID ~= nil
+end
+
 -- File-local state
 local autocompleteDropdown
 
@@ -118,13 +152,19 @@ local function TryAddSpell(input, isPetSpell, forceAura)
             CooldownCompanion:Print("Passive/proc spell " .. spellName .. " is not tracked in the Cooldown Manager.")
             return false
         end
-        -- Multi-CDM-child: if passive/proc spell has multiple CDM entries, auto-add one button per child
-        if passiveOrProc
-            and not IsTexturePanelTarget(CS.selectedGroup)
-            and not IsTriggerPanelTarget(CS.selectedGroup)
-        then
+        -- Multi-CDM-child entries only expand when all rows represent the same
+        -- aura spell ID. If CDM exposes distinct aura IDs, the user must pick
+        -- the specific aura instead of a generic base entry.
+        if passiveOrProc then
             local allChildren = CooldownCompanion.viewerAuraAllChildren[spellId]
-            if allChildren and #allChildren > 1 then
+            if allChildren and #allChildren > 1 and not CDMAuraChildrenShareResolvedSpellID(allChildren) then
+                CooldownCompanion:Print("Choose a specific CDM aura for " .. spellName .. ".")
+                return false
+            end
+            if allChildren and #allChildren > 1
+                and not IsTexturePanelTarget(CS.selectedGroup)
+                and not IsTriggerPanelTarget(CS.selectedGroup)
+            then
                 local count = #allChildren
                 local firstIdx
                 for i = 1, count do
@@ -253,21 +293,16 @@ local function TryAdd(input)
         -- Passive/proc spell: require CDM presence
         if spellFound and passiveOrProc then
             if IsSpellInCDMBuffBar(id) then
-                local idx, notified = CooldownCompanion:AddButtonToGroup(CS.selectedGroup, "spell", id, spellInfo.name, nil, true)
-                if not idx then
-                    return false
-                end
-                SelectNewButton(CS.selectedGroup, idx)
-                if not notified then
-                    CooldownCompanion:Print("Added spell: " .. spellInfo.name)
-                end
-                return true
+                return TryAddSpell(tostring(id), nil, true)
             end
             -- Not in CDM — fall through to try as item, then report error
         end
 
         -- Non-passive spell → add it
         if spellFound and not passiveOrProc then
+            if IsSpellInCDMBuffBar(id) and not IsSpellInCDMCooldown(id) then
+                return TryAddSpell(tostring(id), nil, true)
+            end
             local forceAura = nil
             if IsSpellInCDMCooldown(id) and IsSpellInCDMBuffBar(id) then
                 forceAura = false  -- dual-CDM: default to cooldown mode
@@ -357,18 +392,13 @@ local function TryAdd(input)
             local passiveOrProc = IsPassiveOrProc(spellId)
             if passiveOrProc then
                 if IsSpellInCDMBuffBar(spellId) then
-                    local idx, notified = CooldownCompanion:AddButtonToGroup(CS.selectedGroup, "spell", spellId, spellName, nil, true)
-                    if not idx then
-                        return false
-                    end
-                    SelectNewButton(CS.selectedGroup, idx)
-                    if not notified then
-                        CooldownCompanion:Print("Added spell: " .. spellName)
-                    end
-                    return true
+                    return TryAddSpell(tostring(spellId), nil, true)
                 end
                 -- Not in CDM — fall through to try as item, then report error
             else
+                if IsSpellInCDMBuffBar(spellId) and not IsSpellInCDMCooldown(spellId) then
+                    return TryAddSpell(tostring(spellId), nil, true)
+                end
                 local idx, notified = CooldownCompanion:AddButtonToGroup(CS.selectedGroup, "spell", spellId, spellName)
                 if not idx then
                     return false
@@ -432,6 +462,7 @@ end
 local function BuildAutocompleteCache()
     local cache = {}
     local seen = {}
+    local seenAuras = {}
 
     -- Pre-compute dual-CDM spell set (spells in both cooldown and buff CDM categories)
     local cdmCooldownSet = {}
@@ -469,6 +500,38 @@ local function BuildAutocompleteCache()
         end
     end
 
+    local cdmDistinctAuraBaseSet = {}
+    local cdmAuraIDsByBase = {}
+    for _, cat in ipairs({Enum.CooldownViewerCategory.TrackedBuff, Enum.CooldownViewerCategory.TrackedBar}) do
+        local ids = C_CooldownViewer.GetCooldownViewerCategorySet(cat, true)
+        if ids then
+            for _, cdID in ipairs(ids) do
+                local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
+                if info and IsConcreteSpellID(info.spellID) then
+                    local auraID = ResolveCDMAuraSpellID(info)
+                    if auraID then
+                        local byBase = cdmAuraIDsByBase[info.spellID]
+                        if not byBase then
+                            byBase = {}
+                            cdmAuraIDsByBase[info.spellID] = byBase
+                        end
+                        byBase[auraID] = true
+                    end
+                end
+            end
+        end
+    end
+    for baseID, auraIDs in pairs(cdmAuraIDsByBase) do
+        local firstID
+        for auraID in pairs(auraIDs) do
+            if firstID and firstID ~= auraID then
+                cdmDistinctAuraBaseSet[baseID] = true
+                break
+            end
+            firstID = auraID
+        end
+    end
+
     -- Iterate spellbook skill lines
     local numLines = C_SpellBook.GetNumSpellBookSkillLines()
     for lineIdx = 1, numLines do
@@ -501,15 +564,22 @@ local function BuildAutocompleteCache()
                                 isItem = false,
                                 forceAura = false,
                             })
-                            table.insert(cache, {
-                                id = id,
-                                name = itemInfo.name .. " (Buff)",
-                                nameLower = itemInfo.name:lower(),
-                                icon = itemInfo.iconID or 134400,
-                                category = "Tracked Buff",
-                                isItem = false,
-                                forceAura = true,
-                            })
+                            local resolvedSpellInfo = C_Spell.GetSpellInfo(id)
+                            local spellbookNameIsSpecific = not resolvedSpellInfo
+                                or not resolvedSpellInfo.name
+                                or resolvedSpellInfo.name == itemInfo.name
+                            if not cdmDistinctAuraBaseSet[id] and spellbookNameIsSpecific then
+                                seenAuras[id] = true
+                                table.insert(cache, {
+                                    id = id,
+                                    name = itemInfo.name .. " (Buff)",
+                                    nameLower = itemInfo.name:lower(),
+                                    icon = itemInfo.iconID or 134400,
+                                    category = "Tracked Buff",
+                                    isItem = false,
+                                    forceAura = true,
+                                })
+                            end
                         else
                             table.insert(cache, {
                                 id = id,
@@ -578,18 +648,20 @@ local function BuildAutocompleteCache()
         end
     end
 
-    -- Iterate CDM TrackedBuff + TrackedBar for passive/proc spells
+    -- Iterate CDM TrackedBuff + TrackedBar entries by their specific aura
+    -- identity. Some tracked auras are active spellbook spells, so CDM
+    -- membership is the important addability signal here.
     for _, cat in ipairs({Enum.CooldownViewerCategory.TrackedBuff, Enum.CooldownViewerCategory.TrackedBar}) do
         local ids = C_CooldownViewer.GetCooldownViewerCategorySet(cat, true)
         if ids then
             for _, cdID in ipairs(ids) do
                 local cdInfo = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
                 if cdInfo and cdInfo.spellID then
-                    local id = cdInfo.spellID
-                    if not IsNeverTrackableSpell(id) and not seen[id] then
+                    local id = ResolveCDMAuraSpellID(cdInfo)
+                    if id and not IsNeverTrackableSpell(id) and not seenAuras[id] then
                         local spellInfo = C_Spell.GetSpellInfo(id)
-                        if spellInfo and spellInfo.name and IsPassiveOrProc(id) then
-                            seen[id] = true
+                        if spellInfo and spellInfo.name then
+                            seenAuras[id] = true
                             table.insert(cache, {
                                 id = id,
                                 name = spellInfo.name,

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -112,7 +112,7 @@ end
 ------------------------------------------------------------------------
 -- Helper: Add spell to selected group
 ------------------------------------------------------------------------
-local function TryAddSpell(input, isPetSpell, forceAura)
+local function TryAddSpell(input, isPetSpell, forceAura, displayNameOverride)
     if input == "" or not CS.selectedGroup then return false end
 
     local spellId = tonumber(input)
@@ -147,6 +147,9 @@ local function TryAddSpell(input, isPetSpell, forceAura)
             passiveOrProc = false   -- Cooldown mode: treat as normal spell
         elseif forceAura == true then
             passiveOrProc = true    -- Buff mode: treat as passive/proc
+        end
+        if displayNameOverride and passiveOrProc then
+            spellName = displayNameOverride
         end
         if passiveOrProc and not IsSpellInCDMBuffBar(spellId) then
             CooldownCompanion:Print("Passive/proc spell " .. spellName .. " is not tracked in the Cooldown Manager.")
@@ -780,7 +783,14 @@ local function OnAutocompleteSelect(entry)
     if entry.isItem then
         added = TryAddItem(tostring(entry.id))
     else
-        added = TryAddSpell(tostring(entry.id), entry.isPetSpell, entry.forceAura)
+        local displayNameOverride
+        if entry.category == "Cooldown Manager"
+            and type(entry.name) == "string"
+            and entry.name ~= ""
+        then
+            displayNameOverride = entry.name
+        end
+        added = TryAddSpell(tostring(entry.id), entry.isPetSpell, entry.forceAura, displayNameOverride)
     end
     if added then
         if NotifyTutorialAction and CS.selectedGroup and CS.selectedButton then

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -141,6 +141,12 @@ local function TryAddSpell(input, isPetSpell, forceAura, displayNameOverride)
             PrintBlockedSpellMessage(spellName)
             return false
         end
+        if CooldownCompanion.ABILITY_BUFF_OVERRIDES
+            and CooldownCompanion.ABILITY_BUFF_OVERRIDES[spellId]
+        then
+            CooldownCompanion:Print("Choose a specific CDM aura for " .. spellName .. ".")
+            return false
+        end
         local passiveOrProc = IsPassiveOrProc(spellId)
         -- forceAura overrides passive/proc classification for dual-CDM spells
         if forceAura == false then

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -673,6 +673,7 @@ local function BuildAutocompleteCache()
                                 category = "Cooldown Manager",
                                 isItem = false,
                                 isPassive = true,
+                                forceAura = true,
                             })
                         end
                     end

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -558,11 +558,14 @@ local function BuildAutocompleteCache()
                 then
                     local id = itemInfo.spellID
                     local isAura = IsPassiveOrProc(id)
+                    local isBuffOnlyCDMSpell = cdmBuffSet[id] and not cdmCooldownSet[id]
                     if ShouldSuppressSpellbookEntry(id, lineIdx, isAura) then
                         -- Omit filtered entries to reduce autocomplete noise.
                     elseif not seen[id] then
                         seen[id] = true
-                        if dualCDMSet[id] then
+                        if isBuffOnlyCDMSpell then
+                            -- The CDM aura row below is the addable identity for buff/bar-only entries.
+                        elseif dualCDMSet[id] then
                             -- Dual-CDM spell: insert separate Cooldown and Buff entries
                             table.insert(cache, {
                                 id = id,

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -323,6 +323,24 @@ local function GetButtonIcon(buttonData)
     return 134400
 end
 
+local function GetCooldownInfoDisplaySpellID(cooldownInfo)
+    if type(cooldownInfo) ~= "table" then
+        return nil
+    end
+    for _, spellID in ipairs({
+        cooldownInfo.overrideTooltipSpellID,
+        cooldownInfo.overrideSpellID,
+        cooldownInfo.spellID,
+    }) do
+        if type(spellID) == "number" and spellID > 0
+            and not (issecretvalue and issecretvalue(spellID))
+        then
+            return spellID
+        end
+    end
+    return nil
+end
+
 local function GetConfigEntryDisplayName(buttonData, opts)
     if not buttonData then
         return nil
@@ -330,7 +348,7 @@ local function GetConfigEntryDisplayName(buttonData, opts)
 
     opts = opts or {}
     local includeDecorations = opts.includeDecorations == true
-    local entryName = buttonData.name
+    local entryName = buttonData.customName or buttonData.name
 
     if buttonData.type == "spell" then
         local child
@@ -341,17 +359,17 @@ local function GetConfigEntryDisplayName(buttonData, opts)
             child = CooldownCompanion.viewerAuraFrames[buttonData.id]
         end
 
-        if child and child.cooldownInfo and child.cooldownInfo.overrideSpellID then
-            local spellName = C_Spell.GetSpellName(child.cooldownInfo.overrideSpellID)
-            if spellName then
-                entryName = spellName
+        if not buttonData.customName then
+            local displayId = GetCooldownInfoDisplaySpellID(child and child.cooldownInfo)
+            if not displayId then
+                local raw = C_Spell.GetOverrideSpell(buttonData.id)
+                displayId = (raw and raw ~= 0) and raw or buttonData.id
             end
-        else
-            local raw = C_Spell.GetOverrideSpell(buttonData.id)
-            local displayId = (raw and raw ~= 0) and raw or buttonData.id
-            local spellName = C_Spell.GetSpellName(displayId)
-            if spellName then
-                entryName = spellName
+            if displayId then
+                local spellName = C_Spell.GetSpellName(displayId)
+                if spellName then
+                    entryName = spellName
+                end
             end
         end
 

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -327,17 +327,28 @@ local function GetCooldownInfoDisplaySpellID(cooldownInfo)
     if type(cooldownInfo) ~= "table" then
         return nil
     end
-    for _, spellID in ipairs({
-        cooldownInfo.overrideTooltipSpellID,
-        cooldownInfo.overrideSpellID,
-        cooldownInfo.spellID,
-    }) do
-        if type(spellID) == "number" and spellID > 0
-            and not (issecretvalue and issecretvalue(spellID))
-        then
-            return spellID
-        end
+
+    local tooltipID = cooldownInfo.overrideTooltipSpellID
+    if type(tooltipID) == "number" and tooltipID > 0
+        and not (issecretvalue and issecretvalue(tooltipID))
+    then
+        return tooltipID
     end
+
+    local overrideID = cooldownInfo.overrideSpellID
+    if type(overrideID) == "number" and overrideID > 0
+        and not (issecretvalue and issecretvalue(overrideID))
+    then
+        return overrideID
+    end
+
+    local spellID = cooldownInfo.spellID
+    if type(spellID) == "number" and spellID > 0
+        and not (issecretvalue and issecretvalue(spellID))
+    then
+        return spellID
+    end
+
     return nil
 end
 

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -449,7 +449,7 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
 
         CreateInfoButton(auraEditBox.frame, auraEditBox.frame, "TOPLEFT", "TOPLEFT", auraEditBox.label:GetStringWidth() + 4, -2, {
             "Spell ID Override",
-            {"Most spells are tracked automatically, but some abilities apply a buff or debuff with a different spell ID than the ability itself. If tracking isn't working, enter the buff/debuff spell ID here. Use commas for multiple IDs (e.g. 48517,48518 for both Eclipse forms).\n\nUse \"Pick CDM\" below to visually select a spell from the Cooldown Manager.", 1, 1, 1, true},
+            {"Most spells are tracked automatically, but some abilities apply a buff or debuff with a different spell ID than the ability itself. If tracking isn't working, enter the buff/debuff spell ID here. Use commas only when one entry should intentionally watch multiple IDs.\n\nUse \"Pick CDM\" below to visually select a spell from the Cooldown Manager.", 1, 1, 1, true},
         }, infoButtons)
 
         local overrideCdmSpacer = AceGUI:Create("Label")

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -107,7 +107,11 @@ local GetContinuousTickModeConfig = RBP.GetContinuousTickModeConfig
 local GetContinuousTickPercentConfig = RBP.GetContinuousTickPercentConfig
 local GetContinuousTickAbsoluteConfig = RBP.GetContinuousTickAbsoluteConfig
 local AddCdmAuraReadinessWarning = RBP.AddCdmAuraReadinessWarning
-local BuildAuraBarAutocompleteCache = RBP.BuildAuraBarAutocompleteCache
+local ResolveAuraColorSpellIDFromText = RBP.ResolveAuraColorSpellIDFromText
+local GetAuraBarAutocompleteDisplayName = RBP.GetAuraBarAutocompleteDisplayName
+local GetAuraBarAutocompleteDisplayIcon = RBP.GetAuraBarAutocompleteDisplayIcon
+local GetAuraBarAutocompleteEntryName = RBP.GetAuraBarAutocompleteEntryName
+local ShowAuraBarAutocompleteResults = RBP.ShowAuraBarAutocompleteResults
 local IsResourceBarVerticalConfig = RBP.IsResourceBarVerticalConfig
 local GetResourceThicknessFieldConfig = RBP.GetResourceThicknessFieldConfig
 local GetResourceGapFieldConfig = RBP.GetResourceGapFieldConfig
@@ -1350,10 +1354,13 @@ local function ApplyCustomAuraBarPanelChanges(opts)
     end
 end
 
-local function SetCustomAuraBarTrackedSpell(customBars, capturedIdx, spellId)
+local function SetCustomAuraBarTrackedSpell(customBars, capturedIdx, spellId, labelOverride)
     customBars[capturedIdx].spellID = spellId
     if spellId then
-        customBars[capturedIdx].label = C_Spell.GetSpellName(spellId) or ""
+        customBars[capturedIdx].label = labelOverride
+            or GetAuraBarAutocompleteDisplayName(spellId)
+            or C_Spell.GetSpellName(spellId)
+            or ""
     else
         customBars[capturedIdx].label = ""
     end
@@ -1708,8 +1715,10 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
 
     if cab.enabled and independentSubTab == "settings" then
 
-            local trackedAuraName = cab.spellID and C_Spell.GetSpellName(cab.spellID)
-            local trackedAuraIcon = cab.spellID and C_Spell.GetSpellTexture(cab.spellID)
+            local trackedAuraName = cab.spellID
+                and ((type(cab.label) == "string" and cab.label ~= "" and cab.label)
+                    or GetAuraBarAutocompleteDisplayName(cab.spellID))
+            local trackedAuraIcon = cab.spellID and GetAuraBarAutocompleteDisplayIcon(cab.spellID)
             local trackedAuraLabel = AceGUI:Create("Label")
             local trackedAuraText
             if trackedAuraName then
@@ -1738,7 +1747,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
             local function onAuraBarSelect(entry)
                 CS.HideAutocomplete()
                 local bars = CooldownCompanion:GetSpecCustomAuraBars()
-                SetCustomAuraBarTrackedSpell(bars, capturedIdx, entry.id)
+                SetCustomAuraBarTrackedSpell(bars, capturedIdx, entry.id, GetAuraBarAutocompleteEntryName(entry))
                 ApplyCustomAuraBarPanelChanges({
                     updateAnchors = true,
                     refreshConfig = true,
@@ -1748,8 +1757,10 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
             spellEdit:SetCallback("OnEnterPressed", function(widget, event, text)
                 if CS.ConsumeAutocompleteEnter() then return end
                 CS.HideAutocomplete()
-                text = text:gsub("%s", "")
-                local id = tonumber(text)
+                local id, explicitClear = ResolveAuraColorSpellIDFromText(text)
+                if not id and not explicitClear then
+                    return
+                end
                 local bars = CooldownCompanion:GetSpecCustomAuraBars()
                 SetCustomAuraBarTrackedSpell(bars, capturedIdx, id)
                 ApplyCustomAuraBarPanelChanges({
@@ -1758,13 +1769,7 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
                 })
             end)
             spellEdit:SetCallback("OnTextChanged", function(widget, event, text)
-                if text and #text >= 1 then
-                    local cache = BuildAuraBarAutocompleteCache()
-                    local results = CS.SearchAutocompleteInCache(text, cache)
-                    CS.ShowAutocompleteResults(results, widget, onAuraBarSelect)
-                else
-                    CS.HideAutocomplete()
-                end
+                ShowAuraBarAutocompleteResults(text, widget, onAuraBarSelect)
             end)
 
             CS.SetupAutocompleteKeyHandler(spellEdit)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -1716,8 +1716,8 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
     if cab.enabled and independentSubTab == "settings" then
 
             local trackedAuraName = cab.spellID
-                and ((type(cab.label) == "string" and cab.label ~= "" and cab.label)
-                    or GetAuraBarAutocompleteDisplayName(cab.spellID))
+                and (GetAuraBarAutocompleteDisplayName(cab.spellID)
+                    or (type(cab.label) == "string" and cab.label ~= "" and cab.label))
             local trackedAuraIcon = cab.spellID and GetAuraBarAutocompleteDisplayIcon(cab.spellID)
             local trackedAuraLabel = AceGUI:Create("Label")
             local trackedAuraText

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -78,13 +78,22 @@ local RefreshResourceAuraUnitForSpell = RB.RefreshResourceAuraUnitForSpell
 ------------------------------------------------------------------------
 local auraBarAutocompleteCache = nil
 
+local function IsSharedAuraAutocompleteEntry(entry)
+    if type(entry) ~= "table" or entry.isItem then
+        return false
+    end
+    return entry.category == "Cooldown Manager"
+        or entry.forceAura == true
+        or entry.isPassive == true
+end
+
 local function BuildAuraBarAutocompleteCache()
     local cache = {}
     local sharedCache = CS.autocompleteCache
         or (ST._BuildAutocompleteCache and ST._BuildAutocompleteCache())
         or {}
     for _, entry in ipairs(sharedCache) do
-        if entry.category == "Cooldown Manager" then
+        if IsSharedAuraAutocompleteEntry(entry) then
             cache[#cache + 1] = entry
         end
     end

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -80,36 +80,85 @@ local auraBarAutocompleteCache = nil
 
 local function BuildAuraBarAutocompleteCache()
     local cache = {}
-    local seen = {}
-    for _, cat in ipairs({
-        Enum.CooldownViewerCategory.TrackedBuff,
-        Enum.CooldownViewerCategory.TrackedBar,
-    }) do
-        local catLabel = (cat == Enum.CooldownViewerCategory.TrackedBuff)
-            and "Tracked Buff" or "Tracked Bar"
-        local ids = C_CooldownViewer.GetCooldownViewerCategorySet(cat, true)
-        if ids then
-            for _, cdID in ipairs(ids) do
-                local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
-                if info and info.spellID and not seen[info.spellID] then
-                    seen[info.spellID] = true
-                    local name = C_Spell.GetSpellName(info.spellID)
-                    local icon = C_Spell.GetSpellTexture(info.spellID)
-                    if name then
-                        cache[#cache + 1] = {
-                            id = info.spellID,
-                            name = name,
-                            nameLower = name:lower(),
-                            icon = icon or 134400,
-                            category = catLabel,
-                        }
-                    end
-                end
-            end
+    local sharedCache = CS.autocompleteCache
+        or (ST._BuildAutocompleteCache and ST._BuildAutocompleteCache())
+        or {}
+    for _, entry in ipairs(sharedCache) do
+        if entry.category == "Cooldown Manager" then
+            cache[#cache + 1] = entry
         end
     end
     auraBarAutocompleteCache = cache
     return cache
+end
+
+local function FindAuraBarAutocompleteEntryByID(spellID)
+    if not spellID then
+        return nil
+    end
+    local cache = BuildAuraBarAutocompleteCache()
+    for _, entry in ipairs(cache) do
+        if entry.id == spellID then
+            return entry
+        end
+    end
+    return nil
+end
+
+local function GetAuraBarAutocompleteDisplayName(spellID)
+    local entry = FindAuraBarAutocompleteEntryByID(spellID)
+    if entry and entry.name then
+        return entry.name
+    end
+    return spellID and C_Spell.GetSpellName(spellID) or nil
+end
+
+local function GetAuraBarAutocompleteDisplayIcon(spellID)
+    local entry = FindAuraBarAutocompleteEntryByID(spellID)
+    if entry and entry.icon then
+        return entry.icon
+    end
+    return spellID and C_Spell.GetSpellTexture(spellID) or nil
+end
+
+local function GetAuraBarAutocompleteEntryName(entry)
+    if type(entry) ~= "table" then
+        return nil
+    end
+    return type(entry.name) == "string" and entry.name ~= "" and entry.name or nil
+end
+
+local function ResolveAuraBarAutocompleteEntry(text)
+    if not text then return nil end
+    local cleaned = text:gsub("^%s+", ""):gsub("%s+$", "")
+    if cleaned == "" then
+        return nil
+    end
+
+    local numeric = tonumber(cleaned)
+    local lookup = cleaned:lower()
+    local cache = BuildAuraBarAutocompleteCache()
+    for _, entry in ipairs(cache) do
+        if (numeric and entry.id == numeric) or entry.nameLower == lookup then
+            return entry
+        end
+    end
+
+    return nil
+end
+
+local function SearchAuraBarAutocomplete(text)
+    local cache = BuildAuraBarAutocompleteCache()
+    return CS.SearchAutocompleteInCache(text, cache)
+end
+
+local function ShowAuraBarAutocompleteResults(text, widget, onAuraSelect)
+    if text and #text >= 1 then
+        local results = SearchAuraBarAutocomplete(text)
+        CS.ShowAutocompleteResults(results, widget, onAuraSelect)
+    else
+        CS.HideAutocomplete()
+    end
 end
 
 ------------------------------------------------------------------------
@@ -322,12 +371,9 @@ local function ResolveAuraColorSpellIDFromText(text)
         return numeric, false
     end
 
-    local cache = auraBarAutocompleteCache or BuildAuraBarAutocompleteCache()
-    local lookup = cleaned:lower()
-    for _, entry in ipairs(cache) do
-        if entry.nameLower == lookup then
-            return entry.id, false
-        end
+    local entry = ResolveAuraBarAutocompleteEntry(cleaned)
+    if entry then
+        return entry.id, false
     end
 
     return nil, false
@@ -491,13 +537,7 @@ end
 
 local function AttachAuraAutocompleteHandlers(editBoxWidget, onAuraSelect)
     editBoxWidget:SetCallback("OnTextChanged", function(widget, event, text)
-        if text and #text >= 1 then
-            local cache = auraBarAutocompleteCache or BuildAuraBarAutocompleteCache()
-            local results = CS.SearchAutocompleteInCache(text, cache)
-            CS.ShowAutocompleteResults(results, widget, onAuraSelect)
-        else
-            CS.HideAutocomplete()
-        end
+        ShowAuraBarAutocompleteResults(text, widget, onAuraSelect)
     end)
 
     CS.SetupAutocompleteKeyHandler(editBoxWidget)
@@ -557,7 +597,7 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
     container:AddChild(spellEdit)
 
     if spellID then
-        local auraName = C_Spell.GetSpellName(spellID)
+        local auraName = GetAuraBarAutocompleteDisplayName(spellID)
         if auraName then
             local auraLabel = AceGUI:Create("Label")
             auraLabel:SetText("|cff888888" .. auraName .. "|r")
@@ -925,6 +965,10 @@ ST._RBP = {
     GetContinuousTickPercentConfig = GetContinuousTickPercentConfig,
     GetContinuousTickAbsoluteConfig = GetContinuousTickAbsoluteConfig,
     AttachAuraAutocompleteHandlers = AttachAuraAutocompleteHandlers,
+    GetAuraBarAutocompleteDisplayName = GetAuraBarAutocompleteDisplayName,
+    GetAuraBarAutocompleteDisplayIcon = GetAuraBarAutocompleteDisplayIcon,
+    GetAuraBarAutocompleteEntryName = GetAuraBarAutocompleteEntryName,
+    ShowAuraBarAutocompleteResults = ShowAuraBarAutocompleteResults,
     AddResourceAuraEntryFields = AddResourceAuraEntryFields,
     ClearLegacyResourceAuraFieldsConfig = ClearLegacyResourceAuraFieldsConfig,
     ClearResourceAuraEntryConfig = ClearResourceAuraEntryConfig,

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -143,10 +143,24 @@ local function ResolveDirectBuffViewerSpellID(spellID)
     end
 
     if tonumber(info.overrideTooltipSpellID) == numericID
-        or tonumber(info.overrideSpellID) == numericID
-        or tonumber(info.spellID) == numericID then
+        or tonumber(info.overrideSpellID) == numericID then
         return numericID
     end
+
+    if tonumber(info.spellID) == numericID then
+        local tooltipOverride = tonumber(info.overrideTooltipSpellID)
+        if tooltipOverride and tooltipOverride ~= 0 then
+            return tooltipOverride
+        end
+
+        local spellOverride = tonumber(info.overrideSpellID)
+        if spellOverride and spellOverride ~= 0 then
+            return spellOverride
+        end
+
+        return numericID
+    end
+
     return nil
 end
 

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -786,6 +786,10 @@ end
 -- are completely unlinked by any API (GetCooldownAuraBySpellID returns 0).
 -- Format: [abilitySpellID] = "comma-separated buff spell IDs"
 CooldownCompanion.ABILITY_BUFF_OVERRIDES = {
+    -- Legacy compatibility only: older saved Eclipse buttons may still use
+    -- the ability IDs, but new adds must choose the specific CDM aura row.
+    [1233346] = "48517,48518",  -- Solar Eclipse legacy ability -> Eclipse buffs
+    [1233272] = "48517,48518",  -- Lunar Eclipse legacy ability -> Eclipse buffs
 }
 
 -------------------------------------------------------------------------------

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -130,6 +130,26 @@ local function ResolveViewerFrameForSpellID(spellID, buffOnly)
     return candidate
 end
 
+local function ResolveDirectBuffViewerSpellID(spellID)
+    local numericID = tonumber(spellID)
+    if not numericID or numericID == 0 then
+        return nil
+    end
+
+    local frame = ResolveViewerFrameForSpellID(numericID, true)
+    local info = frame and frame.cooldownInfo
+    if type(info) ~= "table" then
+        return nil
+    end
+
+    if tonumber(info.overrideTooltipSpellID) == numericID
+        or tonumber(info.overrideSpellID) == numericID
+        or tonumber(info.spellID) == numericID then
+        return numericID
+    end
+    return nil
+end
+
 local function CooldownInfoMatchesCandidateSet(cooldownInfo, candidateSet)
     if type(cooldownInfo) ~= "table" then
         return false
@@ -342,6 +362,10 @@ function CooldownCompanion:ResolveAuraSpellID(buttonData)
         return first and tonumber(first)
     end
     if buttonData.type == "spell" then
+        local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
+        if directAuraID then
+            return directAuraID
+        end
         -- Resolve through base spell so form-variant spells (e.g. Stampeding
         -- Roar: 106898/77764/77761) use the base ID for aura lookups — the
         -- buff is always applied as the base spell regardless of form.
@@ -368,6 +392,11 @@ function CooldownCompanion:InferConfirmedAuraSpellIDString(buttonData)
     local overrideBuffs = self.ABILITY_BUFF_OVERRIDES[buttonData.id]
     if overrideBuffs then
         return overrideBuffs
+    end
+
+    local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
+    if directAuraID then
+        return tostring(directAuraID)
     end
 
     local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
@@ -440,6 +469,11 @@ function CooldownCompanion:ResolveStandaloneAuraDefaultSpellID(buttonData)
     local explicitAuraID = ResolveSingleSpellID(buttonData.auraSpellID)
     if explicitAuraID then
         return explicitAuraID
+    end
+
+    local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
+    if directAuraID then
+        return directAuraID
     end
 
     local resolvedAuraID = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
@@ -750,11 +784,8 @@ end
 
 -- Hardcoded ability → buff overrides for spells whose ability ID and buff IDs
 -- are completely unlinked by any API (GetCooldownAuraBySpellID returns 0).
--- Both Eclipse forms map to both buff IDs so whichever buff is active gets tracked.
 -- Format: [abilitySpellID] = "comma-separated buff spell IDs"
 CooldownCompanion.ABILITY_BUFF_OVERRIDES = {
-    [1233346] = "48517,48518",  -- Solar Eclipse → Eclipse (Solar) + Eclipse (Lunar) buffs
-    [1233272] = "48517,48518",  -- Lunar Eclipse → Eclipse (Solar) + Eclipse (Lunar) buffs
 }
 
 -------------------------------------------------------------------------------
@@ -851,6 +882,23 @@ end
 function CooldownCompanion:BuildViewerAuraMap()
     wipe(self.viewerAuraFrames)
     wipe(self.viewerAuraAllChildren)
+
+    local function AddViewerAuraChild(spellID, child)
+        if not spellID or not child then
+            return
+        end
+        if not self.viewerAuraAllChildren[spellID] then
+            self.viewerAuraAllChildren[spellID] = {}
+        end
+        local children = self.viewerAuraAllChildren[spellID]
+        for _, existing in ipairs(children) do
+            if existing == child then
+                return
+            end
+        end
+        table.insert(children, child)
+    end
+
     for _, name in ipairs(VIEWER_NAMES) do
         local viewer = _G[name]
         if viewer then
@@ -865,10 +913,7 @@ function CooldownCompanion:BuildViewerAuraMap()
                         -- Diabolic Ritual twice in Tracked Buffs), not cross-section
                         -- matches (e.g. Agony in Essential + Buffs).
                         if BUFF_VIEWER_SET[name] then
-                            if not self.viewerAuraAllChildren[spellID] then
-                                self.viewerAuraAllChildren[spellID] = {}
-                            end
-                            table.insert(self.viewerAuraAllChildren[spellID], child)
+                            AddViewerAuraChild(spellID, child)
                         end
                     end
                     local override = info.overrideSpellID
@@ -884,6 +929,12 @@ function CooldownCompanion:BuildViewerAuraMap()
                             self.viewerAuraFrames[linked] = child
                         end
                     end
+                    if BUFF_VIEWER_SET[name] then
+                        local specificSpellID = info.overrideTooltipSpellID or info.overrideSpellID
+                        if specificSpellID and specificSpellID ~= spellID then
+                            AddViewerAuraChild(specificSpellID, child)
+                        end
+                    end
                 end
             end
         end
@@ -893,8 +944,8 @@ function CooldownCompanion:BuildViewerAuraMap()
     self:MapButtonSpellsToViewers()
 
     -- Map hardcoded overrides: ability IDs and buff IDs → viewer child.
-    -- Group by buff string so sibling abilities (e.g. Solar/Lunar Eclipse)
-    -- cross-map to the same viewer child even if only one form is current.
+    -- Group by buff string so sibling abilities can cross-map to the same
+    -- viewer child even if only one form is current.
     local groupsByBuffs = {}
     for abilityID, buffIDStr in pairs(self.ABILITY_BUFF_OVERRIDES) do
         if not groupsByBuffs[buffIDStr] then

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1241,9 +1241,10 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
     -- Resolve spell transforms to base spell ID so the override chain can
     -- freely reach all variant forms at runtime.  Skip for items (no spell
     -- transform system), pet spells (may not resolve through GetBaseSpell),
-    -- and CDM child-slot buttons (viewer-frame mapping uses specific IDs).
+    -- forced aura entries, and CDM child-slot buttons (viewer-frame mapping
+    -- uses specific IDs).
     local transformNotified
-    if buttonType == "spell" and not isPetSpell and not cdmChildSlot then
+    if buttonType == "spell" and not isPetSpell and forceAura ~= true and not cdmChildSlot then
         local baseID = ST.ResolveToBaseSpell(id)
         if baseID ~= id then
             id = baseID

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -207,6 +207,9 @@ function CooldownCompanion:OnEnable()
 
     -- Rebuild viewer aura map when Cooldown Manager layout changes (user rearranges spells)
     EventRegistry:RegisterCallback("CooldownViewerSettings.OnDataChanged", function()
+        if ST._configState then
+            ST._configState.autocompleteCache = nil
+        end
         C_Timer.After(0.2, function()
             self:QueueBuildViewerAuraMap()
         end)


### PR DESCRIPTION
## What Players Will Notice
- Balance Druid CDM aura choices like Eclipse and Starweaver now appear and add as their specific aura states instead of a generic parent entry.
- Panel entries, custom aura bars, resource aura pickers, and Auto Add now use the same CDM aura choices more consistently.
- Existing legacy Eclipse entries are preserved, but new additions ask players to choose the specific CDM aura when Blizzard exposes distinct aura IDs.

## Why This Changed
- Blizzard CDM exposes some aura families as separate rows with separate IDs and icons, but the addon could still offer or create generic entries that blurred those states together.
- That made it unclear which aura was being added and could cause the wrong name, icon, or tracking identity to appear in config.

## What Changed
- CDM Tracked Buff and Tracked Bar autocomplete entries now resolve to their specific aura IDs instead of the base spell when Blizzard provides distinct CDM aura rows.
- The old multi-add behavior is limited to CDM entries that share the same resolved aura ID; distinct aura IDs require selecting the specific aura.
- Shared aura dropdowns now use the same autocomplete source so panel entries, custom aura bars, and resource aura controls present matching choices.
- Config display names prefer CDM-specific aura metadata while preserving user custom names.
- Auto Import and action-bar Auto Add preserve specific aura IDs and skip ambiguous generic aura imports rather than guessing.
- Legacy Eclipse ability-ID overrides remain for existing saved buttons, while new adds are blocked from recreating the old generic path.

## Validation
- Ran `luac -p` on all touched Lua files.
- Ran `git diff --check origin/main...HEAD`.
- In-game behavior checks on the branch were reported as working as intended for the new CDM-specific add behavior.
- Legacy Eclipse saved-entry behavior and combat/restricted-content behavior still need final in-game verification before marking this ready.