### PR TITLE
Fix config rows when resizing narrow

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -13,6 +13,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 local BuildHeroTalentSubTreeCheckboxes = ST._BuildHeroTalentSubTreeCheckboxes
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
+local ApplyConfigTextRow = ST._ApplyConfigTextRow
 local SetupGroupRowIndicators = ST._SetupGroupRowIndicators
 local SetupFolderRowIndicators = ST._SetupFolderRowIndicators
 local SetupColumn1MarkerRow = ST._SetupColumn1MarkerRow
@@ -149,13 +150,7 @@ local function RenderBrowseMode()
         backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to My Groups")
         backBtn:SetFullWidth(true)
         backBtn:SetFontObject(GameFontHighlight)
-        ApplyConfigRowIcon(backBtn, 134400, {
-            width = 1,
-            height = 32,
-            alpha = 0,
-            normalLeftPad = 0,
-            normalHideIcon = true,
-        })
+        ApplyConfigTextRow(backBtn)
         backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
         backBtn:SetCallback("OnClick", function()
             CS.browseMode = false
@@ -210,13 +205,7 @@ local function RenderBrowseMode()
         backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to Characters")
         backBtn:SetFullWidth(true)
         backBtn:SetFontObject(GameFontHighlight)
-        ApplyConfigRowIcon(backBtn, 134400, {
-            width = 1,
-            height = 32,
-            alpha = 0,
-            normalLeftPad = 0,
-            normalHideIcon = true,
-        })
+        ApplyConfigTextRow(backBtn)
         backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
         backBtn:SetCallback("OnClick", function()
             CS.browseCharKey = nil
@@ -1226,11 +1215,7 @@ local function RefreshColumn1(preserveDrag)
         if showManualIcon then
             ApplyConfigRowIcon(entry, container.manualIcon)
         else
-            ApplyConfigRowIcon(entry, "Interface\\BUTTONS\\WHITE8X8", {
-                width = inFolder and 13 or 1,
-                height = 30,
-                alpha = 0,
-            })
+            ApplyConfigTextRow(entry, "LEFT", inFolder and 17 or 0)
         end
         entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
 

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -12,6 +12,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- Imports from earlier Config/ files
 local BuildHeroTalentSubTreeCheckboxes = ST._BuildHeroTalentSubTreeCheckboxes
 local CleanRecycledEntry = ST._CleanRecycledEntry
+local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
 local SetupGroupRowIndicators = ST._SetupGroupRowIndicators
 local SetupFolderRowIndicators = ST._SetupFolderRowIndicators
 local SetupColumn1MarkerRow = ST._SetupColumn1MarkerRow
@@ -146,11 +147,15 @@ local function RenderBrowseMode()
         local backBtn = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(backBtn)
         backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to My Groups")
-        backBtn:SetImage(134400)
-        backBtn:SetImageSize(1, 32)
-        backBtn.image:SetAlpha(0)
         backBtn:SetFullWidth(true)
         backBtn:SetFontObject(GameFontHighlight)
+        ApplyConfigRowIcon(backBtn, 134400, {
+            width = 1,
+            height = 32,
+            alpha = 0,
+            normalLeftPad = 0,
+            normalHideIcon = true,
+        })
         backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
         backBtn:SetCallback("OnClick", function()
             CS.browseMode = false
@@ -180,19 +185,15 @@ local function RenderBrowseMode()
             CleanRecycledEntry(entry)
             local displayName, cc = GetClassColoredCharName(charInfo.charKey, charInfo.classFilename)
 
-            -- Class icon (use individual atlas to avoid tiled-sheet border)
-            if charInfo.classFilename then
-                entry:SetImage(134400) -- placeholder to initialise image widget
-                entry.image:SetAtlas("classicon-" .. strlower(charInfo.classFilename), false)
-                entry:SetImageSize(32, 32)
-            else
-                entry:SetImage(134400)
-                entry:SetImageSize(32, 32)
-            end
-
             entry:SetText(displayName)
             entry:SetFullWidth(true)
             entry:SetFontObject(GameFontHighlight)
+            -- Class icon (use individual atlas to avoid tiled-sheet border)
+            if charInfo.classFilename then
+                ApplyConfigRowIcon(entry, 134400, { atlas = "classicon-" .. strlower(charInfo.classFilename) })
+            else
+                ApplyConfigRowIcon(entry, 134400)
+            end
             entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
             entry:SetCallback("OnClick", function()
                 CS.browseCharKey = charInfo.charKey
@@ -207,11 +208,15 @@ local function RenderBrowseMode()
         local backBtn = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(backBtn)
         backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to Characters")
-        backBtn:SetImage(134400)
-        backBtn:SetImageSize(1, 32)
-        backBtn.image:SetAlpha(0)
         backBtn:SetFullWidth(true)
         backBtn:SetFontObject(GameFontHighlight)
+        ApplyConfigRowIcon(backBtn, 134400, {
+            width = 1,
+            height = 32,
+            alpha = 0,
+            normalLeftPad = 0,
+            normalHideIcon = true,
+        })
         backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
         backBtn:SetCallback("OnClick", function()
             CS.browseCharKey = nil
@@ -259,10 +264,9 @@ local function RenderBrowseMode()
             end
 
             entry:SetText(displayName)
-            entry:SetImage(GetContainerIcon(containerId, db))
-            entry:SetImageSize(32, 32)
             entry:SetFullWidth(true)
             entry:SetFontObject(GameFontHighlight)
+            ApplyConfigRowIcon(entry, GetContainerIcon(containerId, db))
             entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
 
             -- Green highlight for selected browse container
@@ -962,6 +966,7 @@ local function RefreshColumn1(preserveDrag)
     for i, bar in ipairs(CS.folderAccentBars) do
         bar:Hide()
         bar:ClearAllPoints()
+        bar._cdcFolderAccentActive = nil
     end
     local accentBarIndex = 0  -- pool cursor, incremented as bars are used
 
@@ -1210,17 +1215,6 @@ local function RefreshColumn1(preserveDrag)
 
         entry:SetText(displayName)
         local showManualIcon = not inFolder and IsValidIconTexture(container.manualIcon)
-        if showManualIcon then
-            entry:SetImage(container.manualIcon)
-            entry:SetImageSize(32, 32)
-        else
-            entry:SetImage("Interface\\BUTTONS\\WHITE8X8")
-            entry:SetImageSize(inFolder and 13 or 1, 30)
-        end
-        if entry.image then
-            entry.image:Show()
-            entry.image:SetAlpha(showManualIcon and 1 or 0)
-        end
         entry:SetFullWidth(true)
         entry:SetFontObject(GameFontHighlight)
         local groupNameWidth = 0
@@ -1228,6 +1222,15 @@ local function RefreshColumn1(preserveDrag)
             entry.label:SetText(groupName)
             groupNameWidth = entry.label:GetStringWidth()
             entry:SetText(displayName)
+        end
+        if showManualIcon then
+            ApplyConfigRowIcon(entry, container.manualIcon)
+        else
+            ApplyConfigRowIcon(entry, "Interface\\BUTTONS\\WHITE8X8", {
+                width = inFolder and 13 or 1,
+                height = 30,
+                alpha = 0,
+            })
         end
         entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
 
@@ -1559,14 +1562,9 @@ local function RefreshColumn1(preserveDrag)
         local entry = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(entry)
         entry:SetText(folder.name .. collapseTag)
-        entry:SetImage(GetFolderIcon(folderId, db))
-        entry:SetImageSize(32, 32)
-        if entry.image then
-            entry.image:Show()
-            entry.image:SetAlpha(1)
-        end
         entry:SetFullWidth(true)
         entry:SetFontObject(GameFontHighlight)
+        ApplyConfigRowIcon(entry, GetFolderIcon(folderId, db))
         local allChildrenInactive = IsFolderFullyInactive(folderId, childContainerIds)
         if allChildrenInactive then
             entry:SetColor(0.5, 0.5, 0.5)
@@ -1867,9 +1865,14 @@ local function RefreshColumn1(preserveDrag)
                                 bar:SetWidth(3)
                                 bar:ClearAllPoints()
                                 bar._cdcFolderId = item.id
+                                bar._cdcFolderAccentActive = true
                                 bar:SetPoint("TOPLEFT", firstEntry.frame, "TOPLEFT", 0, 0)
                                 bar:SetPoint("BOTTOMLEFT", lastEntry.frame, "BOTTOMLEFT", 0, 0)
-                                bar:Show()
+                                if CS.compactConfigRows then
+                                    bar:Hide()
+                                else
+                                    bar:Show()
+                                end
                             end
                         end
                     end

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -14,6 +14,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- Imports from earlier Config/ files
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
+local ApplyConfigTextRow = ST._ApplyConfigTextRow
 local GetButtonIcon = ST._GetButtonIcon
 local GetConfigEntryDisplayName = ST._GetConfigEntryDisplayName
 local GenerateFolderName = ST._GenerateFolderName
@@ -37,17 +38,6 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local SelectConfigFinderResult = ST._SelectConfigFinderResult
-
-local CENTERED_HEADER_ICON_OPTS = {
-    width = 1,
-    height = 32,
-    alpha = 0,
-    compactJustifyH = "CENTER",
-    normalLeftPad = 0,
-    normalRightPad = 0,
-    normalJustifyH = "CENTER",
-    normalHideIcon = true,
-}
 
 local IsTriggerPanelGroup
 
@@ -548,7 +538,7 @@ local function RenderConfigFinderResults()
         header:SetFullWidth(true)
         header:SetFontObject(GameFontHighlight)
         header:SetJustifyH("CENTER")
-        ApplyConfigRowIcon(header, "Interface\\BUTTONS\\WHITE8X8", CENTERED_HEADER_ICON_OPTS)
+        ApplyConfigTextRow(header, "CENTER")
         header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
         ConfigurePanelTypeBadge(header, panel and panel.displayMode, header.label:GetStringWidth())
         if panel and panel.enabled == false then
@@ -1356,7 +1346,7 @@ local function RefreshColumn2()
             header:SetFullWidth(true)
             header:SetFontObject(GameFontHighlight)
             header:SetJustifyH("CENTER")
-            ApplyConfigRowIcon(header, "Interface\\BUTTONS\\WHITE8X8", CENTERED_HEADER_ICON_OPTS)
+            ApplyConfigTextRow(header, "CENTER")
             local textW = header.label:GetStringWidth()
             ConfigurePanelTypeBadge(header, panel.displayMode, textW)
 
@@ -1405,16 +1395,14 @@ local function RefreshColumn2()
                     local entry = AceGUI:Create("InteractiveLabel")
                     CleanRecycledEntry(entry)
                     local icon = GetButtonIcon(buttonData)
+                    entry:SetImage(icon)
+                    entry:SetImageSize(20, 20)
                     entry:SetText(buttonData.name or ("ID: " .. (buttonData.id or "?")))
                     entry:SetFullWidth(true)
                     entry:SetFontObject(GameFontHighlightSmall)
-                    ApplyConfigRowIcon(entry, icon, {
-                        width = 20,
-                        height = 20,
-                        compactHeight = 20,
-                        normalHeight = 20,
-                        desaturated = buttonData.enabled == false,
-                    })
+                    if buttonData.enabled == false and entry.image and entry.image.SetDesaturated then
+                        entry.image:SetDesaturated(true)
+                    end
                     entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
                     if CS.selectedGroup == panelGroupId and CS.selectedButton == buttonIndex then
                         entry:SetColor(0, 1, 0)
@@ -1897,7 +1885,7 @@ local function RefreshColumn2()
                 header:SetFullWidth(true)
                 header:SetFontObject(GameFontHighlight)
                 header:SetJustifyH("CENTER")
-                ApplyConfigRowIcon(header, 134400, CENTERED_HEADER_ICON_OPTS)
+                ApplyConfigTextRow(header, "CENTER")
                 -- Position badge to the left of centered text
                 local textW = header.label:GetStringWidth()
                 ConfigurePanelTypeBadge(header, panel.displayMode, textW)

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -13,6 +13,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
 local CleanRecycledEntry = ST._CleanRecycledEntry
+local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
 local GetButtonIcon = ST._GetButtonIcon
 local GetConfigEntryDisplayName = ST._GetConfigEntryDisplayName
 local GenerateFolderName = ST._GenerateFolderName
@@ -36,6 +37,17 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local SelectConfigFinderResult = ST._SelectConfigFinderResult
+
+local CENTERED_HEADER_ICON_OPTS = {
+    width = 1,
+    height = 32,
+    alpha = 0,
+    compactJustifyH = "CENTER",
+    normalLeftPad = 0,
+    normalRightPad = 0,
+    normalJustifyH = "CENTER",
+    normalHideIcon = true,
+}
 
 local IsTriggerPanelGroup
 
@@ -533,12 +545,10 @@ local function RenderConfigFinderResults()
         local header = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(header)
         header:SetText(headerText)
-        header:SetImage("Interface\\BUTTONS\\WHITE8X8")
-        header:SetImageSize(1, 32)
-        if header.image then header.image:SetAlpha(0) end
         header:SetFullWidth(true)
         header:SetFontObject(GameFontHighlight)
         header:SetJustifyH("CENTER")
+        ApplyConfigRowIcon(header, "Interface\\BUTTONS\\WHITE8X8", CENTERED_HEADER_ICON_OPTS)
         header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
         ConfigurePanelTypeBadge(header, panel and panel.displayMode, header.label:GetStringWidth())
         if panel and panel.enabled == false then
@@ -557,17 +567,14 @@ local function RenderConfigFinderResults()
             local buttonData = entryInfo.button
             local entry = AceGUI:Create("InteractiveLabel")
             CleanRecycledEntry(entry)
+            local entryDisabled = buttonData and buttonData.enabled == false
             entry:SetText(entryInfo.text or (buttonData and buttonData.name) or "Entry")
-            entry:SetImage(buttonData and GetButtonIcon(buttonData) or 134400)
-            entry:SetImageSize(32, 32)
             entry:SetFullWidth(true)
             entry:SetFontObject(GameFontHighlight)
+            ApplyConfigRowIcon(entry, buttonData and GetButtonIcon(buttonData) or 134400, { desaturated = entryDisabled })
             entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-            if buttonData and buttonData.enabled == false then
+            if entryDisabled then
                 entry:SetColor(0.5, 0.5, 0.5)
-                if entry.image and entry.image.SetDesaturated then
-                    entry.image:SetDesaturated(true)
-                end
             end
 
             local buttonIndex = entryInfo.index
@@ -1345,12 +1352,11 @@ local function RefreshColumn2()
             local header = AceGUI:Create("InteractiveLabel")
             CleanRecycledEntry(header)
             header:SetText(headerText)
-            header:SetImage("Interface\\BUTTONS\\WHITE8X8")
-            header.image:SetAlpha(0)
 
             header:SetFullWidth(true)
             header:SetFontObject(GameFontHighlight)
             header:SetJustifyH("CENTER")
+            ApplyConfigRowIcon(header, "Interface\\BUTTONS\\WHITE8X8", CENTERED_HEADER_ICON_OPTS)
             local textW = header.label:GetStringWidth()
             ConfigurePanelTypeBadge(header, panel.displayMode, textW)
 
@@ -1399,19 +1405,21 @@ local function RefreshColumn2()
                     local entry = AceGUI:Create("InteractiveLabel")
                     CleanRecycledEntry(entry)
                     local icon = GetButtonIcon(buttonData)
-                    entry:SetImage(icon)
-                    entry:SetImageSize(20, 20)
                     entry:SetText(buttonData.name or ("ID: " .. (buttonData.id or "?")))
                     entry:SetFullWidth(true)
                     entry:SetFontObject(GameFontHighlightSmall)
+                    ApplyConfigRowIcon(entry, icon, {
+                        width = 20,
+                        height = 20,
+                        compactHeight = 20,
+                        normalHeight = 20,
+                        desaturated = buttonData.enabled == false,
+                    })
                     entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
                     if CS.selectedGroup == panelGroupId and CS.selectedButton == buttonIndex then
                         entry:SetColor(0, 1, 0)
                     elseif buttonData.enabled == false then
                         entry:SetColor(0.5, 0.5, 0.5)
-                    end
-                    if buttonData.enabled == false and entry.image and entry.image.SetDesaturated then
-                        entry.image:SetDesaturated(true)
                     end
                     local capturedIndex = buttonIndex
                     entry:SetCallback("OnClick", function()
@@ -1884,14 +1892,12 @@ local function RefreshColumn2()
                 local header = AceGUI:Create("InteractiveLabel")
                 CleanRecycledEntry(header)
                 header:SetText(headerText)
-                header:SetImage(134400) -- invisible dummy for 32px row height
-                header:SetImageSize(1, 32)
-                header.image:SetAlpha(0)
 
                 -- Mode badge overlay (pooled on widget, same pattern as old Column 1)
                 header:SetFullWidth(true)
                 header:SetFontObject(GameFontHighlight)
                 header:SetJustifyH("CENTER")
+                ApplyConfigRowIcon(header, 134400, CENTERED_HEADER_ICON_OPTS)
                 -- Position badge to the left of centered text
                 local textW = header.label:GetStringWidth()
                 ConfigurePanelTypeBadge(header, panel.displayMode, textW)
@@ -2452,13 +2458,9 @@ local function RefreshColumn2()
                         and GetTriggerRowDisplayText(buttonData)
                         or GetConfigEntryDisplayName(buttonData, { includeDecorations = true })
                     entry:SetText(entryName or ("Unknown " .. buttonData.type))
-                    entry:SetImage(GetButtonIcon(buttonData))
-                    entry:SetImageSize(32, 32)
-                    if entry.image and entry.image.SetDesaturated then
-                        entry.image:SetDesaturated(not usable)
-                    end
                     entry:SetFullWidth(true)
                     entry:SetFontObject(GameFontHighlight)
+                    ApplyConfigRowIcon(entry, GetButtonIcon(buttonData), { desaturated = not usable })
                     entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
                     if buttonData.type == "spell" then
                         BindConfigShiftTooltip(entry, "spell", ResolveColumn2TooltipSpellId(buttonData), entry.frame, "ANCHOR_RIGHT")

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1767,18 +1767,6 @@ local function CreateConfigPanel()
         end
     end
 
-    local function SetCompactConfigRows(compact)
-        compact = compact == true
-        if CS.compactConfigRows == compact then
-            return
-        end
-
-        CS.compactConfigRows = compact
-        if RefreshVisibleConfigCompactRows then
-            RefreshVisibleConfigCompactRows()
-        end
-    end
-
     local function GetScrollRowWidth(scrollWidget, fallbackFrame)
         local contentWidth = scrollWidget and scrollWidget.content and scrollWidget.content.width
         if contentWidth and contentWidth > 0 then
@@ -1798,7 +1786,13 @@ local function CreateConfigPanel()
             return
         end
 
-        SetCompactConfigRows(narrowestRowWidth < CONFIG_COMPACT_ROW_MIN_WIDTH)
+        local compact = narrowestRowWidth < CONFIG_COMPACT_ROW_MIN_WIDTH
+        if CS.compactConfigRows ~= compact then
+            CS.compactConfigRows = compact
+            if RefreshVisibleConfigCompactRows then
+                RefreshVisibleConfigCompactRows()
+            end
+        end
     end
 
     -- Layout columns on size change

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -36,6 +36,7 @@ local CancelFirstIconPanelTutorial = ST._CancelFirstIconPanelTutorial
 local RebuildTutorialAnchors = ST._RebuildTutorialAnchors
 local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
+local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -64,6 +65,8 @@ local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
 local CONFIG_FINDER_BUTTON_GAP = 6
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
+local CONFIG_NESTED_INLINE_GROUP_INSET = 20
 
 if not AceGUI:GetLayout(MANUAL_COLUMN_LAYOUT) then
     -- These columns are positioned and sized manually, so their layout should
@@ -1758,6 +1761,40 @@ local function CreateConfigPanel()
         end
     end
 
+    local function SetCompactConfigRows(compact)
+        compact = compact == true
+        if CS.compactConfigRows == compact then
+            return
+        end
+
+        CS.compactConfigRows = compact
+        if RefreshVisibleConfigCompactRows then
+            RefreshVisibleConfigCompactRows()
+        end
+    end
+
+    local function GetScrollRowWidth(scrollWidget, fallbackFrame)
+        local contentWidth = scrollWidget and scrollWidget.content and scrollWidget.content.width
+        if contentWidth and contentWidth > 0 then
+            return contentWidth
+        end
+
+        local scrollFrame = scrollWidget and scrollWidget.scrollframe
+        local width = (scrollFrame and scrollFrame:GetWidth()) or (fallbackFrame and fallbackFrame:GetWidth()) or 0
+        return math.max(0, width or 0)
+    end
+
+    local function UpdateCompactConfigRows()
+        local col1RowWidth = GetScrollRowWidth(CS.col1Scroll, col1.content)
+        local col2RowWidth = GetScrollRowWidth(CS.col2Scroll, col2.content) - CONFIG_NESTED_INLINE_GROUP_INSET
+        local narrowestRowWidth = math.min(col1RowWidth, math.max(0, col2RowWidth))
+        if narrowestRowWidth <= 0 then
+            return
+        end
+
+        SetCompactConfigRows(narrowestRowWidth < CONFIG_COMPACT_ROW_MIN_WIDTH)
+    end
+
     -- Layout columns on size change
     local function LayoutColumns()
         local w = colParent:GetWidth()
@@ -1839,6 +1876,7 @@ local function CreateConfigPanel()
         col4.frame:SetPoint("TOPLEFT", col3.frame, "TOPRIGHT", pad, 0)
         col4.frame:SetSize(col4Width, h)
 
+        UpdateCompactConfigRows()
         PositionPrimaryAxisUI()
     end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1823,25 +1823,25 @@ local function CreateConfigPanel()
             end
             local wideColWidth = equalColWidth * 2 + pad
             local usedWidth = (wideColWidth * 2) + pad
-            local leftInset = math.floor((w - usedWidth) * 0.5)
+            local leftoverWidth = math.max(0, w - usedWidth)
 
             col1.frame:ClearAllPoints()
-            col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", leftInset, 0)
+            col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", 0, 0)
             col1.frame:SetSize(wideColWidth, h)
 
             col3.frame:ClearAllPoints()
             col3.frame:SetPoint("TOPLEFT", col1.frame, "TOPRIGHT", pad, 0)
-            col3.frame:SetSize(wideColWidth, h)
+            col3.frame:SetSize(wideColWidth + leftoverWidth, h)
             return
         end
 
         local usedWidth = (equalColWidth * 4) + (pad * 3)
-        local leftInset = math.floor((w - usedWidth) * 0.5)
+        local leftoverWidth = math.max(0, w - usedWidth)
 
         local col1Width = equalColWidth
         local col2Width = equalColWidth
         local col3Width = equalColWidth
-        local col4Width = equalColWidth
+        local col4Width = equalColWidth + leftoverWidth
         local finderAvailable = IsConfigFinderAvailable and IsConfigFinderAvailable()
 
         if CS.configFinderBox then
@@ -1867,7 +1867,7 @@ local function CreateConfigPanel()
         end
 
         col1.frame:ClearAllPoints()
-        col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", leftInset, 0)
+        col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", 0, 0)
         col1.frame:SetSize(col1Width, h)
 
         col2.frame:ClearAllPoints()

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -322,6 +322,9 @@ local function QueueConfigFinderRefresh()
         end
         RefreshColumn1()
         RefreshColumn2()
+        if CS.configFrame.UpdateCompactConfigRows then
+            CS.configFrame.UpdateCompactConfigRows()
+        end
         ApplyConfigColumnTitles(CS.configFrame)
         if finderActive then
             ResetScrollState(CS.col1Scroll)
@@ -412,6 +415,9 @@ function CooldownCompanion:RefreshConfigForSpellOverride(pendingSpellIds)
     local selectedEntryAffected = DoesButtonReferencePendingOverrideSpell(GetSelectedConfigButtonData(), pendingSpellIds)
 
     RefreshColumn2()
+    if CS.configFrame.UpdateCompactConfigRows then
+        CS.configFrame.UpdateCompactConfigRows()
+    end
     if selectedEntryAffected then
         RefreshColumn3()
     end
@@ -1911,6 +1917,7 @@ local function CreateConfigPanel()
     frame.col4 = col4
     frame.colParent = colParent
     frame.LayoutColumns = LayoutColumns
+    frame.UpdateCompactConfigRows = UpdateCompactConfigRows
     frame.UpdateModeNavigationUI = UpdateModeNavigationUI
     frame.UpdateBrowseButtonState = UpdateBrowseBtnState
     UpdateBrowseBtnState()
@@ -2002,6 +2009,9 @@ function CooldownCompanion:RefreshConfigPanel()
     end
     RefreshColumn1()
     RefreshColumn2()
+    if CS.configFrame.UpdateCompactConfigRows then
+        CS.configFrame.UpdateCompactConfigRows()
+    end
     RefreshColumn3()
     RefreshColumn4(CS.col4Container)
     ApplyConfigColumnTitles(CS.configFrame)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1135,6 +1135,23 @@ local function ResetConfigRowIcon(entry)
     icon:SetAlpha(1)
 end
 
+local function ResetConfigRowLabel(entry)
+    local label = entry and entry.label
+    if not label then
+        return
+    end
+
+    if label.SetWordWrap then
+        label:SetWordWrap(true)
+    end
+    if label.SetNonSpaceWrap then
+        label:SetNonSpaceWrap(false)
+    end
+    if label.SetMaxLines then
+        label:SetMaxLines(0)
+    end
+end
+
 local function RestoreConfigRowHandlers(entry)
     if not entry then
         return
@@ -1163,6 +1180,7 @@ local function ClearConfigRowIcon(entry, restoreHandlers)
     entry._cdcConfigRowIconOpts = nil
     entry.imageshown = nil
     ResetConfigRowIcon(entry)
+    ResetConfigRowLabel(entry)
     if entry.image then
         entry.image:Show()
         entry.image:SetAlpha(1)
@@ -1208,6 +1226,15 @@ local function ApplyConfigRowIconLayout(entry, opts)
     local rowWidth = frame.width or frame:GetWidth() or 0
     if rowWidth > 0 then
         label:SetWidth(math.max(1, rowWidth - leftPad - rightPad))
+    end
+    if label.SetWordWrap then
+        label:SetWordWrap(false)
+    end
+    if label.SetNonSpaceWrap then
+        label:SetNonSpaceWrap(false)
+    end
+    if label.SetMaxLines then
+        label:SetMaxLines(1)
     end
     label:SetJustifyH(justifyH)
     label:SetJustifyV(justifyV)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1118,114 +1118,81 @@ local BADGE_SIZE = 24
 local BADGE_SPACING = 2
 local BADGE_RIGHT_PAD = 4
 local COMPACT_ROW_HEIGHT = 32
+local CONFIG_ROW_ICON_SIZE = 32
+local CONFIG_ROW_ICON_GAP = 4
+local CONFIG_ROW_RIGHT_PAD = 4
 
-local function ResetConfigRowIcon(entry)
-    local icon = entry and entry.image
-    if not icon then
-        return
-    end
-
-    icon:Hide()
-    icon:ClearAllPoints()
-    icon:SetTexture(nil)
-    icon:SetAtlas(nil)
-    if icon.SetDesaturated then
-        icon:SetDesaturated(false)
-    end
-    icon:SetAlpha(1)
-end
-
-local function ResetConfigRowLabel(entry)
-    local label = entry and entry.label
-    if not label then
-        return
-    end
-
-    if label.SetWordWrap then
-        label:SetWordWrap(true)
-    end
-    if label.SetNonSpaceWrap then
-        label:SetNonSpaceWrap(false)
-    end
-    if label.SetMaxLines then
-        label:SetMaxLines(0)
-    end
-end
-
-local function RestoreConfigRowHandlers(entry)
+local function ClearConfigRowLayout(entry, restoreHandlers)
     if not entry then
         return
     end
 
-    if entry._cdcConfigRowWidthHandlerInstalled then
-        entry.OnWidthSet = entry._cdcConfigRowOriginalOnWidthSet
-        entry._cdcConfigRowOriginalOnWidthSet = nil
-        entry._cdcConfigRowWidthHandlerInstalled = nil
-    end
-
-    if entry._cdcConfigRowReleaseHandlerInstalled then
-        entry.OnRelease = entry._cdcConfigRowOriginalOnRelease
-        entry._cdcConfigRowOriginalOnRelease = nil
-        entry._cdcConfigRowReleaseHandlerInstalled = nil
-    end
-end
-
-local function ClearConfigRowIcon(entry, restoreHandlers)
-    if not entry then
-        return
-    end
-
-    entry._cdcConfigRowIconStored = nil
-    entry._cdcConfigRowIconTexture = nil
-    entry._cdcConfigRowIconOpts = nil
-    entry.imageshown = nil
-    ResetConfigRowIcon(entry)
-    ResetConfigRowLabel(entry)
-    if entry.image then
-        entry.image:Show()
-        entry.image:SetAlpha(1)
-        if entry.image.SetDesaturated then
-            entry.image:SetDesaturated(false)
+    local icon = entry.image
+    if icon then
+        icon:Hide()
+        icon:ClearAllPoints()
+        icon:SetTexture(nil)
+        icon:SetAtlas(nil)
+        icon:SetAlpha(1)
+        if icon.SetDesaturated then
+            icon:SetDesaturated(false)
         end
     end
 
+    local label = entry.label
+    if label then
+        if label.SetWordWrap then label:SetWordWrap(true) end
+        if label.SetNonSpaceWrap then label:SetNonSpaceWrap(false) end
+        if label.SetMaxLines then label:SetMaxLines(0) end
+    end
+
+    entry._cdcConfigRow = nil
+    entry.imageshown = nil
+    if icon then icon:Show() end
+
     if restoreHandlers then
-        RestoreConfigRowHandlers(entry)
+        if entry._cdcConfigRowWidthHandlerInstalled then
+            entry.OnWidthSet = entry._cdcConfigRowOriginalOnWidthSet
+            entry._cdcConfigRowOriginalOnWidthSet = nil
+            entry._cdcConfigRowWidthHandlerInstalled = nil
+        end
+        if entry._cdcConfigRowReleaseHandlerInstalled then
+            entry.OnRelease = entry._cdcConfigRowOriginalOnRelease
+            entry._cdcConfigRowOriginalOnRelease = nil
+            entry._cdcConfigRowReleaseHandlerInstalled = nil
+        end
     end
 end
 
-local function ApplyConfigRowIconLayout(entry, opts)
-    if not (entry and entry._cdcConfigRowIconStored and entry.frame and entry.label) then
+local function ApplyConfigRowLayout(entry)
+    local row = entry and entry._cdcConfigRow
+    if not (row and entry.frame and entry.label) then
         return
     end
 
-    opts = opts or entry._cdcConfigRowIconOpts or {}
-
     local compact = CS.compactConfigRows == true
-    local icon = entry.image
-    local iconWidth = opts.width or opts.iconWidth or 32
-    local iconHeight = opts.height or opts.iconHeight or 32
-    local iconLeftPad = opts.iconLeftPad or 0
-    local gap = opts.normalImageGap
-    if gap == nil then gap = 4 end
-
+    local hasIcon = row.kind == "icon"
     local frame = entry.frame
     local label = entry.label
-    local height = compact and (opts.compactHeight or COMPACT_ROW_HEIGHT) or (opts.normalHeight or iconHeight)
-    local leftPad = compact and (opts.compactLeftPad or 0) or (opts.normalLeftPad or (iconLeftPad + iconWidth + gap))
-    local rightPad = compact and (opts.compactRightPad or opts.rightPad or 4) or (opts.normalRightPad or opts.rightPad or 4)
-    local justifyH = compact and (opts.compactJustifyH or opts.justifyH or "LEFT") or (opts.normalJustifyH or opts.justifyH or "LEFT")
-    local justifyV = compact and (opts.compactJustifyV or opts.justifyV or "MIDDLE") or (opts.normalJustifyV or opts.justifyV or "MIDDLE")
+    local leftPad = 0
 
-    entry:SetHeight(height)
-    frame.height = height
+    if not compact then
+        if hasIcon then
+            leftPad = CONFIG_ROW_ICON_SIZE + CONFIG_ROW_ICON_GAP
+        else
+            leftPad = row.normalLeftPad or 0
+        end
+    end
+
+    entry:SetHeight(COMPACT_ROW_HEIGHT)
+    frame.height = COMPACT_ROW_HEIGHT
 
     label:ClearAllPoints()
     label:SetPoint("LEFT", frame, "LEFT", leftPad, 0)
-    label:SetPoint("RIGHT", frame, "RIGHT", -rightPad, 0)
+    label:SetPoint("RIGHT", frame, "RIGHT", -CONFIG_ROW_RIGHT_PAD, 0)
     local rowWidth = frame.width or frame:GetWidth() or 0
     if rowWidth > 0 then
-        label:SetWidth(math.max(1, rowWidth - leftPad - rightPad))
+        label:SetWidth(math.max(1, rowWidth - leftPad - CONFIG_ROW_RIGHT_PAD))
     end
     if label.SetWordWrap then
         label:SetWordWrap(false)
@@ -1236,60 +1203,57 @@ local function ApplyConfigRowIconLayout(entry, opts)
     if label.SetMaxLines then
         label:SetMaxLines(1)
     end
-    label:SetJustifyH(justifyH)
-    label:SetJustifyV(justifyV)
+    label:SetJustifyH(row.justifyH or "LEFT")
+    label:SetJustifyV("MIDDLE")
 
+    local icon = entry.image
     if icon then
         icon:ClearAllPoints()
-        icon:SetSize(iconWidth, iconHeight)
-        icon:SetPoint("LEFT", frame, "LEFT", iconLeftPad, 0)
+        icon:SetSize(CONFIG_ROW_ICON_SIZE, CONFIG_ROW_ICON_SIZE)
+        icon:SetPoint("LEFT", frame, "LEFT", 0, 0)
 
-        local hideIcon = compact
-            or opts.normalHideIcon == true
-            or opts.alpha == 0
-            or not entry._cdcConfigRowIconTexture
-
-        if hideIcon then
-            icon:Hide()
-        else
-            icon:Show()
-            icon:SetAlpha(opts.alpha ~= nil and opts.alpha or 1)
+        if hasIcon and not compact and (row.texture or row.atlas) then
+            if row.atlas then
+                icon:SetAtlas(row.atlas, false)
+            else
+                icon:SetAtlas(nil)
+                icon:SetTexture(row.texture)
+                icon:SetTexCoord(0, 1, 0, 1)
+            end
+            icon:SetAlpha(1)
             if icon.SetDesaturated then
-                icon:SetDesaturated(opts.desaturated == true)
+                icon:SetDesaturated(row.desaturated == true)
+            end
+            icon:Show()
+        else
+            icon:Hide()
+        end
+    end
+end
+
+local function EnsureConfigRowHandlers(entry)
+    if not entry._cdcConfigRowWidthHandlerInstalled then
+        entry._cdcConfigRowOriginalOnWidthSet = entry.OnWidthSet
+        entry.OnWidthSet = function(self, width)
+            if self._cdcConfigRowOriginalOnWidthSet then
+                self:_cdcConfigRowOriginalOnWidthSet(width)
+            end
+            ApplyConfigRowLayout(self)
+        end
+        entry._cdcConfigRowWidthHandlerInstalled = true
+    end
+
+    if not entry._cdcConfigRowReleaseHandlerInstalled then
+        entry._cdcConfigRowOriginalOnRelease = entry.OnRelease
+        entry.OnRelease = function(self)
+            local originalOnRelease = self._cdcConfigRowOriginalOnRelease
+            ClearConfigRowLayout(self, true)
+            if originalOnRelease then
+                originalOnRelease(self)
             end
         end
+        entry._cdcConfigRowReleaseHandlerInstalled = true
     end
-end
-
-local function EnsureConfigRowWidthHandler(entry)
-    if entry._cdcConfigRowWidthHandlerInstalled then
-        return
-    end
-
-    entry._cdcConfigRowOriginalOnWidthSet = entry.OnWidthSet
-    entry.OnWidthSet = function(self, width)
-        if self._cdcConfigRowOriginalOnWidthSet then
-            self:_cdcConfigRowOriginalOnWidthSet(width)
-        end
-        ApplyConfigRowIconLayout(self)
-    end
-    entry._cdcConfigRowWidthHandlerInstalled = true
-end
-
-local function EnsureConfigRowReleaseHandler(entry)
-    if entry._cdcConfigRowReleaseHandlerInstalled then
-        return
-    end
-
-    entry._cdcConfigRowOriginalOnRelease = entry.OnRelease
-    entry.OnRelease = function(self)
-        local originalOnRelease = self._cdcConfigRowOriginalOnRelease
-        ClearConfigRowIcon(self, true)
-        if originalOnRelease then
-            originalOnRelease(self)
-        end
-    end
-    entry._cdcConfigRowReleaseHandlerInstalled = true
 end
 
 local function CleanRecycledEntry(entry)
@@ -1319,61 +1283,52 @@ local function CleanRecycledEntry(entry)
     entry.frame:SetScript("OnReceiveDrag", nil)
     entry.frame._cdcOnMouseDown = nil
     entry.frame._cdcLastClickTime = nil
-    ClearConfigRowIcon(entry, true)
+    ClearConfigRowLayout(entry, true)
 end
 
 local function ApplyConfigRowIcon(entry, texture, opts)
     opts = opts or {}
-    entry._cdcConfigRowIconStored = true
-    entry._cdcConfigRowIconTexture = texture
-    entry._cdcConfigRowIconOpts = opts
-    EnsureConfigRowWidthHandler(entry)
-    EnsureConfigRowReleaseHandler(entry)
+    entry._cdcConfigRow = {
+        kind = "icon",
+        texture = texture,
+        atlas = opts.atlas,
+        desaturated = opts.desaturated == true,
+    }
+    EnsureConfigRowHandlers(entry)
 
     entry:SetImage(nil)
     entry.imageshown = nil
-    if entry.image then
-        if opts.atlas then
-            entry.image:SetAtlas(opts.atlas, false)
-        else
-            entry.image:SetAtlas(nil)
-            entry.image:SetTexture(texture)
-            entry.image:SetTexCoord(0, 1, 0, 1)
-        end
-        if entry.image.SetDesaturated then
-            entry.image:SetDesaturated(opts.desaturated == true)
-        end
-        entry.image:SetAlpha(opts.alpha ~= nil and opts.alpha or 1)
-    end
 
-    ApplyConfigRowIconLayout(entry, opts)
+    ApplyConfigRowLayout(entry)
 end
 
-local function ReapplyConfigRowIcon(entry)
-    if not (entry and entry._cdcConfigRowIconStored) then
-        return
-    end
+local function ApplyConfigTextRow(entry, justifyH, normalLeftPad)
+    entry._cdcConfigRow = {
+        kind = "text",
+        justifyH = justifyH or "LEFT",
+        normalLeftPad = normalLeftPad or 0,
+    }
+    EnsureConfigRowHandlers(entry)
 
-    ApplyConfigRowIcon(entry, entry._cdcConfigRowIconTexture, entry._cdcConfigRowIconOpts)
+    entry:SetImage(nil)
+    entry.imageshown = nil
+
+    ApplyConfigRowLayout(entry)
 end
 
-local function ReapplyConfigRowIcons(widget)
+local function ReapplyConfigRowLayouts(widget)
     if not widget then
         return
     end
 
-    ReapplyConfigRowIcon(widget)
+    if widget._cdcConfigRow then
+        ApplyConfigRowLayout(widget)
+    end
 
     if widget.children then
         for _, child in ipairs(widget.children) do
-            ReapplyConfigRowIcons(child)
+            ReapplyConfigRowLayouts(child)
         end
-    end
-end
-
-local function RelayoutConfigRowScroll(scrollWidget)
-    if scrollWidget and scrollWidget.DoLayout then
-        scrollWidget:DoLayout()
     end
 end
 
@@ -1389,11 +1344,11 @@ local function UpdateConfigFolderAccentBars()
 end
 
 local function RefreshVisibleConfigCompactRows()
-    ReapplyConfigRowIcons(CS.col1Scroll)
-    ReapplyConfigRowIcons(CS.col2Scroll)
+    ReapplyConfigRowLayouts(CS.col1Scroll)
+    ReapplyConfigRowLayouts(CS.col2Scroll)
     UpdateConfigFolderAccentBars()
-    RelayoutConfigRowScroll(CS.col1Scroll)
-    RelayoutConfigRowScroll(CS.col2Scroll)
+    if CS.col1Scroll and CS.col1Scroll.DoLayout then CS.col1Scroll:DoLayout() end
+    if CS.col2Scroll and CS.col2Scroll.DoLayout then CS.col2Scroll:DoLayout() end
 end
 
 local function AcquireBadge(frame, index)
@@ -2208,6 +2163,7 @@ ST._CompactUntitledInlineGroupConfig = CompactUntitledInlineGroupConfig
 ST._CDM_VIEWER_NAMES = CDM_VIEWER_NAMES
 ST._CleanRecycledEntry = CleanRecycledEntry
 ST._ApplyConfigRowIcon = ApplyConfigRowIcon
+ST._ApplyConfigTextRow = ApplyConfigTextRow
 ST._RefreshVisibleConfigCompactRows = RefreshVisibleConfigCompactRows
 ST._AcquireBadge = AcquireBadge
 ST._SetupGroupRowIndicators = SetupGroupRowIndicators

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -207,6 +207,7 @@ ST._configState = {
     configSearchText = "",
     configFinderBox = nil,
     configFinderSuppressTextChanged = false,
+    compactConfigRows = false,
 
     -- Spec filter inline expansion
     specExpandedGroupId = nil,
@@ -1116,6 +1117,96 @@ end
 local BADGE_SIZE = 24
 local BADGE_SPACING = 2
 local BADGE_RIGHT_PAD = 4
+local COMPACT_ROW_HEIGHT = 32
+
+local function ResetConfigRowIcon(entry)
+    local icon = entry and entry.image
+    if not icon then
+        return
+    end
+
+    icon:Hide()
+    icon:ClearAllPoints()
+    icon:SetTexture(nil)
+    icon:SetAtlas(nil)
+    if icon.SetDesaturated then
+        icon:SetDesaturated(false)
+    end
+    icon:SetAlpha(1)
+end
+
+local function ApplyConfigRowIconLayout(entry, opts)
+    if not (entry and entry._cdcConfigRowIconStored and entry.frame and entry.label) then
+        return
+    end
+
+    opts = opts or entry._cdcConfigRowIconOpts or {}
+
+    local compact = CS.compactConfigRows == true
+    local icon = entry.image
+    local iconWidth = opts.width or opts.iconWidth or 32
+    local iconHeight = opts.height or opts.iconHeight or 32
+    local iconLeftPad = opts.iconLeftPad or 0
+    local gap = opts.normalImageGap
+    if gap == nil then gap = 4 end
+
+    local frame = entry.frame
+    local label = entry.label
+    local height = compact and (opts.compactHeight or COMPACT_ROW_HEIGHT) or (opts.normalHeight or iconHeight)
+    local leftPad = compact and (opts.compactLeftPad or 0) or (opts.normalLeftPad or (iconLeftPad + iconWidth + gap))
+    local rightPad = compact and (opts.compactRightPad or opts.rightPad or 4) or (opts.normalRightPad or opts.rightPad or 4)
+    local justifyH = compact and (opts.compactJustifyH or opts.justifyH or "LEFT") or (opts.normalJustifyH or opts.justifyH or "LEFT")
+    local justifyV = compact and (opts.compactJustifyV or opts.justifyV or "MIDDLE") or (opts.normalJustifyV or opts.justifyV or "MIDDLE")
+
+    entry:SetHeight(height)
+    frame.height = height
+
+    label:ClearAllPoints()
+    label:SetPoint("LEFT", frame, "LEFT", leftPad, 0)
+    label:SetPoint("RIGHT", frame, "RIGHT", -rightPad, 0)
+    local rowWidth = frame.width or frame:GetWidth() or 0
+    if rowWidth > 0 then
+        label:SetWidth(math.max(1, rowWidth - leftPad - rightPad))
+    end
+    label:SetJustifyH(justifyH)
+    label:SetJustifyV(justifyV)
+
+    if icon then
+        icon:ClearAllPoints()
+        icon:SetSize(iconWidth, iconHeight)
+        icon:SetPoint("LEFT", frame, "LEFT", iconLeftPad, 0)
+
+        local hideIcon = compact
+            or opts.normalHideIcon == true
+            or opts.alpha == 0
+            or not entry._cdcConfigRowIconTexture
+
+        if hideIcon then
+            icon:Hide()
+        else
+            icon:Show()
+            icon:SetAlpha(opts.alpha ~= nil and opts.alpha or 1)
+            if icon.SetDesaturated then
+                icon:SetDesaturated(opts.desaturated == true)
+            end
+        end
+    end
+end
+
+local function EnsureConfigRowWidthHandler(entry)
+    if entry._cdcConfigRowWidthHandlerInstalled then
+        return
+    end
+
+    entry._cdcConfigRowOriginalOnWidthSet = entry.OnWidthSet
+    entry.OnWidthSet = function(self, width)
+        if self._cdcConfigRowOriginalOnWidthSet then
+            self:_cdcConfigRowOriginalOnWidthSet(width)
+        end
+        ApplyConfigRowIconLayout(self)
+    end
+    entry._cdcConfigRowWidthHandlerInstalled = true
+end
 
 local function CleanRecycledEntry(entry)
     if entry._cdcModeBadge then entry._cdcModeBadge:Hide() end
@@ -1144,6 +1235,11 @@ local function CleanRecycledEntry(entry)
     entry.frame:SetScript("OnReceiveDrag", nil)
     entry.frame._cdcOnMouseDown = nil
     entry.frame._cdcLastClickTime = nil
+    entry._cdcConfigRowIconStored = nil
+    entry._cdcConfigRowIconTexture = nil
+    entry._cdcConfigRowIconOpts = nil
+    entry.imageshown = nil
+    ResetConfigRowIcon(entry)
     if entry.image then
         entry.image:Show()
         entry.image:SetAlpha(1)
@@ -1151,6 +1247,71 @@ local function CleanRecycledEntry(entry)
             entry.image:SetDesaturated(false)
         end
     end
+end
+
+local function ApplyConfigRowIcon(entry, texture, opts)
+    opts = opts or {}
+    entry._cdcConfigRowIconStored = true
+    entry._cdcConfigRowIconTexture = texture
+    entry._cdcConfigRowIconOpts = opts
+    EnsureConfigRowWidthHandler(entry)
+
+    entry:SetImage(nil)
+    entry.imageshown = nil
+    if entry.image then
+        if opts.atlas then
+            entry.image:SetAtlas(opts.atlas, false)
+        else
+            entry.image:SetAtlas(nil)
+            entry.image:SetTexture(texture)
+            entry.image:SetTexCoord(0, 1, 0, 1)
+        end
+        if entry.image.SetDesaturated then
+            entry.image:SetDesaturated(opts.desaturated == true)
+        end
+        entry.image:SetAlpha(opts.alpha ~= nil and opts.alpha or 1)
+    end
+
+    ApplyConfigRowIconLayout(entry, opts)
+end
+
+local function ReapplyConfigRowIcon(entry)
+    if not (entry and entry._cdcConfigRowIconStored) then
+        return
+    end
+
+    ApplyConfigRowIcon(entry, entry._cdcConfigRowIconTexture, entry._cdcConfigRowIconOpts)
+end
+
+local function ReapplyConfigRowIcons(widget)
+    if not widget then
+        return
+    end
+
+    ReapplyConfigRowIcon(widget)
+
+    if widget.children then
+        for _, child in ipairs(widget.children) do
+            ReapplyConfigRowIcons(child)
+        end
+    end
+end
+
+local function UpdateConfigFolderAccentBars()
+    local showBars = not CS.compactConfigRows
+    for _, bar in ipairs(CS.folderAccentBars or {}) do
+        if showBars and bar._cdcFolderAccentActive then
+            bar:Show()
+        else
+            bar:Hide()
+        end
+    end
+end
+
+local function RefreshVisibleConfigCompactRows()
+    ReapplyConfigRowIcons(CS.col1Scroll)
+    ReapplyConfigRowIcons(CS.col2Scroll)
+    UpdateConfigFolderAccentBars()
 end
 
 local function AcquireBadge(frame, index)
@@ -1964,6 +2125,8 @@ CS.SetConfigPrimaryMode = SetConfigPrimaryMode
 ST._CompactUntitledInlineGroupConfig = CompactUntitledInlineGroupConfig
 ST._CDM_VIEWER_NAMES = CDM_VIEWER_NAMES
 ST._CleanRecycledEntry = CleanRecycledEntry
+ST._ApplyConfigRowIcon = ApplyConfigRowIcon
+ST._RefreshVisibleConfigCompactRows = RefreshVisibleConfigCompactRows
 ST._AcquireBadge = AcquireBadge
 ST._SetupGroupRowIndicators = SetupGroupRowIndicators
 ST._SetupFolderRowIndicators = SetupFolderRowIndicators

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1135,6 +1135,47 @@ local function ResetConfigRowIcon(entry)
     icon:SetAlpha(1)
 end
 
+local function RestoreConfigRowHandlers(entry)
+    if not entry then
+        return
+    end
+
+    if entry._cdcConfigRowWidthHandlerInstalled then
+        entry.OnWidthSet = entry._cdcConfigRowOriginalOnWidthSet
+        entry._cdcConfigRowOriginalOnWidthSet = nil
+        entry._cdcConfigRowWidthHandlerInstalled = nil
+    end
+
+    if entry._cdcConfigRowReleaseHandlerInstalled then
+        entry.OnRelease = entry._cdcConfigRowOriginalOnRelease
+        entry._cdcConfigRowOriginalOnRelease = nil
+        entry._cdcConfigRowReleaseHandlerInstalled = nil
+    end
+end
+
+local function ClearConfigRowIcon(entry, restoreHandlers)
+    if not entry then
+        return
+    end
+
+    entry._cdcConfigRowIconStored = nil
+    entry._cdcConfigRowIconTexture = nil
+    entry._cdcConfigRowIconOpts = nil
+    entry.imageshown = nil
+    ResetConfigRowIcon(entry)
+    if entry.image then
+        entry.image:Show()
+        entry.image:SetAlpha(1)
+        if entry.image.SetDesaturated then
+            entry.image:SetDesaturated(false)
+        end
+    end
+
+    if restoreHandlers then
+        RestoreConfigRowHandlers(entry)
+    end
+end
+
 local function ApplyConfigRowIconLayout(entry, opts)
     if not (entry and entry._cdcConfigRowIconStored and entry.frame and entry.label) then
         return
@@ -1208,6 +1249,22 @@ local function EnsureConfigRowWidthHandler(entry)
     entry._cdcConfigRowWidthHandlerInstalled = true
 end
 
+local function EnsureConfigRowReleaseHandler(entry)
+    if entry._cdcConfigRowReleaseHandlerInstalled then
+        return
+    end
+
+    entry._cdcConfigRowOriginalOnRelease = entry.OnRelease
+    entry.OnRelease = function(self)
+        local originalOnRelease = self._cdcConfigRowOriginalOnRelease
+        ClearConfigRowIcon(self, true)
+        if originalOnRelease then
+            originalOnRelease(self)
+        end
+    end
+    entry._cdcConfigRowReleaseHandlerInstalled = true
+end
+
 local function CleanRecycledEntry(entry)
     if entry._cdcModeBadge then entry._cdcModeBadge:Hide() end
     if entry._cdcModeBadgeHitRect then entry._cdcModeBadgeHitRect:Hide() end
@@ -1235,18 +1292,7 @@ local function CleanRecycledEntry(entry)
     entry.frame:SetScript("OnReceiveDrag", nil)
     entry.frame._cdcOnMouseDown = nil
     entry.frame._cdcLastClickTime = nil
-    entry._cdcConfigRowIconStored = nil
-    entry._cdcConfigRowIconTexture = nil
-    entry._cdcConfigRowIconOpts = nil
-    entry.imageshown = nil
-    ResetConfigRowIcon(entry)
-    if entry.image then
-        entry.image:Show()
-        entry.image:SetAlpha(1)
-        if entry.image.SetDesaturated then
-            entry.image:SetDesaturated(false)
-        end
-    end
+    ClearConfigRowIcon(entry, true)
 end
 
 local function ApplyConfigRowIcon(entry, texture, opts)
@@ -1255,6 +1301,7 @@ local function ApplyConfigRowIcon(entry, texture, opts)
     entry._cdcConfigRowIconTexture = texture
     entry._cdcConfigRowIconOpts = opts
     EnsureConfigRowWidthHandler(entry)
+    EnsureConfigRowReleaseHandler(entry)
 
     entry:SetImage(nil)
     entry.imageshown = nil
@@ -1297,6 +1344,12 @@ local function ReapplyConfigRowIcons(widget)
     end
 end
 
+local function RelayoutConfigRowScroll(scrollWidget)
+    if scrollWidget and scrollWidget.DoLayout then
+        scrollWidget:DoLayout()
+    end
+end
+
 local function UpdateConfigFolderAccentBars()
     local showBars = not CS.compactConfigRows
     for _, bar in ipairs(CS.folderAccentBars or {}) do
@@ -1312,6 +1365,8 @@ local function RefreshVisibleConfigCompactRows()
     ReapplyConfigRowIcons(CS.col1Scroll)
     ReapplyConfigRowIcons(CS.col2Scroll)
     UpdateConfigFolderAccentBars()
+    RelayoutConfigRowScroll(CS.col1Scroll)
+    RelayoutConfigRowScroll(CS.col2Scroll)
 end
 
 local function AcquireBadge(frame, index)


### PR DESCRIPTION
## What Players Will Notice
- The config window stays readable when resized narrow: group and panel rows keep their normal spacing, large left icons disappear instead of stacking into the text, and small status/action badges remain visible.
- Resizing across the compact threshold should feel steadier, without the one-frame icon snap or the small Column 1 icon jiggle.

## Why This Changed
- Narrow config widths could push AceGUI's image row layout into an image-above-text state, making entries overlap or compress badly.
- The column layout also centered around a tiny rounding remainder, which could nudge Column 1 by a pixel while resizing.

## What Changed
- Added a shared config row icon helper that keeps AceGUI in no-image text layout, then manually positions stored row icons in normal mode and hides the large left icons in compact mode.
- Computes compact row mode from usable Column 1/Column 2 row width, refreshes visible compact rows when the threshold changes, and relayouts the affected scroll frames.
- Keeps compact rows at normal row height, clamps row labels to one line, hides folder accent bars during compact mode, and preserves small right-side badges, rename affordances, panel-type badges, click targets, and tooltips.
- Stabilized config column resizing by pinning the column block to the left edge and letting the last visible column absorb leftover rounding pixels.

## Validation
- `luac -p Config\State.lua Config\Panel.lua Config\Column1.lua Config\Column2.lua`
- `git diff --check origin/main...HEAD -- Config\State.lua Config\Panel.lua Config\Column1.lua Config\Column2.lua`
- Addressed review follow-ups for scrollbar relayout, pooled AceGUI row cleanup, wrapped labels, folder accent bars, and column resize jitter.
- In-game resize validation is still needed, including combat/restricted-content testing for Lua errors.