### PR TITLE
Make Custom Bars always attach to their panel

### DIFF
--- a/.github/workflows/discord-pr-merge.yml
+++ b/.github/workflows/discord-pr-merge.yml
@@ -1,0 +1,91 @@
+name: Discord PR Merge Notification
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send merge notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_MERGES }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          node <<'NODE'
+          const {
+            DISCORD_WEBHOOK_URL,
+            GITHUB_TOKEN,
+            REPOSITORY,
+            COMMIT_SHA,
+          } = process.env;
+
+          if (!DISCORD_WEBHOOK_URL) {
+            throw new Error("Missing DISCORD_WEBHOOK_URL_MERGES repository secret.");
+          }
+
+          const headers = {
+            authorization: `Bearer ${GITHUB_TOKEN}`,
+            accept: "application/vnd.github+json",
+            "x-github-api-version": "2022-11-28",
+          };
+
+          const pullsResponse = await fetch(
+            `https://api.github.com/repos/${REPOSITORY}/commits/${COMMIT_SHA}/pulls`,
+            { headers }
+          );
+
+          if (!pullsResponse.ok) {
+            throw new Error(`GitHub PR lookup failed: ${pullsResponse.status} ${await pullsResponse.text()}`);
+          }
+
+          const pulls = await pullsResponse.json();
+          const pull = pulls.find((item) => item.base?.ref === "main" && item.merged_at);
+
+          if (!pull) {
+            console.log("No merged pull request was associated with this push to main.");
+            process.exit(0);
+          }
+
+          const pullResponse = await fetch(
+            `https://api.github.com/repos/${REPOSITORY}/pulls/${pull.number}`,
+            { headers }
+          );
+          const pullDetails = pullResponse.ok ? await pullResponse.json() : pull;
+          const mergedBy = pullDetails.merged_by?.login || "unknown";
+
+          const payload = {
+            username: "GitHub Merges",
+            embeds: [
+              {
+                title: `Merged PR #${pull.number}: ${pull.title}`,
+                url: pull.html_url,
+                color: 5763719,
+                fields: [
+                  { name: "Repository", value: REPOSITORY, inline: true },
+                  { name: "Author", value: pull.user.login, inline: true },
+                  { name: "Merged by", value: mergedBy, inline: true },
+                ],
+              },
+            ],
+          };
+
+          const response = await fetch(DISCORD_WEBHOOK_URL, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Discord webhook failed: ${response.status} ${await response.text()}`);
+          }
+          NODE

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -15,10 +15,6 @@ local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
 ------------------------------------------------------------------------
 -- COLUMN 4: Group / Panel Settings Column
 ------------------------------------------------------------------------
-local function IsTruthyConfigFlag(value)
-    return value == true or value == "true" or value == 1 or value == "1"
-end
-
 local function ClearInfoButtons(buttons)
     if type(buttons) ~= "table" then
         return
@@ -51,10 +47,6 @@ local function GetCustomBarEntryTabs(entry)
         { value = "settings", text = "Settings" },
     }
 
-    if entry and IsTruthyConfigFlag(entry.independentAnchorEnabled) then
-        tabs[#tabs + 1] = { value = "layout", text = "Layout" }
-    end
-
     tabs[#tabs + 1] = { value = "soundalerts", text = "Sound Alerts" }
     tabs[#tabs + 1] = { value = "loadconditions", text = "Load Conditions" }
     return tabs
@@ -64,7 +56,7 @@ local function IsCustomBarEntryTabAllowed(entry, tab)
     if tab == "settings" or tab == "soundalerts" or tab == "loadconditions" then
         return true
     end
-    return entry and IsTruthyConfigFlag(entry.independentAnchorEnabled) and tab == "layout"
+    return false
 end
 
 local function GetCustomBarDetailScrollKey()

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -222,6 +222,29 @@ local function FormatDiagnosticAsText(diag)
         return table.concat(parts, " ")
     end
 
+    local ignoredCustomBarDiagnosticKeys = {
+        independentAnchorEnabled = true,
+        independentLocked = true,
+        independentAnchorTargetMode = true,
+        independentAnchorFrameName = true,
+        independentAnchorGroupId = true,
+        independentAnchor = true,
+        independentSize = true,
+        independentOrientation = true,
+        independentVerticalFillDirection = true,
+    }
+
+    local function dumpCustomBarKV(t)
+        local parts = {}
+        for k, v in pairs(t) do
+            if not ignoredCustomBarDiagnosticKeys[k] then
+                parts[#parts + 1] = tostring(k) .. "=" .. formatValue(v)
+            end
+        end
+        table.sort(parts)
+        return table.concat(parts, " ")
+    end
+
     -- Explicitly include nil-valued keys that are important for debugging
     local function dumpKVWithNils(t, importantKeys)
         local parts = {}
@@ -362,9 +385,6 @@ local function FormatDiagnosticAsText(diag)
             end
             if entry.hideWhenInactive then
                 parts[#parts + 1] = "hideWhenInactive=true"
-            end
-            if entry.isIndependent then
-                parts[#parts + 1] = "independent=true"
             end
             add("  " .. table.concat(parts, " "))
         end
@@ -742,7 +762,7 @@ local function FormatDiagnosticAsText(diag)
                     for slot in pairs(specBars) do slots[#slots + 1] = slot end
                     table.sort(slots, function(a, b) return tostring(a) < tostring(b) end)
                     for _, slot in ipairs(slots) do
-                        add(("      %s: %s"):format(tostring(slot), dumpKV(specBars[slot])))
+                        add(("      %s: %s"):format(tostring(slot), dumpCustomBarKV(specBars[slot])))
                     end
                 end
             end

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -1293,10 +1293,8 @@ local function CleanRecycledEntry(entry)
     if entry.frame._cdcHeaderDisabledBadge then entry.frame._cdcHeaderDisabledBadge:Hide() end
     if entry.frame._cdcDisabledBadge then entry.frame._cdcDisabledBadge:Hide() end
     if entry.frame._cdcCustomBarTypeBadge then entry.frame._cdcCustomBarTypeBadge:Hide() end
-    if entry.frame._cdcCustomBarPlacementBadge then entry.frame._cdcCustomBarPlacementBadge:Hide() end
     if entry.frame._cdcCustomBarAuraStatusBadge then entry.frame._cdcCustomBarAuraStatusBadge:Hide() end
     if entry.frame._cdcCustomBarDisabledBadge then entry.frame._cdcCustomBarDisabledBadge:Hide() end
-    if entry.frame._cdcCustomBarUnlockedBadge then entry.frame._cdcCustomBarUnlockedBadge:Hide() end
     if entry.frame._cdcFallbackRemoveBtn then entry.frame._cdcFallbackRemoveBtn:Hide() end
     if entry.frame._cdcFallbackUpBtn then entry.frame._cdcFallbackUpBtn:Hide() end
     if entry.frame._cdcFallbackDownBtn then entry.frame._cdcFallbackDownBtn:Hide() end

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -746,18 +746,21 @@ local function GetShortLabel(label)
     return first
 end
 
-local function CollectPreviewSlots(rbSettings, cbSettings, layout, isVerticalLayout)
-    local activeResources = GetConfigActiveResources()
-    local customBars = CooldownCompanion:GetSpecCustomAuraBars()
+local function CollectPreviewSlots(rbSettings, cbSettings, layout, isVerticalLayout, includeResourceSlots)
+    includeResourceSlots = includeResourceSlots == true
+    local activeResources = includeResourceSlots and GetConfigActiveResources() or {}
+    local customBars = includeResourceSlots and CooldownCompanion:GetSpecCustomAuraBars() or {}
     local primarySlots = {}
     local castSlots = {}
-    local resourceBarsEnabled = rbSettings and rbSettings.enabled
+    local resourceBarsEnabled = includeResourceSlots and rbSettings and rbSettings.enabled
 
-    layout.resources = layout.resources or {}
-    layout.customAuraBarSlots = layout.customAuraBarSlots or {}
-    layout.customBars = layout.customBars or {}
-    rbSettings = rbSettings or {}
-    rbSettings.resources = rbSettings.resources or {}
+    if includeResourceSlots then
+        layout.resources = layout.resources or {}
+        layout.customAuraBarSlots = layout.customAuraBarSlots or {}
+        layout.customBars = layout.customBars or {}
+        rbSettings = rbSettings or {}
+        rbSettings.resources = rbSettings.resources or {}
+    end
 
     local function GetSlotColor(powerType)
         if powerType == RESOURCE_HEALTH then
@@ -855,7 +858,7 @@ local function CollectPreviewSlots(rbSettings, cbSettings, layout, isVerticalLay
 
     if resourceBarsEnabled then
         for customIndex, customAura in ipairs(customBars or {}) do
-            if customAura and customAura.enabled and customAura.spellID and not IsTruthyConfigFlag(customAura.independentAnchorEnabled) then
+            if customAura and customAura.enabled and customAura.spellID then
                 local customBarId = EnsureCustomBarId(rbSettings, customAura)
                 local spellInfo = C_Spell.GetSpellInfo(customAura.spellID)
                 local label = spellInfo and spellInfo.name or customAura.label or ("Custom Bar " .. customIndex)
@@ -1647,6 +1650,36 @@ local function RenderHorizontalLayout(preview, content, layoutDrag, sourcePanel,
 end
 
 local function RenderVerticalLayout(preview, content, layoutDrag, sourcePanel, primarySlots, castSlots, horizontalBarHeight, verticalBarWidth)
+    if #primarySlots == 0 and #castSlots > 0 then
+        local castPanel = RenderMirroredPanel(preview, content, sourcePanel)
+        local panelWidth = castPanel:GetWidth()
+        local panelHeight = castPanel:GetHeight()
+        local castSlotFrameHeight = math_max(8, horizontalBarHeight)
+        local castAbove = SortSlotsForSide(castSlots, "above", true)
+        local castBelow = SortSlotsForSide(castSlots, "below", false)
+        local castAboveHeight = GetLaneExtent(#castAbove, castSlotFrameHeight)
+        local castBelowHeight = GetLaneExtent(#castBelow, castSlotFrameHeight)
+
+        local castAboveLane = BuildLane(preview, content, layoutDrag, nil, panelWidth, castAboveHeight, "y", "above", true, castAbove, sourcePanel.width, castSlotFrameHeight, "cast")
+        castAboveLane.frame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
+
+        castAboveLane.setPreviewOverflow = function(extra)
+            castAboveLane.frame:ClearAllPoints()
+            castAboveLane.frame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, extra)
+            castAboveLane.frame:SetSize(castAboveLane.baseWidth or panelWidth, (castAboveLane.baseHeight or castAboveHeight) + extra)
+        end
+        castAboveLane.setPreviewOverflow(0)
+
+        castPanel:ClearAllPoints()
+        castPanel:SetPoint("TOPLEFT", castAboveLane.frame, "BOTTOMLEFT", 0, -LAYOUT_PREVIEW_GAP)
+
+        local castBelowLane = BuildLane(preview, content, layoutDrag, nil, panelWidth, castBelowHeight, "y", "below", false, castBelow, sourcePanel.width, castSlotFrameHeight, "cast")
+        castBelowLane.frame:SetPoint("TOPLEFT", castPanel, "BOTTOMLEFT", 0, -LAYOUT_PREVIEW_GAP)
+
+        local iconCenterOffsetY = castAboveHeight + LAYOUT_PREVIEW_GAP + (panelHeight / 2)
+        return panelWidth, castAboveHeight + panelHeight + castBelowHeight + (LAYOUT_PREVIEW_GAP * 2), iconCenterOffsetY
+    end
+
     local panelFrame = RenderMirroredPanel(preview, content, sourcePanel)
     local panelWidth = panelFrame:GetWidth()
     local panelHeight = panelFrame:GetHeight()
@@ -1980,10 +2013,12 @@ local function CreateLayoutDragModel(preview)
             end
         end
 
-        local adjustedIndex = math_max(1, math_min(#filtered + 1, dropTarget.insertIndex or 1))
-        local newOrder = GetLayoutOrderForInsertion(filtered, lane.reversed, adjustedIndex)
         local oldPos = slotData.getPos()
         local oldOrder = slotData.getOrder()
+        local adjustedIndex = math_max(1, math_min(#filtered + 1, dropTarget.insertIndex or 1))
+        local newOrder = (#filtered == 0 and oldPos == lane.side)
+            and oldOrder
+            or GetLayoutOrderForInsertion(filtered, lane.reversed, adjustedIndex)
 
         slotData.setPos(lane.side)
         slotData.setOrder(newOrder)
@@ -2038,7 +2073,13 @@ function ST._BuildLayoutOrderPreviewPanel(container)
         return
     end
 
-    local primarySlots, castSlots = CollectPreviewSlots(rbSettings, cbSettings, layout, preview.isVerticalLayout)
+    local primarySlots, castSlots = CollectPreviewSlots(
+        rbSettings,
+        cbSettings,
+        layout,
+        preview.isVerticalLayout,
+        supportsAttachedResourceBars
+    )
     if not preview.isVerticalLayout then
         for _, castSlot in ipairs(castSlots) do
             table_insert(primarySlots, castSlot)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -1797,74 +1797,6 @@ end
 -- Custom Bars detail panel
 ------------------------------------------------------------------------
 
-local function ClampCustomAuraIndependentDimension(value, fallback)
-    local dimension = tonumber(value) or tonumber(fallback) or 120
-    if dimension < 4 then
-        dimension = 4
-    elseif dimension > 1200 then
-        dimension = 1200
-    end
-    return dimension
-end
-
-local function IsTruthyConfigFlag(value)
-    return value == true or value == 1 or value == "1" or value == "true"
-end
-
-local function NormalizeCustomAuraIndependentOrientation(value)
-    if value == "horizontal" or value == "vertical" then
-        return value
-    end
-    return nil
-end
-
-local function NormalizeCustomAuraIndependentVerticalFillDirection(value)
-    if value == "bottom_to_top" or value == "top_to_bottom" or value == "inherit" then
-        return value
-    end
-    return "inherit"
-end
-
-local function GetResolvedCustomAuraIndependentOrientation(cab, settings)
-    local orientation = NormalizeCustomAuraIndependentOrientation(cab and cab.independentOrientation)
-    if orientation then
-        return orientation
-    end
-    return IsResourceBarVerticalConfig(settings, CooldownCompanion:GetSpecLayoutOrder()) and "vertical" or "horizontal"
-end
-
-local function EnsureCustomAuraIndependentConfig(cab, settings)
-    if type(cab) ~= "table" then return end
-
-    if cab.independentAnchorEnabled ~= nil then
-        cab.independentAnchorEnabled = IsTruthyConfigFlag(cab.independentAnchorEnabled) and true or nil
-    end
-
-    if cab.independentAnchorTargetMode ~= "group" and cab.independentAnchorTargetMode ~= "frame" then
-        cab.independentAnchorTargetMode = "group"
-    end
-    if type(cab.independentLocked) ~= "boolean" then
-        cab.independentLocked = IsTruthyConfigFlag(cab.independentLocked) and true or false
-    end
-
-    cab.independentOrientation = NormalizeCustomAuraIndependentOrientation(cab.independentOrientation)
-    cab.independentVerticalFillDirection = NormalizeCustomAuraIndependentVerticalFillDirection(cab.independentVerticalFillDirection)
-
-    if type(cab.independentAnchor) ~= "table" then
-        cab.independentAnchor = {}
-    end
-    cab.independentAnchor.point = cab.independentAnchor.point or "CENTER"
-    cab.independentAnchor.relativePoint = cab.independentAnchor.relativePoint or "CENTER"
-    cab.independentAnchor.x = tonumber(cab.independentAnchor.x) or 0
-    cab.independentAnchor.y = tonumber(cab.independentAnchor.y) or 0
-
-    if type(cab.independentSize) ~= "table" then
-        cab.independentSize = {}
-    end
-    cab.independentSize.width = ClampCustomAuraIndependentDimension(cab.independentSize.width, 120)
-    cab.independentSize.height = ClampCustomAuraIndependentDimension(cab.independentSize.height, settings and (settings.barHeight or settings.barWidth or 12) or 12)
-end
-
 local function ApplyCustomAuraBarPanelChanges(opts)
     CooldownCompanion:ApplyResourceBars()
     if opts and opts.updateAnchors then
@@ -2071,22 +2003,11 @@ local function DuplicateCustomBarById(settings, customBars, customBarId)
     return newId
 end
 
-local function ToggleCustomBarPlacementLock(entry)
-    if not (type(entry) == "table" and IsTruthyConfigFlag(entry.independentAnchorEnabled)) then
-        return false
-    end
-
-    entry.independentLocked = entry.independentLocked ~= true
-    return true
-end
-
 local function HideCustomBarRowDecorations(frame)
     if not frame then return end
     if frame._cdcCustomBarTypeBadge then frame._cdcCustomBarTypeBadge:Hide() end
-    if frame._cdcCustomBarPlacementBadge then frame._cdcCustomBarPlacementBadge:Hide() end
     if frame._cdcCustomBarAuraStatusBadge then frame._cdcCustomBarAuraStatusBadge:Hide() end
     if frame._cdcCustomBarDisabledBadge then frame._cdcCustomBarDisabledBadge:Hide() end
-    if frame._cdcCustomBarUnlockedBadge then frame._cdcCustomBarUnlockedBadge:Hide() end
     if frame._cdcModeBadgeHitRect then frame._cdcModeBadgeHitRect:Hide() end
     if frame._cdcGenericRenameBadge then frame._cdcGenericRenameBadge:Hide() end
     if frame._cdcAddBtn then frame._cdcAddBtn:Hide() end
@@ -2139,22 +2060,6 @@ local function OpenCustomBarRowMenu(customBars, customBarId, entry)
             })
         end
         UIDropDownMenu_AddButton(duplicateInfo, level)
-
-        if IsTruthyConfigFlag(entry.independentAnchorEnabled) then
-            local lockInfo = UIDropDownMenu_CreateInfo()
-            lockInfo.text = (entry.independentLocked == true) and "Unlock Placement" or "Lock Placement"
-            lockInfo.notCheckable = true
-            lockInfo.func = function()
-                CloseDropDownMenus()
-                if ToggleCustomBarPlacementLock(entry) then
-                    ApplyCustomAuraBarPanelChanges({
-                        updateAnchors = true,
-                        refreshConfig = true,
-                    })
-                end
-            end
-            UIDropDownMenu_AddButton(lockInfo, level)
-        end
 
         local removeInfo = UIDropDownMenu_CreateInfo()
         removeInfo.text = "Remove"
@@ -2518,199 +2423,6 @@ local function BuildCustomBarVisibilityRulesSection(container, customBars, captu
     }, infoButtons)
 end
 
-local function BuildCustomAuraBarAnchorSettings(container, customBars, settings, capturedIdx, infoButtons)
-    local cab = customBars[capturedIdx]
-    if not cab then return end
-    infoButtons = infoButtons or tabInfoButtons
-    EnsureCustomAuraIndependentConfig(cab, settings)
-
-    local unlockCb = AceGUI:Create("CheckBox")
-    unlockCb:SetLabel("Unlock Placement")
-    unlockCb:SetValue(cab.independentLocked ~= true)
-    unlockCb:SetFullWidth(true)
-    unlockCb:SetCallback("OnValueChanged", function(widget, event, val)
-        local unlocked = IsTruthyConfigFlag(val)
-        customBars[capturedIdx].independentLocked = not unlocked
-        CooldownCompanion:ApplyResourceBars()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    container:AddChild(unlockCb)
-
-    local frameRow = AceGUI:Create("SimpleGroup")
-    frameRow:SetLayout("Flow")
-    frameRow:SetFullWidth(true)
-
-    local frameEdit = AceGUI:Create("EditBox")
-    if frameEdit.editbox.Instructions then frameEdit.editbox.Instructions:Hide() end
-    frameEdit:SetLabel("Anchor to Frame")
-    frameEdit:SetText(cab.independentAnchorFrameName or "")
-    frameEdit:SetRelativeWidth(0.68)
-    frameEdit:SetCallback("OnEnterPressed", function(widget, event, text)
-        customBars[capturedIdx].independentAnchorTargetMode = "frame"
-        customBars[capturedIdx].independentAnchorFrameName = text or ""
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    frameRow:AddChild(frameEdit)
-
-    local pickBtn = AceGUI:Create("Button")
-    pickBtn:SetText("Pick")
-    pickBtn:SetRelativeWidth(0.24)
-    pickBtn:SetCallback("OnClick", function()
-        CS.StartPickFrame(function(name)
-            if CS.configFrame then
-                CS.configFrame.frame:Show()
-            end
-            if name then
-                customBars[capturedIdx].independentAnchorTargetMode = "frame"
-                customBars[capturedIdx].independentAnchorFrameName = name
-                CooldownCompanion:ApplyResourceBars()
-            end
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-    end)
-    frameRow:AddChild(pickBtn)
-
-    CreateInfoButton(pickBtn.frame, pickBtn.frame, "LEFT", "RIGHT", 2, 0, {
-        "Pick Frame",
-        {"Hides the config panel and highlights frames under your cursor. Left-click a frame to anchor this Custom Bar to it, or right-click to cancel.", 1, 1, 1, true},
-        " ",
-        {"You can also type a frame name directly into the editbox.", 1, 1, 1, true},
-        " ",
-        {"Middle-click the Custom Bar row to toggle lock/unlock.", 1, 1, 1, true},
-    }, infoButtons)
-
-    container:AddChild(frameRow)
-    pickBtn.frame:SetScript("OnUpdate", function(self)
-        self:SetScript("OnUpdate", nil)
-        local p, rel, rp, xOfs, yOfs = self:GetPoint(1)
-        if yOfs then
-            self:SetPoint(p, rel, rp, xOfs, yOfs - 2)
-        end
-    end)
-
-    local groupDrop = AceGUI:Create("Dropdown")
-    groupDrop:SetLabel("Anchor to Panel")
-    CooldownCompanion:PopulateAnchorDropdown(groupDrop)
-    groupDrop:SetValue(cab.independentAnchorGroupId and tostring(cab.independentAnchorGroupId) or "")
-    groupDrop:SetFullWidth(true)
-    groupDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentAnchorTargetMode = "group"
-        customBars[capturedIdx].independentAnchorGroupId = val ~= "" and tonumber(val) or nil
-        CooldownCompanion:ApplyResourceBars()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    container:AddChild(groupDrop)
-
-    local pointValues = {}
-    for _, pt in ipairs(CS.anchorPoints) do
-        pointValues[pt] = CS.anchorPointLabels[pt]
-    end
-
-    local anchorPointDrop = AceGUI:Create("Dropdown")
-    anchorPointDrop:SetLabel("Anchor Point")
-    anchorPointDrop:SetList(pointValues, CS.anchorPoints)
-    anchorPointDrop:SetValue(cab.independentAnchor.point or "CENTER")
-    anchorPointDrop:SetFullWidth(true)
-    anchorPointDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentAnchor.point = val
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    container:AddChild(anchorPointDrop)
-
-    local relativePointDrop = AceGUI:Create("Dropdown")
-    relativePointDrop:SetLabel("Relative Point")
-    relativePointDrop:SetList(pointValues, CS.anchorPoints)
-    relativePointDrop:SetValue(cab.independentAnchor.relativePoint or "CENTER")
-    relativePointDrop:SetFullWidth(true)
-    relativePointDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentAnchor.relativePoint = val
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    container:AddChild(relativePointDrop)
-
-    local xSlider = AceGUI:Create("Slider")
-    xSlider:SetLabel("X Offset")
-    xSlider:SetSliderValues(-2000, 2000, 0.1)
-    xSlider:SetValue(cab.independentAnchor.x or 0)
-    xSlider:SetFullWidth(true)
-    xSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentAnchor.x = val
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    container:AddChild(xSlider)
-
-    local ySlider = AceGUI:Create("Slider")
-    ySlider:SetLabel("Y Offset")
-    ySlider:SetSliderValues(-2000, 2000, 0.1)
-    ySlider:SetValue(cab.independentAnchor.y or 0)
-    ySlider:SetFullWidth(true)
-    ySlider:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentAnchor.y = val
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    container:AddChild(ySlider)
-
-    local widthSlider = AceGUI:Create("Slider")
-    widthSlider:SetLabel("Width")
-    widthSlider:SetSliderValues(4, 1200, 0.1)
-    widthSlider:SetValue(cab.independentSize.width or 120)
-    widthSlider:SetFullWidth(true)
-    widthSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentSize.width = ClampCustomAuraIndependentDimension(val, 120)
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    container:AddChild(widthSlider)
-
-    local heightSlider = AceGUI:Create("Slider")
-    heightSlider:SetLabel("Height")
-    heightSlider:SetSliderValues(4, 1200, 0.1)
-    heightSlider:SetValue(cab.independentSize.height or 12)
-    heightSlider:SetFullWidth(true)
-    heightSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        customBars[capturedIdx].independentSize.height = ClampCustomAuraIndependentDimension(val, 12)
-        CooldownCompanion:ApplyResourceBars()
-    end)
-    container:AddChild(heightSlider)
-
-    local resolvedOrientation = GetResolvedCustomAuraIndependentOrientation(cab, settings)
-
-    local orientationDrop = AceGUI:Create("Dropdown")
-    orientationDrop:SetLabel("Orientation")
-    orientationDrop:SetList({
-        horizontal = "Horizontal",
-        vertical = "Vertical",
-    }, { "horizontal", "vertical" })
-    orientationDrop:SetValue(resolvedOrientation)
-    orientationDrop:SetFullWidth(true)
-    orientationDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        if val ~= "horizontal" and val ~= "vertical" then
-            return
-        end
-        customBars[capturedIdx].independentOrientation = val
-        CooldownCompanion:ApplyResourceBars()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    container:AddChild(orientationDrop)
-
-    if resolvedOrientation == "vertical" then
-        local fillDrop = AceGUI:Create("Dropdown")
-        fillDrop:SetLabel("Vertical Fill Direction")
-        fillDrop:SetList({
-            inherit = "Inherit Global",
-            bottom_to_top = "Bottom to Top",
-            top_to_bottom = "Top to Bottom",
-        }, { "inherit", "bottom_to_top", "top_to_bottom" })
-        fillDrop:SetValue(cab.independentVerticalFillDirection or "inherit")
-        fillDrop:SetFullWidth(true)
-        fillDrop:SetCallback("OnValueChanged", function(widget, event, val)
-            customBars[capturedIdx].independentVerticalFillDirection = NormalizeCustomAuraIndependentVerticalFillDirection(val)
-            CooldownCompanion:ApplyResourceBars()
-        end)
-        container:AddChild(fillDrop)
-    end
-
-end
-
 local function BuildCustomBarsListPanel(container)
     local settings = CooldownCompanion:GetResourceBarSettings()
     local customBars = CooldownCompanion:GetSpecCustomAuraBars()
@@ -2945,18 +2657,6 @@ local function BuildCustomBarsListPanel(container)
             rightBadgeOffset = -4
         end
 
-        if IsTruthyConfigFlag(entry.independentAnchorEnabled) and entry.independentLocked ~= true then
-            local unlockedBadge = EnsureCustomBarRowIconBadge(rowFrame, "_cdcCustomBarUnlockedBadge", "ShipMissionIcon-Training-Map")
-            unlockedBadge:SetPoint("RIGHT", rightBadgeAnchor, rightBadgePoint, rightBadgeOffset, 0)
-            SetCustomBarRowBadgeTooltip(unlockedBadge, "Placement unlocked", 1, 0.82, 0.2)
-            rightBadgeAnchor = unlockedBadge
-            rightBadgePoint = "LEFT"
-            rightBadgeOffset = -4
-        end
-
-        local placementAnchor = rightBadgeAnchor
-        local placementPoint = rightBadgePoint
-        local placementOffset = rightBadgeOffset
         if not isSpellCustomBar then
             local auraStatusBadge = EnsureCustomBarRowIconBadge(rowFrame, "_cdcCustomBarAuraStatusBadge", "icon_trackedbuffs")
             auraStatusBadge:SetPoint("RIGHT", rightBadgeAnchor, rightBadgePoint, rightBadgeOffset, 0)
@@ -2977,29 +2677,13 @@ local function BuildCustomBarsListPanel(container)
                 end
                 SetCustomBarRowBadgeTooltip(auraStatusBadge, tooltipText, 1, 0.2, 0.2)
             end
-            placementAnchor = auraStatusBadge
-            placementPoint = "LEFT"
-            placementOffset = -4
         end
-
-        local placementBadge = EnsureCustomBarRowTextBadge(rowFrame, "_cdcCustomBarPlacementBadge")
-        placementBadge:SetText(IsTruthyConfigFlag(entry.independentAnchorEnabled) and "|cffb88cffIndependent|r" or "|cff7dff7dAttached|r")
-        placementBadge:SetPoint("RIGHT", placementAnchor, placementPoint, placementOffset, 0)
-        placementBadge:SetWidth(66)
 
         row:SetCallback("OnClick", function(widget, event, mouseButton)
             if mouseButton == "RightButton" then
                 CS.selectedCustomBarId = customBarId
                 wipe(CS.selectedButtons)
                 OpenCustomBarRowMenu(customBars, customBarId, entry)
-            elseif mouseButton == "MiddleButton" then
-                if ToggleCustomBarPlacementLock(entry) then
-                    CS.selectedCustomBarId = customBarId
-                    ApplyCustomAuraBarPanelChanges({
-                        updateAnchors = true,
-                        refreshConfig = true,
-                    })
-                end
             elseif mouseButton == "LeftButton" then
                 if CS.selectedCustomBarId == customBarId then
                     CS.selectedCustomBarId = nil
@@ -3038,7 +2722,6 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     local capturedIdx = selectedIndex
     local capturedId = EnsureCustomBarId(settings, cab)
     local capturedKey = capturedId or tostring(capturedIdx)
-    EnsureCustomAuraIndependentConfig(cab, settings)
     local isSpellCustomBar = IsSpellCustomBarConfig(cab)
     local resolvedAuraUnit = isSpellCustomBar and nil or GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID)
     activeTab = activeTab or "settings"
@@ -3048,26 +2731,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     end
 
     if activeTab == "layout" then
-        if IsTruthyConfigFlag(cab.independentAnchorEnabled) then
-            BuildCustomAuraBarAnchorSettings(container, customBars, settings, capturedIdx, infoButtons)
-
-            local group = CooldownCompanion.db
-                and CooldownCompanion.db.profile
-                and CooldownCompanion.db.profile.groups
-                and CooldownCompanion.db.profile.groups[CS.selectedGroup]
-            BuildAlphaControls(container, cab, function()
-                CooldownCompanion:ApplyResourceBars()
-                CooldownCompanion:RefreshConfigPanel()
-            end, "rb_custom_bar_alpha_" .. tostring(capturedKey), {
-                isGlobal = group and group.isGlobal,
-                infoButtons = infoButtons,
-                onBaselineChanged = function()
-                    CooldownCompanion:ApplyResourceBars()
-                    CooldownCompanion:RefreshConfigPanel()
-                end,
-            })
-        end
-        return
+        activeTab = "settings"
     end
 
     if activeTab == "soundalerts" then
@@ -3083,41 +2747,6 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     if not isSpellCustomBar then
         BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
     end
-    AddCustomBarSettingsHeading(container, "Placement", infoButtons, "Choose whether this Custom Bar appears attached to the panel stack or uses its own independent anchor.")
-
-    local anchorModeDrop = AceGUI:Create("Dropdown")
-    anchorModeDrop:SetLabel("Anchoring Mode")
-    anchorModeDrop:SetList({
-        attached = "Attached to Panel",
-        independent = "Independent",
-    }, { "attached", "independent" })
-    anchorModeDrop:SetValue(IsTruthyConfigFlag(cab.independentAnchorEnabled) and "independent" or "attached")
-    anchorModeDrop:SetFullWidth(true)
-    anchorModeDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        local bars = CooldownCompanion:GetSpecCustomAuraBars()
-        if not bars[capturedIdx] then
-            return
-        end
-
-        local independent = val == "independent"
-        local wasIndependent = IsTruthyConfigFlag(bars[capturedIdx].independentAnchorEnabled)
-        bars[capturedIdx].independentAnchorEnabled = independent and true or nil
-        if independent then
-            EnsureCustomAuraIndependentConfig(bars[capturedIdx], settings)
-            bars[capturedIdx].independentLocked = false
-            if not wasIndependent and CooldownCompanion.InitializeCustomAuraIndependentAnchor then
-                CooldownCompanion:InitializeCustomAuraIndependentAnchor(capturedId)
-            end
-        elseif CS.customBarSettingsTab == "layout" or CS.customBarSettingsTab == "anchor" or CS.customBarSettingsTab == "alpha" then
-            CS.customBarSettingsTab = "settings"
-        end
-
-        ApplyCustomAuraBarPanelChanges({
-            updateAnchors = true,
-            refreshConfig = true,
-        })
-    end)
-    container:AddChild(anchorModeDrop)
 
     if not isSpellCustomBar then
         AddCustomBarSettingsHeading(container, "Display", infoButtons, {
@@ -4046,7 +3675,7 @@ local function BuildLayoutOrderPanel(container)
 
     -- Custom Bar slots
     for slotIdx, cab in ipairs(customBars or {}) do
-        if cab and cab.enabled and cab.spellID and not IsTruthyConfigFlag(cab.independentAnchorEnabled) then
+        if cab and cab.enabled and cab.spellID then
             local customBarId = EnsureCustomBarId(rbSettings, cab)
             local spellInfo = C_Spell.GetSpellInfo(cab.spellID)
             local slotName = "Custom Bar"

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -2224,18 +2224,83 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
     local profile = self.db and self.db.profile
     if not profile or profile._migratedCustomBarsDynamicV2 then return end
 
+    local customBarContentFields = {
+        "spellID",
+        "trackingMode",
+        "displayMode",
+        "maxStacks",
+        "barColor",
+        "barCooldownColor",
+        "barChargeColor",
+        "overlayColor",
+        "soundAlerts",
+        "loadConditions",
+        "talentConditions",
+        "hideWhenInactive",
+        "hideWhileAuraActive",
+        "hideAuraActiveExceptPandemic",
+        "barAuraEffect",
+        "auraGlowCombatOnly",
+        "showPandemicGlow",
+        "pandemicGlowCombatOnly",
+        "thresholdColorEnabled",
+        "maxStacksGlowEnabled",
+        "maxStacksGlowStyle",
+        "maxStacksGlowSize",
+        "maxStacksGlowSpeed",
+        "maxStacksGlowThickness",
+        "showDurationText",
+        "durationTextFont",
+        "durationTextFontSize",
+        "durationTextFontOutline",
+        "decimalTimers",
+        "showStackText",
+        "showText",
+        "stackTextFormat",
+        "stackTextFont",
+        "stackTextFontSize",
+        "stackTextFontOutline",
+        "auraUnit",
+        "hasCharges",
+        "maxCharges",
+    }
+
+    local function HasCustomBarContent(cab)
+        if type(cab) ~= "table" then
+            return false
+        end
+        if cab.enabled == true then
+            return true
+        end
+        for _, field in ipairs(customBarContentFields) do
+            if cab[field] ~= nil then
+                return true
+            end
+        end
+        return false
+    end
+
     local function IsConfiguredCustomBar(cab)
         return type(cab) == "table"
             and (
-                cab.spellID ~= nil
-                or cab.enabled == true
+                HasCustomBarContent(cab)
                 or cab.independentAnchorEnabled ~= nil
-                or cab.trackingMode ~= nil
-                or cab.displayMode ~= nil
-                or cab.maxStacks ~= nil
-                or cab.barColor ~= nil
-                or cab.talentConditions ~= nil
             )
+    end
+
+    local function NormalizeCustomBarAttachedPlacement(entry)
+        if type(entry) ~= "table" then
+            return
+        end
+        entry.independentAnchorEnabled = nil
+        entry.independentLocked = nil
+        entry.independentAnchorTargetMode = nil
+        entry.independentAnchorFrameName = nil
+        entry.independentAnchorGroupId = nil
+        entry.independentAnchor = nil
+        entry.independentSize = nil
+        entry.independentOrientation = nil
+        entry.independentVerticalFillDirection = nil
     end
 
     local function EnsureNextId(settings, entry)
@@ -2321,20 +2386,23 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
                             local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
                             if IsConfiguredCustomBar(cab) then
                                 local entry = CopyTable(cab)
-                                entry.entryType = entry.entryType or "aura"
-                                local id = EnsureNextId(settings, entry)
-                                specBars[#specBars + 1] = entry
+                                NormalizeCustomBarAttachedPlacement(entry)
+                                if HasCustomBarContent(entry) then
+                                    entry.entryType = entry.entryType or "aura"
+                                    local id = EnsureNextId(settings, entry)
+                                    specBars[#specBars + 1] = entry
 
-                                if type(layout) == "table" then
-                                    if type(layout.customBars) ~= "table" then
-                                        layout.customBars = {}
+                                    if type(layout) == "table" then
+                                        if type(layout.customBars) ~= "table" then
+                                            layout.customBars = {}
+                                        end
+                                        local legacySlot = type(layout.customAuraBarSlots) == "table"
+                                            and layout.customAuraBarSlots[slotIdx]
+                                            or nil
+                                        layout.customBars[id] = type(legacySlot) == "table"
+                                            and CopyTable(legacySlot)
+                                            or { position = "below", order = 1000 + #specBars }
                                     end
-                                    local legacySlot = type(layout.customAuraBarSlots) == "table"
-                                        and layout.customAuraBarSlots[slotIdx]
-                                        or nil
-                                    layout.customBars[id] = type(legacySlot) == "table"
-                                        and CopyTable(legacySlot)
-                                        or { position = "below", order = 1000 + #specBars }
                                 end
                             end
                         end
@@ -2370,18 +2438,24 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
                 for _, key in ipairs(numericKeys) do
                     local entry = specBars[key]
                     if IsConfiguredCustomBar(entry) then
-                        entry.entryType = entry.entryType or "aura"
-                        EnsureNextId(settings, entry)
-                        target[#target + 1] = entry
+                        NormalizeCustomBarAttachedPlacement(entry)
+                        if HasCustomBarContent(entry) then
+                            entry.entryType = entry.entryType or "aura"
+                            EnsureNextId(settings, entry)
+                            target[#target + 1] = entry
+                        end
                     end
                     seen[key] = true
                 end
 
                 for key, entry in pairs(specBars) do
                     if not seen[key] and IsConfiguredCustomBar(entry) then
-                        entry.entryType = entry.entryType or "aura"
-                        EnsureNextId(settings, entry)
-                        target[#target + 1] = entry
+                        NormalizeCustomBarAttachedPlacement(entry)
+                        if HasCustomBarContent(entry) then
+                            entry.entryType = entry.entryType or "aura"
+                            EnsureNextId(settings, entry)
+                            target[#target + 1] = entry
+                        end
                     end
                 end
             end

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -529,7 +529,15 @@ local function SanitizeResourceBarAnchors(settings)
         if type(specBars) == "table" then
             for _, customAuraBar in pairs(specBars) do
                 if type(customAuraBar) == "table" then
-                    customAuraBar.independentAnchorGroupId = SanitizeAnchorGroupID(customAuraBar.independentAnchorGroupId)
+                    customAuraBar.independentAnchorEnabled = nil
+                    customAuraBar.independentLocked = nil
+                    customAuraBar.independentAnchorTargetMode = nil
+                    customAuraBar.independentAnchorFrameName = nil
+                    customAuraBar.independentAnchorGroupId = nil
+                    customAuraBar.independentAnchor = nil
+                    customAuraBar.independentSize = nil
+                    customAuraBar.independentOrientation = nil
+                    customAuraBar.independentVerticalFillDirection = nil
                     if ensureCustomAuraBarAuraUnit then
                         ensureCustomAuraBarAuraUnit(customAuraBar, customAuraBar.spellID)
                     end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -75,10 +75,6 @@ local GetResourceDisplayConfig = RB.GetResourceDisplayConfig
 local GetAnchorOffset = RB.GetAnchorOffset
 local RoundToTenths = RB.RoundToTenths
 local ClampIndependentDimension = RB.ClampIndependentDimension
-local IsTruthyConfigFlag = RB.IsTruthyConfigFlag
-local NormalizeCustomAuraIndependentOrientation = RB.NormalizeCustomAuraIndependentOrientation
-local NormalizeCustomAuraIndependentVerticalFillDirection = RB.NormalizeCustomAuraIndependentVerticalFillDirection
-local IsCustomAuraBarIndependent = RB.IsCustomAuraBarIndependent
 local NormalizeCustomAuraStackTextFormat = RB.NormalizeCustomAuraStackTextFormat
 local DetermineActiveResources = RB.DetermineActiveResources
 local GetResourceColors = RB.GetResourceColors
@@ -142,6 +138,8 @@ local containerFrameAbove = nil
 local containerFrameBelow = nil
 local lastAppliedPrimaryLength = nil
 local lastAppliedOrientation = nil
+local lastAppliedLayout = nil
+local lastAppliedIndependentStack = false
 local resourceBarFrames = {}   -- array of bar frame objects (ordered by stacking)
 local activeResources = {}     -- array of power type ints currently displayed
 local isPreviewActive = false
@@ -194,227 +192,6 @@ local function EnsureNonNilNumber(value)
         return 0
     end
     return value
-end
-
-local function GetCustomAuraAlphaModuleId(customBarId)
-    if type(customBarId) ~= "string" or customBarId == "" then
-        return nil
-    end
-    return "custom_bar_" .. customBarId
-end
-
-local function CustomAuraUsesOwnAlpha(cabConfig)
-    if type(cabConfig) ~= "table" then
-        return false
-    end
-
-    if (tonumber(cabConfig.baselineAlpha) or 1) ~= 1 then
-        return true
-    end
-
-    return IsTruthyConfigFlag(cabConfig.forceAlphaInCombat)
-        or IsTruthyConfigFlag(cabConfig.forceAlphaOutOfCombat)
-        or IsTruthyConfigFlag(cabConfig.forceAlphaRegularMounted)
-        or IsTruthyConfigFlag(cabConfig.forceAlphaDragonriding)
-        or IsTruthyConfigFlag(cabConfig.forceAlphaTargetExists)
-        or IsTruthyConfigFlag(cabConfig.forceAlphaMouseover)
-        or IsTruthyConfigFlag(cabConfig.forceHideInCombat)
-        or IsTruthyConfigFlag(cabConfig.forceHideOutOfCombat)
-        or IsTruthyConfigFlag(cabConfig.forceHideRegularMounted)
-        or IsTruthyConfigFlag(cabConfig.forceHideDragonriding)
-end
-
-------------------------------------------------------------------------
--- Independent Anchor Config (writes state — stays in main file)
-------------------------------------------------------------------------
-
-local function EnsureCustomAuraIndependentConfig(cabConfig, settings)
-    if type(cabConfig) ~= "table" then return end
-
-    if cabConfig.independentAnchorEnabled ~= nil then
-        cabConfig.independentAnchorEnabled = IsTruthyConfigFlag(cabConfig.independentAnchorEnabled) and true or nil
-    end
-
-    if cabConfig.independentAnchorTargetMode ~= "group"
-        and cabConfig.independentAnchorTargetMode ~= "frame" then
-        cabConfig.independentAnchorTargetMode = "group"
-    end
-    if type(cabConfig.independentLocked) ~= "boolean" then
-        cabConfig.independentLocked = IsTruthyConfigFlag(cabConfig.independentLocked) and true or false
-    end
-
-    cabConfig.independentOrientation = NormalizeCustomAuraIndependentOrientation(cabConfig.independentOrientation)
-    cabConfig.independentVerticalFillDirection =
-        NormalizeCustomAuraIndependentVerticalFillDirection(cabConfig.independentVerticalFillDirection)
-
-    if type(cabConfig.independentAnchor) ~= "table" then
-        cabConfig.independentAnchor = {}
-    end
-    local anchor = cabConfig.independentAnchor
-    anchor.point = anchor.point or "CENTER"
-    anchor.relativePoint = anchor.relativePoint or "CENTER"
-    anchor.x = tonumber(anchor.x) or 0
-    anchor.y = tonumber(anchor.y) or 0
-
-    if type(cabConfig.independentSize) ~= "table" then
-        cabConfig.independentSize = {}
-    end
-    local size = cabConfig.independentSize
-    size.width = ClampIndependentDimension(size.width, 120)
-    size.height = ClampIndependentDimension(size.height, GetResourceGlobalThickness(settings))
-end
-
-local function ResolveIndependentAnchorTarget(cabConfig, settings)
-    if type(cabConfig) ~= "table" then
-        return UIParent, "UIParent"
-    end
-
-    if cabConfig.independentAnchorTargetMode == "frame" then
-        local frameName = cabConfig.independentAnchorFrameName
-        if type(frameName) == "string" and frameName ~= "" then
-            local frame = _G[frameName]
-            if frame then
-                return frame, frameName
-            end
-        end
-        return UIParent, "UIParent"
-    end
-
-    local groupId = cabConfig.independentAnchorGroupId or GetEffectiveAnchorGroupId(settings)
-    if groupId then
-        local groupFrame = CooldownCompanion.groupFrames[groupId]
-        if groupFrame then
-            return groupFrame, "CooldownCompanionGroup" .. groupId
-        end
-    end
-    return UIParent, "UIParent"
-end
-
-
-local function ShouldInheritIndependentAlpha(settings)
-    if type(settings) ~= "table" then
-        return false
-    end
-
-    local layout = GetSpecLayoutOrder(settings)
-    if layout and layout.inheritAlpha ~= nil then
-        return layout.inheritAlpha == true
-    end
-
-    return settings.inheritAlpha == true
-end
-
-local function ApplyIndependentAlphaSync(frame, settings, targetFrame)
-    if not frame then return end
-    if not frame._cdcIndependentAlphaSync then
-        frame._cdcIndependentAlphaSync = CreateFrame("Frame", nil, frame)
-    end
-
-    if ShouldInheritIndependentAlpha(settings) and targetFrame then
-        frame._cdcIndependentAlphaTarget = targetFrame
-        frame._cdcIndependentLastAlpha = targetFrame:GetEffectiveAlpha()
-        frame:SetAlpha(frame._cdcIndependentLastAlpha)
-
-        local accumulator = 0
-        local syncInterval = 1 / 30
-        frame._cdcIndependentAlphaSync:SetScript("OnUpdate", function(syncFrame, dt)
-            accumulator = accumulator + dt
-            if accumulator < syncInterval then return end
-            accumulator = 0
-
-            local owner = syncFrame:GetParent()
-            local target = owner and owner._cdcIndependentAlphaTarget
-            if not target then return end
-
-            local alpha = target:GetEffectiveAlpha()
-            if alpha ~= owner._cdcIndependentLastAlpha then
-                owner._cdcIndependentLastAlpha = alpha
-                owner:SetAlpha(alpha)
-            end
-        end)
-        return
-    end
-
-    frame._cdcIndependentAlphaTarget = nil
-    frame._cdcIndependentLastAlpha = nil
-    frame._cdcIndependentAlphaSync:SetScript("OnUpdate", nil)
-    frame:SetAlpha(1)
-end
-
-local IsIndependentCustomAuraUnlocked
-
-local function IsIndependentCustomAuraConfigEditing(barInfo)
-    if not barInfo or not barInfo._isIndependent or not IsBarsConfigActive() then
-        return false
-    end
-
-    local configState = ST._configState
-    if type(barInfo.customBarId) ~= "string" or not configState or not configState.resourceBarPanelActive then
-        return false
-    end
-
-    return configState.selectedCustomBarId == barInfo.customBarId
-end
-
-local function ShouldForceVisibleIndependentCustomAura(barInfo)
-    return IsIndependentCustomAuraUnlocked(barInfo) or IsIndependentCustomAuraConfigEditing(barInfo)
-end
-
-local function ApplyIndependentCustomAuraAlpha(barInfo, settings, targetFrame)
-    if not barInfo or not barInfo.frame or not barInfo.cabConfig then return end
-
-    local frame = barInfo.frame
-    local alphaModuleId = GetCustomAuraAlphaModuleId(barInfo.customBarId)
-    local previousAlphaModuleId = frame._cdcCustomAuraAlphaModuleId
-    if previousAlphaModuleId and previousAlphaModuleId ~= alphaModuleId then
-        CooldownCompanion:UnregisterModuleAlpha(previousAlphaModuleId)
-    end
-    frame._cdcCustomAuraAlphaModuleId = alphaModuleId
-
-    local bypassAlpha = barInfo._isIndependent and ShouldForceVisibleIndependentCustomAura(barInfo)
-    local useOwnAlpha = CustomAuraUsesOwnAlpha(barInfo.cabConfig)
-    local desiredMode = bypassAlpha and "bypass" or (useOwnAlpha and "custom" or "inherit")
-
-    if frame._cdcCustomAuraAlphaMode == desiredMode and previousAlphaModuleId == alphaModuleId then
-        if desiredMode == "inherit" then
-            if frame._cdcIndependentAlphaTarget == targetFrame then
-                return
-            end
-        elseif desiredMode == "bypass" then
-            frame:SetAlpha(1)
-            return
-        else
-            return
-        end
-    end
-    frame._cdcCustomAuraAlphaMode = desiredMode
-
-    if not alphaModuleId then
-        frame._cdcCustomAuraAlphaModuleId = nil
-        ApplyIndependentAlphaSync(frame, settings, targetFrame)
-        return
-    end
-
-    if bypassAlpha then
-        CooldownCompanion:UnregisterModuleAlpha(alphaModuleId, true)
-        ApplyIndependentAlphaSync(frame, nil, nil)
-        frame:SetAlpha(1)
-        return
-    end
-
-    if useOwnAlpha then
-        ApplyIndependentAlphaSync(frame, nil, nil)
-        CooldownCompanion:RegisterModuleAlpha(alphaModuleId, barInfo.cabConfig, { frame })
-
-        local alphaState = CooldownCompanion.alphaState and CooldownCompanion.alphaState[alphaModuleId]
-        if alphaState and alphaState.currentAlpha ~= nil then
-            frame:SetAlpha(alphaState.currentAlpha)
-        end
-        return
-    end
-
-    CooldownCompanion:UnregisterModuleAlpha(alphaModuleId)
-    ApplyIndependentAlphaSync(frame, settings, targetFrame)
 end
 
 local function HasCustomAuraBarAuraVisuals(cabConfig)
@@ -629,229 +406,7 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
         bar:SetStatusBarColor(resetColor[1], resetColor[2], resetColor[3], resetColor[4] or 1)
     end
 end
-IsIndependentCustomAuraUnlocked = function(barInfo)
-    return barInfo and barInfo.cabConfig and barInfo.cabConfig.independentLocked ~= true
-end
-
-local function GetIndependentCustomAuraHeaderText(barInfo)
-    if barInfo and barInfo.cabConfig and barInfo.cabConfig.spellID then
-        local spellName = C_Spell.GetSpellName(barInfo.cabConfig.spellID)
-        if spellName and spellName ~= "" then
-            return spellName
-        end
-    end
-    return "Custom Bar"
-end
-
-local function SaveIndependentCustomAuraAnchor(barInfo, refreshConfig)
-    if not barInfo or not barInfo.frame or not barInfo.cabConfig then return end
-    local settings = GetResourceBarSettings()
-    if not settings then return end
-
-    local cabConfig = barInfo.cabConfig
-    EnsureCustomAuraIndependentConfig(cabConfig, settings)
-
-    local frame = barInfo.frame
-    local anchor = cabConfig.independentAnchor
-    local targetFrame = ResolveIndependentAnchorTarget(cabConfig, settings)
-    if not targetFrame then
-        targetFrame = UIParent
-    end
-
-    local cx, cy = frame:GetCenter()
-    local fw, fh = frame:GetSize()
-    local tcx, tcy = targetFrame:GetCenter()
-    local tw, th = targetFrame:GetSize()
-    if not (cx and cy and fw and fh and tcx and tcy and tw and th) then
-        return
-    end
-
-    local fax, fay = GetAnchorOffset(anchor.point, fw, fh)
-    local tax, tay = GetAnchorOffset(anchor.relativePoint, tw, th)
-    anchor.x = RoundToTenths((cx + fax) - (tcx + tax))
-    anchor.y = RoundToTenths((cy + fay) - (tcy + tay))
-
-    if refreshConfig and IsBarsConfigActive() and CooldownCompanion.RefreshConfigPanel then
-        CooldownCompanion:RefreshConfigPanel()
-    end
-end
-
-
-local UpdateIndependentDragState
-
-local function EnsureIndependentDragChrome(frame)
-    if not frame or frame._cdcIndependentDragHandle then return end
-
-    local dragHandle = CreateFrame("Frame", nil, frame, "BackdropTemplate")
-    dragHandle:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 0, 2)
-    dragHandle:SetPoint("BOTTOMRIGHT", frame, "TOPRIGHT", 0, 2)
-    dragHandle:SetHeight(15)
-    dragHandle:SetBackdrop({
-        bgFile = "Interface\\Buttons\\WHITE8X8",
-        edgeFile = "Interface\\Buttons\\WHITE8X8",
-        edgeSize = 1,
-    })
-    dragHandle:SetBackdropColor(0.2, 0.2, 0.2, 0.8)
-    dragHandle:SetBackdropBorderColor(0, 0, 0, 1)
-    dragHandle:EnableMouse(false)
-    dragHandle:RegisterForDrag()
-
-    dragHandle.text = dragHandle:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    dragHandle.text:SetPoint("CENTER")
-    dragHandle.text:SetTextColor(1, 1, 1, 1)
-
-    local NUDGE_GAP = 2
-    local nudger = CreateFrame("Frame", nil, dragHandle, "BackdropTemplate")
-    nudger:SetSize(INDEPENDENT_NUDGE_BTN_SIZE * 2 + NUDGE_GAP, INDEPENDENT_NUDGE_BTN_SIZE * 2 + NUDGE_GAP)
-    nudger:SetPoint("BOTTOM", dragHandle, "TOP", 0, 2)
-    nudger:SetBackdrop({
-        bgFile = "Interface\\Buttons\\WHITE8X8",
-        edgeFile = "Interface\\Buttons\\WHITE8X8",
-        edgeSize = 1,
-    })
-    nudger:SetBackdropColor(0.2, 0.2, 0.2, 0.8)
-    nudger:SetBackdropBorderColor(0, 0, 0, 1)
-    nudger:EnableMouse(false)
-    nudger._cdcButtons = {}
-
-    local directions = {
-        { atlas = "common-dropdown-icon-back", rotation = -math.pi / 2, anchor = "BOTTOM", dx = 0, dy = 1, ox = 0, oy = NUDGE_GAP },  -- up
-        { atlas = "common-dropdown-icon-next", rotation = -math.pi / 2, anchor = "TOP", dx = 0, dy = -1, ox = 0, oy = -NUDGE_GAP },   -- down
-        { atlas = "common-dropdown-icon-back", rotation = 0, anchor = "RIGHT", dx = -1, dy = 0, ox = -NUDGE_GAP, oy = 0 },            -- left
-        { atlas = "common-dropdown-icon-next", rotation = 0, anchor = "LEFT", dx = 1, dy = 0, ox = NUDGE_GAP, oy = 0 },               -- right
-    }
-
-    for _, dir in ipairs(directions) do
-        local btn = CreateFrame("Button", nil, nudger)
-        btn:SetSize(INDEPENDENT_NUDGE_BTN_SIZE, INDEPENDENT_NUDGE_BTN_SIZE)
-        btn:SetPoint(dir.anchor, nudger, "CENTER", dir.ox, dir.oy)
-        btn:EnableMouse(true)
-
-        local arrow = btn:CreateTexture(nil, "OVERLAY")
-        arrow:SetAtlas(dir.atlas, false)
-        arrow:SetAllPoints()
-        arrow:SetRotation(dir.rotation)
-        arrow:SetVertexColor(0.8, 0.8, 0.8, 0.8)
-        btn.arrow = arrow
-
-        local function DoNudge()
-            local info = frame._cdcIndependentBarInfo
-            if not info or not info._isIndependent then return end
-            if not IsIndependentCustomAuraUnlocked(info) then return end
-            frame:AdjustPointsOffset(dir.dx, dir.dy)
-        end
-
-        btn:SetScript("OnEnter", function(self)
-            self.arrow:SetVertexColor(1, 1, 1, 1)
-        end)
-        btn:SetScript("OnLeave", function(self)
-            self.arrow:SetVertexColor(0.8, 0.8, 0.8, 0.8)
-            CancelNudgeTimers(self)
-            local info = frame._cdcIndependentBarInfo
-            if info and info._isIndependent then
-                SaveIndependentCustomAuraAnchor(info, true)
-            end
-        end)
-        btn:SetScript("OnMouseDown", function(self)
-            DoNudge()
-            self._cdcNudgeDelayTimer = C_Timer.NewTimer(INDEPENDENT_NUDGE_REPEAT_DELAY, function()
-                self._cdcNudgeTicker = C_Timer.NewTicker(INDEPENDENT_NUDGE_REPEAT_INTERVAL, function()
-                    DoNudge()
-                end)
-            end)
-        end)
-        btn:SetScript("OnMouseUp", function(self)
-            CancelNudgeTimers(self)
-            local info = frame._cdcIndependentBarInfo
-            if info and info._isIndependent then
-                SaveIndependentCustomAuraAnchor(info, true)
-            end
-        end)
-
-        nudger._cdcButtons[#nudger._cdcButtons + 1] = btn
-    end
-
-    dragHandle:RegisterForDrag("LeftButton")
-    dragHandle:SetScript("OnDragStart", function()
-        local info = frame._cdcIndependentBarInfo
-        if not info or not info._isIndependent then return end
-        if not IsIndependentCustomAuraUnlocked(info) then return end
-        frame:StartMoving()
-    end)
-    dragHandle:SetScript("OnDragStop", function()
-        frame:StopMovingOrSizing()
-        local info = frame._cdcIndependentBarInfo
-        if info and info._isIndependent then
-            SaveIndependentCustomAuraAnchor(info, true)
-        end
-    end)
-    dragHandle:SetScript("OnMouseUp", function(_, button)
-        if button ~= "MiddleButton" then return end
-        local info = frame._cdcIndependentBarInfo
-        if not info or not info._isIndependent or not info.cabConfig then return end
-        info.cabConfig.independentLocked = true
-        SaveIndependentCustomAuraAnchor(info, true)
-        UpdateIndependentDragState(frame, info)
-        local settings = GetResourceBarSettings()
-        if settings then
-            ApplyIndependentCustomAuraAlpha(info, settings, ResolveIndependentAnchorTarget(info.cabConfig, settings))
-        end
-    end)
-
-    frame._cdcIndependentDragHandle = dragHandle
-    frame._cdcIndependentNudger = nudger
-end
-
-UpdateIndependentDragState = function(frame, barInfo)
-    if not frame then return end
-
-    EnsureIndependentDragChrome(frame)
-    local dragHandle = frame._cdcIndependentDragHandle
-    local nudger = frame._cdcIndependentNudger
-    local canShowChrome = barInfo and barInfo._isIndependent
-    local unlocked = canShowChrome and IsIndependentCustomAuraUnlocked(barInfo)
-
-    frame:SetClampedToScreen(true)
-    frame:SetMovable(unlocked)
-    frame:EnableMouse(false)
-    frame:RegisterForDrag()
-
-    if dragHandle then
-        dragHandle:SetShown(unlocked)
-        dragHandle:EnableMouse(unlocked)
-        if unlocked then
-            dragHandle:RegisterForDrag("LeftButton")
-        else
-            dragHandle:RegisterForDrag()
-        end
-        if dragHandle.text then
-            dragHandle.text:SetText(GetIndependentCustomAuraHeaderText(barInfo))
-        end
-        dragHandle:SetFrameStrata(frame:GetFrameStrata())
-        dragHandle:SetFrameLevel(frame:GetFrameLevel() + 20)
-    end
-
-    if nudger then
-        nudger:SetShown(unlocked)
-        nudger:EnableMouse(unlocked)
-        nudger:SetFrameStrata(frame:GetFrameStrata())
-        if dragHandle then
-            nudger:SetFrameLevel(dragHandle:GetFrameLevel() + 5)
-        else
-            nudger:SetFrameLevel(frame:GetFrameLevel() + 25)
-        end
-        if nudger._cdcButtons then
-            for _, btn in ipairs(nudger._cdcButtons) do
-                btn:EnableMouse(unlocked)
-                if not unlocked then
-                    CancelNudgeTimers(btn)
-                end
-            end
-        end
-    end
-end
-
-local function ClearIndependentRuntimeState(frame)
+local function ClearStaleRecycledBarRuntimeState(frame)
     if not frame then return end
     if frame._cdcCustomAuraAlphaModuleId then
         CooldownCompanion:UnregisterModuleAlpha(frame._cdcCustomAuraAlphaModuleId)
@@ -879,47 +434,12 @@ local function ClearIndependentRuntimeState(frame)
         frame._cdcIndependentNudger:Hide()
     end
 
-    ApplyIndependentAlphaSync(frame, nil, nil)
-end
-
-local function ApplyIndependentCustomAuraPlacement(barInfo, cabConfig, settings)
-    if not barInfo or not barInfo.frame then return end
-
-    EnsureCustomAuraIndependentConfig(cabConfig, settings)
-    local frame = barInfo.frame
-    local anchor = cabConfig.independentAnchor
-    local size = cabConfig.independentSize
-    local targetFrame = ResolveIndependentAnchorTarget(cabConfig, settings)
-    local point = anchor.point or "CENTER"
-    local relativePoint = anchor.relativePoint or "CENTER"
-    local x = tonumber(anchor.x) or 0
-    local y = tonumber(anchor.y) or 0
-    local width = ClampIndependentDimension(size.width, frame:GetWidth())
-    local height = ClampIndependentDimension(size.height, frame:GetHeight())
-
-    size.width = width
-    size.height = height
-    anchor.x = x
-    anchor.y = y
-
-    if frame:GetParent() ~= UIParent then
-        frame:SetParent(UIParent)
+    if frame._cdcIndependentAlphaSync then
+        frame._cdcIndependentAlphaSync:SetScript("OnUpdate", nil)
     end
-    frame:ClearAllPoints()
-    frame:SetPoint(point, targetFrame, relativePoint, x, y)
-    frame:SetSize(width, height)
-
-    frame._cdcIndependentBarInfo = barInfo
-    UpdateIndependentDragState(frame, barInfo)
-    ApplyIndependentCustomAuraAlpha(barInfo, settings, targetFrame)
-end
-
-function CooldownCompanion:ApplyIndependentCustomAuraPlacement(barInfo, cabConfig, settings)
-    ApplyIndependentCustomAuraPlacement(barInfo, cabConfig, settings)
-end
-
-function CooldownCompanion:ClearIndependentCustomAuraRuntimeState(frame)
-    ClearIndependentRuntimeState(frame)
+    frame._cdcIndependentAlphaTarget = nil
+    frame._cdcIndependentLastAlpha = nil
+    frame:SetAlpha(1)
 end
 
 ------------------------------------------------------------------------
@@ -2517,24 +2037,19 @@ local function UpdateCustomAuraBar(barInfo)
     end
 
     -- Aura visibility rules hide the bar based on the resolved aura state.
-    -- Independent bars stay visible while being edited or placed so they do not disappear.
     if cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive then
-        local forceVisibleForEditing = barInfo._isIndependent and ShouldForceVisibleIndependentCustomAura(barInfo)
         local hideWhileAuraActive = cabConfig.hideWhileAuraActive == true
             and cabConfig.hideWhenInactive ~= true
             and auraPresent
             and not (cabConfig.hideAuraActiveExceptPandemic == true and inPandemic)
         local hideWhileAuraNotActive = cabConfig.hideWhenInactive == true and not auraPresent
         local shouldShow = not (hideWhileAuraActive or hideWhileAuraNotActive)
-            or forceVisibleForEditing
             or auraPreview
             or pandemicPreview
         local wasShown = barInfo.frame:IsShown()
         barInfo.frame:SetShown(shouldShow)
         if wasShown ~= shouldShow then
-            if not barInfo._isIndependent then
-                layoutDirty = true
-            end
+            layoutDirty = true
         end
         if not shouldShow then
             if isActive then
@@ -2781,6 +2296,7 @@ local function ClearDeferredCustomAuraWakeRetries()
 end
 
 local RelayoutBars
+local RelayoutResourceStack
 
 local function ResolveDeferredCustomAuraWakeRetryBarInfo(entry)
     if not entry or not entry.customBarId or not entry.cabConfig then
@@ -2828,7 +2344,7 @@ local function ProcessDeferredCustomAuraWakeRetries()
             and not frame:IsShown()
         then
             UpdateCustomAuraBar(barInfo)
-            if not barInfo._isIndependent and frame:IsShown() then
+            if frame:IsShown() then
                 relayoutNeeded = true
             end
         end
@@ -2838,9 +2354,7 @@ local function ProcessDeferredCustomAuraWakeRetries()
     StopDeferredCustomAuraWakeRetryFrame()
 
     if relayoutNeeded then
-        layoutDirty = false
-        RelayoutBars()
-        CooldownCompanion:RepositionCastBar()
+        RelayoutResourceStack()
     end
 end
 
@@ -3027,11 +2541,11 @@ local function FinalizeAppliedBarVisibility(barInfo, powerType, previewActive)
     end
 end
 
-local function HideUnusedResourceBarFrames(owner, firstHiddenIndex)
+local function HideUnusedResourceBarFrames(firstHiddenIndex)
     for i = firstHiddenIndex, #resourceBarFrames do
         local barInfo = resourceBarFrames[i]
         if barInfo and barInfo.frame then
-            owner:ClearIndependentCustomAuraRuntimeState(barInfo.frame)
+            ClearStaleRecycledBarRuntimeState(barInfo.frame)
             ClearCustomAuraBarIndicatorState(barInfo, true)
             ClearResourceAuraVisuals(barInfo.frame)
             ClearMaxStacksIndicator(barInfo)
@@ -3046,7 +2560,6 @@ local function HideUnusedResourceBarFrames(owner, firstHiddenIndex)
             barInfo._sndPrevCharges = nil
             barInfo._sndPrevChargeRecharging = nil
             barInfo._sndPrevChargeCooldownStart = nil
-            barInfo._isIndependent = nil
             barInfo._side = nil
             barInfo._order = nil
             barInfo._effectiveThickness = nil
@@ -3084,7 +2597,7 @@ local function PrepareCustomAuraBar(
         customBarId = cabConfig and cabConfig.customBarId
     end
     if not cabConfig then
-        return barInfo, false
+        return barInfo
     end
     customBarId = customBarId or RB.EnsureCustomBarId(settings, cabConfig)
     local isSpellCustomBar = RB.GetCustomBarEntryType and RB.GetCustomBarEntryType(cabConfig) == "spell"
@@ -3092,47 +2605,14 @@ local function PrepareCustomAuraBar(
     local mode = isSpellCustomBar and "continuous" or (isActive and "continuous" or (cabConfig.displayMode or "segmented"))
     local maxStacks = isActive and 1 or (cabConfig.maxStacks or 1)
     local targetBarType = isSpellCustomBar and "custom_cooldown" or ("custom_" .. mode)
-    local isIndependentCustomAura = IsCustomAuraBarIndependent(cabConfig)
     local customOrientation = isVerticalLayout and "vertical" or "horizontal"
-    if isIndependentCustomAura then
-        local independentOrientation = cabConfig.independentOrientation
-        if independentOrientation == "vertical" or independentOrientation == "horizontal" then
-            customOrientation = independentOrientation
-        end
-    end
     local customIsVertical = customOrientation == "vertical"
     local customReverseFill = false
     if customIsVertical then
-        if isIndependentCustomAura then
-            local fillDirection = cabConfig.independentVerticalFillDirection
-            if fillDirection == "top_to_bottom" then
-                customReverseFill = true
-            elseif fillDirection == "bottom_to_top" then
-                customReverseFill = false
-            else
-                customReverseFill = reverseVerticalFill == true
-            end
-        else
-            customReverseFill = reverseVerticalFill
-        end
+        customReverseFill = reverseVerticalFill
     end
     local customWidth = effectiveWidth
     local customHeight = effectiveHeight
-    if isIndependentCustomAura then
-        local independentSize = cabConfig.independentSize
-        customWidth = tonumber(independentSize and independentSize.width) or customWidth
-        customHeight = tonumber(independentSize and independentSize.height) or customHeight
-        if customWidth < 4 then
-            customWidth = 4
-        elseif customWidth > 1200 then
-            customWidth = 1200
-        end
-        if customHeight < 4 then
-            customHeight = 4
-        elseif customHeight > 1200 then
-            customHeight = 1200
-        end
-    end
 
     local needsRecreate = not barInfo or barInfo.barType ~= targetBarType
     if not needsRecreate and mode == "segmented" then
@@ -3275,7 +2755,7 @@ local function PrepareCustomAuraBar(
         ClearMaxStacksIndicator(barInfo)
     end
 
-    return barInfo, isIndependentCustomAura
+    return barInfo
 end
 
 RB.PrepareCustomAuraBar = PrepareCustomAuraBar
@@ -3316,7 +2796,7 @@ RelayoutBars = function()
         local leftBars = {}
         local rightBars = {}
         for _, barInfo in ipairs(resourceBarFrames) do
-            if barInfo and not barInfo._isIndependent and barInfo.frame and barInfo.frame:IsShown() then
+            if barInfo and barInfo.frame and barInfo.frame:IsShown() then
                 if barInfo._side == "left" then
                     table.insert(leftBars, barInfo)
                 else
@@ -3361,7 +2841,7 @@ RelayoutBars = function()
         local aboveBars = {}
         local belowBars = {}
         for _, barInfo in ipairs(resourceBarFrames) do
-            if barInfo and not barInfo._isIndependent and barInfo.frame and barInfo.frame:IsShown() then
+            if barInfo and barInfo.frame and barInfo.frame:IsShown() then
                 if barInfo._side == "above" then
                     table.insert(aboveBars, barInfo)
                 else
@@ -3405,6 +2885,15 @@ RelayoutBars = function()
     end
 end
 
+RelayoutResourceStack = function()
+    layoutDirty = false
+    RelayoutBars()
+    if lastAppliedIndependentStack then
+        UpdateIndependentStackChrome(lastAppliedOrientation == "vertical", lastAppliedLayout)
+    end
+    CooldownCompanion:RepositionCastBar()
+end
+
 ------------------------------------------------------------------------
 -- OnUpdate handler (30 Hz)
 ------------------------------------------------------------------------
@@ -3438,23 +2927,15 @@ local function OnUpdate(self, elapsed)
                 UpdateStaggerBar(barInfo.frame, settings)
             elseif barInfo.barType == "custom_cooldown" then
                 RB.UpdateCustomCooldownBar(barInfo)
-                if barInfo._isIndependent and barInfo.cabConfig then
-                    ApplyIndependentCustomAuraAlpha(barInfo, settings, ResolveIndependentAnchorTarget(barInfo.cabConfig, settings))
-                end
             elseif barInfo.barType == "custom_continuous" then
                 UpdateCustomAuraBar(barInfo)
-                if barInfo._isIndependent and barInfo.cabConfig then
-                    ApplyIndependentCustomAuraAlpha(barInfo, settings, ResolveIndependentAnchorTarget(barInfo.cabConfig, settings))
-                end
                 AnimateCustomAuraBarIndicator(barInfo.frame)
             end
         end
     end
 
     if layoutDirty then
-        layoutDirty = false
-        RelayoutBars()
-        CooldownCompanion:RepositionCastBar()
+        RelayoutResourceStack()
     end
 end
 
@@ -3891,6 +3372,8 @@ function CooldownCompanion:ApplyResourceBars()
     lastAppliedBarSpacing = barSpacing
     lastAppliedBarThickness = globalBarThickness
     lastAppliedOrientation = GetResourceLayoutOrientation(settings)
+    lastAppliedLayout = layout
+    lastAppliedIndependentStack = isIndependentStack
     local segmentGap = layout.segmentGap or settings.segmentGap or 4
     local totalPrimaryLength
     if isIndependentStack then
@@ -3910,16 +3393,14 @@ function CooldownCompanion:ApplyResourceBars()
         local side, order
         if isCustomEntry then
             local cabConfig = entry.config
-            if not IsCustomAuraBarIndependent(cabConfig) then
-                local slotCfg = RB.GetCustomBarLayout(settings, nil, cabConfig, false)
-                if isVerticalLayout then
-                    local storedHorizontalSide = (slotCfg and slotCfg.position) or "below"
-                    side = (slotCfg and slotCfg.verticalPosition) or GetVerticalSideFallback(storedHorizontalSide)
-                    order = (slotCfg and slotCfg.verticalOrder) or (slotCfg and slotCfg.order) or (fallbackOrder + idx)
-                else
-                    side = (slotCfg and slotCfg.position) or "below"
-                    order = (slotCfg and slotCfg.order) or (fallbackOrder + idx)
-                end
+            local slotCfg = RB.GetCustomBarLayout(settings, nil, cabConfig, false)
+            if isVerticalLayout then
+                local storedHorizontalSide = (slotCfg and slotCfg.position) or "below"
+                side = (slotCfg and slotCfg.verticalPosition) or GetVerticalSideFallback(storedHorizontalSide)
+                order = (slotCfg and slotCfg.verticalOrder) or (slotCfg and slotCfg.order) or (fallbackOrder + idx)
+            else
+                side = (slotCfg and slotCfg.position) or "below"
+                order = (slotCfg and slotCfg.order) or (fallbackOrder + idx)
             end
         else
             local res = layout and layout.resources and layout.resources[powerType]
@@ -3948,7 +3429,7 @@ function CooldownCompanion:ApplyResourceBars()
     end
 
     -- Hide existing bars that we don't need
-    HideUnusedResourceBarFrames(self, #filtered + 1)
+    HideUnusedResourceBarFrames(#filtered + 1)
 
     for idx, entry in ipairs(filtered) do
         local isCustomEntry = type(entry) == "table" and entry.kind == "custom"
@@ -4097,27 +3578,13 @@ function CooldownCompanion:ApplyResourceBars()
             StyleContinuousBar(barInfo.frame, powerType, settings)
         end
 
-        local isIndependentCustomAura = false
-        if isCustomEntry then
-            local cabConfig = entry.config
-            isIndependentCustomAura = IsCustomAuraBarIndependent(cabConfig)
+        ClearStaleRecycledBarRuntimeState(barInfo.frame)
+        if barInfo.frame:GetParent() ~= targetContainer then
+            barInfo.frame:SetParent(targetContainer)
         end
-
-        barInfo._isIndependent = isIndependentCustomAura
-        if isIndependentCustomAura then
-            barInfo._side = nil
-            barInfo._order = nil
-            barInfo._effectiveThickness = nil
-            self:ApplyIndependentCustomAuraPlacement(barInfo, barInfo.cabConfig, settings)
-        else
-            self:ClearIndependentCustomAuraRuntimeState(barInfo.frame)
-            if barInfo.frame:GetParent() ~= targetContainer then
-                barInfo.frame:SetParent(targetContainer)
-            end
-            barInfo._side = sideList[idx]
-            barInfo._order = orderList[idx]
-            barInfo._effectiveThickness = effectiveThickness
-        end
+        barInfo._side = sideList[idx]
+        barInfo._order = orderList[idx]
+        barInfo._effectiveThickness = effectiveThickness
 
         FinalizeAppliedBarVisibility(barInfo, powerType, isPreviewActive)
     end
@@ -4268,6 +3735,8 @@ function CooldownCompanion:RevertResourceBars()
     isApplied = false
     lastAppliedPrimaryLength = nil
     lastAppliedOrientation = nil
+    lastAppliedLayout = nil
+    lastAppliedIndependentStack = false
     lastAppliedBarSpacing = nil
     lastAppliedBarThickness = nil
     layoutDirty = false
@@ -4295,7 +3764,7 @@ function CooldownCompanion:RevertResourceBars()
     -- Hide all bars
     for _, barInfo in ipairs(resourceBarFrames) do
         if barInfo.frame then
-            ClearIndependentRuntimeState(barInfo.frame)
+            ClearStaleRecycledBarRuntimeState(barInfo.frame)
             ClearCustomAuraBarIndicatorState(barInfo, true)
             ClearResourceAuraVisuals(barInfo.frame)
             ClearMaxStacksIndicator(barInfo)
@@ -4348,9 +3817,7 @@ local function RefreshCustomAuraBarPreviewState(cabConfig, previewKey, show)
     end
 
     if anyUpdated and layoutDirty then
-        layoutDirty = false
-        RelayoutBars()
-        CooldownCompanion:RepositionCastBar()
+        RelayoutResourceStack()
     end
 end
 
@@ -4411,9 +3878,7 @@ function CooldownCompanion:ClearAllCustomAuraBarPreviews()
     end
 
     if anyUpdated and layoutDirty then
-        layoutDirty = false
-        RelayoutBars()
-        CooldownCompanion:RepositionCastBar()
+        RelayoutResourceStack()
     end
 end
 
@@ -4546,7 +4011,6 @@ function CooldownCompanion:GetResourceBarRuntimeDebugInfo()
             customBarId = barInfo.customBarId,
             barType = barInfo.barType,
             shown = barInfo.frame and barInfo.frame:IsShown() or false,
-            isIndependent = barInfo._isIndependent == true,
         }
         if barInfo.cabConfig and barInfo.cabConfig.spellID then
             entry.spellID = tonumber(barInfo.cabConfig.spellID) or barInfo.cabConfig.spellID
@@ -4555,83 +4019,6 @@ function CooldownCompanion:GetResourceBarRuntimeDebugInfo()
         info[#info + 1] = entry
     end
     return info
-end
-
-function CooldownCompanion:InitializeCustomAuraIndependentAnchor(customBarRef)
-    local settings = GetResourceBarSettings()
-    if not settings then return end
-
-    local customBars = GetSpecCustomAuraBars(settings)
-    local idx = tonumber(customBarRef)
-    local cabConfig
-    if type(customBarRef) == "string" then
-        for entryIndex, entry in ipairs(customBars) do
-            if entry.customBarId == customBarRef then
-                idx = entryIndex
-                cabConfig = entry
-                break
-            end
-        end
-    elseif idx and idx >= 1 then
-        cabConfig = customBars[idx]
-    end
-    if type(cabConfig) ~= "table" then
-        return
-    end
-    local customBarId = RB.EnsureCustomBarId(settings, cabConfig)
-
-    local hasAnchor = type(cabConfig.independentAnchor) == "table"
-        and cabConfig.independentAnchor.x ~= nil
-        and cabConfig.independentAnchor.y ~= nil
-    local hasSize = type(cabConfig.independentSize) == "table"
-        and tonumber(cabConfig.independentSize.width) ~= nil
-        and tonumber(cabConfig.independentSize.height) ~= nil
-
-    if hasAnchor and hasSize then
-        EnsureCustomAuraIndependentConfig(cabConfig, settings)
-        return
-    end
-
-    cabConfig.independentAnchorTargetMode = "group"
-    if cabConfig.independentAnchorGroupId == nil then
-        cabConfig.independentAnchorGroupId = CooldownCompanion:GetFirstAvailableAnchorGroup()
-    end
-    cabConfig.independentAnchor = {
-        point = "CENTER",
-        relativePoint = "CENTER",
-        x = 0,
-        y = 0,
-    }
-    if type(cabConfig.independentSize) ~= "table" then
-        cabConfig.independentSize = {}
-    end
-
-    local sourceFrame = nil
-    for _, barInfo in ipairs(resourceBarFrames) do
-        if barInfo and barInfo.customBarId == customBarId and barInfo.frame then
-            sourceFrame = barInfo.frame
-            break
-        end
-    end
-
-    if sourceFrame then
-        local width, height = sourceFrame:GetSize()
-        cabConfig.independentSize.width = ClampIndependentDimension(width, 120)
-        cabConfig.independentSize.height = ClampIndependentDimension(height, GetResourceGlobalThickness(settings))
-
-        local targetFrame = ResolveIndependentAnchorTarget(cabConfig, settings)
-        local cx, cy = sourceFrame:GetCenter()
-        local tx, ty = targetFrame:GetCenter()
-        if cx and cy and tx and ty then
-            cabConfig.independentAnchor.x = RoundToTenths(cx - tx)
-            cabConfig.independentAnchor.y = RoundToTenths(cy - ty)
-        end
-    else
-        cabConfig.independentSize.width = ClampIndependentDimension(cabConfig.independentSize.width, 120)
-        cabConfig.independentSize.height = ClampIndependentDimension(cabConfig.independentSize.height, GetResourceGlobalThickness(settings))
-    end
-
-    EnsureCustomAuraIndependentConfig(cabConfig, settings)
 end
 
 ------------------------------------------------------------------------
@@ -4661,8 +4048,7 @@ function CooldownCompanion:GetResourceBarPredecessor(side, upToOrder)
 
     local best = nil
     for _, barInfo in ipairs(resourceBarFrames) do
-        if not barInfo._isIndependent
-            and barInfo.frame and barInfo.frame:IsShown()
+        if barInfo.frame and barInfo.frame:IsShown()
             and barInfo._side == side
             and barInfo._order < upToOrder then
             if not best then

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -190,20 +190,68 @@ local function GetPlayerClassID()
     return classID
 end
 
+local customBarContentFields = {
+    "spellID",
+    "trackingMode",
+    "displayMode",
+    "maxStacks",
+    "barColor",
+    "barCooldownColor",
+    "barChargeColor",
+    "overlayColor",
+    "soundAlerts",
+    "loadConditions",
+    "talentConditions",
+    "hideWhenInactive",
+    "hideWhileAuraActive",
+    "hideAuraActiveExceptPandemic",
+    "barAuraEffect",
+    "auraGlowCombatOnly",
+    "showPandemicGlow",
+    "pandemicGlowCombatOnly",
+    "thresholdColorEnabled",
+    "maxStacksGlowEnabled",
+    "maxStacksGlowStyle",
+    "maxStacksGlowSize",
+    "maxStacksGlowSpeed",
+    "maxStacksGlowThickness",
+    "showDurationText",
+    "durationTextFont",
+    "durationTextFontSize",
+    "durationTextFontOutline",
+    "decimalTimers",
+    "showStackText",
+    "showText",
+    "stackTextFormat",
+    "stackTextFont",
+    "stackTextFontSize",
+    "stackTextFontOutline",
+    "auraUnit",
+    "hasCharges",
+    "maxCharges",
+}
+
+local function HasCustomBarContent(cab)
+    if type(cab) ~= "table" then
+        return false
+    end
+    if cab.enabled == true then
+        return true
+    end
+    for _, field in ipairs(customBarContentFields) do
+        if cab[field] ~= nil then
+            return true
+        end
+    end
+    return false
+end
+
 local function IsConfiguredCustomBar(cab)
     return type(cab) == "table"
         and (
-            cab.spellID ~= nil
+            HasCustomBarContent(cab)
             or cab.entryType ~= nil
-            or cab.enabled == true
             or cab.independentAnchorEnabled ~= nil
-            or cab.trackingMode ~= nil
-            or cab.displayMode ~= nil
-            or cab.maxStacks ~= nil
-            or cab.barColor ~= nil
-            or cab.soundAlerts ~= nil
-            or cab.loadConditions ~= nil
-            or cab.talentConditions ~= nil
         )
 end
 
@@ -220,6 +268,22 @@ local function NormalizeCustomBarEntryType(cab)
     end
     cab.entryType = GetCustomBarEntryType(cab)
     return cab.entryType
+end
+
+local function NormalizeCustomBarAttachedPlacement(cab)
+    if type(cab) ~= "table" then
+        return
+    end
+
+    cab.independentAnchorEnabled = nil
+    cab.independentLocked = nil
+    cab.independentAnchorTargetMode = nil
+    cab.independentAnchorFrameName = nil
+    cab.independentAnchorGroupId = nil
+    cab.independentAnchor = nil
+    cab.independentSize = nil
+    cab.independentOrientation = nil
+    cab.independentVerticalFillDirection = nil
 end
 
 local function CustomBarIdOwnedByOther(settings, customBarId, owner)
@@ -323,20 +387,23 @@ local function MigrateLegacyCustomAuraBars(settings, specID, target)
         local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
         if IsConfiguredCustomBar(cab) then
             local entry = CopyTable(cab)
-            entry.entryType = "aura"
-            local id = EnsureCustomBarId(settings, entry)
-            target[#target + 1] = entry
+            NormalizeCustomBarAttachedPlacement(entry)
+            if HasCustomBarContent(entry) then
+                entry.entryType = "aura"
+                local id = EnsureCustomBarId(settings, entry)
+                target[#target + 1] = entry
 
-            local legacyLayout = layout
-                and type(layout.customAuraBarSlots) == "table"
-                and layout.customAuraBarSlots[slotIdx]
-            if type(legacyLayout) == "table" and id then
-                if type(layout.customBars) ~= "table" then
-                    layout.customBars = {}
+                local legacyLayout = layout
+                    and type(layout.customAuraBarSlots) == "table"
+                    and layout.customAuraBarSlots[slotIdx]
+                if type(legacyLayout) == "table" and id then
+                    if type(layout.customBars) ~= "table" then
+                        layout.customBars = {}
+                    end
+                    layout.customBars[id] = CopyTable(legacyLayout)
+                else
+                    EnsureCustomBarLayout(settings, specID, id, 1000 + #target)
                 end
-                layout.customBars[id] = CopyTable(legacyLayout)
-            else
-                EnsureCustomBarLayout(settings, specID, id, 1000 + #target)
             end
         end
     end
@@ -375,18 +442,26 @@ local function NormalizeCustomBars(settings, specID)
     for _, key in ipairs(numericKeys) do
         local entry = specBars[key]
         if IsConfiguredCustomBar(entry) then
-            NormalizeCustomBarEntryType(entry)
-            EnsureCustomBarId(settings, entry)
-            compact[#compact + 1] = entry
+            NormalizeCustomBarAttachedPlacement(entry)
+            if HasCustomBarContent(entry) then
+                NormalizeCustomBarEntryType(entry)
+                local id = EnsureCustomBarId(settings, entry)
+                EnsureCustomBarLayout(settings, specID, id, 1000 + #compact + 1)
+                compact[#compact + 1] = entry
+            end
         end
         seen[key] = true
     end
 
     for key, entry in pairs(specBars) do
         if not seen[key] and IsConfiguredCustomBar(entry) then
-            NormalizeCustomBarEntryType(entry)
-            EnsureCustomBarId(settings, entry)
-            compact[#compact + 1] = entry
+            NormalizeCustomBarAttachedPlacement(entry)
+            if HasCustomBarContent(entry) then
+                NormalizeCustomBarEntryType(entry)
+                local id = EnsureCustomBarId(settings, entry)
+                EnsureCustomBarLayout(settings, specID, id, 1000 + #compact + 1)
+                compact[#compact + 1] = entry
+            end
         end
     end
 
@@ -780,24 +855,6 @@ end
 
 local function IsTruthyConfigFlag(value)
     return value == true or value == 1 or value == "1" or value == "true"
-end
-
-local function NormalizeCustomAuraIndependentOrientation(value)
-    if value == "horizontal" or value == "vertical" then
-        return value
-    end
-    return nil
-end
-
-local function NormalizeCustomAuraIndependentVerticalFillDirection(value)
-    if value == "bottom_to_top" or value == "top_to_bottom" or value == "inherit" then
-        return value
-    end
-    return "inherit"
-end
-
-local function IsCustomAuraBarIndependent(cabConfig)
-    return type(cabConfig) == "table" and IsTruthyConfigFlag(cabConfig.independentAnchorEnabled)
 end
 
 ------------------------------------------------------------------------
@@ -1208,9 +1265,6 @@ RB.ClampIndependentDimension = ClampIndependentDimension
 RB.IsBarsConfigActive = IsBarsConfigActive
 RB.CancelNudgeTimers = CancelNudgeTimers
 RB.IsTruthyConfigFlag = IsTruthyConfigFlag
-RB.NormalizeCustomAuraIndependentOrientation = NormalizeCustomAuraIndependentOrientation
-RB.NormalizeCustomAuraIndependentVerticalFillDirection = NormalizeCustomAuraIndependentVerticalFillDirection
-RB.IsCustomAuraBarIndependent = IsCustomAuraBarIndependent
 RB.NormalizeCustomAuraStackTextFormat = NormalizeCustomAuraStackTextFormat
 RB.IsHealerSpec = IsHealerSpec
 RB.IsAstralPowerAvailableForCurrentDruidSpec = IsAstralPowerAvailableForCurrentDruidSpec


### PR DESCRIPTION
## What Players Will Notice
- Custom Bars now always attach to the Resource Bars panel stack, matching resources instead of having a separate anchoring mode.
- Custom Bar settings are simpler: the old independent placement controls, row badges, lock actions, and layout-only tabs are gone.
- Layout & Order preview stays coherent when Resource Bars or Cast Bar anchoring modes differ, including cast-only preview cases.

## Why This Changed
- Custom Bars and Bar Panels were too easy to mentally blend together. Custom Bars are meant to behave like resources attached to a panel; Bar Panels remain the freely movable/anchorable bar surface.

## What Changed
- Removed per-Custom-Bar independent anchoring UI, runtime placement, alpha handling, drag chrome, diagnostics output, and stale pooled-row affordances.
- Normalized copied, migrated, and runtime Custom Bar settings so old independent placement fields are stripped while real Custom Bar content is preserved.
- Kept the Resource Bars stack and Cast Bar independent anchoring behavior intact.
- Updated Layout & Order preview so attached Custom Bars participate in the resource stack and cast-only preview does not expose independent Resource Bar slots or rewrite Cast Bar order on no-op drags.

## Validation
- User confirmed all tests pass after the review fixes.
- Ran `git diff --check origin/main`.
- Ran `luac -p` on all changed Lua files.
- Ran multiple code-review passes, including focused agent reviews for the cast-only preview follow-ups.
- This publish step did not capture a separate combat/restricted-content validation transcript.