### PR TITLE
Fix migrated Custom Bars returning after deletion

### DIFF
--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -2103,6 +2103,47 @@ local function RemoveCustomBarById(customBars, customBarId)
     return false
 end
 
+local function ClearCustomBarLayoutById(settings, specID, customBarId)
+    if type(settings) ~= "table" or type(settings.layoutOrder) ~= "table" or type(customBarId) ~= "string" or not specID then
+        return
+    end
+
+    specID = tonumber(specID) or specID
+    local layout = settings.layoutOrder[specID]
+    if type(layout) ~= "table" then
+        local stringSpecID = tostring(specID)
+        if stringSpecID ~= specID then
+            layout = settings.layoutOrder[stringSpecID]
+        end
+    end
+
+    if type(layout) == "table" and type(layout.customBars) == "table" then
+        layout.customBars[customBarId] = nil
+    end
+end
+
+local function ClearLegacyCustomAuraBarsForSpec(settings, specID)
+    if type(settings) ~= "table" or type(settings.customAuraBars) ~= "table" or not specID then
+        return
+    end
+
+    specID = tonumber(specID) or specID
+    settings.customAuraBars[specID] = nil
+
+    local stringSpecID = tostring(specID)
+    if stringSpecID ~= specID then
+        settings.customAuraBars[stringSpecID] = nil
+    end
+
+    local layout = type(settings.layoutOrder) == "table" and settings.layoutOrder[specID] or nil
+    if type(layout) ~= "table" and stringSpecID ~= specID and type(settings.layoutOrder) == "table" then
+        layout = settings.layoutOrder[stringSpecID]
+    end
+    if type(layout) == "table" then
+        layout.customAuraBarSlots = nil
+    end
+end
+
 local function DuplicateCustomBarById(settings, customBars, customBarId)
     local sourceIndex = FindCustomBarIndexById(customBars, customBarId)
     local sourceEntry = sourceIndex and customBars[sourceIndex]
@@ -2208,10 +2249,18 @@ local function OpenCustomBarRowMenu(customBars, customBarId, entry)
         removeInfo.notCheckable = true
         removeInfo.func = function()
             CloseDropDownMenus()
-            if RemoveCustomBarById(customBars, customBarId) and CS.selectedCustomBarId == customBarId then
-                ClearCustomBarPreviewState()
-                CS.selectedCustomBarId = nil
-                CS.customBarSettingsTab = "appearance"
+            local settings = CooldownCompanion:GetResourceBarSettings()
+            local specID = GetCurrentConfigSpecID()
+            if RemoveCustomBarById(customBars, customBarId) then
+                ClearCustomBarLayoutById(settings, specID, customBarId)
+                if #customBars == 0 then
+                    ClearLegacyCustomAuraBarsForSpec(settings, specID)
+                end
+                if CS.selectedCustomBarId == customBarId then
+                    ClearCustomBarPreviewState()
+                    CS.selectedCustomBarId = nil
+                    CS.customBarSettingsTab = "appearance"
+                end
             end
             ApplyCustomAuraBarPanelChanges({
                 updateAnchors = true,

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -2122,7 +2122,7 @@ local function ClearCustomBarLayoutById(settings, specID, customBarId)
     end
 end
 
-local function ClearLegacyCustomAuraBarsForSpec(settings, specID)
+local function ClearLegacyCustomAuraBarSeedForSpec(settings, specID)
     if type(settings) ~= "table" or type(settings.customAuraBars) ~= "table" or not specID then
         return
     end
@@ -2142,6 +2142,18 @@ local function ClearLegacyCustomAuraBarsForSpec(settings, specID)
     if type(layout) == "table" then
         layout.customAuraBarSlots = nil
     end
+end
+
+local function DeleteCustomBarById(settings, specID, customBars, customBarId)
+    if not RemoveCustomBarById(customBars, customBarId) then
+        return false
+    end
+
+    ClearCustomBarLayoutById(settings, specID, customBarId)
+    if #customBars == 0 then
+        ClearLegacyCustomAuraBarSeedForSpec(settings, specID)
+    end
+    return true
 end
 
 local function DuplicateCustomBarById(settings, customBars, customBarId)
@@ -2251,11 +2263,7 @@ local function OpenCustomBarRowMenu(customBars, customBarId, entry)
             CloseDropDownMenus()
             local settings = CooldownCompanion:GetResourceBarSettings()
             local specID = GetCurrentConfigSpecID()
-            if RemoveCustomBarById(customBars, customBarId) then
-                ClearCustomBarLayoutById(settings, specID, customBarId)
-                if #customBars == 0 then
-                    ClearLegacyCustomAuraBarsForSpec(settings, specID)
-                end
+            if DeleteCustomBarById(settings, specID, customBars, customBarId) then
                 if CS.selectedCustomBarId == customBarId then
                     ClearCustomBarPreviewState()
                     CS.selectedCustomBarId = nil

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -2156,14 +2156,14 @@ local function DeleteCustomBarById(settings, specID, customBars, customBarId)
     return true
 end
 
-local function DuplicateCustomBarById(settings, customBars, customBarId)
+local function DuplicateCustomBarById(settings, specID, customBars, customBarId)
     local sourceIndex = FindCustomBarIndexById(customBars, customBarId)
     local sourceEntry = sourceIndex and customBars[sourceIndex]
     if type(settings) ~= "table" or type(sourceEntry) ~= "table" then
         return nil
     end
 
-    local sourceLayout = GetCustomBarLayout(settings, nil, sourceEntry, false)
+    local sourceLayout = GetCustomBarLayout(settings, specID, sourceEntry, false)
     local copy = CopyTable(sourceEntry)
     copy.customBarId = nil
 
@@ -2174,7 +2174,7 @@ local function DuplicateCustomBarById(settings, customBars, customBarId)
 
     table.insert(customBars, sourceIndex + 1, copy)
 
-    local targetLayout = EnsureCustomBarLayout(settings, nil, newId, 1000 + sourceIndex + 1)
+    local targetLayout = EnsureCustomBarLayout(settings, specID, newId, 1000 + sourceIndex + 1)
     if type(sourceLayout) == "table" and type(targetLayout) == "table" then
         for key, value in pairs(sourceLayout) do
             targetLayout[key] = CopyTableValue(value)
@@ -2214,7 +2214,7 @@ local function ClearCustomBarPreviewState()
     end
 end
 
-local function OpenCustomBarRowMenu(customBars, customBarId, entry)
+local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
     if not CS.customBarContextMenu then
         CS.customBarContextMenu = CreateFrame("Frame", "CDCCustomBarContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -2243,7 +2243,7 @@ local function OpenCustomBarRowMenu(customBars, customBarId, entry)
         duplicateInfo.notCheckable = true
         duplicateInfo.func = function()
             CloseDropDownMenus()
-            local newId = DuplicateCustomBarById(CooldownCompanion:GetResourceBarSettings(), customBars, customBarId)
+            local newId = DuplicateCustomBarById(CooldownCompanion:GetResourceBarSettings(), specID, customBars, customBarId)
             if newId then
                 ClearCustomBarPreviewState()
                 CS.selectedCustomBarId = newId
@@ -2262,7 +2262,6 @@ local function OpenCustomBarRowMenu(customBars, customBarId, entry)
         removeInfo.func = function()
             CloseDropDownMenus()
             local settings = CooldownCompanion:GetResourceBarSettings()
-            local specID = GetCurrentConfigSpecID()
             if DeleteCustomBarById(settings, specID, customBars, customBarId) then
                 if CS.selectedCustomBarId == customBarId then
                     ClearCustomBarPreviewState()
@@ -2763,6 +2762,7 @@ end
 
 local function BuildCustomBarsListPanel(container)
     local settings = CooldownCompanion:GetResourceBarSettings()
+    local customBarsSpecID = GetCurrentConfigSpecID()
     local customBars = CooldownCompanion:GetSpecCustomAuraBars()
     local selectedId = CS.selectedCustomBarId
     if selectedId and not FindCustomBarIndexById(customBars, selectedId) then
@@ -3029,7 +3029,7 @@ local function BuildCustomBarsListPanel(container)
                 if selectionChanged then
                     CooldownCompanion:RefreshConfigPanel()
                 end
-                OpenCustomBarRowMenu(customBars, customBarId, entry)
+                OpenCustomBarRowMenu(customBars, customBarsSpecID, customBarId, entry)
             elseif mouseButton == "LeftButton" then
                 if CS.selectedCustomBarId == customBarId then
                     ClearCustomBarPreviewState()


### PR DESCRIPTION
## What Players Will Notice
- Players who migrated old Custom Aura Bars into Custom Bars can now fully delete those migrated entries.
- Deleted migrated Custom Bars should no longer instantly reappear after the final migrated entry is removed.

## Why This Changed
- The old migrated bar data still existed in legacy `customAuraBars` saved data after migration.
- Deleting entries removed them from the new `customBars` list, but when that list became empty, the lazy migration-repair path treated the empty list as a failed migration and copied the legacy bars back in.

## What Changed
- Custom Bar deletion now clears the removed bar's current layout entry.
- When the last Custom Bar for a spec is deleted, the matching legacy Custom Aura Bar migration seed and legacy slot layout seed are cleared so they cannot be replayed.
- Row-menu duplicate/remove actions now use the spec captured when the Custom Bars list was built, so deferred menu actions do not mix one spec's row table with another spec's cleanup data.
- The delete cleanup is consolidated into one helper so future delete paths are less likely to skip migration cleanup.

## Validation
- `luac -p ConfigSettings\\ResourceBarPanels.lua`
- Full non-`Libs` Lua syntax sweep passed: 74 files.
- `git diff --check`
- Focused local Lua fixture passed for deleting the final migrated Custom Bar and preventing lazy normalization from restoring it.
- Focused captured-spec fixture passed to confirm deleting one spec's captured row does not clear another spec's legacy/layout data.
- Code review against `origin/main` found no remaining actionable issues.
- In-game migrated-profile validation is still pending, including reload, combat, and restricted-content checks.