### PR TITLE
Keep inactive aura stack segments visible in bar panels

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1716,7 +1716,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
     button._auraTrackingReady = auraTrackingReady
 
-    barAuraStackDisplay = barAuraStackConfigured and auraOverrideActive or false
+    -- Stack-count aura bars own the bar surface even while the aura is inactive.
+    -- Inactive auras render as zero stacks so segmented/overlay placeholders stay visible.
+    barAuraStackDisplay = barAuraStackConfigured or false
     if barAuraStackDisplay then
         button._barAuraStackDisplay = true
         button._barAuraStackValue = 0


### PR DESCRIPTION
## What Players Will Notice
- Bar panel entries using Aura Display Mode -> Stack Count now keep their segmented or overlay bar structure visible even when the tracked standalone aura is not currently active.
- When the aura is inactive, the bar shows the configured segment placeholders at zero stacks instead of waiting to create them after the aura appears.

## Why This Changed
- Stack-count aura bars were only taking over the bar surface while the tracked aura was active, so inactive standalone aura entries fell back to the normal bar path and their segments disappeared.

## What Changed
- Updated `ButtonFrame/CooldownUpdate.lua` so configured bar-panel aura stack displays remain active regardless of current aura state.
- Inactive aura state now renders as zero stacks, while active aura stack values still use the existing aura application and secret-value handling.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p ButtonFrame\CooldownUpdate.lua`
- `luac -p` across all non-`Libs` Lua files
- In-game combat and restricted-content verification is still pending; this should be checked with an inactive standalone aura stack bar, then again when the aura becomes active.