### PR TITLE
Add stack count display modes to spell aura Custom Bars

### DIFF
--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -118,8 +118,32 @@ local function IsHeroSpecProxyCondition(cond)
         and cond.name == cond.heroName
 end
 local function IsSpellCustomBarConfig(cab)
+    if RB.IsSpellCustomBarConfig then
+        return RB.IsSpellCustomBarConfig(cab)
+    end
     return GetCustomBarEntryType and GetCustomBarEntryType(cab) == "spell"
 end
+
+local function IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
+    if isSpellCustomBar == nil then
+        isSpellCustomBar = IsSpellCustomBarConfig(cab)
+    end
+
+    return (not isSpellCustomBar) or (cab and cab.auraTracking == true)
+end
+
+local function GetCustomBarTrackingModeConfig(cab, isSpellCustomBar)
+    if RB.GetCustomBarTrackingMode then
+        return RB.GetCustomBarTrackingMode(cab, isSpellCustomBar)
+    end
+
+    local mode = cab and cab.trackingMode
+    if mode == "active" or mode == "stacks" then
+        return mode
+    end
+    return isSpellCustomBar and "active" or "stacks"
+end
+
 local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForSpell
 
 -- Imports from ResourceBarPanelsHelpers
@@ -2881,9 +2905,10 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
         return
     end
 
-    local isActiveTracking = isSpellCustomBar or (cab.trackingMode or "stacks") == "active"
-    local hasActiveAuraIndicatorControls = (not isSpellCustomBar and isActiveTracking)
-        or (isSpellCustomBar and cab.auraTracking == true)
+    local hasAuraDisplayControls = IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
+    local trackingMode = GetCustomBarTrackingModeConfig(cab, isSpellCustomBar)
+    local isActiveTracking = hasAuraDisplayControls and trackingMode == "active"
+    local hasActiveAuraIndicatorControls = isActiveTracking
 
     if hasActiveAuraIndicatorControls then
         renderedControls = true
@@ -2987,7 +3012,7 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
         else
             CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
         end
-    elseif not isSpellCustomBar then
+    elseif not isSpellCustomBar and hasAuraDisplayControls then
         renderedControls = true
 
         local thresholdHeading = AceGUI:Create("Heading")
@@ -3013,7 +3038,7 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
         end
     end
 
-    if not isActiveTracking then
+    if not isSpellCustomBar and hasAuraDisplayControls and not isActiveTracking then
         renderedControls = true
 
         local indicatorsHeading = AceGUI:Create("Heading")
@@ -3159,6 +3184,9 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     local capturedId = EnsureCustomBarId(settings, cab)
     local capturedKey = capturedId or tostring(capturedIdx)
     local isSpellCustomBar = IsSpellCustomBarConfig(cab)
+    local hasAuraDisplayControls = IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
+    local trackingMode = GetCustomBarTrackingModeConfig(cab, isSpellCustomBar)
+    local isStackDisplay = hasAuraDisplayControls and trackingMode ~= "active"
     local resolvedAuraUnit = GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID)
     activeTab = activeTab or "appearance"
 
@@ -3183,7 +3211,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
 
     BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
 
-    if not isSpellCustomBar then
+    if hasAuraDisplayControls then
         AddCustomBarSettingsHeading(container, "Display", infoButtons, {
             "Determines how the tracked aura is displayed on this Custom Bar.",
             " ",
@@ -3194,17 +3222,21 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     end
 
             -- Tracking Mode dropdown
-            if not isSpellCustomBar then
+            if hasAuraDisplayControls then
             local trackDrop = AceGUI:Create("Dropdown")
             trackDrop:SetLabel("Tracking Mode")
             trackDrop:SetList({
                 active = "Active",
                 stacks = "Stack Count",
             }, { "active", "stacks" })
-            trackDrop:SetValue(cab.trackingMode or "stacks")
+            trackDrop:SetValue(trackingMode)
             trackDrop:SetFullWidth(true)
             trackDrop:SetCallback("OnValueChanged", function(widget, event, val)
                 customBars[capturedIdx].trackingMode = val
+                if val ~= "active" then
+                    CooldownCompanion:SetCustomAuraBarActivePreview(customBars[capturedIdx], false)
+                    CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[capturedIdx], false)
+                end
                 ApplyCustomAuraBarPanelChanges({
                     updateAnchors = true,
                     refreshConfig = true,
@@ -3214,7 +3246,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
             end
 
             -- Max Stacks slider (hidden in "active" tracking mode)
-            if not isSpellCustomBar and (cab.trackingMode or "stacks") ~= "active" then
+            if isStackDisplay then
             local maxSlider = AceGUI:Create("Slider")
             maxSlider:SetLabel("Max Stacks")
             maxSlider:SetSliderValues(1, 99, 1)
@@ -3237,7 +3269,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
             end
 
             -- Display Mode dropdown (hidden in "active" tracking mode)
-            if not isSpellCustomBar and (cab.trackingMode or "stacks") ~= "active" then
+            if isStackDisplay then
             local modeDrop = AceGUI:Create("Dropdown")
             modeDrop:SetLabel("Display Mode")
             modeDrop:SetList({
@@ -3299,7 +3331,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 AddColorPicker(container, customBars[cabIdx], "barColor", "Bar Color", {0.5, 0.5, 1}, false,
                     cabApplyBars, function() CooldownCompanion:RecolorCustomAuraBar(customBars[cabIdx]) end)
 
-                if isSpellCustomBar then
+                if isSpellCustomBar and not isStackDisplay then
                     AddColorPicker(container, customBars[cabIdx], "barCooldownColor", "Bar Cooldown Color", {0.6, 0.13, 0.18, 1}, true,
                         cabApplyBars, cabApplyBars)
                     AddColorPicker(container, customBars[cabIdx], "barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1}, true,
@@ -3307,7 +3339,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 end
 
                 -- Overlay Color (overlay mode only)
-                if not isSpellCustomBar and cab.displayMode == "overlay" and (cab.trackingMode or "stacks") ~= "active" then
+                if cab.displayMode == "overlay" and isStackDisplay then
                     local cpOverlay = AddColorPicker(container, customBars[cabIdx], "overlayColor", "Overlay Color", {1, 0.84, 0}, false,
                         cabApplyBars, function() CooldownCompanion:RecolorCustomAuraBar(customBars[cabIdx]) end)
 
@@ -3323,8 +3355,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 end
 
                 -- ---- Text / Duration controls ----
-                local isActive = isSpellCustomBar or (cab.trackingMode or "stacks") == "active"
-                local isContinuous = isSpellCustomBar or isActive or (cab.displayMode == "continuous")
+                local isActive = not isStackDisplay
+                local isContinuous = isActive or (cab.displayMode == "continuous")
 
                 if isContinuous then
                     local textsHeading = AceGUI:Create("Heading")
@@ -3333,17 +3365,20 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     textsHeading:SetFullWidth(true)
                     container:AddChild(textsHeading)
 
-                    -- Show Duration Text
-                    local durationTextCb = AceGUI:Create("CheckBox")
-                    durationTextCb:SetLabel("Show Duration Text")
-                    durationTextCb:SetValue(cab.showDurationText == true)
-                    durationTextCb:SetFullWidth(true)
-                    durationTextCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        customBars[cabIdx].showDurationText = val or nil
-                        CooldownCompanion:ApplyResourceBars()
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                    container:AddChild(durationTextCb)
+                    local showDurationControls = not (isSpellCustomBar and isStackDisplay)
+                    local durationTextCb
+                    if showDurationControls then
+                        durationTextCb = AceGUI:Create("CheckBox")
+                        durationTextCb:SetLabel("Show Duration Text")
+                        durationTextCb:SetValue(cab.showDurationText == true)
+                        durationTextCb:SetFullWidth(true)
+                        durationTextCb:SetCallback("OnValueChanged", function(widget, event, val)
+                            customBars[cabIdx].showDurationText = val or nil
+                            CooldownCompanion:ApplyResourceBars()
+                            CooldownCompanion:RefreshConfigPanel()
+                        end)
+                        container:AddChild(durationTextCb)
+                    end
 
                     -- Show Stack Text
                     local stackVal = cab.showStackText
@@ -3352,7 +3387,11 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     end
 
                     local stackTextCb = AceGUI:Create("CheckBox")
-                    stackTextCb:SetLabel(isSpellCustomBar and "Show Count Text (Charges/Uses)" or "Show Stack Text")
+                    local stackTextLabel = "Show Stack Text"
+                    if isSpellCustomBar then
+                        stackTextLabel = isStackDisplay and "Show Aura Stack Text" or "Show Count Text (Charges/Uses)"
+                    end
+                    stackTextCb:SetLabel(stackTextLabel)
                     stackTextCb:SetValue(stackVal == true)
                     stackTextCb:SetFullWidth(true)
                     stackTextCb:SetCallback("OnValueChanged", function(widget, event, val)
@@ -3362,10 +3401,11 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                     end)
                     container:AddChild(stackTextCb)
 
-                    local showDuration = cab.showDurationText == true
+                    local showDuration = showDurationControls and cab.showDurationText == true
                     local showStack = (stackVal == true)
-                    local durationAdvExpanded = AddAdvancedToggle(durationTextCb, "rbCabDurationText_" .. capturedKey, rbCabTextAdvBtns, showDuration)
-                    if durationAdvExpanded and showDuration then
+                    local durationAdvExpanded = showDurationControls
+                        and AddAdvancedToggle(durationTextCb, "rbCabDurationText_" .. capturedKey, rbCabTextAdvBtns, showDuration)
+                    if showDurationControls and durationAdvExpanded and showDuration then
                         local fontDrop = AceGUI:Create("Dropdown")
                         fontDrop:SetLabel("Duration Font")
                         CS.SetupFontDropdown(fontDrop)
@@ -3447,7 +3487,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         end
 
                         local fontDrop = AceGUI:Create("Dropdown")
-                        fontDrop:SetLabel(isSpellCustomBar and "Charge Font" or "Stack Font")
+                        local stackFontLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font" or "Charge Font") or "Stack Font"
+                        fontDrop:SetLabel(stackFontLabel)
                         CS.SetupFontDropdown(fontDrop)
                         fontDrop:SetValue(cab.stackTextFont or DEFAULT_RESOURCE_TEXT_FONT)
                         fontDrop:SetFullWidth(true)
@@ -3458,7 +3499,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         container:AddChild(fontDrop)
 
                         local sizeDrop = AceGUI:Create("Slider")
-                        sizeDrop:SetLabel(isSpellCustomBar and "Charge Font Size" or "Stack Font Size")
+                        local stackSizeLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font Size" or "Charge Font Size") or "Stack Font Size"
+                        sizeDrop:SetLabel(stackSizeLabel)
                         sizeDrop:SetSliderValues(6, 24, 1)
                         sizeDrop:SetValue(cab.stackTextFontSize or DEFAULT_RESOURCE_TEXT_SIZE)
                         sizeDrop:SetFullWidth(true)
@@ -3469,7 +3511,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         container:AddChild(sizeDrop)
 
                         local outlineDrop = AceGUI:Create("Dropdown")
-                        outlineDrop:SetLabel(isSpellCustomBar and "Charge Outline" or "Stack Outline")
+                        local stackOutlineLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Outline" or "Charge Outline") or "Stack Outline"
+                        outlineDrop:SetLabel(stackOutlineLabel)
                         outlineDrop:SetList(CS.outlineOptions)
                         outlineDrop:SetValue(cab.stackTextFontOutline or DEFAULT_RESOURCE_TEXT_OUTLINE)
                         outlineDrop:SetFullWidth(true)

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -2004,18 +2004,33 @@ local function ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, a
     return shouldShow, true
 end
 
+function RB.RequestCustomBarPresentationRefresh()
+    if RB.customBarPresentationRefreshPending then
+        return
+    end
+
+    RB.customBarPresentationRefreshPending = true
+    C_Timer.After(0, function()
+        RB.customBarPresentationRefreshPending = nil
+        CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:UpdateAnchorStacking()
+    end)
+end
+
 local function UpdateCustomAuraBar(barInfo)
     local cabConfig = barInfo.cabConfig
     if not cabConfig or not cabConfig.spellID then return end
 
     -- Read aura data from viewer frame (applications may be secret in combat)
+    local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+    local auraState = spellAuraStackDisplay and RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
     local stacks = 0
     local applications = 0
     local auraPresent = false
     local durationObj
     local isActive = cabConfig.trackingMode == "active"
     local useDrain = isActive
-    local needsDuration = useDrain or cabConfig.showDurationText
+    local needsDuration = (useDrain or cabConfig.showDurationText) and not spellAuraStackDisplay
     local bar = barInfo.barType == "custom_continuous" and barInfo.frame or nil
     local auraPreview = bar and bar._barAuraActivePreview
     local pandemicPreview = bar and bar._pandemicPreview
@@ -2024,7 +2039,18 @@ local function UpdateCustomAuraBar(barInfo)
     local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(cabConfig.spellID)
     local auraUnit = configUnit
     local instId = viewerFrame and viewerFrame.auraInstanceID
-    if instId then
+
+    if spellAuraStackDisplay then
+        configUnit = (auraState and auraState.configUnit) or configUnit
+        viewerFrame = auraState and auraState.viewerFrame or nil
+        if auraState and auraState.ready == true and auraState.auraPresent == true and auraState.auraData then
+            auraPresent = true
+            instId = auraState.auraInstanceID
+            auraUnit = auraState.auraUnit or configUnit
+            applications = auraState.auraData.applications or 0
+            stacks = applications
+        end
+    elseif instId then
         local viewerUnit = viewerFrame.auraDataUnit or configUnit
         if viewerUnit == configUnit then
             local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
@@ -2043,7 +2069,7 @@ local function UpdateCustomAuraBar(barInfo)
         end
     end
 
-    if not auraPresent and configUnit == "player" then
+    if not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
         local auraData = C_UnitAuras.GetPlayerAuraBySpellID(cabConfig.spellID)
         if auraData then
             instId = auraData.auraInstanceID
@@ -2059,6 +2085,11 @@ local function UpdateCustomAuraBar(barInfo)
                 durationObj = C_UnitAuras.GetAuraDuration("player", instId)
             end
         end
+    end
+
+    if spellAuraStackDisplay and not auraPresent and not isPreviewActive then
+        RB.RequestCustomBarPresentationRefresh()
+        return
     end
 
     local soundAuraActive = auraPresent
@@ -2090,6 +2121,10 @@ local function UpdateCustomAuraBar(barInfo)
     end
 
     local shouldShow, hasVisibilityRule = ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, auraPreview, pandemicPreview)
+    if spellAuraStackDisplay and auraState and auraState.ready ~= true then
+        hasVisibilityRule = false
+        shouldShow = true
+    end
     if hasVisibilityRule then
         local wasShown = barInfo.frame:IsShown()
         barInfo.frame:SetShown(shouldShow)
@@ -2105,7 +2140,7 @@ local function UpdateCustomAuraBar(barInfo)
     end
 
     local maxStacks = cabConfig.maxStacks or 1
-    local thresholdEnabled = IsCustomAuraMaxThresholdEnabled(cabConfig)
+    local thresholdEnabled = (not spellAuraStackDisplay) and IsCustomAuraMaxThresholdEnabled(cabConfig)
 
     if barInfo.barType == "custom_continuous" then
         local bar = barInfo.frame
@@ -2366,7 +2401,7 @@ local function SpellCustomBarAuraDataMatches(bar, cabConfig, spellID, resolvedAu
         or (baseID and auraSpellID == baseID)
 end
 
-local function ResolveSpellCustomBarAuraState(barInfo)
+function RB.ResolveSpellCustomBarAuraState(barInfo)
     local cabConfig = barInfo and barInfo.cabConfig
     local bar = barInfo and barInfo.frame
     local buttonData, spellID = BuildSpellCustomBarAuraButtonData(cabConfig)
@@ -2465,6 +2500,24 @@ local function UpdateSpellCustomBarChargeText(bar, cooldownResult)
     end
 end
 
+function RB.UpdateSpellCustomBarAuraStackText(bar, cabConfig, stacks, maxStacks, auraPresent)
+    if not (bar and bar.stackText and bar.stackText:IsShown()) then
+        return
+    end
+
+    if not auraPresent then
+        bar.stackText:SetText("")
+        return
+    end
+
+    local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig and cabConfig.stackTextFormat)
+    if stackTextFormat == "current" then
+        bar.stackText:SetFormattedText("%d", stacks)
+    else
+        bar.stackText:SetFormattedText("%d / %d", stacks, maxStacks)
+    end
+end
+
 function RB.UpdateCustomCooldownBar(barInfo)
     local cabConfig = barInfo and barInfo.cabConfig
     local bar = barInfo and barInfo.frame
@@ -2475,11 +2528,14 @@ function RB.UpdateCustomCooldownBar(barInfo)
     local durationObj = cooldownResult and cooldownResult.renderDurationObj
     local cooldownActive = cooldownResult
         and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
-    local auraState = ResolveSpellCustomBarAuraState(barInfo)
+    local auraState = RB.ResolveSpellCustomBarAuraState(barInfo)
     local auraPresent = auraState and auraState.ready == true and auraState.auraPresent == true
     local auraPreview = bar._barAuraActivePreview == true
     local pandemicPreview = bar._pandemicPreview == true
-    local renderAuraState = cabConfig.auraTracking == true and (auraPresent or auraPreview or pandemicPreview)
+    local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+    local renderAuraState = cabConfig.auraTracking == true
+        and not spellAuraStackDisplay
+        and (auraPresent or auraPreview or pandemicPreview)
 
     local barColor = cabConfig.barColor or {0.5, 0.5, 1, 1}
     local cooldownColor = cabConfig.barCooldownColor or {0.6, 0.13, 0.18, 1}
@@ -2535,6 +2591,11 @@ function RB.UpdateCustomCooldownBar(barInfo)
         and not bar:IsShown() then
         bar:Show()
         layoutDirty = true
+    end
+
+    if spellAuraStackDisplay and auraPresent then
+        RB.RequestCustomBarPresentationRefresh()
+        return
     end
 
     if renderAuraState then
@@ -2826,7 +2887,7 @@ end
 
 local function StyleCustomAuraBar(barInfo, cabConfig)
     local barColor = cabConfig.barColor or {0.5, 0.5, 1}
-    local isSpellCustomBar = RB.GetCustomBarEntryType and RB.GetCustomBarEntryType(cabConfig) == "spell"
+    local isSpellCustomBar = RB.IsSpellCustomBarConfig(cabConfig)
     local thresholdEnabled = (not isSpellCustomBar) and IsCustomAuraMaxThresholdEnabled(cabConfig)
     local thresholdColor = GetCustomAuraMaxThresholdColor(cabConfig)
 
@@ -2841,8 +2902,11 @@ local function StyleCustomAuraBar(barInfo, cabConfig)
         end
 
         -- Determine visibility for both text elements
-        local isActive = isSpellCustomBar or cabConfig.trackingMode == "active"
-        local showDuration = cabConfig.showDurationText == true
+        local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local spellAuraStackActive = spellAuraStackDisplay and barInfo.barType ~= "custom_cooldown"
+        local isActive = isSpellCustomBar and not spellAuraStackActive
+            or ((not isSpellCustomBar) and cabConfig.trackingMode == "active")
+        local showDuration = cabConfig.showDurationText == true and not spellAuraStackActive
         local showStack = cabConfig.showStackText
         if isSpellCustomBar then
             showStack = showStack == true
@@ -3004,11 +3068,23 @@ local function PrepareCustomAuraBar(
         return barInfo
     end
     customBarId = customBarId or RB.EnsureCustomBarId(settings, cabConfig)
-    local isSpellCustomBar = RB.GetCustomBarEntryType and RB.GetCustomBarEntryType(cabConfig) == "spell"
-    local isActive = isSpellCustomBar or cabConfig.trackingMode == "active"
-    local mode = isSpellCustomBar and "continuous" or (isActive and "continuous" or (cabConfig.displayMode or "segmented"))
+    local isSpellCustomBar = RB.IsSpellCustomBarConfig(cabConfig)
+    local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+    local spellAuraStackPresent = spellAuraStackDisplay and isPreviewActive
+    if spellAuraStackDisplay and not spellAuraStackPresent and barInfo and barInfo.frame then
+        local auraState = RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
+        spellAuraStackPresent = auraState and auraState.ready == true and auraState.auraPresent == true
+    end
+    local spellAuraStackActive = spellAuraStackDisplay and spellAuraStackPresent
+    local isActive = (isSpellCustomBar and not spellAuraStackActive)
+        or ((not isSpellCustomBar) and cabConfig.trackingMode == "active")
+    local mode = isSpellCustomBar
+        and (spellAuraStackActive and (cabConfig.displayMode or "segmented") or "continuous")
+        or (isActive and "continuous" or (cabConfig.displayMode or "segmented"))
     local maxStacks = isActive and 1 or (cabConfig.maxStacks or 1)
-    local targetBarType = isSpellCustomBar and "custom_cooldown" or ("custom_" .. mode)
+    local targetBarType = (isSpellCustomBar and not spellAuraStackActive)
+        and "custom_cooldown"
+        or ("custom_" .. mode)
     local customOrientation = isVerticalLayout and "vertical" or "horizontal"
     local customIsVertical = customOrientation == "vertical"
     local customReverseFill = false
@@ -4616,18 +4692,36 @@ local function ApplyPreviewDataToBar(barInfo, settings)
         ApplyResourceAuraLanePreview(barInfo, 0.5)
         SetSegmentedText(barInfo.frame, previewStacks, mwMaxStacks)
     elseif barInfo.barType == "custom_cooldown" then
-        barInfo.frame:SetMinMaxValues(0, 1)
-        barInfo.frame:SetValue(0.45)
+        local cabConfig = barInfo.cabConfig
+        local isSpellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local maxStacks = (cabConfig and cabConfig.maxStacks) or 1
+        local previewValue
+        if isSpellAuraStackDisplay then
+            barInfo.frame:SetMinMaxValues(0, maxStacks)
+            previewValue = math.ceil(maxStacks * 0.65)
+            barInfo.frame:SetValue(previewValue)
+        else
+            barInfo.frame:SetMinMaxValues(0, 1)
+            previewValue = 0.45
+            barInfo.frame:SetValue(previewValue)
+        end
         if barInfo.frame.thresholdOverlay then
             barInfo.frame.thresholdOverlay:SetValue(0)
             barInfo.frame.thresholdOverlay:Hide()
         end
         if barInfo.frame.text and barInfo.frame.text:IsShown() then
-            local cabConfig = barInfo.cabConfig
-            barInfo.frame.text:SetText(FormatTime(12.3, cabConfig and cabConfig.decimalTimers))
+            if isSpellAuraStackDisplay then
+                barInfo.frame.text:SetText("")
+            else
+                barInfo.frame.text:SetText(FormatTime(12.3, cabConfig and cabConfig.decimalTimers))
+            end
         end
         if barInfo.frame.stackText and barInfo.frame.stackText:IsShown() then
-            barInfo.frame.stackText:SetText("1 / 2")
+            if isSpellAuraStackDisplay then
+                RB.UpdateSpellCustomBarAuraStackText(barInfo.frame, cabConfig, previewValue, maxStacks, true)
+            else
+                barInfo.frame.stackText:SetText("1 / 2")
+            end
         end
         ClearCustomAuraBarIndicatorState(barInfo, true)
         if barInfo._maxStacksIndicator then

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -265,6 +265,26 @@ local function GetCustomBarEntryType(cab)
     return "aura"
 end
 
+local function IsSpellCustomBarConfig(cab)
+    return GetCustomBarEntryType(cab) == "spell"
+end
+
+local function GetCustomBarTrackingMode(cab, isSpellCustomBar)
+    local mode = cab and cab.trackingMode
+    if mode == "active" or mode == "stacks" then
+        return mode
+    end
+
+    return isSpellCustomBar and "active" or "stacks"
+end
+
+local function IsSpellCustomBarAuraStackDisplay(cab)
+    return type(cab) == "table"
+        and IsSpellCustomBarConfig(cab)
+        and cab.auraTracking == true
+        and GetCustomBarTrackingMode(cab, true) ~= "active"
+end
+
 local function NormalizeCustomBarEntryType(cab)
     if type(cab) ~= "table" then
         return "aura"
@@ -1264,6 +1284,9 @@ RB.GetCustomBarLayout = GetCustomBarLayout
 RB.EnsureCustomBarLayout = EnsureCustomBarLayout
 RB.IsConfiguredCustomBar = IsConfiguredCustomBar
 RB.GetCustomBarEntryType = GetCustomBarEntryType
+RB.IsSpellCustomBarConfig = IsSpellCustomBarConfig
+RB.GetCustomBarTrackingMode = GetCustomBarTrackingMode
+RB.IsSpellCustomBarAuraStackDisplay = IsSpellCustomBarAuraStackDisplay
 RB.IsValidCustomAuraUnit = IsValidCustomAuraUnit
 RB.GetDefaultCustomAuraUnit = GetDefaultCustomAuraUnit
 RB.GetResolvedCustomAuraBarAuraUnit = GetResolvedCustomAuraBarAuraUnit


### PR DESCRIPTION
## What Players Will Notice
- Spell Custom Bars with Aura Tracking can now choose between Active and Stack Count tracking.
- Stack Count mode includes the same Continuous, Segmented, and Overlay display choices that standalone aura Custom Bars already use.
- When the attached aura is not present, the Custom Bar falls back to the spell cooldown or recharge display instead of staying stuck as an empty stack bar.

## Why This Changed
- Aura display settings were available for standalone aura Custom Bars, but spell Custom Bars with attached aura tracking could not configure the same stack-count behavior.
- The new behavior keeps spell-attached aura tracking consistent with the existing Active fallback model while making stack-based aura displays usable for spells.

## What Changed
- Added shared Custom Bar helpers for spell-entry detection and tracking-mode defaults.
- Exposed Tracking Mode, Max Stacks, and Display Mode controls for spell Custom Bars when Aura Tracking is enabled.
- Updated Custom Bar rendering so attached aura Stack Count displays can use Continuous, Segmented, or Overlay while falling back to the spell bar when the aura is absent.
- Kept spell-only Custom Bars and standalone aura Custom Bars on their existing behavior paths.

## Validation
- `luac -p ConfigSettings\ResourceBarPanels.lua`
- `luac -p OtherBars\ResourceBar.lua`
- `luac -p OtherBars\ResourceBarHelpers.lua`
- `git diff --check` against the merge base
- Multi-agent code review found no confirmed actionable code findings after the final runtime-swap pass.
- In-game combat and restricted-content validation is still pending, especially aura appear/drop transitions across Continuous, Segmented, and Overlay stack displays.