### PR TITLE
Fix stale cooldown icons after rapid resets

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -66,9 +66,6 @@ local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
 local TARGET_SWITCH_SAFETY_CAP = 0.60
--- One normal GCD plus a small buffer. The continuity guard is only for the
--- opening post-cast API blind spot, not later cooldown-end GCD transitions.
-local REAL_COOLDOWN_GCD_HOLD_WINDOW = 1.60
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
@@ -719,75 +716,6 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
         allowActionSlotRealFallback = allowActionSlotRealFallback,
     })
-end
-
-local function ClearRealCooldownContinuity(button)
-    button._lastRealCooldownSpellID = nil
-    button._lastRealCooldownDurationObj = nil
-    button._lastRealCooldownAt = nil
-end
-
-local function CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown)
-    return buttonData.type == "spell"
-        and buttonData.isPassive ~= true
-        and buttonData.hasCharges ~= true
-        and cooldownSpellId == buttonData.id
-        and noCooldown ~= true
-end
-
-local function ApplyRealCooldownContinuity(button, buttonData, cooldownSpellId, noCooldown, result, now)
-    if not (button and result and result.fetchOk) then
-        return result
-    end
-
-    if not CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown) then
-        ClearRealCooldownContinuity(button)
-        return result
-    end
-
-    if result.state == COOLDOWN_STATE_COOLDOWN
-        and result.realCooldownShown == true
-        and result.renderDurationObj then
-        button._lastRealCooldownSpellID = cooldownSpellId
-        button._lastRealCooldownDurationObj = result.renderDurationObj
-        button._lastRealCooldownAt = now
-        return result
-    end
-
-    local previousDurationObj = button._lastRealCooldownDurationObj
-    local previousAt = button._lastRealCooldownAt
-    local canReusePrevious = previousDurationObj
-        and previousAt
-        and button._lastRealCooldownSpellID == cooldownSpellId
-        and now - previousAt <= REAL_COOLDOWN_GCD_HOLD_WINDOW
-    local lastOwnCastAt = button._lastOwnSpellCastAt
-    local castAge = lastOwnCastAt and (now - lastOwnCastAt) or nil
-    local recentlyCastThisSpell = castAge and castAge <= REAL_COOLDOWN_GCD_HOLD_WINDOW
-
-    if result.state == COOLDOWN_STATE_READY then
-        ClearRealCooldownContinuity(button)
-        return result
-    end
-
-    if canReusePrevious and result.state == COOLDOWN_STATE_GCD and result.source == "spell-gcd" then
-        if recentlyCastThisSpell and DurationObjectShowsCooldown(previousDurationObj) then
-            if ApplyGCDSyncIfRealEndsInside(result, previousDurationObj, "continuity-gcd-sync") then
-                ClearRealCooldownContinuity(button)
-                return result
-            end
-
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "held-real-cooldown-over-gcd"
-            result.realCooldownShown = true
-            result.realDurationObj = previousDurationObj
-            result.renderDurationObj = previousDurationObj
-            return result
-        end
-
-        ClearRealCooldownContinuity(button)
-    end
-
-    return result
 end
 
 local function ResolveChargeState(button, buttonData)
@@ -1686,14 +1614,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if not auraOverrideActive then
         if buttonData.type == "spell" and not buttonData.isPassive then
             spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
-            spellCooldownResult = ApplyRealCooldownContinuity(
-                button,
-                buttonData,
-                cooldownSpellId,
-                button._noCooldown,
-                spellCooldownResult,
-                now
-            )
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -111,14 +111,16 @@ function CooldownCompanion:EnsureRuntimeInitialized()
 end
 
 function CooldownCompanion:OnEnable()
-    -- Register cooldown events — set dirty flag, let ticker do the actual update.
-    -- The 0.1s ticker runs regardless, so latency is at most ~100ms for
-    -- event-triggered updates — indistinguishable visually since the cooldown
-    -- frame animates independently. This prevents redundant full-update passes
-    -- during event storms.
-    -- Cooldown/state change events that trigger a dirty-flag update pass
+    -- Cooldown events can expose very short ready windows, so refresh them
+    -- immediately instead of waiting for the ticker.
     for _, evt in ipairs({
         "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN", "ACTIONBAR_UPDATE_COOLDOWN",
+    }) do
+        self:RegisterEvent(evt, "OnCooldownStateChanged")
+    end
+
+    -- Broader state changes can wait for the regular ticker pass.
+    for _, evt in ipairs({
         "UNIT_POWER_FREQUENT", "LOSS_OF_CONTROL_ADDED", "LOSS_OF_CONTROL_UPDATE",
         "ITEM_COUNT_CHANGED", "PLAYER_EQUIPMENT_CHANGED",
     }) do
@@ -296,6 +298,11 @@ function CooldownCompanion:MarkCooldownsDirty()
     self._cooldownsDirty = true
 end
 
+function CooldownCompanion:OnCooldownStateChanged()
+    self._cooldownsDirty = true
+    self:UpdateAllCooldowns()
+end
+
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.
 -- Skips buttons without buttonData.
 function CooldownCompanion:ForEachButton(callback)
@@ -388,7 +395,6 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
                and not buttonData.isPassive then
                 local displaySpellID = button._displaySpellId or buttonData.id
                 if spellID == buttonData.id or spellID == displaySpellID then
-                    button._lastOwnSpellCastAt = GetTime()
                     if self.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
                         -- Track charge consumption for restricted-mode color heuristic.
                         -- _chargeRecharging at event time reflects the PRE-cast state:


### PR DESCRIPTION
## What Players Will Notice
- Cooldown buttons now update immediately when a spell becomes available again right after being used.
- Rapid reset cases like Bloodthirst should no longer stay dimmed or stuck in a real cooldown state until the global cooldown finishes.

## Why This Changed
- The cooldown display could preserve an older real-cooldown duration after newer cooldown data showed the spell was available or only on the GCD.
- That made short reset windows look unavailable even when the spell could already be cast again.

## What Changed
- Removed the cached real-cooldown continuity hold from button cooldown updates so current cooldown API/event state wins immediately.
- Kept the existing `ready` / `gcd` / `cooldown` state model and current action-slot real-cooldown fallback.
- Moved critical cooldown events (`SPELL_UPDATE_COOLDOWN`, `ACTIONBAR_UPDATE_COOLDOWN`, and `BAG_UPDATE_COOLDOWN`) onto an immediate refresh handler instead of waiting for the regular ticker.
- Removed the now-unused spell-cast timestamp bookkeeping while preserving charge-spend tracking.

## Validation
- Ran `luac -p ButtonFrame\CooldownUpdate.lua Core\Lifecycle.lua`.
- Ran `git diff --check origin/main...HEAD`.
- Confirmed no remaining references to `_lastRealCooldown*`, `_lastOwnSpellCastAt`, or `REAL_COOLDOWN_GCD_HOLD_WINDOW`.
- Checked DevBridge data for Slamtrelle's Bloodthirst repro: button `44:2` left `cooldown` before the later successful `UNIT_SPELLCAST_SUCCEEDED spellID=23881`, and the captured session had no Cooldown Companion Lua errors.
- Combat repro evidence was captured through DevBridge, but restricted-content verification is still needed before this should be considered ready to merge.