### PR TITLE
Let Healthstone fall back while its cooldown is deferred

### DIFF
--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -18,6 +18,7 @@ local type = type
 local DEFAULT_BAR_AURA_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_BAR_PANDEMIC_COLOR = {1.0, 0.5, 0.0, 1.0}
 local DEFAULT_BAR_CHARGE_COLOR = {1.0, 0.82, 0.0, 1.0}
+local HEALTHSTONE_ITEM_ID = 5512
 
 -- Format remaining seconds for time display (shared across bar, text, and preview modes).
 local function FormatTime(seconds, decimal)
@@ -223,6 +224,19 @@ local function HasItemFallbacks(buttonData)
 end
 CooldownCompanion.HasItemFallbacks = HasItemFallbacks
 
+local function IsDeferredHealthstoneItem(itemID)
+    itemID = tonumber(itemID)
+    if itemID ~= HEALTHSTONE_ITEM_ID then
+        return false
+    end
+    if C_Item.IsUsableItem(itemID) then
+        return false
+    end
+
+    local cdStart, _, enableCooldownTimer = C_Item.GetItemCooldown(itemID)
+    return enableCooldownTimer == false and cdStart and cdStart > 0
+end
+
 local function UpdateItemChargeMetadata(buttonData, itemID)
     if not (buttonData and buttonData.type == "item") then
         return false
@@ -344,8 +358,10 @@ local function ResolveItemFallback(buttonData)
     end
 
     local primaryID = tonumber(buttonData.id)
+    local hasFallbacks = HasItemFallbacks(buttonData)
     local primaryQuantity, primaryKind = GetItemAvailableQuantity(primaryID, buttonData.hasCharges == true)
-    if primaryQuantity > 0 or not HasItemFallbacks(buttonData) then
+    if (primaryQuantity > 0 and not (hasFallbacks and IsDeferredHealthstoneItem(primaryID)))
+            or not hasFallbacks then
         return primaryID, primaryQuantity, primaryKind
     end
 
@@ -353,7 +369,7 @@ local function ResolveItemFallback(buttonData)
         local itemID = tonumber(rawID)
         if itemID and itemID ~= primaryID then
             local quantity, quantityKind = GetItemAvailableQuantity(itemID)
-            if quantity > 0 then
+            if quantity > 0 and not IsDeferredHealthstoneItem(itemID) then
                 return itemID, quantity, quantityKind
             end
         end

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1339,10 +1339,9 @@ local function ConfigureFallbackMoveButton(button, rotation, tooltipTitle, toolt
         button.icon:SetPoint("TOPLEFT", 2, -2)
         button.icon:SetPoint("BOTTOMRIGHT", -2, 2)
     end
-    if not button.highlight then
-        button.highlight = button:CreateTexture(nil, "HIGHLIGHT")
-        button.highlight:SetAllPoints()
-        button.highlight:SetColorTexture(0.3, 0.55, 0.85, 0.25)
+    if button.highlight then
+        button.highlight:Hide()
+        button.highlight:SetAlpha(0)
     end
     button.icon:SetAtlas("arrow-short", false)
     button.icon:SetRotation(rotation)

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1533,9 +1533,11 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
 
     local infoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, {
         "Item Fallbacks",
-        {"Use arrows to choose which item should appear first.", 1, 1, 1, true},
+        {"Use arrows to set item priority.", 1, 1, 1, true},
+        {"If a higher-priority item is unavailable, the next available fallback can appear instead.", 1, 1, 1, true},
         {" ", 1, 1, 1, true},
-        {"Fallbacks are used only when higher-priority items are not in your bags.", 1, 1, 1, true},
+        {"Settings apply to whichever item is currently shown from this priority list.", 1, 1, 1, true},
+        {"This includes options like zero-use visibility and desaturation.", 1, 1, 1, true},
     }, infoButtons)
     heading.right:ClearAllPoints()
     heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)


### PR DESCRIPTION
## What Players Will Notice
- Healthstone entries with item fallbacks can now switch to the next available fallback while Healthstone is in its post-use combat state where it is unusable but has not started its visible cooldown timer yet.
- The Fallbacks tab no longer shows a hover highlight on the up/down arrow badges.
- The Fallbacks tooltip now explains that Settings-tab options apply to whichever item is currently shown from the priority list.

## Why This Changed
- Healthstone has a consistent combat edge case after use: it can become unusable before the normal cooldown timer starts. Without a narrow exception, a fallback chain can stay stuck on Healthstone instead of showing the next usable item.
- The fallback tooltip needed to make the active-item behavior clearer, especially for options like zero-use visibility and desaturation.

## What Changed
- Added a Healthstone-only deferred-cooldown check for item `5512` in item fallback resolution.
- When Healthstone is unusable and `C_Item.GetItemCooldown(5512)` reports the existing deferred-cooldown shape, fallback resolution skips it and tries the configured fallback items.
- Left general item unusability out of fallback resolution so ordinary unusable states do not unexpectedly change priority behavior.
- Removed the fallback arrow hover highlight texture and tightened the Fallbacks tooltip wording.

## Validation
- Ran `luac -p` across the Lua files changed by this branch.
- Ran `git diff --check origin/main...HEAD`.
- Reviewed the branch diff against `origin/main` with no findings.
- In-game verification is still needed for the Healthstone combat case: use Healthstone in combat with a fallback configured and confirm the entry switches to the next available fallback only while Healthstone is unusable and its visible cooldown has not started.