### PR TITLE
Add consumable fallback priorities for item buttons

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -328,12 +328,16 @@ local function UpdateBarDisplay(button)
 
     -- "On cooldown" for bar color/ready text follows canonical state.
     -- _durationObj may also hold aura/totem timing and must not imply cooldown.
+    local itemUsesResolvedCooldownState = button.buttonData.type == "item"
+        and button._resolvedItemQuantityKind == "stacks"
     local isChargeButton = UsesChargeBehavior(button.buttonData)
     local chargeState = button._chargeState
     local auraTimerActive = button._auraActive
         and (button._durationObj or button._viewerBar or button._conditionalPreviewRemaining)
     local onCooldown
-    if isChargeButton then
+    if itemUsesResolvedCooldownState then
+        onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+    elseif isChargeButton then
         onCooldown = chargeState == CHARGE_STATE_MISSING
             or chargeState == CHARGE_STATE_ZERO
     else

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -72,7 +72,7 @@ local function SetBarIconTooltipScripts(button, enable)
             if bd.type == "spell" then
                 GameTooltip:SetSpellByID(button._displaySpellId or bd.id)
             elseif bd.type == "item" then
-                GameTooltip:SetItemByID(bd.id)
+                GameTooltip:SetItemByID(button._resolvedItemId or bd.id)
             end
             GameTooltip:Show()
         end)
@@ -810,6 +810,13 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil
 
+    if buttonData.type == "item" then
+        local resolvedItemID, availableQuantity, quantityKind = CooldownCompanion.ResolveItemFallback(buttonData)
+        button._resolvedItemId = resolvedItemID or buttonData.id
+        button._resolvedItemAvailableQuantity = availableQuantity or 0
+        button._resolvedItemQuantityKind = quantityKind or "stacks"
+    end
+
     -- Per-button visibility runtime state
     button._visibilityHidden = false
     button._prevVisibilityHidden = false
@@ -833,7 +840,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
                 local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
                 if spellName then displayName = spellName end
             elseif buttonData.type == "item" then
-                local itemName = C_Item.GetItemNameByID(buttonData.id)
+                local itemName = C_Item.GetItemNameByID(button._resolvedItemId or buttonData.id)
                 if itemName then displayName = itemName end
             end
         end
@@ -1139,7 +1146,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
                 local spellName = C_Spell.GetSpellName(button._displaySpellId or button.buttonData.id)
                 if spellName then displayName = spellName end
             elseif button.buttonData.type == "item" then
-                local itemName = C_Item.GetItemNameByID(button.buttonData.id)
+                local itemName = C_Item.GetItemNameByID(button._resolvedItemId or button.buttonData.id)
                 if itemName then displayName = itemName end
             end
         end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -744,6 +744,11 @@ local function ResolveChargeState(button, buttonData)
 
     local currentCharges = button._currentReadableCharges
     local maxCharges = buttonData.maxCharges
+    if buttonData.type == "item"
+            and button._resolvedItemId
+            and tonumber(button._resolvedItemId) ~= tonumber(buttonData.id) then
+        maxCharges = button._resolvedItemMaxCharges
+    end
     if button._chargeCountReadable == true and currentCharges ~= nil then
         if currentCharges <= 0 then
             return CHARGE_STATE_ZERO
@@ -933,6 +938,7 @@ local function UpdateResolvedItemState(button, buttonData)
         button._resolvedItemId = nil
         button._resolvedItemAvailableQuantity = nil
         button._resolvedItemQuantityKind = nil
+        button._resolvedItemMaxCharges = nil
         return false
     end
 
@@ -940,6 +946,9 @@ local function UpdateResolvedItemState(button, buttonData)
     local changed = resolvedItemID ~= button._resolvedItemId
         or quantityKind ~= button._resolvedItemQuantityKind
 
+    if changed then
+        button._resolvedItemMaxCharges = nil
+    end
     button._resolvedItemId = resolvedItemID or buttonData.id
     button._resolvedItemAvailableQuantity = availableQuantity or 0
     button._resolvedItemQuantityKind = quantityKind or "stacks"

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -49,6 +49,7 @@ local UpdateItemChargeTracking = ST._UpdateItemChargeTracking
 local ApplyIconCountTextStyle = ST._ApplyIconCountTextStyle
 local UpdateIconModeVisuals = ST._UpdateIconModeVisuals
 local UpdateIconModeGlows = ST._UpdateIconModeGlows
+local CacheButtonBindingKeys = ST._CacheButtonBindingKeys
 
 -- Imports from BarMode
 local ApplyBarCountTextStyle = ST._ApplyBarCountTextStyle
@@ -539,6 +540,17 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
     return button._chargeState == CHARGE_STATE_FULL
 end
 
+function CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
+    if button.keybindText then
+        local text = self:GetDisplayedKeybindText(buttonData, button._resolvedItemId)
+        button.keybindText:SetText(text or "")
+        button.keybindText:SetShown(button.style and button.style.showKeybindText and text ~= nil)
+    end
+    if CacheButtonBindingKeys then
+        CacheButtonBindingKeys(button, buttonData)
+    end
+end
+
 -- Deferred spell cooldown detection: distinguish true held cooldowns from
 -- start-recovery / empower recovery windows. In 12.0.1, unrelated spells can
 -- transiently report isEnabled=false, isActive=false, and a positive
@@ -735,6 +747,9 @@ local function ResolveChargeState(button, buttonData)
     if button._chargeCountReadable == true and currentCharges ~= nil then
         if currentCharges <= 0 then
             return CHARGE_STATE_ZERO
+        end
+        if buttonData.type == "item" and button._resolvedItemQuantityKind == "stacks" then
+            return CHARGE_STATE_FULL
         end
         if maxCharges and maxCharges > 0 then
             if currentCharges >= maxCharges then
@@ -945,6 +960,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if UpdateResolvedItemState(button, buttonData) then
         CooldownCompanion:UpdateButtonIcon(button)
         RestoreBaseDisplayName(button, buttonData)
+        CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
     end
 
     if button.count and button._countTextLaneStyled ~= useChargeTextLane then

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -62,6 +62,7 @@ local UpdateTextDisplay = ST._UpdateTextDisplay
 local IsItemEquippable = CooldownCompanion.IsItemEquippable
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
+local ResolveItemFallback = CooldownCompanion.ResolveItemFallback
 local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
@@ -377,7 +378,7 @@ local function RestoreBaseDisplayName(button, buttonData)
     if buttonData.type == "spell" then
         baseName = C_Spell.GetSpellName(restoreSpellID) or baseName
     elseif buttonData.type == "item" then
-        baseName = C_Item.GetItemNameByID(buttonData.id) or baseName
+        baseName = C_Item.GetItemNameByID(button._resolvedItemId or buttonData.id) or baseName
     end
 
     if baseName then
@@ -866,7 +867,8 @@ end
 local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
     button._isEquippableNotEquipped = false
     local isEquippable = IsItemEquippable(buttonData)
-    if isEquippable and not C_Item.IsEquippedItem(buttonData.id) then
+    local itemID = button._resolvedItemId or buttonData.id
+    if isEquippable and not C_Item.IsEquippedItem(itemID) then
         button._isEquippableNotEquipped = true
         if renderCooldown then
             button.cooldown:SetCooldown(0, 0)
@@ -877,7 +879,7 @@ local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
         return false
     end
 
-    local cdStart, cdDuration, enableCooldownTimer = C_Item.GetItemCooldown(buttonData.id)
+    local cdStart, cdDuration, enableCooldownTimer = C_Item.GetItemCooldown(itemID)
     if not enableCooldownTimer and cdStart > 0 then
         if renderCooldown then
             button.cooldown:SetCooldown(0, 0)
@@ -911,6 +913,24 @@ local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
     return itemGCDOnly == true
 end
 
+local function UpdateResolvedItemState(button, buttonData)
+    if not (buttonData and buttonData.type == "item") then
+        button._resolvedItemId = nil
+        button._resolvedItemAvailableQuantity = nil
+        button._resolvedItemQuantityKind = nil
+        return false
+    end
+
+    local resolvedItemID, availableQuantity, quantityKind = ResolveItemFallback(buttonData)
+    local changed = resolvedItemID ~= button._resolvedItemId
+        or quantityKind ~= button._resolvedItemQuantityKind
+
+    button._resolvedItemId = resolvedItemID or buttonData.id
+    button._resolvedItemAvailableQuantity = availableQuantity or 0
+    button._resolvedItemQuantityKind = quantityKind or "stacks"
+    return changed
+end
+
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
@@ -921,6 +941,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local desatWasActive = button._desatCooldownActive == true
     local conditionalPreview = GetConditionalVisualPreview and GetConditionalVisualPreview(button)
     ClearConditionalVisualPreviewFields(button)
+
+    if UpdateResolvedItemState(button, buttonData) then
+        CooldownCompanion:UpdateButtonIcon(button)
+        RestoreBaseDisplayName(button, buttonData)
+    end
 
     if button.count and button._countTextLaneStyled ~= useChargeTextLane then
         if button._isBar then
@@ -1602,7 +1627,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button._secondaryCdActive = false
             end
         elseif buttonData.type == "item" then
-            local cdStart, cdDuration = C_Item.GetItemCooldown(buttonData.id)
+            local itemID = button._resolvedItemId or buttonData.id
+            local cdStart, cdDuration = C_Item.GetItemCooldown(itemID)
             local probeIsGCDOnly = CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, CooldownCompanion._gcdInfo)
             if cdDuration and cdDuration > 0 and not probeIsGCDOnly then
                 button.secondaryCooldown:SetCooldown(cdStart, cdDuration)
@@ -1798,7 +1824,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._mainCDShown = false
         if buttonData.type == "item" then
             -- Items: 0 charges = on cooldown. No GCD to filter.
-            local chargeCount = C_Item.GetItemCount(buttonData.id, false, true)
+            local itemID = button._resolvedItemId or buttonData.id
+            local chargeCount = C_Item.GetItemCount(itemID, false, true)
             button._mainCDShown = (chargeCount == 0)
         elseif buttonData.type == "spell"
            and button._chargeCountReadable == true
@@ -1956,7 +1983,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Item count display (inventory quantity for non-equipment tracked items)
     if buttonData.type == "item" and not buttonData.hasCharges and not IsItemEquippable(buttonData) then
-        local count = C_Item.GetItemCount(buttonData.id)
+        local count = button._resolvedItemAvailableQuantity
+            or C_Item.GetItemCount(button._resolvedItemId or buttonData.id)
         if button._itemCount ~= count then
             button._itemCount = count
             if count and count >= 1 then
@@ -2136,7 +2164,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local spellID = button._displaySpellId or buttonData.id
             button._isUnusable = not C_Spell_IsSpellUsable(spellID)
         elseif buttonData.type == "item" or buttonData.type == "equipitem" then
-            local usable = IsUsableItem(buttonData.id)
+            local usable = IsUsableItem(button._resolvedItemId or buttonData.id)
             button._isUnusable = not usable
         else
             button._isUnusable = false
@@ -2147,7 +2175,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         elseif buttonData.type == "item" or buttonData.type == "equipitem" then
             -- C_Item.IsItemInRange is protected in combat for non-enemy targets (10.2.0)
             if not InCombatLockdown() or UnitCanAttack("player", "target") then
-                local inRange = IsItemInRange(buttonData.id, "target")
+                local inRange = IsItemInRange(button._resolvedItemId or buttonData.id, "target")
                 button._isOutOfRange = (inRange == false)
             else
                 button._isOutOfRange = false

--- a/ButtonFrame/Glows.lua
+++ b/ButtonFrame/Glows.lua
@@ -759,7 +759,7 @@ local function SetupTooltipScripts(button)
         if self.buttonData.type == "spell" then
             GameTooltip:SetSpellByID(self._displaySpellId or self.buttonData.id)
         elseif self.buttonData.type == "item" then
-            GameTooltip:SetItemByID(self.buttonData.id)
+            GameTooltip:SetItemByID(self._resolvedItemId or self.buttonData.id)
         end
         GameTooltip:Show()
     end)

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -197,7 +197,7 @@ local function UsesChargeTextLane(buttonData)
 end
 CooldownCompanion.UsesChargeTextLane = UsesChargeTextLane
 
-local function GetItemAvailableQuantity(itemID)
+local function GetItemAvailableQuantity(itemID, forceChargeCount)
     itemID = tonumber(itemID)
     if not itemID then
         return 0, "stacks"
@@ -205,6 +205,9 @@ local function GetItemAvailableQuantity(itemID)
 
     local stackCount = C_Item.GetItemCount(itemID) or 0
     local useCount = C_Item.GetItemCount(itemID, false, true) or stackCount
+    if forceChargeCount then
+        return useCount, "charges"
+    end
     if useCount > stackCount then
         return useCount, "charges"
     end
@@ -219,6 +222,42 @@ local function HasItemFallbacks(buttonData)
         and #buttonData.itemFallbacks > 0
 end
 CooldownCompanion.HasItemFallbacks = HasItemFallbacks
+
+local function NormalizeItemFallbackVisibilitySettings(buttonData)
+    if not HasItemFallbacks(buttonData) then
+        return false
+    end
+
+    local changed = false
+    if buttonData.hideWhileZeroCharges then
+        buttonData.hideWhileZeroStacks = true
+    end
+    if buttonData.desaturateWhileZeroCharges then
+        buttonData.desaturateWhileZeroStacks = true
+    end
+    if buttonData.useBaselineAlphaFallbackZeroCharges then
+        buttonData.useBaselineAlphaFallbackZeroStacks = true
+    end
+
+    if buttonData.hideWhileZeroCharges ~= nil then
+        buttonData.hideWhileZeroCharges = nil
+        changed = true
+    end
+    if buttonData.desaturateWhileZeroCharges ~= nil then
+        buttonData.desaturateWhileZeroCharges = nil
+        changed = true
+    end
+    if buttonData.useBaselineAlphaFallbackZeroCharges ~= nil then
+        buttonData.useBaselineAlphaFallbackZeroCharges = nil
+        changed = true
+    end
+    if buttonData.hideCooldownWithCharges ~= nil then
+        buttonData.hideCooldownWithCharges = nil
+        changed = true
+    end
+    return changed
+end
+CooldownCompanion.NormalizeItemFallbackVisibilitySettings = NormalizeItemFallbackVisibilitySettings
 
 local function NormalizeItemFallbacks(buttonData)
     if not (buttonData and type(buttonData.itemFallbacks) == "table") then
@@ -247,6 +286,9 @@ local function NormalizeItemFallbacks(buttonData)
     else
         buttonData.itemFallbacks = normalized
     end
+    if NormalizeItemFallbackVisibilitySettings(buttonData) then
+        changed = true
+    end
     return changed
 end
 CooldownCompanion.NormalizeItemFallbacks = NormalizeItemFallbacks
@@ -257,7 +299,7 @@ local function ResolveItemFallback(buttonData)
     end
 
     local primaryID = tonumber(buttonData.id)
-    local primaryQuantity, primaryKind = GetItemAvailableQuantity(primaryID)
+    local primaryQuantity, primaryKind = GetItemAvailableQuantity(primaryID, buttonData.hasCharges == true)
     if primaryQuantity > 0 or not HasItemFallbacks(buttonData) then
         return primaryID, primaryQuantity, primaryKind
     end

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -11,6 +11,8 @@ local ipairs = ipairs
 local math_floor = math.floor
 local pairs = pairs
 local string_format = string.format
+local tonumber = tonumber
+local type = type
 
 -- Color constants
 local DEFAULT_BAR_AURA_COLOR = {0.2, 1.0, 0.2, 1.0}
@@ -194,6 +196,85 @@ local function UsesChargeTextLane(buttonData)
         or buttonData.isPassive == true
 end
 CooldownCompanion.UsesChargeTextLane = UsesChargeTextLane
+
+local function GetItemAvailableQuantity(itemID)
+    itemID = tonumber(itemID)
+    if not itemID then
+        return 0, "stacks"
+    end
+
+    local stackCount = C_Item.GetItemCount(itemID) or 0
+    local useCount = C_Item.GetItemCount(itemID, false, true) or stackCount
+    if useCount > stackCount then
+        return useCount, "charges"
+    end
+    return stackCount, "stacks"
+end
+CooldownCompanion.GetItemAvailableQuantity = GetItemAvailableQuantity
+
+local function HasItemFallbacks(buttonData)
+    return buttonData
+        and buttonData.type == "item"
+        and type(buttonData.itemFallbacks) == "table"
+        and #buttonData.itemFallbacks > 0
+end
+CooldownCompanion.HasItemFallbacks = HasItemFallbacks
+
+local function NormalizeItemFallbacks(buttonData)
+    if not (buttonData and type(buttonData.itemFallbacks) == "table") then
+        return false
+    end
+
+    local primaryID = tonumber(buttonData.id)
+    local seen = {}
+    local normalized = {}
+    local changed = false
+    for index, rawID in ipairs(buttonData.itemFallbacks) do
+        local itemID = tonumber(rawID)
+        if itemID and itemID > 0 and itemID ~= primaryID and not seen[itemID] then
+            seen[itemID] = true
+            normalized[#normalized + 1] = itemID
+            if rawID ~= itemID or #normalized ~= index then
+                changed = true
+            end
+        else
+            changed = true
+        end
+    end
+
+    if #normalized == 0 then
+        buttonData.itemFallbacks = nil
+    else
+        buttonData.itemFallbacks = normalized
+    end
+    return changed
+end
+CooldownCompanion.NormalizeItemFallbacks = NormalizeItemFallbacks
+
+local function ResolveItemFallback(buttonData)
+    if not (buttonData and buttonData.type == "item") then
+        return nil, 0, "stacks"
+    end
+
+    local primaryID = tonumber(buttonData.id)
+    local primaryQuantity, primaryKind = GetItemAvailableQuantity(primaryID)
+    if primaryQuantity > 0 or not HasItemFallbacks(buttonData) then
+        return primaryID, primaryQuantity, primaryKind
+    end
+
+    for _, rawID in ipairs(buttonData.itemFallbacks) do
+        local itemID = tonumber(rawID)
+        if itemID and itemID ~= primaryID then
+            local quantity, quantityKind = GetItemAvailableQuantity(itemID)
+            if quantity > 0 then
+                return itemID, quantity, quantityKind
+            end
+        end
+    end
+
+    return primaryID, primaryQuantity, primaryKind
+end
+CooldownCompanion.ResolveItemFallback = ResolveItemFallback
 
 -- Position a region in the icon area of a bar button.
 -- inset=0 for backgrounds/bounds, inset=borderSize for the icon texture itself.

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -208,7 +208,7 @@ local function GetItemAvailableQuantity(itemID, forceChargeCount)
     if forceChargeCount then
         return useCount, "charges"
     end
-    if useCount > stackCount then
+    if useCount ~= stackCount then
         return useCount, "charges"
     end
     return stackCount, "stacks"
@@ -223,38 +223,82 @@ local function HasItemFallbacks(buttonData)
 end
 CooldownCompanion.HasItemFallbacks = HasItemFallbacks
 
-local function NormalizeItemFallbackVisibilitySettings(buttonData)
-    if not HasItemFallbacks(buttonData) then
+local function UpdateItemChargeMetadata(buttonData, itemID)
+    if not (buttonData and buttonData.type == "item") then
         return false
     end
 
-    local changed = false
-    if buttonData.hideWhileZeroCharges then
-        buttonData.hideWhileZeroStacks = true
-    end
-    if buttonData.desaturateWhileZeroCharges then
-        buttonData.desaturateWhileZeroStacks = true
-    end
-    if buttonData.useBaselineAlphaFallbackZeroCharges then
-        buttonData.useBaselineAlphaFallbackZeroStacks = true
+    itemID = tonumber(itemID or buttonData.id)
+    if not itemID then
+        return false
     end
 
-    if buttonData.hideWhileZeroCharges ~= nil then
-        buttonData.hideWhileZeroCharges = nil
-        changed = true
+    local stackCount = C_Item.GetItemCount(itemID) or 0
+    local useCount = C_Item.GetItemCount(itemID, false, true) or stackCount
+    if useCount == stackCount then
+        return false
     end
-    if buttonData.desaturateWhileZeroCharges ~= nil then
-        buttonData.desaturateWhileZeroCharges = nil
-        changed = true
+
+    buttonData.hasCharges = true
+    buttonData.showChargeText = true
+    if useCount > (buttonData.maxCharges or 0) then
+        buttonData.maxCharges = useCount
     end
-    if buttonData.useBaselineAlphaFallbackZeroCharges ~= nil then
-        buttonData.useBaselineAlphaFallbackZeroCharges = nil
-        changed = true
+    return true
+end
+CooldownCompanion.UpdateItemChargeMetadata = UpdateItemChargeMetadata
+
+local function NormalizeItemFallbackVisibilitySettings(buttonData, hasFallbacks, hadFallbacks)
+    local changed = false
+
+    if hasFallbacks then
+        if buttonData.hideWhileZeroCharges then
+            buttonData.hideWhileZeroStacks = true
+        end
+        if buttonData.desaturateWhileZeroCharges then
+            buttonData.desaturateWhileZeroStacks = true
+        end
+        if buttonData.useBaselineAlphaFallbackZeroCharges then
+            buttonData.useBaselineAlphaFallbackZeroStacks = true
+        end
+
+        if buttonData.hideWhileZeroCharges ~= nil then
+            buttonData.hideWhileZeroCharges = nil
+            changed = true
+        end
+        if buttonData.desaturateWhileZeroCharges ~= nil then
+            buttonData.desaturateWhileZeroCharges = nil
+            changed = true
+        end
+        if buttonData.useBaselineAlphaFallbackZeroCharges ~= nil then
+            buttonData.useBaselineAlphaFallbackZeroCharges = nil
+            changed = true
+        end
+    elseif hadFallbacks and buttonData.type == "item" and UsesChargeBehavior(buttonData) then
+        if buttonData.hideWhileZeroStacks then
+            buttonData.hideWhileZeroCharges = true
+        end
+        if buttonData.desaturateWhileZeroStacks then
+            buttonData.desaturateWhileZeroCharges = true
+        end
+        if buttonData.useBaselineAlphaFallbackZeroStacks then
+            buttonData.useBaselineAlphaFallbackZeroCharges = true
+        end
+
+        if buttonData.hideWhileZeroStacks ~= nil then
+            buttonData.hideWhileZeroStacks = nil
+            changed = true
+        end
+        if buttonData.desaturateWhileZeroStacks ~= nil then
+            buttonData.desaturateWhileZeroStacks = nil
+            changed = true
+        end
+        if buttonData.useBaselineAlphaFallbackZeroStacks ~= nil then
+            buttonData.useBaselineAlphaFallbackZeroStacks = nil
+            changed = true
+        end
     end
-    if buttonData.hideCooldownWithCharges ~= nil then
-        buttonData.hideCooldownWithCharges = nil
-        changed = true
-    end
+
     return changed
 end
 CooldownCompanion.NormalizeItemFallbackVisibilitySettings = NormalizeItemFallbackVisibilitySettings
@@ -265,6 +309,7 @@ local function NormalizeItemFallbacks(buttonData)
     end
 
     local primaryID = tonumber(buttonData.id)
+    local hadFallbacks = true
     local seen = {}
     local normalized = {}
     local changed = false
@@ -286,7 +331,7 @@ local function NormalizeItemFallbacks(buttonData)
     else
         buttonData.itemFallbacks = normalized
     end
-    if NormalizeItemFallbackVisibilitySettings(buttonData) then
+    if NormalizeItemFallbackVisibilitySettings(buttonData, #normalized > 0, hadFallbacks) then
         changed = true
     end
     return changed

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -590,6 +590,13 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.count:SetText("")
     button.buttonData = buttonData
 
+    if buttonData.type == "item" then
+        local resolvedItemID, availableQuantity, quantityKind = CooldownCompanion.ResolveItemFallback(buttonData)
+        button._resolvedItemId = resolvedItemID or buttonData.id
+        button._resolvedItemAvailableQuantity = availableQuantity or 0
+        button._resolvedItemQuantityKind = quantityKind or "stacks"
+    end
+
     ApplyCountTextStyle(button, style)
 
     -- Aura stack count text: separate FontString for aura stacks and config previews.
@@ -609,7 +616,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
         local xOff = style.keybindXOffset or -2
         local yOff = style.keybindYOffset or -2
         button.keybindText:SetPoint(anchor, xOff, yOff)
-        local text = CooldownCompanion:GetDisplayedKeybindText(buttonData)
+        local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId)
         button.keybindText:SetText(text or "")
         button.keybindText:SetShown(style.showKeybindText and text ~= nil)
     end
@@ -857,7 +864,8 @@ function CooldownCompanion:UpdateButtonIcon(button)
             icon = C_Spell.GetSpellTexture(buttonData.id)
         end
     elseif buttonData.type == "item" then
-        icon = C_Item.GetItemIconByID(buttonData.id)
+        local itemID = button._resolvedItemId or buttonData.id
+        icon = C_Item.GetItemIconByID(itemID)
     end
 
     -- Manual icon override: replaces base icon; aura icon swap still takes precedence
@@ -1328,7 +1336,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
         local xOff = style.keybindXOffset or -2
         local yOff = style.keybindYOffset or -2
         button.keybindText:SetPoint(anchor, xOff, yOff)
-        local text = CooldownCompanion:GetDisplayedKeybindText(button.buttonData)
+        local text = CooldownCompanion:GetDisplayedKeybindText(button.buttonData, button._resolvedItemId)
         button.keybindText:SetText(text or "")
         button.keybindText:SetShown(style.showKeybindText and text ~= nil)
     end

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -25,6 +25,7 @@ local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local FitHighlightFrame = ST._FitHighlightFrame
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
+local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -944,7 +945,8 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
 
     -- Charge-visual suppression: when toggle is active and charges remain,
     -- hide the swipe fill (dark overlay) but keep the edge visible.
-    if UsesChargeBehavior(buttonData) and buttonData.hideCooldownWithCharges and not button._auraActive then
+    if UsesChargeBehavior(buttonData) and buttonData.hideCooldownWithCharges
+            and not HasItemFallbacks(buttonData) and not button._auraActive then
         local hasChargesRemaining = (button._chargeState ~= CHARGE_STATE_ZERO)
         if hasChargesRemaining ~= button._hideCooldownChargesActive then
             button._hideCooldownChargesActive = hasChargesRemaining

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -290,7 +290,7 @@ local function EvaluateTokenPresence(button, tokenName, timeRemaining, timeIsSec
     elseif tokenName == "aura" then
         return button._auraActive == true or auraIsSecret or (auraRemaining and auraRemaining > 0)
     elseif tokenName == "keybind" then
-        local kb = CooldownCompanion:GetKeybindText(button.buttonData)
+        local kb = CooldownCompanion:GetKeybindText(button.buttonData, button._resolvedItemId)
         return kb and kb ~= ""
     elseif tokenName == "pandemic" then
         return button._inPandemic == true
@@ -465,7 +465,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                         if spellName then name = spellName end
                     end
                 elseif not buttonData.customName and buttonData.type == "item" then
-                    local itemName = C_Item.GetItemNameByID(buttonData.id)
+                    local itemName = C_Item.GetItemNameByID(button._resolvedItemId or buttonData.id)
                     if itemName then name = itemName end
                 end
                 if name then
@@ -525,7 +525,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                 end
 
             elseif token == "keybind" then
-                local kb = CooldownCompanion:GetKeybindText(buttonData)
+                local kb = CooldownCompanion:GetKeybindText(buttonData, button._resolvedItemId)
                 if kb and kb ~= "" then
                     parts[#parts + 1] = WrapColor(kb, colorOverride or baseColor)
                 end
@@ -878,6 +878,13 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil
     button._textSecretNameActive = nil
+
+    if buttonData.type == "item" then
+        local resolvedItemID, availableQuantity, quantityKind = CooldownCompanion.ResolveItemFallback(buttonData)
+        button._resolvedItemId = resolvedItemID or buttonData.id
+        button._resolvedItemAvailableQuantity = availableQuantity or 0
+        button._resolvedItemQuantityKind = quantityKind or "stacks"
+    end
 
     -- Per-button visibility runtime state
     button._visibilityHidden = false

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -10,6 +10,7 @@ local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
 local issecretvalue = issecretvalue
+local tonumber = tonumber
 local InCombatLockdown = InCombatLockdown
 local UnitCanAttack = UnitCanAttack
 local IsItemInRange = C_Item.IsItemInRange
@@ -140,8 +141,11 @@ local function UpdateItemChargeTracking(button, buttonData)
 
     -- Update persisted maxCharges upward only for the primary item. Fallback
     -- stacks and charges are runtime choices, not permanent entry metadata.
-    if itemID == buttonData.id and chargeCount > (buttonData.maxCharges or 0) then
+    local isPrimaryItem = tonumber(itemID) == tonumber(buttonData.id)
+    if isPrimaryItem and chargeCount > (buttonData.maxCharges or 0) then
         buttonData.maxCharges = chargeCount
+    elseif not isPrimaryItem and chargeCount > (button._resolvedItemMaxCharges or 0) then
+        button._resolvedItemMaxCharges = chargeCount
     end
 
     -- Items are always readable — feed the same field spells use so the

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -135,10 +135,12 @@ end
 -- Item charge tracking (e.g. Hellstone): simpler than spells, no secret values.
 -- Reads charge count via C_Item.GetItemCount with includeUses, updates text display.
 local function UpdateItemChargeTracking(button, buttonData)
-    local chargeCount = C_Item.GetItemCount(buttonData.id, false, true)
+    local itemID = button._resolvedItemId or buttonData.id
+    local chargeCount = C_Item.GetItemCount(itemID, false, true)
 
-    -- Update persisted maxCharges upward when observable
-    if chargeCount > (buttonData.maxCharges or 0) then
+    -- Update persisted maxCharges upward only for the primary item. Fallback
+    -- stacks and charges are runtime choices, not permanent entry metadata.
+    if itemID == buttonData.id and chargeCount > (buttonData.maxCharges or 0) then
         buttonData.maxCharges = chargeCount
     end
 
@@ -190,7 +192,8 @@ local function UpdateIconTint(button, buttonData, style)
             -- C_Item.IsItemInRange is protected in combat for non-enemy targets (10.2.0);
             -- only call when out of combat or target is attackable.
             if not InCombatLockdown() or UnitCanAttack("player", "target") then
-                local inRange = IsItemInRange(buttonData.id, "target")
+                local itemID = button._resolvedItemId or buttonData.id
+                local inRange = IsItemInRange(itemID, "target")
                 -- inRange is nil when no target or item has no range; only tint on explicit false
                 if inRange == false then
                     r, g, b = 1, 0.2, 0.2
@@ -216,7 +219,8 @@ local function UpdateIconTint(button, buttonData, style)
                 button._unusableTintActive = true
             end
         elseif buttonData.type == "item" then
-            local usable = IsUsableItem(buttonData.id)
+            local itemID = button._resolvedItemId or buttonData.id
+            local usable = IsUsableItem(itemID)
             if not usable then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -284,10 +284,14 @@ local function EvaluateDesaturation(button, buttonData, style)
             wantDesat = true
         end
         if not wantDesat and buttonData.desaturateWhileZeroCharges
+                and not CooldownCompanion.HasItemFallbacks(buttonData)
                 and button._chargeState == CHARGE_STATE_ZERO then
             wantDesat = true
         end
-        if not wantDesat and buttonData.desaturateWhileZeroStacks and (button._itemCount or 0) == 0 then
+        local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
+            and button._resolvedItemAvailableQuantity
+            or button._itemCount
+        if not wantDesat and buttonData.desaturateWhileZeroStacks and (itemUseCount or 0) == 0 then
             wantDesat = true
         end
     end

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -73,10 +73,16 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     -- Phase 1: Evaluate each hide condition and accumulate active reasons as bits.
     local hideReasons = 0
     local auraTrackingReady = button._auraTrackingReady == true
+    local itemUsesResolvedCooldownState = buttonData.type == "item"
+        and button._resolvedItemQuantityKind == "stacks"
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
     if buttonData.hideWhileOnCooldown and not button._noCooldown then
-        if UsesChargeBehavior(buttonData) then
+        if itemUsesResolvedCooldownState then
+            if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
+                hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
+            end
+        elseif UsesChargeBehavior(buttonData) then
             if button._chargeState == CHARGE_STATE_ZERO
                     or button._chargeState == CHARGE_STATE_MISSING then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
@@ -94,7 +100,11 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
 
     -- Check hideWhileNotOnCooldown (skip for no-CD spells — would permanently hide)
     if buttonData.hideWhileNotOnCooldown and not button._noCooldown then
-        if UsesChargeBehavior(buttonData) then
+        if itemUsesResolvedCooldownState then
+            if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN then
+                hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
+            end
+        elseif UsesChargeBehavior(buttonData) then
             if button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -131,10 +131,8 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
 
     -- Check hideWhileZeroCharges (charge-based spells and items)
     if buttonData.hideWhileZeroCharges
-            and (button._chargeState == CHARGE_STATE_ZERO
-                or (buttonData.type == "item"
-                    and buttonData.itemFallbacks
-                    and (button._resolvedItemAvailableQuantity or 0) == 0)) then
+            and not CooldownCompanion.HasItemFallbacks(buttonData)
+            and button._chargeState == CHARGE_STATE_ZERO then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_CHARGES)
     end
 

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -130,12 +130,17 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     end
 
     -- Check hideWhileZeroCharges (charge-based spells and items)
-    if buttonData.hideWhileZeroCharges and button._chargeState == CHARGE_STATE_ZERO then
+    if buttonData.hideWhileZeroCharges
+            and (button._chargeState == CHARGE_STATE_ZERO
+                or (buttonData.type == "item"
+                    and buttonData.itemFallbacks
+                    and (button._resolvedItemAvailableQuantity or 0) == 0)) then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_CHARGES)
     end
 
     -- Check hideWhileZeroStacks (stack-based items)
-    if buttonData.hideWhileZeroStacks and (button._itemCount or 0) == 0 then
+    if buttonData.hideWhileZeroStacks
+            and (button._itemCount or button._resolvedItemAvailableQuantity or 0) == 0 then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_STACKS)
     end
 
@@ -152,7 +157,8 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_UNUSABLE)
             end
         elseif buttonData.type == "item" then
-            if not IsUsableItem(buttonData.id) then
+            local itemID = button._resolvedItemId or buttonData.id
+            if not IsUsableItem(itemID) then
                 hideReasons = bit_bor(hideReasons, HIDE_UNUSABLE)
             end
         end

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -137,8 +137,10 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     end
 
     -- Check hideWhileZeroStacks (stack-based items)
-    if buttonData.hideWhileZeroStacks
-            and (button._itemCount or button._resolvedItemAvailableQuantity or 0) == 0 then
+    local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
+        and button._resolvedItemAvailableQuantity
+        or button._itemCount
+    if buttonData.hideWhileZeroStacks and (itemUseCount or 0) == 0 then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_STACKS)
     end
 

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -768,14 +768,12 @@ local function PlaceRowBadge(frame, badge, offsetX)
     return offsetX - ROW_BADGE_SIZE - ROW_BADGE_SPACING
 end
 
-local function LayoutRowBadges(frame, badge1, badge2, badge3, badge4, badge5, badge6)
+local function LayoutRowBadges(frame, ...)
     local offsetX = -ROW_BADGE_RIGHT_PAD
-    offsetX = PlaceRowBadge(frame, badge1, offsetX)
-    offsetX = PlaceRowBadge(frame, badge2, offsetX)
-    offsetX = PlaceRowBadge(frame, badge3, offsetX)
-    offsetX = PlaceRowBadge(frame, badge4, offsetX)
-    offsetX = PlaceRowBadge(frame, badge5, offsetX)
-    PlaceRowBadge(frame, badge6, offsetX)
+    for index = 1, select("#", ...) do
+        local badge = select(index, ...)
+        offsetX = PlaceRowBadge(frame, badge, offsetX)
+    end
 end
 
 local function IsAuraTrackingConfigReady(buttonData, cdmEnabled)
@@ -2472,7 +2470,7 @@ local function RefreshColumn2()
                     -- Right-side row badges
                     local rowFrame = entry.frame
                     local rowBadgeLevel = rowFrame:GetFrameLevel() + 5
-                    local warnBadge, overrideBadge, soundBadge, auraBadge
+                    local warnBadge, overrideBadge, soundBadge, auraBadge, fallbackBadge
 
                     if not usable and buttonData.enabled ~= false then
                         warnBadge = EnsureRowBadge(rowFrame, "_cdcWarnBtn", "Ping_Marker_Icon_Warning")
@@ -2491,6 +2489,13 @@ local function RefreshColumn2()
                         overrideBadge:SetFrameLevel(rowBadgeLevel)
                         SetRowBadgeTooltip(overrideBadge, "Has appearance overrides")
                         overrideBadge:Show()
+                    end
+
+                    if CooldownCompanion.HasItemFallbacks(buttonData) then
+                        fallbackBadge = EnsureRowBadge(rowFrame, "_cdcFallbackBadge", "banker")
+                        fallbackBadge:SetFrameLevel(rowBadgeLevel)
+                        SetRowBadgeTooltip(fallbackBadge, "Uses item fallbacks")
+                        fallbackBadge:Show()
                     end
 
                     if buttonData.type == "spell" then
@@ -2547,7 +2552,7 @@ local function RefreshColumn2()
                         disabledBadge:Show()
                     end
 
-                    LayoutRowBadges(rowFrame, disabledBadge, warnBadge, overrideBadge, soundBadge, auraBadge, talentBadge)
+                    LayoutRowBadges(rowFrame, disabledBadge, warnBadge, overrideBadge, fallbackBadge, soundBadge, auraBadge, talentBadge)
 
                     entry:SetCallback("OnClick", function(widget, event, mouseButton)
                         if mouseButton == "LeftButton" and not IsControlKeyDown() and not GetCursorInfo() then

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1616,6 +1616,8 @@ local function CreateConfigPanel()
             else
                 ST._BuildSpellSoundAlertsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
             end
+        elseif tab == "fallbacks" then
+            ST._BuildItemFallbacksTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
         elseif tab == "overrides" then
             ST._BuildOverridesTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
         end

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1189,10 +1189,11 @@ local function ApplyConfigRowLayout(entry)
 
     label:ClearAllPoints()
     label:SetPoint("LEFT", frame, "LEFT", leftPad, 0)
-    label:SetPoint("RIGHT", frame, "RIGHT", -CONFIG_ROW_RIGHT_PAD, 0)
+    local rightPad = row.rightPad or CONFIG_ROW_RIGHT_PAD
+    label:SetPoint("RIGHT", frame, "RIGHT", -rightPad, 0)
     local rowWidth = frame.width or frame:GetWidth() or 0
     if rowWidth > 0 then
-        label:SetWidth(math.max(1, rowWidth - leftPad - CONFIG_ROW_RIGHT_PAD))
+        label:SetWidth(math.max(1, rowWidth - leftPad - rightPad))
     end
     if label.SetWordWrap then
         label:SetWordWrap(false)
@@ -1277,6 +1278,9 @@ local function CleanRecycledEntry(entry)
     if entry.frame._cdcAnchorBadge then entry.frame._cdcAnchorBadge:Hide() end
     if entry.frame._cdcHeaderDisabledBadge then entry.frame._cdcHeaderDisabledBadge:Hide() end
     if entry.frame._cdcDisabledBadge then entry.frame._cdcDisabledBadge:Hide() end
+    if entry.frame._cdcFallbackRemoveBtn then entry.frame._cdcFallbackRemoveBtn:Hide() end
+    if entry.frame._cdcFallbackUpBtn then entry.frame._cdcFallbackUpBtn:Hide() end
+    if entry.frame._cdcFallbackDownBtn then entry.frame._cdcFallbackDownBtn:Hide() end
     if entry.frame._cdcMarkerLeft then entry.frame._cdcMarkerLeft:Hide() end
     if entry.frame._cdcMarkerRight then entry.frame._cdcMarkerRight:Hide() end
     entry.frame:SetScript("OnMouseUp", nil)
@@ -1293,6 +1297,7 @@ local function ApplyConfigRowIcon(entry, texture, opts)
         texture = texture,
         atlas = opts.atlas,
         desaturated = opts.desaturated == true,
+        rightPad = opts.rightPad,
     }
     EnsureConfigRowHandlers(entry)
 
@@ -1302,11 +1307,12 @@ local function ApplyConfigRowIcon(entry, texture, opts)
     ApplyConfigRowLayout(entry)
 end
 
-local function ApplyConfigTextRow(entry, justifyH, normalLeftPad)
+local function ApplyConfigTextRow(entry, justifyH, normalLeftPad, rightPad)
     entry._cdcConfigRow = {
         kind = "text",
         justifyH = justifyH or "LEFT",
         normalLeftPad = normalLeftPad or 0,
+        rightPad = rightPad,
     }
     EnsureConfigRowHandlers(entry)
 

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1270,6 +1270,7 @@ local function CleanRecycledEntry(entry)
     if entry.frame._cdcOverrideBadge then entry.frame._cdcOverrideBadge:Hide() end
     if entry.frame._cdcSoundBadge then entry.frame._cdcSoundBadge:Hide() end
     if entry.frame._cdcAuraBadge then entry.frame._cdcAuraBadge:Hide() end
+    if entry.frame._cdcFallbackBadge then entry.frame._cdcFallbackBadge:Hide() end
     if entry.frame._cdcTalentBadge then entry.frame._cdcTalentBadge:Hide() end
     if entry.frame._cdcCollapseIcon then entry.frame._cdcCollapseIcon:Hide() end
     if entry.frame._cdcCollapseBtn then entry.frame._cdcCollapseBtn:Hide() end

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -18,6 +18,7 @@ local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local HasTooltipCooldown = ST.HasTooltipCooldown
 local HasUsageRequirement = ST.HasUsageRequirement
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
+local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -755,7 +756,11 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
     -- Batch: show if any selected button is charge-capable
     local showChargeSection
     if isBatch then showChargeSection = AnySelectedChargeCapable(group)
-    else showChargeSection = UsesChargeBehavior(buttonData) and (buttonData.type == "spell" or (isItem and not CooldownCompanion.IsItemEquippable(buttonData))) end
+    else
+        showChargeSection = UsesChargeBehavior(buttonData)
+            and (buttonData.type == "spell" or (isItem and not CooldownCompanion.IsItemEquippable(buttonData)))
+            and not HasItemFallbacks(buttonData)
+    end
     if showChargeSection then
         -- Hide While At Zero Charges
         local hideZeroChargesCb = AceGUI:Create("CheckBox")
@@ -833,11 +838,12 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         -- Batch: show stacks section if any selected lacks charges (stack-based items)
         local hasStacks
         if isBatch then hasStacks = not AllSelectedChargeCapable(group)
-        else hasStacks = not UsesChargeBehavior(buttonData) end
+        else hasStacks = HasItemFallbacks(buttonData) or not UsesChargeBehavior(buttonData) end
         if hasStacks then
+            local fallbackItemUses = (not isBatch) and HasItemFallbacks(buttonData)
             -- Hide While At Zero Stacks
             local hideZeroStacksCb = AceGUI:Create("CheckBox")
-            hideZeroStacksCb:SetLabel("Hide While At Zero Stacks")
+            hideZeroStacksCb:SetLabel(fallbackItemUses and "Hide While No Uses Available" or "Hide While At Zero Stacks")
             SetCheckboxValue(hideZeroStacksCb, "hideWhileZeroStacks", FilterNonEquippable)
             hideZeroStacksCb:SetFullWidth(true)
             WrapBatchCallback(hideZeroStacksCb, function(widget, event, val)
@@ -876,7 +882,7 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
             -- Desaturate While At Zero Stacks
             if not isTexturePanel then
                 local desatZeroStacksCb = AceGUI:Create("CheckBox")
-                desatZeroStacksCb:SetLabel("Desaturate While At Zero Stacks")
+                desatZeroStacksCb:SetLabel(fallbackItemUses and "Desaturate While No Uses Available" or "Desaturate While At Zero Stacks")
                 SetCheckboxValue(desatZeroStacksCb, "desaturateWhileZeroStacks", FilterNonEquippable)
                 desatZeroStacksCb:SetFullWidth(true)
                 WrapBatchCallback(desatZeroStacksCb, function(widget, event, val)

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -167,6 +167,14 @@ local function AnySelectedNonEquippable(group)
     return false
 end
 
+local function AnySelectedHasItemFallbacks(group)
+    for idx in pairs(CS.selectedButtons) do
+        local bd = group.buttons[idx]
+        if bd and HasItemFallbacks(bd) then return true end
+    end
+    return false
+end
+
 -- Returns true if any selected button is charge-capable (spells or non-equippable items with charges)
 local function AnySelectedChargeCapable(group)
     for idx in pairs(CS.selectedButtons) do
@@ -837,10 +845,10 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
     if showStackSection then
         -- Batch: show stacks section if any selected lacks charges (stack-based items)
         local hasStacks
-        if isBatch then hasStacks = not AllSelectedChargeCapable(group)
+        if isBatch then hasStacks = AnySelectedHasItemFallbacks(group) or not AllSelectedChargeCapable(group)
         else hasStacks = HasItemFallbacks(buttonData) or not UsesChargeBehavior(buttonData) end
         if hasStacks then
-            local fallbackItemUses = (not isBatch) and HasItemFallbacks(buttonData)
+            local fallbackItemUses = isBatch and AnySelectedHasItemFallbacks(group) or HasItemFallbacks(buttonData)
             -- Hide While At Zero Stacks
             local hideZeroStacksCb = AceGUI:Create("CheckBox")
             hideZeroStacksCb:SetLabel(fallbackItemUses and "Hide While No Uses Available" or "Hide While At Zero Stacks")

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -74,6 +74,7 @@ local function FilterTargetAuraTracking(bd)
     return bd.auraTracking == true and bd.auraUnit == "target"
 end
 local function FilterChargeCapable(bd)
+    if HasItemFallbacks(bd) then return false end
     if not UsesChargeBehavior(bd) then return false end
     if bd.type == "spell" then return true end
     if bd.type == "item" and not CooldownCompanion.IsItemEquippable(bd) then return true end

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -26,6 +26,7 @@ local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local NormalizeItemFallbacks = CooldownCompanion.NormalizeItemFallbacks
+local UpdateItemChargeMetadata = CooldownCompanion.UpdateItemChargeMetadata
 
 -- Imports from SectionBuilders.lua (used by BuildOverridesTab)
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -1194,6 +1195,7 @@ local function UpdatePrimaryFallbackItem(buttonData, itemID)
     buttonData.name = GetItemFallbackName(itemID)
     buttonData.hasCharges = nil
     buttonData.maxCharges = nil
+    UpdateItemChargeMetadata(buttonData, itemID)
 end
 
 local function MoveFallbackPriorityItem(buttonData, sourceIndex, targetIndex)

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1181,25 +1181,58 @@ local function TryReceiveFallbackItemDrop(buttonData)
     return added
 end
 
-local function MoveFallbackItem(buttonData, sourceIndex, targetIndex)
-    local fallbackIDs = buttonData and buttonData.itemFallbacks
-    if type(fallbackIDs) ~= "table" then
+local function UpdatePrimaryFallbackItem(buttonData, itemID)
+    buttonData.id = itemID
+    buttonData.name = GetItemFallbackName(itemID)
+    buttonData.hasCharges = nil
+    buttonData.maxCharges = nil
+end
+
+local function MoveFallbackPriorityItem(buttonData, sourceIndex, targetIndex)
+    if not (buttonData and buttonData.type == "item") then
         return false
     end
+    local fallbackIDs = buttonData.itemFallbacks
+    if type(fallbackIDs) ~= "table" then
+        fallbackIDs = {}
+    end
+
     local count = #fallbackIDs
     sourceIndex = tonumber(sourceIndex)
     targetIndex = tonumber(targetIndex)
-    if not sourceIndex or not targetIndex or sourceIndex < 1 or sourceIndex > count then
+    if not sourceIndex or not targetIndex or sourceIndex < 0 or sourceIndex > count then
         return false
     end
-    if targetIndex < 1 then targetIndex = 1 end
+    if targetIndex < 0 then targetIndex = 0 end
     if targetIndex > count then targetIndex = count end
     if targetIndex == sourceIndex then
         return false
     end
 
-    local itemID = table.remove(fallbackIDs, sourceIndex)
-    table.insert(fallbackIDs, targetIndex, itemID)
+    local orderedIDs = { tonumber(buttonData.id) }
+    for _, rawID in ipairs(fallbackIDs) do
+        orderedIDs[#orderedIDs + 1] = tonumber(rawID)
+    end
+
+    local movedID = table.remove(orderedIDs, sourceIndex + 1)
+    if not movedID then
+        return false
+    end
+    table.insert(orderedIDs, targetIndex + 1, movedID)
+
+    local newPrimaryID = orderedIDs[1]
+    if not (newPrimaryID and newPrimaryID > 0) then
+        return false
+    end
+    if newPrimaryID ~= tonumber(buttonData.id) then
+        UpdatePrimaryFallbackItem(buttonData, newPrimaryID)
+    end
+
+    local newFallbacks = {}
+    for index = 2, #orderedIDs do
+        newFallbacks[#newFallbacks + 1] = orderedIDs[index]
+    end
+    buttonData.itemFallbacks = newFallbacks
     NormalizeItemFallbacks(buttonData)
     return true
 end
@@ -1317,10 +1350,10 @@ local function ConfigureFallbackMoveButton(button, rotation, tooltipTitle, toolt
     button:Show()
 end
 
-local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex)
+local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex, isPrimary)
     local frame = entry.frame
     local upBtn = frame._cdcFallbackUpBtn
-    if not upBtn then
+    if not upBtn and not isPrimary then
         upBtn = CreateFrame("Button", nil, frame)
         frame._cdcFallbackUpBtn = upBtn
     end
@@ -1330,6 +1363,30 @@ local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex)
         frame._cdcFallbackDownBtn = downBtn
     end
 
+    local fallbackIDs = buttonData.itemFallbacks or {}
+    if isPrimary then
+        if upBtn then
+            upBtn:Hide()
+        end
+
+        downBtn:ClearAllPoints()
+        downBtn:SetPoint("RIGHT", frame, "RIGHT", -4, 0)
+        downBtn:SetFrameLevel(frame:GetFrameLevel() + 6)
+        ConfigureFallbackMoveButton(
+            downBtn,
+            -math_pi / 2,
+            "Move Down",
+            "Swap this primary item with the first fallback.",
+            #fallbackIDs == 0,
+            function()
+                if MoveFallbackPriorityItem(buttonData, 0, 1) then
+                    RefreshFallbackEntry(CS.selectedGroup)
+                end
+            end
+        )
+        return
+    end
+
     upBtn:ClearAllPoints()
     upBtn:SetPoint("RIGHT", frame, "RIGHT", -24, 0)
     upBtn:SetFrameLevel(frame:GetFrameLevel() + 6)
@@ -1337,16 +1394,15 @@ local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex)
         upBtn,
         math_pi / 2,
         "Move Up",
-        "Move this fallback one priority slot higher.",
-        rowIndex <= 1,
+        rowIndex == 1 and "Make this fallback the primary item." or "Move this fallback one priority slot higher.",
+        false,
         function()
-            if MoveFallbackItem(buttonData, rowIndex, rowIndex - 1) then
+            if MoveFallbackPriorityItem(buttonData, rowIndex, rowIndex - 1) then
                 RefreshFallbackEntry(CS.selectedGroup)
             end
         end
     )
 
-    local fallbackIDs = buttonData.itemFallbacks or {}
     downBtn:ClearAllPoints()
     downBtn:SetPoint("RIGHT", frame, "RIGHT", -4, 0)
     downBtn:SetFrameLevel(frame:GetFrameLevel() + 6)
@@ -1357,7 +1413,7 @@ local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex)
         "Move this fallback one priority slot lower.",
         rowIndex >= #fallbackIDs,
         function()
-            if MoveFallbackItem(buttonData, rowIndex, rowIndex + 1) then
+            if MoveFallbackPriorityItem(buttonData, rowIndex, rowIndex + 1) then
                 RefreshFallbackEntry(CS.selectedGroup)
             end
         end
@@ -1408,16 +1464,17 @@ local function CreateFallbackItemRow(scroll, buttonData, itemID, rowIndex, isPri
     row:SetFullWidth(true)
     row:SetFontObject(GameFontHighlight)
     row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-    ApplyConfigRowIcon(row, C_Item.GetItemIconByID(itemID) or 134400, { rightPad = isPrimary and 4 or 48 })
+    ApplyConfigRowIcon(row, C_Item.GetItemIconByID(itemID) or 134400, { rightPad = isPrimary and 28 or 48 })
     if BindConfigShiftTooltip then
         BindConfigShiftTooltip(row, "item", itemID, row.frame, "ANCHOR_RIGHT")
     end
 
     if isPrimary then
         row:SetColor(1, 1, 1)
+        EnsureFallbackMoveButtons(row, buttonData, 0, true)
         InstallFallbackDropScript(row.frame, buttonData)
     else
-        EnsureFallbackMoveButtons(row, buttonData, rowIndex)
+        EnsureFallbackMoveButtons(row, buttonData, rowIndex, false)
         InstallFallbackRowMenu(row, buttonData, rowIndex)
     end
 
@@ -1454,7 +1511,7 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
 
     local infoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, {
         "Item Fallbacks",
-        {"The primary item is always first. Fallbacks are used only when higher-priority items are not in your bags.", 1, 1, 1, true},
+        {"Use the arrows to set priority. The top item is the primary item, and fallbacks are used only when higher-priority items are not in your bags.", 1, 1, 1, true},
         {"Stacks and charges both count as available uses for choosing the active item.", 1, 1, 1, true},
     }, infoButtons)
     heading.right:ClearAllPoints()

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1306,7 +1306,8 @@ local function InstallFallbackColumnDropTargets(scroll, buttonData)
 end
 
 local function BuildFallbackRowText(itemID, rowIndex, isPrimary)
-    local prefix = isPrimary and "" or (tostring(rowIndex) .. ". ")
+    local displayIndex = isPrimary and 1 or (rowIndex + 1)
+    local prefix = tostring(displayIndex) .. ". "
     return ("%s%s"):format(
         prefix,
         GetItemFallbackDisplayName(itemID)
@@ -1511,8 +1512,9 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
 
     local infoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, {
         "Item Fallbacks",
-        {"Use the arrows to set priority. The top item is the primary item, and fallbacks are used only when higher-priority items are not in your bags.", 1, 1, 1, true},
-        {"Stacks and charges both count as available uses for choosing the active item.", 1, 1, 1, true},
+        {"Use arrows to choose which item should appear first.", 1, 1, 1, true},
+        {" ", 1, 1, 1, true},
+        {"Fallbacks are used only when higher-priority items are not in your bags.", 1, 1, 1, true},
     }, infoButtons)
     heading.right:ClearAllPoints()
     heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1153,6 +1153,10 @@ local function SearchFallbackAutocomplete(buttonData, query)
 end
 
 local function AddItemFallback(buttonData, itemID)
+    if CS.browseMode then
+        return false
+    end
+
     local validID, err = ValidateFallbackItem(buttonData, itemID)
     if not validID then
         CooldownCompanion:Print(err)
@@ -1168,6 +1172,10 @@ local function AddItemFallback(buttonData, itemID)
 end
 
 local function TryReceiveFallbackItemDrop(buttonData)
+    if CS.browseMode then
+        return false
+    end
+
     local cursorType, cursorID = GetCursorInfo()
     if cursorType ~= "item" or not cursorID then
         return false
@@ -1189,6 +1197,10 @@ local function UpdatePrimaryFallbackItem(buttonData, itemID)
 end
 
 local function MoveFallbackPriorityItem(buttonData, sourceIndex, targetIndex)
+    if CS.browseMode then
+        return false
+    end
+
     if not (buttonData and buttonData.type == "item") then
         return false
     end
@@ -1251,7 +1263,7 @@ local function InstallFallbackDropScript(frame, buttonData)
 
     frame:SetScript("OnReceiveDrag", function(self, ...)
         local activeButtonData = self._cdcFallbackDropButtonData
-        if CS.buttonSettingsTab == "fallbacks" and activeButtonData then
+        if CS.buttonSettingsTab == "fallbacks" and not CS.browseMode and activeButtonData then
             local cursorType = GetCursorInfo()
             if cursorType == "item" then
                 TryReceiveFallbackItemDrop(activeButtonData)
@@ -1265,7 +1277,7 @@ local function InstallFallbackDropScript(frame, buttonData)
     end)
     frame:SetScript("OnMouseUp", function(self, button, ...)
         local activeButtonData = self._cdcFallbackDropButtonData
-        if CS.buttonSettingsTab ~= "fallbacks" or button ~= "LeftButton" then
+        if CS.buttonSettingsTab ~= "fallbacks" or CS.browseMode or button ~= "LeftButton" then
             local original = self._cdcFallbackOriginalOnMouseUp
             if original then
                 return original(self, button, ...)
@@ -1315,6 +1327,7 @@ local function BuildFallbackRowText(itemID, rowIndex, isPrimary)
 end
 
 local function ConfigureFallbackMoveButton(button, rotation, tooltipTitle, tooltipBody, disabled, onClick)
+    local isDisabled = disabled or CS.browseMode
     button:SetSize(18, 18)
     if button.text then
         button.text:Hide()
@@ -1332,13 +1345,13 @@ local function ConfigureFallbackMoveButton(button, rotation, tooltipTitle, toolt
     button.icon:SetAtlas("arrow-short", false)
     button.icon:SetRotation(rotation)
     if button.icon.SetDesaturated then
-        button.icon:SetDesaturated(disabled == true)
+        button.icon:SetDesaturated(isDisabled == true)
     end
-    button.icon:SetVertexColor(1, 0.82, 0, disabled and 0.45 or 1)
+    button.icon:SetVertexColor(1, 0.82, 0, isDisabled and 0.45 or 1)
     button.icon:Show()
-    button:SetAlpha(disabled and 0.35 or 1)
+    button:SetAlpha(isDisabled and 0.35 or 1)
     button:EnableMouse(true)
-    button:SetScript("OnClick", disabled and nil or onClick)
+    button:SetScript("OnClick", isDisabled and nil or onClick)
     button:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         GameTooltip:AddLine(tooltipTitle)
@@ -1422,6 +1435,10 @@ local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex, isPrimary)
 end
 
 local function ShowFallbackRowMenu(buttonData, rowIndex)
+    if CS.browseMode then
+        return
+    end
+
     if not CS.fallbackContextMenu then
         CS.fallbackContextMenu = CreateFrame("Frame", "CDCFallbackContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -1448,6 +1465,9 @@ end
 
 local function InstallFallbackRowMenu(entry, buttonData, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
+        if CS.browseMode then
+            return
+        end
         if button == "RightButton" then
             ShowFallbackRowMenu(buttonData, rowIndex)
             return
@@ -1536,9 +1556,13 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
     addBox:DisableButton(true)
     addBox:SetFullWidth(true)
     addBox:SetCallback("OnTextChanged", function(widget, _, text)
+        if CS.browseMode then
+            CS.HideAutocomplete()
+            return
+        end
         if text and #text >= 1 then
             CS.ShowAutocompleteResults(SearchFallbackAutocomplete(buttonData, text), widget, function(entry)
-                if entry and AddItemFallback(buttonData, entry.id) then
+                if entry and not CS.browseMode and AddItemFallback(buttonData, entry.id) then
                     RefreshFallbackEntry(CS.selectedGroup)
                 else
                     CS.HideAutocomplete()
@@ -1549,6 +1573,10 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
         end
     end)
     addBox:SetCallback("OnEnterPressed", function(widget, _, text)
+        if CS.browseMode then
+            CS.HideAutocomplete()
+            return
+        end
         if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
             return
         end

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -2,6 +2,7 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
+local math_pi = math.pi
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
@@ -20,7 +21,11 @@ local HookSliderEditBox = ST._HookSliderEditBox
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
+local CleanRecycledEntry = ST._CleanRecycledEntry
+local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
+local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
+local NormalizeItemFallbacks = CooldownCompanion.NormalizeItemFallbacks
 
 -- Imports from SectionBuilders.lua (used by BuildOverridesTab)
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -70,7 +75,7 @@ local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
 
-local function BuildButtonSettingsTabs(group)
+local function BuildButtonSettingsTabs(group, buttonData)
     if GroupUsesTriggerPanelEntries(group) then
         return {
             { value = "settings", text = "Condition" },
@@ -80,8 +85,12 @@ local function BuildButtonSettingsTabs(group)
 
     local tabs = {
         { value = "settings", text = "Settings" },
-        { value = "soundalerts", text = "Sound Alerts" },
     }
+    if buttonData and buttonData.type == "item" then
+        tabs[#tabs + 1] = { value = "fallbacks", text = "Fallbacks" }
+    else
+        tabs[#tabs + 1] = { value = "soundalerts", text = "Sound Alerts" }
+    end
 
     -- Texture panels only ever manage a single texture entry, so the
     -- per-button Overrides tab does not apply there and just creates noise.
@@ -1029,6 +1038,478 @@ local function BuildEquipItemSettings(scroll, buttonData, infoButtons)
     -- Currently no equip-item-specific settings
 end
 
+local function RefreshFallbackEntry(groupId)
+    if CS.HideAutocomplete then
+        CS.HideAutocomplete()
+    end
+    CooldownCompanion:RefreshGroupFrame(groupId)
+    CooldownCompanion:RefreshConfigPanel()
+end
+
+local function GetItemFallbackName(itemID)
+    return C_Item.GetItemNameByID(itemID) or ("Item " .. tostring(itemID))
+end
+
+local function GetItemQualityAtlas(itemID)
+    local qualityInfo = C_TradeSkillUI.GetItemCraftedQualityInfo(itemID)
+        or C_TradeSkillUI.GetItemReagentQualityInfo(itemID)
+    return qualityInfo and qualityInfo.iconSmall or nil
+end
+
+local function GetItemFallbackDisplayName(itemID)
+    local itemName = GetItemFallbackName(itemID)
+    local qualityAtlas = GetItemQualityAtlas(itemID)
+    if qualityAtlas then
+        return ("%s |A:%s:20:20|a"):format(itemName, qualityAtlas)
+    end
+    return itemName
+end
+
+local function IsExistingFallback(buttonData, itemID)
+    if type(buttonData.itemFallbacks) ~= "table" then
+        return false
+    end
+    for _, existingID in ipairs(buttonData.itemFallbacks) do
+        if tonumber(existingID) == itemID then
+            return true
+        end
+    end
+    return false
+end
+
+local function ValidateFallbackItem(buttonData, itemID)
+    itemID = tonumber(itemID)
+    if not itemID or itemID <= 0 then
+        return nil, "Enter a valid item ID."
+    end
+    if itemID == tonumber(buttonData.id) then
+        return nil, "That item is already the primary item."
+    end
+    if IsExistingFallback(buttonData, itemID) then
+        return nil, "That fallback is already listed."
+    end
+
+    if not C_Item.IsItemDataCachedByID(itemID) then
+        C_Item.RequestLoadItemDataByID(itemID)
+        return nil, "Loading item data. Try again in a moment."
+    end
+
+    if CooldownCompanion.IsItemEquippable({ id = itemID }) then
+        return nil, "Fallbacks only support non-equippable consumable items."
+    end
+
+    if not C_Item.GetItemSpell(itemID) then
+        return nil, "Fallback item must have a usable effect."
+    end
+
+    return itemID
+end
+
+local function IsFallbackAutocompleteCandidate(buttonData, itemID)
+    itemID = tonumber(itemID)
+    if not itemID or itemID <= 0 then
+        return false
+    end
+    if itemID == tonumber(buttonData.id) or IsExistingFallback(buttonData, itemID) then
+        return false
+    end
+    if CooldownCompanion.IsItemEquippable({ id = itemID }) then
+        return false
+    end
+    return C_Item.GetItemSpell(itemID) ~= nil
+end
+
+local function BuildFallbackAutocompleteCache(buttonData)
+    local cache = {}
+    local seen = {}
+    for bag = 0, 4 do
+        local numSlots = C_Container.GetContainerNumSlots(bag)
+        for slot = 1, numSlots do
+            local containerInfo = C_Container.GetContainerItemInfo(bag, slot)
+            local itemID = containerInfo and containerInfo.itemID
+            if itemID and not seen[itemID] and IsFallbackAutocompleteCandidate(buttonData, itemID) then
+                seen[itemID] = true
+                local itemName = containerInfo.itemName or C_Item.GetItemNameByID(itemID) or ("Item " .. tostring(itemID))
+                local displayName = GetItemFallbackDisplayName(itemID)
+                cache[#cache + 1] = {
+                    id = itemID,
+                    name = displayName,
+                    nameLower = itemName:lower(),
+                    icon = containerInfo.iconFileID or C_Item.GetItemIconByID(itemID) or 134400,
+                    category = "Bag",
+                    isItem = true,
+                }
+            end
+        end
+    end
+    return cache
+end
+
+local function SearchFallbackAutocomplete(buttonData, query)
+    if not (CS.SearchAutocompleteInCache and query and #query >= 1) then
+        return nil
+    end
+    return CS.SearchAutocompleteInCache(query, BuildFallbackAutocompleteCache(buttonData))
+end
+
+local function AddItemFallback(buttonData, itemID)
+    local validID, err = ValidateFallbackItem(buttonData, itemID)
+    if not validID then
+        CooldownCompanion:Print(err)
+        return false
+    end
+
+    if not buttonData.itemFallbacks then
+        buttonData.itemFallbacks = {}
+    end
+    buttonData.itemFallbacks[#buttonData.itemFallbacks + 1] = validID
+    NormalizeItemFallbacks(buttonData)
+    return true
+end
+
+local function TryReceiveFallbackItemDrop(buttonData)
+    local cursorType, cursorID = GetCursorInfo()
+    if cursorType ~= "item" or not cursorID then
+        return false
+    end
+
+    local added = AddItemFallback(buttonData, cursorID)
+    ClearCursor()
+    if added then
+        RefreshFallbackEntry(CS.selectedGroup)
+    end
+    return added
+end
+
+local function MoveFallbackItem(buttonData, sourceIndex, targetIndex)
+    local fallbackIDs = buttonData and buttonData.itemFallbacks
+    if type(fallbackIDs) ~= "table" then
+        return false
+    end
+    local count = #fallbackIDs
+    sourceIndex = tonumber(sourceIndex)
+    targetIndex = tonumber(targetIndex)
+    if not sourceIndex or not targetIndex or sourceIndex < 1 or sourceIndex > count then
+        return false
+    end
+    if targetIndex < 1 then targetIndex = 1 end
+    if targetIndex > count then targetIndex = count end
+    if targetIndex == sourceIndex then
+        return false
+    end
+
+    local itemID = table.remove(fallbackIDs, sourceIndex)
+    table.insert(fallbackIDs, targetIndex, itemID)
+    NormalizeItemFallbacks(buttonData)
+    return true
+end
+
+local function InstallFallbackDropScript(frame, buttonData)
+    if not frame or not frame.SetScript then
+        return
+    end
+
+    if not frame._cdcFallbackDropWrapped and frame.GetScript then
+        frame._cdcFallbackOriginalOnReceiveDrag = frame:GetScript("OnReceiveDrag")
+        frame._cdcFallbackOriginalOnMouseUp = frame:GetScript("OnMouseUp")
+        frame._cdcFallbackDropWrapped = true
+    end
+    frame._cdcFallbackDropButtonData = buttonData
+
+    frame:SetScript("OnReceiveDrag", function(self, ...)
+        local activeButtonData = self._cdcFallbackDropButtonData
+        if CS.buttonSettingsTab == "fallbacks" and activeButtonData then
+            local cursorType = GetCursorInfo()
+            if cursorType == "item" then
+                TryReceiveFallbackItemDrop(activeButtonData)
+                return
+            end
+        end
+        local original = self._cdcFallbackOriginalOnReceiveDrag
+        if original then
+            return original(self, ...)
+        end
+    end)
+    frame:SetScript("OnMouseUp", function(self, button, ...)
+        local activeButtonData = self._cdcFallbackDropButtonData
+        if CS.buttonSettingsTab ~= "fallbacks" or button ~= "LeftButton" then
+            local original = self._cdcFallbackOriginalOnMouseUp
+            if original then
+                return original(self, button, ...)
+            end
+            return
+        end
+        if GetCursorInfo() and activeButtonData then
+            TryReceiveFallbackItemDrop(activeButtonData)
+            return
+        end
+
+        local original = self._cdcFallbackOriginalOnMouseUp
+        if original then
+            return original(self, button, ...)
+        end
+    end)
+end
+
+local function InstallFallbackColumnDropTargets(scroll, buttonData)
+    local seen = {}
+    local function addTarget(frame)
+        if frame and not seen[frame] then
+            seen[frame] = true
+            InstallFallbackDropScript(frame, buttonData)
+        end
+    end
+
+    addTarget(scroll and scroll.frame)
+    addTarget(scroll and scroll.scrollframe)
+    addTarget(scroll and scroll.content)
+
+    local parent = scroll and scroll.frame and scroll.frame:GetParent()
+    for _ = 1, 4 do
+        if not parent then break end
+        addTarget(parent)
+        parent = parent.GetParent and parent:GetParent() or nil
+    end
+end
+
+local function BuildFallbackRowText(itemID, rowIndex, isPrimary)
+    local prefix = isPrimary and "" or (tostring(rowIndex) .. ". ")
+    return ("%s%s"):format(
+        prefix,
+        GetItemFallbackDisplayName(itemID)
+    )
+end
+
+local function ConfigureFallbackMoveButton(button, rotation, tooltipTitle, tooltipBody, disabled, onClick)
+    button:SetSize(18, 18)
+    if button.text then
+        button.text:Hide()
+    end
+    if not button.icon then
+        button.icon = button:CreateTexture(nil, "ARTWORK")
+        button.icon:SetPoint("TOPLEFT", 2, -2)
+        button.icon:SetPoint("BOTTOMRIGHT", -2, 2)
+    end
+    if not button.highlight then
+        button.highlight = button:CreateTexture(nil, "HIGHLIGHT")
+        button.highlight:SetAllPoints()
+        button.highlight:SetColorTexture(0.3, 0.55, 0.85, 0.25)
+    end
+    button.icon:SetAtlas("arrow-short", false)
+    button.icon:SetRotation(rotation)
+    if button.icon.SetDesaturated then
+        button.icon:SetDesaturated(disabled == true)
+    end
+    button.icon:SetVertexColor(1, 0.82, 0, disabled and 0.45 or 1)
+    button.icon:Show()
+    button:SetAlpha(disabled and 0.35 or 1)
+    button:EnableMouse(true)
+    button:SetScript("OnClick", disabled and nil or onClick)
+    button:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:AddLine(tooltipTitle)
+        GameTooltip:AddLine(tooltipBody, 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    button:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    button:Show()
+end
+
+local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex)
+    local frame = entry.frame
+    local upBtn = frame._cdcFallbackUpBtn
+    if not upBtn then
+        upBtn = CreateFrame("Button", nil, frame)
+        frame._cdcFallbackUpBtn = upBtn
+    end
+    local downBtn = frame._cdcFallbackDownBtn
+    if not downBtn then
+        downBtn = CreateFrame("Button", nil, frame)
+        frame._cdcFallbackDownBtn = downBtn
+    end
+
+    upBtn:ClearAllPoints()
+    upBtn:SetPoint("RIGHT", frame, "RIGHT", -24, 0)
+    upBtn:SetFrameLevel(frame:GetFrameLevel() + 6)
+    ConfigureFallbackMoveButton(
+        upBtn,
+        math_pi / 2,
+        "Move Up",
+        "Move this fallback one priority slot higher.",
+        rowIndex <= 1,
+        function()
+            if MoveFallbackItem(buttonData, rowIndex, rowIndex - 1) then
+                RefreshFallbackEntry(CS.selectedGroup)
+            end
+        end
+    )
+
+    local fallbackIDs = buttonData.itemFallbacks or {}
+    downBtn:ClearAllPoints()
+    downBtn:SetPoint("RIGHT", frame, "RIGHT", -4, 0)
+    downBtn:SetFrameLevel(frame:GetFrameLevel() + 6)
+    ConfigureFallbackMoveButton(
+        downBtn,
+        -math_pi / 2,
+        "Move Down",
+        "Move this fallback one priority slot lower.",
+        rowIndex >= #fallbackIDs,
+        function()
+            if MoveFallbackItem(buttonData, rowIndex, rowIndex + 1) then
+                RefreshFallbackEntry(CS.selectedGroup)
+            end
+        end
+    )
+end
+
+local function ShowFallbackRowMenu(buttonData, rowIndex)
+    if not CS.fallbackContextMenu then
+        CS.fallbackContextMenu = CreateFrame("Frame", "CDCFallbackContextMenu", UIParent, "UIDropDownMenuTemplate")
+    end
+
+    UIDropDownMenu_Initialize(CS.fallbackContextMenu, function(_, level)
+        if level ~= 1 then return end
+        local info = UIDropDownMenu_CreateInfo()
+        info.text = "|cffff4444Delete|r"
+        info.notCheckable = true
+        info.func = function()
+            CloseDropDownMenus()
+            local fallbackIDs = buttonData.itemFallbacks
+            if type(fallbackIDs) == "table" then
+                table.remove(fallbackIDs, rowIndex)
+                NormalizeItemFallbacks(buttonData)
+                RefreshFallbackEntry(CS.selectedGroup)
+            end
+        end
+        UIDropDownMenu_AddButton(info, level)
+    end, "MENU")
+    CS.fallbackContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
+    ToggleDropDownMenu(1, nil, CS.fallbackContextMenu, "cursor", 0, 0)
+end
+
+local function InstallFallbackRowMenu(entry, buttonData, rowIndex)
+    entry.frame:SetScript("OnMouseUp", function(_, button)
+        if button == "RightButton" then
+            ShowFallbackRowMenu(buttonData, rowIndex)
+            return
+        end
+        if button == "LeftButton" and GetCursorInfo() then
+            TryReceiveFallbackItemDrop(buttonData)
+        end
+    end)
+end
+
+local function CreateFallbackItemRow(scroll, buttonData, itemID, rowIndex, isPrimary)
+    local row = AceGUI:Create("InteractiveLabel")
+    CleanRecycledEntry(row)
+    row:SetText(BuildFallbackRowText(itemID, rowIndex, isPrimary))
+    row:SetFullWidth(true)
+    row:SetFontObject(GameFontHighlight)
+    row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+    ApplyConfigRowIcon(row, C_Item.GetItemIconByID(itemID) or 134400, { rightPad = isPrimary and 4 or 48 })
+    if BindConfigShiftTooltip then
+        BindConfigShiftTooltip(row, "item", itemID, row.frame, "ANCHOR_RIGHT")
+    end
+
+    if isPrimary then
+        row:SetColor(1, 1, 1)
+        InstallFallbackDropScript(row.frame, buttonData)
+    else
+        EnsureFallbackMoveButtons(row, buttonData, rowIndex)
+        InstallFallbackRowMenu(row, buttonData, rowIndex)
+    end
+
+    scroll:AddChild(row)
+    return row
+end
+
+local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
+    if not (buttonData and buttonData.type == "item") then
+        local label = AceGUI:Create("Label")
+        label:SetText("Fallbacks are available for item entries only.")
+        label:SetFullWidth(true)
+        scroll:AddChild(label)
+        return
+    end
+
+    if CooldownCompanion.IsItemEquippable(buttonData) then
+        local label = AceGUI:Create("Label")
+        label:SetText("Fallbacks are available for non-equippable consumable items only.")
+        label:SetFullWidth(true)
+        scroll:AddChild(label)
+        return
+    end
+
+    NormalizeItemFallbacks(buttonData)
+    InstallFallbackColumnDropTargets(scroll, buttonData)
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText("Item Fallbacks")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    InstallFallbackDropScript(heading.frame, buttonData)
+    scroll:AddChild(heading)
+
+    local infoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, {
+        "Item Fallbacks",
+        {"The primary item is always first. Fallbacks are used only when higher-priority items are not in your bags.", 1, 1, 1, true},
+        {"Stacks and charges both count as available uses for choosing the active item.", 1, 1, 1, true},
+    }, infoButtons)
+    heading.right:ClearAllPoints()
+    heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)
+    heading.right:SetPoint("LEFT", infoBtn, "RIGHT", 4, 0)
+
+    local primaryID = tonumber(buttonData.id)
+    CreateFallbackItemRow(scroll, buttonData, primaryID, 0, true)
+
+    local fallbackIDs = buttonData.itemFallbacks or {}
+    if #fallbackIDs > 0 then
+        for index, itemID in ipairs(fallbackIDs) do
+            CreateFallbackItemRow(scroll, buttonData, itemID, index, false)
+        end
+    end
+
+    local addBox = AceGUI:Create("EditBox")
+    addBox:SetLabel("Search Bag Consumables")
+    addBox:SetText("")
+    addBox:DisableButton(true)
+    addBox:SetFullWidth(true)
+    addBox:SetCallback("OnTextChanged", function(widget, _, text)
+        if text and #text >= 1 then
+            CS.ShowAutocompleteResults(SearchFallbackAutocomplete(buttonData, text), widget, function(entry)
+                if entry and AddItemFallback(buttonData, entry.id) then
+                    RefreshFallbackEntry(CS.selectedGroup)
+                else
+                    CS.HideAutocomplete()
+                end
+            end)
+        else
+            CS.HideAutocomplete()
+        end
+    end)
+    addBox:SetCallback("OnEnterPressed", function(widget, _, text)
+        if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
+            return
+        end
+        CS.HideAutocomplete()
+        if AddItemFallback(buttonData, text) then
+            widget:SetText("")
+            RefreshFallbackEntry(CS.selectedGroup)
+        end
+    end)
+    if addBox.editbox and addBox.editbox.Instructions then
+        addBox.editbox.Instructions:Hide()
+    end
+    InstallFallbackDropScript(addBox.frame, buttonData)
+    InstallFallbackDropScript(addBox.editbox, buttonData)
+    if CS.SetupAutocompleteKeyHandler then
+        CS.SetupAutocompleteKeyHandler(addBox)
+    end
+    scroll:AddChild(addBox)
+end
+
 ------------------------------------------------------------------------
 -- TYPE CLASSIFICATION (for batch visibility)
 ------------------------------------------------------------------------
@@ -1112,7 +1593,8 @@ local function RefreshButtonSettingsColumn()
 
     if hasSelection then
         local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
-        bsCol.bsTabGroup:SetTabs(BuildButtonSettingsTabs(group))
+        local buttonData = group and group.buttons and group.buttons[CS.selectedButton]
+        bsCol.bsTabGroup:SetTabs(BuildButtonSettingsTabs(group, buttonData))
 
         if GroupUsesTriggerPanelEntries(group)
             and CS.buttonSettingsTab ~= "settings"
@@ -1120,6 +1602,10 @@ local function RefreshButtonSettingsColumn()
             CS.buttonSettingsTab = "settings"
         elseif GroupUsesTexturePanelEntries(group) and CS.buttonSettingsTab == "overrides" then
             CS.buttonSettingsTab = "settings"
+        elseif buttonData and buttonData.type == "item" and CS.buttonSettingsTab == "soundalerts" then
+            CS.buttonSettingsTab = "fallbacks"
+        elseif buttonData and buttonData.type ~= "item" and CS.buttonSettingsTab == "fallbacks" then
+            CS.buttonSettingsTab = "soundalerts"
         end
 
         if bsCol.bsPlaceholder then bsCol.bsPlaceholder:Hide() end
@@ -1256,6 +1742,7 @@ end
 ST._BuildSpellSettings = BuildSpellSettings
 ST._BuildItemSettings = BuildItemSettings
 ST._BuildEquipItemSettings = BuildEquipItemSettings
+ST._BuildItemFallbacksTab = BuildItemFallbacksTab
 ST._RefreshButtonSettingsColumn = RefreshButtonSettingsColumn
 ST._RefreshButtonSettingsMultiSelect = RefreshButtonSettingsMultiSelect
 ST._RefreshPanelMultiSelect = RefreshPanelMultiSelect

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -578,7 +578,7 @@ local function IsTextureIndicatorSectionActive(button, sectionKey, config)
             return not C_Spell_IsSpellUsable(spellID)
         end
         if buttonData.type == "item" or buttonData.type == "equipitem" then
-            return not C_Item_IsUsableItem(buttonData.id)
+            return not C_Item_IsUsableItem(button._resolvedItemId or buttonData.id)
         end
         return false
     end
@@ -618,7 +618,7 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
 
         if buttonData.type == "item" or buttonData.type == "equipitem" then
             if not InCombatLockdown() or UnitCanAttack("player", "target") then
-                local inRange = C_Item_IsItemInRange(buttonData.id, "target")
+                local inRange = C_Item_IsItemInRange(button._resolvedItemId or buttonData.id, "target")
                 if inRange == nil then
                     return nil
                 end
@@ -640,7 +640,7 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
             return C_Spell_IsSpellUsable(spellID)
         end
         if buttonData.type == "item" or buttonData.type == "equipitem" then
-            return C_Item_IsUsableItem(buttonData.id)
+            return C_Item_IsUsableItem(button._resolvedItemId or buttonData.id)
         end
         return false
     end

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -292,18 +292,9 @@ function CooldownCompanion:RefreshChargeFlags(typeFilter)
                 end
                 buttonData.hasCharges = hasRealCharges
             elseif buttonData.type == "item" and typeFilter ~= "spell" then
-                -- Never clear hasCharges for items: at 0 charges both count APIs
-                -- return 0, indistinguishable from "item not owned".
-                local plainCount = C_Item.GetItemCount(buttonData.id)
-                local chargeCount = C_Item.GetItemCount(buttonData.id, false, true)
-                if not issecretvalue(plainCount) and not issecretvalue(chargeCount) then
-                    if chargeCount > plainCount then
-                        buttonData.hasCharges = true
-                        if chargeCount > (buttonData.maxCharges or 0) then
-                            buttonData.maxCharges = chargeCount
-                        end
-                    end
-                end
+                -- Never clear hasCharges for items; unavailable charged items can
+                -- be indistinguishable from unowned items through count APIs.
+                self.UpdateItemChargeMetadata(buttonData, buttonData.id)
             end
         end
     end

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1330,13 +1330,7 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
 
     -- Auto-detect charges for items (e.g. Hellstone: GetItemCount with includeUses > plain count)
     if buttonType == "item" then
-        local plainCount = C_Item.GetItemCount(id)
-        local chargeCount = C_Item.GetItemCount(id, false, true)
-        if chargeCount > plainCount then
-            group.buttons[buttonIndex].hasCharges = true
-            group.buttons[buttonIndex].showChargeText = true
-            group.buttons[buttonIndex].maxCharges = chargeCount
-        end
+        self.UpdateItemChargeMetadata(group.buttons[buttonIndex], id)
     end
 
     -- Record original classification (immutable label for config display).

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -191,7 +191,8 @@ local function CacheButtonBindingKeys(button, buttonData)
     if buttonData.type == "spell" then
         slots = C_ActionBar.FindSpellActionButtons(buttonData.id)
     elseif buttonData.type == "item" then
-        local slot = CooldownCompanion._itemSlotCache[buttonData.id]
+        local itemID = button._resolvedItemId or buttonData.id
+        local slot = CooldownCompanion._itemSlotCache[itemID]
         if slot then slots = {slot} end
     end
     if slots then
@@ -308,7 +309,7 @@ function CooldownCompanion:RebuildAddonSlotBindings()
 end
 
 -- Return the formatted keybind text for a button, or nil if none found.
-function CooldownCompanion:GetKeybindText(buttonData)
+function CooldownCompanion:GetKeybindText(buttonData, itemIDOverride)
     if not buttonData then return nil end
 
     if buttonData.type == "spell" then
@@ -322,7 +323,7 @@ function CooldownCompanion:GetKeybindText(buttonData)
             end
         end
     elseif buttonData.type == "item" then
-        local slot = self._itemSlotCache[buttonData.id]
+        local slot = self._itemSlotCache[itemIDOverride or buttonData.id]
         if slot then
             return GetKeybindForSlot(slot)
         end
@@ -334,7 +335,7 @@ end
 -- Return the icon-only display text for keybind overlays.
 -- This intentionally leaves GetKeybindText unchanged so text-mode {keybind}
 -- tokens continue reflecting the detected action bar bind only.
-function CooldownCompanion:GetDisplayedKeybindText(buttonData)
+function CooldownCompanion:GetDisplayedKeybindText(buttonData, itemIDOverride)
     if not buttonData then return nil end
 
     local customText = buttonData.customKeybindText
@@ -342,14 +343,14 @@ function CooldownCompanion:GetDisplayedKeybindText(buttonData)
         return customText
     end
 
-    return self:GetKeybindText(buttonData)
+    return self:GetKeybindText(buttonData, itemIDOverride)
 end
 
 -- Refresh keybind text and binding key caches on all buttons.
 function CooldownCompanion:OnKeybindsChanged()
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
-            local text = CooldownCompanion:GetDisplayedKeybindText(buttonData)
+            local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId)
             button.keybindText:SetText(text or "")
             button.keybindText:SetShown(button.style.showKeybindText and text ~= nil)
         end


### PR DESCRIPTION
## What Players Will Notice
- Item buttons can now use an ordered fallback list, so a consumable entry can automatically show and track the first available usable item from the player''s bags.
- The new Fallbacks tab lets players search bag consumables, drop bag items onto the settings column, reorder priority with arrow controls, and promote a fallback into the primary slot.
- Entries with fallbacks show a Column 2 badge, and icon, text, bar, tooltip, count, cooldown, keybind, glow, visibility, and desaturation behavior follow the currently resolved item.

## Why This Changed
- Players often want one button to represent a priority chain of similar consumables, such as higher-quality potions before lower-quality ones, without creating several separate entries or relying on external macros.
- The priority editor needed to be clear enough to manage mixed stack-based and charge-based consumables while preserving the existing saved entry shape.

## What Changed
- Added item fallback normalization, availability resolution, charge metadata refresh, and visibility setting migration helpers.
- Added a Fallbacks tab for item entries with bag-only autocomplete, bag-item drops, ordered rows, quality markers, right-click delete, and primary/fallback swapping.
- Updated runtime button display paths so resolved fallback items drive item cooldowns, counts, usability, range, keybind text, tooltips, icons, bar/text/icon displays, glows, and visibility decisions.
- Added Column 2 fallback badges and recycled-row cleanup so fallback indicators do not leak into unrelated rows.
- Adjusted charge/stack visibility controls so fallback-enabled consumables use the unified “No Uses Available” behavior instead of exposing stale charge-only controls.

## Validation
- Ran `luac -p` across the Lua files changed by this branch.
- Ran `git diff --check origin/main...HEAD`.
- Reviewed the fallback UI and runtime state flow through several code review passes, including follow-up fixes for keybind refresh, charge fallback availability, zero-use visibility, resolved cooldown styling, and browse-mode safeguards.
- In-game combat and restricted-content verification is still needed before treating the feature as release-complete.