### PR TITLE
Add icon fill timers for icon cooldown and aura displays

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -113,6 +113,12 @@ local function ClearConditionalVisualPreviewFields(button)
     button._conditionalBarAuraActivePreview = nil
 end
 
+local function HideIconFillForHiddenButton(button)
+    if not (button and button.iconFill) then return end
+    button.iconFill:Hide()
+    button.iconFill:SetScript("OnUpdate", nil)
+end
+
 local function ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)
     if not (button and button.count and (style.chargeFontColor or style.chargeFontColorMissing or style.chargeFontColorZero)) then
         return
@@ -2089,6 +2095,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         -- Non-compact mode: alpha=0 for hidden, restore for visible
         if button._visibilityHidden then
             button.cooldown:Hide()  -- prevent stale IsShown() across ticks
+            HideIconFillForHiddenButton(button)
             if button._lastVisAlpha ~= 0 then
                 button:SetAlpha(0)
                 button._lastVisAlpha = 0
@@ -2109,6 +2116,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- auto-hide the CooldownFrame; without this, bar mode _mainCDShown
             -- and icon mode force-show both read stale true on next tick.
             button.cooldown:Hide()
+            HideIconFillForHiddenButton(button)
             DispatchStandaloneTextureVisual(button)
             return  -- Skip visual updates for hidden buttons
         else

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -16,6 +16,7 @@ local ipairs = ipairs
 local unpack = unpack
 local UnitExists = UnitExists
 local InCombatLockdown = InCombatLockdown
+local GetTime = GetTime
 
 -- Imports from Helpers
 local ApplyStrataOrder = ST._ApplyStrataOrder
@@ -55,6 +56,9 @@ local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
+local DEFAULT_ICON_FILL_COOLDOWN_COLOR = {0.6, 0.13, 0.18, 0.55}
+local DEFAULT_ICON_FILL_AURA_COLOR = {0.2, 1.0, 0.2, 0.55}
+local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1
 local BLIZZARD_AURA_SWIPE_G = 0.95
@@ -67,6 +71,29 @@ local function ApplyAuraBlizzardCooldownLayer(button)
     if button and button.auraBlizzardCooldown and button.cooldown then
         button.auraBlizzardCooldown:SetFrameLevel(button.cooldown:GetFrameLevel())
     end
+end
+
+local function ApplyIconFillLayer(button)
+    if button and button.iconFill then
+        local fillLevel = button:GetFrameLevel() + 1
+        if button.cooldown and button.cooldown.GetFrameLevel then
+            local cooldownLevel = button.cooldown:GetFrameLevel()
+            if cooldownLevel and cooldownLevel > fillLevel then
+                fillLevel = cooldownLevel - 1
+            end
+        end
+        button.iconFill:SetFrameLevel(fillLevel)
+    end
+end
+
+local function AnchorIconFill(button)
+    if not (button and button.iconFill and button.icon) then
+        return
+    end
+
+    button.iconFill:ClearAllPoints()
+    button.iconFill:SetPoint("TOPLEFT", button.icon, "TOPLEFT", 0, 0)
+    button.iconFill:SetPoint("BOTTOMRIGHT", button.icon, "BOTTOMRIGHT", 0, 0)
 end
 
 local function AnchorAuraBlizzardCooldown(button)
@@ -101,7 +128,194 @@ local function HideBlizzardAuraSwipe(button, style)
     end
     if button and button._auraBlizzardSwipeActive then
         button._auraBlizzardSwipeActive = nil
+        if button._iconFillActive ~= true then
+            ApplyDefaultCooldownSwipeStyle(button, style)
+        end
+    end
+end
+
+local function IsIconFillAvailable(button, style)
+    if not (button and button.iconFill and style and style.iconFillEnabled == true) then
+        return false
+    end
+
+    local group = button._groupId
+        and CooldownCompanion.db and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[button._groupId]
+    if group then
+        if (group.displayMode or "icons") ~= "icons" then
+            return false
+        end
+        if group.masqueEnabled == true then
+            return false
+        end
+    end
+
+    return true
+end
+
+local function ResolveIconFillPreviewRemaining(button)
+    local duration = button and button._conditionalPreviewDuration
+    local startTime = button and button._conditionalPreviewStartTime
+    if not (duration and startTime and duration > 0) then
+        return nil, nil
+    end
+
+    local remaining
+    if button._conditionalPreviewLoop
+        and button._conditionalPreviewLoopStartTime
+        and button._conditionalPreviewLoopDuration
+        and button._conditionalPreviewLoopDuration > 0 then
+        local elapsed = GetTime() - button._conditionalPreviewLoopStartTime
+        if elapsed < 0 then elapsed = 0 end
+        local cycleElapsed = elapsed % button._conditionalPreviewLoopDuration
+        remaining = button._conditionalPreviewLoopDuration - cycleElapsed
+        if remaining > duration then remaining = duration end
+    else
+        remaining = duration - (GetTime() - startTime)
+        if remaining < 0 then remaining = 0 end
+    end
+
+    return remaining, duration
+end
+
+local function SetIconFillFromCooldownWidget(button)
+    if not (button and button.iconFill and button.cooldown) then
+        return false
+    end
+
+    local startMs, durMs = button.cooldown:GetCooldownTimes()
+    if not (startMs and durMs)
+        or issecretvalue(startMs)
+        or issecretvalue(durMs)
+        or durMs <= 0 then
+        return false
+    end
+
+    local elapsed = (GetTime() * 1000) - startMs
+    if elapsed < 0 then elapsed = 0 end
+    if elapsed > durMs then elapsed = durMs end
+
+    local value = elapsed / durMs
+    if button._iconFillMode == "aura" then
+        value = 1 - value
+    end
+
+    button.iconFill:SetValue(value)
+    return true
+end
+
+local function SetIconFillValue(button)
+    if not (button and button.iconFill and button._iconFillMode) then
+        return
+    end
+
+    if button._iconFillMode == "aura_static" then
+        button.iconFill:SetValue(1)
+        return
+    end
+
+    local remaining, duration = ResolveIconFillPreviewRemaining(button)
+    if remaining and duration and duration > 0 then
+        if button._iconFillMode == "aura" then
+            button.iconFill:SetValue(remaining / duration)
+        else
+            button.iconFill:SetValue(1 - (remaining / duration))
+        end
+        return
+    end
+
+    if button._durationObj then
+        if button._iconFillMode == "aura" then
+            button.iconFill:SetValue(button._durationObj:GetRemainingPercent())
+        else
+            button.iconFill:SetValue(button._durationObj:GetElapsedPercent())
+        end
+        return
+    end
+
+    if SetIconFillFromCooldownWidget(button) then
+        return
+    end
+
+    if button._iconFillMode == "cooldown" and button.buttonData and button.buttonData.type == "item" then
+        local durationSeconds = button._itemCdDuration or 0
+        if durationSeconds > 0 then
+            local elapsed = GetTime() - (button._itemCdStart or 0)
+            if elapsed < 0 then elapsed = 0 end
+            local value = elapsed / durationSeconds
+            if value > 1 then value = 1 end
+            button.iconFill:SetValue(value)
+            return
+        end
+    end
+
+    button.iconFill:SetValue(0)
+end
+
+local function IconFillOnUpdate(self)
+    SetIconFillValue(self._owner)
+end
+
+local function HideIconFill(button, style)
+    if not (button and button.iconFill) then
+        return
+    end
+
+    button.iconFill:Hide()
+    button.iconFill:SetScript("OnUpdate", nil)
+    if button._iconFillActive then
+        button._iconFillActive = nil
+        button._iconFillMode = nil
+        button._iconFillAuraActive = nil
         ApplyDefaultCooldownSwipeStyle(button, style)
+    end
+end
+
+local function UpdateIconFill(button, buttonData, style)
+    if not IsIconFillAvailable(button, style) then
+        HideIconFill(button, style)
+        return
+    end
+
+    local auraPreview = button._conditionalAuraPreview == true
+        or button._conditionalAuraDurationTextPreview == true
+    local cooldownPreview = button._conditionalPreviewDomain == "cooldown"
+    local mode
+    local color
+
+    if button._auraActive == true or auraPreview then
+        color = style.iconFillAuraColor or DEFAULT_ICON_FILL_AURA_COLOR
+        if button._auraHasTimer == false and not auraPreview then
+            mode = "aura_static"
+        else
+            mode = "aura"
+        end
+    elseif cooldownPreview
+        or button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        or (UsesChargeBehavior(buttonData) and button._chargeRecharging == true and button._hideCooldownChargesActive ~= true) then
+        mode = "cooldown"
+        color = style.iconFillCooldownColor or DEFAULT_ICON_FILL_COOLDOWN_COLOR
+    end
+
+    if not mode then
+        HideIconFill(button, style)
+        return
+    end
+
+    button._iconFillActive = true
+    button._iconFillMode = mode
+    button._iconFillAuraActive = (mode == "aura" or mode == "aura_static") or nil
+    button.iconFill:SetStatusBarColor(color[1], color[2], color[3], color[4])
+    SetIconFillValue(button)
+    button.iconFill:Show()
+    button.iconFill:SetScript("OnUpdate", IconFillOnUpdate)
+
+    button.cooldown:SetDrawSwipe(false)
+    button.cooldown:SetDrawEdge(false)
+    if button._iconFillAuraActive then
+        HideBlizzardAuraSwipe(button, style)
     end
 end
 
@@ -111,6 +325,7 @@ local function UpdateBlizzardAuraSwipe(button, style)
     end
 
     local enabled = style.auraUseBlizzardSwipe == true
+        and button._iconFillAuraActive ~= true
         and (button._auraActive == true or button._conditionalAuraDurationTextPreview == true)
         and (button._conditionalAuraDurationTextPreview == true or button._auraHasTimer ~= false)
 
@@ -224,6 +439,17 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.icon:SetPoint("BOTTOMRIGHT", -borderSize, borderSize)
 
     ApplyIconTexCoord(button.icon, width, height)
+
+    button.iconFill = CreateFrame("StatusBar", button:GetName() .. "IconFill", button)
+    button.iconFill._owner = button
+    AnchorIconFill(button)
+    button.iconFill:SetMinMaxValues(0, 1)
+    button.iconFill:SetValue(0)
+    button.iconFill:SetOrientation("HORIZONTAL")
+    button.iconFill:SetReverseFill(false)
+    button.iconFill:SetStatusBarTexture(ICON_FILL_TEXTURE)
+    button.iconFill:Hide()
+    SetFrameClickThroughRecursive(button.iconFill, true, true)
 
     -- Border using textures (not BackdropTemplate which captures mouse)
     local borderColor = style.borderColor or {0, 0, 0, 1}
@@ -374,6 +600,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
 
     -- Apply configurable strata ordering (LoC always on top)
     ApplyStrataOrder(button, style.strataOrder)
+    ApplyIconFillLayer(button)
     ApplyAuraBlizzardCooldownLayer(button)
 
     -- Store button data
@@ -437,6 +664,9 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Re-apply full click-through on overlay frames (the recursive call above
     -- re-enables motion on them when tooltips are on, causing them to steal hover events)
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    if button.iconFill then
+        SetFrameClickThroughRecursive(button.iconFill, true, true)
+    end
     if button.auraBlizzardCooldown then
         SetFrameClickThroughRecursive(button.auraBlizzardCooldown, true, true)
     end
@@ -709,6 +939,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         button.cooldown:SetDrawSwipe(swipeEnabled and fillEnabled)
     end
 
+    UpdateIconFill(button, buttonData, style)
     UpdateBlizzardAuraSwipe(button, style)
 
     -- When separate text positions: move primary text to aura anchor during aura, cooldown anchor otherwise
@@ -986,6 +1217,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._auraSpellID = CooldownCompanion:ResolveAuraSpellID(button.buttonData)
     button._auraUnit = button.buttonData.auraUnit or "player"
     button._auraStackText = nil
+    button._iconFillActive = nil
+    button._iconFillMode = nil
+    button._iconFillAuraActive = nil
     if button.auraStackCount then button.auraStackCount:SetText("") end
     button._visibilityHidden = false
     button._prevVisibilityHidden = false
@@ -1000,6 +1234,17 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button.icon:SetPoint("BOTTOMRIGHT", -borderSize, borderSize)
 
     ApplyIconTexCoord(button.icon, width, height)
+
+    if button.iconFill then
+        AnchorIconFill(button)
+        button.iconFill:SetMinMaxValues(0, 1)
+        button.iconFill:SetValue(0)
+        button.iconFill:SetOrientation("HORIZONTAL")
+        button.iconFill:SetReverseFill(false)
+        button.iconFill:SetStatusBarTexture(ICON_FILL_TEXTURE)
+        button.iconFill:SetScript("OnUpdate", nil)
+        button.iconFill:Hide()
+    end
 
     -- Update border textures
     local borderColor = style.borderColor or {0, 0, 0, 1}
@@ -1130,6 +1375,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Apply configurable strata ordering (LoC always on top)
     ApplyStrataOrder(button, style.strataOrder)
+    ApplyIconFillLayer(button)
     ApplyAuraBlizzardCooldownLayer(button)
     CooldownCompanion:UpdateAuraTextureVisual(button)
 
@@ -1144,6 +1390,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Re-apply full click-through on overlay frames (the recursive call above
     -- re-enables motion on them when tooltips are on, causing them to steal hover events)
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    if button.iconFill then
+        SetFrameClickThroughRecursive(button.iconFill, true, true)
+    end
     if button.auraBlizzardCooldown then
         SetFrameClickThroughRecursive(button.auraBlizzardCooldown, true, true)
     end

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -264,7 +264,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
 
     local sectionOrder = {
         "borderSettings", "cooldownText", "auraText", "auraStackText",
-        "iconFillTimer", "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
+        "iconFillTimer", "cooldownSwipe", "auraDurationSwipe", "showGCDSwipe", "keybindText", "chargeText", "desaturation", "showOutOfRange", "showTooltips",
         "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "auraIndicator", "pandemicGlow", "readyGlow", "keyPressHighlight",
         "barColor", "barCooldownColor", "barChargeColor", "barBgColor", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
         "textFont", "textColors", "textBackground",

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -25,6 +25,7 @@ local BuildShowTooltipsControls = ST._BuildShowTooltipsControls
 local BuildShowOutOfRangeControls = ST._BuildShowOutOfRangeControls
 local BuildShowGCDSwipeControls = ST._BuildShowGCDSwipeControls
 local BuildCooldownSwipeControls = ST._BuildCooldownSwipeControls
+local BuildIconFillTimerControls = ST._BuildIconFillTimerControls
 local BuildLossOfControlControls = ST._BuildLossOfControlControls
 local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildIconTintControls = ST._BuildIconTintControls
@@ -78,6 +79,7 @@ end
 local PREVIEWABLE_OVERRIDE_SECTIONS = {
     cooldownText = true,
     cooldownSwipe = true,
+    iconFillTimer = true,
     desaturation = true,
     auraText = true,
     auraStackText = true,
@@ -262,7 +264,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
 
     local sectionOrder = {
         "borderSettings", "cooldownText", "auraText", "auraStackText",
-        "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
+        "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "iconFillTimer", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
         "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "auraIndicator", "pandemicGlow", "readyGlow", "keyPressHighlight",
         "barColor", "barCooldownColor", "barChargeColor", "barBgColor", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
         "textFont", "textColors", "textBackground",
@@ -276,6 +278,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         keybindText = BuildKeybindTextControls,
         chargeText = BuildChargeTextControls,
         desaturation = BuildDesaturationControls,
+        iconFillTimer = BuildIconFillTimerControls,
         cooldownSwipe = BuildCooldownSwipeControls,
         showGCDSwipe = BuildShowGCDSwipeControls,
         showOutOfRange = BuildShowOutOfRangeControls,
@@ -489,6 +492,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                             isOverride = true,
                             fallbackStyle = group.style,
                             afterEnableCallback = afterEnableCallback,
+                            masqueEnabled = group.masqueEnabled == true,
                         })
 
                         if previewAdvExpanded and sectionId == "procGlow" and overrides.procGlowStyle ~= "none" then
@@ -509,6 +513,9 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                             local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
                             if sectionId == "cooldownText" or sectionId == "cooldownSwipe" or sectionId == "desaturation" then
                                 AddConditionalPreviewButton(scroll, "Preview Cooldown State", "cooldown", target)
+                            elseif sectionId == "iconFillTimer" then
+                                AddConditionalPreviewButton(scroll, "Preview Cooldown Fill", "cooldown", target)
+                                AddConditionalPreviewButton(scroll, "Preview Aura Fill", "aura_duration_text", target)
                             elseif sectionId == "auraText" or sectionId == "auraDurationSwipe" then
                                 AddConditionalPreviewButton(scroll, "Preview Aura Duration Text", "aura_duration_text", target)
                             elseif sectionId == "auraStackText" then

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -264,7 +264,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
 
     local sectionOrder = {
         "borderSettings", "cooldownText", "auraText", "auraStackText",
-        "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "iconFillTimer", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
+        "iconFillTimer", "auraDurationSwipe", "keybindText", "chargeText", "desaturation", "cooldownSwipe", "showGCDSwipe", "showOutOfRange", "showTooltips",
         "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "auraIndicator", "pandemicGlow", "readyGlow", "keyPressHighlight",
         "barColor", "barCooldownColor", "barChargeColor", "barBgColor", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
         "textFont", "textColors", "textBackground",
@@ -293,11 +293,11 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         procGlow = BuildProcGlowControls,
         pandemicGlow = BuildPandemicGlowControls,
         auraIndicator = BuildAuraIndicatorControls,
-        auraDurationSwipe = function(container, styleTable, onChange)
+        auraDurationSwipe = function(container, styleTable, onChange, opts)
             BuildAuraDurationSwipeControls(container, styleTable, function()
                 onChange()
                 CooldownCompanion:UpdateAllCooldowns()
-            end)
+            end, opts)
         end,
         readyGlow = BuildReadyGlowControls,
         keyPressHighlight = BuildKeyPressHighlightControls,

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2034,7 +2034,7 @@ local function BuildEffectsTab(container)
     -- ================================================================
     -- Cooldown Swipe
     -- ================================================================
-    local iconFillTimerActive = style.iconFillEnabled == true
+    local iconFillTimerActive = style.iconFillEnabled == true and group.masqueEnabled ~= true
     local swipeCb = AceGUI:Create("CheckBox")
     swipeCb:SetLabel("Show Cooldown/Duration Swipe")
     swipeCb:SetValue(style.showCooldownSwipe ~= false)
@@ -2769,9 +2769,11 @@ local function BuildAppearanceTab(container)
     local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:UpdateAllCooldowns()
-    end)
+    end, {
+        masqueEnabled = group.masqueEnabled == true,
+    })
     local auraSwipePromoteBtn
-    if style.iconFillEnabled ~= true then
+    if style.iconFillEnabled ~= true or group.masqueEnabled == true then
         auraSwipePromoteBtn = CreateCheckboxPromoteButton(auraSwipeCb, nil, "auraDurationSwipe", group, style)
     end
     local auraSwipeInfoAnchor = auraSwipeCb.checkbg

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -40,6 +40,7 @@ local BuildShowTooltipsControls = ST._BuildShowTooltipsControls
 local BuildShowOutOfRangeControls = ST._BuildShowOutOfRangeControls
 local BuildShowGCDSwipeControls = ST._BuildShowGCDSwipeControls
 local BuildCooldownSwipeControls = ST._BuildCooldownSwipeControls
+local BuildIconFillTimerControls = ST._BuildIconFillTimerControls
 local BuildLossOfControlControls = ST._BuildLossOfControlControls
 local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildIconTintControls = ST._BuildIconTintControls
@@ -2029,6 +2030,21 @@ local function BuildEffectsTab(container)
     end)
     container:AddChild(desatCb)
     CreateCheckboxPromoteButton(desatCb, nil, "desaturation", group, style)
+
+    local iconFillHeading = AceGUI:Create("Heading")
+    iconFillHeading:SetText("Icon Fill Timer")
+    ColorHeading(iconFillHeading)
+    iconFillHeading:SetFullWidth(true)
+    container:AddChild(iconFillHeading)
+
+    local iconFillCb = BuildIconFillTimerControls(container, style, function()
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+    end, {
+        masqueEnabled = group.masqueEnabled == true,
+    })
+    if not group.masqueEnabled then
+        CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
+    end
 
     -- ================================================================
     -- Cooldown Swipe

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2031,39 +2031,35 @@ local function BuildEffectsTab(container)
     container:AddChild(desatCb)
     CreateCheckboxPromoteButton(desatCb, nil, "desaturation", group, style)
 
-    local iconFillHeading = AceGUI:Create("Heading")
-    iconFillHeading:SetText("Icon Fill Timer")
-    ColorHeading(iconFillHeading)
-    iconFillHeading:SetFullWidth(true)
-    container:AddChild(iconFillHeading)
-
-    local iconFillCb = BuildIconFillTimerControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end, {
-        masqueEnabled = group.masqueEnabled == true,
-    })
-    if not group.masqueEnabled then
-        CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
-    end
-
     -- ================================================================
     -- Cooldown Swipe
     -- ================================================================
+    local iconFillTimerActive = style.iconFillEnabled == true
     local swipeCb = AceGUI:Create("CheckBox")
     swipeCb:SetLabel("Show Cooldown/Duration Swipe")
     swipeCb:SetValue(style.showCooldownSwipe ~= false)
     swipeCb:SetFullWidth(true)
+    swipeCb:SetDisabled(iconFillTimerActive)
     swipeCb:SetCallback("OnValueChanged", function(widget, event, val)
+        if iconFillTimerActive then return end
         style.showCooldownSwipe = val
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(swipeCb)
+    if iconFillTimerActive then
+        local swipeNote = AceGUI:Create("Label")
+        swipeNote:SetText("|cff888888Unavailable while Icon Fill Timer is enabled.|r")
+        swipeNote:SetFullWidth(true)
+        container:AddChild(swipeNote)
+    end
 
-    local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false)
-    CreateCheckboxPromoteButton(swipeCb, swipeAdvBtn, "cooldownSwipe", group, style)
+    local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive)
+    if not iconFillTimerActive then
+        CreateCheckboxPromoteButton(swipeCb, swipeAdvBtn, "cooldownSwipe", group, style)
+    end
 
-    if swipeAdvExpanded and style.showCooldownSwipe ~= false then
+    if swipeAdvExpanded and style.showCooldownSwipe ~= false and not iconFillTimerActive then
         -- Reverse Swipe
         local reverseCb = AceGUI:Create("CheckBox")
         reverseCb:SetLabel("Reverse Swipe")
@@ -2750,11 +2746,34 @@ local function BuildAppearanceTab(container)
         end
     end -- auraStackAdvExpanded + showAuraStackText
 
+    local iconFillCb = BuildIconFillTimerControls(container, style, function()
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+    end, {
+        masqueEnabled = group.masqueEnabled == true,
+    })
+    local iconFillPromoteBtn
+    if not group.masqueEnabled then
+        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
+    end
+    local iconFillInfoAnchor = iconFillCb.checkbg
+    local iconFillInfoXOff = iconFillCb.text:GetStringWidth() + 4
+    if iconFillPromoteBtn and iconFillPromoteBtn:IsShown() then
+        iconFillInfoAnchor = iconFillPromoteBtn
+        iconFillInfoXOff = 4
+    end
+    CreateInfoButton(iconFillCb.frame, iconFillInfoAnchor, "LEFT", "RIGHT", iconFillInfoXOff, 0, {
+        "Icon Fill Timer",
+        {"Replaces icon radial cooldown and aura swipes with a rectangular fill over the icon. Aura fill takes priority while active.", 1, 1, 1, true},
+    }, tabInfoButtons)
+
     local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:UpdateAllCooldowns()
     end)
-    local auraSwipePromoteBtn = CreateCheckboxPromoteButton(auraSwipeCb, nil, "auraDurationSwipe", group, style)
+    local auraSwipePromoteBtn
+    if style.iconFillEnabled ~= true then
+        auraSwipePromoteBtn = CreateCheckboxPromoteButton(auraSwipeCb, nil, "auraDurationSwipe", group, style)
+    end
     local auraSwipeInfoAnchor = auraSwipeCb.checkbg
     local auraSwipeInfoXOff = auraSwipeCb.text:GetStringWidth() + 4
     if auraSwipePromoteBtn and auraSwipePromoteBtn:IsShown() then

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -107,6 +107,14 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
 
+local function AddIndicatorsHeading(container, text)
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(text)
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+end
+
 -- Imports from BarModeTabs.lua
 local BuildBarAppearanceTab = ST._BuildBarAppearanceTab
 local BuildBarEffectsTab = ST._BuildBarEffectsTab
@@ -2010,30 +2018,66 @@ local function BuildEffectsTab(container)
         return
     end
 
+    AddIndicatorsHeading(container, "Glows")
     BuildProcGlowSection(container, group, style)
     BuildAuraGlowSection(container, group, style)
-
     BuildPandemicGlowSection(container, group, style)
     BuildReadyGlowSection(container, group, style)
     BuildKeyPressHighlightSection(container, group, style)
 
-    -- ================================================================
-    -- Desaturate on Cooldown
-    -- ================================================================
-    local desatCb = AceGUI:Create("CheckBox")
-    desatCb:SetLabel("Show Desaturate On Cooldown")
-    desatCb:SetValue(style.desaturateOnCooldown or false)
-    desatCb:SetFullWidth(true)
-    desatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.desaturateOnCooldown = val
+    local assistedCb = AceGUI:Create("CheckBox")
+    assistedCb:SetLabel("Show Assisted Highlight")
+    assistedCb:SetValue(style.showAssistedHighlight or false)
+    assistedCb:SetFullWidth(true)
+    assistedCb:SetCallback("OnValueChanged", function(widget, event, val)
+        style.showAssistedHighlight = val
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    container:AddChild(desatCb)
-    CreateCheckboxPromoteButton(desatCb, nil, "desaturation", group, style)
+    container:AddChild(assistedCb)
 
-    -- ================================================================
-    -- Cooldown Swipe
-    -- ================================================================
+    local assistedAdvExpanded = AddAdvancedToggle(assistedCb, "assistedHighlight", tabInfoButtons, style.showAssistedHighlight or false)
+
+    if assistedAdvExpanded and style.showAssistedHighlight then
+        local assistedCombatCb = AceGUI:Create("CheckBox")
+        assistedCombatCb:SetLabel("Show Only In Combat")
+        assistedCombatCb:SetValue(style.assistedHighlightCombatOnly or false)
+        assistedCombatCb:SetFullWidth(true)
+        assistedCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.assistedHighlightCombatOnly = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        container:AddChild(assistedCombatCb)
+        ApplyCheckboxIndent(assistedCombatCb, 20)
+
+        BuildAssistedHighlightControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+    end -- assistedAdvExpanded
+
+    AddIndicatorsHeading(container, "Timers")
+    local iconFillCb = BuildIconFillTimerControls(container, style, function()
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+    end, {
+        masqueEnabled = group.masqueEnabled == true,
+    })
+    local iconFillPromoteBtn
+    if not group.masqueEnabled then
+        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
+    end
+    local iconFillInfoAnchor = iconFillCb.checkbg
+    local iconFillInfoXOff = iconFillCb.text:GetStringWidth() + 4
+    if iconFillPromoteBtn and iconFillPromoteBtn:IsShown() then
+        iconFillInfoAnchor = iconFillPromoteBtn
+        iconFillInfoXOff = 4
+    end
+    CreateInfoButton(iconFillCb.frame, iconFillInfoAnchor, "LEFT", "RIGHT", iconFillInfoXOff, 0, {
+        "Icon Fill Timer",
+        {"Shows cooldowns and tracked aura durations as a rectangular fill over the icon instead of radial swipes. Active auras use the aura fill color.", 1, 1, 1, true},
+        " ",
+        {"Show Cooldown/Duration Swipe and Blizzard CDM Aura Swipe Style are unavailable while Icon Fill Timer is active.", 0.7, 0.7, 0.7, true},
+    }, tabInfoButtons)
+
     local iconFillTimerActive = style.iconFillEnabled == true and group.masqueEnabled ~= true
     local swipeCb = AceGUI:Create("CheckBox")
     swipeCb:SetLabel("Show Cooldown/Duration Swipe")
@@ -2047,12 +2091,6 @@ local function BuildEffectsTab(container)
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(swipeCb)
-    if iconFillTimerActive then
-        local swipeNote = AceGUI:Create("Label")
-        swipeNote:SetText("|cff888888Unavailable while Icon Fill Timer is enabled.|r")
-        swipeNote:SetFullWidth(true)
-        container:AddChild(swipeNote)
-    end
 
     local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive)
     if not iconFillTimerActive then
@@ -2120,9 +2158,27 @@ local function BuildEffectsTab(container)
         end
     end -- swipeAdvExpanded
 
-    -- ================================================================
-    -- GCD Swipe
-    -- ================================================================
+    local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:UpdateAllCooldowns()
+    end, {
+        masqueEnabled = group.masqueEnabled == true,
+    })
+    local auraSwipePromoteBtn
+    if not iconFillTimerActive then
+        auraSwipePromoteBtn = CreateCheckboxPromoteButton(auraSwipeCb, nil, "auraDurationSwipe", group, style)
+    end
+    local auraSwipeInfoAnchor = auraSwipeCb.checkbg
+    local auraSwipeInfoXOff = auraSwipeCb.text:GetStringWidth() + 4
+    if auraSwipePromoteBtn and auraSwipePromoteBtn:IsShown() then
+        auraSwipeInfoAnchor = auraSwipePromoteBtn
+        auraSwipeInfoXOff = 4
+    end
+    CreateInfoButton(auraSwipeCb.frame, auraSwipeInfoAnchor, "LEFT", "RIGHT", auraSwipeInfoXOff, 0, {
+        "Blizzard-style Aura Duration Swipe",
+        {"While this style is shown for an active aura, the Cooldown/Duration Swipe settings do not affect that aura overlay.", 1, 1, 1, true},
+    }, tabInfoButtons)
+
     local gcdCb = AceGUI:Create("CheckBox")
     gcdCb:SetLabel("Show GCD Swipe")
     gcdCb:SetValue(style.showGCDSwipe == true)
@@ -2134,7 +2190,18 @@ local function BuildEffectsTab(container)
     container:AddChild(gcdCb)
     CreateCheckboxPromoteButton(gcdCb, nil, "showGCDSwipe", group, style)
 
-    -- Out of Range
+    AddIndicatorsHeading(container, "States")
+    local desatCb = AceGUI:Create("CheckBox")
+    desatCb:SetLabel("Show Desaturate On Cooldown")
+    desatCb:SetValue(style.desaturateOnCooldown or false)
+    desatCb:SetFullWidth(true)
+    desatCb:SetCallback("OnValueChanged", function(widget, event, val)
+        style.desaturateOnCooldown = val
+        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+    end)
+    container:AddChild(desatCb)
+    CreateCheckboxPromoteButton(desatCb, nil, "desaturation", group, style)
+
     local oorCb = BuildShowOutOfRangeControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
@@ -2167,39 +2234,6 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
     end)
     CreateCheckboxPromoteButton(tooltipCb, nil, "showTooltips", group, style)
-
-    -- ================================================================
-    -- Assisted Highlight (icon-only)
-    -- ================================================================
-    local assistedCb = AceGUI:Create("CheckBox")
-    assistedCb:SetLabel("Show Assisted Highlight")
-    assistedCb:SetValue(style.showAssistedHighlight or false)
-    assistedCb:SetFullWidth(true)
-    assistedCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.showAssistedHighlight = val
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    container:AddChild(assistedCb)
-
-    local assistedAdvExpanded = AddAdvancedToggle(assistedCb, "assistedHighlight", tabInfoButtons, style.showAssistedHighlight or false)
-
-    if assistedAdvExpanded and style.showAssistedHighlight then
-    local assistedCombatCb = AceGUI:Create("CheckBox")
-    assistedCombatCb:SetLabel("Show Only In Combat")
-    assistedCombatCb:SetValue(style.assistedHighlightCombatOnly or false)
-    assistedCombatCb:SetFullWidth(true)
-    assistedCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.assistedHighlightCombatOnly = val
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(assistedCombatCb)
-    ApplyCheckboxIndent(assistedCombatCb, 20)
-
-    BuildAssistedHighlightControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    end -- assistedAdvExpanded
 
     -- Apply "Hide CDC Tooltips" to tab info buttons (skip advanced toggles)
     if CooldownCompanion.db.profile.hideInfoButtons then
@@ -2745,47 +2779,6 @@ local function BuildAppearanceTab(container)
             AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
         end
     end -- auraStackAdvExpanded + showAuraStackText
-
-    local iconFillCb = BuildIconFillTimerControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end, {
-        masqueEnabled = group.masqueEnabled == true,
-    })
-    local iconFillPromoteBtn
-    if not group.masqueEnabled then
-        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
-    end
-    local iconFillInfoAnchor = iconFillCb.checkbg
-    local iconFillInfoXOff = iconFillCb.text:GetStringWidth() + 4
-    if iconFillPromoteBtn and iconFillPromoteBtn:IsShown() then
-        iconFillInfoAnchor = iconFillPromoteBtn
-        iconFillInfoXOff = 4
-    end
-    CreateInfoButton(iconFillCb.frame, iconFillInfoAnchor, "LEFT", "RIGHT", iconFillInfoXOff, 0, {
-        "Icon Fill Timer",
-        {"Replaces icon radial cooldown and aura swipes with a rectangular fill over the icon. Aura fill takes priority while active.", 1, 1, 1, true},
-    }, tabInfoButtons)
-
-    local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        CooldownCompanion:UpdateAllCooldowns()
-    end, {
-        masqueEnabled = group.masqueEnabled == true,
-    })
-    local auraSwipePromoteBtn
-    if style.iconFillEnabled ~= true or group.masqueEnabled == true then
-        auraSwipePromoteBtn = CreateCheckboxPromoteButton(auraSwipeCb, nil, "auraDurationSwipe", group, style)
-    end
-    local auraSwipeInfoAnchor = auraSwipeCb.checkbg
-    local auraSwipeInfoXOff = auraSwipeCb.text:GetStringWidth() + 4
-    if auraSwipePromoteBtn and auraSwipePromoteBtn:IsShown() then
-        auraSwipeInfoAnchor = auraSwipePromoteBtn
-        auraSwipeInfoXOff = 4
-    end
-    CreateInfoButton(auraSwipeCb.frame, auraSwipeInfoAnchor, "LEFT", "RIGHT", auraSwipeInfoXOff, 0, {
-        "Blizzard-style Aura Duration Swipe",
-        {"While this style is shown for an active aura, the Cooldown/Duration Swipe settings do not affect that aura overlay.", 1, 1, 1, true},
-    }, tabInfoButtons)
 
     -- Show Keybind/Custom Text toggle
     local kbCb = AceGUI:Create("CheckBox")

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -373,22 +373,46 @@ local function BuildShowGCDSwipeControls(container, styleTable, refreshCallback)
     container:AddChild(cb)
 end
 
-local function BuildCooldownSwipeControls(container, styleTable, refreshCallback)
+local function IsIconFillTimerEnabled(styleTable, opts)
+    if styleTable and styleTable.iconFillEnabled ~= nil then
+        return styleTable.iconFillEnabled == true
+    end
+    return opts and opts.fallbackStyle and opts.fallbackStyle.iconFillEnabled == true
+end
+
+local function AddDisabledReason(container, reason)
+    if not reason then return end
+    local note = AceGUI:Create("Label")
+    note:SetText("|cff888888" .. reason .. "|r")
+    note:SetFullWidth(true)
+    container:AddChild(note)
+end
+
+local function BuildCooldownSwipeControls(container, styleTable, refreshCallback, opts)
+    opts = opts or {}
+    local disabledByIconFill = IsIconFillTimerEnabled(styleTable, opts)
+    local disabledReason = disabledByIconFill and "Unavailable while Icon Fill Timer is enabled." or nil
+
     local cb = AceGUI:Create("CheckBox")
     cb:SetLabel("Show Cooldown/Duration Swipe")
     cb:SetValue(styleTable.showCooldownSwipe ~= false)
     cb:SetFullWidth(true)
+    cb:SetDisabled(disabledByIconFill)
     cb:SetCallback("OnValueChanged", function(widget, event, val)
+        if disabledByIconFill then return end
         styleTable.showCooldownSwipe = val
         refreshCallback()
     end)
     container:AddChild(cb)
+    AddDisabledReason(container, disabledReason)
 
     local reverseCb = AceGUI:Create("CheckBox")
     reverseCb:SetLabel("Reverse Swipe")
     reverseCb:SetValue(styleTable.cooldownSwipeReverse or false)
     reverseCb:SetFullWidth(true)
+    reverseCb:SetDisabled(disabledByIconFill)
     reverseCb:SetCallback("OnValueChanged", function(widget, event, val)
+        if disabledByIconFill then return end
         styleTable.cooldownSwipeReverse = val
         refreshCallback()
     end)
@@ -399,7 +423,9 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
     fillCb:SetLabel("Show Swipe Fill")
     fillCb:SetValue(styleTable.showCooldownSwipeFill ~= false)
     fillCb:SetFullWidth(true)
+    fillCb:SetDisabled(disabledByIconFill)
     fillCb:SetCallback("OnValueChanged", function(widget, event, val)
+        if disabledByIconFill then return end
         styleTable.showCooldownSwipeFill = val
         refreshCallback()
         CooldownCompanion:RefreshConfigPanel()
@@ -415,7 +441,9 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         alphaSlider:SetIsPercent(true)
         alphaSlider:SetValue(styleTable.cooldownSwipeAlpha or 0.8)
         alphaSlider:SetFullWidth(true)
+        if alphaSlider.SetDisabled then alphaSlider:SetDisabled(disabledByIconFill) end
         alphaSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            if disabledByIconFill then return end
             styleTable.cooldownSwipeAlpha = val
             refreshCallback()
         end)
@@ -426,7 +454,9 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
     edgeCb:SetLabel("Show Swipe Edge")
     edgeCb:SetValue(styleTable.showCooldownSwipeEdge ~= false)
     edgeCb:SetFullWidth(true)
+    edgeCb:SetDisabled(disabledByIconFill)
     edgeCb:SetCallback("OnValueChanged", function(widget, event, val)
+        if disabledByIconFill then return end
         styleTable.showCooldownSwipeEdge = val
         refreshCallback()
         CooldownCompanion:RefreshConfigPanel()
@@ -436,7 +466,8 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
 
     -- Swipe Edge Color (only when edge is visible)
     if styleTable.showCooldownSwipeEdge ~= false then
-        AddColorPicker(container, styleTable, "cooldownSwipeEdgeColor", "Swipe Edge Color", {1, 1, 1, 1}, true, refreshCallback, refreshCallback)
+        local edgeColor = AddColorPicker(container, styleTable, "cooldownSwipeEdgeColor", "Swipe Edge Color", {1, 1, 1, 1}, true, refreshCallback, refreshCallback)
+        if edgeColor.SetDisabled then edgeColor:SetDisabled(disabledByIconFill) end
     end
 end
 
@@ -474,16 +505,22 @@ local function BuildIconFillTimerControls(container, styleTable, refreshCallback
     return cb
 end
 
-local function BuildAuraDurationSwipeControls(container, styleTable, refreshCallback)
+local function BuildAuraDurationSwipeControls(container, styleTable, refreshCallback, opts)
+    opts = opts or {}
+    local disabledByIconFill = IsIconFillTimerEnabled(styleTable, opts)
+
     local cb = AceGUI:Create("CheckBox")
     cb:SetLabel("Blizzard CDM Aura Swipe Style")
     cb:SetValue(styleTable.auraUseBlizzardSwipe == true)
     cb:SetFullWidth(true)
+    cb:SetDisabled(disabledByIconFill)
     cb:SetCallback("OnValueChanged", function(widget, event, val)
+        if disabledByIconFill then return end
         styleTable.auraUseBlizzardSwipe = val == true
         refreshCallback()
     end)
     container:AddChild(cb)
+    AddDisabledReason(container, disabledByIconFill and "Unavailable while Icon Fill Timer is enabled." or nil)
     return cb
 end
 

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -374,6 +374,9 @@ local function BuildShowGCDSwipeControls(container, styleTable, refreshCallback)
 end
 
 local function IsIconFillTimerEnabled(styleTable, opts)
+    if opts and opts.masqueEnabled == true then
+        return false
+    end
     if styleTable and styleTable.iconFillEnabled ~= nil then
         return styleTable.iconFillEnabled == true
     end

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -440,6 +440,40 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
     end
 end
 
+local function BuildIconFillTimerControls(container, styleTable, refreshCallback, opts)
+    opts = opts or {}
+    local disabledByMasque = opts.masqueEnabled == true
+
+    local cb = AceGUI:Create("CheckBox")
+    cb:SetLabel("Enable Icon Fill Timer")
+    cb:SetValue(styleTable.iconFillEnabled == true)
+    cb:SetFullWidth(true)
+    cb:SetDisabled(disabledByMasque)
+    cb:SetCallback("OnValueChanged", function(widget, event, val)
+        if disabledByMasque then return end
+        styleTable.iconFillEnabled = val == true
+        refreshCallback()
+        CooldownCompanion:UpdateAllCooldowns()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(cb)
+
+    if disabledByMasque then
+        local note = AceGUI:Create("Label")
+        note:SetText("|cff888888Unavailable while Masque skinning is enabled for this group.|r")
+        note:SetFullWidth(true)
+        container:AddChild(note)
+        return cb
+    end
+
+    if styleTable.iconFillEnabled == true then
+        AddColorPicker(container, styleTable, "iconFillCooldownColor", "Cooldown Fill Color", {0.6, 0.13, 0.18, 0.55}, true, refreshCallback, refreshCallback)
+        AddColorPicker(container, styleTable, "iconFillAuraColor", "Aura Fill Color", {0.2, 1.0, 0.2, 0.55}, true, refreshCallback, refreshCallback)
+    end
+
+    return cb
+end
+
 local function BuildAuraDurationSwipeControls(container, styleTable, refreshCallback)
     local cb = AceGUI:Create("CheckBox")
     cb:SetLabel("Blizzard CDM Aura Swipe Style")
@@ -1165,6 +1199,7 @@ ST._BuildShowTooltipsControls = BuildShowTooltipsControls
 ST._BuildShowOutOfRangeControls = BuildShowOutOfRangeControls
 ST._BuildShowGCDSwipeControls = BuildShowGCDSwipeControls
 ST._BuildCooldownSwipeControls = BuildCooldownSwipeControls
+ST._BuildIconFillTimerControls = BuildIconFillTimerControls
 ST._BuildAuraDurationSwipeControls = BuildAuraDurationSwipeControls
 ST._BuildLossOfControlControls = BuildLossOfControlControls
 ST._BuildUnusableDimmingControls = BuildUnusableDimmingControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -383,18 +383,9 @@ local function IsIconFillTimerEnabled(styleTable, opts)
     return opts and opts.fallbackStyle and opts.fallbackStyle.iconFillEnabled == true
 end
 
-local function AddDisabledReason(container, reason)
-    if not reason then return end
-    local note = AceGUI:Create("Label")
-    note:SetText("|cff888888" .. reason .. "|r")
-    note:SetFullWidth(true)
-    container:AddChild(note)
-end
-
 local function BuildCooldownSwipeControls(container, styleTable, refreshCallback, opts)
     opts = opts or {}
     local disabledByIconFill = IsIconFillTimerEnabled(styleTable, opts)
-    local disabledReason = disabledByIconFill and "Unavailable while Icon Fill Timer is enabled." or nil
 
     local cb = AceGUI:Create("CheckBox")
     cb:SetLabel("Show Cooldown/Duration Swipe")
@@ -407,7 +398,6 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         refreshCallback()
     end)
     container:AddChild(cb)
-    AddDisabledReason(container, disabledReason)
 
     local reverseCb = AceGUI:Create("CheckBox")
     reverseCb:SetLabel("Reverse Swipe")
@@ -479,7 +469,7 @@ local function BuildIconFillTimerControls(container, styleTable, refreshCallback
     local disabledByMasque = opts.masqueEnabled == true
 
     local cb = AceGUI:Create("CheckBox")
-    cb:SetLabel("Enable Icon Fill Timer")
+    cb:SetLabel("Icon Fill Timer")
     cb:SetValue(styleTable.iconFillEnabled == true)
     cb:SetFullWidth(true)
     cb:SetDisabled(disabledByMasque)
@@ -523,7 +513,6 @@ local function BuildAuraDurationSwipeControls(container, styleTable, refreshCall
         refreshCallback()
     end)
     container:AddChild(cb)
-    AddDisabledReason(container, disabledByIconFill and "Unavailable while Icon Fill Timer is enabled." or nil)
     return cb
 end
 

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -113,6 +113,9 @@ local defaults = {
                         iconCooldownTintColor = {1, 0, 0.102, 1}, -- cooldown tint (default: 60% opacity white)
                         iconAuraTintEnabled = false,             -- apply separate tint when aura is active
                         iconAuraTintColor = {0, 0.925, 1, 1},       -- aura tint (default: white full opacity)
+                        iconFillEnabled = false,
+                        iconFillCooldownColor = {0.6, 0.13, 0.18, 0.55},
+                        iconFillAuraColor = {0.2, 1.0, 0.2, 0.55},
                         showLossOfControl = false,
                         procGlowOverhang = 32,
                         procGlowColor = {1, 1, 1, 1},
@@ -277,6 +280,9 @@ local defaults = {
             iconCooldownTintColor = {1, 0, 0.102, 1},
             iconAuraTintEnabled = false,
             iconAuraTintColor = {0, 0.925, 1, 1},
+            iconFillEnabled = false,
+            iconFillCooldownColor = {0.6, 0.13, 0.18, 0.55},
+            iconFillAuraColor = {0.2, 1.0, 0.2, 0.55},
             showLossOfControl = false,
             procGlowOverhang = 32,
             procGlowColor = {1, 1, 1, 1},
@@ -640,6 +646,11 @@ ST.OVERRIDE_SECTIONS = {
         label = "Icon Tint",
         keys = {"iconTintColor", "iconCooldownTintEnabled", "iconCooldownTintColor", "iconAuraTintEnabled", "iconAuraTintColor", "backgroundColor"},
         modes = {icons = true, bars = true},
+    },
+    iconFillTimer = {
+        label = "Icon Fill Timer",
+        keys = {"iconFillEnabled", "iconFillCooldownColor", "iconFillAuraColor"},
+        modes = {icons = true},
     },
     assistedHighlight = {
         label = "Assisted Highlight",

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -882,6 +882,9 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
     if style.showCooldownSwipe == nil then style.showCooldownSwipe = true end
     if style.showCooldownSwipeFill == nil then style.showCooldownSwipeFill = true end
     if style.auraUseBlizzardSwipe == nil then style.auraUseBlizzardSwipe = false end
+    if style.iconFillEnabled == nil then style.iconFillEnabled = false end
+    if style.iconFillCooldownColor == nil then style.iconFillCooldownColor = {0.6, 0.13, 0.18, 0.55} end
+    if style.iconFillAuraColor == nil then style.iconFillAuraColor = {0.2, 1.0, 0.2, 0.55} end
     if style.barAuraEffect == nil then style.barAuraEffect = "color" end
 
     if displayMode == "textures" then

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -150,6 +150,7 @@ function CooldownCompanion:ClearMigrationSentinels()
     profile._migratedCustomAuraSlots5 = nil
     profile._migratedCustomAuraSlots5v2 = nil
     profile._migratedBaseSpells = nil
+    profile._migratedIconFillTimerDefaults = nil
     profile._migratedLayoutOrder = nil
     profile._migratedSpecOverrides = nil
 end

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -108,6 +108,7 @@ function CooldownCompanion:RunAllMigrations()
     self:MigrateTalentConditions()
     self:MigrateChoiceTalentConditions()
     self:MigrateNewDefaults()
+    self:MigrateIconFillTimerDefaults()
     self:MigrateCharacterScopedBarSettings()
     self:MigratePanelAnchorCenter()
     self:MigrateContainerAnchorsToScreenOffsets()
@@ -1452,6 +1453,31 @@ function CooldownCompanion:MigrateNewDefaults()
     end
 
     profile.newDefaultsMigrated = true
+end
+
+local ICON_FILL_COOLDOWN_COLOR_DEFAULT = {0.6, 0.13, 0.18, 0.55}
+local ICON_FILL_AURA_COLOR_DEFAULT = {0.2, 1.0, 0.2, 0.55}
+
+local function EnsureIconFillTimerDefaults(style)
+    if type(style) ~= "table" then return end
+    if rawget(style, "iconFillEnabled") == nil then style.iconFillEnabled = false end
+    if rawget(style, "iconFillCooldownColor") == nil then style.iconFillCooldownColor = CopyTable(ICON_FILL_COOLDOWN_COLOR_DEFAULT) end
+    if rawget(style, "iconFillAuraColor") == nil then style.iconFillAuraColor = CopyTable(ICON_FILL_AURA_COLOR_DEFAULT) end
+end
+
+function CooldownCompanion:MigrateIconFillTimerDefaults()
+    local profile = self.db and self.db.profile
+    if not profile or profile._migratedIconFillTimerDefaults then return end
+
+    EnsureIconFillTimerDefaults(rawget(profile, "globalStyle"))
+
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            EnsureIconFillTimerDefaults(group and group.style)
+        end
+    end
+
+    profile._migratedIconFillTimerDefaults = true
 end
 
 function CooldownCompanion:MigrateCharacterScopedBarSettings()


### PR DESCRIPTION
## What Players Will Notice
- Icon panels now have an optional `Icon Fill Timer` style that shows cooldowns and tracked aura durations as a rectangular fill over the icon instead of radial swipes.
- Active auras use the aura fill color and take priority over cooldown fill; untimed active auras show a static full aura-colored fill.
- The icon-mode Indicators tab is easier to scan, with `Glows`, `Timers`, and `States` sections and the fill timer placed beside the swipe settings it replaces.

## Why This Changed
- Some icon layouts need a simpler full-icon timer visual without turning the display into a bar or mixing icon and bar display modes.
- The new option keeps the behavior icon-only, off by default, and unavailable for Masque-skinned groups where v1 does not support masked fill rendering.

## What Changed
- Added an icon-mode fill overlay that can render cooldown progress, timed aura drain, and untimed active aura fill using separate cooldown and aura colors.
- Disabled the normal cooldown/duration swipe and Blizzard CDM aura swipe controls only when Icon Fill Timer is effectively active; GCD swipe remains editable.
- Added defaults, migration support, per-entry override support, config placement, tooltip copy, and import-sentinel handling for the new settings.
- Cleared the fill overlay when hidden buttons return early from cooldown updates so hidden buttons do not keep a stale per-frame fill updater attached.

## Validation
- Ran `luac -p` on the touched runtime, config, defaults, group management, and migration files.
- Ran `git diff --check` against the branch changes.
- Reviewed the branch against `origin/main`; follow-up findings for hidden-button cleanup and migration sentinel clearing were fixed.
- In-game validation is still needed before marking ready: cooldown fill, timed aura drain, untimed aura fill, Masque-disabled groups, and combat/restricted-content behavior.
