### PR TITLE
Let each specialization customize Resource Bars independently

### DIFF
--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -1128,10 +1128,22 @@ local function RefreshColumn2()
         if CS.col2ButtonBar then CS.col2ButtonBar:Hide() end
         if col2 and col2._infoBtn then col2._infoBtn:Hide() end
         if not col2 then return end
+        if col2._infoBtn and not col2._defaultInfoOnEnter then
+            col2._defaultInfoOnEnter = col2._infoBtn:GetScript("OnEnter")
+            col2._defaultInfoOnLeave = col2._infoBtn:GetScript("OnLeave")
+        end
 
         -- Update column title based on active bar panel tab
         local col2Title = "Customization: Resources"
-        if CS.barPanelTab == "castbar_anchoring" then
+        if CS.barPanelTab == "resource_anchoring" then
+            local specIdx = C_SpecializationInfo.GetSpecialization()
+            if specIdx then
+                local _, specName = C_SpecializationInfo.GetSpecializationInfo(specIdx)
+                if specName and specName ~= "" then
+                    col2Title = "Customization: Resources (" .. ST._GetClassColoredText(specName) .. ")"
+                end
+            end
+        elseif CS.barPanelTab == "castbar_anchoring" then
             col2Title = "Customization: Cast Bar"
         elseif CS.barPanelTab == "frame_anchoring" then
             col2Title = "Customization: Unit Frames"
@@ -1141,6 +1153,18 @@ local function RefreshColumn2()
         HideAllBarWidgets(col2)
 
         if CS.barPanelTab == "resource_anchoring" then
+            if col2._infoBtn then
+                col2._infoBtn:SetScript("OnEnter", function(self)
+                    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+                    GameTooltip:AddLine("Resource Customization")
+                    GameTooltip:AddLine("Every control in Styling, Layout, Colors, and Health edits the active specialization's Resource Bar customization.", 1, 1, 1, true)
+                    GameTooltip:Show()
+                end)
+                col2._infoBtn:SetScript("OnLeave", function()
+                    GameTooltip:Hide()
+                end)
+                col2._infoBtn:Show()
+            end
             if not col2._resourceStylingTabGroup then
                 local tabGroup = AceGUI:Create("TabGroup")
                 tabGroup:SetLayout("Fill")
@@ -1182,23 +1206,13 @@ local function RefreshColumn2()
                 col2._resourceStylingTabGroup = tabGroup
             end
 
-            -- Build dynamic "Colors: SpecName" tab text (updates on spec change)
-            local colorsTabText = "Colors"
-            local specIdx = C_SpecializationInfo.GetSpecialization()
-            if specIdx then
-                local _, specName = C_SpecializationInfo.GetSpecializationInfo(specIdx)
-                if specName and specName ~= "" then
-                    colorsTabText = "Colors: " .. ST._GetClassColoredText(specName)
-                end
-            end
-
             local rbSettings = CooldownCompanion:GetResourceBarSettings()
             local health = rbSettings and rbSettings.resources and rbSettings.resources[RESOURCE_HEALTH]
             local healthEnabled = health and health.enabled == true
             local tabs = {
                 { value = "bar_text", text = "Styling" },
                 { value = "positioning", text = "Layout" },
-                { value = "colors", text = colorsTabText },
+                { value = "colors", text = "Colors" },
             }
             if healthEnabled then
                 tabs[#tabs + 1] = { value = "health", text = "Health" }
@@ -1290,7 +1304,11 @@ local function RefreshColumn2()
 
     -- Normal mode: hide bars styling scroll and tab groups
     if col2 then HideAllBarWidgets(col2) end
-    if col2 and col2._infoBtn then col2._infoBtn:Show() end
+    if col2 and col2._infoBtn then
+        if col2._defaultInfoOnEnter then col2._infoBtn:SetScript("OnEnter", col2._defaultInfoOnEnter) end
+        if col2._defaultInfoOnLeave then col2._infoBtn:SetScript("OnLeave", col2._defaultInfoOnLeave) end
+        col2._infoBtn:Show()
+    end
 
     CancelDrag()
     CS.HideAutocomplete()

--- a/ConfigSettings/CastBarPanels.lua
+++ b/ConfigSettings/CastBarPanels.lua
@@ -19,10 +19,10 @@ local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggl
 -- CAST BAR SETTINGS PANEL
 ------------------------------------------------------------------------
 
-local function CanShowAttachedCastBarOffsetControls(rbSettings, cbSettings)
+local function CanShowAttachedCastBarOffsetControls(rbSettings, cbSettings, layout)
     return rbSettings
         and rbSettings.enabled
-        and rbSettings.independentAnchorEnabled ~= true
+        and (not layout or layout.independentAnchorEnabled ~= true)
         and cbSettings
         and cbSettings.enabled
         and cbSettings.independentAnchorEnabled ~= true
@@ -35,31 +35,36 @@ local function RefreshAttachedCastBarOffset(refreshConfig)
     end
 end
 
-local function BuildAttachedCastBarOffsetControls(container)
+local function BuildAttachedCastBarOffsetControls(container, layout)
     local rbSettings = CooldownCompanion:GetResourceBarSettings()
     local cbSettings = CooldownCompanion:GetCastBarSettings()
-    if not CanShowAttachedCastBarOffsetControls(rbSettings, cbSettings) then
+    layout = layout or CooldownCompanion:GetSpecLayoutOrder()
+    if not layout or not CanShowAttachedCastBarOffsetControls(rbSettings, cbSettings, layout) then
         return false
     end
+    if type(layout.castBar) ~= "table" then
+        layout.castBar = {}
+    end
+    local castLayout = layout.castBar
 
     local offsetToggle = AceGUI:Create("CheckBox")
     offsetToggle:SetLabel("Enable Cast Bar-Only Y Offset")
-    offsetToggle:SetValue(cbSettings.panelAnchorYOffsetEnabled == true)
+    offsetToggle:SetValue(castLayout.panelAnchorYOffsetEnabled == true)
     offsetToggle:SetFullWidth(true)
     offsetToggle:SetCallback("OnValueChanged", function(widget, event, val)
-        cbSettings.panelAnchorYOffsetEnabled = val == true
+        castLayout.panelAnchorYOffsetEnabled = val == true
         RefreshAttachedCastBarOffset(true)
     end)
     container:AddChild(offsetToggle)
 
-    if cbSettings.panelAnchorYOffsetEnabled then
+    if castLayout.panelAnchorYOffsetEnabled then
         local offsetSlider = AceGUI:Create("Slider")
         offsetSlider:SetLabel("Cast Bar Y Offset")
         offsetSlider:SetSliderValues(-100, 100, 0.1)
-        offsetSlider:SetValue(cbSettings.panelAnchorYOffset or 0)
+        offsetSlider:SetValue(castLayout.panelAnchorYOffset or 0)
         offsetSlider:SetFullWidth(true)
         offsetSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            cbSettings.panelAnchorYOffset = val
+            castLayout.panelAnchorYOffset = val
             RefreshAttachedCastBarOffset(false)
         end)
         HookSliderEditBox(offsetSlider)
@@ -186,19 +191,21 @@ local function BuildCastBarPositioningPanel(container)
 
     if not settings.independentAnchorEnabled then
         local rbSettings = CooldownCompanion:GetResourceBarSettings()
+        local layout = CooldownCompanion:GetSpecLayoutOrder()
         local ySlider = AceGUI:Create("Slider")
         ySlider:SetLabel("Y Offset")
         ySlider:SetSliderValues(-100, 100, 0.1)
-        ySlider:SetValue(rbSettings and rbSettings.yOffset or 3)
+        ySlider:SetValue((layout and (layout.yOffset or layout.verticalXOffset)) or (rbSettings and rbSettings.yOffset) or 3)
         ySlider:SetFullWidth(true)
         ySlider:SetCallback("OnValueChanged", function(widget, event, val)
-            if rbSettings then rbSettings.yOffset = val end
+            if layout then layout.yOffset = val end
             CooldownCompanion:ApplyResourceBars()
+            CooldownCompanion:RepositionCastBar()
             CooldownCompanion:UpdateAnchorStacking()
         end)
         container:AddChild(ySlider)
 
-        BuildAttachedCastBarOffsetControls(container)
+        BuildAttachedCastBarOffsetControls(container, layout)
         return
     end
 

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -1063,10 +1063,11 @@ ST._HookSliderEditBox = HookSliderEditBox
 -- config: table with alpha fields (baselineAlpha, forceAlpha*, forceHide*, fade*, etc.)
 -- refreshFn: function called after value changes (typically RefreshConfigPanel)
 -- collapseKey: string key for CS.collapsedSections
--- opts (optional): { onBaselineChanged = fn(val), isGlobal = bool }
+-- opts (optional): { onBaselineChanged = fn(val), isGlobal = bool, disabled = bool }
 local function BuildAlphaControls(container, config, refreshFn, collapseKey, opts)
     opts = opts or {}
     local tabInfoBtns = CS.tabInfoButtons
+    local controlsDisabled = opts.disabled == true
 
     local alphaHeading = AceGUI:Create("Heading")
     alphaHeading:SetText("Alpha")
@@ -1087,7 +1088,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
     baseAlphaSlider:SetSliderValues(0, 1, 0.1)
     baseAlphaSlider:SetValue(config.baselineAlpha or 1)
     baseAlphaSlider:SetFullWidth(true)
+    baseAlphaSlider:SetDisabled(controlsDisabled)
     baseAlphaSlider:SetCallback("OnValueChanged", function(widget, event, val)
+        if controlsDisabled then return end
         config.baselineAlpha = val
         if opts.onBaselineChanged then
             opts.onBaselineChanged(val)
@@ -1123,7 +1126,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
             cb:SetLabel(TriStateLabel(label, val))
             cb:SetValue(val)
             cb:SetFullWidth(true)
+            cb:SetDisabled(controlsDisabled)
             cb:SetCallback("OnValueChanged", function(widget, event, newVal)
+                if controlsDisabled then return end
                 config[visibleKey] = (newVal == true)
                 config[hiddenKey] = (newVal == nil)
                 refreshFn()
@@ -1147,7 +1152,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
             travelCb:SetLabel("Include Druid Travel Form (applies to both)")
             travelCb:SetValue(travelVal)
             travelCb:SetFullWidth(true)
+            travelCb:SetDisabled(controlsDisabled)
             travelCb:SetCallback("OnValueChanged", function(widget, event, val)
+                if controlsDisabled then return end
                 config.treatTravelFormAsMounted = val
             end)
             container:AddChild(travelCb)
@@ -1158,7 +1165,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         targetCb:SetLabel(targetVal and "Target Exists - |cff00ff00Fully Visible|r" or "Target Exists")
         targetCb:SetValue(targetVal)
         targetCb:SetFullWidth(true)
+        targetCb:SetDisabled(controlsDisabled)
         targetCb:SetCallback("OnValueChanged", function(widget, event, val)
+            if controlsDisabled then return end
             config.forceAlphaTargetExists = val
             refreshFn()
         end)
@@ -1170,7 +1179,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
             enemyOnlyCb:SetLabel("Enemy Only")
             enemyOnlyCb:SetValue(enemyOnlyVal)
             enemyOnlyCb:SetFullWidth(true)
+            enemyOnlyCb:SetDisabled(controlsDisabled)
             enemyOnlyCb:SetCallback("OnValueChanged", function(widget, event, val)
+                if controlsDisabled then return end
                 config.forceAlphaTargetEnemyOnly = val
                 refreshFn()
             end)
@@ -1183,7 +1194,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         mouseoverCb:SetLabel(mouseoverVal and "Mouseover - |cff00ff00Fully Visible|r" or "Mouseover")
         mouseoverCb:SetValue(mouseoverVal)
         mouseoverCb:SetFullWidth(true)
+        mouseoverCb:SetDisabled(controlsDisabled)
         mouseoverCb:SetCallback("OnValueChanged", function(widget, event, val)
+            if controlsDisabled then return end
             config.forceAlphaMouseover = val
             refreshFn()
         end)
@@ -1198,7 +1211,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeCb:SetLabel("Custom Fade Settings")
         fadeCb:SetValue(config.customFade or false)
         fadeCb:SetFullWidth(true)
+        fadeCb:SetDisabled(controlsDisabled)
         fadeCb:SetCallback("OnValueChanged", function(widget, event, val)
+            if controlsDisabled then return end
             config.customFade = val or nil
             refreshFn()
         end)
@@ -1210,7 +1225,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeDelaySlider:SetSliderValues(0, 5, 0.1)
         fadeDelaySlider:SetValue(config.fadeDelay or 1)
         fadeDelaySlider:SetFullWidth(true)
+        fadeDelaySlider:SetDisabled(controlsDisabled)
         fadeDelaySlider:SetCallback("OnValueChanged", function(widget, event, val)
+            if controlsDisabled then return end
             config.fadeDelay = val
         end)
         container:AddChild(fadeDelaySlider)
@@ -1220,7 +1237,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeInSlider:SetSliderValues(0, 5, 0.1)
         fadeInSlider:SetValue(config.fadeInDuration or 0.2)
         fadeInSlider:SetFullWidth(true)
+        fadeInSlider:SetDisabled(controlsDisabled)
         fadeInSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            if controlsDisabled then return end
             config.fadeInDuration = val
         end)
         container:AddChild(fadeInSlider)
@@ -1230,7 +1249,9 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeOutSlider:SetSliderValues(0, 5, 0.1)
         fadeOutSlider:SetValue(config.fadeOutDuration or 0.2)
         fadeOutSlider:SetFullWidth(true)
+        fadeOutSlider:SetDisabled(controlsDisabled)
         fadeOutSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            if controlsDisabled then return end
             config.fadeOutDuration = val
         end)
         container:AddChild(fadeOutSlider)

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -1984,6 +1984,8 @@ local function CreateLayoutDragModel(preview)
         slotData.setOrder(newOrder)
 
         if oldPos ~= lane.side or oldOrder ~= newOrder then
+            CooldownCompanion:ApplyResourceBars()
+            CooldownCompanion:RepositionCastBar()
             CooldownCompanion:UpdateAnchorStacking()
             CooldownCompanion:RefreshConfigPanel()
         end
@@ -2001,14 +2003,15 @@ function ST._BuildLayoutOrderPreviewPanel(container)
     preview.host = container
     preview.rbSettings = CooldownCompanion:GetResourceBarSettings()
     preview.cbSettings = CooldownCompanion:GetCastBarSettings()
-    preview.isVerticalLayout = preview.rbSettings and IsResourceBarVerticalConfig(preview.rbSettings) or false
+    local layout = CooldownCompanion:GetSpecLayoutOrder()
+    preview.isVerticalLayout = preview.rbSettings and IsResourceBarVerticalConfig(preview.rbSettings, layout) or false
 
     ResetPreviewState(preview)
     HidePreviewMessage(preview)
 
     local rbSettings = preview.rbSettings
     local cbSettings = preview.cbSettings
-    local supportsAttachedResourceBars = rbSettings and not IsTruthyConfigFlag(rbSettings.independentAnchorEnabled)
+    local supportsAttachedResourceBars = rbSettings and not (layout and IsTruthyConfigFlag(layout.independentAnchorEnabled))
     local hasAttachedCastBar = cbSettings and cbSettings.enabled and not IsTruthyConfigFlag(cbSettings.independentAnchorEnabled)
     if not supportsAttachedResourceBars and not hasAttachedCastBar then
         SetPreviewMessage(preview, "These settings apply only when Resource Bars or Cast Bar are anchored to a panel.")
@@ -2016,7 +2019,6 @@ function ST._BuildLayoutOrderPreviewPanel(container)
         return
     end
 
-    local layout = CooldownCompanion:GetSpecLayoutOrder()
     if not layout then
         SetPreviewMessage(preview, "Specialization data loading...")
         FinalizePreviewState(preview)

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -1096,7 +1096,8 @@ local function EnsureResourcePreview(frame, slot, preview, width, height)
 
     local barInfo = frame.previewBarInfo
     local rbSettings = preview.rbSettings
-    local segmentGap = rbSettings.segmentGap or 4
+    local layout = preview.layout
+    local segmentGap = (layout and layout.segmentGap) or rbSettings.segmentGap or 4
 
     if slot.kind == "custom" then
         local customBars = CooldownCompanion:GetSpecCustomAuraBars()
@@ -2007,6 +2008,7 @@ function ST._BuildLayoutOrderPreviewPanel(container)
     preview.isVerticalLayout = preview.rbSettings and IsResourceBarVerticalConfig(preview.rbSettings, layout) or false
 
     ResetPreviewState(preview)
+    preview.layout = layout
     HidePreviewMessage(preview)
 
     local rbSettings = preview.rbSettings

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -1165,13 +1165,9 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                         resSettings.textFormat = "percent"
                     end
                 elseif isSegmentedResource then
-                    resSettings.showText = val and true or nil
+                    resSettings.showText = val == true
                 else
-                    if val then
-                        resSettings.showText = nil
-                    else
-                        resSettings.showText = false
-                    end
+                    resSettings.showText = val == true
                 end
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:RefreshConfigPanel()
@@ -1334,7 +1330,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     hideAtZeroCb:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "hideTextAtZero", false) == true)
                     hideAtZeroCb:SetFullWidth(true)
                     hideAtZeroCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        resSettings.hideTextAtZero = val and true or nil
+                        resSettings.hideTextAtZero = val == true
                         CooldownCompanion:ApplyResourceBars()
                     end)
                     container:AddChild(hideAtZeroCb)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -98,6 +98,8 @@ local DEFAULT_ESSENCE_RECHARGING_COLOR = RB.DEFAULT_ESSENCE_RECHARGING_COLOR
 local DEFAULT_ESSENCE_MAX_COLOR = RB.DEFAULT_ESSENCE_MAX_COLOR
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
+local GetResourceSpecOverrideTable = RB.GetResourceSpecOverrideTable
+local RESOURCE_HEALTH_DISPLAY_KEYS = RB.RESOURCE_HEALTH_DISPLAY_KEYS
 
 local function IsHeroSpecProxyCondition(cond)
     return type(cond) == "table"
@@ -134,11 +136,62 @@ local IsResourceBarVerticalConfig = RBP.IsResourceBarVerticalConfig
 local GetResourceThicknessFieldConfig = RBP.GetResourceThicknessFieldConfig
 local GetResourceGapFieldConfig = RBP.GetResourceGapFieldConfig
 
+local function EnsureResourceLayoutAnchor(settings, layout)
+    if type(layout.independentAnchor) ~= "table" then
+        layout.independentAnchor = type(settings.independentAnchor) == "table" and CopyTable(settings.independentAnchor)
+            or { point = "CENTER", relativePoint = "CENTER", x = 0, y = 0 }
+    end
+    layout.independentAnchor.point = layout.independentAnchor.point or "CENTER"
+    layout.independentAnchor.relativePoint = layout.independentAnchor.relativePoint or "CENTER"
+    layout.independentAnchor.x = tonumber(layout.independentAnchor.x) or 0
+    layout.independentAnchor.y = tonumber(layout.independentAnchor.y) or 0
+    if layout.independentAnchorLocked == nil then
+        layout.independentAnchorLocked = settings.independentAnchorLocked
+    end
+    if layout.independentWidth == nil then
+        layout.independentWidth = settings.independentWidth
+    end
+end
+
 local ResolveSpecOverrideKey = ST._ResolveSpecOverrideKey
 local StartDragTracking = ST._StartDragTracking
 local GetDragIndicator = ST._GetDragIndicator
 local HideDragIndicator = ST._HideDragIndicator
 local ResetDragIndicatorStyle = ST._ResetDragIndicatorStyle
+
+local function CopyTableValue(value)
+    return type(value) == "table" and CopyTable(value) or value
+end
+
+local function SeedSpecResourceDisplaySettings(settings, powerType, specID, keys)
+    local specSettings = GetResourceSpecOverrideTable(settings, powerType, specID, true)
+    local baseSettings = settings and settings.resources and settings.resources[powerType]
+    if not specSettings then return baseSettings end
+    if type(baseSettings) == "table" and type(keys) == "table" then
+        for _, key in ipairs(keys) do
+            if specSettings[key] == nil and baseSettings[key] ~= nil then
+                specSettings[key] = CopyTableValue(baseSettings[key])
+            end
+        end
+    end
+    return specSettings
+end
+
+local function ReadDisplaySetting(baseSettings, specSettings, key, fallback)
+    if type(specSettings) == "table" and specSettings[key] ~= nil then
+        return specSettings[key]
+    end
+    if type(baseSettings) == "table" and baseSettings[key] ~= nil then
+        return baseSettings[key]
+    end
+    return fallback
+end
+
+CS._SeedSpecResourceDisplaySettings = SeedSpecResourceDisplaySettings
+CS._ReadResourceDisplaySetting = ReadDisplaySetting
+CS._GetCurrentConfigSpecID = GetCurrentConfigSpecID
+CS._GetSpecResourceDisplayProfile = RB.GetSpecResourceDisplayProfile
+CS._ResourceTextDisplayKeys = RB.RESOURCE_TEXT_DISPLAY_KEYS
 
 local HealthResource = { ID = RB.RESOURCE_HEALTH }
 
@@ -184,6 +237,26 @@ function HealthResource.EnsureSettings(settings)
     return settings.resources[HealthResource.ID]
 end
 
+function HealthResource.EnsureDisplaySettings(settings, specID)
+    local base = HealthResource.EnsureSettings(settings)
+    local health = SeedSpecResourceDisplaySettings(settings, HealthResource.ID, specID, RESOURCE_HEALTH_DISPLAY_KEYS)
+    if not health then return base end
+    if health.showAbsorbs == nil then health.showAbsorbs = base.showAbsorbs ~= false end
+    if health.showHealAbsorbs == nil then health.showHealAbsorbs = base.showHealAbsorbs ~= false end
+    if health.showIncomingHeals == nil then health.showIncomingHeals = base.showIncomingHeals ~= false end
+    if health.showLowHealthAlert == nil then health.showLowHealthAlert = base.showLowHealthAlert == true end
+    if health.healthLowHealthAlertMissingHealthOnly == nil then health.healthLowHealthAlertMissingHealthOnly = base.healthLowHealthAlertMissingHealthOnly == true end
+    if type(health.healthAbsorbColor) ~= "table" then health.healthAbsorbColor = CopyTableValue(base.healthAbsorbColor or DEFAULT_HEALTH_ABSORB_COLOR) end
+    if type(health.healthHealAbsorbColor) ~= "table" then health.healthHealAbsorbColor = CopyTableValue(base.healthHealAbsorbColor or DEFAULT_HEALTH_HEAL_ABSORB_COLOR) end
+    if type(health.healthIncomingHealColor) ~= "table" then health.healthIncomingHealColor = CopyTableValue(base.healthIncomingHealColor or DEFAULT_HEALTH_INCOMING_HEAL_COLOR) end
+    if type(health.healthLowHealthAlertColor) ~= "table" then health.healthLowHealthAlertColor = CopyTableValue(base.healthLowHealthAlertColor or DEFAULT_HEALTH_LOW_HEALTH_ALERT_COLOR) end
+    HealthResource.NormalizeEffectTexture(health, "healthAbsorbTexture")
+    HealthResource.NormalizeEffectTexture(health, "healthHealAbsorbTexture")
+    HealthResource.NormalizeEffectTexture(health, "healthIncomingHealTexture")
+    HealthResource.NormalizeEffectTexture(health, "healthLowHealthAlertTexture")
+    return health
+end
+
 function HealthResource.AddOpacitySlider(container, health, key, label, defaultValue, applyBars)
     local slider = AceGUI:Create("Slider")
     slider:SetLabel(label)
@@ -224,7 +297,15 @@ function HealthResource.AddEffectStyleControls(container, checkbox, health, opti
 end
 
 function HealthResource.BuildColorControls(container, settings, applyBars)
-    local health = HealthResource.EnsureSettings(settings)
+    local specID = GetCurrentConfigSpecID()
+    if not specID then
+        local label = AceGUI:Create("Label")
+        label:SetText("Specialization data loading...")
+        label:SetFullWidth(true)
+        container:AddChild(label)
+        return
+    end
+    local health = HealthResource.EnsureDisplaySettings(settings, specID)
     local fillGradientEnabled = health.healthBarGradient
     if fillGradientEnabled == nil then
         fillGradientEnabled = DEFAULT_HEALTH_BAR_GRADIENT
@@ -460,7 +541,8 @@ CS.healthResourceUI = HealthResource
 local function BuildResourceBarAnchoringPanel(container)
     local db = CooldownCompanion.db.profile
     local settings = CooldownCompanion:GetResourceBarSettings()
-    local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings)
+    local layout = CooldownCompanion:GetSpecLayoutOrder()
+    local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
 
     -- Enable Resource Bars
     local enableCb = AceGUI:Create("CheckBox")
@@ -484,38 +566,15 @@ local function BuildResourceBarAnchoringPanel(container)
     if not settings.enabled then return end
     if not settings.resources then settings.resources = {} end
 
-    local isIndependentStack = settings.independentAnchorEnabled == true
-
-    -- Anchoring Mode dropdown
-    local anchorModeDrop = AceGUI:Create("Dropdown")
-    anchorModeDrop:SetLabel("Anchoring Mode")
-    anchorModeDrop:SetList({
-        attached = "Attached to Panel",
-        independent = "Independent",
-    }, { "attached", "independent" })
-    anchorModeDrop:SetValue(isIndependentStack and "independent" or "attached")
-    anchorModeDrop:SetFullWidth(true)
-    anchorModeDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.independentAnchorEnabled = (val == "independent")
-        CooldownCompanion:EvaluateResourceBars()
-        CooldownCompanion:UpdateAnchorStacking()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    container:AddChild(anchorModeDrop)
-
-    -- Inherit panel alpha (only when attached to panel)
-    if not isIndependentStack then
-        local inheritCb = AceGUI:Create("CheckBox")
-        inheritCb:SetLabel("Inherit panel alpha")
-        inheritCb:SetValue(settings.inheritAlpha)
-        inheritCb:SetFullWidth(true)
-        inheritCb:SetCallback("OnValueChanged", function(widget, event, val)
-            settings.inheritAlpha = val
-            CooldownCompanion:ApplyResourceBars()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        container:AddChild(inheritCb)
+    if not layout then
+        local label = AceGUI:Create("Label")
+        label:SetText("Specialization data loading...")
+        label:SetFullWidth(true)
+        container:AddChild(label)
+        return
     end
+
+    local isIndependentStack = layout.independentAnchorEnabled == true
 
     -- Preview toggle (ephemeral)
     local previewCb = AceGUI:Create("CheckBox")
@@ -600,31 +659,36 @@ local function BuildResourceBarAnchoringPanel(container)
             end)
             container:AddChild(resCb)
 
-            if settings.customBarHeights then
+            if layout.customBarHeights then
                 local advExpanded = AddAdvancedToggle(resCb, "rbHeight_" .. pt, rbHeightAdvBtns, enabled)
                 if advExpanded then
+                    if type(layout.resources[pt]) ~= "table" then
+                        layout.resources[pt] = {}
+                    end
+                    local resLayout = layout.resources[pt]
                     local resHeightSlider = AceGUI:Create("Slider")
                     resHeightSlider:SetLabel(thicknessLabel)
                     resHeightSlider:SetSliderValues(4, 40, 0.1)
                     if thicknessField == "barWidth" then
                         resHeightSlider:SetValue(
-                            settings.resources[pt].barWidth or settings.resources[pt].barHeight
-                            or settings.barWidth or settings.barHeight or 12
+                            resLayout.barWidth or resLayout.barHeight
+                            or layout.barWidth or layout.barHeight or settings.barWidth or settings.barHeight or 12
                         )
                     else
                         resHeightSlider:SetValue(
-                            settings.resources[pt].barHeight or settings.resources[pt].barWidth
-                            or settings.barHeight or settings.barWidth or 12
+                            resLayout.barHeight or resLayout.barWidth
+                            or layout.barHeight or layout.barWidth or settings.barHeight or settings.barWidth or 12
                         )
                     end
                     resHeightSlider:SetFullWidth(true)
                     local capturedPt = pt
                     resHeightSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                        if not settings.resources[capturedPt] then
-                            settings.resources[capturedPt] = {}
+                        if not layout.resources[capturedPt] then
+                            layout.resources[capturedPt] = {}
                         end
-                        settings.resources[capturedPt][thicknessField] = val
+                        layout.resources[capturedPt][thicknessField] = val
                         CooldownCompanion:ApplyResourceBars()
+                        CooldownCompanion:RepositionCastBar()
                         CooldownCompanion:UpdateAnchorStacking()
                     end)
                     container:AddChild(resHeightSlider)
@@ -634,19 +698,21 @@ local function BuildResourceBarAnchoringPanel(container)
     end
 
     -- ============ Alpha Section ============
-    if isIndependentStack or not settings.inheritAlpha then
-        local group = db.groups[CS.selectedGroup]
-        BuildAlphaControls(container, settings, function()
-            CooldownCompanion:ApplyResourceBars()
-            CooldownCompanion:RefreshConfigPanel()
-        end, "rb_alpha", { isGlobal = group and group.isGlobal })
-    end
+    local group = db.groups[CS.selectedGroup]
+    BuildAlphaControls(container, settings, function()
+        CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RefreshConfigPanel()
+    end, "rb_alpha", {
+        isGlobal = group and group.isGlobal,
+        disabled = not isIndependentStack and layout.inheritAlpha == true,
+    })
 end
 
 ------------------------------------------------------------------------
 
 local function BuildResourceBarPositioningPanel(container)
     local settings = CooldownCompanion:GetResourceBarSettings()
+    local layout = CooldownCompanion:GetSpecLayoutOrder()
 
     if not settings.enabled then
         local label = AceGUI:Create("Label")
@@ -656,9 +722,35 @@ local function BuildResourceBarPositioningPanel(container)
         return
     end
 
-    local isVerticalLayout = IsResourceBarVerticalConfig(settings)
-    local gapField, gapLabel = GetResourceGapFieldConfig(settings)
-    local isIndependentStack = settings.independentAnchorEnabled == true
+    if not layout then
+        local label = AceGUI:Create("Label")
+        label:SetText("Specialization data loading...")
+        label:SetFullWidth(true)
+        container:AddChild(label)
+        return
+    end
+
+    local isVerticalLayout = IsResourceBarVerticalConfig(settings, layout)
+    local gapField, gapLabel = GetResourceGapFieldConfig(settings, layout)
+    local isIndependentStack = layout.independentAnchorEnabled == true
+
+    -- Anchoring Mode dropdown
+    local anchorModeDrop = AceGUI:Create("Dropdown")
+    anchorModeDrop:SetLabel("Anchoring Mode")
+    anchorModeDrop:SetList({
+        attached = "Attached to Panel",
+        independent = "Independent",
+    }, { "attached", "independent" })
+    anchorModeDrop:SetValue(isIndependentStack and "independent" or "attached")
+    anchorModeDrop:SetFullWidth(true)
+    anchorModeDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        layout.independentAnchorEnabled = (val == "independent")
+        CooldownCompanion:EvaluateResourceBars()
+        CooldownCompanion:RepositionCastBar()
+        CooldownCompanion:UpdateAnchorStacking()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(anchorModeDrop)
 
     -- Bar Orientation
     local orientDrop = AceGUI:Create("Dropdown")
@@ -667,11 +759,12 @@ local function BuildResourceBarPositioningPanel(container)
         horizontal = "Horizontal",
         vertical = "Vertical",
     }, { "horizontal", "vertical" })
-    orientDrop:SetValue(settings.orientation or "horizontal")
+    orientDrop:SetValue(layout.orientation or settings.orientation or "horizontal")
     orientDrop:SetFullWidth(true)
     orientDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.orientation = val
+        layout.orientation = val
         CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
         CooldownCompanion:RefreshConfigPanel()
     end)
@@ -684,12 +777,13 @@ local function BuildResourceBarPositioningPanel(container)
         bottom_to_top = "Bottom to Top",
         top_to_bottom = "Top to Bottom",
     }, { "bottom_to_top", "top_to_bottom" })
-    fillDirDrop:SetValue(settings.verticalFillDirection or "bottom_to_top")
+    fillDirDrop:SetValue(layout.verticalFillDirection or settings.verticalFillDirection or "bottom_to_top")
     fillDirDrop:SetDisabled(not isVerticalLayout)
     fillDirDrop:SetFullWidth(true)
     fillDirDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.verticalFillDirection = val
+        layout.verticalFillDirection = val
         CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
     end)
     container:AddChild(fillDirDrop)
@@ -698,11 +792,12 @@ local function BuildResourceBarPositioningPanel(container)
     local spacingSlider = AceGUI:Create("Slider")
     spacingSlider:SetLabel("Bar Spacing")
     spacingSlider:SetSliderValues(0, 20, 0.1)
-    spacingSlider:SetValue(settings.barSpacing or 3.6)
+    spacingSlider:SetValue(layout.barSpacing or settings.barSpacing or 3.6)
     spacingSlider:SetFullWidth(true)
     spacingSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.barSpacing = val
+        layout.barSpacing = val
         CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
     end)
     container:AddChild(spacingSlider)
@@ -711,16 +806,16 @@ local function BuildResourceBarPositioningPanel(container)
     local segGapSlider = AceGUI:Create("Slider")
     segGapSlider:SetLabel("Segment Gap")
     segGapSlider:SetSliderValues(0, 20, 0.1)
-    segGapSlider:SetValue(settings.segmentGap or 4)
+    segGapSlider:SetValue(layout.segmentGap or settings.segmentGap or 4)
     segGapSlider:SetFullWidth(true)
     segGapSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.segmentGap = val
+        layout.segmentGap = val
         CooldownCompanion:ApplyResourceBars()
     end)
     container:AddChild(segGapSlider)
 
     -- Bar Height + Custom Heights
-    ST._BuildBarHeightControls(container, settings)
+    ST._BuildBarHeightControls(container, settings, layout)
 
     -- ============ Anchor Settings (independent mode only) ============
     if isIndependentStack then
@@ -739,17 +834,15 @@ local function BuildResourceBarPositioningPanel(container)
         end)
 
         if not stackPosCollapsed then
-            if type(settings.independentAnchor) ~= "table" then
-                settings.independentAnchor = { point = "CENTER", relativePoint = "CENTER", x = 0, y = 0 }
-            end
-            local anchor = settings.independentAnchor
+            EnsureResourceLayoutAnchor(settings, layout)
+            local anchor = layout.independentAnchor
 
             local unlockCb = AceGUI:Create("CheckBox")
             unlockCb:SetLabel("Unlock Placement")
-            unlockCb:SetValue(not settings.independentAnchorLocked)
+            unlockCb:SetValue(not layout.independentAnchorLocked)
             unlockCb:SetFullWidth(true)
             unlockCb:SetCallback("OnValueChanged", function(widget, event, val)
-                settings.independentAnchorLocked = not val
+                layout.independentAnchorLocked = not val
                 CooldownCompanion:ApplyResourceBars()
             end)
             container:AddChild(unlockCb)
@@ -757,10 +850,10 @@ local function BuildResourceBarPositioningPanel(container)
             local widthSlider = AceGUI:Create("Slider")
             widthSlider:SetLabel("Bar Width")
             widthSlider:SetSliderValues(20, 600, 1)
-            widthSlider:SetValue(settings.independentWidth or 200)
+            widthSlider:SetValue(layout.independentWidth or settings.independentWidth or 200)
             widthSlider:SetFullWidth(true)
             widthSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                settings.independentWidth = val
+                layout.independentWidth = val
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:UpdateAnchorStacking()
             end)
@@ -825,23 +918,25 @@ local function BuildResourceBarPositioningPanel(container)
             gapSlider:SetLabel(gapLabel)
             gapSlider:SetSliderValues(-100, 100, 0.1)
             if gapField == "verticalXOffset" then
-                gapSlider:SetValue(settings.verticalXOffset or settings.yOffset or 3)
+                gapSlider:SetValue(layout.verticalXOffset or layout.yOffset or settings.verticalXOffset or settings.yOffset or 3)
             else
-                gapSlider:SetValue(settings.yOffset or settings.verticalXOffset or 3)
+                gapSlider:SetValue(layout.yOffset or layout.verticalXOffset or settings.yOffset or settings.verticalXOffset or 3)
             end
             gapSlider:SetFullWidth(true)
             gapSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                settings[gapField] = val
+                layout[gapField] = val
                 CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:RepositionCastBar()
                 CooldownCompanion:UpdateAnchorStacking()
             end)
             container:AddChild(gapSlider)
 
             if ST._BuildAttachedCastBarOffsetControls then
-                ST._BuildAttachedCastBarOffsetControls(container)
+                ST._BuildAttachedCastBarOffsetControls(container, layout)
             end
         end
     end
+
 end
 
 ------------------------------------------------------------------------
@@ -856,33 +951,49 @@ local function GetResourceBarTextureOptions()
 end
 
 -- Extracted to its own function to keep upvalue counts manageable in the caller.
-local function BuildBarHeightControls(container, settings)
-    local thicknessField, thicknessLabel, customThicknessLabel = GetResourceThicknessFieldConfig(settings)
+local function BuildBarHeightControls(container, settings, layout)
+    layout = layout or settings
+    local thicknessField, thicknessLabel, customThicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
 
     local hSlider = AceGUI:Create("Slider")
     hSlider:SetLabel(thicknessLabel)
     hSlider:SetSliderValues(4, 40, 0.1)
     if thicknessField == "barWidth" then
-        hSlider:SetValue(settings.barWidth or settings.barHeight or 12)
+        hSlider:SetValue(layout.barWidth or layout.barHeight or settings.barWidth or settings.barHeight or 12)
     else
-        hSlider:SetValue(settings.barHeight or settings.barWidth or 12)
+        hSlider:SetValue(layout.barHeight or layout.barWidth or settings.barHeight or settings.barWidth or 12)
     end
     hSlider:SetFullWidth(true)
     hSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        settings[thicknessField] = val
+        layout[thicknessField] = val
         CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
     end)
-    hSlider:SetDisabled(settings.customBarHeights or false)
+    hSlider:SetDisabled(layout.customBarHeights or false)
     container:AddChild(hSlider)
+
+    if layout.independentAnchorEnabled ~= true then
+        local inheritCb = AceGUI:Create("CheckBox")
+        inheritCb:SetLabel("Inherit panel alpha")
+        inheritCb:SetValue(layout.inheritAlpha)
+        inheritCb:SetFullWidth(true)
+        inheritCb:SetCallback("OnValueChanged", function(widget, event, val)
+            layout.inheritAlpha = val == true
+            CooldownCompanion:ApplyResourceBars()
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        container:AddChild(inheritCb)
+    end
 
     local customHeightsCb = AceGUI:Create("CheckBox")
     customHeightsCb:SetLabel(customThicknessLabel)
-    customHeightsCb:SetValue(settings.customBarHeights or false)
+    customHeightsCb:SetValue(layout.customBarHeights or false)
     customHeightsCb:SetFullWidth(true)
     customHeightsCb:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.customBarHeights = val
+        layout.customBarHeights = val
         CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
         CooldownCompanion:RefreshConfigPanel()
     end)
@@ -915,6 +1026,15 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
 
     local applyBars = function() CooldownCompanion:ApplyResourceBars() end
     local healthResourceID = -1 -- Keep aligned with RB.RESOURCE_HEALTH without adding an upvalue here.
+    local displaySpecID = CS._GetCurrentConfigSpecID()
+    local displayProfile = displaySpecID and CS._GetSpecResourceDisplayProfile(settings, displaySpecID) or nil
+    if not displaySpecID or not displayProfile then
+        local label = AceGUI:Create("Label")
+        label:SetText("Specialization data loading...")
+        label:SetFullWidth(true)
+        container:AddChild(label)
+        return
+    end
     local function isHealthTextFormat(textFormat)
         return textFormat == "percent"
             or textFormat == "percent_no_sign"
@@ -929,10 +1049,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
     local texDrop = AceGUI:Create("Dropdown")
     texDrop:SetLabel("Bar Texture")
     texDrop:SetList(GetResourceBarTextureOptions())
-    texDrop:SetValue(settings.barTexture or "Solid")
+    texDrop:SetValue(displayProfile.barTexture or settings.barTexture or "Solid")
     texDrop:SetFullWidth(true)
     texDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.barTexture = val
+        displayProfile.barTexture = val
         CooldownCompanion:ApplyResourceBars()
         -- Defer panel rebuild to next frame so it doesn't interfere with current callback
         C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
@@ -940,21 +1060,21 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
     container:AddChild(texDrop)
 
     -- Brightness slider (only for Blizzard Class texture)
-    if settings.barTexture == "blizzard_class" then
+    if (displayProfile.barTexture or settings.barTexture) == "blizzard_class" then
         local brightSlider = AceGUI:Create("Slider")
         brightSlider:SetLabel("Class Texture Brightness")
         brightSlider:SetSliderValues(0.5, 2.0, 0.1)
-        brightSlider:SetValue(settings.classBarBrightness or 1.3)
+        brightSlider:SetValue(displayProfile.classBarBrightness or settings.classBarBrightness or 1.3)
         brightSlider:SetFullWidth(true)
         brightSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            settings.classBarBrightness = val
+            displayProfile.classBarBrightness = val
             CooldownCompanion:ApplyResourceBars()
         end)
         container:AddChild(brightSlider)
     end
 
     -- Resource Background Color
-    AddColorPicker(container, settings, "backgroundColor", "Resource Background Color", { 0, 0, 0, 0.5 }, true, applyBars)
+    AddColorPicker(container, displayProfile, "backgroundColor", "Resource Background Color", { 0, 0, 0, 0.5 }, true, applyBars)
 
     -- Border Style
     local borderDrop = AceGUI:Create("Dropdown")
@@ -963,26 +1083,26 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
         pixel = "Pixel",
         none = "None",
     }, { "pixel", "none" })
-    borderDrop:SetValue(settings.borderStyle or "pixel")
+    borderDrop:SetValue(displayProfile.borderStyle or settings.borderStyle or "pixel")
     borderDrop:SetFullWidth(true)
     borderDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        settings.borderStyle = val
+        displayProfile.borderStyle = val
         CooldownCompanion:ApplyResourceBars()
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(borderDrop)
 
-    if settings.borderStyle == "pixel" then
-        AddColorPicker(container, settings, "borderColor", "Border Color", { 0, 0, 0, 1 }, true, applyBars)
+    if (displayProfile.borderStyle or settings.borderStyle or "pixel") == "pixel" then
+        AddColorPicker(container, displayProfile, "borderColor", "Border Color", { 0, 0, 0, 1 }, true, applyBars)
 
         local borderSizeSlider = AceGUI:Create("Slider")
         borderSizeSlider:SetLabel("Border Size")
         borderSizeSlider:SetSliderValues(0, 4, 0.1)
-        borderSizeSlider:SetValue(settings.borderSize or 1)
+        borderSizeSlider:SetValue(displayProfile.borderSize or settings.borderSize or 1)
         borderSizeSlider:SetIsPercent(false)
         borderSizeSlider:SetFullWidth(true)
         borderSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            settings.borderSize = val
+            displayProfile.borderSize = val
             CooldownCompanion:ApplyResourceBars()
         end)
         container:AddChild(borderSizeSlider)
@@ -1021,15 +1141,17 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
             elseif not settings.resources[capturedPt] then
                 settings.resources[capturedPt] = {}
             end
-            local resSettings = settings.resources[capturedPt]
+            local baseSettings = settings.resources[capturedPt]
+            local resSettings = CS._SeedSpecResourceDisplaySettings(settings, capturedPt, displaySpecID, CS._ResourceTextDisplayKeys) or baseSettings
             local name = POWER_NAMES[capturedPt] or ("Power " .. capturedPt)
 
             local showTextEnabled
+            local showTextValue = CS._ReadResourceDisplaySetting(baseSettings, resSettings, "showText", nil)
             if isHealthResource or isSegmentedResource then
                 -- Segmented resources and Health are off by default unless explicitly enabled.
-                showTextEnabled = resSettings.showText == true
+                showTextEnabled = showTextValue == true
             else
-                showTextEnabled = resSettings.showText ~= false
+                showTextEnabled = showTextValue ~= false
             end
 
             local cb = AceGUI:Create("CheckBox")
@@ -1037,20 +1159,18 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
             cb:SetValue(showTextEnabled)
             cb:SetFullWidth(true)
             cb:SetCallback("OnValueChanged", function(widget, event, val)
-                if not settings.resources[capturedPt] then settings.resources[capturedPt] = {} end
                 if isHealthResource then
-                    local healthSettings = settings.resources[capturedPt]
-                    healthSettings.showText = val and true or false
-                    if not isHealthTextFormat(healthSettings.textFormat) then
-                        healthSettings.textFormat = "percent"
+                    resSettings.showText = val and true or false
+                    if not isHealthTextFormat(resSettings.textFormat) then
+                        resSettings.textFormat = "percent"
                     end
                 elseif isSegmentedResource then
-                    settings.resources[capturedPt].showText = val and true or nil
+                    resSettings.showText = val and true or nil
                 else
                     if val then
-                        settings.resources[capturedPt].showText = nil
+                        resSettings.showText = nil
                     else
-                        settings.resources[capturedPt].showText = false
+                        resSettings.showText = false
                     end
                 end
                 CooldownCompanion:ApplyResourceBars()
@@ -1096,7 +1216,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     textFormatOrder = { "current", "current_max", "percent" }
                 end
                 textFormatDrop:SetList(textFormatOptions, textFormatOrder)
-                local textFormatValue = resSettings.textFormat or (isHealthResource and "percent" or DEFAULT_RESOURCE_TEXT_FORMAT)
+                local textFormatValue = CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textFormat", isHealthResource and "percent" or DEFAULT_RESOURCE_TEXT_FORMAT)
                 if isHealthResource then
                     if not isHealthTextFormat(textFormatValue) then
                         textFormatValue = "percent"
@@ -1115,21 +1235,21 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 textFormatDrop:SetCallback("OnValueChanged", function(widget, event, val)
                     if isHealthResource then
                         if isHealthTextFormat(val) then
-                            settings.resources[capturedPt].textFormat = val
+                            resSettings.textFormat = val
                         else
-                            settings.resources[capturedPt].textFormat = "percent"
+                            resSettings.textFormat = "percent"
                         end
                     elseif isSegmentedResource then
                         if val == "current" or val == "current_max" then
-                            settings.resources[capturedPt].textFormat = val
+                            resSettings.textFormat = val
                         else
-                            settings.resources[capturedPt].textFormat = DEFAULT_RESOURCE_TEXT_FORMAT
+                            resSettings.textFormat = DEFAULT_RESOURCE_TEXT_FORMAT
                         end
                     else
                         if val == "current" or val == "current_max" or val == "percent" then
-                            settings.resources[capturedPt].textFormat = val
+                            resSettings.textFormat = val
                         else
-                            settings.resources[capturedPt].textFormat = DEFAULT_RESOURCE_TEXT_FORMAT
+                            resSettings.textFormat = DEFAULT_RESOURCE_TEXT_FORMAT
                         end
                     end
                     CooldownCompanion:ApplyResourceBars()
@@ -1139,10 +1259,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 local fontDrop = AceGUI:Create("Dropdown")
                 fontDrop:SetLabel("Font")
                 CS.SetupFontDropdown(fontDrop)
-                fontDrop:SetValue(resSettings.textFont or DEFAULT_RESOURCE_TEXT_FONT)
+                fontDrop:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textFont", DEFAULT_RESOURCE_TEXT_FONT))
                 fontDrop:SetFullWidth(true)
                 fontDrop:SetCallback("OnValueChanged", function(widget, event, val)
-                    settings.resources[capturedPt].textFont = val
+                    resSettings.textFont = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 container:AddChild(fontDrop)
@@ -1150,10 +1270,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 local sizeDrop = AceGUI:Create("Slider")
                 sizeDrop:SetLabel("Font Size")
                 sizeDrop:SetSliderValues(6, 24, 1)
-                sizeDrop:SetValue(resSettings.textFontSize or DEFAULT_RESOURCE_TEXT_SIZE)
+                sizeDrop:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textFontSize", DEFAULT_RESOURCE_TEXT_SIZE))
                 sizeDrop:SetFullWidth(true)
                 sizeDrop:SetCallback("OnValueChanged", function(widget, event, val)
-                    settings.resources[capturedPt].textFontSize = val
+                    resSettings.textFontSize = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 container:AddChild(sizeDrop)
@@ -1161,15 +1281,15 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 local outlineDrop = AceGUI:Create("Dropdown")
                 outlineDrop:SetLabel("Outline")
                 outlineDrop:SetList(CS.outlineOptions)
-                outlineDrop:SetValue(resSettings.textFontOutline or DEFAULT_RESOURCE_TEXT_OUTLINE)
+                outlineDrop:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textFontOutline", DEFAULT_RESOURCE_TEXT_OUTLINE))
                 outlineDrop:SetFullWidth(true)
                 outlineDrop:SetCallback("OnValueChanged", function(widget, event, val)
-                    settings.resources[capturedPt].textFontOutline = val
+                    resSettings.textFontOutline = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 container:AddChild(outlineDrop)
 
-                AddColorPicker(container, settings.resources[capturedPt], "textFontColor", "Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, applyBars)
+                AddColorPicker(container, resSettings, "textFontColor", "Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, applyBars)
 
                 local textAnchorDrop = AceGUI:Create("Dropdown")
                 textAnchorDrop:SetLabel("Text Anchor")
@@ -1178,10 +1298,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     textAnchorValues[pt] = CS.anchorPointLabels[pt]
                 end
                 textAnchorDrop:SetList(textAnchorValues, CS.anchorPoints)
-                textAnchorDrop:SetValue(resSettings.textAnchor or DEFAULT_RESOURCE_TEXT_ANCHOR)
+                textAnchorDrop:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textAnchor", DEFAULT_RESOURCE_TEXT_ANCHOR))
                 textAnchorDrop:SetFullWidth(true)
                 textAnchorDrop:SetCallback("OnValueChanged", function(widget, event, val)
-                    settings.resources[capturedPt].textAnchor = val
+                    resSettings.textAnchor = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 container:AddChild(textAnchorDrop)
@@ -1189,10 +1309,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 local textXSlider = AceGUI:Create("Slider")
                 textXSlider:SetLabel("Text X Offset")
                 textXSlider:SetSliderValues(-50, 50, 0.1)
-                textXSlider:SetValue(resSettings.textXOffset or DEFAULT_RESOURCE_TEXT_X_OFFSET)
+                textXSlider:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textXOffset", DEFAULT_RESOURCE_TEXT_X_OFFSET))
                 textXSlider:SetFullWidth(true)
                 textXSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                    settings.resources[capturedPt].textXOffset = val
+                    resSettings.textXOffset = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 container:AddChild(textXSlider)
@@ -1200,10 +1320,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 local textYSlider = AceGUI:Create("Slider")
                 textYSlider:SetLabel("Text Y Offset")
                 textYSlider:SetSliderValues(-50, 50, 0.1)
-                textYSlider:SetValue(resSettings.textYOffset or DEFAULT_RESOURCE_TEXT_Y_OFFSET)
+                textYSlider:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "textYOffset", DEFAULT_RESOURCE_TEXT_Y_OFFSET))
                 textYSlider:SetFullWidth(true)
                 textYSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                    settings.resources[capturedPt].textYOffset = val
+                    resSettings.textYOffset = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 container:AddChild(textYSlider)
@@ -1211,11 +1331,10 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                 if HIDE_AT_ZERO_ELIGIBLE[capturedPt] then
                     local hideAtZeroCb = AceGUI:Create("CheckBox")
                     hideAtZeroCb:SetLabel("Hide at 0")
-                    hideAtZeroCb:SetValue(resSettings.hideTextAtZero == true)
+                    hideAtZeroCb:SetValue(CS._ReadResourceDisplaySetting(baseSettings, resSettings, "hideTextAtZero", false) == true)
                     hideAtZeroCb:SetFullWidth(true)
                     hideAtZeroCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        if not settings.resources[capturedPt] then settings.resources[capturedPt] = {} end
-                        settings.resources[capturedPt].hideTextAtZero = val and true or nil
+                        resSettings.hideTextAtZero = val and true or nil
                         CooldownCompanion:ApplyResourceBars()
                     end)
                     container:AddChild(hideAtZeroCb)
@@ -1254,14 +1373,9 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
         CooldownCompanion:RefreshConfigPanel()
     end)
 
-    local colorInfoBtn = CreateInfoButton(colorHeading.frame, colorCollapseBtn, "LEFT", "RIGHT", 4, 0, {
-        "Per-Resource Colors",
-        {"Resource colors are saved per specialization.", 1, 1, 1, true},
-    }, colorHeading)
-
     colorHeading.right:ClearAllPoints()
     colorHeading.right:SetPoint("RIGHT", colorHeading.frame, "RIGHT", -3, 0)
-    colorHeading.right:SetPoint("LEFT", colorInfoBtn, "RIGHT", 4, 0)
+    colorHeading.right:SetPoint("LEFT", colorCollapseBtn, "RIGHT", 4, 0)
 
     local _colorSpecID = GetCurrentConfigSpecID()
 
@@ -1280,7 +1394,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
             end
 
             if pt == healthResourceID then
-                -- Health colors are character-level and rendered above.
+                -- Health colors are rendered in the Health tab.
             elseif pt == 4 then
                 -- Combo Points: two color pickers (normal vs at max)
                 local _p4n = { comboColor = ReadSpecOverrideKey(settings, 4, _colorSpecID, "comboColor", DEFAULT_COMBO_COLOR) }
@@ -1417,7 +1531,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
             else
                 local name = POWER_NAMES[pt] or ("Power " .. pt)
 
-                if settings.barTexture == "blizzard_class" and ST.POWER_ATLAS_TYPES and ST.POWER_ATLAS_TYPES[pt] then
+                if (displayProfile.barTexture or settings.barTexture) == "blizzard_class" and ST.POWER_ATLAS_TYPES and ST.POWER_ATLAS_TYPES[pt] then
                     -- Atlas-backed type; color picker not applicable
                 else
                     local capturedGenericPt = pt
@@ -1710,7 +1824,7 @@ local function GetResolvedCustomAuraIndependentOrientation(cab, settings)
     if orientation then
         return orientation
     end
-    return IsResourceBarVerticalConfig(settings) and "vertical" or "horizontal"
+    return IsResourceBarVerticalConfig(settings, CooldownCompanion:GetSpecLayoutOrder()) and "vertical" or "horizontal"
 end
 
 local function EnsureCustomAuraIndependentConfig(cab, settings)
@@ -1962,7 +2076,8 @@ end
 
 local function BuildCustomAuraBarPanel(container, slotIdx)
     local settings = CooldownCompanion:GetResourceBarSettings()
-    local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings)
+    local layout = CooldownCompanion:GetSpecLayoutOrder()
+    local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
     local customBars = CooldownCompanion:GetSpecCustomAuraBars()
     local maxSlots = ST.MAX_CUSTOM_AURA_BARS or 3
     local rbCabTextAdvBtns = {}
@@ -2273,20 +2388,31 @@ local function BuildCustomAuraBarPanel(container, slotIdx)
             end
 
             -- Per-slot bar thickness override
-            if settings.customBarHeights then
+            if layout and layout.customBarHeights then
+                if type(layout.customAuraBarSlots) ~= "table" then
+                    layout.customAuraBarSlots = {}
+                end
+                if type(layout.customAuraBarSlots[capturedIdx]) ~= "table" then
+                    layout.customAuraBarSlots[capturedIdx] = {}
+                end
+                local slotLayout = layout.customAuraBarSlots[capturedIdx]
                 local cabHeightSlider = AceGUI:Create("Slider")
                 cabHeightSlider:SetLabel(thicknessLabel)
                 cabHeightSlider:SetSliderValues(4, 40, 0.1)
                 if thicknessField == "barWidth" then
-                    cabHeightSlider:SetValue(cab.barWidth or cab.barHeight or settings.barWidth or settings.barHeight or 12)
+                    cabHeightSlider:SetValue(slotLayout.barWidth or slotLayout.barHeight or layout.barWidth or layout.barHeight or settings.barWidth or settings.barHeight or 12)
                 else
-                    cabHeightSlider:SetValue(cab.barHeight or cab.barWidth or settings.barHeight or settings.barWidth or 12)
+                    cabHeightSlider:SetValue(slotLayout.barHeight or slotLayout.barWidth or layout.barHeight or layout.barWidth or settings.barHeight or settings.barWidth or 12)
                 end
                 cabHeightSlider:SetFullWidth(true)
                 local cabIdx = capturedIdx
                 cabHeightSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                    customBars[cabIdx][thicknessField] = val
+                    if not layout.customAuraBarSlots[cabIdx] then
+                        layout.customAuraBarSlots[cabIdx] = {}
+                    end
+                    layout.customAuraBarSlots[cabIdx][thicknessField] = val
                     CooldownCompanion:ApplyResourceBars()
+                    CooldownCompanion:RepositionCastBar()
                     CooldownCompanion:UpdateAnchorStacking()
                 end)
                 container:AddChild(cabHeightSlider)
@@ -2912,7 +3038,6 @@ local function BuildLayoutOrderPanel(container)
 
     local rbSettings = CooldownCompanion:GetResourceBarSettings()
     local cbSettings = CooldownCompanion:GetCastBarSettings()
-    local isVerticalLayout = IsResourceBarVerticalConfig(rbSettings)
 
     if not rbSettings or not rbSettings.enabled then
         local label = AceGUI:Create("Label")
@@ -2930,6 +3055,7 @@ local function BuildLayoutOrderPanel(container)
         container:AddChild(label)
         return
     end
+    local isVerticalLayout = IsResourceBarVerticalConfig(rbSettings, layout)
 
     -- Build the ordered list of all active bar slots
     local activeResources = GetConfigActiveResources()
@@ -2964,6 +3090,8 @@ local function BuildLayoutOrderPanel(container)
 
     -- Helper: refresh after any order/position change
     local function ApplyAndRefresh()
+        CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
         CooldownCompanion:RefreshConfigPanel()
     end

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -476,6 +476,9 @@ local function IsResourceAuraOverlayEnabledConfig(resource, specID)
         if type(specData) == "table" and type(specData.auraOverlayEnabled) == "boolean" then
             return specData.auraOverlayEnabled
         end
+        if resource.auraOverlayEnabled == false then
+            return false
+        end
         if type(GetResourceAuraEntryConfig(resource, specID)) == "table" then
             return true
         end

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -465,10 +465,23 @@ local function GetOrCreateResourceAuraEntryConfig(resource, specID)
     return entry
 end
 
-local function IsResourceAuraOverlayEnabledConfig(resource)
+local function IsResourceAuraOverlayEnabledConfig(resource, specID)
     if type(resource) ~= "table" then
         return false
     end
+    if specID then
+        local specData = type(resource.specOverrides) == "table"
+            and (resource.specOverrides[specID] or resource.specOverrides[tostring(specID)])
+            or nil
+        if type(specData) == "table" and type(specData.auraOverlayEnabled) == "boolean" then
+            return specData.auraOverlayEnabled
+        end
+        if type(GetResourceAuraEntryConfig(resource, specID)) == "table" then
+            return true
+        end
+        return false
+    end
+
     if type(resource.auraOverlayEnabled) == "boolean" then
         return resource.auraOverlayEnabled
     end
@@ -756,6 +769,19 @@ local function ClearResourceAuraEntryConfig(powerType, resource, specID)
     if not next(resource.auraOverlayEntries) then
         resource.auraOverlayEntries = nil
     end
+    if type(resource.specOverrides) == "table" then
+        local specData = resource.specOverrides[specID] or resource.specOverrides[tostring(specID)]
+        if type(specData) == "table" then
+            specData.auraOverlayEnabled = nil
+            if not next(specData) then
+                resource.specOverrides[specID] = nil
+                resource.specOverrides[tostring(specID)] = nil
+                if not next(resource.specOverrides) then
+                    resource.specOverrides = nil
+                end
+            end
+        end
+    end
 
     CooldownCompanion:ApplyResourceBars()
     CooldownCompanion:RefreshConfigPanel()
@@ -768,14 +794,23 @@ local function AddResourceAuraOverrideControls(container, settings, powerType, r
     end
     local res = settings.resources[powerType]
     local auraAdvKey = "rbAuraOverlay_" .. powerType
+    local currentSpecID = GetCurrentConfigSpecID()
+    if not currentSpecID then
+        local specUnavailLabel = AceGUI:Create("Label")
+        specUnavailLabel:SetText("Specialization data not yet available.")
+        specUnavailLabel:SetFullWidth(true)
+        container:AddChild(specUnavailLabel)
+        return
+    end
+    local auraOverlayEnabled = IsResourceAuraOverlayEnabledConfig(res, currentSpecID)
 
     local enableAuraOverlayCb = AceGUI:Create("CheckBox")
     enableAuraOverlayCb:SetLabel("Enable " .. resourceName .. " Aura Overlay")
-    enableAuraOverlayCb:SetValue(IsResourceAuraOverlayEnabledConfig(res))
+    enableAuraOverlayCb:SetValue(auraOverlayEnabled)
     enableAuraOverlayCb:SetFullWidth(true)
     enableAuraOverlayCb:SetCallback("OnValueChanged", function(widget, event, val)
         if not settings.resources[powerType] then settings.resources[powerType] = {} end
-        settings.resources[powerType].auraOverlayEnabled = (val == true)
+        WriteSpecOverrideKey(settings, powerType, currentSpecID, "auraOverlayEnabled", val == true)
 
         if val then
             if type(CooldownCompanion.db.profile.showAdvanced) ~= "table" then
@@ -792,20 +827,10 @@ local function AddResourceAuraOverrideControls(container, settings, powerType, r
         enableAuraOverlayCb,
         auraAdvKey,
         auraAdvButtons or tabInfoButtons,
-        IsResourceAuraOverlayEnabledConfig(res)
+        auraOverlayEnabled
     )
 
-    if not IsResourceAuraOverlayEnabledConfig(res) or not auraAdvExpanded then
-        return
-    end
-
-    -- Aura overlay fields are shown for the current spec only; switching specs reconfigures the fields
-    local currentSpecID = GetCurrentConfigSpecID()
-    if not currentSpecID then
-        local specUnavailLabel = AceGUI:Create("Label")
-        specUnavailLabel:SetText("Specialization data not yet available.")
-        specUnavailLabel:SetFullWidth(true)
-        container:AddChild(specUnavailLabel)
+    if not auraOverlayEnabled or not auraAdvExpanded then
         return
     end
 
@@ -946,19 +971,22 @@ end
 -- Simple queries
 ------------------------------------------------------------------------
 
-local function IsResourceBarVerticalConfig(settings)
+local function IsResourceBarVerticalConfig(settings, layout)
+    if layout and layout.orientation ~= nil then
+        return layout.orientation == "vertical"
+    end
     return settings and settings.orientation == "vertical"
 end
 
-local function GetResourceThicknessFieldConfig(settings)
-    if IsResourceBarVerticalConfig(settings) then
+local function GetResourceThicknessFieldConfig(settings, layout)
+    if IsResourceBarVerticalConfig(settings, layout) then
         return "barWidth", "Bar Width", "Custom Resource Bar Widths"
     end
     return "barHeight", "Bar Height", "Custom Resource Bar Heights"
 end
 
-local function GetResourceGapFieldConfig(settings)
-    if IsResourceBarVerticalConfig(settings) then
+local function GetResourceGapFieldConfig(settings, layout)
+    if IsResourceBarVerticalConfig(settings, layout) then
         return "verticalXOffset", "X Offset"
     end
     return "yOffset", "Y Offset"

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -508,6 +508,7 @@ local defaults = {
             },
             customAuraBars = {},
             layoutOrder = {},
+            displayProfiles = {},
             textFont = "Friz Quadrata TT",
             textFontSize = 10,
             textFontOutline = "OUTLINE",

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -116,8 +116,10 @@ function CooldownCompanion:RunAllMigrations()
     self:MigrateStrataOrderExpansion()
     self:MigrateCustomAuraBarSlots5()
     self:MigrateLayoutOrderToSpecKeyed()
+    self:MigrateResourceBarExpandedSpecLayouts()
     self:MigrateBaseSpellResolution()
     self:MigrateSpecColorsToSpecOverrides()
+    self:MigrateResourceBarDisplayProfiles()
     return true
 end
 
@@ -152,7 +154,10 @@ function CooldownCompanion:ClearMigrationSentinels()
     profile._migratedBaseSpells = nil
     profile._migratedIconFillTimerDefaults = nil
     profile._migratedLayoutOrder = nil
+    profile._migratedResourceBarExpandedSpecLayouts = nil
     profile._migratedSpecOverrides = nil
+    profile._migratedResourceBarDisplayProfiles = nil
+    profile._migratedResourceBarDisplayProfilesV2 = nil
 end
 
 function CooldownCompanion:MigrateGroupOwnership()
@@ -1830,6 +1835,140 @@ function CooldownCompanion:MigrateLayoutOrderToSpecKeyed()
     profile._migratedLayoutOrder = true
 end
 
+-- Expand the per-spec resource-bar layout table from ordering-only data into
+-- the single layout profile used by the Layout tab.  Existing global fields are
+-- copied into every same-class spec so a reload preserves the visible layout.
+function CooldownCompanion:MigrateResourceBarExpandedSpecLayouts()
+    local profile = self.db.profile
+    if profile._migratedResourceBarExpandedSpecLayouts then return end
+
+    local _, _, classID = UnitClass("player")
+    if not classID then return end
+
+    local specIDs = {}
+    for i = 1, (C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0) do
+        local specID = GetSpecializationInfoForClassID(classID, i)
+        if specID then
+            specIDs[#specIDs + 1] = specID
+        end
+    end
+    if #specIDs == 0 then return end
+
+    local function SetMissing(tbl, key, value)
+        if tbl[key] == nil then
+            tbl[key] = value
+        end
+    end
+
+    local function EnsureExpandedLayout(rbSettings, cbSettings, specID)
+        if type(rbSettings) ~= "table" then return end
+        rbSettings.specPlacementOverrides = nil
+        if type(rbSettings.layoutOrder) ~= "table" then rbSettings.layoutOrder = {} end
+        if type(rbSettings.layoutOrder[specID]) ~= "table" then
+            rbSettings.layoutOrder[specID] = {
+                resources = {},
+                customAuraBarSlots = {},
+                castBar = { position = "below", order = 2000 },
+            }
+        end
+
+        local layout = rbSettings.layoutOrder[specID]
+        if type(layout.resources) ~= "table" then layout.resources = {} end
+        if type(layout.customAuraBarSlots) ~= "table" then layout.customAuraBarSlots = {} end
+        if type(layout.castBar) ~= "table" then layout.castBar = {} end
+
+        SetMissing(layout, "independentAnchorEnabled", rbSettings.independentAnchorEnabled == true)
+        SetMissing(layout, "orientation", rbSettings.orientation or "horizontal")
+        SetMissing(layout, "verticalFillDirection", rbSettings.verticalFillDirection or "bottom_to_top")
+        SetMissing(layout, "barSpacing", rbSettings.barSpacing or 3.6)
+        SetMissing(layout, "segmentGap", rbSettings.segmentGap or 4)
+        SetMissing(layout, "barHeight", rbSettings.barHeight or 12)
+        SetMissing(layout, "barWidth", rbSettings.barWidth or layout.barHeight or 12)
+        SetMissing(layout, "customBarHeights", rbSettings.customBarHeights == true)
+        SetMissing(layout, "inheritAlpha", rbSettings.inheritAlpha == true)
+        SetMissing(layout, "yOffset", rbSettings.yOffset or 3)
+        SetMissing(layout, "verticalXOffset", rbSettings.verticalXOffset or layout.yOffset or 3)
+        SetMissing(layout, "independentWidth", rbSettings.independentWidth)
+        SetMissing(layout, "independentAnchorLocked", rbSettings.independentAnchorLocked)
+        if layout.independentAnchor == nil and type(rbSettings.independentAnchor) == "table" then
+            layout.independentAnchor = CopyTable(rbSettings.independentAnchor)
+        end
+
+        if type(rbSettings.resources) == "table" then
+            for pt, res in pairs(rbSettings.resources) do
+                if type(res) == "table" then
+                    if type(layout.resources[pt]) ~= "table" then layout.resources[pt] = {} end
+                    local target = layout.resources[pt]
+                    SetMissing(target, "position", res.position)
+                    SetMissing(target, "order", res.order)
+                    SetMissing(target, "verticalPosition", res.verticalPosition)
+                    SetMissing(target, "verticalOrder", res.verticalOrder)
+                    SetMissing(target, "barHeight", res.barHeight)
+                    SetMissing(target, "barWidth", res.barWidth)
+                end
+            end
+        end
+
+        if type(rbSettings.customAuraBarSlots) == "table" then
+            for slotIdx, slot in pairs(rbSettings.customAuraBarSlots) do
+                if type(slot) == "table" then
+                    if type(layout.customAuraBarSlots[slotIdx]) ~= "table" then layout.customAuraBarSlots[slotIdx] = {} end
+                    local target = layout.customAuraBarSlots[slotIdx]
+                    SetMissing(target, "position", slot.position)
+                    SetMissing(target, "order", slot.order)
+                    SetMissing(target, "verticalPosition", slot.verticalPosition)
+                    SetMissing(target, "verticalOrder", slot.verticalOrder)
+                end
+            end
+        end
+
+        local specCustomBars = type(rbSettings.customAuraBars) == "table" and rbSettings.customAuraBars[specID] or nil
+        if type(specCustomBars) == "table" then
+            for slotIdx, cab in pairs(specCustomBars) do
+                if type(cab) == "table" and (cab.barHeight ~= nil or cab.barWidth ~= nil) then
+                    if type(layout.customAuraBarSlots[slotIdx]) ~= "table" then layout.customAuraBarSlots[slotIdx] = {} end
+                    local target = layout.customAuraBarSlots[slotIdx]
+                    SetMissing(target, "barHeight", cab.barHeight)
+                    SetMissing(target, "barWidth", cab.barWidth)
+                end
+            end
+        end
+
+        if type(cbSettings) == "table" then
+            SetMissing(layout.castBar, "position", cbSettings.position or "below")
+            SetMissing(layout.castBar, "order", cbSettings.order or 2000)
+            SetMissing(layout.castBar, "panelAnchorYOffsetEnabled", cbSettings.panelAnchorYOffsetEnabled == true)
+            SetMissing(layout.castBar, "panelAnchorYOffset", cbSettings.panelAnchorYOffset or 0)
+        else
+            SetMissing(layout.castBar, "position", "below")
+            SetMissing(layout.castBar, "order", 2000)
+            SetMissing(layout.castBar, "panelAnchorYOffsetEnabled", false)
+            SetMissing(layout.castBar, "panelAnchorYOffset", 0)
+        end
+    end
+
+    local rbStore = rawget(profile, "resourceBarsByChar")
+    local cbStore = rawget(profile, "castBarByChar")
+    if type(rbStore) == "table" then
+        for charKey, rbSettings in pairs(rbStore) do
+            local cbSettings = type(cbStore) == "table" and cbStore[charKey] or nil
+            for _, specID in ipairs(specIDs) do
+                EnsureExpandedLayout(rbSettings, cbSettings, specID)
+            end
+        end
+    end
+
+    local seed = rawget(profile, "legacyResourceBarsSeed")
+    if type(seed) == "table" then
+        local cbSeed = rawget(profile, "legacyCastBarSeed")
+        for _, specID in ipairs(specIDs) do
+            EnsureExpandedLayout(seed, cbSeed, specID)
+        end
+    end
+
+    profile._migratedResourceBarExpandedSpecLayouts = true
+end
+
 -- Resolve stored spell IDs to their base form so the override chain can
 -- freely transform to any variant at runtime.  Skip items (implicit via
 -- type check), pet spells (may not resolve through GetBaseSpell), and CDM
@@ -1896,5 +2035,185 @@ function CooldownCompanion:MigrateSpecColorsToSpecOverrides()
     end
 
     profile._migratedSpecOverrides = true
+end
+
+-- Copy existing global Resource Bar display choices into the active class's
+-- per-spec display profiles so old profiles preserve their visible styling.
+function CooldownCompanion:MigrateResourceBarDisplayProfiles()
+    local profile = self.db and self.db.profile
+    if not profile then return end
+    if profile._migratedResourceBarDisplayProfilesV2 then return end
+
+    local _, _, classID = UnitClass("player")
+    if not classID then return end
+
+    local specIDs = {}
+    for i = 1, (C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0) do
+        local specID = GetSpecializationInfoForClassID(classID, i)
+        if specID then
+            specIDs[#specIDs + 1] = specID
+        end
+    end
+    if #specIDs == 0 then return end
+
+    local profileKeys = {
+        "barTexture",
+        "classBarBrightness",
+        "backgroundColor",
+        "borderStyle",
+        "borderColor",
+        "borderSize",
+    }
+    local resourceDisplayKeys = {
+        "showText",
+        "textFormat",
+        "textFont",
+        "textFontSize",
+        "textFontOutline",
+        "textFontColor",
+        "textAnchor",
+        "textXOffset",
+        "textYOffset",
+        "hideTextAtZero",
+        "color",
+        "comboColor",
+        "comboMaxColor",
+        "comboChargedColor",
+        "runeReadyColor",
+        "runeRechargingColor",
+        "runeMaxColor",
+        "shardReadyColor",
+        "shardRechargingColor",
+        "shardMaxColor",
+        "holyColor",
+        "holyMaxColor",
+        "chiColor",
+        "chiMaxColor",
+        "arcaneColor",
+        "arcaneMaxColor",
+        "essenceReadyColor",
+        "essenceRechargingColor",
+        "essenceMaxColor",
+        "mwBaseColor",
+        "mwOverlayColor",
+        "mwMaxColor",
+        "staggerGreenColor",
+        "staggerYellowColor",
+        "staggerRedColor",
+        "segThresholdEnabled",
+        "segThresholdValue",
+        "segThresholdColor",
+        "continuousTickEnabled",
+        "continuousTickMode",
+        "continuousTickPercent",
+        "continuousTickAbsolute",
+        "continuousTickColor",
+        "continuousTickCombatOnly",
+        "continuousTickWidth",
+        "healthBarColor",
+        "healthBarOpacity",
+        "healthBarGradient",
+        "healthBarFullColor",
+        "healthBarHalfColor",
+        "healthBarLowColor",
+        "healthBackgroundColor",
+        "healthBackgroundGradient",
+        "healthBackgroundFullColor",
+        "healthBackgroundHalfColor",
+        "healthBackgroundLowColor",
+        "healthBackgroundOpacity",
+        "showAbsorbs",
+        "showHealAbsorbs",
+        "showIncomingHeals",
+        "showLowHealthAlert",
+        "healthAbsorbColor",
+        "healthAbsorbTexture",
+        "healthHealAbsorbColor",
+        "healthHealAbsorbTexture",
+        "healthIncomingHealColor",
+        "healthIncomingHealTexture",
+        "healthLowHealthAlertColor",
+        "healthLowHealthAlertTexture",
+        "healthLowHealthAlertMissingHealthOnly",
+    }
+
+    local function CopyMissingKey(source, target, key)
+        if target[key] == nil and source[key] ~= nil then
+            target[key] = type(source[key]) == "table" and CopyTable(source[key]) or source[key]
+        end
+    end
+
+    local function GetAuraEntryForSpec(resource, specID)
+        if type(resource) ~= "table" or type(resource.auraOverlayEntries) ~= "table" then
+            return nil
+        end
+        return resource.auraOverlayEntries[specID] or resource.auraOverlayEntries[tostring(specID)]
+    end
+
+    local function MigrateSettings(rbSettings)
+        if type(rbSettings) ~= "table" then return end
+        if type(rbSettings.displayProfiles) ~= "table" then
+            rbSettings.displayProfiles = {}
+        end
+
+        for _, specID in ipairs(specIDs) do
+            if type(rbSettings.displayProfiles[specID]) ~= "table" then
+                rbSettings.displayProfiles[specID] = {}
+            end
+            local targetProfile = rbSettings.displayProfiles[specID]
+            for _, key in ipairs(profileKeys) do
+                CopyMissingKey(rbSettings, targetProfile, key)
+            end
+
+            local layout = type(rbSettings.layoutOrder) == "table"
+                and (rbSettings.layoutOrder[specID] or rbSettings.layoutOrder[tostring(specID)])
+                or nil
+            if type(layout) == "table" and layout.inheritAlpha == nil then
+                layout.inheritAlpha = rbSettings.inheritAlpha == true
+            end
+
+            if type(rbSettings.resources) == "table" then
+                for _, resource in pairs(rbSettings.resources) do
+                    if type(resource) == "table" then
+                        if type(resource.specOverrides) ~= "table" then
+                            resource.specOverrides = {}
+                        end
+                        if type(resource.specOverrides[specID]) ~= "table" then
+                            resource.specOverrides[specID] = {}
+                        end
+                        local targetResource = resource.specOverrides[specID]
+                        for _, key in ipairs(resourceDisplayKeys) do
+                            CopyMissingKey(resource, targetResource, key)
+                        end
+                        if targetResource.auraOverlayEnabled == nil then
+                            local hasAuraEntry = type(GetAuraEntryForSpec(resource, specID)) == "table"
+                            if type(resource.auraOverlayEnabled) == "boolean" then
+                                if resource.auraOverlayEnabled == false then
+                                    targetResource.auraOverlayEnabled = false
+                                elseif hasAuraEntry then
+                                    targetResource.auraOverlayEnabled = true
+                                end
+                            elseif hasAuraEntry then
+                                targetResource.auraOverlayEnabled = true
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    MigrateSettings(rawget(profile, "resourceBars"))
+    MigrateSettings(rawget(profile, "legacyResourceBarsSeed"))
+
+    local store = rawget(profile, "resourceBarsByChar")
+    if type(store) == "table" then
+        for _, charSettings in pairs(store) do
+            MigrateSettings(charSettings)
+        end
+    end
+
+    profile._migratedResourceBarDisplayProfiles = true
+    profile._migratedResourceBarDisplayProfilesV2 = true
 end
 

--- a/OtherBars/CastBar.lua
+++ b/OtherBars/CastBar.lua
@@ -66,16 +66,18 @@ local function GetAttachedCastBarPanelYOffset(settings)
     if not settings or settings.independentAnchorEnabled == true then
         return 0
     end
-    if settings.panelAnchorYOffsetEnabled ~= true then
-        return 0
-    end
     local rbSettings = CooldownCompanion:GetResourceBarSettings()
+    local specLayout = CooldownCompanion:GetSpecLayoutOrder()
+    local castLayout = specLayout and specLayout.castBar
     if not rbSettings
         or rbSettings.enabled ~= true
-        or rbSettings.independentAnchorEnabled == true then
+        or (specLayout and specLayout.independentAnchorEnabled == true) then
         return 0
     end
-    return tonumber(settings.panelAnchorYOffset) or 0
+    if not castLayout or castLayout.panelAnchorYOffsetEnabled ~= true then
+        return 0
+    end
+    return tonumber(castLayout.panelAnchorYOffset) or 0
 end
 
 ------------------------------------------------------------------------
@@ -813,10 +815,17 @@ local function ApplyPosition(cb, s, height)
     local cbLayout = specLayout and specLayout.castBar
     local cbPosition = (cbLayout and cbLayout.position) or "below"
     local cbOrder = (cbLayout and cbLayout.order) or 2000
-    local predecessor = CooldownCompanion:GetResourceBarPredecessor(cbPosition, cbOrder)
+    local predecessor = nil
+    if not (specLayout and specLayout.independentAnchorEnabled == true) then
+        predecessor = CooldownCompanion:GetResourceBarPredecessor(cbPosition, cbOrder)
+    end
     local rbSettings = CooldownCompanion:GetResourceBarSettings()
-    local gap = rbSettings and (rbSettings.yOffset or 3) or 3
-    local barSpacing = rbSettings and (rbSettings.barSpacing or 3.6) or 3.6
+    local gap = specLayout and (specLayout.yOffset or specLayout.verticalXOffset)
+        or (rbSettings and (rbSettings.yOffset or rbSettings.verticalXOffset))
+        or 3
+    local barSpacing = specLayout and specLayout.barSpacing
+        or (rbSettings and rbSettings.barSpacing)
+        or 3.6
     local panelYOffset = GetAttachedCastBarPanelYOffset(s)
 
     if predecessor then

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -2974,7 +2974,7 @@ local function PrepareCustomAuraBar(
             elseif fillDirection == "bottom_to_top" then
                 customReverseFill = false
             else
-                customReverseFill = settings.verticalFillDirection == "top_to_bottom"
+                customReverseFill = reverseVerticalFill == true
             end
         else
             customReverseFill = reverseVerticalFill

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -70,6 +70,8 @@ local GetPlayerClassID = RB.GetPlayerClassID
 local GetSpecCustomAuraBars = RB.GetSpecCustomAuraBars
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
 local GetSpecLayoutOrder = RB.GetSpecLayoutOrder
+local GetResourceDisplayValue = RB.GetResourceDisplayValue
+local GetResourceDisplayConfig = RB.GetResourceDisplayConfig
 local GetAnchorOffset = RB.GetAnchorOffset
 local RoundToTenths = RB.RoundToTenths
 local ClampIndependentDimension = RB.ClampIndependentDimension
@@ -926,11 +928,12 @@ end
 -- Independent Stack Anchoring (entire resource bar stack to UIParent)
 ------------------------------------------------------------------------
 
-local function EnsureIndependentStackConfig(settings)
-    if type(settings.independentAnchor) ~= "table" then
-        settings.independentAnchor = {}
+local function EnsureIndependentStackConfig(settings, layout)
+    layout = layout or GetSpecLayoutOrder(settings) or settings
+    if type(layout.independentAnchor) ~= "table" then
+        layout.independentAnchor = type(settings.independentAnchor) == "table" and CopyTable(settings.independentAnchor) or {}
     end
-    local anchor = settings.independentAnchor
+    local anchor = layout.independentAnchor
     anchor.point = anchor.point or "CENTER"
     anchor.relativePoint = anchor.relativePoint or "CENTER"
     anchor.x = tonumber(anchor.x) or 0
@@ -938,17 +941,22 @@ local function EnsureIndependentStackConfig(settings)
     if anchor.relativeTo ~= nil and type(anchor.relativeTo) ~= "string" then
         anchor.relativeTo = nil
     end
-    settings.independentWidth = ClampIndependentDimension(settings.independentWidth, 200)
+    layout.independentWidth = ClampIndependentDimension(layout.independentWidth or settings.independentWidth, 200)
+    if layout.independentAnchorLocked == nil then
+        layout.independentAnchorLocked = settings.independentAnchorLocked
+    end
 end
 
 local function SaveIndependentStackAnchor(refreshConfig)
     if not independentWrapperFrame then return end
     local settings = GetResourceBarSettings()
     if not settings then return end
-    EnsureIndependentStackConfig(settings)
+    local placementSettings = GetSpecLayoutOrder(settings)
+    if not placementSettings then return end
+    EnsureIndependentStackConfig(settings, placementSettings)
 
     local frame = independentWrapperFrame
-    local anchor = settings.independentAnchor
+    local anchor = placementSettings.independentAnchor
 
     local cx, cy = frame:GetCenter()
     local fw, fh = frame:GetSize()
@@ -1040,14 +1048,17 @@ local function CreateIndependentWrapperFrame()
 
         local function DoNudge()
             local settings = GetResourceBarSettings()
-            if not settings or settings.independentAnchorLocked then return end
+            if not settings then return end
+            local placementSettings = GetSpecLayoutOrder(settings)
+            if not placementSettings then return end
+            if placementSettings.independentAnchorLocked then return end
             frame:AdjustPointsOffset(dir.dx, dir.dy)
             -- Write position per step and update coord label (GroupFrame pattern)
             local _, _, _, x, y = frame:GetPoint()
             if x and y then
-                EnsureIndependentStackConfig(settings)
-                settings.independentAnchor.x = RoundToTenths(x)
-                settings.independentAnchor.y = RoundToTenths(y)
+                EnsureIndependentStackConfig(settings, placementSettings)
+                placementSettings.independentAnchor.x = RoundToTenths(x)
+                placementSettings.independentAnchor.y = RoundToTenths(y)
                 if frame._coordLabel then
                     frame._coordLabel.text:SetText(("x:%.1f, y:%.1f"):format(x, y))
                 end
@@ -1092,7 +1103,10 @@ local function CreateIndependentWrapperFrame()
     dragHandle:RegisterForDrag("LeftButton")
     dragHandle:SetScript("OnDragStart", function()
         local settings = GetResourceBarSettings()
-        if not settings or settings.independentAnchorLocked then return end
+        if not settings then return end
+        local placementSettings = GetSpecLayoutOrder(settings)
+        if not placementSettings then return end
+        if placementSettings.independentAnchorLocked then return end
         if InCombatLockdown() then return end
         frame:StartMoving()
     end)
@@ -1104,10 +1118,12 @@ local function CreateIndependentWrapperFrame()
         if button ~= "MiddleButton" then return end
         local settings = GetResourceBarSettings()
         if not settings then return end
-        settings.independentAnchorLocked = true
+        local placementSettings = GetSpecLayoutOrder(settings)
+        if not placementSettings then return end
+        placementSettings.independentAnchorLocked = true
         frame:StopMovingOrSizing()
         SaveIndependentStackAnchor(true)
-        UpdateIndependentStackDragState(settings)
+        UpdateIndependentStackDragState(settings, placementSettings)
     end)
 
     frame._dragHandle = dragHandle
@@ -1116,10 +1132,11 @@ local function CreateIndependentWrapperFrame()
     independentWrapperFrame = frame
 end
 
-UpdateIndependentStackDragState = function(settings)
+UpdateIndependentStackDragState = function(settings, placementSettings)
     if not independentWrapperFrame then return end
     local frame = independentWrapperFrame
-    local unlocked = settings and settings.independentAnchorEnabled and not settings.independentAnchorLocked
+    placementSettings = placementSettings or (settings and GetSpecLayoutOrder(settings)) or settings
+    local unlocked = placementSettings and placementSettings.independentAnchorEnabled == true and not placementSettings.independentAnchorLocked
 
     frame:SetMovable(unlocked or false)
 
@@ -1185,7 +1202,7 @@ end
 
 --- Re-anchor drag handle and coord label to frame the bar content.
 --- Called after containers are positioned and RelayoutBars() completes.
-local function UpdateIndependentStackChrome(isVerticalLayout)
+local function UpdateIndependentStackChrome(isVerticalLayout, placementSettings)
     if not independentWrapperFrame then return end
     if not containerFrameAbove or not containerFrameBelow then return end
     local frame = independentWrapperFrame
@@ -1228,10 +1245,11 @@ local function UpdateIndependentStackChrome(isVerticalLayout)
         end
 
         local settings = GetResourceBarSettings()
-        if settings and settings.independentAnchor then
+        placementSettings = placementSettings or (settings and GetSpecLayoutOrder(settings)) or settings
+        if placementSettings and placementSettings.independentAnchor then
             coordLabel.text:SetText(("x:%.1f, y:%.1f"):format(
-                settings.independentAnchor.x or 0,
-                settings.independentAnchor.y or 0
+                placementSettings.independentAnchor.x or 0,
+                placementSettings.independentAnchor.y or 0
             ))
         end
     end
@@ -1295,7 +1313,7 @@ end
 ------------------------------------------------------------------------
 
 function HealthBar.GetConfig(settings)
-    return settings and settings.resources and settings.resources[RESOURCE_HEALTH] or nil
+    return GetResourceDisplayConfig(settings, RESOURCE_HEALTH)
 end
 
 function HealthBar.GetColor(config, key, fallback)
@@ -3049,19 +3067,20 @@ local function PrepareCustomAuraBar(
         )
     end
     if mode == "continuous" then
-        local barTexture = CooldownCompanion:FetchStatusBar(settings.barTexture or "Solid")
+        local barTextureName = GetResourceDisplayValue(settings, "barTexture", "Solid")
+        local barTexture = CooldownCompanion:FetchStatusBar(barTextureName)
         barInfo.frame:SetStatusBarTexture(barTexture)
         barInfo.frame:SetOrientation(customIsVertical and "VERTICAL" or "HORIZONTAL")
         barInfo.frame:SetReverseFill(customIsVertical and customReverseFill or false)
         barInfo.frame._isVertical = customIsVertical
         barInfo.frame._reverseFill = customReverseFill
-        local bgc = settings.backgroundColor or { 0, 0, 0, 0.5 }
+        local bgc = GetResourceDisplayValue(settings, "backgroundColor", { 0, 0, 0, 0.5 })
         barInfo.frame.bg:ClearAllPoints()
         barInfo.frame.bg:SetAllPoints(barInfo.frame)
         barInfo.frame.bg:SetColorTexture(bgc[1], bgc[2], bgc[3], bgc[4])
-        local borderStyle = settings.borderStyle or "pixel"
-        local borderColor = settings.borderColor or { 0, 0, 0, 1 }
-        local borderSize = settings.borderSize or 1
+        local borderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
+        local borderColor = GetResourceDisplayValue(settings, "borderColor", { 0, 0, 0, 1 })
+        local borderSize = GetResourceDisplayValue(settings, "borderSize", 1)
         if borderStyle == "pixel" then
             ApplyPixelBorders(barInfo.frame.borders, barInfo.frame, borderColor, borderSize)
         else
@@ -3098,9 +3117,9 @@ local function PrepareCustomAuraBar(
 
     if cabConfig.maxStacksGlowEnabled then
         EnsureMaxStacksIndicator(barInfo)
-        local indBorderStyle = settings.borderStyle or "pixel"
-        local indBorderSize = settings.borderSize or 1
-        local indBarTexture = CooldownCompanion:FetchStatusBar(settings.barTexture or "Solid")
+        local indBorderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
+        local indBorderSize = GetResourceDisplayValue(settings, "borderSize", 1)
+        local indBarTexture = CooldownCompanion:FetchStatusBar(GetResourceDisplayValue(settings, "barTexture", "Solid"))
         LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, indBarTexture, indBorderStyle, indBorderSize)
     else
         ClearMaxStacksIndicator(barInfo)
@@ -3308,6 +3327,7 @@ local function EnableLifecycleEvents()
                         if not rebuilt then
                             CooldownCompanion:EvaluateResourceBars()
                         end
+                        CooldownCompanion:RepositionCastBar()
                         CooldownCompanion:UpdateAnchorStacking()
                     end)
                 end
@@ -3416,7 +3436,7 @@ end
 ------------------------------------------------------------------------
 
 local function StyleContinuousBar(bar, powerType, settings)
-    local texName = settings.barTexture or "Solid"
+    local texName = GetResourceDisplayValue(settings, "barTexture", "Solid")
     local isVertical = IsVerticalResourceLayout(settings)
     local reverseFill = IsVerticalFillReversed(settings)
 
@@ -3441,14 +3461,14 @@ local function StyleContinuousBar(bar, powerType, settings)
 
     ApplyContinuousFillColor(bar, powerType, settings, nil)
 
-    local bgc = settings.backgroundColor or { 0, 0, 0, 0.5 }
+    local bgc = GetResourceDisplayValue(settings, "backgroundColor", { 0, 0, 0, 0.5 })
     bar.bg:ClearAllPoints()
     bar.bg:SetAllPoints(bar)
     bar.bg:SetColorTexture(bgc[1], bgc[2], bgc[3], bgc[4])
 
-    local borderStyle = settings.borderStyle or "pixel"
-    local borderColor = settings.borderColor or { 0, 0, 0, 1 }
-    local borderSize = settings.borderSize or 1
+    local borderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
+    local borderColor = GetResourceDisplayValue(settings, "borderColor", { 0, 0, 0, 1 })
+    local borderSize = GetResourceDisplayValue(settings, "borderSize", 1)
 
     if borderStyle == "pixel" then
         ApplyPixelBorders(bar.borders, bar, borderColor, borderSize)
@@ -3457,7 +3477,7 @@ local function StyleContinuousBar(bar, powerType, settings)
     end
 
     -- Text setup
-    local resourceConfig = settings.resources and settings.resources[powerType]
+    local resourceConfig = GetResourceDisplayConfig(settings, powerType)
     local textFormat = resourceConfig and resourceConfig.textFormat or DEFAULT_RESOURCE_TEXT_FORMAT
     if textFormat ~= "current" and textFormat ~= "current_max" and textFormat ~= "percent" then
         textFormat = DEFAULT_RESOURCE_TEXT_FORMAT
@@ -3502,7 +3522,7 @@ end
 
 function HealthBar.Style(bar, settings)
     local resourceConfig = HealthBar.GetConfig(settings)
-    local texName = settings.barTexture or "Solid"
+    local texName = GetResourceDisplayValue(settings, "barTexture", "Solid")
     local isVertical = IsVerticalResourceLayout(settings)
     local reverseFill = IsVerticalFillReversed(settings)
     local texture = CooldownCompanion:FetchStatusBar(texName == "blizzard_class" and "Blizzard" or texName)
@@ -3527,9 +3547,9 @@ function HealthBar.Style(bar, settings)
     HealthBar.SetBackgroundAnchors(bar)
     HealthBar.ApplyBackgroundColor(bar, resourceConfig)
 
-    local borderStyle = settings.borderStyle or "pixel"
-    local borderColor = settings.borderColor or { 0, 0, 0, 1 }
-    local borderSize = settings.borderSize or 1
+    local borderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
+    local borderColor = GetResourceDisplayValue(settings, "borderColor", { 0, 0, 0, 1 })
+    local borderSize = GetResourceDisplayValue(settings, "borderSize", 1)
 
     if borderStyle == "pixel" then
         ApplyPixelBorders(bar.borders, bar, borderColor, borderSize)
@@ -3576,7 +3596,7 @@ local function StyleSegmentedText(holder, powerType, settings)
         return
     end
 
-    local resourceConfig = settings.resources and settings.resources[powerType]
+    local resourceConfig = GetResourceDisplayConfig(settings, powerType)
     local textFormat = resourceConfig and resourceConfig.textFormat or DEFAULT_RESOURCE_TEXT_FORMAT
     if textFormat ~= "current" and textFormat ~= "current_max" then
         textFormat = DEFAULT_RESOURCE_TEXT_FORMAT
@@ -3632,7 +3652,13 @@ function CooldownCompanion:ApplyResourceBars()
         return
     end
 
-    local isIndependentStack = settings.independentAnchorEnabled == true
+    local layout = GetSpecLayoutOrder(settings)
+    if not layout then
+        self:RevertResourceBars()
+        return
+    end
+
+    local isIndependentStack = layout.independentAnchorEnabled == true
     local groupId, groupFrame
 
     if isIndependentStack then
@@ -3698,21 +3724,20 @@ function CooldownCompanion:ApplyResourceBars()
 
     -- Create or recycle bar frames
     local globalBarThickness = GetResourceGlobalThickness(settings)
-    local barSpacing = settings.barSpacing or 3.6
+    local barSpacing = layout.barSpacing or settings.barSpacing or 3.6
     lastAppliedBarSpacing = barSpacing
     lastAppliedBarThickness = globalBarThickness
     lastAppliedOrientation = GetResourceLayoutOrientation(settings)
-    local segmentGap = settings.segmentGap or 4
+    local segmentGap = layout.segmentGap or settings.segmentGap or 4
     local totalPrimaryLength
     if isIndependentStack then
-        EnsureIndependentStackConfig(settings)
-        totalPrimaryLength = settings.independentWidth
+        EnsureIndependentStackConfig(settings, layout)
+        totalPrimaryLength = layout.independentWidth
     else
         totalPrimaryLength = GetResourcePrimaryLength(groupFrame, settings)
     end
 
     -- Determine side/order for each bar (per-spec layout)
-    local layout = GetSpecLayoutOrder(settings)
     local sideList = {}
     local orderList = {}
     local fallbackOrder = 900
@@ -3769,18 +3794,18 @@ function CooldownCompanion:ApplyResourceBars()
 
         -- Resolve per-bar thickness override
         local effectiveThickness = globalBarThickness
-        if settings.customBarHeights then
+        if layout.customBarHeights then
             local thicknessKey = isVerticalLayout and "barWidth" or "barHeight"
             if powerType >= CUSTOM_AURA_BAR_BASE and powerType < CUSTOM_AURA_BAR_BASE + MAX_CUSTOM_AURA_BARS then
                 local cabIdx = powerType - CUSTOM_AURA_BAR_BASE + 1
-                local cab = customBars[cabIdx]
+                local slotLayout = layout.customAuraBarSlots and layout.customAuraBarSlots[cabIdx]
                 if thicknessKey == "barWidth" then
-                    effectiveThickness = (cab and (cab.barWidth or cab.barHeight)) or globalBarThickness
+                    effectiveThickness = (slotLayout and (slotLayout.barWidth or slotLayout.barHeight)) or globalBarThickness
                 else
-                    effectiveThickness = (cab and (cab.barHeight or cab.barWidth)) or globalBarThickness
+                    effectiveThickness = (slotLayout and (slotLayout.barHeight or slotLayout.barWidth)) or globalBarThickness
                 end
             else
-                local res = settings.resources and settings.resources[powerType]
+                local res = layout.resources and layout.resources[powerType]
                 if thicknessKey == "barWidth" then
                     effectiveThickness = (res and (res.barWidth or res.barHeight)) or globalBarThickness
                 else
@@ -3936,7 +3961,7 @@ function CooldownCompanion:ApplyResourceBars()
     activeResources = filtered
 
     -- Layout: per-element positioning using side containers
-    local gap = GetResourceAnchorGap(settings)
+    local gap = GetResourceAnchorGap(settings, layout)
     lastAppliedPrimaryLength = totalPrimaryLength
 
     -- Anchor containers to anchor reference (group frame or independent wrapper)
@@ -3945,7 +3970,7 @@ function CooldownCompanion:ApplyResourceBars()
     if isIndependentStack then
         -- Independent mode: create wrapper frame at saved position, anchor containers to it
         CreateIndependentWrapperFrame()
-        local anchor = settings.independentAnchor
+        local anchor = layout.independentAnchor
         local relFrame = UIParent
         if anchor.relativeTo and anchor.relativeTo ~= "UIParent" then
             relFrame = _G[anchor.relativeTo] or UIParent
@@ -3966,7 +3991,7 @@ function CooldownCompanion:ApplyResourceBars()
             containerFrameBelow:SetPoint("TOP", independentWrapperFrame, "BOTTOM", 0, -gap)
         end
 
-        UpdateIndependentStackDragState(settings)
+        UpdateIndependentStackDragState(settings, layout)
     elseif groupFrame then
         -- Group-relative mode (original behavior)
         HideIndependentWrapperFrame()
@@ -3988,7 +4013,7 @@ function CooldownCompanion:ApplyResourceBars()
 
     -- Anchor drag chrome to frame the content (after containers are sized)
     if isIndependentStack then
-        UpdateIndependentStackChrome(isVerticalLayout)
+        UpdateIndependentStackChrome(isVerticalLayout, layout)
     end
 
     -- Enable OnUpdate
@@ -4019,7 +4044,7 @@ function CooldownCompanion:ApplyResourceBars()
         if #frames > 0 then
             CooldownCompanion:RegisterModuleAlpha(rbModuleId, settings, frames)
         end
-    elseif settings.inheritAlpha and groupFrame then
+    elseif layout.inheritAlpha and groupFrame then
         -- Attached + inheriting: sync to group alpha via 30Hz polling
         CooldownCompanion:UnregisterModuleAlpha(rbModuleId)
 
@@ -4775,7 +4800,8 @@ local function InstallHooks()
     hooksecurefunc(CooldownCompanion, "UpdateGroupLayout", function(self, groupId)
         local s = GetResourceBarSettings()
         if not s or not s.enabled then return end
-        if s.independentAnchorEnabled then return end  -- independent stack: width not tied to group
+        local layout = GetSpecLayoutOrder(s)
+        if layout and layout.independentAnchorEnabled then return end  -- independent stack: width not tied to group
         local anchorGroupId = GetEffectiveAnchorGroupId(s)
         if anchorGroupId ~= groupId then return end
         local groupFrame = CooldownCompanion.groupFrames[groupId]
@@ -4791,7 +4817,8 @@ local function InstallHooks()
     hooksecurefunc(CooldownCompanion, "ResizeGroupFrame", function(self, groupId)
         local s = GetResourceBarSettings()
         if not s or not s.enabled then return end
-        if s.independentAnchorEnabled then return end  -- independent stack: width not tied to group
+        local layout = GetSpecLayoutOrder(s)
+        if layout and layout.independentAnchorEnabled then return end  -- independent stack: width not tied to group
         local anchorGroupId = GetEffectiveAnchorGroupId(s)
         if anchorGroupId ~= groupId then return end
         local groupFrame = CooldownCompanion.groupFrames[groupId]

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -291,13 +291,26 @@ local function ResolveIndependentAnchorTarget(cabConfig, settings)
 end
 
 
+local function ShouldInheritIndependentAlpha(settings)
+    if type(settings) ~= "table" then
+        return false
+    end
+
+    local layout = GetSpecLayoutOrder(settings)
+    if layout and layout.inheritAlpha ~= nil then
+        return layout.inheritAlpha == true
+    end
+
+    return settings.inheritAlpha == true
+end
+
 local function ApplyIndependentAlphaSync(frame, settings, targetFrame)
     if not frame then return end
     if not frame._cdcIndependentAlphaSync then
         frame._cdcIndependentAlphaSync = CreateFrame("Frame", nil, frame)
     end
 
-    if settings and settings.inheritAlpha and targetFrame then
+    if ShouldInheritIndependentAlpha(settings) and targetFrame then
         frame._cdcIndependentAlphaTarget = targetFrame
         frame._cdcIndependentLastAlpha = targetFrame:GetEffectiveAlpha()
         frame:SetAlpha(frame._cdcIndependentLastAlpha)

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -38,16 +38,84 @@ local DRUID_BALANCE_SPEC_ID = 102
 
 local ResolveSpecOverrideKey = ST._ResolveSpecOverrideKey
 
+local RESOURCE_DISPLAY_PROFILE_KEYS = {
+    "barTexture",
+    "classBarBrightness",
+    "backgroundColor",
+    "borderStyle",
+    "borderColor",
+    "borderSize",
+}
+
+local RESOURCE_TEXT_DISPLAY_KEYS = {
+    "showText",
+    "textFormat",
+    "textFont",
+    "textFontSize",
+    "textFontOutline",
+    "textFontColor",
+    "textAnchor",
+    "textXOffset",
+    "textYOffset",
+    "hideTextAtZero",
+}
+
+local RESOURCE_HEALTH_DISPLAY_KEYS = {
+    "healthBarColor",
+    "healthBarOpacity",
+    "healthBarGradient",
+    "healthBarFullColor",
+    "healthBarHalfColor",
+    "healthBarLowColor",
+    "healthBackgroundColor",
+    "healthBackgroundGradient",
+    "healthBackgroundFullColor",
+    "healthBackgroundHalfColor",
+    "healthBackgroundLowColor",
+    "healthBackgroundOpacity",
+    "showAbsorbs",
+    "showHealAbsorbs",
+    "showIncomingHeals",
+    "showLowHealthAlert",
+    "healthAbsorbColor",
+    "healthAbsorbTexture",
+    "healthHealAbsorbColor",
+    "healthHealAbsorbTexture",
+    "healthIncomingHealColor",
+    "healthIncomingHealTexture",
+    "healthLowHealthAlertColor",
+    "healthLowHealthAlertTexture",
+    "healthLowHealthAlertMissingHealthOnly",
+}
+
 ------------------------------------------------------------------------
 -- Layout Helpers
 ------------------------------------------------------------------------
+
+local GetSpecLayoutOrder
 
 local function GetResourceBarSettings()
     return CooldownCompanion:GetResourceBarSettings()
 end
 
+local function GetResourceLayout(settings)
+    if type(settings) ~= "table" then return nil end
+    return GetSpecLayoutOrder and GetSpecLayoutOrder(settings) or nil
+end
+
+local function GetResourceLayoutValue(settings, key, fallback)
+    local layout = GetResourceLayout(settings)
+    if layout and layout[key] ~= nil then
+        return layout[key]
+    end
+    if settings and settings[key] ~= nil then
+        return settings[key]
+    end
+    return fallback
+end
+
 local function IsVerticalResourceLayout(settings)
-    return settings and settings.orientation == "vertical"
+    return GetResourceLayoutValue(settings, "orientation", "horizontal") == "vertical"
 end
 
 local function GetResourceLayoutOrientation(settings)
@@ -58,7 +126,7 @@ local function IsVerticalFillReversed(settings)
     if not IsVerticalResourceLayout(settings) then
         return false
     end
-    return settings.verticalFillDirection == "top_to_bottom"
+    return GetResourceLayoutValue(settings, "verticalFillDirection", "bottom_to_top") == "top_to_bottom"
 end
 
 local function GetResourcePrimaryLength(groupFrame, settings)
@@ -71,16 +139,27 @@ end
 
 local function GetResourceGlobalThickness(settings)
     if IsVerticalResourceLayout(settings) then
-        return settings.barWidth or settings.barHeight or 12
+        return GetResourceLayoutValue(settings, "barWidth")
+            or GetResourceLayoutValue(settings, "barHeight")
+            or 12
     end
-    return settings.barHeight or settings.barWidth or 12
+    return GetResourceLayoutValue(settings, "barHeight")
+        or GetResourceLayoutValue(settings, "barWidth")
+        or 12
 end
 
-local function GetResourceAnchorGap(settings)
+local function GetResourceAnchorGap(settings, layout)
+    layout = layout or GetResourceLayout(settings)
     if IsVerticalResourceLayout(settings) then
-        return settings.verticalXOffset or settings.yOffset or 3
+        return (layout and (layout.verticalXOffset or layout.yOffset))
+            or settings.verticalXOffset
+            or settings.yOffset
+            or 3
     end
-    return settings.yOffset or settings.verticalXOffset or 3
+    return (layout and (layout.yOffset or layout.verticalXOffset))
+        or settings.yOffset
+        or settings.verticalXOffset
+        or 3
 end
 
 local function GetVerticalSideFallback(horizontalSide)
@@ -262,22 +341,188 @@ local function RefreshResourceAuraUnitForSpell(resourceAuraEntry, spellID)
     return EnsureResourceAuraUnit(resourceAuraEntry, resolvedSpellID, GetDefaultResourceAuraUnit(resolvedSpellID), false)
 end
 
-local function CreateDefaultLayoutOrder()
-    return {
+local function CopyIndependentAnchor(anchor)
+    if type(anchor) ~= "table" then
+        return nil
+    end
+    return CopyTable(anchor)
+end
+
+local function SeedResourceLayoutFromGlobal(layout, settings, cbSettings, specID)
+    if type(layout) ~= "table" or type(settings) ~= "table" then
+        return layout
+    end
+
+    if type(layout.resources) ~= "table" then layout.resources = {} end
+    if type(layout.customAuraBarSlots) ~= "table" then layout.customAuraBarSlots = {} end
+    if type(layout.castBar) ~= "table" then layout.castBar = {} end
+
+    if layout.independentAnchorEnabled == nil then
+        layout.independentAnchorEnabled = settings.independentAnchorEnabled == true
+    end
+    if layout.orientation == nil then layout.orientation = settings.orientation or "horizontal" end
+    if layout.verticalFillDirection == nil then layout.verticalFillDirection = settings.verticalFillDirection or "bottom_to_top" end
+    if layout.barSpacing == nil then layout.barSpacing = settings.barSpacing or 3.6 end
+    if layout.segmentGap == nil then layout.segmentGap = settings.segmentGap or 4 end
+    if layout.barHeight == nil then layout.barHeight = settings.barHeight or 12 end
+    if layout.barWidth == nil then layout.barWidth = settings.barWidth or layout.barHeight or 12 end
+    if layout.customBarHeights == nil then layout.customBarHeights = settings.customBarHeights == true end
+    if layout.inheritAlpha == nil then layout.inheritAlpha = settings.inheritAlpha == true end
+    if layout.yOffset == nil then layout.yOffset = settings.yOffset or 3 end
+    if layout.verticalXOffset == nil then layout.verticalXOffset = settings.verticalXOffset or layout.yOffset or 3 end
+    if layout.independentWidth == nil then layout.independentWidth = settings.independentWidth end
+    if layout.independentAnchorLocked == nil then layout.independentAnchorLocked = settings.independentAnchorLocked end
+    if type(layout.independentAnchor) ~= "table" then
+        layout.independentAnchor = CopyIndependentAnchor(settings.independentAnchor)
+    end
+
+    if type(settings.resources) == "table" then
+        for pt, res in pairs(settings.resources) do
+            if type(res) == "table" and (res.barHeight ~= nil or res.barWidth ~= nil) then
+                if type(layout.resources[pt]) ~= "table" then layout.resources[pt] = {} end
+                local target = layout.resources[pt]
+                if target.barHeight == nil then target.barHeight = res.barHeight end
+                if target.barWidth == nil then target.barWidth = res.barWidth end
+            end
+        end
+    end
+
+    if specID and type(settings.customAuraBars) == "table" and type(settings.customAuraBars[specID]) == "table" then
+        for slotIdx, cab in pairs(settings.customAuraBars[specID]) do
+            if type(cab) == "table" and (cab.barHeight ~= nil or cab.barWidth ~= nil) then
+                if type(layout.customAuraBarSlots[slotIdx]) ~= "table" then layout.customAuraBarSlots[slotIdx] = {} end
+                local target = layout.customAuraBarSlots[slotIdx]
+                if target.barHeight == nil then target.barHeight = cab.barHeight end
+                if target.barWidth == nil then target.barWidth = cab.barWidth end
+            end
+        end
+    end
+
+    if type(cbSettings) ~= "table" and CooldownCompanion.GetCastBarSettings then
+        cbSettings = CooldownCompanion:GetCastBarSettings()
+    end
+    if type(cbSettings) == "table" then
+        if layout.castBar.position == nil then layout.castBar.position = cbSettings.position or "below" end
+        if layout.castBar.order == nil then layout.castBar.order = cbSettings.order or 2000 end
+        if layout.castBar.panelAnchorYOffsetEnabled == nil then
+            layout.castBar.panelAnchorYOffsetEnabled = cbSettings.panelAnchorYOffsetEnabled == true
+        end
+        if layout.castBar.panelAnchorYOffset == nil then
+            layout.castBar.panelAnchorYOffset = cbSettings.panelAnchorYOffset or 0
+        end
+    else
+        if layout.castBar.position == nil then layout.castBar.position = "below" end
+        if layout.castBar.order == nil then layout.castBar.order = 2000 end
+        if layout.castBar.panelAnchorYOffsetEnabled == nil then layout.castBar.panelAnchorYOffsetEnabled = false end
+        if layout.castBar.panelAnchorYOffset == nil then layout.castBar.panelAnchorYOffset = 0 end
+    end
+
+    return layout
+end
+
+local function CreateDefaultLayoutOrder(settings, cbSettings, specID)
+    return SeedResourceLayoutFromGlobal({
         resources = {},
         customAuraBarSlots = {},
         castBar = { position = "below", order = 2000 },
-    }
+    }, settings, cbSettings, specID)
 end
 
-local function GetSpecLayoutOrder(settings)
-    local specID = GetCurrentSpecID()
+GetSpecLayoutOrder = function(settings, specID)
+    if type(settings) ~= "table" then return nil end
+    specID = specID or GetCurrentSpecID()
     if not specID then return nil end
+    specID = tonumber(specID) or specID
     if not settings.layoutOrder then settings.layoutOrder = {} end
-    if not settings.layoutOrder[specID] then
-        settings.layoutOrder[specID] = CreateDefaultLayoutOrder()
+    if type(settings.layoutOrder[specID]) ~= "table" then
+        settings.layoutOrder[specID] = CreateDefaultLayoutOrder(settings, nil, specID)
+    else
+        SeedResourceLayoutFromGlobal(settings.layoutOrder[specID], settings, nil, specID)
     end
     return settings.layoutOrder[specID]
+end
+
+local function SeedResourceDisplayProfileFromGlobal(profile, settings)
+    if type(profile) ~= "table" or type(settings) ~= "table" then
+        return profile
+    end
+    for _, key in ipairs(RESOURCE_DISPLAY_PROFILE_KEYS) do
+        if profile[key] == nil then
+            local value = settings[key]
+            profile[key] = type(value) == "table" and CopyTable(value) or value
+        end
+    end
+    if profile.barTexture == nil then profile.barTexture = "Solid" end
+    if profile.backgroundColor == nil then profile.backgroundColor = { 0, 0, 0, 0.5 } end
+    if profile.borderStyle == nil then profile.borderStyle = "pixel" end
+    if profile.borderColor == nil then profile.borderColor = { 0, 0, 0, 1 } end
+    if profile.borderSize == nil then profile.borderSize = 1 end
+    if profile.classBarBrightness == nil then profile.classBarBrightness = 1.3 end
+    return profile
+end
+
+local function GetSpecResourceDisplayProfile(settings, specID)
+    if type(settings) ~= "table" then return nil end
+    specID = specID or GetCurrentSpecID()
+    if not specID then return nil end
+    specID = tonumber(specID) or specID
+    if type(settings.displayProfiles) ~= "table" then
+        settings.displayProfiles = {}
+    end
+    if type(settings.displayProfiles[specID]) ~= "table" then
+        settings.displayProfiles[specID] = {}
+    end
+    return SeedResourceDisplayProfileFromGlobal(settings.displayProfiles[specID], settings)
+end
+
+local function GetResourceDisplayValue(settings, key, fallback)
+    local profile = GetSpecResourceDisplayProfile(settings)
+    if profile and profile[key] ~= nil then
+        return profile[key]
+    end
+    if settings and settings[key] ~= nil then
+        return settings[key]
+    end
+    return fallback
+end
+
+local function GetResourceDisplayConfig(settings, powerType)
+    local resource = settings and settings.resources and settings.resources[powerType]
+    if type(resource) ~= "table" then return nil end
+    local specID = GetCurrentSpecID()
+    if not specID then return resource end
+    local resolved = CopyTable(resource)
+    local specOverrides = resource.specOverrides
+    local specData = type(specOverrides) == "table" and (specOverrides[specID] or specOverrides[tostring(specID)]) or nil
+    if type(specData) == "table" then
+        for key, value in pairs(specData) do
+            resolved[key] = value
+        end
+    end
+    return resolved
+end
+
+local function GetResourceSpecOverrideTable(settings, powerType, specID, create)
+    if type(settings) ~= "table" or not specID then return nil end
+    specID = tonumber(specID) or specID
+    if type(settings.resources) ~= "table" then
+        if not create then return nil end
+        settings.resources = {}
+    end
+    if type(settings.resources[powerType]) ~= "table" then
+        if not create then return nil end
+        settings.resources[powerType] = {}
+    end
+    local resource = settings.resources[powerType]
+    if type(resource.specOverrides) ~= "table" then
+        if not create then return nil end
+        resource.specOverrides = {}
+    end
+    if type(resource.specOverrides[specID]) ~= "table" then
+        if not create then return nil end
+        resource.specOverrides[specID] = {}
+    end
+    return resource.specOverrides[specID]
 end
 
 local function GetAnchorOffset(point, width, height)
@@ -734,6 +979,13 @@ RB.EnsureResourceAuraUnit = EnsureResourceAuraUnit
 RB.RefreshResourceAuraUnitForSpell = RefreshResourceAuraUnitForSpell
 RB.CreateDefaultLayoutOrder = CreateDefaultLayoutOrder
 RB.GetSpecLayoutOrder = GetSpecLayoutOrder
+RB.SeedResourceLayoutFromGlobal = SeedResourceLayoutFromGlobal
+RB.GetSpecResourceDisplayProfile = GetSpecResourceDisplayProfile
+RB.GetResourceDisplayValue = GetResourceDisplayValue
+RB.GetResourceDisplayConfig = GetResourceDisplayConfig
+RB.GetResourceSpecOverrideTable = GetResourceSpecOverrideTable
+RB.RESOURCE_TEXT_DISPLAY_KEYS = RESOURCE_TEXT_DISPLAY_KEYS
+RB.RESOURCE_HEALTH_DISPLAY_KEYS = RESOURCE_HEALTH_DISPLAY_KEYS
 RB.GetAnchorOffset = GetAnchorOffset
 RB.RoundToTenths = RoundToTenths
 RB.ClampIndependentDimension = ClampIndependentDimension

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -143,6 +143,9 @@ local function IsResourceAuraOverlayEnabled(resource)
         if type(specData) == "table" and type(specData.auraOverlayEnabled) == "boolean" then
             return specData.auraOverlayEnabled
         end
+        if resource.auraOverlayEnabled == false then
+            return false
+        end
         return type(GetResourceAuraEntry(resource, specID)) == "table"
     end
 

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -29,9 +29,14 @@ local IsVerticalFillReversed = RB.IsVerticalFillReversed
 local GetCurrentSpecID = RB.GetCurrentSpecID
 local GetResourceColors = RB.GetResourceColors
 local GetContinuousTickConfig = RB.GetContinuousTickConfig
+local GetSpecResourceDisplayProfile = RB.GetSpecResourceDisplayProfile
 local GetSafeRGBColor = RB.GetSafeRGBColor
 local SupportsResourceAuraStackMode = RB.SupportsResourceAuraStackMode
 local GetResolvedResourceAuraUnit = RB.GetResolvedResourceAuraUnit
+
+local function GetResourceDisplayStyle(settings)
+    return GetSpecResourceDisplayProfile and GetSpecResourceDisplayProfile(settings) or settings
+end
 
 ------------------------------------------------------------------------
 -- Resource Aura Overlay
@@ -130,6 +135,17 @@ local function IsResourceAuraOverlayEnabled(resource)
     if type(resource) ~= "table" then
         return false
     end
+    local specID = GetCurrentSpecID()
+    if specID then
+        local specData = type(resource.specOverrides) == "table"
+            and (resource.specOverrides[specID] or resource.specOverrides[tostring(specID)])
+            or nil
+        if type(specData) == "table" and type(specData.auraOverlayEnabled) == "boolean" then
+            return specData.auraOverlayEnabled
+        end
+        return type(GetResourceAuraEntry(resource, specID)) == "table"
+    end
+
     if type(resource.auraOverlayEnabled) == "boolean" then
         return resource.auraOverlayEnabled
     end
@@ -230,9 +246,10 @@ end
 
 local function LayoutResourceAuraStackSegments(holder, settings, orientationOverride, reverseFillOverride)
     if not holder or not holder.auraStackSegments or not holder.segments then return end
-    local barTexture = CooldownCompanion:FetchStatusBar(settings and settings.barTexture or "Solid")
-    local borderStyle = settings and settings.borderStyle or "pixel"
-    local borderSize = settings and settings.borderSize or 1
+    local style = GetResourceDisplayStyle(settings)
+    local barTexture = CooldownCompanion:FetchStatusBar(style and style.barTexture or "Solid")
+    local borderStyle = style and style.borderStyle or "pixel"
+    local borderSize = style and style.borderSize or 1
     local isVertical
     if orientationOverride == "vertical" then
         isVertical = true
@@ -379,8 +396,9 @@ local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, ma
     local marker = bar.tickMarker
     marker:SetColorTexture(tickColor[1], tickColor[2], tickColor[3], tickColor[4] ~= nil and tickColor[4] or 1)
 
-    local borderStyle = settings and settings.borderStyle or "pixel"
-    local borderSize = (borderStyle == "pixel") and (settings.borderSize or 1) or 0
+    local style = GetResourceDisplayStyle(settings)
+    local borderStyle = style and style.borderStyle or "pixel"
+    local borderSize = (borderStyle == "pixel") and (style and style.borderSize or 1) or 0
     local width = bar:GetWidth() or 0
     local height = bar:GetHeight() or 0
     if width <= 0 or height <= 0 then
@@ -417,7 +435,8 @@ end
 local function ApplyContinuousFillColor(bar, powerType, settings, overrideColor)
     if not bar or not settings then return end
 
-    local texName = settings.barTexture or "Solid"
+    local style = GetResourceDisplayStyle(settings)
+    local texName = style and style.barTexture or "Solid"
     local atlasInfo = (texName == "blizzard_class") and POWER_ATLAS_INFO[powerType] or nil
     if atlasInfo then
         if overrideColor then
@@ -426,7 +445,7 @@ local function ApplyContinuousFillColor(bar, powerType, settings, overrideColor)
             return
         end
 
-        local brightness = settings.classBarBrightness or 1.3
+        local brightness = style and style.classBarBrightness or 1.3
         bar:SetStatusBarColor(1, 1, 1, 1)
         if brightness > 1.0 then
             bar.brightnessOverlay:SetAlpha(brightness - 1.0)
@@ -760,11 +779,12 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
     local n = #holder.segments
     if n == 0 then return end
 
-    local barTexture = CooldownCompanion:FetchStatusBar(settings and settings.barTexture or "Solid")
-    local bgColor = settings and settings.backgroundColor or { 0, 0, 0, 0.5 }
-    local borderStyle = settings and settings.borderStyle or "pixel"
-    local borderColor = settings and settings.borderColor or { 0, 0, 0, 1 }
-    local borderSize = settings and settings.borderSize or 1
+    local style = GetResourceDisplayStyle(settings)
+    local barTexture = CooldownCompanion:FetchStatusBar(style and style.barTexture or "Solid")
+    local bgColor = style and style.backgroundColor or { 0, 0, 0, 0.5 }
+    local borderStyle = style and style.borderStyle or "pixel"
+    local borderColor = style and style.borderColor or { 0, 0, 0, 1 }
+    local borderSize = style and style.borderSize or 1
     local isVertical
     if orientationOverride == "vertical" then
         isVertical = true
@@ -892,11 +912,12 @@ end
 local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, settings, halfSegments, orientationOverride, reverseFillOverride)
     if not holder or not holder.segments then return end
 
-    local barTexture = CooldownCompanion:FetchStatusBar(settings and settings.barTexture or "Solid")
-    local bgColor = settings and settings.backgroundColor or { 0, 0, 0, 0.5 }
-    local borderStyle = settings and settings.borderStyle or "pixel"
-    local borderColor = settings and settings.borderColor or { 0, 0, 0, 1 }
-    local borderSize = settings and settings.borderSize or 1
+    local style = GetResourceDisplayStyle(settings)
+    local barTexture = CooldownCompanion:FetchStatusBar(style and style.barTexture or "Solid")
+    local bgColor = style and style.backgroundColor or { 0, 0, 0, 0.5 }
+    local borderStyle = style and style.borderStyle or "pixel"
+    local borderColor = style and style.borderColor or { 0, 0, 0, 1 }
+    local borderSize = style and style.borderSize or 1
     local isVertical
     if orientationOverride == "vertical" then
         isVertical = true


### PR DESCRIPTION
## What Players Will Notice
- Resource Bar customization is now scoped to the active specialization, so each spec can keep its own Resource Bar layout, styling, colors, and Health display settings.
- The Resource customization column now shows the active spec in the column header while the tabs use plain labels: Styling, Layout, Colors, and Health.
- Layout changes such as attached vs. independent mode, offsets, ordering, sizing, spacing, segment gap, and attached Cast Bar placement can differ between specs.
- Styling, resource text, per-resource colors, threshold/tick markers, aura overlays, and Health visuals can also differ per spec.

## Why This Changed
- Some specs need different Resource Bar placement or presentation to coexist cleanly with third-party addons or spec-specific UI setups.
- The old mix of global Resource Bar settings plus a few spec-scoped pieces made the config model harder to reason about once Layout, Colors, Styling, and Health all lived together in the same customization column.

## What Changed
- Expanded the per-spec Resource Bar layout profile so runtime placement, layout preview, independent dragging, attached offsets, resource order, custom aura bar sizing, alpha inheritance, and attached Cast Bar positioning all resolve through the active spec layout.
- Added per-spec Resource Bar display profiles for styling and display behavior, while preserving global setup data such as resource enablement and custom aura definitions.
- Routed Resource Bar rendering, text styling, color resolution, Health effect styling, and aura overlay enablement through active-spec resolvers.
- Added migrations that seed each same-class spec from existing global settings so existing profiles keep their visible layout and appearance after reload.
- Removed the temporary spec-copy UI from the customization column; the existing character-copy badge behavior is left unchanged for a later cleanup pass.

## Validation
- Ran `luac -p` across 121 Lua files.
- Ran `git diff --check origin/main...HEAD`.
- Reviewed the branch against `origin/main` and fixed follow-up issues for layout preview segment gap, per-spec text toggle fallback, independent custom aura alpha inheritance, and disabled aura overlay fallback.
- In-game combat and restricted-content validation has not been performed yet, so Resource Bars and attached Cast Bar placement still need a live smoke test before treating this as fully verified.