### PR TITLE
Fix Roll the Bones aura variation names

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -800,6 +800,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraTrackingReady = buttonData.isPassive == true
     button._showingAuraIcon = false
     button._auraViewerFrame = nil
+    button._activeAuraSpellID = nil
     button._lastViewerTexId = nil
 
     button._auraInstanceID = nil
@@ -924,6 +925,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._auraActive = nil
     button._showingAuraIcon = nil
     button._auraViewerFrame = nil
+    button._activeAuraSpellID = nil
     button._lastViewerTexId = nil
 
     button._auraInstanceID = nil

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -805,6 +805,8 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraInstanceID = nil
     button._viewerBar = nil
     button._viewerAuraVisualsActive = nil
+    button._auraDisplayName = nil
+    button._auraNameOverrideActive = nil
 
     -- Per-button visibility runtime state
     button._visibilityHidden = false
@@ -823,7 +825,9 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     if style.showBarNameText ~= false or buttonData.customName then
         local displayName = buttonData.customName or buttonData.name
         if not buttonData.customName then
-            if buttonData.type == "spell" then
+            if button._auraActive and button._auraDisplayName then
+                displayName = button._auraDisplayName
+            elseif buttonData.type == "spell" then
                 local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
                 if spellName then displayName = spellName end
             elseif buttonData.type == "item" then
@@ -928,6 +932,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._pandemicGraceStart = nil
     button._pandemicGraceSuppressed = nil
     button._viewerAuraVisualsActive = nil
+    button._auraDisplayName = nil
+    button._auraNameOverrideActive = nil
     button._auraSpellID = CooldownCompanion:ResolveAuraSpellID(button.buttonData)
     button._auraUnit = button.buttonData.auraUnit or "player"
     button._auraStackText = nil
@@ -1123,7 +1129,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     if newStyle.showBarNameText ~= false or (button.buttonData and button.buttonData.customName) then
         local displayName = button.buttonData.customName or button.buttonData.name
         if not button.buttonData.customName then
-            if button.buttonData.type == "spell" then
+            if button._auraActive and button._auraDisplayName then
+                displayName = button._auraDisplayName
+            elseif button.buttonData.type == "spell" then
                 local spellName = C_Spell.GetSpellName(button._displaySpellId or button.buttonData.id)
                 if spellName then displayName = spellName end
             elseif button.buttonData.type == "item" then

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -801,6 +801,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._showingAuraIcon = false
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
+    button._activeAuraSpellIDFromFallback = nil
     button._lastViewerTexId = nil
 
     button._auraInstanceID = nil
@@ -926,6 +927,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._showingAuraIcon = nil
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
+    button._activeAuraSpellIDFromFallback = nil
     button._lastViewerTexId = nil
 
     button._auraInstanceID = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1104,6 +1104,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeRealCooldownShown = false
     local auraDisplayNameState
     local activeAuraSpellID
+    local activeAuraSpellIDSourceResolved = false
     local activeAuraSpellIDFromFallback = false
     local previousActiveAuraSpellID = button._activeAuraSpellID
     local previousActiveAuraSpellIDFromFallback = button._activeAuraSpellIDFromFallback == true
@@ -1203,6 +1204,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     if auraData then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                        activeAuraSpellIDSourceResolved = true
                         button._durationObj = durationObj
                         button._viewerBar = nil  -- primary path: DurationObject available
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1356,6 +1358,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     if durationObj then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
+                        activeAuraSpellIDSourceResolved = true
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1482,7 +1485,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if auraOverrideActive then
             button._auraHasTimer = auraHasTimer
             button._activeAuraSpellID = activeAuraSpellID or button._activeAuraSpellID
-            if activeAuraSpellID then
+            if activeAuraSpellIDSourceResolved then
                 button._activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback or nil
             end
         end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1386,6 +1386,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     if durationObj then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                        if activeAuraSpellID then
+                            activeAuraSpellIDSourceResolved = true
+                            activeAuraSpellIDFromFallback = true
+                        end
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1480,8 +1480,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._auraInstanceID = nil
             button._auraUnit = configUnit
             button._activeAuraSpellID = nil
-        elseif auraDisplayNameState and not auraDisplayNameState.nameApplied then
-            PreserveSecretAuraTextRender(auraDisplayNameState)
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1104,6 +1104,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeRealCooldownShown = false
     local auraDisplayNameState
     local activeAuraSpellID
+    local activeAuraSpellIDFromFallback = false
+    local previousActiveAuraSpellID = button._activeAuraSpellID
+    local previousActiveAuraSpellIDFromFallback = button._activeAuraSpellIDFromFallback == true
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
     local auraOverrideActive = false
@@ -1316,6 +1319,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
                     if auraData then
                         activeAuraSpellID = numId
+                        activeAuraSpellIDFromFallback = true
                         break
                     end
                 end
@@ -1325,6 +1329,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
                     if auraData then
                         activeAuraSpellID = fallbackId
+                        activeAuraSpellIDFromFallback = true
                     end
                 end
             else
@@ -1334,11 +1339,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
                 if auraData then
                     activeAuraSpellID = fallbackId
+                    activeAuraSpellIDFromFallback = true
                 end
                 if not auraData then
                     auraData = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID)
                     if auraData then
                         activeAuraSpellID = button._auraSpellID
+                        activeAuraSpellIDFromFallback = true
                     end
                 end
             end
@@ -1475,11 +1482,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if auraOverrideActive then
             button._auraHasTimer = auraHasTimer
             button._activeAuraSpellID = activeAuraSpellID or button._activeAuraSpellID
+            if activeAuraSpellID then
+                button._activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback or nil
+            end
         end
         if not auraOverrideActive then
             button._auraInstanceID = nil
             button._auraUnit = configUnit
             button._activeAuraSpellID = nil
+            button._activeAuraSpellIDFromFallback = nil
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the
@@ -1514,7 +1525,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if buttonData.auraShowAuraIcon and button._auraSpellID then
             local shouldShow = auraOverrideActive
             button._auraViewerFrame = shouldShow and viewerFrame or nil
-            if shouldShow ~= (button._showingAuraIcon or false) then
+            local activeAuraSpellChanged = shouldShow
+                and (button._activeAuraSpellID ~= previousActiveAuraSpellID
+                    or (button._activeAuraSpellIDFromFallback == true) ~= previousActiveAuraSpellIDFromFallback)
+            if shouldShow ~= (button._showingAuraIcon or false) or activeAuraSpellChanged then
                 button._showingAuraIcon = shouldShow
                 CooldownCompanion:UpdateButtonIcon(button)
             elseif shouldShow and viewerFrame then

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -327,8 +327,8 @@ local function ApplyAuraDisplayName(button, auraData)
         if button.nameText and not (buttonData and buttonData.customName) then
             button.nameText:SetText(auraName)
             button._auraNameOverrideActive = true
-            return true
         end
+        return true, auraName, true
     elseif auraName and auraName ~= "" then
         button._auraDisplayName = auraName
         button._auraNameOverrideActive = true
@@ -341,9 +341,10 @@ local function RestoreBaseDisplayName(button, buttonData)
         return
     end
 
+    local restoreSpellID = button._displaySpellId or buttonData.id
     local baseName = buttonData.name
     if buttonData.type == "spell" then
-        baseName = C_Spell.GetSpellName(buttonData.id) or baseName
+        baseName = C_Spell.GetSpellName(restoreSpellID) or baseName
     elseif buttonData.type == "item" then
         baseName = C_Item.GetItemNameByID(buttonData.id) or baseName
     end
@@ -1028,6 +1029,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
     local auraDisplayNameApplied = false
+    local auraSecretDisplayName
+    local hasAuraSecretDisplayName = false
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
     local auraOverrideActive = false
@@ -1114,7 +1117,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     -- old target after a target switch), causing ghost auras.
                     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
                     if auraData then
-                        auraDisplayNameApplied = ApplyAuraDisplayName(button, auraData) or auraDisplayNameApplied
+                        local nameApplied, secretName, nameIsSecret = ApplyAuraDisplayName(button, auraData)
+                        if nameApplied then auraDisplayNameApplied = true end
+                        if nameIsSecret then
+                            auraSecretDisplayName = secretName
+                            hasAuraSecretDisplayName = true
+                        end
                         button._durationObj = durationObj
                         button._viewerBar = nil  -- primary path: DurationObject available
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1239,7 +1247,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if instId and not issecretvalue(instId) then
                     local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
                     if durationObj then
-                        auraDisplayNameApplied = ApplyAuraDisplayName(button, auraData) or auraDisplayNameApplied
+                        local nameApplied, secretName, nameIsSecret = ApplyAuraDisplayName(button, auraData)
+                        if nameApplied then auraDisplayNameApplied = true end
+                        if nameIsSecret then
+                            auraSecretDisplayName = secretName
+                            hasAuraSecretDisplayName = true
+                        end
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1265,7 +1278,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if auraData then
                     local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
                     if durationObj then
-                        auraDisplayNameApplied = ApplyAuraDisplayName(button, auraData) or auraDisplayNameApplied
+                        local nameApplied, secretName, nameIsSecret = ApplyAuraDisplayName(button, auraData)
+                        if nameApplied then auraDisplayNameApplied = true end
+                        if nameIsSecret then
+                            auraSecretDisplayName = secretName
+                            hasAuraSecretDisplayName = true
+                        end
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1498,9 +1516,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button._auraNameOverrideActive = true
             elseif auraDisplayNameApplied then
                 -- Secret aura names are already passed through directly above.
-            elseif viewerFrame then
+            end
+            if viewerFrame then
                 local viewerName = GetViewerNameFontString(viewerFrame)
-                if button.nameText and not buttonData.customName and viewerName and viewerName.GetText then
+                if not auraDisplayNameApplied and button.nameText and not buttonData.customName and viewerName and viewerName.GetText then
                     -- Pass through the CDM-rendered text directly; avoid calling viewer mixin methods
                     -- from tainted code (they can execute secret-value logic internally).
                     button.nameText:SetText(viewerName:GetText())
@@ -2144,7 +2163,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Mode-specific visual dispatch
     if button._isText then
-        UpdateTextDisplay(button)
+        UpdateTextDisplay(button, auraSecretDisplayName, hasAuraSecretDisplayName)
     elseif button._isBar then
         UpdateBarDisplay(button)
         DispatchStandaloneTextureVisual(button)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1042,6 +1042,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraEventRemoved = button._auraEventRemoved
     button._auraEventRemoved = nil
     if buttonData.auraTracking and button._auraSpellID then
+        button._auraDisplayName = nil
         local configUnit = GetConfiguredAuraUnit(buttonData)
         local auraUnit = button._auraUnit or configUnit
 
@@ -1384,7 +1385,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if not auraOverrideActive then
             button._auraInstanceID = nil
             button._auraUnit = configUnit
-            button._auraDisplayName = nil
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1042,6 +1042,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraEventRemoved = button._auraEventRemoved
     button._auraEventRemoved = nil
     if buttonData.auraTracking and button._auraSpellID then
+        local priorAuraDisplayName = button._auraDisplayName
         button._auraDisplayName = nil
         local configUnit = GetConfiguredAuraUnit(buttonData)
         local auraUnit = button._auraUnit or configUnit
@@ -1064,13 +1065,19 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         -- Cache parsed IDs on the button to avoid per-tick gmatch allocation.
         if not viewerFrame and buttonData.auraSpellID then
             local ids = button._parsedAuraIDs
-            if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID then
+            if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
                 ids = {}
+                button._parsedAuraIDsIncludeButtonID = nil
                 for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                    ids[#ids + 1] = tonumber(id)
+                    local numId = tonumber(id)
+                    ids[#ids + 1] = numId
+                    if numId == buttonData.id then
+                        button._parsedAuraIDsIncludeButtonID = true
+                    end
                 end
                 button._parsedAuraIDs = ids
                 button._parsedAuraIDsRaw = buttonData.auraSpellID
+                button._parsedAuraIDsButtonID = buttonData.id
             end
             for _, numId in ipairs(ids) do
                 local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
@@ -1222,7 +1229,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local auraData
             if buttonData.auraSpellID then
                 local ids = button._parsedAuraIDs
-                if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID then
+                if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
                     ids = {}
                     button._parsedAuraIDsIncludeButtonID = nil
                     for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
@@ -1234,6 +1241,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     end
                     button._parsedAuraIDs = ids
                     button._parsedAuraIDsRaw = buttonData.auraSpellID
+                    button._parsedAuraIDsButtonID = buttonData.id
                 end
                 for _, numId in ipairs(ids) do
                     auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
@@ -1346,6 +1354,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if now - button._auraGraceStart <= 0.3 or button._targetSwitchAt then
                     button._durationObj = prevAuraDurationObj
                     auraOverrideActive = true
+                    if priorAuraDisplayName then
+                        button._auraDisplayName = priorAuraDisplayName
+                        auraDisplayNameApplied = true
+                    end
                 else
                     button._auraGraceStart = nil
                 end
@@ -1386,6 +1398,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             else
                 button._durationObj = prevAuraDurationObj
                 auraOverrideActive = true
+                if priorAuraDisplayName then
+                    button._auraDisplayName = priorAuraDisplayName
+                    auraDisplayNameApplied = true
+                end
             end
         end
         button._auraActive = auraOverrideActive

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -341,6 +341,13 @@ local function RecordAuraDisplayName(state, auraData)
     end
 end
 
+local function GetReadableAuraSpellID(auraData)
+    local spellID = auraData and auraData.spellId
+    if spellID and not issecretvalue(spellID) then
+        return spellID
+    end
+end
+
 local function PreserveSecretAuraTextRender(state)
     if not (state and state.priorSecretTextActive) then return end
     state.preserveSecretTextRender = true
@@ -1096,6 +1103,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
     local auraDisplayNameState
+    local activeAuraSpellID
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
     local auraOverrideActive = false
@@ -1191,6 +1199,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
                     if auraData then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
+                        activeAuraSpellID = GetReadableAuraSpellID(auraData)
                         button._durationObj = durationObj
                         button._viewerBar = nil  -- primary path: DurationObject available
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1305,20 +1314,32 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 end
                 for _, numId in ipairs(ids) do
                     auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
-                    if auraData then break end
+                    if auraData then
+                        activeAuraSpellID = numId
+                        break
+                    end
                 end
                 if not auraData and not button._parsedAuraIDsIncludeButtonID then
                     local baseId = C_Spell.GetBaseSpell(buttonData.id)
                     local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
                     auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+                    if auraData then
+                        activeAuraSpellID = fallbackId
+                    end
                 end
             else
                 local baseId = C_Spell.GetBaseSpell(buttonData.id)
                 -- Try base spell first for implicit form-variant spells where the buff is applied as base.
                 local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
                 auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+                if auraData then
+                    activeAuraSpellID = fallbackId
+                end
                 if not auraData then
                     auraData = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID)
+                    if auraData then
+                        activeAuraSpellID = button._auraSpellID
+                    end
                 end
             end
             if auraData then
@@ -1327,6 +1348,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
                     if durationObj then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
+                        activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1353,6 +1375,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
                     if durationObj then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
+                        activeAuraSpellID = GetReadableAuraSpellID(auraData)
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1451,10 +1474,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._auraActive = auraOverrideActive
         if auraOverrideActive then
             button._auraHasTimer = auraHasTimer
+            button._activeAuraSpellID = activeAuraSpellID or button._activeAuraSpellID
         end
         if not auraOverrideActive then
             button._auraInstanceID = nil
             button._auraUnit = configUnit
+            button._activeAuraSpellID = nil
         elseif auraDisplayNameState and not auraDisplayNameState.nameApplied then
             PreserveSecretAuraTextRender(auraDisplayNameState)
         end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1224,8 +1224,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 local ids = button._parsedAuraIDs
                 if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID then
                     ids = {}
+                    button._parsedAuraIDsIncludeButtonID = nil
                     for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                        ids[#ids + 1] = tonumber(id)
+                        local numId = tonumber(id)
+                        ids[#ids + 1] = numId
+                        if numId == buttonData.id then
+                            button._parsedAuraIDsIncludeButtonID = true
+                        end
                     end
                     button._parsedAuraIDs = ids
                     button._parsedAuraIDsRaw = buttonData.auraSpellID
@@ -1233,6 +1238,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 for _, numId in ipairs(ids) do
                     auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
                     if auraData then break end
+                end
+                if not auraData and not button._parsedAuraIDsIncludeButtonID then
+                    local baseId = C_Spell.GetBaseSpell(buttonData.id)
+                    local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
+                    auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
                 end
             else
                 local baseId = C_Spell.GetBaseSpell(buttonData.id)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -319,6 +319,40 @@ local function GetViewerNameFontString(viewerFrame)
     return bar and bar.Name or nil
 end
 
+local function ApplyAuraDisplayName(button, auraData)
+    if not (button and auraData) then return end
+    local auraName = auraData.name
+    if issecretvalue(auraName) then
+        local buttonData = button.buttonData
+        if button.nameText and not (buttonData and buttonData.customName) then
+            button.nameText:SetText(auraName)
+            button._auraNameOverrideActive = true
+            return true
+        end
+    elseif auraName and auraName ~= "" then
+        button._auraDisplayName = auraName
+        button._auraNameOverrideActive = true
+        return true
+    end
+end
+
+local function RestoreBaseDisplayName(button, buttonData)
+    if not (button and button.nameText and buttonData) or buttonData.customName then
+        return
+    end
+
+    local baseName = buttonData.name
+    if buttonData.type == "spell" then
+        baseName = C_Spell.GetSpellName(buttonData.id) or baseName
+    elseif buttonData.type == "item" then
+        baseName = C_Item.GetItemNameByID(buttonData.id) or baseName
+    end
+
+    if baseName then
+        button.nameText:SetText(baseName)
+    end
+end
+
 -- Hidden scratch CooldownFrame for probing DurationObject activity.
 -- DurationObject:IsZero() returns a secret boolean in tainted contexts;
 -- feeding the object to a Cooldown widget and checking IsShown() yields
@@ -993,6 +1027,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeDuration
     local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
+    local auraDisplayNameApplied = false
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
     local auraOverrideActive = false
@@ -1079,6 +1114,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     -- old target after a target switch), causing ghost auras.
                     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
                     if auraData then
+                        auraDisplayNameApplied = ApplyAuraDisplayName(button, auraData) or auraDisplayNameApplied
                         button._durationObj = durationObj
                         button._viewerBar = nil  -- primary path: DurationObject available
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1174,18 +1210,36 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         local canUsePlayerAuraFallback = auraTrackingReady and configUnit == "player"
 
         if canUsePlayerAuraFallback and not auraOverrideActive then
-            local baseId = C_Spell.GetBaseSpell(buttonData.id)
-            -- Try base spell first (buff is applied as base), then _auraSpellID
-            local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
-            local auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
-            if not auraData then
-                auraData = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID)
+            local auraData
+            if buttonData.auraSpellID then
+                local ids = button._parsedAuraIDs
+                if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID then
+                    ids = {}
+                    for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+                        ids[#ids + 1] = tonumber(id)
+                    end
+                    button._parsedAuraIDs = ids
+                    button._parsedAuraIDsRaw = buttonData.auraSpellID
+                end
+                for _, numId in ipairs(ids) do
+                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
+                    if auraData then break end
+                end
+            else
+                local baseId = C_Spell.GetBaseSpell(buttonData.id)
+                -- Try base spell first for implicit form-variant spells where the buff is applied as base.
+                local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
+                auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+                if not auraData then
+                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID)
+                end
             end
             if auraData then
                 local instId = auraData.auraInstanceID
                 if instId and not issecretvalue(instId) then
                     local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
                     if durationObj then
+                        auraDisplayNameApplied = ApplyAuraDisplayName(button, auraData) or auraDisplayNameApplied
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1211,6 +1265,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if auraData then
                     local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
                     if durationObj then
+                        auraDisplayNameApplied = ApplyAuraDisplayName(button, auraData) or auraDisplayNameApplied
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1311,6 +1366,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if not auraOverrideActive then
             button._auraInstanceID = nil
             button._auraUnit = configUnit
+            button._auraDisplayName = nil
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the
@@ -1437,7 +1493,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         -- active. This mirrors CDM state-based names (e.g. Light/Moderate/Heavy).
         -- Icon is NOT passed through — UpdateButtonIcon is the sole authoritative source.
         if auraOverrideActive then
-            if viewerFrame then
+            if button.nameText and not buttonData.customName and button._auraDisplayName then
+                button.nameText:SetText(button._auraDisplayName)
+                button._auraNameOverrideActive = true
+            elseif auraDisplayNameApplied then
+                -- Secret aura names are already passed through directly above.
+            elseif viewerFrame then
                 local viewerName = GetViewerNameFontString(viewerFrame)
                 if button.nameText and not buttonData.customName and viewerName and viewerName.GetText then
                     -- Pass through the CDM-rendered text directly; avoid calling viewer mixin methods
@@ -1453,15 +1514,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 end
                 button._viewerAuraVisualsActive = true
             end
-        elseif button._viewerAuraVisualsActive then
+        elseif button._viewerAuraVisualsActive or button._auraNameOverrideActive then
             button._viewerAuraVisualsActive = nil
-            if button.nameText and not buttonData.customName then
-                local restoreSpellID = button._displaySpellId or buttonData.id
-                local baseName = C_Spell.GetSpellName(restoreSpellID)
-                if baseName then
-                    button.nameText:SetText(baseName)
-                end
-            end
+            button._auraNameOverrideActive = nil
+            RestoreBaseDisplayName(button, buttonData)
             -- Multi-slot buttons got their icon from per-tick viewer reads while
             -- the aura was active. Now that the aura has dropped, re-sync the icon
             -- to the viewer's current (base) state.

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -319,20 +319,41 @@ local function GetViewerNameFontString(viewerFrame)
     return bar and bar.Name or nil
 end
 
-local function ApplyAuraDisplayName(button, auraData)
-    if not (button and auraData) then return end
+local function CreateAuraDisplayNameState(button)
+    return {
+        priorReadableName = button and button._auraDisplayName or nil,
+        priorSecretTextActive = button and button._isText and button._textSecretNameActive == true or false,
+    }
+end
+
+local function RecordAuraDisplayName(state, auraData)
+    if not (state and auraData) then return end
     local auraName = auraData.name
     if issecretvalue(auraName) then
-        local buttonData = button.buttonData
-        if button.nameText and not (buttonData and buttonData.customName) then
-            button.nameText:SetText(auraName)
-            button._auraNameOverrideActive = true
-        end
-        return true, auraName, true
-    elseif auraName and auraName ~= "" then
-        button._auraDisplayName = auraName
-        button._auraNameOverrideActive = true
+        state.secretName = auraName
+        state.hasSecretName = true
+        state.nameApplied = true
         return true
+    elseif auraName and auraName ~= "" then
+        state.readableName = auraName
+        state.nameApplied = true
+        return true
+    end
+end
+
+local function PreserveSecretAuraTextRender(state)
+    if not (state and state.priorSecretTextActive) then return end
+    state.preserveSecretTextRender = true
+    state.nameApplied = true
+end
+
+local function PreserveAuraDisplayNameDuringGrace(state)
+    if not state then return end
+    if state.priorReadableName then
+        state.readableName = state.priorReadableName
+        state.nameApplied = true
+    elseif state.priorSecretTextActive then
+        PreserveSecretAuraTextRender(state)
     end
 end
 
@@ -351,6 +372,52 @@ local function RestoreBaseDisplayName(button, buttonData)
 
     if baseName then
         button.nameText:SetText(baseName)
+    end
+end
+
+local function CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, state)
+    if auraOverrideActive then
+        if state and state.readableName then
+            button._auraDisplayName = state.readableName
+            if button.nameText and not buttonData.customName then
+                button.nameText:SetText(state.readableName)
+                button._auraNameOverrideActive = true
+            end
+        elseif state and state.hasSecretName then
+            if button.nameText and not buttonData.customName then
+                button.nameText:SetText(state.secretName)
+                button._auraNameOverrideActive = true
+            end
+        elseif state and state.preserveSecretTextRender then
+            button._auraNameOverrideActive = true
+        end
+
+        if viewerFrame then
+            local viewerName = GetViewerNameFontString(viewerFrame)
+            if not (state and state.nameApplied) and button.nameText and not buttonData.customName and viewerName and viewerName.GetText then
+                -- Pass through the CDM-rendered text directly; avoid calling viewer mixin methods
+                -- from tainted code (they can execute secret-value logic internally).
+                button.nameText:SetText(viewerName:GetText())
+            end
+            -- Multi-slot buttons read their icon from the viewer's Icon widget.
+            -- Event-driven UpdateButtonIcon calls can race with the CDM viewer's
+            -- internal icon update on transforms (e.g. Diabolic Ritual), so re-sync
+            -- the icon every tick to ensure it reflects the viewer's current state.
+            if buttonData.cdmChildSlot then
+                CooldownCompanion:UpdateButtonIcon(button)
+            end
+            button._viewerAuraVisualsActive = true
+        end
+    elseif button._viewerAuraVisualsActive or button._auraNameOverrideActive then
+        button._viewerAuraVisualsActive = nil
+        button._auraNameOverrideActive = nil
+        RestoreBaseDisplayName(button, buttonData)
+        -- Multi-slot buttons got their icon from per-tick viewer reads while
+        -- the aura was active. Now that the aura has dropped, re-sync the icon
+        -- to the viewer's current (base) state.
+        if buttonData.cdmChildSlot then
+            CooldownCompanion:UpdateButtonIcon(button)
+        end
     end
 end
 
@@ -1028,9 +1095,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeDuration
     local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
-    local auraDisplayNameApplied = false
-    local auraSecretDisplayName
-    local hasAuraSecretDisplayName = false
+    local auraDisplayNameState
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
     local auraOverrideActive = false
@@ -1042,7 +1107,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraEventRemoved = button._auraEventRemoved
     button._auraEventRemoved = nil
     if buttonData.auraTracking and button._auraSpellID then
-        local priorAuraDisplayName = button._auraDisplayName
+        auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
         local configUnit = GetConfiguredAuraUnit(buttonData)
         local auraUnit = button._auraUnit or configUnit
@@ -1125,12 +1190,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     -- old target after a target switch), causing ghost auras.
                     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
                     if auraData then
-                        local nameApplied, secretName, nameIsSecret = ApplyAuraDisplayName(button, auraData)
-                        if nameApplied then auraDisplayNameApplied = true end
-                        if nameIsSecret then
-                            auraSecretDisplayName = secretName
-                            hasAuraSecretDisplayName = true
-                        end
+                        RecordAuraDisplayName(auraDisplayNameState, auraData)
                         button._durationObj = durationObj
                         button._viewerBar = nil  -- primary path: DurationObject available
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1266,12 +1326,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if instId and not issecretvalue(instId) then
                     local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
                     if durationObj then
-                        local nameApplied, secretName, nameIsSecret = ApplyAuraDisplayName(button, auraData)
-                        if nameApplied then auraDisplayNameApplied = true end
-                        if nameIsSecret then
-                            auraSecretDisplayName = secretName
-                            hasAuraSecretDisplayName = true
-                        end
+                        RecordAuraDisplayName(auraDisplayNameState, auraData)
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1297,12 +1352,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if auraData then
                     local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
                     if durationObj then
-                        local nameApplied, secretName, nameIsSecret = ApplyAuraDisplayName(button, auraData)
-                        if nameApplied then auraDisplayNameApplied = true end
-                        if nameIsSecret then
-                            auraSecretDisplayName = secretName
-                            hasAuraSecretDisplayName = true
-                        end
+                        RecordAuraDisplayName(auraDisplayNameState, auraData)
                         button._durationObj = durationObj
                         button._viewerBar = nil
                         button.cooldown:SetCooldownFromDurationObject(durationObj)
@@ -1354,10 +1404,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if now - button._auraGraceStart <= 0.3 or button._targetSwitchAt then
                     button._durationObj = prevAuraDurationObj
                     auraOverrideActive = true
-                    if priorAuraDisplayName then
-                        button._auraDisplayName = priorAuraDisplayName
-                        auraDisplayNameApplied = true
-                    end
+                    PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
                 else
                     button._auraGraceStart = nil
                 end
@@ -1398,10 +1445,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             else
                 button._durationObj = prevAuraDurationObj
                 auraOverrideActive = true
-                if priorAuraDisplayName then
-                    button._auraDisplayName = priorAuraDisplayName
-                    auraDisplayNameApplied = true
-                end
+                PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
             end
         end
         button._auraActive = auraOverrideActive
@@ -1411,6 +1455,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if not auraOverrideActive then
             button._auraInstanceID = nil
             button._auraUnit = configUnit
+        elseif auraDisplayNameState and not auraDisplayNameState.nameApplied then
+            PreserveSecretAuraTextRender(auraDisplayNameState)
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the
@@ -1533,43 +1579,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
         button._inPandemic = inPandemic
 
-        -- Pass through the CDM item's current name text when aura tracking is
-        -- active. This mirrors CDM state-based names (e.g. Light/Moderate/Heavy).
-        -- Icon is NOT passed through — UpdateButtonIcon is the sole authoritative source.
-        if auraOverrideActive then
-            if button.nameText and not buttonData.customName and button._auraDisplayName then
-                button.nameText:SetText(button._auraDisplayName)
-                button._auraNameOverrideActive = true
-            elseif auraDisplayNameApplied then
-                -- Secret aura names are already passed through directly above.
-            end
-            if viewerFrame then
-                local viewerName = GetViewerNameFontString(viewerFrame)
-                if not auraDisplayNameApplied and button.nameText and not buttonData.customName and viewerName and viewerName.GetText then
-                    -- Pass through the CDM-rendered text directly; avoid calling viewer mixin methods
-                    -- from tainted code (they can execute secret-value logic internally).
-                    button.nameText:SetText(viewerName:GetText())
-                end
-                -- Multi-slot buttons read their icon from the viewer's Icon widget.
-                -- Event-driven UpdateButtonIcon calls can race with the CDM viewer's
-                -- internal icon update on transforms (e.g. Diabolic Ritual), so re-sync
-                -- the icon every tick to ensure it reflects the viewer's current state.
-                if buttonData.cdmChildSlot then
-                    CooldownCompanion:UpdateButtonIcon(button)
-                end
-                button._viewerAuraVisualsActive = true
-            end
-        elseif button._viewerAuraVisualsActive or button._auraNameOverrideActive then
-            button._viewerAuraVisualsActive = nil
-            button._auraNameOverrideActive = nil
-            RestoreBaseDisplayName(button, buttonData)
-            -- Multi-slot buttons got their icon from per-tick viewer reads while
-            -- the aura was active. Now that the aura has dropped, re-sync the icon
-            -- to the viewer's current (base) state.
-            if buttonData.cdmChildSlot then
-                CooldownCompanion:UpdateButtonIcon(button)
-            end
-        end
+        -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
+        CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
     end
     button._auraTrackingReady = auraTrackingReady
 
@@ -2189,7 +2200,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Mode-specific visual dispatch
     if button._isText then
-        UpdateTextDisplay(button, auraSecretDisplayName, hasAuraSecretDisplayName)
+        if not (auraDisplayNameState and auraDisplayNameState.preserveSecretTextRender) then
+            UpdateTextDisplay(button, auraDisplayNameState and auraDisplayNameState.secretName, auraDisplayNameState and auraDisplayNameState.hasSecretName == true)
+        end
     elseif button._isBar then
         UpdateBarDisplay(button)
         DispatchStandaloneTextureVisual(button)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -392,6 +392,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button._auraTrackingReady = buttonData.isPassive == true
     button._showingAuraIcon = false
     button._auraViewerFrame = nil
+    button._activeAuraSpellID = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
     button._spellTexBaseline = nil
@@ -619,8 +620,9 @@ function CooldownCompanion:UpdateButtonIcon(button)
     end
 
     -- Aura icon swap: show the tracked aura spell's icon while aura is active
+    local auraIconSpellID = button._activeAuraSpellID or button._auraSpellID
     if buttonData.type == "spell" and button._auraActive
-       and buttonData.auraShowAuraIcon and button._auraSpellID then
+       and buttonData.auraShowAuraIcon and auraIconSpellID then
         -- Read the viewer frame's Icon texture (updates per-stage for multi-stage
         -- auras like Hot Streak). GetTextureFileID may return a secret value in
         -- combat; pass it straight through — do not test or branch on it.
@@ -638,7 +640,7 @@ function CooldownCompanion:UpdateButtonIcon(button)
         end
         if not hasViewerIcon then
             -- Fallback: static spell texture (viewer hidden or unavailable)
-            local auraIcon = C_Spell.GetSpellTexture(button._auraSpellID)
+            local auraIcon = C_Spell.GetSpellTexture(auraIconSpellID)
             if auraIcon then icon = auraIcon end
         end
     end
@@ -967,6 +969,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._auraActive = nil
     button._showingAuraIcon = nil
     button._auraViewerFrame = nil
+    button._activeAuraSpellID = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
     button._spellTexBaseline = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -393,6 +393,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button._showingAuraIcon = false
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
+    button._activeAuraSpellIDFromFallback = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
     button._spellTexBaseline = nil
@@ -626,7 +627,7 @@ function CooldownCompanion:UpdateButtonIcon(button)
         -- Read the viewer frame's Icon texture (updates per-stage for multi-stage
         -- auras like Hot Streak). GetTextureFileID may return a secret value in
         -- combat; pass it straight through — do not test or branch on it.
-        local vf = button._auraViewerFrame
+        local vf = button._activeAuraSpellIDFromFallback and nil or button._auraViewerFrame
         local hasViewerIcon
         if vf then
             local iconTexture = vf.Icon
@@ -970,6 +971,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._showingAuraIcon = nil
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
+    button._activeAuraSpellIDFromFallback = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
     button._spellTexBaseline = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -398,6 +398,8 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
 
     button._auraInstanceID = nil
     button._viewerAuraVisualsActive = nil
+    button._auraDisplayName = nil
+    button._auraNameOverrideActive = nil
 
     -- Key press highlight runtime state
     button._keyPressHighlightActive = nil
@@ -974,6 +976,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._pandemicGraceStart = nil
     button._pandemicGraceSuppressed = nil
     button._viewerAuraVisualsActive = nil
+    button._auraDisplayName = nil
+    button._auraNameOverrideActive = nil
     button._auraSpellID = CooldownCompanion:ResolveAuraSpellID(button.buttonData)
     button._auraUnit = button.buttonData.auraUnit or "player"
     button._auraStackText = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -322,14 +322,16 @@ end
 ------------------------------------------------------------------------
 -- SUBSTITUTE TOKENS
 -- Builds the final display string from pre-parsed segments.
--- Returns: displayText, secretValue, secretColorToken, secretStackValue
+-- Returns: displayText, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue
 ------------------------------------------------------------------------
-local function SubstituteTokens(button, segments, style, effectState)
+local function SubstituteTokens(button, segments, style, effectState, secretNameOverride, hasSecretNameOverride)
     local buttonData = button.buttonData
     local parts = {}
     local secretValue = nil
     local secretColorToken = nil
     local secretStackValue = nil
+    local secretNameValue = nil
+    local hasSecretNameValue = false
 
     local baseColor = style.textFontColor or DEFAULT_WHITE
     local cdColor = style.textCooldownColor or DEFAULT_CD_COLOR
@@ -451,7 +453,12 @@ local function SubstituteTokens(button, segments, style, effectState)
             if token == "name" then
                 local name = buttonData.customName or buttonData.name or ""
                 if not buttonData.customName and buttonData.type == "spell" then
-                    if button._auraActive and button._auraDisplayName then
+                    if button._auraActive and hasSecretNameOverride then
+                        secretNameValue = secretNameOverride
+                        hasSecretNameValue = true
+                        parts[#parts + 1] = WrapColor("%NAME%", colorOverride or baseColor)
+                        name = nil
+                    elseif button._auraActive and button._auraDisplayName then
                         name = button._auraDisplayName
                     else
                         local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
@@ -461,7 +468,9 @@ local function SubstituteTokens(button, segments, style, effectState)
                     local itemName = C_Item.GetItemNameByID(buttonData.id)
                     if itemName then name = itemName end
                 end
-                parts[#parts + 1] = WrapColor(name, colorOverride or baseColor)
+                if name then
+                    parts[#parts + 1] = WrapColor(name, colorOverride or baseColor)
+                end
 
             elseif token == "time" then
                 if timeIsSecret then
@@ -570,14 +579,14 @@ local function SubstituteTokens(button, segments, style, effectState)
         end
     end
 
-    return table_concat(parts), secretValue, secretColorToken, secretStackValue
+    return table_concat(parts), secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue
 end
 
 ------------------------------------------------------------------------
 -- UPDATE TEXT DISPLAY
 -- Called each tick from CooldownUpdate.lua after data is resolved.
 ------------------------------------------------------------------------
-local function UpdateTextDisplay(button)
+local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverride)
     local style = button.style
     if not style or not button._textSegments then return end
 
@@ -587,9 +596,9 @@ local function UpdateTextDisplay(button)
         es.pulseActive = false
     end
 
-    local text, secretValue, secretColorToken, secretStackValue = SubstituteTokens(button, button._textSegments, style, es)
+    local text, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue = SubstituteTokens(button, button._textSegments, style, es, secretNameOverride, hasSecretNameOverride)
 
-    if secretValue or secretStackValue then
+    if secretValue or secretStackValue or hasSecretNameValue then
         -- Secret value pass-through: use SetFormattedText with the secret value
         -- Per-token coloring via |c..|r escape sequences works alongside % format specifiers
         -- (they operate at different layers: WoW text rendering vs C sprintf)
@@ -606,6 +615,7 @@ local function UpdateTextDisplay(button)
             {text = "%AURA%",   val = secretValue,      fmt = timeFmt},
             {text = "%STATUS%", val = secretValue,      fmt = timeFmt},
             {text = "%STACKS%", val = secretStackValue,  fmt = "%s"},
+            {text = "%NAME%",   val = secretNameValue,   fmt = "%s", active = hasSecretNameValue},
         }
 
         -- Single left-to-right pass: build format string and ordered args together
@@ -615,7 +625,7 @@ local function UpdateTextDisplay(button)
         while pos <= #fmtStr do
             local bestIdx, bestInfo
             for _, info in ipairs(allPlaceholders) do
-                if info.val then
+                if info.active or info.val then
                     local idx = fmtStr:find(info.text, pos, true)
                     if idx and (not bestIdx or idx < bestIdx) then
                         bestIdx = idx

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -589,7 +589,6 @@ end
 local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverride)
     local style = button.style
     if not style or not button._textSegments then return end
-    button._textSecretNameActive = hasSecretNameOverride == true
 
     -- Reset pulse content flag before substitution
     local es = button._effectState
@@ -598,6 +597,7 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
     end
 
     local text, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue = SubstituteTokens(button, button._textSegments, style, es, secretNameOverride, hasSecretNameOverride)
+    button._textSecretNameActive = hasSecretNameValue == true
 
     if secretValue or secretStackValue or hasSecretNameValue then
         -- Secret value pass-through: use SetFormattedText with the secret value

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -870,6 +870,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._auraTrackingReady = buttonData.isPassive == true
     button._showingAuraIcon = false
     button._auraViewerFrame = nil
+    button._activeAuraSpellID = nil
     button._lastViewerTexId = nil
     button._auraInstanceID = nil
     button._viewerBar = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -589,6 +589,7 @@ end
 local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverride)
     local style = button.style
     if not style or not button._textSegments then return end
+    button._textSecretNameActive = hasSecretNameOverride == true
 
     -- Reset pulse content flag before substitution
     local es = button._effectState
@@ -680,6 +681,15 @@ local function EffectOnUpdate(self, elapsed)
     local now = GetTime()
     local es = self._effectState
     es.pulseAlpha = ComputePulse(now)
+
+    if self._textSecretNameActive then
+        if es.pulseActive then
+            self.textString:SetAlpha(es.pulseAlpha)
+        else
+            self.textString:SetAlpha(1.0)
+        end
+        return
+    end
 
     UpdateTextDisplay(self)
 end
@@ -865,6 +875,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._viewerBar = nil
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil
+    button._textSecretNameActive = nil
 
     -- Per-button visibility runtime state
     button._visibilityHidden = false

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -871,6 +871,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._showingAuraIcon = false
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
+    button._activeAuraSpellIDFromFallback = nil
     button._lastViewerTexId = nil
     button._auraInstanceID = nil
     button._viewerBar = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -451,8 +451,12 @@ local function SubstituteTokens(button, segments, style, effectState)
             if token == "name" then
                 local name = buttonData.customName or buttonData.name or ""
                 if not buttonData.customName and buttonData.type == "spell" then
-                    local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
-                    if spellName then name = spellName end
+                    if button._auraActive and button._auraDisplayName then
+                        name = button._auraDisplayName
+                    else
+                        local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
+                        if spellName then name = spellName end
+                    end
                 elseif not buttonData.customName and buttonData.type == "item" then
                     local itemName = C_Item.GetItemNameByID(buttonData.id)
                     if itemName then name = itemName end
@@ -849,6 +853,8 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._lastViewerTexId = nil
     button._auraInstanceID = nil
     button._viewerBar = nil
+    button._auraDisplayName = nil
+    button._auraNameOverrideActive = nil
 
     -- Per-button visibility runtime state
     button._visibilityHidden = false

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -43,6 +43,45 @@ local function QueueSpellAvailabilitySettlingRefresh(addon)
     end)
 end
 
+local function PlayerHasTrackedAuraForButton(button, buttonData)
+    if button._activeAuraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(button._activeAuraSpellID) then
+        return true
+    end
+
+    if buttonData.auraSpellID then
+        local includesButtonID
+        for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+            local spellID = tonumber(id)
+            if spellID then
+                if spellID == buttonData.id then
+                    includesButtonID = true
+                end
+                if C_UnitAuras.GetPlayerAuraBySpellID(spellID) then
+                    return true
+                end
+            end
+        end
+        if not includesButtonID and buttonData.type == "spell" then
+            local baseId = C_Spell.GetBaseSpell(buttonData.id)
+            if baseId and baseId ~= button._auraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(baseId) then
+                return true
+            end
+        end
+        return false
+    end
+
+    if buttonData.type ~= "spell" then
+        return button._auraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID) ~= nil
+    end
+
+    local baseId = C_Spell.GetBaseSpell(buttonData.id)
+    if baseId and baseId ~= button._auraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(baseId) then
+        return true
+    end
+
+    return button._auraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID) ~= nil
+end
+
 function CooldownCompanion:RefreshSpellAvailabilityState(opts)
     opts = opts or {}
     self:CachePlayerState()
@@ -421,7 +460,7 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
                         local unit = button._auraUnit or "player"
                         local apiConfirms = false
                         if unit == "player" and button._auraSpellID then
-                            apiConfirms = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID) ~= nil
+                            apiConfirms = PlayerHasTrackedAuraForButton(button, bd)
                         elseif unit == "target" and UnitExists("target") and button._auraInstanceID then
                             apiConfirms = C_UnitAuras.GetAuraDuration("target", button._auraInstanceID) ~= nil
                         end


### PR DESCRIPTION
## What Players Will Notice
- Roll the Bones aura displays can show the active buff variation name, such as a specific Roll the Bones effect, instead of going blank or falling back to an unrelated/base spell name during combat.
- When the Roll the Bones aura ends, the display name returns to the base Roll the Bones entry instead of leaving the last variation name behind.
- Aura icon swaps for multi-ID tracked auras are less likely to get stuck on a stale viewer icon when the active variation changes or is recovered through fallback aura data.

## Why This Changed
- Roll the Bones behaves like a parent/tracked aura with several specific active variants, and those variant names can be secret values in combat. The old display path could lose the variant name, read the wrong viewer state, or keep stale state after the aura ended.

## What Changed
- Added aura display-name state that can carry readable and secret aura names through the cooldown update path for bar and text displays.
- Updated text-mode `{name}` rendering so secret aura names survive effect redraws without forcing unrelated text formats to preserve stale renders.
- Tracked the matched active aura spell ID for comma-separated aura configurations, cached aura-instance fallback, aura-icon swapping, and the post-login aura cleanup sweep.
- Kept CDM viewer-name/icon pass-through for existing viewer-driven buttons while restoring base names/icons when aura visuals clear.

## Validation
- `luac -p ButtonFrame\CooldownUpdate.lua ButtonFrame\IconMode.lua ButtonFrame\BarMode.lua ButtonFrame\TextMode.lua Core\EventHandlers.lua`
- `git diff --check origin/main...HEAD`
- Reviewed the high-risk paths for Roll the Bones-style multi-ID aura tracking, text-mode secret `{name}` rendering, aura icon swaps, cached aura fallback, and login/reload cleanup.
- Earlier in-game testing during the branch confirmed the core Roll the Bones name display/reset behavior before the final fallback cleanups. Final combat/restricted-content validation is still needed for the completed branch.