### PR TITLE
Add cascading load conditions across config levels

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -46,6 +46,7 @@ local GenerateGroupName
 ------------------------------------------------------------------------
 local function ClearSelection()
     CooldownCompanion:ClearAllConfigPreviews()
+    CS.selectedFolder = nil
     CS.selectedContainer = nil
     CS.selectedGroup = nil
     CS.selectedButton = nil
@@ -748,6 +749,9 @@ local function ShowFolderContextMenu(db, folderId, folder)
             end
             if folder.heroTalents and next(folder.heroTalents) then
                 folderData.heroTalents = CopyTable(folder.heroTalents)
+            end
+            if CooldownCompanion:HasLocalLoadConditions(folder) then
+                folderData.loadConditions = CopyTable(folder.loadConditions)
             end
 
             local orderedCids = {}
@@ -1572,7 +1576,7 @@ local function RefreshColumn1(preserveDrag)
             collapseBtn._arrow = collapseBtn:CreateTexture(nil, "ARTWORK")
             collapseBtn._arrow:SetSize(12, 12)
             collapseBtn._arrow:SetPoint("CENTER")
-            collapseBtn._arrow:SetAtlas("glues-characterSelect-icon-arrowDown-small")
+            collapseBtn._arrow:SetAtlas("glues-characterselect-icon-arrowdown-small")
             entry.frame._cdcCollapseBtn = collapseBtn
         end
         collapseBtn:SetParent(entry.frame)
@@ -1639,6 +1643,7 @@ local function RefreshColumn1(preserveDrag)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
+                CooldownCompanion:ClearAllConfigPreviews()
                 CS.selectedFolder = folderId
                 CS.selectedContainer = nil
                 CS.selectedGroup = nil

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -1274,6 +1274,7 @@ local function RefreshColumn1(preserveDrag)
                     wipe(CS.selectedGroups)
                     wipe(CS.selectedPanels)
                     wipe(CS.selectedButtons)
+                    CS.selectedFolder = nil
                     CS.selectedContainer = containerId
                     CS.selectedGroup = nil
                     CS.selectedButton = nil
@@ -1302,6 +1303,7 @@ local function RefreshColumn1(preserveDrag)
                     if CS.selectedContainer and not CS.selectedGroups[CS.selectedContainer] and next(CS.selectedGroups) then
                         CS.selectedGroups[CS.selectedContainer] = true
                     end
+                    CS.selectedFolder = nil
                     ClearSelection()
                     CooldownCompanion:RefreshConfigPanel()
                     return
@@ -1309,6 +1311,7 @@ local function RefreshColumn1(preserveDrag)
                 -- Normal click: toggle-through selection, clear multi-select
                 CooldownCompanion:ClearAllConfigPreviews()
                 wipe(CS.selectedGroups)
+                CS.selectedFolder = nil
                 if CS.selectedContainer == containerId then
                     if CS.selectedGroup then
                         -- First re-click: clear panel selection (return to container settings)
@@ -1539,19 +1542,16 @@ local function RefreshColumn1(preserveDrag)
 
         local isCollapsed = CS.collapsedFolders[folderId]
 
-        -- Collapse indicator as inline texture in label
-        local collapseTag = isCollapsed
-            and "  |A:common-icon-plus:10:10|a"
-            or "  |A:common-icon-minus:10:10|a"
-
         local entry = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(entry)
-        entry:SetText(folder.name .. collapseTag)
+        entry:SetText(folder.name)
         entry:SetFullWidth(true)
         entry:SetFontObject(GameFontHighlight)
         ApplyConfigRowIcon(entry, GetFolderIcon(folderId, db))
         local allChildrenInactive = IsFolderFullyInactive(folderId, childContainerIds)
-        if allChildrenInactive then
+        if CS.selectedFolder == folderId and not CS.selectedContainer and not CS.selectedGroup then
+            entry:SetColor(0.25, 0.62, 1.0)
+        elseif allChildrenInactive then
             entry:SetColor(0.5, 0.5, 0.5)
         else
             entry:SetColor(1.0, 0.82, 0.0)
@@ -1564,6 +1564,33 @@ local function RefreshColumn1(preserveDrag)
         entry.frame._cdcItemKind = "folder"
         entry.frame._cdcFolderId = folderId
         entry.frame._cdcSection = sectionTag
+
+        local collapseBtn = entry.frame._cdcCollapseBtn
+        if not collapseBtn then
+            collapseBtn = CreateFrame("Button", nil, entry.frame)
+            collapseBtn:SetSize(16, 16)
+            collapseBtn._arrow = collapseBtn:CreateTexture(nil, "ARTWORK")
+            collapseBtn._arrow:SetSize(12, 12)
+            collapseBtn._arrow:SetPoint("CENTER")
+            collapseBtn._arrow:SetAtlas("glues-characterSelect-icon-arrowDown-small")
+            entry.frame._cdcCollapseBtn = collapseBtn
+        end
+        collapseBtn:SetParent(entry.frame)
+        collapseBtn:ClearAllPoints()
+        collapseBtn:SetPoint("LEFT", entry.label, "RIGHT", 4, 0)
+        collapseBtn._arrow:SetRotation(isCollapsed and (math.pi / 2) or 0)
+        collapseBtn:Show()
+        collapseBtn._arrow:Show()
+        collapseBtn:SetScript("OnClick", function()
+            CS.collapsedFolders[folderId] = not CS.collapsedFolders[folderId]
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        collapseBtn:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:AddLine(isCollapsed and "Expand" or "Collapse")
+            GameTooltip:Show()
+        end)
+        collapseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
         TrackRenderedRow({
             kind = "folder",
@@ -1612,7 +1639,13 @@ local function RefreshColumn1(preserveDrag)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
-                CS.collapsedFolders[folderId] = not CS.collapsedFolders[folderId]
+                CS.selectedFolder = folderId
+                CS.selectedContainer = nil
+                CS.selectedGroup = nil
+                CS.selectedButton = nil
+                wipe(CS.selectedGroups)
+                wipe(CS.selectedPanels)
+                wipe(CS.selectedButtons)
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "MiddleButton" then
                 -- Lock/unlock all containers in this folder

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -2438,7 +2438,8 @@ local function RefreshColumn2()
                 for i, buttonData in ipairs(panelButtons) do
                     local entry = AceGUI:Create("InteractiveLabel")
                     CleanRecycledEntry(entry)
-                    local usable = CooldownCompanion:IsButtonUsable(buttonData)
+                    local usable = CooldownCompanion:IsButtonUsable(buttonData, panel)
+                    local loadAllowed = CooldownCompanion:IsButtonLoadConditionMet(buttonData, panel)
 
                     local entryName = IsTriggerPanelGroup(panel)
                         and GetTriggerRowDisplayText(buttonData)
@@ -2453,6 +2454,12 @@ local function RefreshColumn2()
                     elseif buttonData.type == "item" then
                         BindConfigShiftTooltip(entry, "item", buttonData.id, entry.frame, "ANCHOR_RIGHT")
                     end
+                    entry:SetUserData(
+                        "cdcShiftTooltipExtraLine",
+                        CooldownCompanion:HasLocalLoadConditions(buttonData)
+                            and "This entry adds load conditions."
+                            or nil
+                    )
 
                     -- Selection highlighting: only show if this panel is the selected one
                     if CS.selectedGroup == panelId then
@@ -2475,7 +2482,11 @@ local function RefreshColumn2()
                     if not usable and buttonData.enabled ~= false then
                         warnBadge = EnsureRowBadge(rowFrame, "_cdcWarnBtn", "Ping_Marker_Icon_Warning")
                         warnBadge:SetFrameLevel(rowBadgeLevel)
-                        SetRowBadgeTooltip(warnBadge, "Spell/item unavailable", 1, 0.3, 0.3)
+                        if not loadAllowed then
+                            SetRowBadgeTooltip(warnBadge, "Hidden by load conditions", 1, 0.3, 0.3)
+                        else
+                            SetRowBadgeTooltip(warnBadge, "Spell/item unavailable", 1, 0.3, 0.3)
+                        end
                         warnBadge:Show()
                     end
 

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -32,6 +32,9 @@ local function RefreshColumn4(container)
         if container.containerTabGroup then
             container.containerTabGroup.frame:Hide()
         end
+        if container.folderTabGroup then
+            container.folderTabGroup.frame:Hide()
+        end
         if container.customAuraScroll then
             container.customAuraScroll.frame:Hide()
         end
@@ -78,6 +81,9 @@ local function RefreshColumn4(container)
         if container.containerTabGroup then
             container.containerTabGroup.frame:Hide()
         end
+        if container.folderTabGroup then
+            container.folderTabGroup.frame:Hide()
+        end
         return
     end
 
@@ -97,7 +103,62 @@ local function RefreshColumn4(container)
         if container.containerTabGroup then
             container.containerTabGroup.frame:Hide()
         end
+        if container.folderTabGroup then
+            container.folderTabGroup.frame:Hide()
+        end
         return
+    end
+
+    -- Folder settings: direct folder selection with no child group/panel selected.
+    if CS.selectedFolder and not CS.selectedContainer and not CS.selectedGroup then
+        if container.placeholderLabel then container.placeholderLabel:Hide() end
+        if container.tabGroup then container.tabGroup.frame:Hide() end
+        if container.containerTabGroup then container.containerTabGroup.frame:Hide() end
+
+        if not container.folderTabGroup then
+            local tabGroup = AceGUI:Create("TabGroup")
+            tabGroup:SetLayout("Fill")
+            tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
+                CS.selectedFolderTab = tab
+                widget:ReleaseChildren()
+
+                local scroll = AceGUI:Create("ScrollFrame")
+                scroll:SetLayout("List")
+                widget:AddChild(scroll)
+                CS.col4Scroll = scroll
+
+                if tab == "general" then
+                    ST._BuildFolderGeneralTab(scroll, CS.selectedFolder)
+                elseif tab == "loadconditions" then
+                    ST._BuildFolderLoadConditionsTab(scroll, CS.selectedFolder)
+                end
+
+                if CS.browseMode then
+                    ST._DisableAllWidgets(scroll)
+                end
+            end)
+            tabGroup.frame:SetParent(container)
+            tabGroup.frame:ClearAllPoints()
+            tabGroup.frame:SetPoint("TOPLEFT", container, "TOPLEFT", 0, 0)
+            tabGroup.frame:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", 0, 0)
+            container.folderTabGroup = tabGroup
+        end
+
+        container.folderTabGroup:SetTabs({
+            { value = "general",         text = "General" },
+            { value = "loadconditions",  text = "Load Conditions" },
+        })
+        container.folderTabGroup.frame:Show()
+        local folderTab = CS.selectedFolderTab
+        if folderTab ~= "general" and folderTab ~= "loadconditions" then
+            folderTab = "general"
+        end
+        container.folderTabGroup:SelectTab(folderTab or "general")
+        return
+    end
+
+    if container.folderTabGroup then
+        container.folderTabGroup.frame:Hide()
     end
 
     -- Group settings: direct group selection with no panel selected.
@@ -151,6 +212,9 @@ local function RefreshColumn4(container)
     -- Hide container tab group when not in container mode
     if container.containerTabGroup then
         container.containerTabGroup.frame:Hide()
+    end
+    if container.folderTabGroup then
+        container.folderTabGroup.frame:Hide()
     end
 
     if not CS.selectedGroup then

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -386,9 +386,12 @@ local function FormatDiagnosticAsText(diag)
                 indent, i, btn.type or "?", tostring(btn.id or "?"), btn.name or "?")
             local extras = {}
             for k, v in pairs(btn) do
-                if k ~= "type" and k ~= "id" and k ~= "name" then
+                if k ~= "type" and k ~= "id" and k ~= "name" and k ~= "loadConditions" then
                     extras[#extras + 1] = tostring(k) .. "=" .. formatValue(v)
                 end
+            end
+            if btn.loadConditions then
+                extras[#extras + 1] = "entryLoadLocal=" .. dumpKV(btn.loadConditions)
             end
             if btn.auraTracking and not btn.auraUnit then
                 extras[#extras + 1] = "auraUnit=player(default)"
@@ -597,6 +600,9 @@ local function FormatDiagnosticAsText(diag)
                 end
                 if g.heroTalents and next(g.heroTalents) then
                     add("    heroTalents: " .. formatSpecList(g.heroTalents))
+                end
+                if g.loadConditions then
+                    add("    loadLocal: " .. dumpKV(g.loadConditions))
                 end
 
                 -- Panel style
@@ -850,6 +856,9 @@ local function FormatDiagnosticAsText(diag)
                 end
                 if f.heroTalents and next(f.heroTalents) then
                     add(("  heroTalents: %s"):format(formatSpecList(f.heroTalents)))
+                end
+                if f.loadConditions and next(f.loadConditions) then
+                    add(("  loadLocal: %s"):format(dumpKV(f.loadConditions)))
                 end
             end
         end

--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -34,6 +34,18 @@ local LOAD_CONDITIONS_DEFAULTS = {
     vehicleUI = true,
 }
 
+local LOCAL_LOAD_CONDITIONS_DEFAULTS = {
+    raid = false,
+    dungeon = false,
+    delve = false,
+    battleground = false,
+    arena = false,
+    openWorld = false,
+    rested = false,
+    petBattle = false,
+    vehicleUI = false,
+}
+
 local PANEL_DEFAULTS = {
     displayMode = "icons",
     masqueEnabled = false,
@@ -313,7 +325,10 @@ local function GetEntityDefaults(formatVersion)
     return COMPACT_ENTITY_DEFAULTS[formatVersion]
 end
 
-local function GetLoadConditionsDefaults(formatVersion)
+local function GetLoadConditionsDefaults(formatVersion, localScope)
+    if localScope then
+        return LOCAL_LOAD_CONDITIONS_DEFAULTS
+    end
     local entityDefaults = GetEntityDefaults(formatVersion)
     if entityDefaults and entityDefaults.loadConditions then
         return entityDefaults.loadConditions
@@ -368,19 +383,82 @@ local function CompactAnchorIfDefault(anchor, defaultAnchor)
     return CopyTable(anchor)
 end
 
-local function CompactLoadConditions(loadConditions, formatVersion)
+local function CompactLoadConditions(loadConditions, formatVersion, localScope)
     if type(loadConditions) ~= "table" then
         return nil
     end
-    local compact = CompactTableAgainstDefaults(loadConditions, GetLoadConditionsDefaults(formatVersion))
+    local compact = CompactTableAgainstDefaults(loadConditions, GetLoadConditionsDefaults(formatVersion, localScope))
+    if localScope then
+        return compact
+    end
     return compact or {}
 end
 
-local function RehydrateLoadConditions(loadConditions, formatVersion)
+local function RehydrateLoadConditions(loadConditions, formatVersion, localScope)
     if type(loadConditions) ~= "table" then
         return nil
     end
-    return MergeWithDefaults(loadConditions, GetLoadConditionsDefaults(formatVersion))
+    if localScope then
+        local localOnly = {}
+        for key, value in pairs(loadConditions) do
+            if value == true then
+                localOnly[key] = true
+            end
+        end
+        return next(localOnly) and localOnly or nil
+    end
+    return MergeWithDefaults(loadConditions, GetLoadConditionsDefaults(formatVersion, localScope))
+end
+
+local function CompactButton(button, formatVersion)
+    if type(button) ~= "table" then
+        return CopyValue(button)
+    end
+
+    local compact = {}
+    for key, value in pairs(button) do
+        if key == "loadConditions" then
+            local compactLoadConditions = CompactLoadConditions(value, formatVersion, true)
+            if compactLoadConditions then
+                compact.loadConditions = compactLoadConditions
+            end
+        else
+            compact[key] = CopyValue(value)
+        end
+    end
+    return compact
+end
+
+local function RehydrateButton(button, formatVersion)
+    if type(button) ~= "table" then
+        return
+    end
+
+    if button.loadConditions ~= nil then
+        button.loadConditions = RehydrateLoadConditions(button.loadConditions, formatVersion, true)
+    end
+end
+
+local function CompactButtons(buttons, formatVersion)
+    if type(buttons) ~= "table" then
+        return CopyValue(buttons)
+    end
+
+    local compact = {}
+    for index, button in ipairs(buttons) do
+        compact[index] = CompactButton(button, formatVersion)
+    end
+    return compact
+end
+
+local function RehydrateButtons(buttons, formatVersion)
+    if type(buttons) ~= "table" then
+        return
+    end
+
+    for _, button in ipairs(buttons) do
+        RehydrateButton(button, formatVersion)
+    end
 end
 
 local function CompactPanel(group, styleDefaults, panelContainerRef, formatVersion)
@@ -401,6 +479,8 @@ local function CompactPanel(group, styleDefaults, panelContainerRef, formatVersi
             if compactLoadConditions then
                 compact.loadConditions = compactLoadConditions
             end
+        elseif key == "buttons" then
+            compact.buttons = CompactButtons(value, formatVersion)
         elseif key == "anchor" then
             local compactAnchor = CompactAnchorIfDefault(value, BuildPanelDefaultAnchor(panelContainerRef))
             if compactAnchor then
@@ -428,6 +508,7 @@ local function RehydratePanel(group, styleDefaults, panelContainerRef, formatVer
     if group.loadConditions ~= nil then
         group.loadConditions = RehydrateLoadConditions(group.loadConditions, formatVersion)
     end
+    RehydrateButtons(group.buttons, formatVersion)
 
     local defaultAnchor = BuildPanelDefaultAnchor(panelContainerRef)
     if group.anchor == nil and defaultAnchor then
@@ -500,14 +581,19 @@ local function RehydrateContainer(container, formatVersion)
     end
 end
 
-local function CompactFolder(folder)
+local function CompactFolder(folder, formatVersion)
     if type(folder) ~= "table" then
         return nil
     end
 
     local compact = {}
     for key, value in pairs(folder) do
-        if key == "specs" or key == "heroTalents" then
+        if key == "loadConditions" then
+            local compactLoadConditions = CompactLoadConditions(value, formatVersion, true)
+            if compactLoadConditions then
+                compact.loadConditions = compactLoadConditions
+            end
+        elseif key == "specs" or key == "heroTalents" then
             if type(value) == "table" and next(value) ~= nil then
                 compact[key] = CopyTable(value)
             end
@@ -516,6 +602,24 @@ local function CompactFolder(folder)
         end
     end
     return compact
+end
+
+local function RehydrateFolder(folder, formatVersion)
+    if type(folder) ~= "table" then
+        return
+    end
+    if folder.specs and not next(folder.specs) then
+        folder.specs = nil
+    end
+    if folder.heroTalents and not next(folder.heroTalents) then
+        folder.heroTalents = nil
+    end
+    if folder.loadConditions ~= nil then
+        folder.loadConditions = RehydrateLoadConditions(folder.loadConditions, formatVersion, true)
+        if folder.loadConditions and not next(folder.loadConditions) then
+            folder.loadConditions = nil
+        end
+    end
 end
 
 local function CompactScopedSettings(settings, defaultKey, preserveEmptyRoot, formatVersion)
@@ -677,7 +781,7 @@ local function CompactProfile(profile, formatVersion)
             elseif key == "folders" and type(value) == "table" then
                 local compactFolders = {}
                 for folderId, folder in pairs(value) do
-                    compactFolders[folderId] = CompactFolder(folder)
+                    compactFolders[folderId] = CompactFolder(folder, formatVersion)
                 end
                 compact.folders = compactFolders
             else
@@ -744,14 +848,7 @@ local function RehydrateProfile(profile, formatVersion)
 
     if type(profile.folders) == "table" then
         for _, folder in pairs(profile.folders) do
-            if type(folder) == "table" then
-                if folder.specs and not next(folder.specs) then
-                    folder.specs = nil
-                end
-                if folder.heroTalents and not next(folder.heroTalents) then
-                    folder.heroTalents = nil
-                end
-            end
+            RehydrateFolder(folder, formatVersion)
         end
     end
 
@@ -806,10 +903,10 @@ local function CompactEntityPayload(payload, formatVersion)
         end
     end
     if payload.folder then
-        compact.folder = CompactFolder(payload.folder)
+        compact.folder = CompactFolder(payload.folder, formatVersion)
     end
     if type(payload.containers) ~= "table" and payload.type == "folder" then
-        compact.folder = CompactFolder(payload.folder)
+        compact.folder = CompactFolder(payload.folder, formatVersion)
     end
 
     return compact
@@ -834,6 +931,9 @@ local function RehydrateEntityPayload(payload, formatVersion)
     end
     if type(payload.container) == "table" then
         RehydrateContainer(payload.container, formatVersion)
+    end
+    if type(payload.folder) == "table" then
+        RehydrateFolder(payload.folder, formatVersion)
     end
     if type(payload.panels) == "table" then
         local panelContainerRef = payload._originalContainerId

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1562,6 +1562,7 @@ local function CreateConfigPanel()
         { value = "settings",  text = "Settings" },
         { value = "soundalerts", text = "Sound Alerts" },
         { value = "overrides", text = "Overrides" },
+        { value = "loadconditions", text = "Load Conditions" },
     })
     bsTabGroup:SetLayout("Fill")
 
@@ -1618,6 +1619,8 @@ local function CreateConfigPanel()
             end
         elseif tab == "fallbacks" then
             ST._BuildItemFallbacksTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
+        elseif tab == "loadconditions" then
+            ST._BuildEntryLoadConditionsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
         elseif tab == "overrides" then
             ST._BuildOverridesTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
         end

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -834,6 +834,9 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
         if data and data.folderId then
             CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:DeleteFolder(data.folderId)
+            if CS.selectedFolder == data.folderId then
+                CS.selectedFolder = nil
+            end
             if CS.selectedGroup then
                 local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
                 if not group then
@@ -1131,6 +1134,18 @@ local function ImportGroupData(text)
         if not importedSpecs then
             importedHeroTalents = nil
         end
+        local importedLoadConditions = nil
+        if type(data.folder.loadConditions) == "table" then
+            importedLoadConditions = {}
+            for key, enabled in pairs(data.folder.loadConditions) do
+                if enabled == true then
+                    importedLoadConditions[key] = true
+                end
+            end
+            if not next(importedLoadConditions) then
+                importedLoadConditions = nil
+            end
+        end
         db.folders[folderId] = {
             name = data.folder.name or "Imported Folder",
             order = folderId,
@@ -1139,6 +1154,7 @@ local function ImportGroupData(text)
             manualIcon = importedManualIcon,
             specs = importedSpecs,
             heroTalents = importedHeroTalents,
+            loadConditions = importedLoadConditions,
         }
         local count = 0
         if data.containers then

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2006,6 +2006,7 @@ local function ResetConfigSelection(full)
         ST._CancelAutoAddFlow()
     end
     CooldownCompanion:ClearAllConfigPreviews()
+    CS.selectedFolder = nil
     CS.selectedButton = nil
     wipe(CS.selectedButtons)
     wipe(CS.selectedPanels)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -119,6 +119,7 @@ local PROFILE_BAR_HEIGHT = 36
 ------------------------------------------------------------------------
 ST._configState = {
     -- Selection state
+    selectedFolder = nil,        -- folderId selected in Column 1
     selectedContainer = nil,     -- containerId selected in Column 1
     selectedGroup = nil,         -- panelId (groupId) selected in Column 2 panel list
     selectedButton = nil,
@@ -126,6 +127,7 @@ ST._configState = {
     selectedPanels = {},         -- multi-selected panel IDs (within a container)
     selectedGroups = {},         -- multi-selected container IDs
     selectedTab = "appearance",
+    selectedFolderTab = "general",
     selectedContainerTab = "general",
     buttonSettingsTab = "settings",
     panelSettingsTab = "appearance",
@@ -562,6 +564,7 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
     wipe(CS.selectedButtons)
+    CS.selectedFolder = nil
     CS.selectedContainer = containerId
     CS.selectedGroup = panelId
     CS.selectedButton = buttonIndex
@@ -1035,6 +1038,10 @@ local function ShowConfigShiftTooltip()
             HideConfigShiftTooltip(active)
         end
         return false
+    end
+    local extraLine = widget:GetUserData("cdcShiftTooltipExtraLine")
+    if extraLine then
+        GameTooltip:AddLine(extraLine, 0.7, 0.7, 0.7, true)
     end
     active.tooltipOwner = owner
     active.tooltipShown = true

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -60,7 +60,7 @@ local function GetActiveInheritedLabel(sources, key, optionDefault)
     return nil
 end
 
-local function AddInheritedLoadSummary(container, sources)
+local function AddInheritedLoadSummary(container, sources, collapsedKey)
     local labelsBySource = {}
     local hasAny = false
 
@@ -86,6 +86,15 @@ local function AddInheritedLoadSummary(container, sources)
     ColorHeading(heading)
     heading:SetFullWidth(true)
     container:AddChild(heading)
+
+    local collapsed = collapsedKey and CS.collapsedSections[collapsedKey]
+    if collapsedKey then
+        AttachCollapseButton(heading, collapsed, function()
+            CS.collapsedSections[collapsedKey] = not CS.collapsedSections[collapsedKey]
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+    end
+    if collapsed then return end
 
     local inherited = {}
     for _, source in ipairs(sources or {}) do
@@ -119,13 +128,22 @@ local function AddScopedLoadConditionToggles(container, opts)
         end
     end
 
-    AddInheritedLoadSummary(container, inheritedSources)
+    AddInheritedLoadSummary(container, inheritedSources, opts.inheritedCollapsedKey)
 
     local heading = AceGUI:Create("Heading")
     heading:SetText((inheritedAny and opts.headingTextWhenInherited) or opts.headingText or "Hide When In")
     ColorHeading(heading)
     heading:SetFullWidth(true)
     container:AddChild(heading)
+
+    local localCollapsed = opts.localCollapsedKey and CS.collapsedSections[opts.localCollapsedKey]
+    if opts.localCollapsedKey then
+        AttachCollapseButton(heading, localCollapsed, function()
+            CS.collapsedSections[opts.localCollapsedKey] = not CS.collapsedSections[opts.localCollapsedKey]
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+    end
+    if localCollapsed then return end
 
     if inheritedAny then
         local inheritedLabel = AceGUI:Create("Label")
@@ -1563,6 +1581,8 @@ local function BuildLoadConditionsTab(container)
         inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group),
         headingText = "Hide This Panel In",
         headingTextWhenInherited = "Also Hide This Panel In",
+        inheritedCollapsedKey = "loadconditions_panel_inherited",
+        localCollapsedKey = "loadconditions_panel_local",
         onChanged = function()
             CooldownCompanion:RefreshGroupFrame(groupId)
             CooldownCompanion:RefreshConfigPanel()
@@ -1703,6 +1723,8 @@ local function BuildEntryLoadConditionsTab(container, buttonData, infoButtons)
         inheritedSources = CooldownCompanion:GetLoadConditionSourcesForGroup(group),
         headingText = "Hide This Entry In",
         headingTextWhenInherited = "Also Hide This Entry In",
+        inheritedCollapsedKey = "loadconditions_entry_inherited",
+        localCollapsedKey = "loadconditions_entry_local",
         preserveMissing = true,
         onChanged = function()
             if buttonData.loadConditions and not next(buttonData.loadConditions) then

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -23,6 +23,150 @@ local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
 
+local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
+
+local function GetLoadConditionValue(loadConditions, key, defaults, optionDefault)
+    if type(loadConditions) ~= "table" then return false end
+    local val = loadConditions[key]
+    if val == nil then
+        if defaults and defaults[key] ~= nil then
+            val = defaults[key]
+        else
+            val = optionDefault or false
+        end
+    end
+    return val == true
+end
+
+local function SetLoadConditionValue(loadConditions, key, value, defaults, optionDefault)
+    if type(loadConditions) ~= "table" then return end
+    local defaultValue = optionDefault or false
+    if defaults and defaults[key] ~= nil then
+        defaultValue = defaults[key]
+    end
+    if value == defaultValue then
+        loadConditions[key] = nil
+    else
+        loadConditions[key] = value == true
+    end
+end
+
+local function GetActiveInheritedLabel(sources, key, optionDefault)
+    for _, source in ipairs(sources or {}) do
+        if GetLoadConditionValue(source.loadConditions, key, source.defaults, optionDefault) then
+            return source.label
+        end
+    end
+    return nil
+end
+
+local function AddInheritedLoadSummary(container, sources, localLoadConditions, localDefaults, localLabel)
+    local hasAny = false
+    for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
+        if GetActiveInheritedLabel(sources, cond.key, cond.default) then
+            hasAny = true
+            break
+        end
+    end
+    if not hasAny then
+        for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
+            if GetLoadConditionValue(localLoadConditions, cond.key, localDefaults, cond.default) then
+                hasAny = true
+                break
+            end
+        end
+    end
+    if not hasAny then return end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText("Effective Load Conditions")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
+    local inherited = {}
+    for _, source in ipairs(sources or {}) do
+        local labels = {}
+        for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
+            if GetLoadConditionValue(source.loadConditions, cond.key, source.defaults, cond.default) then
+                labels[#labels + 1] = cond.label
+            end
+        end
+        if #labels > 0 then
+            inherited[#inherited + 1] = "|cff888888Inherited from " .. source.label .. ":|r " .. table.concat(labels, ", ")
+        end
+    end
+    local localLabels = {}
+    for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
+        if GetLoadConditionValue(localLoadConditions, cond.key, localDefaults, cond.default) then
+            localLabels[#localLabels + 1] = cond.label
+        end
+    end
+    if #localLabels > 0 then
+        inherited[#inherited + 1] = "|cff888888" .. (localLabel or "This Scope Adds") .. ":|r " .. table.concat(localLabels, ", ")
+    end
+
+    local label = AceGUI:Create("Label")
+    label:SetText(table.concat(inherited, "\n"))
+    label:SetFullWidth(true)
+    container:AddChild(label)
+end
+
+local function AddScopedLoadConditionToggles(container, opts)
+    local target = opts.target
+    if not target.loadConditions and not opts.preserveMissing then
+        target.loadConditions = {}
+    end
+    local loadConditions = target.loadConditions or {}
+    local defaults = opts.defaults
+    local inheritedSources = opts.inheritedSources or {}
+    local onChanged = opts.onChanged
+
+    AddInheritedLoadSummary(container, inheritedSources, loadConditions, defaults, opts.headingText)
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(opts.headingText or "This Scope Adds")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
+    local inheritedAny = false
+    for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
+        if GetActiveInheritedLabel(inheritedSources, cond.key, cond.default) then
+            inheritedAny = true
+            break
+        end
+    end
+    if inheritedAny then
+        local inheritedLabel = AceGUI:Create("Label")
+        inheritedLabel:SetText("|cff888888Inherited active conditions are locked here. Local conditions can only add more restrictions.|r")
+        inheritedLabel:SetFullWidth(true)
+        container:AddChild(inheritedLabel)
+    end
+
+    for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
+        local inheritedLabel = GetActiveInheritedLabel(inheritedSources, cond.key, cond.default)
+        local cb = AceGUI:Create("CheckBox")
+        cb:SetLabel(inheritedLabel and (cond.label .. " |cff888888(Inherited from " .. inheritedLabel .. ")|r") or cond.label)
+        cb:SetFullWidth(true)
+        if inheritedLabel then
+            cb:SetValue(true)
+            cb:SetDisabled(true)
+        else
+            cb:SetValue(GetLoadConditionValue(loadConditions, cond.key, defaults, cond.default))
+            cb:SetCallback("OnValueChanged", function(widget, event, newVal)
+                if not target.loadConditions then
+                    target.loadConditions = {}
+                    loadConditions = target.loadConditions
+                end
+                SetLoadConditionValue(loadConditions, cond.key, newVal, defaults, cond.default)
+                if onChanged then onChanged() end
+            end)
+        end
+        container:AddChild(cb)
+    end
+end
+
 ------------------------------------------------------------------------
 -- BATCH HELPERS (multi-select visibility)
 ------------------------------------------------------------------------
@@ -1423,42 +1567,6 @@ local function BuildLoadConditionsTab(container)
     local effectiveSpecs, inheritedSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
     local effectiveHeroTalents, inheritedHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
 
-    -- Look up parent container's load conditions for inheritance
-    local containerLc = nil
-    if group.parentContainerId then
-        local containers = CooldownCompanion.db.profile.groupContainers
-        local parentContainer = containers and containers[group.parentContainerId]
-        if parentContainer then
-            containerLc = parentContainer.loadConditions
-        end
-    end
-
-    local function isContainerConditionActive(key, defaultVal)
-        if not containerLc then return false end
-        local val = containerLc[key]
-        if val == nil then val = defaultVal or false end
-        return val
-    end
-
-    local function CreateLoadConditionToggle(label, key, defaultVal)
-        local cb = AceGUI:Create("CheckBox")
-        cb:SetLabel(label)
-        cb:SetFullWidth(true)
-        if isContainerConditionActive(key, defaultVal) then
-            cb:SetValue(true)
-            cb:SetDisabled(true)
-        else
-            local val = lc[key]
-            if val == nil then val = defaultVal or false end
-            cb:SetValue(val)
-            cb:SetCallback("OnValueChanged", function(widget, event, newVal)
-                lc[key] = newVal
-                CooldownCompanion:RefreshGroupFrame(groupId)
-            end)
-        end
-        return cb
-    end
-
     local heading = AceGUI:Create("Heading")
     heading:SetText("Do Not Load When In")
     ColorHeading(heading)
@@ -1472,37 +1580,16 @@ local function BuildLoadConditionsTab(container)
     end)
 
     if not instanceCollapsed then
-    local conditions = {
-        { key = "raid",          label = "Raid" },
-        { key = "dungeon",       label = "Dungeon" },
-        { key = "delve",         label = "Delve" },
-        { key = "battleground",  label = "Battleground" },
-        { key = "arena",         label = "Arena" },
-        { key = "openWorld",     label = "Open World" },
-        { key = "rested",        label = "Rested Area" },
-        { key = "petBattle",     label = "Pet Battle", default = true },
-        { key = "vehicleUI",    label = "Vehicle / Override UI", default = true },
-    }
-
-    if containerLc then
-        local anyInherited = false
-        for _, cond in ipairs(conditions) do
-            if isContainerConditionActive(cond.key, cond.default) then
-                anyInherited = true
-                break
-            end
-        end
-        if anyInherited then
-            local inheritedLabel = AceGUI:Create("Label")
-            inheritedLabel:SetText("|cff888888Some conditions inherited from group settings.|r")
-            inheritedLabel:SetFullWidth(true)
-            container:AddChild(inheritedLabel)
-        end
-    end
-
-    for _, cond in ipairs(conditions) do
-        container:AddChild(CreateLoadConditionToggle(cond.label, cond.key, cond.default))
-    end
+    AddScopedLoadConditionToggles(container, {
+        target = group,
+        defaults = CooldownCompanion:GetDefaultLoadConditions(),
+        inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group),
+        headingText = "This Panel Adds",
+        onChanged = function()
+            CooldownCompanion:RefreshGroupFrame(groupId)
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
     end -- not instanceCollapsed
 
     -- Specialization heading
@@ -1627,11 +1714,46 @@ local function BuildLoadConditionsTab(container)
     end -- not specCollapsed
 end
 
+local function BuildEntryLoadConditionsTab(container, buttonData, infoButtons)
+    if not (CS.selectedGroup and buttonData) then return end
+    local groupId = CS.selectedGroup
+    local group = CooldownCompanion.db.profile.groups[groupId]
+    if not group then return end
+
+    AddScopedLoadConditionToggles(container, {
+        target = buttonData,
+        defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
+        inheritedSources = CooldownCompanion:GetLoadConditionSourcesForGroup(group),
+        headingText = "This Entry Adds",
+        preserveMissing = true,
+        onChanged = function()
+            if buttonData.loadConditions and not next(buttonData.loadConditions) then
+                buttonData.loadConditions = nil
+            end
+            CooldownCompanion:RefreshGroupFrame(groupId)
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
+
+    if CooldownCompanion:HasLocalLoadConditions(buttonData) then
+        local clearBtn = AceGUI:Create("Button")
+        clearBtn:SetText("Clear Entry Load Conditions")
+        clearBtn:SetFullWidth(true)
+        clearBtn:SetCallback("OnClick", function()
+            buttonData.loadConditions = nil
+            CooldownCompanion:RefreshGroupFrame(groupId)
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        container:AddChild(clearBtn)
+    end
+end
 
 ------------------------------------------------------------------------
 -- EXPORTS
 ------------------------------------------------------------------------
 ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
+ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
+ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
 ST._GetConditionDisplayName = GetConditionDisplayName
 ST._GetConditionListContextSuffix = GetConditionListContextSuffix

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -60,50 +60,39 @@ local function GetActiveInheritedLabel(sources, key, optionDefault)
     return nil
 end
 
-local function AddInheritedLoadSummary(container, sources, localLoadConditions, localDefaults, localLabel)
+local function AddInheritedLoadSummary(container, sources)
+    local labelsBySource = {}
     local hasAny = false
+
+    local function AddLabel(sourceLabel, conditionLabel)
+        if not labelsBySource[sourceLabel] then
+            labelsBySource[sourceLabel] = {}
+        end
+        labelsBySource[sourceLabel][#labelsBySource[sourceLabel] + 1] = conditionLabel
+        hasAny = true
+    end
+
     for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
-        if GetActiveInheritedLabel(sources, cond.key, cond.default) then
-            hasAny = true
-            break
+        local inheritedLabel = GetActiveInheritedLabel(sources, cond.key, cond.default)
+        if inheritedLabel then
+            AddLabel(inheritedLabel, cond.label)
         end
     end
-    if not hasAny then
-        for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
-            if GetLoadConditionValue(localLoadConditions, cond.key, localDefaults, cond.default) then
-                hasAny = true
-                break
-            end
-        end
-    end
+
     if not hasAny then return end
 
     local heading = AceGUI:Create("Heading")
-    heading:SetText("Effective Load Conditions")
+    heading:SetText("Inherited Load Conditions")
     ColorHeading(heading)
     heading:SetFullWidth(true)
     container:AddChild(heading)
 
     local inherited = {}
     for _, source in ipairs(sources or {}) do
-        local labels = {}
-        for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
-            if GetLoadConditionValue(source.loadConditions, cond.key, source.defaults, cond.default) then
-                labels[#labels + 1] = cond.label
-            end
+        local labels = labelsBySource[source.label]
+        if labels then
+            inherited[#inherited + 1] = "|cff888888From " .. source.label .. ":|r " .. table.concat(labels, ", ")
         end
-        if #labels > 0 then
-            inherited[#inherited + 1] = "|cff888888Inherited from " .. source.label .. ":|r " .. table.concat(labels, ", ")
-        end
-    end
-    local localLabels = {}
-    for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
-        if GetLoadConditionValue(localLoadConditions, cond.key, localDefaults, cond.default) then
-            localLabels[#localLabels + 1] = cond.label
-        end
-    end
-    if #localLabels > 0 then
-        inherited[#inherited + 1] = "|cff888888" .. (localLabel or "This Scope Adds") .. ":|r " .. table.concat(localLabels, ", ")
     end
 
     local label = AceGUI:Create("Label")
@@ -122,14 +111,6 @@ local function AddScopedLoadConditionToggles(container, opts)
     local inheritedSources = opts.inheritedSources or {}
     local onChanged = opts.onChanged
 
-    AddInheritedLoadSummary(container, inheritedSources, loadConditions, defaults, opts.headingText)
-
-    local heading = AceGUI:Create("Heading")
-    heading:SetText(opts.headingText or "This Scope Adds")
-    ColorHeading(heading)
-    heading:SetFullWidth(true)
-    container:AddChild(heading)
-
     local inheritedAny = false
     for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
         if GetActiveInheritedLabel(inheritedSources, cond.key, cond.default) then
@@ -137,9 +118,18 @@ local function AddScopedLoadConditionToggles(container, opts)
             break
         end
     end
+
+    AddInheritedLoadSummary(container, inheritedSources)
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText((inheritedAny and opts.headingTextWhenInherited) or opts.headingText or "Hide When In")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
     if inheritedAny then
         local inheritedLabel = AceGUI:Create("Label")
-        inheritedLabel:SetText("|cff888888Inherited active conditions are locked here. Local conditions can only add more restrictions.|r")
+        inheritedLabel:SetText("|cff888888Inherited rules are locked here. You can only add more places to hide this.|r")
         inheritedLabel:SetFullWidth(true)
         container:AddChild(inheritedLabel)
     end
@@ -147,7 +137,7 @@ local function AddScopedLoadConditionToggles(container, opts)
     for _, cond in ipairs(LOAD_CONDITION_OPTIONS) do
         local inheritedLabel = GetActiveInheritedLabel(inheritedSources, cond.key, cond.default)
         local cb = AceGUI:Create("CheckBox")
-        cb:SetLabel(inheritedLabel and (cond.label .. " |cff888888(Inherited from " .. inheritedLabel .. ")|r") or cond.label)
+        cb:SetLabel(inheritedLabel and (cond.label .. " |cff888888(locked by " .. inheritedLabel .. ")|r") or cond.label)
         cb:SetFullWidth(true)
         if inheritedLabel then
             cb:SetValue(true)
@@ -1567,30 +1557,17 @@ local function BuildLoadConditionsTab(container)
     local effectiveSpecs, inheritedSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
     local effectiveHeroTalents, inheritedHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
 
-    local heading = AceGUI:Create("Heading")
-    heading:SetText("Do Not Load When In")
-    ColorHeading(heading)
-    heading:SetFullWidth(true)
-    container:AddChild(heading)
-
-    local instanceCollapsed = CS.collapsedSections["loadconditions_instance"]
-    AttachCollapseButton(heading, instanceCollapsed, function()
-        CS.collapsedSections["loadconditions_instance"] = not CS.collapsedSections["loadconditions_instance"]
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-
-    if not instanceCollapsed then
     AddScopedLoadConditionToggles(container, {
         target = group,
         defaults = CooldownCompanion:GetDefaultLoadConditions(),
         inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group),
-        headingText = "This Panel Adds",
+        headingText = "Hide This Panel In",
+        headingTextWhenInherited = "Also Hide This Panel In",
         onChanged = function()
             CooldownCompanion:RefreshGroupFrame(groupId)
             CooldownCompanion:RefreshConfigPanel()
         end,
     })
-    end -- not instanceCollapsed
 
     -- Specialization heading
     local specHeading = AceGUI:Create("Heading")
@@ -1724,7 +1701,8 @@ local function BuildEntryLoadConditionsTab(container, buttonData, infoButtons)
         target = buttonData,
         defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
         inheritedSources = CooldownCompanion:GetLoadConditionSourcesForGroup(group),
-        headingText = "This Entry Adds",
+        headingText = "Hide This Entry In",
+        headingTextWhenInherited = "Also Hide This Entry In",
         preserveMissing = true,
         onChanged = function()
             if buttonData.loadConditions and not next(buttonData.loadConditions) then

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -80,6 +80,7 @@ local function BuildButtonSettingsTabs(group, buttonData)
     if GroupUsesTriggerPanelEntries(group) then
         return {
             { value = "settings", text = "Condition" },
+            { value = "loadconditions", text = "Load Conditions" },
             { value = "soundalerts", text = "Sound Alerts" },
         }
     end
@@ -98,6 +99,7 @@ local function BuildButtonSettingsTabs(group, buttonData)
     if not GroupUsesTexturePanelEntries(group) then
         tabs[#tabs + 1] = { value = "overrides", text = "Overrides" }
     end
+    tabs[#tabs + 1] = { value = "loadconditions", text = "Load Conditions" }
 
     return tabs
 end
@@ -1688,6 +1690,7 @@ local function RefreshButtonSettingsColumn()
 
         if GroupUsesTriggerPanelEntries(group)
             and CS.buttonSettingsTab ~= "settings"
+            and CS.buttonSettingsTab ~= "loadconditions"
             and CS.buttonSettingsTab ~= "soundalerts" then
             CS.buttonSettingsTab = "settings"
         elseif GroupUsesTexturePanelEntries(group) and CS.buttonSettingsTab == "overrides" then

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -240,7 +240,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
     if not buttonData.overrideSections or not next(buttonData.overrideSections) then
         if displayMode ~= "text" then
             local noOverridesLabel = AceGUI:Create("Label")
-            noOverridesLabel:SetText("|cff888888No appearance overrides are currently set.\n\nIf you want to override a setting for this specific button, click the |A:Crosshair_VehichleCursor_32:0:0|a badge next to the associated panel level setting while this button is selected.|r")
+            noOverridesLabel:SetText("|cff888888No appearance overrides are currently set.\n\nAppearance overrides still come from the |A:Crosshair_VehichleCursor_32:0:0|a badge next to panel-level appearance settings while this button is selected.|r")
             noOverridesLabel:SetFullWidth(true)
             scroll:AddChild(noOverridesLabel)
         end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -3277,11 +3277,18 @@ local function BuildFolderGeneralTab(scroll, folderId)
     nameBox:SetLabel("Name")
     nameBox:SetText(folder.name or "")
     nameBox:SetFullWidth(true)
+    local function CommitFolderName(widget, text)
+        if CooldownCompanion:RenameFolder(folderId, text) then
+            CooldownCompanion:RefreshConfigPanel()
+        elseif widget and widget.SetText then
+            widget:SetText(folder.name or "")
+        end
+    end
     nameBox:SetCallback("OnEnterPressed", function(widget, event, text)
-        CooldownCompanion:RenameFolder(folderId, text)
+        CommitFolderName(widget, text)
     end)
     nameBox:SetCallback("OnEditFocusLost", function(widget)
-        CooldownCompanion:RenameFolder(folderId, widget:GetText())
+        CommitFolderName(widget, widget:GetText())
     end)
     scroll:AddChild(nameBox)
 

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -26,6 +26,7 @@ local BuildAlphaControls = ST._BuildAlphaControls
 local OpenTriggerPanelIconPicker = ST._OpenTriggerPanelIconPicker
 local ApplyEdgePositions = ST._ApplyEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
+local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
 
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -3118,26 +3119,6 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         CooldownCompanion:RefreshContainerPanels(containerId)
     end
 
-    if not container.loadConditions then
-        container.loadConditions = {}
-    end
-    local loadConditions = container.loadConditions
-
-    local function CreateLoadConditionToggle(label, key, defaultVal)
-        local cb = AceGUI:Create("CheckBox")
-        cb:SetLabel(label)
-        local val = loadConditions[key]
-        if val == nil then val = defaultVal or false end
-        cb:SetValue(val)
-        cb:SetFullWidth(true)
-        cb:SetCallback("OnValueChanged", function(widget, event, newVal)
-            loadConditions[key] = newVal
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        return cb
-    end
-
     local heading = AceGUI:Create("Heading")
     heading:SetText("Do Not Load When In")
     ColorHeading(heading)
@@ -3151,21 +3132,16 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end)
 
     if not instanceCollapsed then
-    local conditions = {
-        { key = "raid",          label = "Raid" },
-        { key = "dungeon",       label = "Dungeon" },
-        { key = "delve",         label = "Delve" },
-        { key = "battleground",  label = "Battleground" },
-        { key = "arena",         label = "Arena" },
-        { key = "openWorld",     label = "Open World" },
-        { key = "rested",        label = "Rested Area" },
-        { key = "petBattle",     label = "Pet Battle", default = true },
-        { key = "vehicleUI",     label = "Vehicle / Override UI", default = true },
-    }
-
-    for _, cond in ipairs(conditions) do
-        scroll:AddChild(CreateLoadConditionToggle(cond.label, cond.key, cond.default))
-    end
+    AddScopedLoadConditionToggles(scroll, {
+        target = container,
+        defaults = CooldownCompanion:GetDefaultLoadConditions(),
+        inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container),
+        headingText = "This Group Adds",
+        onChanged = function()
+            RefreshPanels()
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
     end -- not instanceCollapsed
 
     -- Spec filter section
@@ -3297,9 +3273,79 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end -- not specCollapsed
 end
 
+local function BuildFolderGeneralTab(scroll, folderId)
+    local db = CooldownCompanion.db.profile
+    local folder = db.folders and db.folders[folderId]
+    if not folder then return end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText("Folder")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    scroll:AddChild(heading)
+
+    local nameBox = AceGUI:Create("EditBox")
+    nameBox:SetLabel("Name")
+    nameBox:SetText(folder.name or "")
+    nameBox:SetFullWidth(true)
+    nameBox:SetCallback("OnEnterPressed", function(widget, event, text)
+        CooldownCompanion:RenameFolder(folderId, text)
+    end)
+    nameBox:SetCallback("OnEditFocusLost", function(widget)
+        CooldownCompanion:RenameFolder(folderId, widget:GetText())
+    end)
+    scroll:AddChild(nameBox)
+
+    local section = AceGUI:Create("Label")
+    section:SetText("|cff888888Section:|r " .. tostring(folder.section or "character"))
+    section:SetFullWidth(true)
+    scroll:AddChild(section)
+end
+
+local function BuildFolderLoadConditionsTab(scroll, folderId)
+    local db = CooldownCompanion.db.profile
+    local folder = db.folders and db.folders[folderId]
+    if not folder then return end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText("Do Not Load When In")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    scroll:AddChild(heading)
+
+    AddScopedLoadConditionToggles(scroll, {
+        target = folder,
+        defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
+        inheritedSources = {},
+        headingText = "This Folder Adds",
+        preserveMissing = true,
+        onChanged = function()
+            if folder.loadConditions and not next(folder.loadConditions) then
+                folder.loadConditions = nil
+            end
+            CooldownCompanion:RefreshAllGroups()
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
+
+    if CooldownCompanion:HasLocalLoadConditions(folder) then
+        local clearBtn = AceGUI:Create("Button")
+        clearBtn:SetText("Clear Folder Load Conditions")
+        clearBtn:SetFullWidth(true)
+        clearBtn:SetCallback("OnClick", function()
+            folder.loadConditions = nil
+            CooldownCompanion:RefreshAllGroups()
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        scroll:AddChild(clearBtn)
+    end
+end
+
 -- Expose for Config.lua
 ST._BuildLayoutTab = BuildLayoutTab
 ST._BuildAppearanceTab = BuildAppearanceTab
 ST._BuildEffectsTab = BuildEffectsTab
 ST._BuildContainerGeneralTab = BuildContainerGeneralTab
 ST._BuildContainerLoadConditionsTab = BuildContainerLoadConditionsTab
+ST._BuildFolderGeneralTab = BuildFolderGeneralTab
+ST._BuildFolderLoadConditionsTab = BuildFolderLoadConditionsTab

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -3125,6 +3125,8 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container),
         headingText = "Hide This Group In",
         headingTextWhenInherited = "Also Hide This Group In",
+        inheritedCollapsedKey = "container_loadconditions_inherited",
+        localCollapsedKey = "container_loadconditions_local",
         onChanged = function()
             RefreshPanels()
             CooldownCompanion:RefreshConfigPanel()
@@ -3299,6 +3301,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
         defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
         inheritedSources = {},
         headingText = "Hide This Folder In",
+        localCollapsedKey = "folder_loadconditions_local",
         preserveMissing = true,
         onChanged = function()
             if folder.loadConditions and not next(folder.loadConditions) then

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -3119,30 +3119,17 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         CooldownCompanion:RefreshContainerPanels(containerId)
     end
 
-    local heading = AceGUI:Create("Heading")
-    heading:SetText("Do Not Load When In")
-    ColorHeading(heading)
-    heading:SetFullWidth(true)
-    scroll:AddChild(heading)
-
-    local instanceCollapsed = CS.collapsedSections["container_loadconditions_instance"]
-    AttachCollapseButton(heading, instanceCollapsed, function()
-        CS.collapsedSections["container_loadconditions_instance"] = not CS.collapsedSections["container_loadconditions_instance"]
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-
-    if not instanceCollapsed then
     AddScopedLoadConditionToggles(scroll, {
         target = container,
         defaults = CooldownCompanion:GetDefaultLoadConditions(),
         inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container),
-        headingText = "This Group Adds",
+        headingText = "Hide This Group In",
+        headingTextWhenInherited = "Also Hide This Group In",
         onChanged = function()
             RefreshPanels()
             CooldownCompanion:RefreshConfigPanel()
         end,
     })
-    end -- not instanceCollapsed
 
     -- Spec filter section
     local specHeading = AceGUI:Create("Heading")
@@ -3307,17 +3294,11 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     local folder = db.folders and db.folders[folderId]
     if not folder then return end
 
-    local heading = AceGUI:Create("Heading")
-    heading:SetText("Do Not Load When In")
-    ColorHeading(heading)
-    heading:SetFullWidth(true)
-    scroll:AddChild(heading)
-
     AddScopedLoadConditionToggles(scroll, {
         target = folder,
         defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
         inheritedSources = {},
-        headingText = "This Folder Adds",
+        headingText = "Hide This Folder In",
         preserveMissing = true,
         onChanged = function()
             if folder.loadConditions and not next(folder.loadConditions) then

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -16,7 +16,7 @@ end
 -- Helper: attach a reusable collapse/expand arrow button to an AceGUI Heading.
 -- Stores the button on heading.frame._cdcCollapseBtn so it survives widget
 -- recycling without creating duplicate textures or stale handlers.
-local COLLAPSE_ARROW_ATLAS = "glues-characterSelect-icon-arrowDown-small"
+local COLLAPSE_ARROW_ATLAS = "glues-characterselect-icon-arrowdown-small"
 local COLLAPSE_ROTATION_RIGHT = math.pi / 2   -- collapsed: arrow points right
 local COLLAPSE_ROTATION_DOWN  = 0              -- expanded:  arrow points down
 

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -545,7 +545,7 @@ local function GetSavedPreviewButtons(group)
     for _, buttonData in ipairs(group.buttons or {}) do
         if buttonData and buttonData.enabled ~= false then
             fallbackButtons[#fallbackButtons + 1] = { buttonData = buttonData }
-            if not CooldownCompanion.IsButtonUsable or CooldownCompanion:IsButtonUsable(buttonData) then
+            if not CooldownCompanion.IsButtonUsable or CooldownCompanion:IsButtonUsable(buttonData, group) then
                 buttons[#buttons + 1] = { buttonData = buttonData }
             end
         end

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -238,7 +238,7 @@ local defaults = {
         nextGroupId = 1,
         groupContainers = {},  -- [containerId] = { name, order, folderId, enabled, locked, specs, heroTalents, loadConditions, alpha/fade, anchor, ... }
         nextContainerId = 1,
-        folders = {},       -- [folderId] = { name, order, section, manualIcon?, specs?, heroTalents? }
+        folders = {},       -- [folderId] = { name, order, section, manualIcon?, specs?, heroTalents?, loadConditions? }
         nextFolderId = 1,
         globalStyle = {
             buttonSize = 36,

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -633,7 +633,7 @@ function CooldownCompanion:CreateGroupFrame(groupId)
         group = group,
         checkCharVisibility = true,
         checkLoadConditions = true,
-        requireButtons = false,
+        requireButtons = true,
     }) then
         frame:Show()
         -- Apply current alpha from the alpha fade system so frame doesn't flash at 1.0
@@ -862,7 +862,7 @@ local function GetButtonDimensions(group)
         if GetEffectiveTextHeight then
             local maxHeight = GetEffectiveTextHeight(style, style.textFormat or "{name}  {status}")
             for _, buttonData in ipairs(group.buttons or {}) do
-                if CooldownCompanion:IsButtonUsable(buttonData) then
+                if CooldownCompanion:IsButtonUsable(buttonData, group) then
                     local effectiveStyle = CooldownCompanion:GetEffectiveStyle(style, buttonData)
                     local fmt = buttonData.textFormat or effectiveStyle.textFormat or "{name}  {status}"
                     local buttonHeight = GetEffectiveTextHeight(effectiveStyle, fmt)
@@ -957,7 +957,7 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     local xMul, yMul, growthAnchor = GetGrowthMultipliers(style.growthOrigin)
     local visibleIndex = 0
     for i, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData) then
+        if self:IsButtonUsable(buttonData, group) then
             visibleIndex = visibleIndex + 1
             local effectiveStyle = self:GetEffectiveStyle(style, buttonData)
             local button

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1159,9 +1159,11 @@ end
 
 function CooldownCompanion:RenameFolder(folderId, newName)
     local folder = self.db.profile.folders[folderId]
-    if folder then
-        folder.name = newName
-    end
+    if not folder then return false end
+    local normalizedName = tostring(newName or ""):match("^%s*(.-)%s*$")
+    if normalizedName == "" then return false end
+    folder.name = normalizedName
+    return true
 end
 
 function CooldownCompanion:MoveGroupToFolder(id, folderId)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -806,12 +806,13 @@ function CooldownCompanion:IsHeroTalentAllowed(group)
     return effectiveHeroTalents[heroSpecId] == true
 end
 
-function CooldownCompanion:GroupHasUsableButtons(group)
+function CooldownCompanion:GroupHasUsableButtons(group, opts)
+    opts = opts or {}
     if not (group and group.buttons and #group.buttons > 0) then
         return false
     end
     for _, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group) then
+        if self:IsButtonUsable(buttonData, group, opts) then
             return true
         end
     end
@@ -841,7 +842,9 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if group.enabled == false then return false end
     end
 
-    if opts.requireButtons and not self:GroupHasUsableButtons(group) then
+    if opts.requireButtons and not self:GroupHasUsableButtons(group, {
+        checkLoadConditions = opts.checkLoadConditions,
+    }) then
         return false
     end
 
@@ -1346,10 +1349,11 @@ local function SpellIDsMatchCanonicalForm(storedSpellID, resolvedSpellID)
         and storedBaseSpellID == resolvedBaseSpellID
 end
 
-function CooldownCompanion:IsButtonUsable(buttonData, group)
+function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
+    opts = opts or {}
     if buttonData.enabled == false then return false end
 
-    if not self:IsButtonLoadConditionMet(buttonData, group) then return false end
+    if opts.checkLoadConditions ~= false and not self:IsButtonLoadConditionMet(buttonData, group) then return false end
 
     -- Per-button talent condition: gate visibility on a specific talent node.
     if not self:IsTalentConditionMet(buttonData) then return false end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -17,6 +17,42 @@ local UnitExists = UnitExists
 local UnitCanAttack = UnitCanAttack
 local InCombatLockdown = InCombatLockdown
 
+local LOAD_CONDITION_DEFAULTS = {
+    raid = false,
+    dungeon = false,
+    delve = false,
+    battleground = false,
+    arena = false,
+    openWorld = false,
+    rested = false,
+    petBattle = true,
+    vehicleUI = true,
+}
+
+local LOCAL_LOAD_CONDITION_DEFAULTS = {
+    raid = false,
+    dungeon = false,
+    delve = false,
+    battleground = false,
+    arena = false,
+    openWorld = false,
+    rested = false,
+    petBattle = false,
+    vehicleUI = false,
+}
+
+ST.LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS or {
+    { key = "raid",          label = "Raid" },
+    { key = "dungeon",       label = "Dungeon" },
+    { key = "delve",         label = "Delve" },
+    { key = "battleground",  label = "Battleground" },
+    { key = "arena",         label = "Arena" },
+    { key = "openWorld",     label = "Open World" },
+    { key = "rested",        label = "Rested Area" },
+    { key = "petBattle",     label = "Pet Battle", default = true },
+    { key = "vehicleUI",     label = "Vehicle / Override UI", default = true },
+}
+
 -- LibSharedMedia for font/texture selection
 local LSM = LibStub("LibSharedMedia-3.0")
 
@@ -770,6 +806,18 @@ function CooldownCompanion:IsHeroTalentAllowed(group)
     return effectiveHeroTalents[heroSpecId] == true
 end
 
+function CooldownCompanion:GroupHasUsableButtons(group)
+    if not (group and group.buttons and #group.buttons > 0) then
+        return false
+    end
+    for _, buttonData in ipairs(group.buttons) do
+        if self:IsButtonUsable(buttonData, group) then
+            return true
+        end
+    end
+    return false
+end
+
 function CooldownCompanion:IsGroupActive(groupId, opts)
     opts = opts or {}
     local group = opts.group or self.db.profile.groups[groupId]
@@ -788,16 +836,12 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if container.enabled == false then return false end
         if group.enabled == false then return false end
 
-        -- Container-level load conditions
-        if opts.checkLoadConditions ~= false and not self:CheckLoadConditions(container) then
-            return false
-        end
     else
         -- Legacy path: enabled lives on the group
         if group.enabled == false then return false end
     end
 
-    if opts.requireButtons and (not group.buttons or #group.buttons == 0) then
+    if opts.requireButtons and not self:GroupHasUsableButtons(group) then
         return false
     end
 
@@ -817,9 +861,10 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         return false
     end
 
-    -- Group-level load conditions (for panels, adds to container restrictions)
-    if opts.checkLoadConditions ~= false and not self:CheckLoadConditions(group) then
-        return false
+    if opts.checkLoadConditions ~= false then
+        if not self:IsGroupLoadConditionMet(group) then
+            return false
+        end
     end
 
     return true
@@ -1146,9 +1191,30 @@ function CooldownCompanion:PopulatePanelAnchorTargetDropdown(dropdown, sourceGro
     return eligibleCount
 end
 
-function CooldownCompanion:CheckLoadConditions(group)
-    local lc = group.loadConditions
+function CooldownCompanion:GetDefaultLoadConditions()
+    return CopyTable(LOAD_CONDITION_DEFAULTS)
+end
+
+function CooldownCompanion:GetLocalLoadConditionDefaults()
+    return CopyTable(LOCAL_LOAD_CONDITION_DEFAULTS)
+end
+
+function CooldownCompanion:HasLocalLoadConditions(entity)
+    if not (type(entity) == "table" and type(entity.loadConditions) == "table") then
+        return false
+    end
+    for _, value in pairs(entity.loadConditions) do
+        if value == true then
+            return true
+        end
+    end
+    return false
+end
+
+function CooldownCompanion:EvaluateLoadConditions(loadConditions, defaults)
+    local lc = loadConditions
     if not lc then return true end
+    defaults = defaults or LOAD_CONDITION_DEFAULTS
 
     local instanceType = self._currentInstanceType
 
@@ -1174,16 +1240,82 @@ function CooldownCompanion:CheckLoadConditions(group)
     -- If rested condition is enabled and player is resting, unload
     if lc.rested and self._isResting then return false end
 
-    -- If pet battle condition is enabled and player is in a pet battle, unload
-    -- Default is true (hide during pet battles); nil treated as true since
-    -- AceDB has no per-group metatable defaults for loadConditions sub-keys.
-    if lc.petBattle ~= false and self._inPetBattle then return false end
+    -- If pet battle condition is enabled and player is in a pet battle, unload.
+    -- Group/panel scopes default this on; folder/entry scopes default it off.
+    local petBattle = lc.petBattle
+    if petBattle == nil then petBattle = defaults.petBattle or false end
+    if petBattle and self._inPetBattle then return false end
 
     -- If vehicle/override UI condition is enabled and player is in a vehicle or
-    -- override bar, unload. Default is true; nil treated as true (same as petBattle).
-    if lc.vehicleUI ~= false and self._inVehicleUI then return false end
+    -- override bar, unload. Defaults follow the same scope rules as pet battles.
+    local vehicleUI = lc.vehicleUI
+    if vehicleUI == nil then vehicleUI = defaults.vehicleUI or false end
+    if vehicleUI and self._inVehicleUI then return false end
 
     return true
+end
+
+function CooldownCompanion:CheckLoadConditions(group)
+    return self:EvaluateLoadConditions(group and group.loadConditions)
+end
+
+local function AddLoadConditionSource(sources, label, entity, defaults)
+    if type(entity) == "table" and type(entity.loadConditions) == "table" then
+        sources[#sources + 1] = {
+            label = label,
+            loadConditions = entity.loadConditions,
+            defaults = defaults,
+        }
+    end
+end
+
+function CooldownCompanion:GetInheritedLoadConditionSources(group)
+    local sources = {}
+    local db = self.db and self.db.profile
+    if not (db and group) then return sources end
+
+    local container = self:GetParentContainer(group)
+    if container then
+        local folder = container.folderId and db.folders and db.folders[container.folderId]
+        AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS)
+        AddLoadConditionSource(sources, "Group", container, LOAD_CONDITION_DEFAULTS)
+        return sources
+    end
+
+    local folder = group.folderId and db.folders and db.folders[group.folderId]
+    AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS)
+    return sources
+end
+
+function CooldownCompanion:GetLoadConditionSourcesForGroup(group)
+    local sources = self:GetInheritedLoadConditionSources(group)
+    if group then
+        AddLoadConditionSource(sources, group.parentContainerId and "Panel" or "Group", group, LOAD_CONDITION_DEFAULTS)
+    end
+    return sources
+end
+
+function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
+    local sources = self:GetLoadConditionSourcesForGroup(group)
+    AddLoadConditionSource(sources, "Entry", buttonData, LOCAL_LOAD_CONDITION_DEFAULTS)
+    return sources
+end
+
+function CooldownCompanion:EvaluateLoadConditionSources(sources)
+    for _, source in ipairs(sources or {}) do
+        if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
+            return false, source.label
+        end
+    end
+    return true, nil
+end
+
+function CooldownCompanion:IsGroupLoadConditionMet(group)
+    return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForGroup(group))
+end
+
+function CooldownCompanion:IsButtonLoadConditionMet(buttonData, group)
+    return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForEntry(buttonData, group))
 end
 
 
@@ -1214,8 +1346,10 @@ local function SpellIDsMatchCanonicalForm(storedSpellID, resolvedSpellID)
         and storedBaseSpellID == resolvedBaseSpellID
 end
 
-function CooldownCompanion:IsButtonUsable(buttonData)
+function CooldownCompanion:IsButtonUsable(buttonData, group)
     if buttonData.enabled == false then return false end
+
+    if not self:IsButtonLoadConditionMet(buttonData, group) then return false end
 
     -- Per-button talent condition: gate visibility on a specific talent node.
     if not self:IsTalentConditionMet(buttonData) then return false end
@@ -1303,7 +1437,7 @@ function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
     local usableButtons = {}
     local usableCount = 0
     for _, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData) then
+        if self:IsButtonUsable(buttonData, group) then
             usableCount = usableCount + 1
             usableButtons[usableCount] = buttonData
         end
@@ -1536,7 +1670,10 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
                 self:UnloadGroup(groupId)
             else
                 local frame = self.groupFrames[groupId]
-                if not frame then
+                if frame and self:GroupButtonSetNeedsRebuild(groupId, group) then
+                    self:RefreshGroupFrame(groupId)
+                    frame = self.groupFrames[groupId]
+                elseif not frame then
                     if self:GroupButtonSetNeedsRebuild(groupId, group) then
                         self:DiscardDormantFrame(groupId)
                     end


### PR DESCRIPTION
## What Players Will Notice
- Load conditions can now be configured at every organization level: folders, groups, panels, and individual entries.
- Parent load conditions act as inherited rules, while child levels can add more places to hide without bypassing the parent.
- Folder rows can be selected directly to edit folder settings, with a dedicated collapse arrow handling expand/collapse.
- Entry settings now include a Load Conditions tab, and the Load Conditions / Overrides tab order is cleaner.

## Why This Changed
- Panel-only load conditions made it awkward to express common rules across larger structures or narrow rules for a single entry.
- Treating entry behavior as an override was confusing; the final model is additive inheritance from folder to group to panel to entry.

## What Changed
- Centralized load-condition evaluation and effective source resolution for folder, group, panel, and entry scopes.
- Added folder-level local `loadConditions` and entry-level local `buttonData.loadConditions`, while preserving existing group and panel default pet battle / vehicle behavior.
- Updated panel/entry usability and visibility refresh paths so effective load-condition changes can rebuild entry sets without incorrectly bypassing parent gates.
- Added folder settings UI, inherited load summaries, local load condition controls, diagnostics, and import/export preservation for folder and entry load rules.
- Cleaned up selection state, folder sharing, collapse-arrow atlas naming, and inline folder rename validation found during review.

## Validation
- Ran `luac -p` across 74 Lua files.
- Ran `git diff --check` against `origin/main`.
- Reviewed the branch against `origin/main`; no remaining actionable findings were found after fixes.
- Verified the folder collapse arrow atlas name against `UiTextureAtlasMember` before updating it.
- In-game verification is still required before this leaves draft: out-of-combat context transitions, combat deferral behavior, and restricted/instance contexts.