### PR TITLE
Restore folder selection and collapse controls

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -16,6 +16,7 @@ local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
 local ApplyConfigTextRow = ST._ApplyConfigTextRow
 local SetupGroupRowIndicators = ST._SetupGroupRowIndicators
 local SetupFolderRowIndicators = ST._SetupFolderRowIndicators
+local GetConfigRowBadgeReserve = ST._GetConfigRowBadgeReserve
 local SetupColumn1MarkerRow = ST._SetupColumn1MarkerRow
 local GetGroupIcon = ST._GetGroupIcon
 local GetContainerIcon = ST._GetContainerIcon
@@ -1546,22 +1547,20 @@ local function RefreshColumn1(preserveDrag)
 
         local isCollapsed = CS.collapsedFolders[folderId]
         local function ToggleFolderCollapsed()
-            CS.selectedFolder = nil
             CS.collapsedFolders[folderId] = not CS.collapsedFolders[folderId]
             CooldownCompanion:RefreshConfigPanel()
         end
-        local collapseTag = isCollapsed
-            and "  |A:common-icon-plus:10:10|a"
-            or "  |A:common-icon-minus:10:10|a"
 
         local entry = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(entry)
-        entry:SetText(folder.name .. collapseTag)
+        entry:SetText(folder.name)
         entry:SetFullWidth(true)
         entry:SetFontObject(GameFontHighlight)
         ApplyConfigRowIcon(entry, GetFolderIcon(folderId, db))
         local allChildrenInactive = IsFolderFullyInactive(folderId, childContainerIds)
-        if allChildrenInactive then
+        if CS.selectedFolder == folderId and not CS.selectedContainer and not CS.selectedGroup then
+            entry:SetColor(0.25, 0.62, 1.0)
+        elseif allChildrenInactive then
             entry:SetColor(0.5, 0.5, 0.5)
         else
             entry:SetColor(1.0, 0.82, 0.0)
@@ -1574,6 +1573,61 @@ local function RefreshColumn1(preserveDrag)
         entry.frame._cdcItemKind = "folder"
         entry.frame._cdcFolderId = folderId
         entry.frame._cdcSection = sectionTag
+
+        local collapseBtn = entry.frame._cdcCollapseBtn
+        if not collapseBtn then
+            collapseBtn = CreateFrame("Button", nil, entry.frame)
+            collapseBtn:SetSize(16, 16)
+            collapseBtn:SetPropagateMouseClicks(false)
+            collapseBtn:SetPropagateMouseMotion(false)
+            collapseBtn._arrow = collapseBtn:CreateTexture(nil, "ARTWORK")
+            collapseBtn._arrow:SetSize(10, 10)
+            collapseBtn._arrow:SetPoint("CENTER")
+            entry.frame._cdcCollapseBtn = collapseBtn
+        end
+        collapseBtn:SetParent(entry.frame)
+        local function PositionCollapseButton()
+            collapseBtn:ClearAllPoints()
+            local collapseButtonGap = 4
+            local collapseButtonWidth = collapseBtn:GetWidth() or 16
+            local badgeReserve = GetConfigRowBadgeReserve(entry.frame)
+            local labelRightPad = badgeReserve + collapseButtonWidth + (collapseButtonGap * 2)
+            local leftPad = 0
+            if entry.label and entry.label.GetPoint then
+                local _, _, _, xOfs = entry.label:GetPoint(1)
+                leftPad = xOfs or 0
+                entry.label:ClearAllPoints()
+                entry.label:SetPoint("LEFT", entry.frame, "LEFT", leftPad, 0)
+            end
+            local folderNameWidth = entry.label and entry.label:GetStringWidth() or 0
+            local rowWidth = entry.frame.width or entry.frame:GetWidth() or 0
+            local visibleLabelWidth = rowWidth > 0 and math.max(1, rowWidth - leftPad - labelRightPad) or (entry.label and entry.label:GetWidth() or 0)
+            if visibleLabelWidth > 0 then
+                if entry.label and entry.label.SetWidth then
+                    entry.label:SetWidth(visibleLabelWidth)
+                end
+                folderNameWidth = math.min(folderNameWidth, visibleLabelWidth)
+            end
+            collapseBtn:SetPoint("LEFT", entry.label, "LEFT", folderNameWidth + collapseButtonGap, 0)
+        end
+        entry._cdcAfterConfigRowLayout = PositionCollapseButton
+        PositionCollapseButton()
+        collapseBtn:SetFrameLevel(entry.frame:GetFrameLevel() + 25)
+        collapseBtn._arrow:SetAtlas(isCollapsed and "common-icon-plus" or "common-icon-minus", false)
+        collapseBtn._arrow:SetRotation(0)
+        collapseBtn:Show()
+        collapseBtn._arrow:Show()
+        collapseBtn:SetScript("OnClick", function()
+            ToggleFolderCollapsed()
+        end)
+        collapseBtn:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:AddLine(isCollapsed and "Expand" or "Collapse")
+            GameTooltip:Show()
+        end)
+        collapseBtn:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+        end)
 
         TrackRenderedRow({
             kind = "folder",
@@ -1622,7 +1676,15 @@ local function RefreshColumn1(preserveDrag)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
-                ToggleFolderCollapsed()
+                CooldownCompanion:ClearAllConfigPreviews()
+                CS.selectedFolder = folderId
+                CS.selectedContainer = nil
+                CS.selectedGroup = nil
+                CS.selectedButton = nil
+                wipe(CS.selectedGroups)
+                wipe(CS.selectedPanels)
+                wipe(CS.selectedButtons)
+                CooldownCompanion:RefreshConfigPanel()
             elseif button == "MiddleButton" then
                 -- Lock/unlock all containers in this folder
                 local containers = db.groupContainers or {}

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -265,7 +265,6 @@ local function RefreshColumn4(container)
             local tabGroup = AceGUI:Create("TabGroup")
             tabGroup:SetLayout("Fill")
             tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
-                CS.selectedFolderTab = tab
                 widget:ReleaseChildren()
 
                 local scroll = AceGUI:Create("ScrollFrame")
@@ -273,11 +272,7 @@ local function RefreshColumn4(container)
                 widget:AddChild(scroll)
                 CS.col4Scroll = scroll
 
-                if tab == "general" then
-                    ST._BuildFolderGeneralTab(scroll, CS.selectedFolder)
-                elseif tab == "loadconditions" then
-                    ST._BuildFolderLoadConditionsTab(scroll, CS.selectedFolder)
-                end
+                ST._BuildFolderLoadConditionsTab(scroll, CS.selectedFolder)
 
                 if CS.browseMode then
                     ST._DisableAllWidgets(scroll)
@@ -291,15 +286,10 @@ local function RefreshColumn4(container)
         end
 
         container.folderTabGroup:SetTabs({
-            { value = "general",         text = "General" },
             { value = "loadconditions",  text = "Load Conditions" },
         })
         container.folderTabGroup.frame:Show()
-        local folderTab = CS.selectedFolderTab
-        if folderTab ~= "general" and folderTab ~= "loadconditions" then
-            folderTab = "general"
-        end
-        container.folderTabGroup:SelectTab(folderTab or "general")
+        container.folderTabGroup:SelectTab("loadconditions")
         return
     end
 
@@ -514,6 +504,7 @@ local function RefreshProfileBar(bar)
     profileDrop:SetCallback("OnValueChanged", function(widget, event, val)
         CooldownCompanion:ClearAllConfigPreviews()
         db:SetProfile(val)
+        CS.selectedFolder = nil
         CS.selectedContainer = nil
         CS.selectedGroup = nil
         CS.selectedButton = nil

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -169,12 +169,23 @@ local function GetSelectedGroupHeaderName(selection)
     return container and NormalizeHeaderName(container.name)
 end
 
+local function GetSelectedFolderHeaderName(selection)
+    if not (selection and selection.hasSelectedFolder and CS.selectedFolder) then
+        return nil
+    end
+
+    local profile = GetConfigProfile()
+    local folder = profile and profile.folders and profile.folders[CS.selectedFolder]
+    return folder and NormalizeHeaderName(folder.name)
+end
+
 local function GetConfigSelectionSummary()
     return {
         panelMultiCount = CountSelections(CS.selectedPanels),
         groupMultiCount = CountSelections(CS.selectedGroups),
         hasSelectedPanel = CS.selectedGroup ~= nil,
         hasSelectedGroup = CS.selectedContainer ~= nil,
+        hasSelectedFolder = CS.selectedFolder ~= nil and CS.selectedContainer == nil and CS.selectedGroup == nil,
     }
 end
 
@@ -200,6 +211,9 @@ local function GetColumn4HeaderMode(selection)
     end
     if selection.panelMultiCount >= 2 or selection.hasSelectedPanel then
         return "panel"
+    end
+    if selection.hasSelectedFolder then
+        return "folder"
     end
     return "group"
 end
@@ -232,6 +246,12 @@ local function GetColumn4HeaderTitle(selection)
             return "Panel: " .. panelName
         end
         return "Panel Settings"
+    elseif mode == "folder" then
+        local folderName = GetSelectedFolderHeaderName(selection)
+        if folderName then
+            return "Folder: " .. folderName
+        end
+        return "Folder Settings"
     end
     local groupName = GetSelectedGroupHeaderName(selection)
     if groupName then
@@ -895,6 +915,7 @@ local function CreateConfigPanel()
         CS.browseMode = true
         CS.browseCharKey = nil
         CS.browseContainerId = nil
+        CS.selectedFolder = nil
         CS.selectedContainer = nil
         CS.selectedGroup = nil
         CS.selectedButton = nil
@@ -1478,7 +1499,12 @@ local function CreateConfigPanel()
         else
             local selection = GetConfigSelectionSummary()
             local mode = GetColumn4HeaderMode(selection)
-            if mode == "panel" then
+            if mode == "folder" then
+                GameTooltip:AddLine("Folder Settings")
+                GameTooltip:AddLine("The selected folder is configured here.", 1, 1, 1, true)
+                GameTooltip:AddLine(" ")
+                GameTooltip:AddLine("Folder load conditions apply to all groups inside the folder.", 1, 1, 1, true)
+            elseif mode == "panel" then
                 GameTooltip:AddLine("Panel Settings")
                 if selection.panelMultiCount >= 2 then
                     GameTooltip:AddLine("Select a single panel to configure it here.", 1, 1, 1, true)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -127,7 +127,6 @@ ST._configState = {
     selectedPanels = {},         -- multi-selected panel IDs (within a container)
     selectedGroups = {},         -- multi-selected container IDs
     selectedTab = "appearance",
-    selectedFolderTab = "general",
     selectedContainerTab = "general",
     buttonSettingsTab = "settings",
     panelSettingsTab = "appearance",
@@ -1240,6 +1239,10 @@ local function ApplyConfigRowLayout(entry)
             icon:Hide()
         end
     end
+
+    if entry._cdcAfterConfigRowLayout then
+        entry:_cdcAfterConfigRowLayout()
+    end
 end
 
 local function EnsureConfigRowHandlers(entry)
@@ -1299,6 +1302,7 @@ local function CleanRecycledEntry(entry)
     if entry.frame._cdcFallbackDownBtn then entry.frame._cdcFallbackDownBtn:Hide() end
     if entry.frame._cdcMarkerLeft then entry.frame._cdcMarkerLeft:Hide() end
     if entry.frame._cdcMarkerRight then entry.frame._cdcMarkerRight:Hide() end
+    entry._cdcAfterConfigRowLayout = nil
     entry.frame:SetScript("OnMouseUp", nil)
     entry.frame:SetScript("OnReceiveDrag", nil)
     entry.frame._cdcOnMouseDown = nil
@@ -1568,6 +1572,25 @@ local function SetupFolderRowIndicators(entry, folder)
             end
         end
     end
+end
+
+local function GetConfigRowBadgeReserve(frame)
+    local reserve = BADGE_RIGHT_PAD
+    local hasShownBadge = false
+
+    if frame and frame._cdcBadges then
+        for _, badge in ipairs(frame._cdcBadges) do
+            if badge:IsShown() then
+                if hasShownBadge then
+                    reserve = reserve + BADGE_SPACING
+                end
+                reserve = reserve + badge:GetWidth()
+                hasShownBadge = true
+            end
+        end
+    end
+
+    return reserve
 end
 
 local function EnsureColumn1MarkerParts(frame)
@@ -2195,6 +2218,7 @@ ST._RefreshVisibleConfigCompactRows = RefreshVisibleConfigCompactRows
 ST._AcquireBadge = AcquireBadge
 ST._SetupGroupRowIndicators = SetupGroupRowIndicators
 ST._SetupFolderRowIndicators = SetupFolderRowIndicators
+ST._GetConfigRowBadgeReserve = GetConfigRowBadgeReserve
 ST._ApplyColumn1MarkerAppearance = ApplyColumn1MarkerAppearance
 ST._SetupColumn1MarkerRow = SetupColumn1MarkerRow
 ST._CreateScrollFrame = CreateScrollFrame


### PR DESCRIPTION
## What Players Will Notice
- Folder rows in the Groups column can be clicked to open Folder settings in Column 4, so folder load conditions can be edited directly.
- The folder plus/minus badge remains a separate control for expanding and collapsing child groups.
- Folder names, filter badges, and the collapse control have reserved space so they do not overlap in narrower layouts.

## Why This Changed
- After load conditions became available on folders, groups, panels, and entries, folder rows in Column 1 still behaved primarily as expand/collapse controls. That made folder load conditions harder to reach and accidentally changed the older folder collapse affordance.

## What Changed
- Folder row clicks now select the folder, clear other selection state, and show the existing folder load-condition editor in Column 4.
- Folder expand/collapse moved back to a dedicated plus/minus button that preserves the previous expand/collapse behavior without clearing the selected folder.
- Column 4 headers and help text now recognize folder selection, stale folder tab state was removed, and profile/browse transitions clear folder selection where needed.
- Folder row layout now reserves space for status badges and the collapse control so long names clip before the button area.

## Validation
- `git diff --check origin/main...HEAD` passed.
- `luac -p` passed across all addon Lua files.
- Several static review-intake passes were addressed for folder selection, Column 4 folder state, collapse-button positioning, and dead tab state.
- In-game smoke testing is still needed for folder selection, load-condition editing, plus/minus expand/collapse, compact/narrow layouts, drag behavior, and combat/restricted-content coverage.