### PR TITLE
Fix segmented resource color flicker

### DIFF
--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -44,7 +44,6 @@ local LayoutOverlaySegments = RB.LayoutOverlaySegments
 local StyleContinuousBar = RB.StyleContinuousBar
 local StyleHealthBar = RB.StyleHealthBar
 local StyleSegmentedBar = RB.StyleSegmentedBar
-local ApplySegmentedPreviewColors = RB.ApplySegmentedPreviewColors
 local PrepareCustomAuraBar = RB.PrepareCustomAuraBar
 local EnsureCustomBarId = RB.EnsureCustomBarId
 local EnsureCustomBarLayout = RB.EnsureCustomBarLayout
@@ -1190,7 +1189,6 @@ local function EnsureResourcePreview(frame, slot, preview, width, height)
         barInfo.frame:SetSize(width, height)
         LayoutSegments(barInfo.frame, width, height, segmentGap, rbSettings)
         StyleSegmentedBar(barInfo.frame, slot.powerType, rbSettings)
-        ApplySegmentedPreviewColors(barInfo.frame, slot.powerType, rbSettings)
     else
         if not barInfo or barInfo.barType ~= "continuous" then
             if barInfo and barInfo.frame then

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -44,6 +44,7 @@ local LayoutOverlaySegments = RB.LayoutOverlaySegments
 local StyleContinuousBar = RB.StyleContinuousBar
 local StyleHealthBar = RB.StyleHealthBar
 local StyleSegmentedBar = RB.StyleSegmentedBar
+local ApplySegmentedPreviewColors = RB.ApplySegmentedPreviewColors
 local PrepareCustomAuraBar = RB.PrepareCustomAuraBar
 local EnsureCustomBarId = RB.EnsureCustomBarId
 local EnsureCustomBarLayout = RB.EnsureCustomBarLayout
@@ -1189,6 +1190,7 @@ local function EnsureResourcePreview(frame, slot, preview, width, height)
         barInfo.frame:SetSize(width, height)
         LayoutSegments(barInfo.frame, width, height, segmentGap, rbSettings)
         StyleSegmentedBar(barInfo.frame, slot.powerType, rbSettings)
+        ApplySegmentedPreviewColors(barInfo.frame, slot.powerType, rbSettings)
     else
         if not barInfo or barInfo.barType ~= "continuous" then
             if barInfo and barInfo.frame then

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -3774,10 +3774,50 @@ local function StyleSegmentedBar(holder, powerType, settings)
     StyleSegmentedText(holder, powerType, settings)
 end
 
+local function ApplySegmentedPreviewColors(holder, powerType, settings, previewValue)
+    if not holder or not holder.segments then return end
+
+    local numSegments = #holder.segments
+    if numSegments <= 0 then return end
+
+    previewValue = tonumber(previewValue) or (numSegments * 0.6)
+    local filled = math_min(numSegments, math_max(0, math_floor(previewValue)))
+    local hasPartial = previewValue > filled and filled < numSegments
+
+    local thresholdEnabled, thresholdValue, thresholdColor = GetSegmentedThresholdConfig(powerType, settings)
+    local thresholdActive = thresholdEnabled and thresholdValue and filled >= thresholdValue
+
+    local readyColor, rechargingColor, maxColor = GetResourceColors(powerType, settings)
+    local filledColor = readyColor
+    local emptyColor = readyColor
+
+    if powerType == 5 or powerType == 7 or powerType == 19 then
+        filledColor = (filled >= numSegments) and maxColor or (thresholdActive and thresholdColor or readyColor)
+        emptyColor = rechargingColor or readyColor
+    elseif powerType == 4 then
+        filledColor = (filled >= numSegments) and rechargingColor or (thresholdActive and thresholdColor or readyColor)
+        emptyColor = readyColor
+    elseif RESOURCE_COLOR_DEFS[powerType] then
+        filledColor = (filled >= numSegments) and rechargingColor or (thresholdActive and thresholdColor or readyColor)
+        emptyColor = readyColor
+    end
+
+    for i, seg in ipairs(holder.segments) do
+        local color = (i <= filled) and filledColor or emptyColor
+        if i == filled + 1 and hasPartial then
+            color = emptyColor
+        end
+        if type(color) == "table" then
+            seg:SetStatusBarColor(color[1], color[2], color[3], color[4] ~= nil and color[4] or 1)
+        end
+    end
+end
+
 RB.StyleContinuousBar = StyleContinuousBar
 RB.StyleHealthBar = HealthBar.Style
 RB.StyleSegmentedText = StyleSegmentedText
 RB.StyleSegmentedBar = StyleSegmentedBar
+RB.ApplySegmentedPreviewColors = ApplySegmentedPreviewColors
 
 function CooldownCompanion:ApplyResourceBars()
     local settings = GetResourceBarSettings()
@@ -4651,6 +4691,7 @@ local function ApplyPreviewDataToBar(barInfo, settings)
     elseif barInfo.barType == "segmented" then
         local n = #barInfo.frame.segments
         local filled = math_floor(n * 0.6)
+        local previewValue = filled + 0.5
         for i, seg in ipairs(barInfo.frame.segments) do
             if i <= filled then
                 seg:SetValue(1)
@@ -4660,8 +4701,9 @@ local function ApplyPreviewDataToBar(barInfo, settings)
                 seg:SetValue(0)
             end
         end
+        ApplySegmentedPreviewColors(barInfo.frame, barInfo.powerType, settings, previewValue)
         ApplyResourceAuraLanePreview(barInfo, 0.5)
-        SetSegmentedText(barInfo.frame, filled + 0.5, n)
+        SetSegmentedText(barInfo.frame, previewValue, n)
     elseif barInfo.barType == "stagger_continuous" then
         barInfo.frame:SetMinMaxValues(0, 100)
         barInfo.frame:SetValue(45)

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -3768,12 +3768,9 @@ local function StyleSegmentedText(holder, powerType, settings)
 end
 
 local function StyleSegmentedBar(holder, powerType, settings)
-    -- All segmented types use their first color return as the initial segment color.
-    -- UpdateSegmentedBar dynamically recolors per-segment each tick.
-    local color = GetResourceColors(powerType, settings)
-    for _, seg in ipairs(holder.segments) do
-        seg:SetStatusBarColor(color[1], color[2], color[3], 1)
-    end
+    -- Segment colors are live state, not static style. ApplyResourceBars() can
+    -- run during combat events, so avoid briefly repainting every segment with
+    -- the generic ready color before UpdateSegmentedBar restores per-segment state.
     StyleSegmentedText(holder, powerType, settings)
 end
 
@@ -4059,6 +4056,9 @@ function CooldownCompanion:ApplyResourceBars()
             barInfo.frame:SetSize(effectiveWidth, effectiveHeight)
             LayoutSegments(barInfo.frame, effectiveWidth, effectiveHeight, segmentGap, settings)
             StyleSegmentedBar(barInfo.frame, powerType, settings)
+            if not isPreviewActive then
+                UpdateSegmentedBar(barInfo.frame, powerType, settings, {})
+            end
         else
             -- Continuous bar
             if not barInfo or barInfo.barType ~= "continuous" then

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -3787,19 +3787,22 @@ local function ApplySegmentedPreviewColors(holder, powerType, settings, previewV
     local thresholdEnabled, thresholdValue, thresholdColor = GetSegmentedThresholdConfig(powerType, settings)
     local thresholdActive = thresholdEnabled and thresholdValue and filled >= thresholdValue
 
-    local readyColor, rechargingColor, maxColor = GetResourceColors(powerType, settings)
-    local filledColor = readyColor
-    local emptyColor = readyColor
+    local color1, color2, color3 = GetResourceColors(powerType, settings)
+    local filledColor = color1
+    local emptyColor = color1
 
     if powerType == 5 or powerType == 7 or powerType == 19 then
+        local readyColor, rechargingColor, maxColor = color1, color2, color3
         filledColor = (filled >= numSegments) and maxColor or (thresholdActive and thresholdColor or readyColor)
         emptyColor = rechargingColor or readyColor
     elseif powerType == 4 then
-        filledColor = (filled >= numSegments) and rechargingColor or (thresholdActive and thresholdColor or readyColor)
-        emptyColor = readyColor
+        local normalColor, maxColor = color1, color2
+        filledColor = (filled >= numSegments) and maxColor or (thresholdActive and thresholdColor or normalColor)
+        emptyColor = normalColor
     elseif RESOURCE_COLOR_DEFS[powerType] then
-        filledColor = (filled >= numSegments) and rechargingColor or (thresholdActive and thresholdColor or readyColor)
-        emptyColor = readyColor
+        local normalColor, maxColor = color1, color2
+        filledColor = (filled >= numSegments) and maxColor or (thresholdActive and thresholdColor or normalColor)
+        emptyColor = normalColor
     end
 
     for i, seg in ipairs(holder.segments) do
@@ -3817,7 +3820,6 @@ RB.StyleContinuousBar = StyleContinuousBar
 RB.StyleHealthBar = HealthBar.Style
 RB.StyleSegmentedText = StyleSegmentedText
 RB.StyleSegmentedBar = StyleSegmentedBar
-RB.ApplySegmentedPreviewColors = ApplySegmentedPreviewColors
 
 function CooldownCompanion:ApplyResourceBars()
     local settings = GetResourceBarSettings()


### PR DESCRIPTION
## What Players Will Notice
- Segmented resource bars should no longer briefly flash the wrong ready color when an ability triggers a resource-bar refresh.
- The fix is especially targeted at the Death Knight rune flicker seen around Festering Strike, while keeping segmented preview colors intact.

## Why This Changed
- `ApplyResourceBars()` can run during combat-related updates. The segmented style pass was repainting every segment with a generic ready color before the live update restored each segment's actual ready/recharging state, creating a quick visual flicker.

## What Changed
- `StyleSegmentedBar()` now styles segmented resource text only, leaving live segment colors to the live resource update path.
- Live segmented bars immediately refresh their per-segment state after layout/style work when not in preview mode.
- Segmented previews now get a dedicated preview color pass so ready, recharging, max, and threshold colors remain visible without reintroducing live flicker.

## Validation
- `luac -p OtherBars\ResourceBar.lua ConfigSettings\ResourceBarLayoutOrderPreview.lua`
- `git diff --check origin/main...HEAD`
- In-game DK rune testing confirmed the flicker is gone.
- Combat behavior was confirmed by the reporter after the fix.