### PR TITLE
Reduce duplicate cooldown refresh work after cooldown events

### DIFF
--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -255,7 +255,7 @@ local function ForEachAuraLayoutInfo(callback)
 end
 
 function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
-    self._cooldownsDirty = true
+    self:MarkCooldownsDirty()
     if unit == "player" and self._isDracthyr then
         self:InvalidateMountAlphaCache()
     end
@@ -333,7 +333,7 @@ function CooldownCompanion:ClearAuraUnit(unitToken)
             end
         end
     end)
-    self._cooldownsDirty = true
+    self:MarkCooldownsDirty()
 end
 
 function CooldownCompanion:OnTargetChanged()

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -168,14 +168,22 @@ function CooldownCompanion:OnSpellRangeCheckUpdate(event, spellIdentifier, isInR
     if checksRange then
         outOfRange = not isInRange
     end
+    local changed = false
     self:ForEachButton(function(button, bd)
         if bd.type == "spell" and bd.id == spellIdentifier then
-            button._spellOutOfRange = outOfRange
+            if button._spellOutOfRange ~= outOfRange then
+                button._spellOutOfRange = outOfRange
+                changed = true
+            end
         end
     end)
+    if changed then
+        self:MarkCooldownsDirty()
+    end
 end
 
 function CooldownCompanion:OnBagChanged()
+    self:MarkCooldownsDirty()
     self:RefreshChargeFlags("item")
     self:RefreshConfigPanel()
 end
@@ -467,7 +475,7 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
                     end
                 end
             end)
-            self._cooldownsDirty = true
+            self:MarkCooldownsDirty()
         end)
     end
 end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1519,7 +1519,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
         end
     end
 
-    self._cooldownsDirty = true
+    self:MarkCooldownsDirty()
 end
 
 function CooldownCompanion:RefreshAllGroupsForSpellAvailability()

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -101,9 +101,11 @@ function CooldownCompanion:EnsureRuntimeInitialized()
                 self.assistedSpellID = AssistedCombatManager.lastNextCastSpellID
             end
 
-            self:UpdateAllCooldowns()
+            if not self:CanSkipTickerCooldownRefresh() then
+                self:RunCooldownRefresh("ticker")
+            end
             self:UpdateAllGroupLayouts()
-            self._cooldownsDirty = false
+            self:ClearCooldownsDirty()
         end)
     end
 
@@ -201,7 +203,7 @@ function CooldownCompanion:OnEnable()
             if ST._QueueInheritedUnitFrameAlphaResync then
                 ST._QueueInheritedUnitFrameAlphaResync()
             end
-            self._cooldownsDirty = true
+            self:MarkCooldownsDirty()
             self:UpdateAllCooldowns()
         end)
     end
@@ -296,11 +298,32 @@ end
 
 function CooldownCompanion:MarkCooldownsDirty()
     self._cooldownsDirty = true
+    self._cooldownDirtySerial = (self._cooldownDirtySerial or 0) + 1
+end
+
+function CooldownCompanion:ClearCooldownsDirty()
+    self._cooldownsDirty = false
+end
+
+function CooldownCompanion:RunCooldownRefresh(source)
+    self:UpdateAllCooldowns()
+    self._lastCooldownRefreshSerial = self._cooldownDirtySerial or 0
+    self._lastCooldownRefreshSource = source
+end
+
+function CooldownCompanion:CanSkipTickerCooldownRefresh()
+    -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
+    -- target, and other dirty paths keep their normal ticker confirmation.
+    return self._cooldownsDirty
+        and self._lastCooldownRefreshSource == "cooldown-event"
+        and self._lastCooldownRefreshSerial == (self._cooldownDirtySerial or 0)
 end
 
 function CooldownCompanion:OnCooldownStateChanged()
-    self._cooldownsDirty = true
-    self:UpdateAllCooldowns()
+    self:MarkCooldownsDirty()
+    -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
+    -- the next ticker walk when no other dirty state appears afterward.
+    self:RunCooldownRefresh("cooldown-event")
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.
@@ -384,7 +407,7 @@ end
 
 function CooldownCompanion:OnProcGlowHide(event, spellID)
     self.procOverlaySpells[spellID] = nil
-    self._cooldownsDirty = true
+    self:MarkCooldownsDirty()
     self:UpdateAllCooldowns()
 end
 


### PR DESCRIPTION
## What Changed
- Added dirty serial tracking so immediate cooldown-event refreshes can satisfy the next ticker refresh only when no other dirty state arrived afterward.
- Routed aura, target, bag, range, and spell-availability dirty markers through the shared dirty helper so non-cooldown state changes still get their normal ticker confirmation.
- Avoided marking range state dirty when the cached out-of-range value did not actually change.

## Why This Changed
- Cooldown events already force an immediate refresh for accuracy, and the next 0.1s ticker could repeat the same full button pass. This reduces duplicate refresh work without relaxing aura or target confirmation paths.

## Developer Impact
- Centralizes cooldown dirty bookkeeping around helper functions and records the source/serial of the last refresh, making future refresh coalescing decisions less tied to raw `_cooldownsDirty` assignments.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Core\Aura.lua Core\EventHandlers.lua Core\GroupOperations.lua Core\Lifecycle.lua`
- Code review against `origin/main`: no actionable findings.
- Not yet verified in-game under combat or restricted-content conditions.