### PR TITLE
Add independent bar color override badges

### DIFF
--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -12,6 +12,7 @@ local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateCheckboxPromoteButton = ST._CreateCheckboxPromoteButton
+local CreateColorPickerPromoteButton = ST._CreateColorPickerPromoteButton
 local CreateInfoButton = ST._CreateInfoButton
 local BuildCompactModeControls = ST._BuildCompactModeControls
 local BuildGroupSettingPresetControls = ST._BuildGroupSettingPresetControls
@@ -121,7 +122,8 @@ local function BuildBarAppearanceTab(container, group, style)
     container:AddChild(barTexDrop)
 
     -- Bar Color (basic)
-    AddColorPicker(container, style, "barColor", "Bar Color", {0.2, 0.6, 1.0, 1.0}, true, refreshStyle, refreshStyle)
+    local barColorPicker = AddColorPicker(container, style, "barColor", "Bar Color", {0.2, 0.6, 1.0, 1.0}, true, refreshStyle, refreshStyle)
+    CreateColorPickerPromoteButton(barColorPicker, "barColor", group, style)
 
     if barAdvExpanded then
     local updateFreqSlider = AceGUI:Create("Slider")
@@ -139,13 +141,17 @@ local function BuildBarAppearanceTab(container, group, style)
     end -- not barSettingsCollapsed
 
     -- Contextual color pickers (no heading/collapse/promote)
-    AddColorPicker(container, style, "barCooldownColor", "Bar Cooldown Color", {0.6, 0.6, 0.6, 1.0}, true, refreshStyle, refreshStyle)
+    local barCooldownColorPicker = AddColorPicker(container, style, "barCooldownColor", "Bar Cooldown Color", {0.6, 0.6, 0.6, 1.0}, true, refreshStyle, refreshStyle)
+    CreateColorPickerPromoteButton(barCooldownColorPicker, "barCooldownColor", group, style)
 
-    AddColorPicker(container, style, "barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1.0}, true, refreshStyle, refreshStyle)
+    local barChargeColorPicker = AddColorPicker(container, style, "barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1.0}, true, refreshStyle, refreshStyle)
+    CreateColorPickerPromoteButton(barChargeColorPicker, "barChargeColor", group, style)
 
-    AddColorPicker(container, style, "barBgColor", "Bar Background Color", {0.1, 0.1, 0.1, 0.8}, true, refreshStyle, refreshStyle)
+    local barBgColorPicker = AddColorPicker(container, style, "barBgColor", "Bar Background Color", {0.1, 0.1, 0.1, 0.8}, true, refreshStyle, refreshStyle)
+    CreateColorPickerPromoteButton(barBgColorPicker, "barBgColor", group, style)
 
-    AddColorPicker(container, style, "borderColor", "Border Color", {0, 0, 0, 1}, true, refreshStyle, refreshStyle)
+    local borderColorPicker = AddColorPicker(container, style, "borderColor", "Border Color", {0, 0, 0, 1}, true, refreshStyle, refreshStyle)
+    CreateColorPickerPromoteButton(borderColorPicker, "borderSettings", group, style)
 
     -- ================================================================
     -- Show Icon (standalone checkbox with advanced toggle + promote)

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -9,6 +9,7 @@ local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateRevertButton = ST._CreateRevertButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
+local AddColorPicker = ST._AddColorPicker
 local HasTooltipCooldown = ST.HasTooltipCooldown
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
@@ -38,7 +39,6 @@ local BuildKeyPressHighlightControls = ST._BuildKeyPressHighlightControls
 local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
 local BuildBarAuraPulseControls = ST._BuildBarAuraPulseControls
 local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
-local BuildBarColorsControls = ST._BuildBarColorsControls
 local BuildBarNameTextControls = ST._BuildBarNameTextControls
 local BuildBarReadyTextControls = ST._BuildBarReadyTextControls
 local BuildTextFontControls = ST._BuildTextFontControls
@@ -220,6 +220,12 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
     end
 end
 
+local function BuildSingleBarColorControl(key, label, defaultColor)
+    return function(container, styleTable, onChange)
+        AddColorPicker(container, styleTable, key, label, defaultColor, true, onChange, onChange)
+    end
+end
+
 function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
     local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
     if not group then return end
@@ -258,7 +264,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         "borderSettings", "cooldownText", "auraText", "auraStackText",
         "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
         "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "auraIndicator", "pandemicGlow", "readyGlow", "keyPressHighlight",
-        "barColors", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
+        "barColor", "barCooldownColor", "barChargeColor", "barBgColor", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
         "textFont", "textColors", "textBackground",
     }
 
@@ -292,7 +298,10 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         end,
         readyGlow = BuildReadyGlowControls,
         keyPressHighlight = BuildKeyPressHighlightControls,
-        barColors = BuildBarColorsControls,
+        barColor = BuildSingleBarColorControl("barColor", "Bar Color", {0.2, 0.6, 1.0, 1.0}),
+        barCooldownColor = BuildSingleBarColorControl("barCooldownColor", "Bar Cooldown Color", {0.6, 0.6, 0.6, 1.0}),
+        barChargeColor = BuildSingleBarColorControl("barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1.0}),
+        barBgColor = BuildSingleBarColorControl("barBgColor", "Bar Background Color", {0.1, 0.1, 0.1, 0.8}),
         barNameText = BuildBarNameTextControls,
         barReadyText = BuildBarReadyTextControls,
         pandemicBar = function(container, styleTable, onChange, opts)

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -305,6 +305,77 @@ local function CreateCheckboxPromoteButton(cbWidget, anchorAfterFrame, sectionId
     return promoteBtn
 end
 
+local function CreateColorPickerPromoteButton(colorPickerWidget, sectionId, group, groupStyle)
+    if not GroupSupportsPerButtonOverrides(group) then
+        return nil
+    end
+
+    local btnData = CS.selectedButton and group.buttons[CS.selectedButton]
+    local frame = colorPickerWidget.frame
+    local promoteBtn = frame._cdcColorPromoteBtn
+
+    if not promoteBtn then
+        promoteBtn = CreateFrame("Button", nil, frame)
+        promoteBtn:SetSize(16, 16)
+        promoteBtn.icon = promoteBtn:CreateTexture(nil, "OVERLAY")
+        promoteBtn.icon:SetSize(12, 12)
+        promoteBtn.icon:SetPoint("CENTER")
+        frame._cdcColorPromoteBtn = promoteBtn
+    end
+
+    promoteBtn:SetParent(frame)
+    promoteBtn:ClearAllPoints()
+    promoteBtn:SetPoint("LEFT", colorPickerWidget.colorSwatch, "RIGHT", colorPickerWidget.text:GetStringWidth() + 8, 0)
+    promoteBtn:Show()
+    promoteBtn.icon:Show()
+
+    local multiCount = 0
+    if CS.selectedButtons then
+        for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
+    end
+    local canPromote = CS.selectedButton ~= nil and multiCount < 2
+        and btnData ~= nil
+        and not (btnData.overrideSections and btnData.overrideSections[sectionId])
+
+    if canPromote then
+        promoteBtn.icon:SetAtlas("Crosshair_VehichleCursor_32")
+        promoteBtn:Enable()
+    else
+        promoteBtn.icon:SetAtlas("Crosshair_unableVehichleCursor_32")
+        promoteBtn:Disable()
+    end
+
+    local sectionDef = ST.OVERRIDE_SECTIONS[sectionId]
+    local sectionLabel = sectionDef and sectionDef.label or sectionId
+
+    promoteBtn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        if canPromote then
+            GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        else
+            GameTooltip:AddLine("Select a button to add an override", 0.5, 0.5, 0.5)
+        end
+        GameTooltip:Show()
+    end)
+    promoteBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
+    promoteBtn:SetScript("OnClick", function()
+        if not canPromote then return end
+        CooldownCompanion:PromoteSection(btnData, groupStyle, sectionId)
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CS.buttonSettingsTab = "overrides"
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+
+    colorPickerWidget:SetCallback("OnRelease", function()
+        promoteBtn:ClearAllPoints()
+        promoteBtn:Hide()
+        promoteBtn:SetParent(nil)
+    end)
+
+    table.insert(tabInfoButtons, promoteBtn)
+    return promoteBtn
+end
+
 ------------------------------------------------------------------------
 -- INFO BUTTON HELPER
 ------------------------------------------------------------------------
@@ -949,6 +1020,7 @@ ST._AddAdvancedToggle = AddAdvancedToggle
 ST._CreatePromoteButton = CreatePromoteButton
 ST._CreateRevertButton = CreateRevertButton
 ST._CreateCheckboxPromoteButton = CreateCheckboxPromoteButton
+ST._CreateColorPickerPromoteButton = CreateColorPickerPromoteButton
 ST._CreateInfoButton = CreateInfoButton
 ST._BuildCompactModeControls = BuildCompactModeControls
 ST._BuildGroupSettingPresetControls = BuildGroupSettingPresetControls

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -692,9 +692,24 @@ ST.OVERRIDE_SECTIONS = {
         keys = {"showBarIcon", "barIconReverse", "barIconOffset", "barIconSizeOverride", "barIconSize"},
         modes = {bars = true},
     },
-    barColors = {
-        label = "Bar Colors",
-        keys = {"barColor", "barCooldownColor", "barChargeColor", "barBgColor"},
+    barColor = {
+        label = "Bar Color",
+        keys = {"barColor"},
+        modes = {bars = true},
+    },
+    barCooldownColor = {
+        label = "Bar Cooldown Color",
+        keys = {"barCooldownColor"},
+        modes = {bars = true},
+    },
+    barChargeColor = {
+        label = "Bar Recharging Color",
+        keys = {"barChargeColor"},
+        modes = {bars = true},
+    },
+    barBgColor = {
+        label = "Bar Background Color",
+        keys = {"barBgColor"},
         modes = {bars = true},
     },
     barNameText = {


### PR DESCRIPTION
## What Players Will Notice
- Bar panels now show override badges next to the main bar color settings, so a selected entry can override bar colors directly from the panel settings UI.
- Each bar color can be overridden independently: normal bar color, cooldown color, recharging color, and background color no longer have to be promoted as one grouped color override.
- Border color also exposes the same per-entry override affordance from the bar settings surface.

## Why This Changed
- These color settings were visible at the panel level but did not have the inline override badge players expect from other per-button configurable settings.
- Grouping all bar colors together made small one-off color changes heavier than necessary.

## What Changed
- Added a reusable color-picker promote badge helper that mirrors the existing checkbox and heading override badge behavior.
- Wired the bar color rows and border color row to clickable override badges in bar appearance settings.
- Split the old bar color override definition into independent override sections for each bar color, and updated the Overrides tab to edit and revert those sections separately.

## Validation
- Ran `luac -p Core\Defaults.lua Core\Migrations.lua ConfigSettings\Helpers.lua ConfigSettings\BarModeTabs.lua ConfigSettings\ButtonSettingsOverrides.lua`.
- Ran `git diff --check origin/main...HEAD`.
- In-game placement, click behavior, combat, and restricted-content validation have not been performed yet.