### PR TITLE
Let Custom Bars track spell cooldowns

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -636,7 +636,9 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
                     result.source = "action-slot-real-no-spell-info"
                     result.renderDurationObj = slotProbe.realDurationObj
                     result.isOnGCD = CooldownCompanion._gcdActive == true
-                    ApplyGCDSyncIfRealEndsInside(result, slotProbe.realDurationObj, "action-slot-gcd-sync")
+                    if options.syncRealCooldownToGCD ~= false then
+                        ApplyGCDSyncIfRealEndsInside(result, slotProbe.realDurationObj, "action-slot-gcd-sync")
+                    end
                 elseif slotProbe.shown and slotProbe.durationObj then
                     result.state = COOLDOWN_STATE_GCD
                     result.source = "action-slot-gcd-no-spell-info"
@@ -675,7 +677,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
     end
 
-    if result.state == COOLDOWN_STATE_COOLDOWN
+    if options.syncRealCooldownToGCD ~= false
+        and result.state == COOLDOWN_STATE_COOLDOWN
         and result.realCooldownShown == true
         and result.realDurationObj then
         ApplyGCDSyncIfRealEndsInside(result, result.realDurationObj, "spell-gcd-sync")
@@ -697,7 +700,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
                 return result
             end
 
-            if ApplyGCDSyncIfRealEndsInside(result, slotProbe.realDurationObj, "action-slot-gcd-sync") then
+            if options.syncRealCooldownToGCD ~= false
+                and ApplyGCDSyncIfRealEndsInside(result, slotProbe.realDurationObj, "action-slot-gcd-sync") then
                 return result
             end
 
@@ -735,6 +739,73 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
         allowActionSlotRealFallback = allowActionSlotRealFallback,
     })
+end
+
+function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
+    local spellID = tonumber(customBar and customBar.spellID)
+    local result
+    if not spellID then
+        return EvaluateSpellCooldownLane(nil, 0, nil)
+    end
+
+    local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
+    if not cooldownSpellID or cooldownSpellID == 0 then
+        cooldownSpellID = spellID
+    end
+
+    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
+        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
+        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
+        customBar._cooldownSecrecySpellID = cooldownSpellID
+    end
+
+    local charges = C_Spell.GetSpellCharges(cooldownSpellID)
+    local maxCharges = charges and tonumber(charges.maxCharges)
+    if maxCharges and maxCharges > 1 then
+        customBar.hasCharges = true
+        customBar.maxCharges = maxCharges
+    elseif charges then
+        customBar.hasCharges = nil
+        customBar.maxCharges = maxCharges
+    elseif not charges then
+        customBar.hasCharges = nil
+    end
+
+    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
+        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
+        syncRealCooldownToGCD = false,
+    })
+    result.baseSpellID = spellID
+    result.cooldownSpellID = cooldownSpellID
+
+    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
+        result.hasCharges = true
+        result.maxCharges = maxCharges
+        result.charges = charges
+
+        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
+            result.currentCharges = charges.currentCharges
+            if result.currentCharges <= 0 then
+                result.chargeState = CHARGE_STATE_ZERO
+            elseif result.currentCharges >= maxCharges then
+                result.chargeState = CHARGE_STATE_FULL
+            else
+                result.chargeState = CHARGE_STATE_MISSING
+            end
+        end
+
+        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+        result.chargeDurationObj = chargeDurationObj
+        result.chargeRecharging = chargeRecharging or false
+        if chargeRecharging then
+            result.state = COOLDOWN_STATE_COOLDOWN
+            result.source = "spell-charge-recharge"
+            result.renderDurationObj = chargeDurationObj
+        end
+    end
+
+    return result
 end
 
 local function ResolveChargeState(button, buttonData)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -10,6 +10,7 @@ local CooldownCompanion = ST.Addon
 local AceGUI = LibStub("AceGUI-3.0")
 local LSM = LibStub("LibSharedMedia-3.0")
 local CS = ST._configState
+local IsPassiveOrProc = ST._IsPassiveOrProc
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
@@ -99,6 +100,7 @@ local DEFAULT_ESSENCE_READY_COLOR = RB.DEFAULT_ESSENCE_READY_COLOR
 local DEFAULT_ESSENCE_RECHARGING_COLOR = RB.DEFAULT_ESSENCE_RECHARGING_COLOR
 local DEFAULT_ESSENCE_MAX_COLOR = RB.DEFAULT_ESSENCE_MAX_COLOR
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
+local GetCustomBarEntryType = RB.GetCustomBarEntryType
 local EnsureCustomBarId = RB.EnsureCustomBarId
 local EnsureCustomBarLayout = RB.EnsureCustomBarLayout
 local GetCustomBarLayout = RB.GetCustomBarLayout
@@ -113,6 +115,9 @@ local function IsHeroSpecProxyCondition(cond)
         and type(cond.name) == "string"
         and type(cond.heroName) == "string"
         and cond.name == cond.heroName
+end
+local function IsSpellCustomBarConfig(cab)
+    return GetCustomBarEntryType and GetCustomBarEntryType(cab) == "spell"
 end
 local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForSpell
 
@@ -134,7 +139,9 @@ local ResolveAuraColorSpellIDFromText = RBP.ResolveAuraColorSpellIDFromText
 local GetAuraBarAutocompleteDisplayName = RBP.GetAuraBarAutocompleteDisplayName
 local GetAuraBarAutocompleteDisplayIcon = RBP.GetAuraBarAutocompleteDisplayIcon
 local GetAuraBarAutocompleteEntryName = RBP.GetAuraBarAutocompleteEntryName
+local ResolveAuraBarAutocompleteEntry = RBP.ResolveAuraBarAutocompleteEntry
 local ShowAuraBarAutocompleteResults = RBP.ShowAuraBarAutocompleteResults
+local BuildAuraBarAutocompleteCache = RBP.BuildAuraBarAutocompleteCache
 local IsResourceBarVerticalConfig = RBP.IsResourceBarVerticalConfig
 local GetResourceThicknessFieldConfig = RBP.GetResourceThicknessFieldConfig
 local GetResourceGapFieldConfig = RBP.GetResourceGapFieldConfig
@@ -2718,18 +2725,85 @@ local function BuildCustomBarsListPanel(container)
     addBox:SetLabel("")
     addBox:SetFullWidth(true)
     addBox:DisableButton(true)
-    local updatePlaceholder = ConfigureCustomBarAddInstructions(addBox, "Add aura by name or ID")
+    local updatePlaceholder = ConfigureCustomBarAddInstructions(addBox, "Add spell or aura by name or ID")
 
-    local function AddCustomBarFromSpell(spellId, labelOverride)
+    local function GetCustomBarEntryTypeForAutocomplete(entry)
+        if type(entry) ~= "table" then
+            return "spell"
+        end
+        if entry.forceAura == true or entry.isPassive == true then
+            return "aura"
+        end
+        if entry.forceAura == false then
+            return "spell"
+        end
+        if IsPassiveOrProc and entry.id and IsPassiveOrProc(entry.id) then
+            return "aura"
+        end
+        return "spell"
+    end
+
+    local function StripExplicitCustomBarEntryTypeSuffix(text)
+        local cleaned = text and text:gsub("^%s+", ""):gsub("%s+$", ""):lower() or ""
+        if cleaned:match("%s%((buff)%)$") or cleaned:match("%s%((aura)%)$") then
+            return (text or ""):gsub("%s+%([Bb][Uu][Ff][Ff]%)%s*$", ""):gsub("%s+%([Aa][Uu][Rr][Aa]%)%s*$", ""), "aura"
+        end
+        if cleaned:match("%s%((cooldown)%)$") then
+            return (text or ""):gsub("%s+%([Cc][Oo][Oo][Ll][Dd][Oo][Ww][Nn]%)%s*$", ""), "spell"
+        end
+        return text, nil
+    end
+
+    local function GetCustomBarEntryTypeForSpellID(spellId, explicitType)
+        if explicitType then
+            return explicitType
+        end
+        if not spellId or not C_Spell.GetSpellInfo(spellId) then
+            return "aura"
+        end
+        local sawAuraEntry = false
+        local sawSpellEntry = false
+        local cache = BuildAuraBarAutocompleteCache and BuildAuraBarAutocompleteCache() or nil
+        for _, entry in ipairs(cache or {}) do
+            if entry.id == spellId then
+                if GetCustomBarEntryTypeForAutocomplete(entry) == "aura" then
+                    sawAuraEntry = true
+                else
+                    sawSpellEntry = true
+                end
+            end
+        end
+        if sawAuraEntry and not sawSpellEntry then
+            return "aura"
+        elseif sawSpellEntry and not sawAuraEntry then
+            return "spell"
+        end
+        if IsPassiveOrProc and IsPassiveOrProc(spellId) then
+            return "aura"
+        end
+        return "spell"
+    end
+
+    local function AddCustomBarFromSpell(spellId, labelOverride, entryType)
         if not spellId then return false end
+        entryType = entryType == "aura" and "aura" or "spell"
         local entry = {
-            entryType = "aura",
+            entryType = entryType,
             enabled = true,
-            trackingMode = "active",
             spellID = spellId,
             label = labelOverride or GetAuraBarAutocompleteDisplayName(spellId) or C_Spell.GetSpellName(spellId) or "",
         }
-        RefreshCustomAuraBarAuraUnitForSpell(entry, spellId)
+        if entryType == "aura" then
+            entry.trackingMode = "active"
+            RefreshCustomAuraBarAuraUnitForSpell(entry, spellId)
+        else
+            local charges = C_Spell.GetSpellCharges(spellId)
+            local maxCharges = charges and tonumber(charges.maxCharges)
+            if maxCharges and maxCharges > 1 then
+                entry.hasCharges = true
+                entry.maxCharges = maxCharges
+            end
+        end
         local id = EnsureCustomBarId(settings, entry)
         customBars[#customBars + 1] = entry
         EnsureCustomBarLayout(settings, nil, id, 1000 + #customBars)
@@ -2742,26 +2816,44 @@ local function BuildCustomBarsListPanel(container)
     end
 
     local function CommitCustomBarText(widget, text)
-        local id, explicitClear = ResolveAuraColorSpellIDFromText(text)
+        local lookupText, explicitType = StripExplicitCustomBarEntryTypeSuffix(text)
+        local autocompleteEntry = ResolveAuraBarAutocompleteEntry and (
+            ResolveAuraBarAutocompleteEntry(text)
+            or (lookupText ~= text and ResolveAuraBarAutocompleteEntry(lookupText))
+        )
+        if autocompleteEntry and AddCustomBarFromSpell(
+            autocompleteEntry.id,
+            GetAuraBarAutocompleteEntryName(autocompleteEntry),
+            explicitType or GetCustomBarEntryTypeForAutocomplete(autocompleteEntry)
+        ) then
+            widget:SetText("")
+            return true
+        end
+
+        local id, explicitClear = ResolveAuraColorSpellIDFromText(lookupText)
         if explicitClear then
             widget:SetText("")
             return true
         end
-        if AddCustomBarFromSpell(id) then
+        if AddCustomBarFromSpell(id, nil, GetCustomBarEntryTypeForSpellID(id, explicitType)) then
             widget:SetText("")
             return true
         end
 
         local cleaned = text and text:gsub("^%s+", ""):gsub("%s+$", "") or ""
         if cleaned ~= "" then
-            CooldownCompanion:Print("Custom Bar aura not found: " .. cleaned)
+            CooldownCompanion:Print("Custom Bar spell or aura not found: " .. cleaned)
         end
         return false
     end
 
     local function onAuraBarSelect(entry)
         CS.HideAutocomplete()
-        if entry and AddCustomBarFromSpell(entry.id, GetAuraBarAutocompleteEntryName(entry)) then
+        if entry and AddCustomBarFromSpell(
+            entry.id,
+            GetAuraBarAutocompleteEntryName(entry),
+            GetCustomBarEntryTypeForAutocomplete(entry)
+        ) then
             addBox._cdcCustomBarAutocompleteCommitted = true
             addBox:SetText("")
         end
@@ -2837,8 +2929,9 @@ local function BuildCustomBarsListPanel(container)
         end
 
         local rowFrame = row.frame
-        local resolvedRowAuraUnit = GetResolvedCustomAuraBarAuraUnit(entry, entry.spellID)
-        local auraStatus = ResolveCustomBarAuraTrackingStatus(entry, resolvedRowAuraUnit)
+        local isSpellCustomBar = IsSpellCustomBarConfig(entry)
+        local resolvedRowAuraUnit = isSpellCustomBar and nil or GetResolvedCustomAuraBarAuraUnit(entry, entry.spellID)
+        local auraStatus = (not isSpellCustomBar) and ResolveCustomBarAuraTrackingStatus(entry, resolvedRowAuraUnit) or nil
         local rightBadgeAnchor = rowFrame
         local rightBadgePoint = "RIGHT"
         local rightBadgeOffset = -4
@@ -2861,29 +2954,37 @@ local function BuildCustomBarsListPanel(container)
             rightBadgeOffset = -4
         end
 
-        local auraStatusBadge = EnsureCustomBarRowIconBadge(rowFrame, "_cdcCustomBarAuraStatusBadge", "icon_trackedbuffs")
-        auraStatusBadge:SetPoint("RIGHT", rightBadgeAnchor, rightBadgePoint, rightBadgeOffset, 0)
-        if auraStatus.ready == true then
-            auraStatusBadge.icon:SetVertexColor(1, 1, 1, 1)
-            SetCustomBarRowBadgeTooltip(auraStatusBadge, "Aura tracking: Active", 0.2, 1, 0.2)
-        else
-            auraStatusBadge.icon:SetVertexColor(1, 0.2, 0.2, 1)
-            local tooltipText = "Aura tracking: Inactive"
-            if auraStatus.state == "cdmDisabled" then
-                tooltipText = "Aura tracking: Inactive (Blizzard CDM disabled)"
-            elseif auraStatus.state == "trackedAuraUnavailable" then
-                tooltipText = "Aura tracking: Inactive (tracked in CDM, but the Buffs/Debuffs viewer is not currently readable)"
-            elseif auraStatus.state == "associatedAuraNotTracked" then
-                tooltipText = "Aura tracking: Inactive (associated aura is not currently tracked in CDM)"
-            elseif auraStatus.state == "noAssociatedAura" then
-                tooltipText = "Aura tracking: Inactive (no associated aura found)"
+        local placementAnchor = rightBadgeAnchor
+        local placementPoint = rightBadgePoint
+        local placementOffset = rightBadgeOffset
+        if not isSpellCustomBar then
+            local auraStatusBadge = EnsureCustomBarRowIconBadge(rowFrame, "_cdcCustomBarAuraStatusBadge", "icon_trackedbuffs")
+            auraStatusBadge:SetPoint("RIGHT", rightBadgeAnchor, rightBadgePoint, rightBadgeOffset, 0)
+            if auraStatus.ready == true then
+                auraStatusBadge.icon:SetVertexColor(1, 1, 1, 1)
+                SetCustomBarRowBadgeTooltip(auraStatusBadge, "Aura tracking: Active", 0.2, 1, 0.2)
+            else
+                auraStatusBadge.icon:SetVertexColor(1, 0.2, 0.2, 1)
+                local tooltipText = "Aura tracking: Inactive"
+                if auraStatus.state == "cdmDisabled" then
+                    tooltipText = "Aura tracking: Inactive (Blizzard CDM disabled)"
+                elseif auraStatus.state == "trackedAuraUnavailable" then
+                    tooltipText = "Aura tracking: Inactive (tracked in CDM, but the Buffs/Debuffs viewer is not currently readable)"
+                elseif auraStatus.state == "associatedAuraNotTracked" then
+                    tooltipText = "Aura tracking: Inactive (associated aura is not currently tracked in CDM)"
+                elseif auraStatus.state == "noAssociatedAura" then
+                    tooltipText = "Aura tracking: Inactive (no associated aura found)"
+                end
+                SetCustomBarRowBadgeTooltip(auraStatusBadge, tooltipText, 1, 0.2, 0.2)
             end
-            SetCustomBarRowBadgeTooltip(auraStatusBadge, tooltipText, 1, 0.2, 0.2)
+            placementAnchor = auraStatusBadge
+            placementPoint = "LEFT"
+            placementOffset = -4
         end
 
         local placementBadge = EnsureCustomBarRowTextBadge(rowFrame, "_cdcCustomBarPlacementBadge")
         placementBadge:SetText(IsTruthyConfigFlag(entry.independentAnchorEnabled) and "|cffb88cffIndependent|r" or "|cff7dff7dAttached|r")
-        placementBadge:SetPoint("RIGHT", auraStatusBadge, "LEFT", -4, 0)
+        placementBadge:SetPoint("RIGHT", placementAnchor, placementPoint, placementOffset, 0)
         placementBadge:SetWidth(66)
 
         row:SetCallback("OnClick", function(widget, event, mouseButton)
@@ -2938,7 +3039,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     local capturedId = EnsureCustomBarId(settings, cab)
     local capturedKey = capturedId or tostring(capturedIdx)
     EnsureCustomAuraIndependentConfig(cab, settings)
-    local resolvedAuraUnit = GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID)
+    local isSpellCustomBar = IsSpellCustomBarConfig(cab)
+    local resolvedAuraUnit = isSpellCustomBar and nil or GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID)
     activeTab = activeTab or "settings"
 
     if activeTab == "anchor" or activeTab == "alpha" then
@@ -2978,7 +3080,9 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
         return
     end
 
-    BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
+    if not isSpellCustomBar then
+        BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
+    end
     AddCustomBarSettingsHeading(container, "Placement", infoButtons, "Choose whether this Custom Bar appears attached to the panel stack or uses its own independent anchor.")
 
     local anchorModeDrop = AceGUI:Create("Dropdown")
@@ -3015,15 +3119,18 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     end)
     container:AddChild(anchorModeDrop)
 
-    AddCustomBarSettingsHeading(container, "Display", infoButtons, {
-        "Determines how the tracked aura is displayed on this Custom Bar.",
-        " ",
-        "Active: shows the aura's remaining duration while it is active.",
-        " ",
-        "Stack Count: ignores duration and shows only the aura's current stack count.",
-    })
+    if not isSpellCustomBar then
+        AddCustomBarSettingsHeading(container, "Display", infoButtons, {
+            "Determines how the tracked aura is displayed on this Custom Bar.",
+            " ",
+            "Active: shows the aura's remaining duration while it is active.",
+            " ",
+            "Stack Count: ignores duration and shows only the aura's current stack count.",
+        })
+    end
 
             -- Tracking Mode dropdown
+            if not isSpellCustomBar then
             local trackDrop = AceGUI:Create("Dropdown")
             trackDrop:SetLabel("Tracking Mode")
             trackDrop:SetList({
@@ -3040,9 +3147,10 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 })
             end)
             container:AddChild(trackDrop)
+            end
 
             -- Max Stacks slider (hidden in "active" tracking mode)
-            if (cab.trackingMode or "stacks") ~= "active" then
+            if not isSpellCustomBar and (cab.trackingMode or "stacks") ~= "active" then
             local maxSlider = AceGUI:Create("Slider")
             maxSlider:SetLabel("Max Stacks")
             maxSlider:SetSliderValues(1, 99, 1)
@@ -3065,7 +3173,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
             end
 
             -- Display Mode dropdown (hidden in "active" tracking mode)
-            if (cab.trackingMode or "stacks") ~= "active" then
+            if not isSpellCustomBar and (cab.trackingMode or "stacks") ~= "active" then
             local modeDrop = AceGUI:Create("Dropdown")
             modeDrop:SetLabel("Display Mode")
             modeDrop:SetList({
@@ -3127,8 +3235,15 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 AddColorPicker(container, customBars[cabIdx], "barColor", "Bar Color", {0.5, 0.5, 1}, false,
                     cabApplyBars, function() CooldownCompanion:RecolorCustomAuraBar(customBars[cabIdx]) end)
 
+                if isSpellCustomBar then
+                    AddColorPicker(container, customBars[cabIdx], "barCooldownColor", "Cooldown Color", {0.6, 0.13, 0.18, 1}, true,
+                        cabApplyBars, cabApplyBars)
+                    AddColorPicker(container, customBars[cabIdx], "barChargeColor", "Recharge Color", {1.0, 0.82, 0.0, 1}, true,
+                        cabApplyBars, cabApplyBars)
+                end
+
                 -- Overlay Color (overlay mode only)
-                if cab.displayMode == "overlay" and (cab.trackingMode or "stacks") ~= "active" then
+                if not isSpellCustomBar and cab.displayMode == "overlay" and (cab.trackingMode or "stacks") ~= "active" then
                     local cpOverlay = AddColorPicker(container, customBars[cabIdx], "overlayColor", "Overlay Color", {1, 0.84, 0}, false,
                         cabApplyBars, function() CooldownCompanion:RecolorCustomAuraBar(customBars[cabIdx]) end)
 
@@ -3143,8 +3258,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     end)
                 end
 
-                local isActiveTracking = (cab.trackingMode or "stacks") == "active"
-                if isActiveTracking then
+                local isActiveTracking = isSpellCustomBar or (cab.trackingMode or "stacks") == "active"
+                if isActiveTracking and not isSpellCustomBar then
                     local indicatorsHeading = AceGUI:Create("Heading")
                     indicatorsHeading:SetText("Indicators")
                     ColorHeading(indicatorsHeading)
@@ -3244,7 +3359,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     else
                         CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
                     end
-                else
+                elseif not isSpellCustomBar then
                     local thresholdCb = AceGUI:Create("CheckBox")
                     thresholdCb:SetLabel("Enable Max Stack Color")
                     thresholdCb:SetValue(cab.thresholdColorEnabled == true)
@@ -3381,8 +3496,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 end
 
                 -- ---- Text / Duration controls ----
-                local isActive = (cab.trackingMode or "stacks") == "active"
-                local isContinuous = isActive or (cab.displayMode == "continuous")
+                local isActive = isSpellCustomBar or (cab.trackingMode or "stacks") == "active"
+                local isContinuous = isSpellCustomBar or isActive or (cab.displayMode == "continuous")
 
                 if isContinuous then
                     local textsHeading = AceGUI:Create("Heading")
@@ -3410,7 +3525,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     end
 
                     local stackTextCb = AceGUI:Create("CheckBox")
-                    stackTextCb:SetLabel("Show Stack Text")
+                    stackTextCb:SetLabel(isSpellCustomBar and "Show Charge Text" or "Show Stack Text")
                     stackTextCb:SetValue(stackVal == true)
                     stackTextCb:SetFullWidth(true)
                     stackTextCb:SetCallback("OnValueChanged", function(widget, event, val)
@@ -3505,7 +3620,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         end
 
                         local fontDrop = AceGUI:Create("Dropdown")
-                        fontDrop:SetLabel("Stack Font")
+                        fontDrop:SetLabel(isSpellCustomBar and "Charge Font" or "Stack Font")
                         CS.SetupFontDropdown(fontDrop)
                         fontDrop:SetValue(cab.stackTextFont or DEFAULT_RESOURCE_TEXT_FONT)
                         fontDrop:SetFullWidth(true)
@@ -3516,7 +3631,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         container:AddChild(fontDrop)
 
                         local sizeDrop = AceGUI:Create("Slider")
-                        sizeDrop:SetLabel("Stack Font Size")
+                        sizeDrop:SetLabel(isSpellCustomBar and "Charge Font Size" or "Stack Font Size")
                         sizeDrop:SetSliderValues(6, 24, 1)
                         sizeDrop:SetValue(cab.stackTextFontSize or DEFAULT_RESOURCE_TEXT_SIZE)
                         sizeDrop:SetFullWidth(true)
@@ -3527,7 +3642,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         container:AddChild(sizeDrop)
 
                         local outlineDrop = AceGUI:Create("Dropdown")
-                        outlineDrop:SetLabel("Stack Outline")
+                        outlineDrop:SetLabel(isSpellCustomBar and "Charge Outline" or "Stack Outline")
                         outlineDrop:SetList(CS.outlineOptions)
                         outlineDrop:SetValue(cab.stackTextFontOutline or DEFAULT_RESOURCE_TEXT_OUTLINE)
                         outlineDrop:SetFullWidth(true)
@@ -3541,7 +3656,9 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     end
                 end
 
-                BuildCustomBarVisibilityRulesSection(container, customBars, capturedIdx, cab, resolvedAuraUnit, capturedKey, infoButtons)
+                if not isSpellCustomBar then
+                    BuildCustomBarVisibilityRulesSection(container, customBars, capturedIdx, cab, resolvedAuraUnit, capturedKey, infoButtons)
+                end
 
                 -- ---- Talent Conditions section ----
                 local talentHeading = AceGUI:Create("Heading")

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -144,7 +144,8 @@ local function ResolveAuraBarAutocompleteEntry(text)
     local lookup = cleaned:lower()
     local cache = BuildAuraBarAutocompleteCache()
     for _, entry in ipairs(cache) do
-        if (numeric and entry.id == numeric) or entry.nameLower == lookup then
+        local entryNameLower = type(entry.name) == "string" and entry.name:lower() or nil
+        if (numeric and entry.id == numeric) or entry.nameLower == lookup or entryNameLower == lookup then
             return entry
         end
     end
@@ -1031,6 +1032,7 @@ ST._RBP = {
     GetAuraBarAutocompleteDisplayName = GetAuraBarAutocompleteDisplayName,
     GetAuraBarAutocompleteDisplayIcon = GetAuraBarAutocompleteDisplayIcon,
     GetAuraBarAutocompleteEntryName = GetAuraBarAutocompleteEntryName,
+    ResolveAuraBarAutocompleteEntry = ResolveAuraBarAutocompleteEntry,
     ShowAuraBarAutocompleteResults = ShowAuraBarAutocompleteResults,
     AddResourceAuraEntryFields = AddResourceAuraEntryFields,
     ClearLegacyResourceAuraFieldsConfig = ClearLegacyResourceAuraFieldsConfig,

--- a/Core/SoundAlerts.lua
+++ b/Core/SoundAlerts.lua
@@ -15,6 +15,7 @@ local next = next
 local type = type
 local tostring = tostring
 local tonumber = tonumber
+local issecretvalue = issecretvalue
 
 local function UsesChargeBehavior(buttonData)
     return CooldownCompanion.UsesChargeBehavior(buttonData)
@@ -99,6 +100,29 @@ local function AddCooldownIDForSpell(spellToCooldownIDs, spellID, cooldownID)
         spellToCooldownIDs[spellID] = entry
     end
     entry[cooldownID] = true
+end
+
+local function IsSpellCustomBarChargeAlertMerged(customBar)
+    if type(customBar) ~= "table" or customBar.entryType ~= "spell" then
+        return false
+    end
+    if customBar.hasCharges == true or (tonumber(customBar.maxCharges) or 0) > 1 then
+        return true
+    end
+    local events = customBar.soundAlerts and customBar.soundAlerts.events
+    return type(events) == "table" and events.chargeGained ~= nil
+end
+
+local function NormalizeSpellCustomBarAlertEvents(scopedEvents)
+    if type(scopedEvents) ~= "table" then
+        return scopedEvents
+    end
+
+    if scopedEvents.chargeGained then
+        scopedEvents.available = true
+        scopedEvents.chargeGained = nil
+    end
+    return scopedEvents
 end
 
 local function ResolveGroup(groupOrId)
@@ -335,6 +359,13 @@ function CooldownCompanion:GetScopedValidSoundAlertEventsForCustomBar(customBar)
     if entryType == "aura" then
         scopedEvents.onAuraApplied = true
         scopedEvents.onAuraRemoved = true
+    elseif entryType == "spell" then
+        return NormalizeSpellCustomBarAlertEvents(self:GetScopedValidSoundAlertEventsForButton({
+            type = "spell",
+            id = customBar.spellID,
+            hasCharges = customBar.hasCharges,
+            maxCharges = customBar.maxCharges,
+        }, customBar.spellID))
     end
 
     if not next(scopedEvents) then
@@ -479,6 +510,12 @@ end
 function CooldownCompanion:GetCustomBarSoundAlertSelection(customBar, eventKey)
     local cfg = self:GetCustomBarSoundAlertConfig(customBar, false)
     local events = cfg and cfg.events
+    if events and IsSpellCustomBarChargeAlertMerged(customBar) and eventKey == "available" then
+        local merged = events.available or events.chargeGained
+        if merged then
+            return merged
+        end
+    end
     if events and events[eventKey] then
         return events[eventKey]
     end
@@ -527,10 +564,24 @@ function CooldownCompanion:SetCustomBarSoundAlertEvent(customBar, eventKey, soun
 
     local cfg = self:GetCustomBarSoundAlertConfig(customBar, true)
     local events = cfg.events
-    if not soundName or soundName == SOUND_NONE_KEY then
-        events[eventKey] = nil
+    if customBar.entryType == "spell" and eventKey == "chargeGained" then
+        eventKey = "available"
+    end
+
+    if customBar.entryType == "spell" and eventKey == "available" then
+        if not soundName or soundName == SOUND_NONE_KEY then
+            events.available = nil
+            events.chargeGained = nil
+        else
+            events.available = soundName
+            events.chargeGained = nil
+        end
     else
-        events[eventKey] = soundName
+        if not soundName or soundName == SOUND_NONE_KEY then
+            events[eventKey] = nil
+        else
+            events[eventKey] = soundName
+        end
     end
 
     if not next(events) then
@@ -604,6 +655,9 @@ function CooldownCompanion:GetSoundAlertEventLabelForButton(buttonData, eventKey
 end
 
 function CooldownCompanion:GetCustomBarSoundAlertEventLabel(customBar, eventKey)
+    if IsSpellCustomBarChargeAlertMerged(customBar) and eventKey == "available" then
+        return CHARGE_AVAILABLE_MERGED_LABEL
+    end
     return self:GetSoundAlertEventLabel(eventKey)
 end
 
@@ -718,8 +772,14 @@ function CooldownCompanion:PlayButtonSoundAlertEvent(buttonData, eventKey)
 end
 
 function CooldownCompanion:PlayCustomBarSoundAlertEvent(customBar, eventKey)
+    if customBar and customBar.entryType == "spell" and eventKey == "chargeGained" then
+        eventKey = "available"
+    end
     local cfg = self:GetCustomBarSoundAlertConfig(customBar, false)
     local soundName = cfg and cfg.events and cfg.events[eventKey]
+    if (not soundName) and customBar and customBar.entryType == "spell" and eventKey == "available" then
+        soundName = cfg and cfg.events and cfg.events.chargeGained
+    end
     if not soundName or soundName == SOUND_NONE_KEY then return false end
 
     return PlaySharedMediaSound(soundName, self:GetCustomBarSoundAlertChannel(customBar), GetCustomBarSpeechText(customBar))
@@ -739,23 +799,13 @@ function CooldownCompanion:PlayTriggerPanelSoundAlertEvent(groupOrId, eventKey)
     return PlaySharedMediaSound(soundName, DEFAULT_SOUND_CHANNEL, GetTriggerPanelSpeechText(group))
 end
 
-function CooldownCompanion:GetEnabledSoundAlertEventsForButton(buttonData, spellIDOverride)
-    local cfg = self:GetButtonSoundAlertConfig(buttonData, false)
-    if not cfg or type(cfg.events) ~= "table" then
-        return nil
-    end
-
-    local validEvents = self:GetScopedValidSoundAlertEventsForButton(buttonData, spellIDOverride)
-    if not validEvents then
-        return nil
-    end
-
+local function CollectEnabledSoundAlertEvents(events, validEvents, mergeChargeEvents)
     local enabledEvents = {}
     for _, eventKey in ipairs(SOUND_ALERT_EVENT_ORDER) do
-        if not (UsesChargeBehavior(buttonData) and eventKey == "chargeGained") then
-            local soundName = cfg.events[eventKey]
-            if UsesChargeBehavior(buttonData) and eventKey == "available" and not soundName then
-                soundName = cfg.events.chargeGained
+        if not (mergeChargeEvents and eventKey == "chargeGained") then
+            local soundName = events[eventKey]
+            if mergeChargeEvents and eventKey == "available" and not soundName then
+                soundName = events.chargeGained
             end
             if validEvents[eventKey] and soundName and soundName ~= SOUND_NONE_KEY then
                 enabledEvents[eventKey] = true
@@ -769,6 +819,20 @@ function CooldownCompanion:GetEnabledSoundAlertEventsForButton(buttonData, spell
     return enabledEvents
 end
 
+function CooldownCompanion:GetEnabledSoundAlertEventsForButton(buttonData, spellIDOverride)
+    local cfg = self:GetButtonSoundAlertConfig(buttonData, false)
+    if not cfg or type(cfg.events) ~= "table" then
+        return nil
+    end
+
+    local validEvents = self:GetScopedValidSoundAlertEventsForButton(buttonData, spellIDOverride)
+    if not validEvents then
+        return nil
+    end
+
+    return CollectEnabledSoundAlertEvents(cfg.events, validEvents, UsesChargeBehavior(buttonData))
+end
+
 function CooldownCompanion:GetEnabledSoundAlertEventsForCustomBar(customBar)
     local cfg = self:GetCustomBarSoundAlertConfig(customBar, false)
     if not cfg or type(cfg.events) ~= "table" then
@@ -780,21 +844,88 @@ function CooldownCompanion:GetEnabledSoundAlertEventsForCustomBar(customBar)
         return nil
     end
 
-    local enabledEvents = {}
-    for _, eventKey in ipairs(SOUND_ALERT_EVENT_ORDER) do
-        local soundName = cfg.events[eventKey]
-        if validEvents[eventKey] and soundName and soundName ~= SOUND_NONE_KEY then
-            enabledEvents[eventKey] = true
+    return CollectEnabledSoundAlertEvents(cfg.events, validEvents, IsSpellCustomBarChargeAlertMerged(customBar))
+end
+
+local function DidGainChargeSincePreviousState(state, cooldownActive, currentCharges, chargeRecharging, chargeCooldownStartTime)
+    if currentCharges and state._sndPrevCharges and currentCharges > state._sndPrevCharges then
+        return true
+    end
+    if chargeRecharging and state._sndPrevChargeRecharging
+       and chargeCooldownStartTime and state._sndPrevChargeCooldownStart
+       and chargeCooldownStartTime > state._sndPrevChargeCooldownStart then
+        return true
+    end
+    if (not chargeRecharging) and state._sndPrevChargeRecharging then
+        return true
+    end
+    if state._sndPrevCooldownActive and not cooldownActive
+       and state._sndPrevChargeRecharging then
+        -- Fallback for charge spells where readable counts/timestamps are
+        -- unavailable: only treat cooldown edge as a gain if we were already
+        -- in a charge-recharging state.
+        return true
+    end
+    return false
+end
+
+local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
+    local cooldownActive = opts.cooldownActive and true or false
+    local auraActive = opts.auraActive and true or false
+    local chargeRecharging = opts.chargeRecharging and true or false
+    local currentCharges = opts.currentCharges
+    local chargeCooldownStartTime = opts.chargeCooldownStartTime
+
+    if not state._sndInitialized then
+        state._sndInitialized = true
+        state._sndPrevCooldownActive = cooldownActive
+        if opts.includeAuraEvents then
+            state._sndPrevAuraActive = auraActive
+        end
+        state._sndPrevCharges = currentCharges
+        state._sndPrevChargeRecharging = chargeRecharging
+        state._sndPrevChargeCooldownStart = chargeCooldownStartTime
+        return
+    end
+
+    if opts.includeAuraEvents then
+        if enabledEvents.onAuraApplied and auraActive and not state._sndPrevAuraActive then
+            opts.play("onAuraApplied")
+        end
+
+        if enabledEvents.onAuraRemoved and state._sndPrevAuraActive and not auraActive then
+            opts.play("onAuraRemoved")
         end
     end
 
-    if not next(enabledEvents) then
-        return nil
+    if enabledEvents.onCooldown and cooldownActive and not state._sndPrevCooldownActive then
+        opts.play("onCooldown")
     end
-    return enabledEvents
+
+    if enabledEvents.available then
+        if opts.usesChargeBehavior then
+            if DidGainChargeSincePreviousState(state, cooldownActive, currentCharges, chargeRecharging, chargeCooldownStartTime) then
+                opts.play("available")
+            end
+        elseif state._sndPrevCooldownActive and not cooldownActive then
+            opts.play("available")
+        end
+    end
+
+    state._sndPrevCooldownActive = cooldownActive
+    if opts.includeAuraEvents then
+        state._sndPrevAuraActive = auraActive
+    end
+    state._sndPrevChargeRecharging = chargeRecharging
+    if currentCharges ~= nil then
+        state._sndPrevCharges = currentCharges
+    end
+    if chargeCooldownStartTime ~= nil then
+        state._sndPrevChargeCooldownStart = chargeCooldownStartTime
+    end
 end
 
-function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive)
+function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, cooldownActive, cooldownResult)
     local customBar = barInfo and barInfo.cabConfig
     local enabledEvents = self:GetEnabledSoundAlertEventsForCustomBar(customBar)
     if not enabledEvents then
@@ -804,22 +935,35 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive)
         return
     end
 
-    auraActive = auraActive and true or false
-    if not barInfo._sndInitialized then
-        barInfo._sndInitialized = true
-        barInfo._sndPrevAuraActive = auraActive
+    if customBar and customBar.entryType == "spell" then
+        local chargeRecharging = cooldownResult and cooldownResult.chargeRecharging == true
+        local currentCharges = cooldownResult and cooldownResult.currentCharges
+        local chargeCooldownStartTime
+        local charges = cooldownResult and cooldownResult.charges
+        if charges and charges.cooldownStartTime ~= nil and not issecretvalue(charges.cooldownStartTime) then
+            chargeCooldownStartTime = charges.cooldownStartTime
+        end
+
+        UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, {
+            cooldownActive = cooldownActive,
+            currentCharges = currentCharges,
+            chargeRecharging = chargeRecharging,
+            chargeCooldownStartTime = chargeCooldownStartTime,
+            usesChargeBehavior = cooldownResult and cooldownResult.hasCharges == true,
+            play = function(eventKey)
+                self:PlayCustomBarSoundAlertEvent(customBar, eventKey)
+            end,
+        })
         return
     end
 
-    if enabledEvents.onAuraApplied and auraActive and not barInfo._sndPrevAuraActive then
-        self:PlayCustomBarSoundAlertEvent(customBar, "onAuraApplied")
-    end
-
-    if enabledEvents.onAuraRemoved and barInfo._sndPrevAuraActive and not auraActive then
-        self:PlayCustomBarSoundAlertEvent(customBar, "onAuraRemoved")
-    end
-
-    barInfo._sndPrevAuraActive = auraActive
+    UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, {
+        auraActive = auraActive,
+        includeAuraEvents = true,
+        play = function(eventKey)
+            self:PlayCustomBarSoundAlertEvent(customBar, eventKey)
+        end,
+    })
 end
 
 function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isOnGCD, cooldownActive, auraActive, currentCharges, _maxCharges, chargeRecharging, chargeCooldownStartTime)
@@ -841,68 +985,18 @@ function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isO
         return
     end
 
-    cooldownActive = cooldownActive and true or false
-    auraActive = auraActive and true or false
-    chargeRecharging = chargeRecharging and true or false
-
-    if not button._sndInitialized then
-        button._sndInitialized = true
-        button._sndPrevCooldownActive = cooldownActive
-        button._sndPrevAuraActive = auraActive
-        button._sndPrevCharges = currentCharges
-        button._sndPrevChargeRecharging = chargeRecharging
-        button._sndPrevChargeCooldownStart = chargeCooldownStartTime
-        return
-    end
-
-    if enabledEvents.onAuraApplied and auraActive and not button._sndPrevAuraActive then
-        self:PlayButtonSoundAlertEvent(buttonData, "onAuraApplied")
-    end
-
-    if enabledEvents.onAuraRemoved and button._sndPrevAuraActive and not auraActive then
-        self:PlayButtonSoundAlertEvent(buttonData, "onAuraRemoved")
-    end
-
-    if enabledEvents.onCooldown and cooldownActive and not button._sndPrevCooldownActive then
-        self:PlayButtonSoundAlertEvent(buttonData, "onCooldown")
-    end
-
-    if enabledEvents.available then
-        if UsesChargeBehavior(buttonData) then
-            local gainedCharge = false
-            if currentCharges and button._sndPrevCharges and currentCharges > button._sndPrevCharges then
-                gainedCharge = true
-            elseif chargeRecharging and button._sndPrevChargeRecharging
-               and chargeCooldownStartTime and button._sndPrevChargeCooldownStart
-               and chargeCooldownStartTime > button._sndPrevChargeCooldownStart then
-                gainedCharge = true
-            elseif (not chargeRecharging) and button._sndPrevChargeRecharging then
-                gainedCharge = true
-            elseif button._sndPrevCooldownActive and not cooldownActive
-               and button._sndPrevChargeRecharging then
-                -- Fallback for charge spells where readable counts/timestamps are
-                -- unavailable: only treat cooldown edge as a gain if we were
-                -- already in a charge-recharging state.
-                gainedCharge = true
-            end
-
-            if gainedCharge then
-                self:PlayButtonSoundAlertEvent(buttonData, "available")
-            end
-        elseif (not UsesChargeBehavior(buttonData)) and button._sndPrevCooldownActive and not cooldownActive then
-            self:PlayButtonSoundAlertEvent(buttonData, "available")
-        end
-    end
-
-    button._sndPrevCooldownActive = cooldownActive
-    button._sndPrevAuraActive = auraActive
-    button._sndPrevChargeRecharging = chargeRecharging
-    if currentCharges ~= nil then
-        button._sndPrevCharges = currentCharges
-    end
-    if chargeCooldownStartTime ~= nil then
-        button._sndPrevChargeCooldownStart = chargeCooldownStartTime
-    end
+    UpdateCooldownSoundAlertTransitions(button, enabledEvents, {
+        cooldownActive = cooldownActive,
+        auraActive = auraActive,
+        currentCharges = currentCharges,
+        chargeRecharging = chargeRecharging,
+        chargeCooldownStartTime = chargeCooldownStartTime,
+        includeAuraEvents = true,
+        usesChargeBehavior = UsesChargeBehavior(buttonData),
+        play = function(eventKey)
+            self:PlayButtonSoundAlertEvent(buttonData, eventKey)
+        end,
+    })
 end
 
 function CooldownCompanion:UpdateTriggerPanelSoundAlerts(frame, group, triggerMatched)

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -2674,6 +2674,86 @@ local function UpdateCustomAuraBar(barInfo)
     end
 end
 
+function RB.UpdateCustomCooldownBar(barInfo)
+    local cabConfig = barInfo and barInfo.cabConfig
+    local bar = barInfo and barInfo.frame
+    if not (cabConfig and cabConfig.spellID and bar) then return end
+
+    local cooldownResult = CooldownCompanion.EvaluateSpellCooldownStateForCustomBar
+        and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig)
+    local durationObj = cooldownResult and cooldownResult.renderDurationObj
+    local cooldownActive = cooldownResult
+        and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
+
+    local barColor = cabConfig.barColor or {0.5, 0.5, 1, 1}
+    local cooldownColor = cabConfig.barCooldownColor or {0.6, 0.13, 0.18, 1}
+    local rechargeColor = cabConfig.barChargeColor or {1.0, 0.82, 0.0, 1}
+    local chargeState = cooldownResult and cooldownResult.chargeState
+    local fillColor = barColor
+    if cooldownResult and cooldownResult.hasCharges == true then
+        if chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO then
+            fillColor = cooldownColor
+        elseif cooldownActive then
+            fillColor = rechargeColor
+        end
+    elseif cooldownActive then
+        fillColor = cooldownColor
+    end
+    bar:SetStatusBarColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] ~= nil and fillColor[4] or 1)
+
+    bar:SetMinMaxValues(0, 1)
+    if cooldownActive and durationObj then
+        bar:SetValue(durationObj:GetElapsedPercent())
+    elseif cooldownActive then
+        bar:SetValue(0)
+    else
+        bar:SetValue(1)
+    end
+
+    if bar.thresholdOverlay then
+        bar.thresholdOverlay:SetValue(0)
+        bar.thresholdOverlay:Hide()
+    end
+
+    if bar.text and bar.text:IsShown() then
+        if cooldownActive and durationObj then
+            local remaining = durationObj:GetRemainingDuration()
+            if durationObj:HasSecretValues() then
+                bar.text:SetFormattedText(cabConfig.decimalTimers and "%.1f" or "%.0f", remaining)
+            elseif remaining and remaining > 0 then
+                bar.text:SetText(FormatTime(remaining, cabConfig.decimalTimers))
+            else
+                bar.text:SetText("")
+            end
+        else
+            bar.text:SetText("")
+        end
+    end
+
+    if bar.stackText and bar.stackText:IsShown() then
+        local currentCharges = cooldownResult and cooldownResult.currentCharges
+        local maxCharges = cooldownResult and cooldownResult.maxCharges
+        if currentCharges and maxCharges and maxCharges > 1 then
+            bar.stackText:SetFormattedText("%d / %d", currentCharges, maxCharges)
+        else
+            bar.stackText:SetText("")
+        end
+    end
+
+    if barInfo._maxStacksIndicator then
+        barInfo._maxStacksIndicator:SetValue(0)
+    end
+
+    if CooldownCompanion.UpdateCustomBarSoundAlerts then
+        local soundCooldownActive = cooldownActive
+        if cooldownResult and cooldownResult.hasCharges == true then
+            soundCooldownActive = cooldownResult.chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO
+                or (cooldownResult.chargeState == nil and cooldownActive)
+        end
+        CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false, soundCooldownActive, cooldownResult)
+    end
+end
+
 local function GetHiddenCustomAuraWakeUnit(cabConfig)
     if not cabConfig or not cabConfig.spellID then
         return nil
@@ -2831,10 +2911,11 @@ end
 
 local function StyleCustomAuraBar(barInfo, cabConfig)
     local barColor = cabConfig.barColor or {0.5, 0.5, 1}
-    local thresholdEnabled = IsCustomAuraMaxThresholdEnabled(cabConfig)
+    local isSpellCustomBar = RB.GetCustomBarEntryType and RB.GetCustomBarEntryType(cabConfig) == "spell"
+    local thresholdEnabled = (not isSpellCustomBar) and IsCustomAuraMaxThresholdEnabled(cabConfig)
     local thresholdColor = GetCustomAuraMaxThresholdColor(cabConfig)
 
-    if barInfo.barType == "custom_continuous" then
+    if barInfo.barType == "custom_continuous" or barInfo.barType == "custom_cooldown" then
         local bar = barInfo.frame
         bar.style = cabConfig
         local isVertical = bar._isVertical == true
@@ -2845,10 +2926,12 @@ local function StyleCustomAuraBar(barInfo, cabConfig)
         end
 
         -- Determine visibility for both text elements
-        local isActive = cabConfig.trackingMode == "active"
+        local isActive = isSpellCustomBar or cabConfig.trackingMode == "active"
         local showDuration = cabConfig.showDurationText == true
         local showStack = cabConfig.showStackText
-        if showStack == nil then
+        if isSpellCustomBar then
+            showStack = showStack == true
+        elseif showStack == nil then
             -- Backwards compat: fall back to showText for stacks mode
             if not isActive then
                 showStack = cabConfig.showText == true
@@ -2927,11 +3010,17 @@ local function FinalizeAppliedBarVisibility(barInfo, powerType, previewActive)
     if barInfo and type(barInfo.customBarId) == "string" then
         if previewActive then
             barInfo.frame:Show()
-        elseif barInfo.cabConfig and barInfo.cabConfig.hideWhenInactive then
+        elseif barInfo.barType ~= "custom_cooldown"
+            and barInfo.cabConfig
+            and barInfo.cabConfig.hideWhenInactive then
             UpdateCustomAuraBar(barInfo)
         else
             barInfo.frame:Show()
-            UpdateCustomAuraBar(barInfo)
+            if barInfo.barType == "custom_cooldown" then
+                RB.UpdateCustomCooldownBar(barInfo)
+            else
+                UpdateCustomAuraBar(barInfo)
+            end
         end
     else
         barInfo.frame:Show()
@@ -2953,6 +3042,10 @@ local function HideUnusedResourceBarFrames(owner, firstHiddenIndex)
             barInfo.customBarIndex = nil
             barInfo._sndInitialized = nil
             barInfo._sndPrevAuraActive = nil
+            barInfo._sndPrevCooldownActive = nil
+            barInfo._sndPrevCharges = nil
+            barInfo._sndPrevChargeRecharging = nil
+            barInfo._sndPrevChargeCooldownStart = nil
             barInfo._isIndependent = nil
             barInfo._side = nil
             barInfo._order = nil
@@ -2994,10 +3087,11 @@ local function PrepareCustomAuraBar(
         return barInfo, false
     end
     customBarId = customBarId or RB.EnsureCustomBarId(settings, cabConfig)
-    local isActive = cabConfig.trackingMode == "active"
-    local mode = isActive and "continuous" or (cabConfig.displayMode or "segmented")
+    local isSpellCustomBar = RB.GetCustomBarEntryType and RB.GetCustomBarEntryType(cabConfig) == "spell"
+    local isActive = isSpellCustomBar or cabConfig.trackingMode == "active"
+    local mode = isSpellCustomBar and "continuous" or (isActive and "continuous" or (cabConfig.displayMode or "segmented"))
     local maxStacks = isActive and 1 or (cabConfig.maxStacks or 1)
-    local targetBarType = "custom_" .. mode
+    local targetBarType = isSpellCustomBar and "custom_cooldown" or ("custom_" .. mode)
     local isIndependentCustomAura = IsCustomAuraBarIndependent(cabConfig)
     local customOrientation = isVerticalLayout and "vertical" or "horizontal"
     if isIndependentCustomAura then
@@ -3058,7 +3152,7 @@ local function PrepareCustomAuraBar(
         if mode == "continuous" then
             local bar = CreateContinuousBar(targetContainer)
             bar:SetMinMaxValues(0, maxStacks)
-            barInfo = { frame = bar, barType = "custom_continuous" }
+            barInfo = { frame = bar, barType = targetBarType }
         elseif mode == "segmented" then
             local holder = CreateSegmentedBar(targetContainer, maxStacks)
             for si = 1, maxStacks do
@@ -3083,6 +3177,10 @@ local function PrepareCustomAuraBar(
     if barInfo.customBarId ~= customBarId then
         barInfo._sndInitialized = nil
         barInfo._sndPrevAuraActive = nil
+        barInfo._sndPrevCooldownActive = nil
+        barInfo._sndPrevCharges = nil
+        barInfo._sndPrevChargeRecharging = nil
+        barInfo._sndPrevChargeCooldownStart = nil
     end
     barInfo.cabConfig = cabConfig
     barInfo.powerType = legacyPowerType
@@ -3164,11 +3262,15 @@ local function PrepareCustomAuraBar(
     StyleCustomAuraBar(barInfo, cabConfig)
 
     if cabConfig.maxStacksGlowEnabled then
-        EnsureMaxStacksIndicator(barInfo)
-        local indBorderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
-        local indBorderSize = GetResourceDisplayValue(settings, "borderSize", 1)
-        local indBarTexture = CooldownCompanion:FetchStatusBar(GetResourceDisplayValue(settings, "barTexture", "Solid"))
-        LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, indBarTexture, indBorderStyle, indBorderSize)
+        if isSpellCustomBar then
+            ClearMaxStacksIndicator(barInfo)
+        else
+            EnsureMaxStacksIndicator(barInfo)
+            local indBorderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
+            local indBorderSize = GetResourceDisplayValue(settings, "borderSize", 1)
+            local indBarTexture = CooldownCompanion:FetchStatusBar(GetResourceDisplayValue(settings, "barTexture", "Solid"))
+            LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, indBarTexture, indBorderStyle, indBorderSize)
+        end
     else
         ClearMaxStacksIndicator(barInfo)
     end
@@ -3334,6 +3436,11 @@ local function OnUpdate(self, elapsed)
                 UpdateMaelstromWeaponBar(barInfo.frame, settings, auraActiveCache)
             elseif barInfo.barType == "stagger_continuous" then
                 UpdateStaggerBar(barInfo.frame, settings)
+            elseif barInfo.barType == "custom_cooldown" then
+                RB.UpdateCustomCooldownBar(barInfo)
+                if barInfo._isIndependent and barInfo.cabConfig then
+                    ApplyIndependentCustomAuraAlpha(barInfo, settings, ResolveIndependentAnchorTarget(barInfo.cabConfig, settings))
+                end
             elseif barInfo.barType == "custom_continuous" then
                 UpdateCustomAuraBar(barInfo)
                 if barInfo._isIndependent and barInfo.cabConfig then
@@ -4695,6 +4802,24 @@ local function ApplyPreviewDataToBar(barInfo, settings)
         end
         ApplyResourceAuraLanePreview(barInfo, 0.5)
         SetSegmentedText(barInfo.frame, previewStacks, mwMaxStacks)
+    elseif barInfo.barType == "custom_cooldown" then
+        barInfo.frame:SetMinMaxValues(0, 1)
+        barInfo.frame:SetValue(0.45)
+        if barInfo.frame.thresholdOverlay then
+            barInfo.frame.thresholdOverlay:SetValue(0)
+            barInfo.frame.thresholdOverlay:Hide()
+        end
+        if barInfo.frame.text and barInfo.frame.text:IsShown() then
+            local cabConfig = barInfo.cabConfig
+            barInfo.frame.text:SetText(FormatTime(12.3, cabConfig and cabConfig.decimalTimers))
+        end
+        if barInfo.frame.stackText and barInfo.frame.stackText:IsShown() then
+            barInfo.frame.stackText:SetText("1 / 2")
+        end
+        ClearCustomAuraBarIndicatorState(barInfo, true)
+        if barInfo._maxStacksIndicator then
+            barInfo._maxStacksIndicator:SetValue(0)
+        end
     elseif barInfo.barType == "custom_continuous" then
         local cabConfig = barInfo.cabConfig
         local isActive = cabConfig and cabConfig.trackingMode == "active"

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -194,14 +194,32 @@ local function IsConfiguredCustomBar(cab)
     return type(cab) == "table"
         and (
             cab.spellID ~= nil
+            or cab.entryType ~= nil
             or cab.enabled == true
             or cab.independentAnchorEnabled ~= nil
             or cab.trackingMode ~= nil
             or cab.displayMode ~= nil
             or cab.maxStacks ~= nil
             or cab.barColor ~= nil
+            or cab.soundAlerts ~= nil
+            or cab.loadConditions ~= nil
             or cab.talentConditions ~= nil
         )
+end
+
+local function GetCustomBarEntryType(cab)
+    if type(cab) == "table" and cab.entryType == "spell" then
+        return "spell"
+    end
+    return "aura"
+end
+
+local function NormalizeCustomBarEntryType(cab)
+    if type(cab) ~= "table" then
+        return "aura"
+    end
+    cab.entryType = GetCustomBarEntryType(cab)
+    return cab.entryType
 end
 
 local function CustomBarIdOwnedByOther(settings, customBarId, owner)
@@ -305,7 +323,7 @@ local function MigrateLegacyCustomAuraBars(settings, specID, target)
         local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
         if IsConfiguredCustomBar(cab) then
             local entry = CopyTable(cab)
-            entry.entryType = entry.entryType or "aura"
+            entry.entryType = "aura"
             local id = EnsureCustomBarId(settings, entry)
             target[#target + 1] = entry
 
@@ -357,7 +375,7 @@ local function NormalizeCustomBars(settings, specID)
     for _, key in ipairs(numericKeys) do
         local entry = specBars[key]
         if IsConfiguredCustomBar(entry) then
-            entry.entryType = entry.entryType or "aura"
+            NormalizeCustomBarEntryType(entry)
             EnsureCustomBarId(settings, entry)
             compact[#compact + 1] = entry
         end
@@ -366,7 +384,7 @@ local function NormalizeCustomBars(settings, specID)
 
     for key, entry in pairs(specBars) do
         if not seen[key] and IsConfiguredCustomBar(entry) then
-            entry.entryType = entry.entryType or "aura"
+            NormalizeCustomBarEntryType(entry)
             EnsureCustomBarId(settings, entry)
             compact[#compact + 1] = entry
         end
@@ -1163,6 +1181,7 @@ RB.EnsureCustomBarId = EnsureCustomBarId
 RB.GetCustomBarLayout = GetCustomBarLayout
 RB.EnsureCustomBarLayout = EnsureCustomBarLayout
 RB.IsConfiguredCustomBar = IsConfiguredCustomBar
+RB.GetCustomBarEntryType = GetCustomBarEntryType
 RB.IsValidCustomAuraUnit = IsValidCustomAuraUnit
 RB.GetDefaultCustomAuraUnit = GetDefaultCustomAuraUnit
 RB.GetResolvedCustomAuraBarAuraUnit = GetResolvedCustomAuraBarAuraUnit


### PR DESCRIPTION
## What Players Will Notice
- Custom Bars can now track spell cooldowns in addition to auras, so players can add cooldown spells to the panel stack and see them as bars.
- Charge-based cooldown spells can show charge text, use separate ready/cooldown/recharge colors, and play the same available or charge-gained sound alert through the Custom Bar sound settings.
- The Custom Bar add box now infers whether an entry is an aura or a cooldown spell, including explicit autocomplete suffixes like aura/buff/cooldown, without a separate Add As dropdown.

## Why This Changed
- Custom Bars had already moved beyond the old Custom Aura Bar model, but they still only displayed aura state. Cooldowns were already tracked well in Bar Panels, so this brings that spell cooldown behavior into attached Custom Bars without forcing players to use a separate bar panel.

## What Changed
- Added a Custom Bar cooldown evaluation path that reuses the existing spell cooldown lane, override spell handling, secrecy caching, charge detection, and charge recharge duration data.
- Added runtime rendering for spell Custom Bars, including cooldown fill progress, ready/full-charge color, cooldown/no-charge color, recharge color, charge text, preview behavior, and sound-alert transition state.
- Updated Custom Bar config so spell entries skip aura-only tracking/display controls, expose cooldown/recharge color settings, and use spell-aware row badges and text labels.
- Extended Custom Bar autocomplete and normalization so legacy aura bars remain aura entries while new entries can be spell cooldowns or auras through the same edit box.
- Shared cooldown sound-alert transition helpers between buttons and spell Custom Bars, including merged available/charge-gained behavior for charge spells.

## Validation
- Ran `luac -p` across 74 non-Libs Lua files.
- Ran `git diff --check origin/main...HEAD`.
- Ran a final code review pass with no actionable findings.
- In-game combat/restricted-content validation has not been performed in this Codex session and is still needed before treating the feature as fully runtime-verified.