### PR TITLE
Add aura stack display modes to bar panels

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -16,9 +16,11 @@ local pairs = pairs
 local ipairs = ipairs
 local unpack = unpack
 local math_floor = math.floor
+local math_ceil = math.ceil
 local math_sin = math.sin
 local math_pi = math.pi
 local string_format = string.format
+local table_concat = table.concat
 local InCombatLockdown = InCombatLockdown
 
 -- Imports from Helpers
@@ -39,6 +41,7 @@ local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_BAR_COLOR = {0.2, 0.6, 1.0, 1.0}
 local DEFAULT_READY_TEXT_COLOR = {0.2, 1.0, 0.2, 1.0}
+local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -122,6 +125,705 @@ local function ResolveConditionalPreviewRemaining(button)
     return previewRemaining, previewDuration
 end
 
+local function GetResourceBarVisuals()
+    return ST._RB
+end
+
+local function GetBarAuraVisualSettings(button)
+    local style = button.style or {}
+    local settings = button._barAuraVisualSettings
+    if not settings then
+        settings = { displayProfiles = {} }
+        button._barAuraVisualSettings = settings
+    end
+
+    settings.barTexture = style.barTexture or "Solid"
+    settings.backgroundColor = style.barBgColor or {0.1, 0.1, 0.1, 0.8}
+    settings.borderStyle = style.borderStyle or "pixel"
+    settings.borderColor = style.borderColor or {0, 0, 0, 1}
+    settings.borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+
+    local RB = GetResourceBarVisuals()
+    local specID = RB and RB.GetCurrentSpecID and RB.GetCurrentSpecID()
+    if specID then
+        local profile = settings.displayProfiles[specID]
+        if not profile then
+            profile = {}
+            settings.displayProfiles[specID] = profile
+        end
+        profile.barTexture = settings.barTexture
+        profile.backgroundColor = settings.backgroundColor
+        profile.borderStyle = settings.borderStyle
+        profile.borderColor = settings.borderColor
+        profile.borderSize = settings.borderSize
+    end
+
+    return settings
+end
+
+local function GetBarAuraStackColors(button)
+    local auraBar = button.buttonData and button.buttonData.auraBar or nil
+    local style = button.style or {}
+    return style.barColor or DEFAULT_BAR_COLOR,
+        (auraBar and auraBar.overlayColor) or DEFAULT_CUSTOM_AURA_MAX_COLOR,
+        (auraBar and auraBar.thresholdMaxColor) or DEFAULT_CUSTOM_AURA_MAX_COLOR
+end
+
+local function BarAuraColorKey(color)
+    if type(color) ~= "table" then
+        return "nil"
+    end
+    return table_concat({
+        tostring(color[1] or ""),
+        tostring(color[2] or ""),
+        tostring(color[3] or ""),
+        tostring(color[4] or ""),
+    }, ":")
+end
+
+local function HideBarAuraBaseFill(button)
+    if not button or not button.statusBar then return end
+    if button._barAuraBaseFillHidden then return end
+    local texture = button.statusBar.GetStatusBarTexture and button.statusBar:GetStatusBarTexture()
+    if texture then
+        texture:SetAlpha(0)
+    end
+    button.statusBar:SetStatusBarColor(0, 0, 0, 0)
+    if button.bg then
+        button.bg:Hide()
+    end
+    if button.borderTextures then
+        for _, textureFrame in ipairs(button.borderTextures) do
+            textureFrame:Hide()
+        end
+    end
+    button._barAuraBaseFillHidden = true
+end
+
+local function RestoreBarAuraBaseFill(button)
+    if not (button and button.statusBar and button._barAuraBaseFillHidden) then return end
+    button._barAuraBaseFillHidden = nil
+    local texture = button.statusBar.GetStatusBarTexture and button.statusBar:GetStatusBarTexture()
+    if texture then
+        texture:SetAlpha(1)
+    end
+    button._barCdColor = nil
+    button._barAuraColor = nil
+    local style = button.style or {}
+    local color = style.barColor or DEFAULT_BAR_COLOR
+    button.statusBar:SetStatusBarColor(color[1], color[2], color[3], color[4] or 1)
+    if button.bg then
+        button.bg:Show()
+    end
+    if button.borderTextures then
+        for _, textureFrame in ipairs(button.borderTextures) do
+            textureFrame:Show()
+        end
+    end
+end
+
+local function GetBarAuraStackSurface(button)
+    return button and (button._barBounds or button.statusBar)
+end
+
+local function PositionBarAuraStackHolder(button, holder)
+    if not (button and holder and button.statusBar) then return end
+    local surface = GetBarAuraStackSurface(button)
+    holder:SetParent(button)
+    holder:ClearAllPoints()
+    holder:SetAllPoints(surface or button.statusBar)
+    holder:SetFrameLevel(button.statusBar:GetFrameLevel() + 1)
+    holder._isVertical = button._isVertical == true
+    holder._reverseFill = button.style and button.style.barReverseFill == true
+end
+
+local function ClearBarAuraStackVisual(button, keepIndicator)
+    local RB = GetResourceBarVisuals()
+    if not button then return end
+    if not button._barAuraStackVisualActive and not button._barAuraBaseFillHidden then
+        return
+    end
+
+    RestoreBarAuraBaseFill(button)
+    button._barAuraStackVisualActive = nil
+    button._barAuraStackVisualMode = nil
+    button._barAuraStackLayoutKey = nil
+    button._barAuraStackAppliedState = nil
+
+    if button._barAuraStackSegments then
+        button._barAuraStackSegments:Hide()
+    end
+    if button._barAuraStackOverlay then
+        button._barAuraStackOverlay:Hide()
+    end
+    if button.statusBar and button.statusBar.thresholdOverlay then
+        button.statusBar.thresholdOverlay:Hide()
+        button.statusBar.thresholdOverlay:SetValue(0)
+    end
+    if button.statusBar then
+        button.statusBar:SetMinMaxValues(0, 1)
+    end
+    if not keepIndicator and RB and RB.ClearMaxStacksIndicator then
+        if button._barAuraStackIndicatorInfo then
+            RB.ClearMaxStacksIndicator(button._barAuraStackIndicatorInfo)
+            button._barAuraStackIndicatorInfo._barAuraStackIndicatorKey = nil
+        end
+        if button._barAuraStackContinuousInfo then
+            RB.ClearMaxStacksIndicator(button._barAuraStackContinuousInfo)
+            button._barAuraStackContinuousInfo._barAuraStackIndicatorKey = nil
+        end
+    end
+end
+
+function CooldownCompanion:RefreshBarPanelAuraStackVisual(button)
+    if not button then return end
+    button._barAuraStackLayoutKey = nil
+    button._barAuraStackAppliedState = nil
+    if button._barAuraStackIndicatorInfo then
+        button._barAuraStackIndicatorInfo._barAuraStackIndicatorKey = nil
+    end
+    if button._barAuraStackContinuousInfo then
+        button._barAuraStackContinuousInfo._barAuraStackIndicatorKey = nil
+    end
+    button._barFillElapsed = button._barUpdateInterval or 0.025
+end
+
+local function ClearBarAuraStackIndicatorInfo(info, RB)
+    if not info then return end
+    if RB and RB.ClearMaxStacksIndicator then
+        RB.ClearMaxStacksIndicator(info)
+    end
+    info._barAuraStackIndicatorKey = nil
+end
+
+local function ReparentBarAuraStackIndicatorInfo(info, frame)
+    if info and info._maxStacksIndicator and frame then
+        info._maxStacksIndicator:SetParent(frame)
+    end
+end
+
+local function CreateBarAuraStackSegment(holder, RB)
+    local segment = CreateFrame("StatusBar", nil, holder)
+    segment:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
+    segment:SetMinMaxValues(0, 1)
+    segment:SetValue(0)
+
+    segment.bg = segment:CreateTexture(nil, "BACKGROUND")
+    segment.bg:SetAllPoints()
+    segment.bg:SetColorTexture(0, 0, 0, 0.5)
+
+    segment.borders = RB and RB.CreatePixelBorders and RB.CreatePixelBorders(segment) or nil
+    SetFrameClickThroughRecursive(segment, true, true)
+    return segment
+end
+
+local function EnsureBarAuraSegmentCapacity(holder, count, RB)
+    if not (holder and holder.segments) then return end
+    for i = #holder.segments + 1, count do
+        holder.segments[i] = CreateBarAuraStackSegment(holder, RB)
+    end
+    holder._activeSegments = count
+    holder._numSegments = count
+    for i, segment in ipairs(holder.segments) do
+        segment:SetMinMaxValues(i - 1, i)
+        if i > count then
+            segment:SetValue(0)
+            segment:Hide()
+        end
+    end
+end
+
+local function EnsureBarAuraOverlayCapacity(holder, halfSegments, RB)
+    if not (holder and holder.segments and holder.overlaySegments) then return end
+    for i = #holder.segments + 1, halfSegments do
+        local segment = CreateBarAuraStackSegment(holder, RB)
+        segment:SetMinMaxValues(i - 1, i)
+        holder.segments[i] = segment
+
+        local overlaySegment = CreateFrame("StatusBar", nil, holder)
+        overlaySegment:SetFrameLevel(holder:GetFrameLevel() + 2)
+        overlaySegment:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
+        overlaySegment:SetMinMaxValues(i + halfSegments - 1, i + halfSegments)
+        overlaySegment:SetValue(0)
+        SetFrameClickThroughRecursive(overlaySegment, true, true)
+        holder.overlaySegments[i] = overlaySegment
+    end
+    holder._activeSegments = halfSegments
+    for i, segment in ipairs(holder.segments) do
+        segment:SetMinMaxValues(i - 1, i)
+        if i > halfSegments then
+            segment:SetValue(0)
+            segment:Hide()
+        end
+    end
+    for i, segment in ipairs(holder.overlaySegments) do
+        segment:SetMinMaxValues(i + halfSegments - 1, i + halfSegments)
+        if i > halfSegments then
+            segment:SetValue(0)
+            segment:Hide()
+        end
+    end
+end
+
+local function EnsureBarAuraStackVisual(button, mode, maxStacks)
+    if mode == "continuous" then
+        return nil
+    end
+
+    local RB = GetResourceBarVisuals()
+    if not RB then return nil end
+
+    if mode == "overlay" then
+        local halfSegments = math_ceil(maxStacks / 2)
+        if not button._barAuraStackOverlay then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackIndicatorInfo, RB)
+            local holder = RB.CreateOverlayBar and RB.CreateOverlayBar(button, halfSegments)
+            if not holder then return nil end
+            SetFrameClickThroughRecursive(holder, true, true)
+            button._barAuraStackOverlay = holder
+            button._barAuraStackLayoutKey = nil
+        end
+        if button._barAuraStackOverlaySegments ~= halfSegments then
+            EnsureBarAuraOverlayCapacity(button._barAuraStackOverlay, halfSegments, RB)
+            button._barAuraStackOverlaySegments = halfSegments
+            button._barAuraStackLayoutKey = nil
+        end
+        PositionBarAuraStackHolder(button, button._barAuraStackOverlay)
+        button._barAuraStackOverlay:Show()
+        if button._barAuraStackSegments then
+            button._barAuraStackSegments:Hide()
+        end
+        return button._barAuraStackOverlay
+    end
+
+    if not button._barAuraStackSegments then
+        ClearBarAuraStackIndicatorInfo(button._barAuraStackIndicatorInfo, RB)
+        local holder = RB.CreateSegmentedBar and RB.CreateSegmentedBar(button, maxStacks)
+        if not holder then return nil end
+        SetFrameClickThroughRecursive(holder, true, true)
+        button._barAuraStackSegments = holder
+        button._barAuraStackLayoutKey = nil
+    end
+    if button._barAuraStackSegmentsCount ~= maxStacks then
+        EnsureBarAuraSegmentCapacity(button._barAuraStackSegments, maxStacks, RB)
+        button._barAuraStackSegmentsCount = maxStacks
+        button._barAuraStackLayoutKey = nil
+    end
+    PositionBarAuraStackHolder(button, button._barAuraStackSegments)
+    button._barAuraStackSegments:Show()
+    if button._barAuraStackOverlay then
+        button._barAuraStackOverlay:Hide()
+    end
+    return button._barAuraStackSegments
+end
+
+local function GetBarAuraStackWidgetValue(value, valueAvailable)
+    if valueAvailable then
+        return value
+    end
+    return 0
+end
+
+local function ApplyBarAuraStackSegmentValues(segments, color, value, valueAvailable)
+    if not segments then return end
+    local widgetValue = GetBarAuraStackWidgetValue(value, valueAvailable)
+    for _, segment in ipairs(segments) do
+        segment:SetStatusBarColor(color[1], color[2], color[3], color[4] or 1)
+        segment:SetValue(widgetValue)
+    end
+end
+
+local function ApplyBarAuraStackSegmentOnlyValues(segments, value, valueAvailable)
+    if not segments then return end
+    local widgetValue = GetBarAuraStackWidgetValue(value, valueAvailable)
+    for _, segment in ipairs(segments) do
+        segment:SetValue(widgetValue)
+    end
+end
+
+local function ApplyBarAuraStackValuesOnly(button, mode, stackValue, valueAvailable)
+    local widgetValue = GetBarAuraStackWidgetValue(stackValue, valueAvailable)
+    if mode == "continuous" then
+        button.statusBar:SetValue(widgetValue)
+        if button.statusBar.thresholdOverlay and button.statusBar.thresholdOverlay:IsShown() then
+            button.statusBar.thresholdOverlay:SetValue(widgetValue)
+        end
+    else
+        local holder = mode == "overlay" and button._barAuraStackOverlay or button._barAuraStackSegments
+        if not holder then return end
+        ApplyBarAuraStackSegmentOnlyValues(holder.segments, stackValue, valueAvailable)
+        if mode == "overlay" then
+            ApplyBarAuraStackSegmentOnlyValues(holder.overlaySegments, stackValue, valueAvailable)
+        end
+        if holder.thresholdSegments then
+            ApplyBarAuraStackSegmentOnlyValues(holder.thresholdSegments, stackValue, valueAvailable)
+        end
+    end
+
+    local info = mode == "continuous" and button._barAuraStackContinuousInfo or button._barAuraStackIndicatorInfo
+    if info and info._maxStacksIndicator then
+        info._maxStacksIndicator:SetValue(widgetValue)
+    end
+end
+
+local function BuildBarAuraStackLayoutKey(button, mode, maxStacks, width, height, gap, showThreshold)
+    local style = button.style or {}
+    local auraBar = button.buttonData and button.buttonData.auraBar or nil
+    return table_concat({
+        tostring(mode),
+        tostring(maxStacks),
+        tostring(width),
+        tostring(height),
+        tostring(gap),
+        button._isVertical and "1" or "0",
+        style.barReverseFill and "1" or "0",
+        tostring(style.barTexture or "Solid"),
+        tostring(style.borderStyle or "pixel"),
+        tostring(style.borderSize or ST.DEFAULT_BORDER_SIZE or 1),
+        BarAuraColorKey(style.barBgColor),
+        BarAuraColorKey(style.borderColor),
+        BarAuraColorKey(auraBar and auraBar.thresholdMaxColor),
+        showThreshold and "1" or "0",
+    }, "|")
+end
+
+local function BarAuraColorStateChanged(state, rKey, gKey, bKey, aKey, color)
+    local r, g, b, a
+    if type(color) == "table" then
+        r, g, b, a = color[1], color[2], color[3], color[4]
+    end
+    return state[rKey] ~= r or state[gKey] ~= g or state[bKey] ~= b or state[aKey] ~= a
+end
+
+local function StoreBarAuraColorState(state, rKey, gKey, bKey, aKey, color)
+    if type(color) == "table" then
+        state[rKey], state[gKey], state[bKey], state[aKey] = color[1], color[2], color[3], color[4]
+    else
+        state[rKey], state[gKey], state[bKey], state[aKey] = nil, nil, nil, nil
+    end
+end
+
+local function GetBarAuraStackSurfaceSize(button, mode)
+    local surface = mode == "continuous" and button.statusBar or GetBarAuraStackSurface(button)
+    local width = surface and surface:GetWidth() or button.statusBar:GetWidth() or 0
+    local height = surface and surface:GetHeight() or button.statusBar:GetHeight() or 0
+    return width, height
+end
+
+local function GetBarAuraStackVisualDirtyState(button, mode, maxStacks, stackValue, valueAvailable)
+    local width, height = GetBarAuraStackSurfaceSize(button, mode)
+    if width <= 0 or height <= 0 then
+        return false, false, false
+    end
+
+    local style = button.style or {}
+    local auraBar = button.buttonData and button.buttonData.auraBar or nil
+    local stackBarColor, overlayColor, thresholdColor = GetBarAuraStackColors(button)
+    local showThreshold = auraBar and auraBar.thresholdColorEnabled == true
+    local state = button._barAuraStackAppliedState
+    local layoutDirty = state == nil
+    if not state then
+        state = {}
+        button._barAuraStackAppliedState = state
+    end
+
+    local gap = CooldownCompanion:GetBarPanelAuraSegmentGap(button.buttonData)
+    layoutDirty = layoutDirty
+        or state.mode ~= mode
+        or state.maxStacks ~= maxStacks
+        or state.width ~= width
+        or state.height ~= height
+        or state.gap ~= gap
+        or state.isVertical ~= (button._isVertical == true)
+        or state.reverseFill ~= (style.barReverseFill == true)
+        or state.barTexture ~= (style.barTexture or "Solid")
+        or state.borderStyle ~= (style.borderStyle or "pixel")
+        or state.borderSize ~= (style.borderSize or ST.DEFAULT_BORDER_SIZE or 1)
+        or state.showThreshold ~= showThreshold
+        or state.maxStacksGlowEnabled ~= (auraBar and auraBar.maxStacksGlowEnabled == true)
+        or state.maxStacksGlowStyle ~= (auraBar and auraBar.maxStacksGlowStyle or nil)
+        or state.maxStacksGlowSize ~= (auraBar and auraBar.maxStacksGlowSize or nil)
+        or state.maxStacksGlowSpeed ~= (auraBar and auraBar.maxStacksGlowSpeed or nil)
+        or BarAuraColorStateChanged(state, "barBgR", "barBgG", "barBgB", "barBgA", style.barBgColor)
+        or BarAuraColorStateChanged(state, "borderR", "borderG", "borderB", "borderA", style.borderColor)
+        or BarAuraColorStateChanged(state, "stackR", "stackG", "stackB", "stackA", stackBarColor)
+        or BarAuraColorStateChanged(state, "overlayR", "overlayG", "overlayB", "overlayA", overlayColor)
+        or BarAuraColorStateChanged(state, "thresholdR", "thresholdG", "thresholdB", "thresholdA", thresholdColor)
+        or BarAuraColorStateChanged(state, "glowR", "glowG", "glowB", "glowA", auraBar and auraBar.maxStacksGlowColor)
+
+    local stackValueIsSecret = valueAvailable and issecretvalue and issecretvalue(stackValue)
+    local valueDirty = button._barAuraStackValueDirty == true
+    if not valueAvailable then
+        valueDirty = valueDirty or state.stackValueAvailable == true
+    elseif stackValueIsSecret then
+        valueDirty = true
+    elseif not stackValueIsSecret and (state.stackValueAvailable ~= true or state.stackValue ~= stackValue) then
+        valueDirty = true
+    end
+    if not layoutDirty and not valueDirty then
+        return false, false, true
+    end
+
+    if layoutDirty then
+        state.mode = mode
+        state.maxStacks = maxStacks
+        state.width = width
+        state.height = height
+        state.gap = gap
+        state.isVertical = button._isVertical == true
+        state.reverseFill = style.barReverseFill == true
+        state.barTexture = style.barTexture or "Solid"
+        state.borderStyle = style.borderStyle or "pixel"
+        state.borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+        state.showThreshold = showThreshold
+        state.maxStacksGlowEnabled = auraBar and auraBar.maxStacksGlowEnabled == true
+        state.maxStacksGlowStyle = auraBar and auraBar.maxStacksGlowStyle or nil
+        state.maxStacksGlowSize = auraBar and auraBar.maxStacksGlowSize or nil
+        state.maxStacksGlowSpeed = auraBar and auraBar.maxStacksGlowSpeed or nil
+        StoreBarAuraColorState(state, "barBgR", "barBgG", "barBgB", "barBgA", style.barBgColor)
+        StoreBarAuraColorState(state, "borderR", "borderG", "borderB", "borderA", style.borderColor)
+        StoreBarAuraColorState(state, "stackR", "stackG", "stackB", "stackA", stackBarColor)
+        StoreBarAuraColorState(state, "overlayR", "overlayG", "overlayB", "overlayA", overlayColor)
+        StoreBarAuraColorState(state, "thresholdR", "thresholdG", "thresholdB", "thresholdA", thresholdColor)
+        StoreBarAuraColorState(state, "glowR", "glowG", "glowB", "glowA", auraBar and auraBar.maxStacksGlowColor)
+    end
+
+    state.stackValueAvailable = valueAvailable or false
+    if valueAvailable and not stackValueIsSecret then
+        state.stackValue = stackValue
+    else
+        state.stackValue = nil
+    end
+
+    return layoutDirty, valueDirty, true
+end
+
+local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, valueAvailable)
+    local RB = GetResourceBarVisuals()
+    if not RB then return end
+
+    local auraBar = button.buttonData and button.buttonData.auraBar or nil
+    local stackBarColor, overlayColor, thresholdColor = GetBarAuraStackColors(button)
+    local showThreshold = auraBar and auraBar.thresholdColorEnabled == true
+    local surface = mode == "continuous" and button.statusBar or GetBarAuraStackSurface(button)
+    local width = surface and surface:GetWidth() or button.statusBar:GetWidth() or 0
+    local height = surface and surface:GetHeight() or button.statusBar:GetHeight() or 0
+    if width <= 0 or height <= 0 then
+        return
+    end
+
+    button.statusBar._isVertical = button._isVertical == true
+    button.statusBar._reverseFill = button.style and button.style.barReverseFill == true
+
+    local settings = GetBarAuraVisualSettings(button)
+    local orientation = button._isVertical and "vertical" or "horizontal"
+    local reverseFill = button.style and button.style.barReverseFill == true
+    local gap = CooldownCompanion:GetBarPanelAuraSegmentGap(button.buttonData)
+    local barTexture = CooldownCompanion:FetchStatusBar(button.style and button.style.barTexture or "Solid")
+    local borderStyle = button.style and button.style.borderStyle or "pixel"
+    local borderSize = button.style and button.style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+    local layoutKey = BuildBarAuraStackLayoutKey(button, mode, maxStacks, width, height, gap, showThreshold)
+    local layoutChanged = button._barAuraStackLayoutKey ~= layoutKey
+
+    if mode == "continuous" then
+        if button._barAuraStackVisualMode ~= "continuous" then
+            ClearBarAuraStackVisual(button, true)
+            layoutChanged = true
+        end
+        button._barAuraStackVisualActive = true
+        button._barAuraStackVisualMode = "continuous"
+        button.statusBar:SetMinMaxValues(0, maxStacks)
+        button.statusBar:SetValue(GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+        button.statusBar:SetStatusBarColor(stackBarColor[1], stackBarColor[2], stackBarColor[3], stackBarColor[4] or 1)
+        if showThreshold and RB.EnsureCustomAuraContinuousThresholdOverlay and RB.LayoutCustomAuraContinuousThresholdOverlay then
+            RB.EnsureCustomAuraContinuousThresholdOverlay(button.statusBar)
+            if layoutChanged then
+                RB.LayoutCustomAuraContinuousThresholdOverlay(button.statusBar, barTexture, borderStyle, borderSize)
+            end
+            local overlay = button.statusBar.thresholdOverlay
+            if overlay then
+                RB.SetCustomAuraMaxThresholdRange(overlay, maxStacks)
+                overlay:SetStatusBarColor(thresholdColor[1], thresholdColor[2], thresholdColor[3], thresholdColor[4] or 1)
+                overlay:SetValue(GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+                overlay:Show()
+            end
+        elseif button.statusBar.thresholdOverlay then
+            button.statusBar.thresholdOverlay:Hide()
+            button.statusBar.thresholdOverlay:SetValue(0)
+        end
+        button._barAuraStackLayoutKey = layoutKey
+        return
+    end
+
+    local holder = EnsureBarAuraStackVisual(button, mode, maxStacks)
+    if not holder then return end
+    button._barAuraStackVisualActive = true
+    button._barAuraStackVisualMode = mode
+    HideBarAuraBaseFill(button)
+    if button.statusBar.thresholdOverlay then
+        button.statusBar.thresholdOverlay:Hide()
+        button.statusBar.thresholdOverlay:SetValue(0)
+    end
+    holder._isVertical = button._isVertical == true
+    holder._reverseFill = reverseFill
+
+    if mode == "overlay" then
+        local halfSegments = math_ceil(maxStacks / 2)
+        if layoutChanged then
+            if showThreshold and RB.EnsureCustomAuraOverlayThresholdOverlays then
+                RB.EnsureCustomAuraOverlayThresholdOverlays(holder, halfSegments)
+            end
+            if RB.LayoutOverlaySegments then
+                RB.LayoutOverlaySegments(holder, width, height, gap, settings, halfSegments, orientation, reverseFill)
+            end
+        end
+        ApplyBarAuraStackSegmentValues(holder.segments, stackBarColor, stackValue, valueAvailable)
+        ApplyBarAuraStackSegmentValues(holder.overlaySegments, overlayColor, stackValue, valueAvailable)
+    else
+        if layoutChanged then
+            if showThreshold and RB.EnsureCustomAuraSegmentThresholdOverlays then
+                RB.EnsureCustomAuraSegmentThresholdOverlays(holder)
+            end
+            if RB.LayoutSegments then
+                RB.LayoutSegments(holder, width, height, gap, settings, orientation, reverseFill)
+            end
+        end
+        ApplyBarAuraStackSegmentValues(holder.segments, stackBarColor, stackValue, valueAvailable)
+    end
+
+    if holder.thresholdSegments then
+        for _, segment in ipairs(holder.thresholdSegments) do
+            if showThreshold and RB.SetCustomAuraMaxThresholdRange then
+                if layoutChanged then
+                    RB.SetCustomAuraMaxThresholdRange(segment, maxStacks)
+                    segment:SetStatusBarColor(thresholdColor[1], thresholdColor[2], thresholdColor[3], thresholdColor[4] or 1)
+                end
+                segment:SetValue(GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+                segment:Show()
+            elseif layoutChanged then
+                segment:SetValue(0)
+                segment:Hide()
+            end
+        end
+    end
+    button._barAuraStackLayoutKey = layoutKey
+end
+
+local function BuildBarAuraStackIndicatorKey(button, info, glowConfig, mode, maxStacks)
+    local style = button.style or {}
+    return table_concat({
+        tostring(mode),
+        tostring(info and info.frame),
+        tostring(maxStacks),
+        tostring(glowConfig.maxStacksGlowStyle or "solidBorder"),
+        BarAuraColorKey(glowConfig.maxStacksGlowColor),
+        tostring(glowConfig.maxStacksGlowSize or 2),
+        tostring(glowConfig.maxStacksGlowSpeed or 0.5),
+        tostring(style.barTexture or "Solid"),
+        tostring(style.borderStyle or "pixel"),
+        tostring(style.borderSize or ST.DEFAULT_BORDER_SIZE or 1),
+    }, "|")
+end
+
+local function UpdateBarAuraStackIndicator(button, mode, maxStacks, stackValue, stackValueAvailable)
+    local RB = GetResourceBarVisuals()
+    if not (RB and RB.EnsureMaxStacksIndicator and RB.LayoutMaxStacksIndicator and RB.ClearMaxStacksIndicator) then
+        return
+    end
+
+    local auraBar = button.buttonData and button.buttonData.auraBar or nil
+    if not (auraBar and auraBar.maxStacksGlowEnabled == true) then
+        if button._barAuraStackIndicatorInfo then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackIndicatorInfo, RB)
+        end
+        if button._barAuraStackContinuousInfo then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackContinuousInfo, RB)
+        end
+        return
+    end
+
+    local frame = mode == "continuous" and button.statusBar
+        or (mode == "overlay" and button._barAuraStackOverlay or button._barAuraStackSegments)
+    if not frame then return end
+
+    local info
+    if mode == "continuous" then
+        button._barAuraStackContinuousInfo = button._barAuraStackContinuousInfo or { frame = button.statusBar }
+        if button._barAuraStackContinuousInfo.frame ~= button.statusBar then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackContinuousInfo, RB)
+        end
+        button._barAuraStackContinuousInfo.frame = button.statusBar
+        ReparentBarAuraStackIndicatorInfo(button._barAuraStackContinuousInfo, button.statusBar)
+        info = button._barAuraStackContinuousInfo
+        if button._barAuraStackIndicatorInfo then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackIndicatorInfo, RB)
+        end
+    else
+        button._barAuraStackIndicatorInfo = button._barAuraStackIndicatorInfo or { frame = frame }
+        if button._barAuraStackIndicatorInfo.frame ~= frame then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackIndicatorInfo, RB)
+        end
+        button._barAuraStackIndicatorInfo.frame = frame
+        ReparentBarAuraStackIndicatorInfo(button._barAuraStackIndicatorInfo, frame)
+        info = button._barAuraStackIndicatorInfo
+        if button._barAuraStackContinuousInfo then
+            ClearBarAuraStackIndicatorInfo(button._barAuraStackContinuousInfo, RB)
+        end
+    end
+
+    local glowConfig = auraBar
+    if mode ~= "continuous" and glowConfig.maxStacksGlowStyle == "pulsingOverlay" then
+        glowConfig = {}
+        for k, v in pairs(auraBar) do
+            glowConfig[k] = v
+        end
+        glowConfig.maxStacksGlowStyle = "solidBorder"
+    end
+
+    RB.EnsureMaxStacksIndicator(info)
+    local indicatorKey = BuildBarAuraStackIndicatorKey(button, info, glowConfig, mode, maxStacks)
+    if info._barAuraStackIndicatorKey ~= indicatorKey then
+        RB.LayoutMaxStacksIndicator(
+            info,
+            glowConfig,
+            maxStacks,
+            CooldownCompanion:FetchStatusBar(button.style and button.style.barTexture or "Solid"),
+            button.style and button.style.borderStyle or "pixel",
+            button.style and button.style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+        )
+        info._barAuraStackIndicatorKey = indicatorKey
+    end
+    if info._maxStacksIndicator then
+        info._maxStacksIndicator:SetValue(GetBarAuraStackWidgetValue(stackValue, stackValueAvailable))
+    end
+end
+
+local function ApplyBarAuraStackVisual(button, stackValue, stackValueAvailable)
+    local maxStacks = button._barAuraStackMax or 1
+    local mode = button._barAuraStackMode or "segmented"
+    local widgetValue = GetBarAuraStackWidgetValue(stackValue, stackValueAvailable)
+    local layoutDirty, valueDirty, canUpdate = GetBarAuraStackVisualDirtyState(button, mode, maxStacks, widgetValue, stackValueAvailable)
+    if not canUpdate then
+        button._barAuraStackAppliedState = nil
+        return
+    end
+
+    if layoutDirty then
+        if mode == "continuous" then
+            LayoutBarAuraStackVisual(button, "continuous", maxStacks, widgetValue, stackValueAvailable)
+        else
+            button.statusBar:SetMinMaxValues(0, 1)
+            button.statusBar:SetValue(0)
+            LayoutBarAuraStackVisual(button, mode, maxStacks, widgetValue, stackValueAvailable)
+        end
+        UpdateBarAuraStackIndicator(button, mode, maxStacks, widgetValue, stackValueAvailable)
+        button._barAuraStackValueDirty = nil
+    elseif valueDirty then
+        ApplyBarAuraStackValuesOnly(button, mode, widgetValue, stackValueAvailable)
+        button._barAuraStackValueDirty = nil
+    end
+end
+
 -- Lightweight OnUpdate: interpolates bar fill + time text between ticker updates.
 local function UpdateBarFill(button)
     -- Single-bar path
@@ -136,6 +838,7 @@ local function UpdateBarFill(button)
     local auraDurationTextPreview = button._conditionalAuraDurationTextPreview == true
 
     if previewRemaining and previewRemaining > 0 and not button._barGCDSuppressed then
+        ClearBarAuraStackVisual(button)
         onCooldown = true
         previewDuration = previewDuration or previewRemaining
         if previewDuration <= 0 then
@@ -150,7 +853,14 @@ local function UpdateBarFill(button)
         if frac < 0 then frac = 0 end
         if frac > 1 then frac = 1 end
         button.statusBar:SetValue(frac)
+    elseif button._barAuraStackDisplay then
+        onCooldown = true
+        if not button._barAuraStackValueSecret then
+            ApplyBarAuraStackVisual(button, button._barAuraStackValue, button._barAuraStackValueAvailable == true)
+        end
+        button.timeText:SetText("")
     elseif button._durationObj and not button._barGCDSuppressed then
+        ClearBarAuraStackVisual(button)
         onCooldown = true
         -- SetValue accepts secret values; fraction animates natively in the engine
         if button._auraActive then
@@ -159,6 +869,7 @@ local function UpdateBarFill(button)
             button.statusBar:SetValue(button._durationObj:GetElapsedPercent())     -- fill: 0→1
         end
     elseif button._viewerBar and button._auraActive and not button._barGCDSuppressed then
+        ClearBarAuraStackVisual(button)
         -- Totem/guardian: mirror viewer's BuffBar StatusBar (secret pass-through).
         -- Blizzard fills viewerFrame.Bar with SetMinMaxValues(0, duration) and
         -- SetValue(remaining) each frame.  Both GetValue and GetMinMaxValues
@@ -171,11 +882,13 @@ local function UpdateBarFill(button)
             button.statusBar:SetValue(viewerBar:GetValue())
         end
     elseif button._cooldownDeferred then
+        ClearBarAuraStackVisual(button)
         -- Deferred cooldown (timer hasn't started): show as "on cooldown"
         -- with a static full bar (no animation, no time text).
         onCooldown = true
         button.statusBar:SetValue(0)
     elseif button.buttonData.type == "item" then
+        ClearBarAuraStackVisual(button)
         -- Items: use stored C_Item.GetItemCooldown values (avoids hidden-widget staleness)
         local startMs = (button._itemCdStart or 0) * 1000
         local durationMs = (button._itemCdDuration or 0) * 1000
@@ -198,9 +911,9 @@ local function UpdateBarFill(button)
     end
 
     if onCooldown then
-        local showTimeText = (button._auraActive or auraDurationTextPreview)
+        local showTimeText = not button._barAuraStackDisplay and ((button._auraActive or auraDurationTextPreview)
             and (button.style.showAuraText ~= false)
-            or (not button._auraActive and not auraDurationTextPreview and button.style.showCooldownText)
+            or (not button._auraActive and not auraDurationTextPreview and button.style.showCooldownText))
         if showTimeText then
             -- Switch font/color when mode changes
             local mode = (button._auraActive or auraDurationTextPreview) and "aura" or "cd"
@@ -259,6 +972,7 @@ local function UpdateBarFill(button)
             end
         end
     else
+        ClearBarAuraStackVisual(button)
         -- Restore 0-1 range if exiting viewer bar pass-through
         if button._viewerBar then
             button.statusBar:SetMinMaxValues(0, 1)
@@ -295,8 +1009,11 @@ local function ApplyBarCountTextStyle(button, style)
     local defAnchor = showIcon and "BOTTOMRIGHT" or "BOTTOM"
     local defXOff = showIcon and -2 or 0
     local defYOff = 2
+    local useChargeTextLane = buttonData
+        and UsesChargeTextLane(buttonData)
+        and not CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
 
-    if buttonData and UsesChargeTextLane(buttonData) then
+    if useChargeTextLane then
         ApplyFontStyle(button.count, style, "charge")
         local chargeAnchor, chargeXOffset, chargeYOffset
         if showIcon then
@@ -318,7 +1035,7 @@ local function ApplyBarCountTextStyle(button, style)
     else
         AnchorBarCountText(button, showIcon, defAnchor, defXOff, defYOff)
     end
-    button._countTextLaneStyled = buttonData and UsesChargeTextLane(buttonData) or false
+    button._countTextLaneStyled = useChargeTextLane or false
 end
 
 -- Update bar-specific display elements (colors, desaturation, aura effects).
@@ -330,9 +1047,11 @@ local function UpdateBarDisplay(button)
     -- _durationObj may also hold aura/totem timing and must not imply cooldown.
     local itemUsesResolvedCooldownState = button.buttonData.type == "item"
         and button._resolvedItemQuantityKind == "stacks"
-    local isChargeButton = UsesChargeBehavior(button.buttonData)
+    local barAuraStackDisplay = button._barAuraStackDisplay == true
+    local stackSegmentLayerActive = barAuraStackDisplay and button._barAuraStackMode ~= "continuous"
+    local isChargeButton = UsesChargeBehavior(button.buttonData) and not barAuraStackDisplay
     local chargeState = button._chargeState
-    local auraTimerActive = button._auraActive
+    local auraTimerActive = barAuraStackDisplay or button._auraActive
         and (button._durationObj or button._viewerBar or button._conditionalPreviewRemaining)
     local onCooldown
     if itemUsesResolvedCooldownState then
@@ -382,12 +1101,14 @@ local function UpdateBarDisplay(button)
     UpdateLossOfControl(button)
 
     -- Bar aura visuals in bar mode are driven by barAuraEffect, not icon-mode aura flags.
-    local barAuraVisualsEnabled = style.barAuraEffect ~= "none"
+    local barAuraVisualsEnabled = style.barAuraEffect ~= "none" and not barAuraStackDisplay
     local inCombat = InCombatLockdown()
 
     -- Bar aura color: override bar fill when aura is active (pandemic overrides aura color)
     local wantAuraColor
-    if button._pandemicPreview or button._conditionalPreviewKind == "pandemic" then
+    if barAuraStackDisplay then
+        wantAuraColor = nil
+    elseif button._pandemicPreview or button._conditionalPreviewKind == "pandemic" then
         wantAuraColor = (button.style and button.style.barPandemicColor) or DEFAULT_BAR_PANDEMIC_COLOR
     elseif button._barAuraActivePreview or button._conditionalBarAuraActivePreview then
         wantAuraColor = (button.style and button.style.barAuraColor) or DEFAULT_BAR_AURA_COLOR
@@ -405,16 +1126,18 @@ local function UpdateBarDisplay(button)
         if not wantAuraColor then
             -- Reset to normal color immediately (don't wait for next tick)
             button._barCdColor = nil
-            local resetColor
-            if onCooldown then
-                if isChargeButton and chargeState == CHARGE_STATE_MISSING then
-                    resetColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
-                else
-                    resetColor = style.barCooldownColor
+            if not barAuraStackDisplay then
+                local resetColor
+                if onCooldown then
+                    if isChargeButton and chargeState == CHARGE_STATE_MISSING then
+                        resetColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
+                    else
+                        resetColor = style.barCooldownColor
+                    end
                 end
+                local c = resetColor or style.barColor or DEFAULT_BAR_COLOR
+                button.statusBar:SetStatusBarColor(c[1], c[2], c[3], c[4])
             end
-            local c = resetColor or style.barColor or DEFAULT_BAR_COLOR
-            button.statusBar:SetStatusBarColor(c[1], c[2], c[3], c[4])
         end
     end
     if wantAuraColor and not button._barColorShiftActive then
@@ -422,10 +1145,10 @@ local function UpdateBarDisplay(button)
     end
 
     -- Bar aura effect (pandemic overrides effect color)
-    local barAuraEffectPandemic = button._pandemicPreview
+    local barAuraEffectPandemic = not barAuraStackDisplay and (button._pandemicPreview
         or button._conditionalPreviewKind == "pandemic"
         or (button._auraActive and button._inPandemic and style.showPandemicGlow ~= false
-            and (not style.pandemicGlowCombatOnly or inCombat))
+            and (not style.pandemicGlowCombatOnly or inCombat)))
     local barAuraEffectShow = button._barAuraEffectPreview or button._barAuraActivePreview
         or button._conditionalBarAuraActivePreview
         or button._pandemicPreview
@@ -485,6 +1208,9 @@ local function UpdateBarDisplay(button)
         button._barColorShiftActive = nil
         local c = wantAuraColor or wantCdColor or style.barColor or DEFAULT_BAR_COLOR
         button.statusBar:SetStatusBarColor(c[1], c[2], c[3], c[4])
+    end
+    if stackSegmentLayerActive then
+        HideBarAuraBaseFill(button)
     end
 
     -- Keep the cooldown widget hidden — SetCooldown auto-shows it
@@ -657,8 +1383,14 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button.statusBar:SetStatusBarColor(barColor[1], barColor[2], barColor[3], barColor[4])
     button.statusBar:EnableMouse(false)
 
+    -- Dedicated text layer above custom segment holders.
+    button.barTextFrame = CreateFrame("Frame", nil, button)
+    SetBarAreaPoints(button.barTextFrame, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderSize)
+    button.barTextFrame:SetFrameLevel(button.statusBar:GetFrameLevel() + 20)
+    button.barTextFrame:EnableMouse(false)
+
     -- Name text
-    button.nameText = button.statusBar:CreateFontString(nil, "OVERLAY")
+    button.nameText = button.barTextFrame:CreateFontString(nil, "OVERLAY")
     ApplyFontStyle(button.nameText, style, "barName", 10)
     local nameOffX = style.barNameTextOffsetX or 0
     local nameOffY = style.barNameTextOffsetY or 0
@@ -686,7 +1418,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     end
 
     -- Time text
-    button.timeText = button.statusBar:CreateFontString(nil, "OVERLAY")
+    button.timeText = button.barTextFrame:CreateFontString(nil, "OVERLAY")
     ApplyFontStyle(button.timeText, style, "cooldown")
     local cdOffX = style.barCdTextOffsetX or 0
     local cdOffY = style.barCdTextOffsetY or 0
@@ -771,7 +1503,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     ApplyBarCountTextStyle(button, style)
 
     -- Aura stack count text: separate FontString for aura stacks and config previews.
-    button.auraStackCount = button.overlayFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+    button.auraStackCount = (button.barTextFrame or button.overlayFrame):CreateFontString(nil, "OVERLAY", "NumberFontNormal")
     button.auraStackCount:SetText("")
     ApplyFontStyle(button.auraStackCount, style, "auraStack")
     local asAnchor = style.auraStackAnchor or "BOTTOMLEFT"
@@ -870,6 +1602,9 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     if button.statusBar then
         SetFrameClickThroughRecursive(button.statusBar, true, true)
     end
+    if button.barTextFrame then
+        SetFrameClickThroughRecursive(button.barTextFrame, true, true)
+    end
     if button._barBounds then
         SetFrameClickThroughRecursive(button._barBounds, true, true)
     end
@@ -943,6 +1678,13 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
 
     button._auraInstanceID = nil
     button._viewerBar = nil
+    button._barAuraStackDisplay = nil
+    button._barAuraStackValue = nil
+    button._barAuraStackValueSecret = nil
+    button._barAuraStackMax = nil
+    button._barAuraStackMode = nil
+    button._barAuraVisualSettings = nil
+    ClearBarAuraStackVisual(button)
     button._inPandemic = nil
     button._pandemicGraceStart = nil
     button._pandemicGraceSuppressed = nil
@@ -1037,6 +1779,12 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button.statusBar:SetStatusBarTexture(CooldownCompanion:FetchStatusBar(newStyle.barTexture or "Solid"))
     local barColor = newStyle.barColor or {0.2, 0.6, 1.0, 1.0}
     button.statusBar:SetStatusBarColor(barColor[1], barColor[2], barColor[3], barColor[4])
+
+    if button.barTextFrame then
+        button.barTextFrame:ClearAllPoints()
+        SetBarAreaPoints(button.barTextFrame, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderSize)
+        button.barTextFrame:SetFrameLevel(button.statusBar:GetFrameLevel() + 20)
+    end
 
     -- Update background
     local bgColor = newStyle.barBgColor or {0.1, 0.1, 0.1, 0.8}
@@ -1167,6 +1915,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     if button.statusBar then
         SetFrameClickThroughRecursive(button.statusBar, true, true)
     end
+    if button.barTextFrame then
+        SetFrameClickThroughRecursive(button.barTextFrame, true, true)
+    end
     if button._barBounds then
         SetFrameClickThroughRecursive(button._barBounds, true, true)
     end
@@ -1193,3 +1944,4 @@ end
 -- Exports
 ST._UpdateBarDisplay = UpdateBarDisplay
 ST._ApplyBarCountTextStyle = ApplyBarCountTextStyle
+CooldownCompanion.ApplyBarPanelAuraStackVisual = ApplyBarAuraStackVisual

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -135,7 +135,7 @@ local function ApplyChargeTextColor(button, buttonData, style, usesChargeBehavio
         cc = style.chargeFontColor or DEFAULT_WHITE
     elseif usesChargeBehavior then
         cc = style.chargeFontColor or DEFAULT_WHITE
-    elseif UsesChargeTextLane(buttonData) then
+    elseif UsesChargeTextLane(buttonData) and not (button and button._barAuraStackDisplay) then
         cc = style.chargeFontColor or DEFAULT_WHITE
     end
 
@@ -1029,8 +1029,12 @@ end
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
-    local usesChargeBehavior = UsesChargeBehavior(buttonData)
-    local useChargeTextLane = UsesChargeTextLane(buttonData)
+    local barAuraStackDisplay = button._isBar and CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
+    local previousBarAuraStackValue = button._barAuraStackValue
+    local previousBarAuraStackValueAvailable = button._barAuraStackValueAvailable == true
+    local previousBarAuraStackValueSecret = button._barAuraStackValueSecret == true
+    local usesChargeBehavior = UsesChargeBehavior(buttonData) and not barAuraStackDisplay
+    local useChargeTextLane = UsesChargeTextLane(buttonData) and not barAuraStackDisplay
     local now = GetTime()
     local isGCDOnly = false
     local desatWasActive = button._desatCooldownActive == true
@@ -1145,6 +1149,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._cooldownState = COOLDOWN_STATE_READY
     button._chargeState = nil
     button._chargeCooldownVisualActive = nil
+    button._barAuraStackDisplay = barAuraStackDisplay or nil
+    button._barAuraStackValue = barAuraStackDisplay and 0 or nil
+    button._barAuraStackValueAvailable = barAuraStackDisplay or nil
+    button._barAuraStackMax = barAuraStackDisplay and CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData) or nil
+    button._barAuraStackMode = barAuraStackDisplay and CooldownCompanion:GetBarPanelAuraStackDisplayMode(buttonData) or nil
+    button._barAuraStackValueSecret = nil
+    if not barAuraStackDisplay then
+        button._barAuraStackValueDirty = nil
+    end
     -- Fetch cooldown data and update the cooldown widget.
     -- isOnGCD is NeverSecret (always readable even during restricted combat).
     local fetchOk, isOnGCD
@@ -1163,6 +1176,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local activeAuraSpellIDFromFallback = false
     local previousActiveAuraSpellID = button._activeAuraSpellID
     local previousActiveAuraSpellIDFromFallback = button._activeAuraSpellIDFromFallback == true
+    local auraApplications
+    local auraGraceHeld = false
+    local barAuraSecretStackValue
+    local preserveBarAuraStackText
 
     -- Aura tracking: check for active buff/debuff and override cooldown swipe
     local auraOverrideActive = false
@@ -1245,28 +1262,32 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local viewerInstId = viewerFrame.auraInstanceID
             if viewerInstId then
                 local unit = viewerFrame.auraDataUnit or auraUnit
-                local durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
                 -- Gate on unit compatibility: CDM's GetAuraData() checks player
                 -- auras first, so auraDataUnit can incorrectly be "player" for a
                 -- viewer child that tracks a target debuff.  Reject the mismatch
                 -- so target-debuff buttons don't display random player buff durations.
-                if durationObj and unit == configUnit then
+                if unit == configUnit then
                     -- Cross-validate: confirm the aura instance actually exists
-                    -- on the claimed unit.  GetAuraDuration may return data for
-                    -- stale instance IDs that belong to a different unit (e.g.
-                    -- old target after a target switch), causing ghost auras.
+                    -- on the claimed unit.  Stack-count displays may not have a
+                    -- duration object, but still need the validated applications.
                     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
-                    if auraData then
+                    local durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
+                    if auraData and (durationObj or barAuraStackDisplay) then
+                        auraApplications = auraData.applications
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = GetReadableAuraSpellID(auraData)
                         activeAuraSpellIDSourceResolved = true
-                        button._durationObj = durationObj
-                        button._viewerBar = nil  -- primary path: DurationObject available
-                        button.cooldown:SetCooldownFromDurationObject(durationObj)
+                        button._viewerBar = nil
+                        if durationObj then
+                            button._durationObj = durationObj
+                            button.cooldown:SetCooldownFromDurationObject(durationObj)
+                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                        else
+                            auraHasTimer = false
+                        end
                         button._auraInstanceID = viewerInstId
                         button._auraUnit = unit
                         auraOverrideActive = true
-                        auraHasTimer = DurationObjectShowsCooldown(durationObj)
                         fetchOk = true
                     end
                 end
@@ -1407,20 +1428,25 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 end
             end
             if auraData then
+                auraApplications = auraData.applications
                 local instId = auraData.auraInstanceID
                 if instId and not issecretvalue(instId) then
                     local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                    if durationObj then
+                    if durationObj or barAuraStackDisplay then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
                         activeAuraSpellIDSourceResolved = true
-                        button._durationObj = durationObj
                         button._viewerBar = nil
-                        button.cooldown:SetCooldownFromDurationObject(durationObj)
+                        if durationObj then
+                            button._durationObj = durationObj
+                            button.cooldown:SetCooldownFromDurationObject(durationObj)
+                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                        else
+                            auraHasTimer = false
+                        end
                         button._auraInstanceID = instId
                         button._auraUnit = "player"
                         auraOverrideActive = true
-                        auraHasTimer = DurationObjectShowsCooldown(durationObj)
                         fetchOk = true
                     end
                 end
@@ -1437,19 +1463,25 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if cachedUnit == configUnit then
                 local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, button._auraInstanceID)
                 if auraData then
+                    auraApplications = auraData.applications
                     local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
-                    if durationObj then
+                    if durationObj or barAuraStackDisplay then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = GetReadableAuraSpellID(auraData)
                         if activeAuraSpellID then
                             activeAuraSpellIDSourceResolved = true
                             activeAuraSpellIDFromFallback = true
                         end
-                        button._durationObj = durationObj
                         button._viewerBar = nil
-                        button.cooldown:SetCooldownFromDurationObject(durationObj)
+                        if durationObj then
+                            button._durationObj = durationObj
+                            button.cooldown:SetCooldownFromDurationObject(durationObj)
+                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                        else
+                            auraHasTimer = false
+                        end
+                        button._auraUnit = cachedUnit
                         auraOverrideActive = true
-                        auraHasTimer = DurationObjectShowsCooldown(durationObj)
                         fetchOk = true
                     end
                 end
@@ -1496,6 +1528,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if now - button._auraGraceStart <= 0.3 or button._targetSwitchAt then
                     button._durationObj = prevAuraDurationObj
                     auraOverrideActive = true
+                    auraGraceHeld = true
                     PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
                 else
                     button._auraGraceStart = nil
@@ -1508,8 +1541,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         else
             button._auraGraceStart = nil
             if button._targetSwitchAt then
-                if auraOverrideActive and button._durationObj then
-                    -- Primary path provided fresh DurationObject: hold complete
+                if auraOverrideActive and (button._durationObj or barAuraStackDisplay) then
+                    -- Primary path provided fresh aura data: hold complete
                     button._targetSwitchAt = nil
                     button._targetSwitchDataReceived = nil
                 elseif not button._auraActive then
@@ -1537,6 +1570,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             else
                 button._durationObj = prevAuraDurationObj
                 auraOverrideActive = true
+                auraGraceHeld = true
                 PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
             end
         end
@@ -1683,12 +1717,78 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
     button._auraTrackingReady = auraTrackingReady
 
+    if barAuraStackDisplay then
+        button._viewerBar = nil
+        button.cooldown:SetCooldown(0, 0)
+        button.cooldown:Hide()
+
+        local stackValue = 0
+        local stackValueAvailable = true
+        local stackValueFromSecretText
+        local previousValueIsSecret = previousBarAuraStackValueSecret
+            or (previousBarAuraStackValueAvailable and issecretvalue(previousBarAuraStackValue))
+        if auraOverrideActive then
+            stackValue = auraApplications
+            local stackValueIsSecret = issecretvalue(stackValue)
+            if not stackValueIsSecret and stackValue == nil and button._auraStackText ~= nil then
+                if issecretvalue(button._auraStackText) then
+                    stackValue = button._auraStackText
+                    stackValueIsSecret = true
+                    stackValueFromSecretText = true
+                else
+                    stackValue = tonumber(button._auraStackText)
+                    stackValueIsSecret = false
+                end
+            end
+            if not stackValueIsSecret and stackValue == nil then
+                if auraGraceHeld and previousBarAuraStackValueAvailable and not previousValueIsSecret then
+                    stackValue = previousBarAuraStackValue
+                    stackValueIsSecret = previousValueIsSecret
+                elseif auraGraceHeld and previousValueIsSecret then
+                    stackValueAvailable = false
+                    preserveBarAuraStackText = true
+                else
+                    stackValue = 1
+                end
+            end
+            if stackValueAvailable and not stackValueIsSecret and stackValue < 1 then
+                stackValue = 1
+            end
+        end
+        local stackValueIsSecret = stackValueAvailable and issecretvalue(stackValue)
+        local stackValueChanged = previousBarAuraStackValueAvailable ~= stackValueAvailable
+        if not stackValueChanged and stackValueAvailable and not stackValueIsSecret and not previousValueIsSecret then
+            stackValueChanged = previousBarAuraStackValue ~= stackValue
+        end
+        if auraGraceHeld and previousValueIsSecret and not stackValueAvailable then
+            button._barAuraStackValue = nil
+            button._barAuraStackValueAvailable = nil
+            button._barAuraStackValueSecret = true
+            button._barAuraStackValueDirty = nil
+        elseif stackValueIsSecret then
+            if not stackValueFromSecretText then
+                barAuraSecretStackValue = stackValue
+            end
+            button._barAuraStackValue = nil
+            button._barAuraStackValueAvailable = nil
+            button._barAuraStackValueSecret = true
+            button._barAuraStackValueDirty = nil
+            if not stackValueFromSecretText and CooldownCompanion.ApplyBarPanelAuraStackVisual then
+                CooldownCompanion.ApplyBarPanelAuraStackVisual(button, stackValue, true)
+            end
+        else
+            button._barAuraStackValue = stackValue
+            button._barAuraStackValueAvailable = stackValueAvailable or nil
+            button._barAuraStackValueDirty = previousValueIsSecret or stackValueChanged
+        end
+    end
+
     if buttonData.isPassive and not auraOverrideActive then
         button.cooldown:Hide()
     end
 
     -- Probe spell CD during aura override (shared by secondary CD and sound alerts).
-    if auraOverrideActive and buttonData.type == "spell" and not buttonData.isPassive then
+    if auraOverrideActive and not barAuraStackDisplay and buttonData.type == "spell" and not buttonData.isPassive then
         auraProbeInfo = C_Spell.GetSpellCooldown(cooldownSpellId)
         if auraProbeInfo and auraProbeInfo.isActive then
             local auraProbeNormalDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId)
@@ -1703,7 +1803,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
 
     -- Secondary cooldown text display during aura override
-    if auraOverrideActive and button.secondaryCooldown then
+    if auraOverrideActive and not barAuraStackDisplay and button.secondaryCooldown then
         if buttonData.type == "spell" and not buttonData.isPassive then
             if auraProbeInfo then
                 if not auraProbeIsGCDOnly then
@@ -1739,7 +1839,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button.secondaryCooldown:SetCooldown(0, 0)
     end
 
-    if not auraOverrideActive then
+    if not auraOverrideActive and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
             spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
             if spellCooldownResult and spellCooldownResult.fetchOk then
@@ -1777,7 +1877,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             isGCDOnly = EvaluateItemCooldown(button, buttonData, style, true)
             fetchOk = true
         end
-    elseif buttonData.type == "item" then
+    elseif not barAuraStackDisplay and buttonData.type == "item" then
         -- Items keep underlying cooldown state during aura override for visibility/desaturation.
         -- Spell aura overrides intentionally do not: the aura owns the spell visual state.
         isGCDOnly = EvaluateItemCooldown(button, buttonData, style, false)
@@ -1820,6 +1920,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         -- Both intentionally reuse the charge-text font/toggle without driving
         -- charge-specific cooldown logic.
         if buttonData.type == "spell"
+                and not barAuraStackDisplay
                 and not (button._auraTrackingReady and button.style and button.style.showAuraStackText ~= false)
                 and button.style and button.style.showChargeText then
             local displayCountShown = false
@@ -1868,7 +1969,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             elseif not displayCountShown then
                 button.count:SetText("")
             end
-        elseif (buttonData._hasDisplayCount or buttonData._displayCountFamily or HasCastCountText(buttonData) or buttonData._castCountCandidate) and buttonData.type == "spell"
+        elseif not barAuraStackDisplay
+                and (buttonData._hasDisplayCount or buttonData._displayCountFamily or HasCastCountText(buttonData) or buttonData._castCountCandidate) and buttonData.type == "spell"
                 and not (button._auraTrackingReady and button.style and button.style.showAuraStackText ~= false) then
             -- Count text disabled: ensure display/use-count and cast-count text is cleared.
             button.count:SetText("")
@@ -1883,7 +1985,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Skip for charge spells: their _durationObj is the recharge cycle, never the GCD.
     if button._isBar then
         button._barGCDSuppressed = fetchOk and isGCDOnly
-            and not usesChargeBehavior and not buttonData.isPassive
+            and not usesChargeBehavior and not buttonData.isPassive and not barAuraStackDisplay
     end
 
     -- Bar mode icon-only GCD swipe.
@@ -2094,7 +2196,23 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Aura stack count display (aura-tracking spells with stackable auras)
     -- Text is a secret value in combat — pass through directly to SetText.
     -- Blizzard sets it to "" when stacks <= 1 and the count string when > 1.
-    if button.auraStackCount and (button._auraTrackingReady or buttonData.isPassive or button._conditionalAuraStackTextPreview)
+    if button.auraStackCount and button._barAuraStackDisplay then
+        if style.showAuraStackText ~= false and button._auraActive then
+            if not preserveBarAuraStackText then
+                if barAuraSecretStackValue ~= nil then
+                    button.auraStackCount:SetFormattedText("%d", barAuraSecretStackValue)
+                elseif button._barAuraStackValueAvailable and not issecretvalue(button._barAuraStackValue) then
+                    button.auraStackCount:SetFormattedText("%d", button._barAuraStackValue)
+                elseif button._auraStackText ~= nil then
+                    button.auraStackCount:SetText(button._auraStackText)
+                else
+                    button.auraStackCount:SetText("")
+                end
+            end
+        else
+            button.auraStackCount:SetText("")
+        end
+    elseif button.auraStackCount and (button._auraTrackingReady or buttonData.isPassive or button._conditionalAuraStackTextPreview)
        and (style.showAuraStackText ~= false) then
         if button._auraActive or button._conditionalAuraStackTextPreview then
             button.auraStackCount:SetText(button._auraStackText or "")

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -73,11 +73,12 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     -- Phase 1: Evaluate each hide condition and accumulate active reasons as bits.
     local hideReasons = 0
     local auraTrackingReady = button._auraTrackingReady == true
+    local barAuraStackDisplay = button._barAuraStackDisplay == true
     local itemUsesResolvedCooldownState = buttonData.type == "item"
         and button._resolvedItemQuantityKind == "stacks"
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
-    if buttonData.hideWhileOnCooldown and not button._noCooldown then
+    if buttonData.hideWhileOnCooldown and not button._noCooldown and not barAuraStackDisplay then
         if itemUsesResolvedCooldownState then
             if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
@@ -99,7 +100,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     end
 
     -- Check hideWhileNotOnCooldown (skip for no-CD spells — would permanently hide)
-    if buttonData.hideWhileNotOnCooldown and not button._noCooldown then
+    if buttonData.hideWhileNotOnCooldown and not button._noCooldown and not barAuraStackDisplay then
         if itemUsesResolvedCooldownState then
             if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
@@ -141,6 +142,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
 
     -- Check hideWhileZeroCharges (charge-based spells and items)
     if buttonData.hideWhileZeroCharges
+            and not barAuraStackDisplay
             and not CooldownCompanion.HasItemFallbacks(buttonData)
             and button._chargeState == CHARGE_STATE_ZERO then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_CHARGES)

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -3,6 +3,7 @@ local CooldownCompanion = ST.Addon
 local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 local math_pi = math.pi
+local RB = ST._RB or {}
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
@@ -67,6 +68,7 @@ local RefreshButtonSettingsMultiSelect = ST._RefreshButtonSettingsMultiSelect
 local RefreshPanelMultiSelect = ST._RefreshPanelMultiSelect
 local BuildOverridesTab = ST._BuildOverridesTab
 local SOUND_ALERT_NONE_OPTION_KEY = "None" -- Keep in sync with Core/SoundAlerts.lua SOUND_NONE_KEY.
+local DEFAULT_CUSTOM_AURA_MAX_COLOR = RB.DEFAULT_CUSTOM_AURA_MAX_COLOR or { 1, 0.84, 0 }
 
 local function GroupUsesTexturePanelEntries(group)
     return group and (group.displayMode or "icons") == "textures"
@@ -267,6 +269,64 @@ local function SetupWrappedStatusLabel(scroll, label, text, justifyH)
         label:SetWidth(math.max(1, contentWidth - 20))
     end
     label:SetText(text)
+end
+
+local function EnsureButtonSettingsAuraBar(buttonData)
+    if type(buttonData.auraBar) ~= "table" then
+        buttonData.auraBar = {}
+    end
+    return buttonData.auraBar
+end
+
+local function RefreshSelectedBarPanelAuraDisplay(options)
+    CooldownCompanion:RefreshGroupFrame(CS.selectedGroup)
+    if options and options.updateCooldowns then
+        CooldownCompanion:UpdateAllCooldowns()
+    end
+    if options and options.refreshConfig then
+        CooldownCompanion:RefreshConfigPanel()
+    end
+end
+
+local function RefreshSelectedBarPanelAuraButton()
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[CS.selectedGroup]
+    local button = frame and frame.buttons and frame.buttons[CS.selectedButton]
+    if not button then
+        return
+    end
+
+    if CooldownCompanion.RefreshBarPanelAuraStackVisual then
+        CooldownCompanion:RefreshBarPanelAuraStackVisual(button)
+    end
+    CooldownCompanion:UpdateButtonCooldown(button)
+end
+
+local function AddButtonSettingsSubHeading(scroll, text, infoButtons, tooltipLines)
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(text)
+    ColorHeading(heading)
+    heading:SetHeight(22)
+    heading:SetFullWidth(true)
+    heading.label:ClearAllPoints()
+    heading.label:SetPoint("CENTER", heading.frame, "CENTER", 0, 2)
+    heading.left:ClearAllPoints()
+    heading.left:SetPoint("LEFT", heading.frame, "LEFT", 3, 0)
+    heading.left:SetPoint("RIGHT", heading.label, "LEFT", -5, 0)
+    heading.right:ClearAllPoints()
+    heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)
+    heading.right:SetPoint("LEFT", heading.label, "RIGHT", 5, 0)
+    scroll:AddChild(heading)
+
+    if tooltipLines then
+        local tooltip = { text }
+        for _, line in ipairs(tooltipLines) do
+            tooltip[#tooltip + 1] = line
+        end
+        local infoBtn = CreateInfoButton(heading.frame, heading.label, "LEFT", "RIGHT", 4, 0, tooltip, infoButtons)
+        heading.right:ClearAllPoints()
+        heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)
+        heading.right:SetPoint("LEFT", infoBtn, "RIGHT", 4, 0)
+    end
 end
 
 local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons, options)
@@ -631,6 +691,204 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
     end
 end
 
+local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
+    local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
+    if not group or group.displayMode ~= "bars" then
+        return
+    end
+    if not CooldownCompanion:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+
+    local auraBar = type(buttonData.auraBar) == "table" and buttonData.auraBar or {}
+    local displayKind = CooldownCompanion:GetBarPanelAuraDisplayKind(buttonData)
+    local isStackDisplay = displayKind == "stacks"
+    local stackDisplayMode = CooldownCompanion:GetBarPanelAuraStackDisplayMode(buttonData)
+
+    AddButtonSettingsSubHeading(scroll, "Aura Display Mode", infoButtons, {
+        {"Determines how the tracked aura is displayed on this bar panel entry.", 1, 1, 1, true},
+        " ",
+        {"Active: shows the aura's remaining duration while it is active.", 1, 1, 1, true},
+        " ",
+        {"Stack Count: ignores duration and shows only the aura's current stack count.", 1, 1, 1, true},
+    })
+
+    local trackingDrop = AceGUI:Create("Dropdown")
+    trackingDrop:SetList({
+        active = "Active",
+        stacks = "Stack Count",
+    }, { "active", "stacks" })
+    trackingDrop:SetValue(displayKind)
+    trackingDrop:SetFullWidth(true)
+    trackingDrop:SetCallback("OnValueChanged", function(_, _, value)
+        CooldownCompanion:SetBarPanelAuraDisplayKind(buttonData, value)
+        RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true, refreshConfig = true })
+    end)
+    scroll:AddChild(trackingDrop)
+
+    if not isStackDisplay then
+        return
+    end
+    auraBar = EnsureButtonSettingsAuraBar(buttonData)
+
+    local maxStacksSlider = AceGUI:Create("Slider")
+    maxStacksSlider:SetLabel("Max Stacks")
+    maxStacksSlider:SetSliderValues(1, 99, 1)
+    maxStacksSlider:SetValue(CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData))
+    maxStacksSlider:SetFullWidth(true)
+    local pendingMaxStacks = CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData)
+    local function NormalizeMaxStacks(value)
+        return math.max(1, math.min(99, math.floor((tonumber(value) or pendingMaxStacks or 1) + 0.5)))
+    end
+    local function CommitMaxStacks(value)
+        local committedValue = NormalizeMaxStacks(value)
+        if CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData) == committedValue then
+            return
+        end
+        CooldownCompanion:SetBarPanelAuraMaxStacks(buttonData, committedValue)
+        RefreshSelectedBarPanelAuraButton()
+    end
+    maxStacksSlider:SetCallback("OnValueChanged", function(_, _, value)
+        pendingMaxStacks = NormalizeMaxStacks(value)
+    end)
+    maxStacksSlider:SetCallback("OnMouseUp", function(_, _, value)
+        CommitMaxStacks(value)
+    end)
+    HookSliderEditBox(maxStacksSlider)
+    scroll:AddChild(maxStacksSlider)
+
+    local displayModeDrop = AceGUI:Create("Dropdown")
+    displayModeDrop:SetLabel("Display Mode")
+    displayModeDrop:SetList({
+        continuous = "Continuous",
+        segmented = "Segmented",
+        overlay = "Overlay",
+    }, { "continuous", "segmented", "overlay" })
+    displayModeDrop:SetValue(stackDisplayMode)
+    displayModeDrop:SetFullWidth(true)
+    displayModeDrop:SetCallback("OnValueChanged", function(_, _, value)
+        CooldownCompanion:SetBarPanelAuraStackDisplayMode(buttonData, value)
+        if value ~= "continuous" and auraBar.maxStacksGlowStyle == "pulsingOverlay" then
+            auraBar.maxStacksGlowStyle = "solidBorder"
+        end
+        RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true, refreshConfig = true })
+    end)
+    scroll:AddChild(displayModeDrop)
+
+    if stackDisplayMode == "segmented" or stackDisplayMode == "overlay" then
+        local segmentGapSlider = AceGUI:Create("Slider")
+        segmentGapSlider:SetLabel("Segment Gap")
+        segmentGapSlider:SetSliderValues(0, 20, 0.1)
+        segmentGapSlider:SetValue(CooldownCompanion:GetBarPanelAuraSegmentGap(buttonData))
+        segmentGapSlider:SetFullWidth(true)
+        segmentGapSlider:SetCallback("OnValueChanged", function(_, _, value)
+            CooldownCompanion:SetBarPanelAuraSegmentGap(buttonData, value)
+            RefreshSelectedBarPanelAuraButton()
+        end)
+        scroll:AddChild(segmentGapSlider)
+    end
+
+    if stackDisplayMode == "overlay" then
+        AddButtonSettingsSubHeading(scroll, "Colors")
+        AddColorPicker(scroll, auraBar, "overlayColor", "Overlay Color", {1, 0.84, 0, 1}, true,
+            function() RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true }) end)
+    end
+
+    AddButtonSettingsSubHeading(scroll, "Max Stack Settings")
+    local thresholdCb = AceGUI:Create("CheckBox")
+    thresholdCb:SetLabel("Enable Max Stack Color")
+    thresholdCb:SetValue(auraBar.thresholdColorEnabled == true)
+    thresholdCb:SetFullWidth(true)
+    thresholdCb:SetCallback("OnValueChanged", function(_, _, value)
+        auraBar.thresholdColorEnabled = value and true or nil
+        RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true, refreshConfig = true })
+    end)
+    scroll:AddChild(thresholdCb)
+
+    if auraBar.thresholdColorEnabled == true then
+        AddColorPicker(scroll, auraBar, "thresholdMaxColor", "Max Stack Color", DEFAULT_CUSTOM_AURA_MAX_COLOR, false,
+            function() RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true }) end)
+    end
+
+    local indicatorCb = AceGUI:Create("CheckBox")
+    indicatorCb:SetLabel("Max Stack Indicator")
+    indicatorCb:SetValue(auraBar.maxStacksGlowEnabled == true)
+    indicatorCb:SetFullWidth(true)
+    indicatorCb:SetCallback("OnValueChanged", function(_, _, value)
+        auraBar.maxStacksGlowEnabled = value and true or nil
+        RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true, refreshConfig = true })
+    end)
+    scroll:AddChild(indicatorCb)
+
+    local indicatorAdvExpanded, indicatorAdvBtn = AddAdvancedToggle(indicatorCb, "barPanelAuraMaxStacksIndicator_" .. CS.selectedGroup .. "_" .. CS.selectedButton, infoButtons, auraBar.maxStacksGlowEnabled == true)
+    CreateInfoButton(indicatorCb.frame, indicatorAdvBtn, "LEFT", "RIGHT", 4, 0, {
+        "Max Stack Indicator",
+        {"Due to combat restrictions, individual bar segments cannot be highlighted independently.", 1, 1, 1, true},
+        " ",
+        {"The indicator covers the whole bar entry and appears automatically when the aura reaches its maximum stack count.", 1, 1, 1, true},
+        " ",
+        {"The Pulsing Overlay style is only available for continuous display mode.", 1, 1, 1, true},
+    }, indicatorCb)
+
+    if indicatorAdvExpanded and auraBar.maxStacksGlowEnabled == true then
+        local currentStyle = auraBar.maxStacksGlowStyle or "solidBorder"
+        local isContinuousDisplay = stackDisplayMode == "continuous"
+        if currentStyle == "pulsingOverlay" and not isContinuousDisplay then
+            currentStyle = "solidBorder"
+        end
+
+        local styleList = {
+            solidBorder = "Solid Border",
+            pulsingBorder = "Pulsing Border",
+        }
+        local styleOrder = { "solidBorder", "pulsingBorder" }
+        if isContinuousDisplay then
+            styleList.pulsingOverlay = "Pulsing Overlay"
+            styleOrder = { "solidBorder", "pulsingBorder", "pulsingOverlay" }
+        end
+
+        local indicatorStyleDrop = AceGUI:Create("Dropdown")
+        indicatorStyleDrop:SetLabel("Indicator Style")
+        indicatorStyleDrop:SetList(styleList, styleOrder)
+        indicatorStyleDrop:SetValue(currentStyle)
+        indicatorStyleDrop:SetFullWidth(true)
+        indicatorStyleDrop:SetCallback("OnValueChanged", function(_, _, value)
+            auraBar.maxStacksGlowStyle = value
+            RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true, refreshConfig = true })
+        end)
+        scroll:AddChild(indicatorStyleDrop)
+
+        AddColorPicker(scroll, auraBar, "maxStacksGlowColor", "Indicator Color", {1, 0.84, 0, 0.9}, true,
+            function() RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true }) end)
+
+        if currentStyle ~= "pulsingOverlay" then
+            local sizeSlider = AceGUI:Create("Slider")
+            sizeSlider:SetLabel("Border Size")
+            sizeSlider:SetSliderValues(1, 8, 1)
+            sizeSlider:SetValue(auraBar.maxStacksGlowSize or 2)
+            sizeSlider:SetFullWidth(true)
+            sizeSlider:SetCallback("OnValueChanged", function(_, _, value)
+                auraBar.maxStacksGlowSize = value
+                RefreshSelectedBarPanelAuraButton()
+            end)
+            scroll:AddChild(sizeSlider)
+        end
+
+        if currentStyle == "pulsingBorder" or currentStyle == "pulsingOverlay" then
+            local speedSlider = AceGUI:Create("Slider")
+            speedSlider:SetLabel("Pulse Duration")
+            speedSlider:SetSliderValues(0.1, 2.0, 0.1)
+            speedSlider:SetValue(auraBar.maxStacksGlowSpeed or 0.5)
+            speedSlider:SetFullWidth(true)
+            speedSlider:SetCallback("OnValueChanged", function(_, _, value)
+                auraBar.maxStacksGlowSpeed = value
+                RefreshSelectedBarPanelAuraButton()
+            end)
+            scroll:AddChild(speedSlider)
+        end
+    end
+end
+
 local function BuildSpellSoundAlertsSection(scroll, buttonData, infoButtons)
     local soundHeading = AceGUI:Create("Heading")
     soundHeading:SetText("Sound Alerts")
@@ -934,6 +1192,7 @@ local function BuildSpellSettings(scroll, buttonData, infoButtons)
             useCollapse = true,
             collapsedKey = CS.selectedGroup .. "_" .. CS.selectedButton .. "_aura",
         })
+        BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
     end -- buttonData.type == "spell"
 
     -- Charge text settings now live in group Appearance tab (with per-button overrides)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -3212,7 +3212,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
 
     if hasAuraDisplayControls then
-        AddCustomBarSettingsHeading(container, "Display", infoButtons, {
+        AddCustomBarSettingsHeading(container, "Aura Display Mode", infoButtons, {
             "Determines how the tracked aura is displayed on this Custom Bar.",
             " ",
             "Active: shows the aura's remaining duration while it is active.",
@@ -3221,10 +3221,9 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
         })
     end
 
-            -- Tracking Mode dropdown
+            -- Aura Display Mode dropdown
             if hasAuraDisplayControls then
             local trackDrop = AceGUI:Create("Dropdown")
-            trackDrop:SetLabel("Tracking Mode")
             trackDrop:SetList({
                 active = "Active",
                 stacks = "Stack Count",

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -705,6 +705,163 @@ function CooldownCompanion:NormalizeStandaloneAuraButtonData(buttonData, sibling
     return changed
 end
 
+local BAR_PANEL_AURA_STACK_MODES = {
+    stacks = true,
+    stack = true,
+    stack_continuous = true,
+    stack_segmented = true,
+    stack_overlay = true,
+}
+
+local BAR_PANEL_AURA_ACTIVE_MODES = {
+    active = true,
+    duration = true,
+}
+
+local BAR_PANEL_AURA_STACK_MODE_BY_DISPLAY = {
+    continuous = "stack_continuous",
+    segmented = "stack_segmented",
+    overlay = "stack_overlay",
+}
+
+local function NormalizeBarPanelAuraStackMode(mode)
+    if mode == "stack_continuous" then
+        return "stack_continuous"
+    elseif mode == "stack_overlay" then
+        return "stack_overlay"
+    elseif mode == "stack_segmented" then
+        return "stack_segmented"
+    end
+    return nil
+end
+
+local function GetBarPanelAuraStackDisplayFromMode(mode)
+    mode = NormalizeBarPanelAuraStackMode(mode)
+    if mode == "stack_continuous" then
+        return "continuous"
+    elseif mode == "stack_overlay" then
+        return "overlay"
+    end
+    return "segmented"
+end
+
+local function EnsureBarPanelAuraSettings(buttonData)
+    if type(buttonData.auraBar) ~= "table" then
+        buttonData.auraBar = {}
+    end
+    return buttonData.auraBar
+end
+
+local function SetBarPanelAuraStackMode(auraBar, stackMode)
+    auraBar.mode = stackMode
+    auraBar.stackDisplayMode = stackMode
+end
+
+local function ClampBarPanelAuraNumber(value, minValue, maxValue, defaultValue)
+    value = tonumber(value) or defaultValue
+    if value < minValue then
+        return minValue
+    elseif value > maxValue then
+        return maxValue
+    end
+    return value
+end
+
+function CooldownCompanion:IsBarPanelAuraDisplayEligible(buttonData)
+    if not (buttonData and buttonData.type == "spell") then
+        return false
+    end
+    return buttonData.addedAs == "aura" or buttonData.auraTracking == true
+end
+
+function CooldownCompanion:GetBarPanelAuraDisplayKind(buttonData)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return "active"
+    end
+
+    local auraBar = buttonData.auraBar
+    local mode = type(auraBar) == "table" and auraBar.mode or nil
+    if BAR_PANEL_AURA_STACK_MODES[mode] then
+        return "stacks"
+    end
+    if mode == nil or BAR_PANEL_AURA_ACTIVE_MODES[mode] then
+        return "active"
+    end
+    return "active"
+end
+
+function CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
+    return self:GetBarPanelAuraDisplayKind(buttonData) == "stacks"
+end
+
+function CooldownCompanion:SetBarPanelAuraDisplayKind(buttonData, kind)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+
+    local auraBar = EnsureBarPanelAuraSettings(buttonData)
+    if kind == "stacks" then
+        local stackMode = NormalizeBarPanelAuraStackMode(auraBar.mode)
+            or NormalizeBarPanelAuraStackMode(auraBar.stackDisplayMode)
+            or "stack_segmented"
+        SetBarPanelAuraStackMode(auraBar, stackMode)
+        auraBar.maxStacks = self:GetBarPanelAuraMaxStacks(buttonData)
+        return
+    end
+
+    local stackMode = NormalizeBarPanelAuraStackMode(auraBar.mode)
+    if stackMode then
+        auraBar.stackDisplayMode = stackMode
+    end
+    auraBar.mode = "duration"
+end
+
+function CooldownCompanion:GetBarPanelAuraStackDisplayMode(buttonData)
+    local auraBar = buttonData and buttonData.auraBar
+    local mode = type(auraBar) == "table" and auraBar.mode or nil
+    if type(auraBar) == "table" then
+        mode = NormalizeBarPanelAuraStackMode(mode) or NormalizeBarPanelAuraStackMode(auraBar.stackDisplayMode)
+    end
+    return GetBarPanelAuraStackDisplayFromMode(mode)
+end
+
+function CooldownCompanion:SetBarPanelAuraStackDisplayMode(buttonData, displayMode)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+
+    local auraBar = EnsureBarPanelAuraSettings(buttonData)
+    local stackMode = BAR_PANEL_AURA_STACK_MODE_BY_DISPLAY[displayMode] or "stack_segmented"
+    SetBarPanelAuraStackMode(auraBar, stackMode)
+    auraBar.maxStacks = self:GetBarPanelAuraMaxStacks(buttonData)
+end
+
+function CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData)
+    local auraBar = buttonData and buttonData.auraBar
+    local value = type(auraBar) == "table" and auraBar.maxStacks or nil
+    return math.floor(ClampBarPanelAuraNumber(value, 1, 99, 1) + 0.5)
+end
+
+function CooldownCompanion:SetBarPanelAuraMaxStacks(buttonData, value)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+    EnsureBarPanelAuraSettings(buttonData).maxStacks = math.floor(ClampBarPanelAuraNumber(value, 1, 99, 1) + 0.5)
+end
+
+function CooldownCompanion:GetBarPanelAuraSegmentGap(buttonData)
+    local auraBar = buttonData and buttonData.auraBar
+    local value = type(auraBar) == "table" and auraBar.segmentGap or nil
+    return ClampBarPanelAuraNumber(value, 0, 20, 4)
+end
+
+function CooldownCompanion:SetBarPanelAuraSegmentGap(buttonData, value)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+    EnsureBarPanelAuraSettings(buttonData).segmentGap = ClampBarPanelAuraNumber(value, 0, 20, 4)
+end
+
 function CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
     if not (buttonData and buttonData.type == "spell") then
         return false

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -38,6 +38,19 @@ local function GetResourceDisplayStyle(settings)
     return GetSpecResourceDisplayProfile and GetSpecResourceDisplayProfile(settings) or settings
 end
 
+local function ClampSegmentGapToFit(totalSize, segmentCount, gap)
+    gap = tonumber(gap) or 0
+    if gap <= 0 or segmentCount <= 1 then
+        return 0
+    end
+
+    local maxGap = (totalSize - segmentCount) / (segmentCount - 1)
+    if maxGap < 0 then
+        maxGap = 0
+    end
+    return math_min(gap, maxGap)
+end
+
 ------------------------------------------------------------------------
 -- Resource Aura Overlay
 ------------------------------------------------------------------------
@@ -262,12 +275,10 @@ local function LayoutResourceAuraStackSegments(holder, settings, orientationOver
         isVertical = IsVerticalResourceLayout(settings)
     end
     local reverseFill = false
-    if isVertical then
-        if reverseFillOverride == nil then
-            reverseFill = IsVerticalFillReversed(settings)
-        else
-            reverseFill = reverseFillOverride == true
-        end
+    if reverseFillOverride ~= nil then
+        reverseFill = reverseFillOverride == true
+    elseif isVertical then
+        reverseFill = IsVerticalFillReversed(settings)
     end
 
     for i, auraSeg in ipairs(holder.auraStackSegments) do
@@ -296,7 +307,7 @@ local function LayoutResourceAuraStackSegments(holder, settings, orientationOver
             end
             auraSeg:SetStatusBarTexture(barTexture)
             auraSeg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-            auraSeg:SetReverseFill(isVertical and reverseFill or false)
+            auraSeg:SetReverseFill(reverseFill)
             auraSeg:SetFrameLevel(baseSeg:GetFrameLevel() + 4)
         else
             auraSeg:Hide()
@@ -650,28 +661,47 @@ local function EnsureCustomAuraContinuousThresholdOverlay(bar)
 end
 
 local function EnsureCustomAuraSegmentThresholdOverlays(holder)
-    if not holder or not holder.segments or holder.thresholdSegments then return end
-    holder.thresholdSegments = {}
-    for i = 1, #holder.segments do
-        local seg = CreateFrame("StatusBar", nil, holder)
-        seg:SetFrameLevel(holder:GetFrameLevel() + 3)
-        seg:SetMinMaxValues(0, 1)
-        seg:SetValue(0)
-        seg:Hide()
-        holder.thresholdSegments[i] = seg
+    if not holder or not holder.segments then return end
+    holder.thresholdSegments = holder.thresholdSegments or {}
+    local count = holder._activeSegments or #holder.segments
+    for i = 1, count do
+        if not holder.thresholdSegments[i] then
+            local seg = CreateFrame("StatusBar", nil, holder)
+            seg:SetFrameLevel(holder:GetFrameLevel() + 3)
+            seg:SetMinMaxValues(0, 1)
+            seg:SetValue(0)
+            seg:Hide()
+            holder.thresholdSegments[i] = seg
+        end
+    end
+    for i = count + 1, #holder.thresholdSegments do
+        local seg = holder.thresholdSegments[i]
+        if seg then
+            seg:SetValue(0)
+            seg:Hide()
+        end
     end
 end
 
 local function EnsureCustomAuraOverlayThresholdOverlays(holder, halfSegments)
-    if not holder or holder.thresholdSegments then return end
-    holder.thresholdSegments = {}
+    if not holder then return end
+    holder.thresholdSegments = holder.thresholdSegments or {}
     for i = 1, halfSegments do
-        local seg = CreateFrame("StatusBar", nil, holder)
-        seg:SetFrameLevel(holder:GetFrameLevel() + 4)
-        seg:SetMinMaxValues(0, 1)
-        seg:SetValue(0)
-        seg:Hide()
-        holder.thresholdSegments[i] = seg
+        if not holder.thresholdSegments[i] then
+            local seg = CreateFrame("StatusBar", nil, holder)
+            seg:SetFrameLevel(holder:GetFrameLevel() + 4)
+            seg:SetMinMaxValues(0, 1)
+            seg:SetValue(0)
+            seg:Hide()
+            holder.thresholdSegments[i] = seg
+        end
+    end
+    for i = halfSegments + 1, #holder.thresholdSegments do
+        local seg = holder.thresholdSegments[i]
+        if seg then
+            seg:SetValue(0)
+            seg:Hide()
+        end
     end
 end
 
@@ -693,7 +723,7 @@ local function LayoutCustomAuraContinuousThresholdOverlay(bar, barTexture, borde
     end
     overlay:SetStatusBarTexture(barTexture)
     overlay:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-    overlay:SetReverseFill(isVertical and reverseFill or false)
+    overlay:SetReverseFill(reverseFill)
 end
 
 ------------------------------------------------------------------------
@@ -779,7 +809,7 @@ end
 
 local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, orientationOverride, reverseFillOverride)
     if not holder or not holder.segments then return end
-    local n = #holder.segments
+    local n = holder._activeSegments or #holder.segments
     if n == 0 then return end
 
     local style = GetResourceDisplayStyle(settings)
@@ -797,24 +827,32 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
         isVertical = IsVerticalResourceLayout(settings)
     end
     local reverseFill = false
-    if isVertical then
-        if reverseFillOverride == nil then
-            reverseFill = IsVerticalFillReversed(settings)
-        else
-            reverseFill = reverseFillOverride == true
-        end
+    if reverseFillOverride ~= nil then
+        reverseFill = reverseFillOverride == true
+    elseif isVertical then
+        reverseFill = IsVerticalFillReversed(settings)
     end
     local subSize
     if isVertical then
+        gap = ClampSegmentGapToFit(totalHeight, n, gap)
         subSize = (totalHeight - (n - 1) * gap) / n
     else
+        gap = ClampSegmentGapToFit(totalWidth, n, gap)
         subSize = (totalWidth - (n - 1) * gap) / n
     end
     if subSize < 1 then subSize = 1 end
 
-    for i, seg in ipairs(holder.segments) do
+    for i = 1, #holder.segments do
+        local seg = holder.segments[i]
         seg:ClearAllPoints()
-        if isVertical then
+        if i > n then
+            seg:SetValue(0)
+            seg:Hide()
+            if holder.thresholdSegments and holder.thresholdSegments[i] then
+                holder.thresholdSegments[i]:SetValue(0)
+                holder.thresholdSegments[i]:Hide()
+            end
+        elseif isVertical then
             seg:SetSize(totalWidth, subSize)
             local yOfs
             if reverseFill then
@@ -826,33 +864,42 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
             seg:SetPoint("BOTTOMLEFT", holder, "BOTTOMLEFT", 0, yOfs)
         else
             seg:SetSize(subSize, totalHeight)
-            local xOfs = (i - 1) * (subSize + gap)
+            local xOfs
+            if reverseFill then
+                xOfs = totalWidth - subSize - ((i - 1) * (subSize + gap))
+                if xOfs < 0 then xOfs = 0 end
+            else
+                xOfs = (i - 1) * (subSize + gap)
+            end
             seg:SetPoint("TOPLEFT", holder, "TOPLEFT", xOfs, 0)
         end
 
-        seg:SetStatusBarTexture(barTexture)
-        seg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-        seg:SetReverseFill(isVertical and reverseFill or false)
-        seg.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])
+        if i <= n then
+            seg:Show()
+            seg:SetStatusBarTexture(barTexture)
+            seg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
+            seg:SetReverseFill(reverseFill)
+            seg.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])
 
-        if borderStyle == "pixel" then
-            ApplyPixelBorders(seg.borders, seg, borderColor, borderSize)
-        else
-            HidePixelBorders(seg.borders)
-        end
-
-        if holder.thresholdSegments and holder.thresholdSegments[i] then
-            local thresholdSeg = holder.thresholdSegments[i]
-            thresholdSeg:ClearAllPoints()
             if borderStyle == "pixel" then
-                thresholdSeg:SetPoint("TOPLEFT", seg, "TOPLEFT", borderSize, -borderSize)
-                thresholdSeg:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -borderSize, borderSize)
+                ApplyPixelBorders(seg.borders, seg, borderColor, borderSize)
             else
-                thresholdSeg:SetAllPoints(seg)
+                HidePixelBorders(seg.borders)
             end
-            thresholdSeg:SetStatusBarTexture(barTexture)
-            thresholdSeg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-            thresholdSeg:SetReverseFill(isVertical and reverseFill or false)
+
+            if holder.thresholdSegments and holder.thresholdSegments[i] then
+                local thresholdSeg = holder.thresholdSegments[i]
+                thresholdSeg:ClearAllPoints()
+                if borderStyle == "pixel" then
+                    thresholdSeg:SetPoint("TOPLEFT", seg, "TOPLEFT", borderSize, -borderSize)
+                    thresholdSeg:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -borderSize, borderSize)
+                else
+                    thresholdSeg:SetAllPoints(seg)
+                end
+                thresholdSeg:SetStatusBarTexture(barTexture)
+                thresholdSeg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
+                thresholdSeg:SetReverseFill(reverseFill)
+            end
         end
     end
 
@@ -930,17 +977,17 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
         isVertical = IsVerticalResourceLayout(settings)
     end
     local reverseFill = false
-    if isVertical then
-        if reverseFillOverride == nil then
-            reverseFill = IsVerticalFillReversed(settings)
-        else
-            reverseFill = reverseFillOverride == true
-        end
+    if reverseFillOverride ~= nil then
+        reverseFill = reverseFillOverride == true
+    elseif isVertical then
+        reverseFill = IsVerticalFillReversed(settings)
     end
     local subSize
     if isVertical then
+        gap = ClampSegmentGapToFit(totalHeight, halfSegments, gap)
         subSize = (totalHeight - (halfSegments - 1) * gap) / halfSegments
     else
+        gap = ClampSegmentGapToFit(totalWidth, halfSegments, gap)
         subSize = (totalWidth - (halfSegments - 1) * gap) / halfSegments
     end
     if subSize < 1 then subSize = 1 end
@@ -960,13 +1007,19 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
             seg:SetPoint("BOTTOMLEFT", holder, "BOTTOMLEFT", 0, yOfs)
         else
             seg:SetSize(subSize, totalHeight)
-            local xOfs = (i - 1) * (subSize + gap)
+            local xOfs
+            if reverseFill then
+                xOfs = totalWidth - subSize - ((i - 1) * (subSize + gap))
+                if xOfs < 0 then xOfs = 0 end
+            else
+                xOfs = (i - 1) * (subSize + gap)
+            end
             seg:SetPoint("TOPLEFT", holder, "TOPLEFT", xOfs, 0)
         end
 
         seg:SetStatusBarTexture(barTexture)
         seg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-        seg:SetReverseFill(isVertical and reverseFill or false)
+        seg:SetReverseFill(reverseFill)
         seg.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])
 
         if borderStyle == "pixel" then
@@ -986,7 +1039,7 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
         end
         ov:SetStatusBarTexture(barTexture)
         ov:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-        ov:SetReverseFill(isVertical and reverseFill or false)
+        ov:SetReverseFill(reverseFill)
 
         if holder.thresholdSegments and holder.thresholdSegments[i] then
             local thresholdSeg = holder.thresholdSegments[i]
@@ -999,7 +1052,24 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
             end
             thresholdSeg:SetStatusBarTexture(barTexture)
             thresholdSeg:SetOrientation(isVertical and "VERTICAL" or "HORIZONTAL")
-            thresholdSeg:SetReverseFill(isVertical and reverseFill or false)
+            thresholdSeg:SetReverseFill(reverseFill)
+        end
+    end
+    for i = halfSegments + 1, #holder.segments do
+        local seg = holder.segments[i]
+        if seg then
+            seg:SetValue(0)
+            seg:Hide()
+        end
+        local ov = holder.overlaySegments and holder.overlaySegments[i]
+        if ov then
+            ov:SetValue(0)
+            ov:Hide()
+        end
+        local thresholdSeg = holder.thresholdSegments and holder.thresholdSegments[i]
+        if thresholdSeg then
+            thresholdSeg:SetValue(0)
+            thresholdSeg:Hide()
         end
     end
 


### PR DESCRIPTION
## What Players Will Notice
- Bar panel aura entries can now display tracked auras as stack counts instead of only active-duration bars.
- Stack-count bar panel entries can use continuous, segmented, or overlay displays that visually line up with custom aura bars.
- Max-stack color and max-stack indicator controls are available for stack-count bar panel entries without adding duplicate bar color or stack text settings.

## Why This Changed
- Custom aura bars already supported choosing between active aura duration and stack-count displays. Bar panels needed the same aura display behavior while preserving their existing panel-level identity and override model.
- The settings were kept next to Aura Tracking so the display choice is tied to the aura being tracked, rather than mixed into the Overrides tab.

## What Changed
- Added bar-panel aura display helpers for Active vs Stack Count mode, stack display mode, max stacks, and segment gap handling.
- Added bar panel config controls for Aura Display Mode, stack display mode, max stacks, segment gap, overlay color, max-stack color, and max-stack indicator settings.
- Reused the custom/resource bar visual helpers so segmented and overlay stack bars share the same clean segment layout behavior.
- Updated bar cooldown/render logic so Stack Count entries can render aura applications even when no duration object is available.
- Kept combat secret stack values pass-through only: secret values are sent directly to widget setters and are not cached or compared in Lua.
- Updated visibility and text handling so stack-count aura bars are not treated like regular cooldown or charge entries.

## Validation
- `luac -p` passed for all 74 Lua files.
- `git diff --check` passed.
- Static review/fix passes were run around segmented rendering, config placement, secret stack values, max-stack indicators, and grace-held aura state.
- In-game combat/restricted-content validation is still required before merge, especially for secret aura application values, target-switch grace behavior, and max-stack indicators across continuous, segmented, and overlay modes.