### PR TITLE
Improve aura stack and sound parity for bars

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1011,7 +1011,7 @@ local function ApplyBarCountTextStyle(button, style)
     local defYOff = 2
     local useChargeTextLane = buttonData
         and UsesChargeTextLane(buttonData)
-        and not CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
+        and not (button and button._barAuraStackDisplay)
 
     if useChargeTextLane then
         ApplyFontStyle(button.count, style, "charge")

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1029,12 +1029,13 @@ end
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
-    local barAuraStackDisplay = button._isBar and CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
+    local barAuraStackConfigured = button._isBar and CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
+    local barAuraStackDisplay = false
     local previousBarAuraStackValue = button._barAuraStackValue
     local previousBarAuraStackValueAvailable = button._barAuraStackValueAvailable == true
     local previousBarAuraStackValueSecret = button._barAuraStackValueSecret == true
-    local usesChargeBehavior = UsesChargeBehavior(buttonData) and not barAuraStackDisplay
-    local useChargeTextLane = UsesChargeTextLane(buttonData) and not barAuraStackDisplay
+    local usesChargeBehavior = UsesChargeBehavior(buttonData)
+    local useChargeTextLane = UsesChargeTextLane(buttonData)
     local now = GetTime()
     local isGCDOnly = false
     local desatWasActive = button._desatCooldownActive == true
@@ -1149,15 +1150,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._cooldownState = COOLDOWN_STATE_READY
     button._chargeState = nil
     button._chargeCooldownVisualActive = nil
-    button._barAuraStackDisplay = barAuraStackDisplay or nil
-    button._barAuraStackValue = barAuraStackDisplay and 0 or nil
-    button._barAuraStackValueAvailable = barAuraStackDisplay or nil
-    button._barAuraStackMax = barAuraStackDisplay and CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData) or nil
-    button._barAuraStackMode = barAuraStackDisplay and CooldownCompanion:GetBarPanelAuraStackDisplayMode(buttonData) or nil
+    button._barAuraStackDisplay = nil
+    button._barAuraStackValue = nil
+    button._barAuraStackValueAvailable = nil
+    button._barAuraStackMax = nil
+    button._barAuraStackMode = nil
     button._barAuraStackValueSecret = nil
-    if not barAuraStackDisplay then
-        button._barAuraStackValueDirty = nil
-    end
+    button._barAuraStackValueDirty = nil
     -- Fetch cooldown data and update the cooldown widget.
     -- isOnGCD is NeverSecret (always readable even during restricted combat).
     local fetchOk, isOnGCD
@@ -1272,7 +1271,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     -- duration object, but still need the validated applications.
                     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
                     local durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
-                    if auraData and (durationObj or barAuraStackDisplay) then
+                    if auraData and (durationObj or barAuraStackConfigured) then
                         auraApplications = auraData.applications
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = GetReadableAuraSpellID(auraData)
@@ -1432,7 +1431,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 local instId = auraData.auraInstanceID
                 if instId and not issecretvalue(instId) then
                     local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                    if durationObj or barAuraStackDisplay then
+                    if durationObj or barAuraStackConfigured then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
                         activeAuraSpellIDSourceResolved = true
@@ -1465,7 +1464,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 if auraData then
                     auraApplications = auraData.applications
                     local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
-                    if durationObj or barAuraStackDisplay then
+                    if durationObj or barAuraStackConfigured then
                         RecordAuraDisplayName(auraDisplayNameState, auraData)
                         activeAuraSpellID = GetReadableAuraSpellID(auraData)
                         if activeAuraSpellID then
@@ -1541,7 +1540,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         else
             button._auraGraceStart = nil
             if button._targetSwitchAt then
-                if auraOverrideActive and (button._durationObj or barAuraStackDisplay) then
+                if auraOverrideActive and (button._durationObj or barAuraStackConfigured) then
                     -- Primary path provided fresh aura data: hold complete
                     button._targetSwitchAt = nil
                     button._targetSwitchDataReceived = nil
@@ -1716,6 +1715,26 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
     end
     button._auraTrackingReady = auraTrackingReady
+
+    barAuraStackDisplay = barAuraStackConfigured and auraOverrideActive or false
+    if barAuraStackDisplay then
+        button._barAuraStackDisplay = true
+        button._barAuraStackValue = 0
+        button._barAuraStackValueAvailable = true
+        button._barAuraStackMax = CooldownCompanion:GetBarPanelAuraMaxStacks(buttonData)
+        button._barAuraStackMode = CooldownCompanion:GetBarPanelAuraStackDisplayMode(buttonData)
+    end
+    usesChargeBehavior = UsesChargeBehavior(buttonData) and not barAuraStackDisplay
+    useChargeTextLane = UsesChargeTextLane(buttonData) and not barAuraStackDisplay
+    if button.count and button._countTextLaneStyled ~= useChargeTextLane then
+        if button._isBar then
+            ApplyBarCountTextStyle(button, style)
+        elseif not button._isText then
+            ApplyIconCountTextStyle(button, style)
+        else
+            button._countTextLaneStyled = useChargeTextLane
+        end
+    end
 
     if barAuraStackDisplay then
         button._viewerBar = nil
@@ -2199,12 +2218,25 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if button.auraStackCount and button._barAuraStackDisplay then
         if style.showAuraStackText ~= false and button._auraActive then
             if not preserveBarAuraStackText then
+                local function SetBarAuraStackCountText(value)
+                    if CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData) == "current_max" then
+                        button.auraStackCount:SetFormattedText("%d / %d", value, button._barAuraStackMax or 1)
+                    else
+                        button.auraStackCount:SetFormattedText("%d", value)
+                    end
+                end
+
                 if barAuraSecretStackValue ~= nil then
-                    button.auraStackCount:SetFormattedText("%d", barAuraSecretStackValue)
+                    SetBarAuraStackCountText(barAuraSecretStackValue)
                 elseif button._barAuraStackValueAvailable and not issecretvalue(button._barAuraStackValue) then
-                    button.auraStackCount:SetFormattedText("%d", button._barAuraStackValue)
+                    SetBarAuraStackCountText(button._barAuraStackValue)
                 elseif button._auraStackText ~= nil then
-                    button.auraStackCount:SetText(button._auraStackText)
+                    local auraStackTextValue = button._auraStackText
+                    if issecretvalue(auraStackTextValue) or tonumber(auraStackTextValue) then
+                        SetBarAuraStackCountText(auraStackTextValue)
+                    else
+                        button.auraStackCount:SetText(auraStackTextValue)
+                    end
                 else
                     button.auraStackCount:SetText("")
                 end

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -775,6 +775,20 @@ local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
     end)
     scroll:AddChild(displayModeDrop)
 
+    local stackTextFormatDrop = AceGUI:Create("Dropdown")
+    stackTextFormatDrop:SetLabel("Stack Text Format")
+    stackTextFormatDrop:SetList({
+        current = "Current Value",
+        current_max = "Current / Max",
+    }, { "current", "current_max" })
+    stackTextFormatDrop:SetValue(CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData))
+    stackTextFormatDrop:SetFullWidth(true)
+    stackTextFormatDrop:SetCallback("OnValueChanged", function(_, _, value)
+        CooldownCompanion:SetBarPanelAuraStackTextFormat(buttonData, value)
+        RefreshSelectedBarPanelAuraButton()
+    end)
+    scroll:AddChild(stackTextFormatDrop)
+
     if stackDisplayMode == "segmented" or stackDisplayMode == "overlay" then
         local segmentGapSlider = AceGUI:Create("Slider")
         segmentGapSlider:SetLabel("Segment Gap")

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -745,6 +745,13 @@ local function GetBarPanelAuraStackDisplayFromMode(mode)
     return "segmented"
 end
 
+local function NormalizeBarPanelAuraStackTextFormat(format)
+    if format == "current_max" then
+        return "current_max"
+    end
+    return "current"
+end
+
 local function EnsureBarPanelAuraSettings(buttonData)
     if type(buttonData.auraBar) ~= "table" then
         buttonData.auraBar = {}
@@ -860,6 +867,18 @@ function CooldownCompanion:SetBarPanelAuraSegmentGap(buttonData, value)
         return
     end
     EnsureBarPanelAuraSettings(buttonData).segmentGap = ClampBarPanelAuraNumber(value, 0, 20, 4)
+end
+
+function CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData)
+    local auraBar = buttonData and buttonData.auraBar
+    return NormalizeBarPanelAuraStackTextFormat(type(auraBar) == "table" and auraBar.stackTextFormat or nil)
+end
+
+function CooldownCompanion:SetBarPanelAuraStackTextFormat(buttonData, format)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+    EnsureBarPanelAuraSettings(buttonData).stackTextFormat = NormalizeBarPanelAuraStackTextFormat(format)
 end
 
 function CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)

--- a/Core/SoundAlerts.lua
+++ b/Core/SoundAlerts.lua
@@ -365,6 +365,9 @@ function CooldownCompanion:GetScopedValidSoundAlertEventsForCustomBar(customBar)
             id = customBar.spellID,
             hasCharges = customBar.hasCharges,
             maxCharges = customBar.maxCharges,
+            auraTracking = customBar.auraTracking == true,
+            auraSpellID = customBar.auraSpellID,
+            auraUnit = customBar.auraUnit,
         }, customBar.spellID))
     end
 
@@ -946,9 +949,11 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, coold
 
         UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, {
             cooldownActive = cooldownActive,
+            auraActive = auraActive,
             currentCharges = currentCharges,
             chargeRecharging = chargeRecharging,
             chargeCooldownStartTime = chargeCooldownStartTime,
+            includeAuraEvents = customBar.auraTracking == true,
             usesChargeBehavior = cooldownResult and cooldownResult.hasCharges == true,
             play = function(eventKey)
                 self:PlayCustomBarSoundAlertEvent(customBar, eventKey)

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -2088,6 +2088,9 @@ local function UpdateCustomAuraBar(barInfo)
     end
 
     if spellAuraStackDisplay and not auraPresent and not isPreviewActive then
+        if CooldownCompanion.UpdateCustomBarSoundAlerts then
+            CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false)
+        end
         RB.RequestCustomBarPresentationRefresh()
         return
     end
@@ -2594,6 +2597,7 @@ function RB.UpdateCustomCooldownBar(barInfo)
     end
 
     if spellAuraStackDisplay and auraPresent then
+        UpdateSpellCustomBarSounds(true)
         RB.RequestCustomBarPresentationRefresh()
         return
     end


### PR DESCRIPTION
## What Players Will Notice
- Bar panel aura stack displays now keep normal cooldown behavior when the tracked aura is not active instead of losing cooldown presentation just because Stack Count mode is configured.
- Bar panel stack text can now show either the current stack value or Current / Max, matching the Custom Bars stack text option.
- Spell Custom Bars with aura tracking can now use aura-applied and aura-removed sound alerts more consistently, including when the bar swaps between cooldown mode and stack-display mode.

## Why This Changed
- The Custom Bars overhaul left a few meaningful parity gaps between standalone Custom Bars and aura-tracking bars inside bar panels.
- The biggest behavior issue was that configured stack display was being treated as active stack display too early, which could suppress normal cooldown behavior while no aura was present.
- Custom Bar sound alert state also needed to be updated before presentation refreshes rebuild the bar frame, otherwise aura transition sounds could be missed at the exact moment the bar changed display type.

## What Changed
- Split bar-panel stack configuration from active stack rendering so Stack Count only takes over while an aura is actually active.
- Updated bar count-text lane styling to follow the current runtime stack state instead of the saved stack-display setting alone.
- Added bar-panel stack text format helpers and a Stack Text Format dropdown for Current Value vs Current / Max.
- Passed aura-tracking metadata into Custom Bar sound-alert scope checks and included aura transition handling for spell Custom Bars.
- Fired Custom Bar sound-alert updates before cooldown/stack presentation refreshes swap the underlying bar frame.

## Validation
- Reviewed the branch for feature parity gaps between bar panels and Custom Bars.
- Reviewed Custom Bar runtime/display transition logic around cooldown mode, stack mode, and sound-alert state.
- Ran `git diff --check origin/main..HEAD`.
- Ran `luac -p` across 121 Lua files.
- In-game combat and restricted-content validation has not been run yet and should still be completed before release.