### PR TITLE
Improve runtime and config performance in hot display paths

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -825,6 +825,18 @@ local function ApplyBarAuraStackVisual(button, stackValue, stackValueAvailable)
 end
 
 -- Lightweight OnUpdate: interpolates bar fill + time text between ticker updates.
+local function SetBarTimeText(button, text)
+    if button._lastBarTimeText ~= text then
+        button._lastBarTimeText = text
+        button.timeText:SetText(text)
+    end
+end
+
+local function SetBarTimeFormattedText(button, fmt, value)
+    button._lastBarTimeText = nil
+    button.timeText:SetFormattedText(fmt, value)
+end
+
 local function UpdateBarFill(button)
     -- Single-bar path
     -- DurationObject percent methods return secret values during combat in 12.0.1,
@@ -858,7 +870,7 @@ local function UpdateBarFill(button)
         if not button._barAuraStackValueSecret then
             ApplyBarAuraStackVisual(button, button._barAuraStackValue, button._barAuraStackValueAvailable == true)
         end
-        button.timeText:SetText("")
+        SetBarTimeText(button, "")
     elseif button._durationObj and not button._barGCDSuppressed then
         ClearBarAuraStackVisual(button)
         onCooldown = true
@@ -944,17 +956,17 @@ local function UpdateBarFill(button)
             -- Secret: pass secret number to C++ SetFormattedText ("%.1f" / "%.0f" format)
             local decimal = button.style.decimalTimers
             if previewRemaining and previewRemaining > 0 then
-                button.timeText:SetText(FormatTime(previewRemaining, decimal))
+                SetBarTimeText(button, FormatTime(previewRemaining, decimal))
             elseif button._durationObj then
                 local remaining = button._durationObj:GetRemainingDuration()
                 if not button._durationObj:HasSecretValues() then
                     if remaining > 0 then
-                        button.timeText:SetText(FormatTime(remaining, decimal))
+                        SetBarTimeText(button, FormatTime(remaining, decimal))
                     else
-                        button.timeText:SetText("")
+                        SetBarTimeText(button, "")
                     end
                 else
-                    button.timeText:SetFormattedText(decimal and "%.1f" or "%.0f", remaining)
+                    SetBarTimeFormattedText(button, decimal and "%.1f" or "%.0f", remaining)
                 end
             elseif button._viewerBar then
                 -- Totem: viewer bar values may be secret (set by Blizzard's internal totem tracking).
@@ -962,12 +974,12 @@ local function UpdateBarFill(button)
                 -- secure code sets it, so the widget reports plain — but the actual
                 -- number returned by GetValue() is a secret wrapper).
                 -- Always use SetFormattedText for secret-safe pass-through.
-                button.timeText:SetFormattedText(decimal and "%.1f" or "%.0f", button._viewerBar:GetValue())
+                SetBarTimeFormattedText(button, decimal and "%.1f" or "%.0f", button._viewerBar:GetValue())
             else
                 if itemRemaining > 0 then
-                    button.timeText:SetText(FormatTime(itemRemaining, decimal))
+                    SetBarTimeText(button, FormatTime(itemRemaining, decimal))
                 else
-                    button.timeText:SetText("")
+                    SetBarTimeText(button, "")
                 end
             end
         end
@@ -980,10 +992,10 @@ local function UpdateBarFill(button)
         end
         if button._barAuraActivePreview or button._conditionalBarAuraActivePreview then
             button.statusBar:SetValue(1)
-            button.timeText:SetText("")
+            SetBarTimeText(button, "")
         elseif button.buttonData.isPassive then
             button.statusBar:SetValue(0)
-            button.timeText:SetText("")
+            SetBarTimeText(button, "")
         else
         button.statusBar:SetValue(1)
         if button.style.showBarReadyText then
@@ -994,9 +1006,9 @@ local function UpdateBarFill(button)
                 local o = button.style.barReadyFontOutline or "OUTLINE"
                 button.timeText:SetFont(f, s, o)
             end
-            button.timeText:SetText(button.style.barReadyText or "Ready")
+            SetBarTimeText(button, button.style.barReadyText or "Ready")
         else
-            button.timeText:SetText("")
+            SetBarTimeText(button, "")
         end
         end
     end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -119,6 +119,7 @@ local function HideIconFillForHiddenButton(button)
     if not (button and button.iconFill) then return end
     button.iconFill:Hide()
     button.iconFill:SetScript("OnUpdate", nil)
+    button._iconFillOnUpdateInstalled = nil
 end
 
 local function ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1196,7 +1196,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         local auraUnit = button._auraUnit or configUnit
 
         local viewerFrame
-        local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
+        local cdmEnabled
+        if CooldownCompanion._cooldownUpdatePassActive then
+            cdmEnabled = CooldownCompanion._cdmViewerEnabled == true
+        else
+            cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
+        end
 
         -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
         -- untainted code that matches spell IDs to auras during combat and

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -103,8 +103,15 @@ local function ApplyIconFillGeometry(button, style)
     end
 
     local orientation = style and style.iconFillOrientation == "horizontal" and "HORIZONTAL" or "VERTICAL"
+    local reverseFill = style and style.iconFillReverse == true or false
+    if button._iconFillOrientation == orientation and button._iconFillReverseFill == reverseFill then
+        return
+    end
+
+    button._iconFillOrientation = orientation
+    button._iconFillReverseFill = reverseFill
     button.iconFill:SetOrientation(orientation)
-    button.iconFill:SetReverseFill(style and style.iconFillReverse == true or false)
+    button.iconFill:SetReverseFill(reverseFill)
 end
 
 local function ResolveIconFillTimerValue(button, elapsedPercent)
@@ -281,11 +288,18 @@ local function HideIconFill(button, style)
     end
 
     button.iconFill:Hide()
-    button.iconFill:SetScript("OnUpdate", nil)
+    if button._iconFillOnUpdateInstalled then
+        button.iconFill:SetScript("OnUpdate", nil)
+        button._iconFillOnUpdateInstalled = nil
+    end
     if button._iconFillActive then
         button._iconFillActive = nil
         button._iconFillMode = nil
         button._iconFillAuraActive = nil
+        button._iconFillColorR = nil
+        button._iconFillColorG = nil
+        button._iconFillColorB = nil
+        button._iconFillColorA = nil
         ApplyDefaultCooldownSwipeStyle(button, style)
     end
 end
@@ -325,10 +339,28 @@ local function UpdateIconFill(button, buttonData, style)
     button._iconFillMode = mode
     button._iconFillAuraActive = (mode == "aura" or mode == "aura_static") or nil
     ApplyIconFillGeometry(button, style)
-    button.iconFill:SetStatusBarColor(color[1], color[2], color[3], color[4])
+    local colorA = color[4]
+    if button._iconFillColorR ~= color[1]
+        or button._iconFillColorG ~= color[2]
+        or button._iconFillColorB ~= color[3]
+        or button._iconFillColorA ~= colorA then
+        button._iconFillColorR = color[1]
+        button._iconFillColorG = color[2]
+        button._iconFillColorB = color[3]
+        button._iconFillColorA = colorA
+        button.iconFill:SetStatusBarColor(color[1], color[2], color[3], colorA)
+    end
     SetIconFillValue(button)
     button.iconFill:Show()
-    button.iconFill:SetScript("OnUpdate", IconFillOnUpdate)
+    if mode == "aura_static" then
+        if button._iconFillOnUpdateInstalled then
+            button.iconFill:SetScript("OnUpdate", nil)
+            button._iconFillOnUpdateInstalled = nil
+        end
+    elseif not button._iconFillOnUpdateInstalled then
+        button.iconFill:SetScript("OnUpdate", IconFillOnUpdate)
+        button._iconFillOnUpdateInstalled = true
+    end
 
     button.cooldown:SetDrawSwipe(false)
     button.cooldown:SetDrawEdge(false)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1300,6 +1300,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
         ApplyIconFillGeometry(button, style)
         button.iconFill:SetStatusBarTexture(ICON_FILL_TEXTURE)
         button.iconFill:SetScript("OnUpdate", nil)
+        button._iconFillOnUpdateInstalled = nil
         button.iconFill:Hide()
     end
 

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -22,6 +22,7 @@ local math_pi = math.pi
 local string_format = string.format
 local table_concat = table.concat
 local issecretvalue = issecretvalue
+local wipe = wipe
 local C_UnitAuras_GetAuraApplicationDisplayCount = C_UnitAuras.GetAuraApplicationDisplayCount
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
@@ -326,7 +327,13 @@ end
 ------------------------------------------------------------------------
 local function SubstituteTokens(button, segments, style, effectState, secretNameOverride, hasSecretNameOverride)
     local buttonData = button.buttonData
-    local parts = {}
+    local parts = button._textModeParts
+    if parts then
+        wipe(parts)
+    else
+        parts = {}
+        button._textModeParts = parts
+    end
     local secretValue = nil
     local secretColorToken = nil
     local secretStackValue = nil
@@ -396,7 +403,13 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
 
     -- Color override state for {cooldown}...{/cooldown} etc.
     local colorOverride = nil
-    local colorStack = {}
+    local colorStack = button._textModeColorStack
+    if colorStack then
+        wipe(colorStack)
+    else
+        colorStack = {}
+        button._textModeColorStack = colorStack
+    end
 
     for _, seg in ipairs(segments) do
         -- Conditional section handling
@@ -620,8 +633,20 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
         }
 
         -- Single left-to-right pass: build format string and ordered args together
-        local args = {}
-        local resultParts = {}
+        local args = button._textModeSecretArgs
+        if args then
+            wipe(args)
+        else
+            args = {}
+            button._textModeSecretArgs = args
+        end
+        local resultParts = button._textModeSecretParts
+        if resultParts then
+            wipe(resultParts)
+        else
+            resultParts = {}
+            button._textModeSecretParts = resultParts
+        end
         local pos = 1
         while pos <= #fmtStr do
             local bestIdx, bestInfo
@@ -650,6 +675,7 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
 
         local finalFmt = table_concat(resultParts)
         button.textString:SetFormattedText(finalFmt, unpack(args))
+        wipe(args)
     else
         -- Normal path: full per-token coloring via escape sequences
         local baseColor = style.textFontColor or DEFAULT_WHITE

--- a/Config/AutoImport.lua
+++ b/Config/AutoImport.lua
@@ -822,7 +822,30 @@ local function GetActiveFlowState()
     return state
 end
 
+local function GetPreviewCacheKey(state)
+    local parts = state._previewCacheKeyParts
+    if not parts then
+        parts = {}
+        state._previewCacheKeyParts = parts
+    end
+    wipe(parts)
+    parts[#parts + 1] = tostring(state.source or "")
+    parts[#parts + 1] = tostring(state.sortMode or "")
+    if state.source == SOURCE_ACTION_BARS then
+        for i = 1, ACTION_BAR_COUNT do
+            parts[#parts + 1] = state.selectedBars and state.selectedBars[i] and "1" or "0"
+        end
+    end
+    return table.concat(parts, ":")
+end
+
 local function BuildPreviewForFlowState(state)
+    local cacheKey = GetPreviewCacheKey(state)
+    if state.preview and state.previewCacheKey == cacheKey then
+        NormalizeSelectionState(state.preview, state.selectedEntries)
+        return state.preview
+    end
+
     local preview
     if state.source == SOURCE_ACTION_BARS then
         preview = BuildActionBarPreview(state.selectedBars)
@@ -833,6 +856,7 @@ local function BuildPreviewForFlowState(state)
     end
     SortPreview(preview, state.sortMode)
     state.preview = preview
+    state.previewCacheKey = cacheKey
     NormalizeSelectionState(preview, state.selectedEntries)
     return preview
 end
@@ -845,6 +869,7 @@ local function AdvanceToReview(state)
     state.step = AUTO_ADD_STEP_REVIEW
     state.selectedEntries = {}
     state.preview = nil
+    state.previewCacheKey = nil
 end
 
 local function RenderStep1(container, state)

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -30,6 +30,7 @@ local IsConfigFinderAvailable = ST._IsConfigFinderAvailable
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local SetConfigFinderText = ST._SetConfigFinderText
 local ClearConfigFinderText = ST._ClearConfigFinderText
+local InvalidateConfigFinderResults = ST._InvalidateConfigFinderResults
 local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
 local StartFirstIconPanelTutorial = ST._StartFirstIconPanelTutorial
 local CancelFirstIconPanelTutorial = ST._CancelFirstIconPanelTutorial
@@ -1962,6 +1963,9 @@ function CooldownCompanion:RefreshConfigPanel()
         ClearConfigFinderText()
     elseif SetConfigFinderText then
         SetConfigFinderText(CS.configSearchText or "")
+    end
+    if InvalidateConfigFinderResults then
+        InvalidateConfigFinderResults()
     end
     if ClearConfigShiftTooltipHover then
         ClearConfigShiftTooltipHover()

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -452,6 +452,12 @@ end
 
 local function SetConfigFinderText(text, opts)
     text = type(text) == "string" and text or ""
+    if CS.configSearchText ~= text then
+        CS._configFinderResults = nil
+        CS._configFinderResultsQuery = nil
+        CS._configFinderResultsDb = nil
+        CS._configFinderResultsCharKey = nil
+    end
     CS.configSearchText = text
 
     if opts and opts.syncWidget == false then
@@ -473,6 +479,13 @@ local function ClearConfigFinderText(opts)
     SetConfigFinderText("", opts)
 end
 
+local function InvalidateConfigFinderResults()
+    CS._configFinderResults = nil
+    CS._configFinderResultsQuery = nil
+    CS._configFinderResultsDb = nil
+    CS._configFinderResultsCharKey = nil
+end
+
 local function IsContainerVisibleInConfig(container, charKey)
     if not container then
         return false
@@ -492,6 +505,13 @@ local function BuildConfigFinderResults()
     end
 
     local charKey = CooldownCompanion.db.keys.char
+    if CS._configFinderResults
+        and CS._configFinderResultsQuery == query
+        and CS._configFinderResultsDb == db
+        and CS._configFinderResultsCharKey == charKey then
+        return CS._configFinderResults
+    end
+
     local results = {
         query = query,
         containerMatches = {},
@@ -517,7 +537,7 @@ local function BuildConfigFinderResults()
         local container = containerId and db.groupContainers and db.groupContainers[containerId]
         if IsContainerVisibleInConfig(container, charKey) then
             local panelMatches = ConfigFinderTextMatches(panel.name, query)
-            local entryMatches = {}
+            local entryMatches
 
             for buttonIndex, buttonData in ipairs(panel.buttons or {}) do
                 local entryName = GetConfigEntryDisplayName(buttonData, { includeDecorations = true })
@@ -525,6 +545,9 @@ local function BuildConfigFinderResults()
                     or ("Unknown " .. tostring(buttonData.type))
                 local idText = buttonData.id and tostring(buttonData.id) or nil
                 if ConfigFinderTextMatches(entryName, query) or ConfigFinderTextMatches(idText, query) then
+                    if not entryMatches then
+                        entryMatches = {}
+                    end
                     entryMatches[#entryMatches + 1] = {
                         index = buttonIndex,
                         button = buttonData,
@@ -533,10 +556,11 @@ local function BuildConfigFinderResults()
                 end
             end
 
-            if panelMatches or #entryMatches > 0 then
+            local entryMatchCount = entryMatches and #entryMatches or 0
+            if panelMatches or entryMatchCount > 0 then
                 markContainer(containerId)
                 results.totalPanelResults = results.totalPanelResults + 1
-                results.totalEntryResults = results.totalEntryResults + #entryMatches
+                results.totalEntryResults = results.totalEntryResults + entryMatchCount
                 results.panelResults[#results.panelResults + 1] = {
                     containerId = containerId,
                     container = container,
@@ -558,6 +582,10 @@ local function BuildConfigFinderResults()
         return (a.panel and a.panel.order or 0) < (b.panel and b.panel.order or 0)
     end)
 
+    CS._configFinderResults = results
+    CS._configFinderResultsQuery = query
+    CS._configFinderResultsDb = db
+    CS._configFinderResultsCharKey = charKey
     return results
 end
 
@@ -2234,6 +2262,7 @@ ST._IsConfigFinderActive = IsConfigFinderActive
 ST._SetConfigFinderText = SetConfigFinderText
 ST._ClearConfigFinderText = ClearConfigFinderText
 ST._BuildConfigFinderResults = BuildConfigFinderResults
+ST._InvalidateConfigFinderResults = InvalidateConfigFinderResults
 ST._SelectConfigFinderResult = SelectConfigFinderResult
 ST._GetGroupIcon = GetGroupIcon
 ST._GetContainerIcon = GetContainerIcon

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -78,22 +78,28 @@ local RefreshResourceAuraUnitForSpell = RB.RefreshResourceAuraUnitForSpell
 -- Aura bar autocomplete cache (spell/aura entries only)
 ------------------------------------------------------------------------
 local auraBarAutocompleteCache = nil
+local auraBarAutocompleteSource = nil
 
 local function IsSharedAuraAutocompleteEntry(entry)
     return type(entry) == "table" and entry.isItem ~= true
 end
 
 local function BuildAuraBarAutocompleteCache()
-    local cache = {}
     local sharedCache = CS.autocompleteCache
         or (ST._BuildAutocompleteCache and ST._BuildAutocompleteCache())
         or {}
+    if auraBarAutocompleteCache and auraBarAutocompleteSource == sharedCache then
+        return auraBarAutocompleteCache
+    end
+
+    local cache = {}
     for _, entry in ipairs(sharedCache) do
         if IsSharedAuraAutocompleteEntry(entry) then
             cache[#cache + 1] = entry
         end
     end
     auraBarAutocompleteCache = cache
+    auraBarAutocompleteSource = sharedCache
     return cache
 end
 

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -11,6 +11,7 @@ local CooldownCompanion = ST.Addon
 
 local ipairs = ipairs
 local pairs = pairs
+local select = select
 local wipe = wipe
 local tostring = tostring
 local tonumber = tonumber
@@ -38,6 +39,77 @@ local function IsBuffViewerChild(frame)
     local parent = frame:GetParent()
     local parentName = parent and parent:GetName()
     return BUFF_VIEWER_SET[parentName] == true
+end
+
+local function SetViewerChildrenMouseMotion(enabled, ...)
+    for i = 1, select("#", ...) do
+        local child = select(i, ...)
+        if child then
+            child:SetMouseMotionEnabled(enabled)
+        end
+    end
+end
+
+local function FindMatchingViewerChild(spellID, buffOnly, ...)
+    for i = 1, select("#", ...) do
+        local child = select(i, ...)
+        local info = child and child.cooldownInfo
+        if info and (not buffOnly or IsBuffViewerChild(child)) then
+            if info.spellID == spellID
+               or info.overrideSpellID == spellID
+               or info.overrideTooltipSpellID == spellID then
+                return child
+            end
+            if info.linkedSpellIDs then
+                for _, linkedSpellID in ipairs(info.linkedSpellIDs) do
+                    if linkedSpellID == spellID then
+                        return child
+                    end
+                end
+            end
+        end
+    end
+    return nil
+end
+
+local function AddViewerAuraMapChildren(addon, viewerName, addViewerAuraChild, ...)
+    local isBuffViewer = BUFF_VIEWER_SET[viewerName] == true
+    for i = 1, select("#", ...) do
+        local child = select(i, ...)
+        local info = child and child.cooldownInfo
+        if info then
+            local spellID = info.spellID
+            if spellID then
+                addon.viewerAuraFrames[spellID] = child
+                -- Track all children per base spellID for buff viewers only.
+                -- Duplicate detection is for same-section duplicates (e.g.
+                -- Diabolic Ritual twice in Tracked Buffs), not cross-section
+                -- matches (e.g. Agony in Essential + Buffs).
+                if isBuffViewer then
+                    addViewerAuraChild(spellID, child)
+                end
+            end
+            local override = info.overrideSpellID
+            if override then
+                addon.viewerAuraFrames[override] = child
+            end
+            local tooltipOverride = info.overrideTooltipSpellID
+            if tooltipOverride then
+                addon.viewerAuraFrames[tooltipOverride] = child
+            end
+            if info.linkedSpellIDs then
+                for _, linked in ipairs(info.linkedSpellIDs) do
+                    addon.viewerAuraFrames[linked] = child
+                end
+            end
+            if isBuffViewer then
+                local specificSpellID = info.overrideTooltipSpellID or info.overrideSpellID
+                if specificSpellID and specificSpellID ~= spellID then
+                    addViewerAuraChild(specificSpellID, child)
+                end
+            end
+        end
+    end
 end
 
 local function AddAuraCandidateID(candidateSet, spellID)
@@ -992,22 +1064,9 @@ FindChildInViewers = function(viewerNames, spellID, buffOnly)
     for _, name in ipairs(viewerNames) do
         local viewer = _G[name]
         if viewer then
-            for _, child in pairs({viewer:GetChildren()}) do
-                local info = child.cooldownInfo
-                if info and (not buffOnly or IsBuffViewerChild(child)) then
-                    if info.spellID == spellID
-                       or info.overrideSpellID == spellID
-                       or info.overrideTooltipSpellID == spellID then
-                        return child
-                    end
-                    if info.linkedSpellIDs then
-                        for _, linkedSpellID in ipairs(info.linkedSpellIDs) do
-                            if linkedSpellID == spellID then
-                                return child
-                            end
-                        end
-                    end
-                end
+            local child = FindMatchingViewerChild(spellID, buffOnly, viewer:GetChildren())
+            if child then
+                return child
             end
         end
     end
@@ -1025,9 +1084,7 @@ function CooldownCompanion:ApplyCdmAlpha()
             cdmAlphaGuard[viewer] = nil
             if not InCombatLockdown() then
                 if hidden then
-                    for _, child in pairs({viewer:GetChildren()}) do
-                        child:SetMouseMotionEnabled(false)
-                    end
+                    SetViewerChildrenMouseMotion(false, viewer:GetChildren())
                 else
                     -- Restore tooltip state using Blizzard's own pattern
                     for itemFrame in viewer.itemFramePool:EnumerateActive() do
@@ -1096,41 +1153,7 @@ function CooldownCompanion:BuildViewerAuraMap()
     for _, name in ipairs(VIEWER_NAMES) do
         local viewer = _G[name]
         if viewer then
-            for _, child in pairs({viewer:GetChildren()}) do
-                local info = child.cooldownInfo
-                if info then
-                    local spellID = info.spellID
-                    if spellID then
-                        self.viewerAuraFrames[spellID] = child
-                        -- Track all children per base spellID for buff viewers only.
-                        -- Duplicate detection is for same-section duplicates (e.g.
-                        -- Diabolic Ritual twice in Tracked Buffs), not cross-section
-                        -- matches (e.g. Agony in Essential + Buffs).
-                        if BUFF_VIEWER_SET[name] then
-                            AddViewerAuraChild(spellID, child)
-                        end
-                    end
-                    local override = info.overrideSpellID
-                    if override then
-                        self.viewerAuraFrames[override] = child
-                    end
-                    local tooltipOverride = info.overrideTooltipSpellID
-                    if tooltipOverride then
-                        self.viewerAuraFrames[tooltipOverride] = child
-                    end
-                    if info.linkedSpellIDs then
-                        for _, linked in ipairs(info.linkedSpellIDs) do
-                            self.viewerAuraFrames[linked] = child
-                        end
-                    end
-                    if BUFF_VIEWER_SET[name] then
-                        local specificSpellID = info.overrideTooltipSpellID or info.overrideSpellID
-                        if specificSpellID and specificSpellID ~= spellID then
-                            AddViewerAuraChild(specificSpellID, child)
-                        end
-                    end
-                end
-            end
+            AddViewerAuraMapChildren(self, name, AddViewerAuraChild, viewer:GetChildren())
         end
     end
     -- Ensure tracked buttons can find their viewer child even if
@@ -1198,9 +1221,7 @@ function CooldownCompanion:BuildViewerAuraMap()
         for _, name2 in ipairs(VIEWER_NAMES) do
             local v = _G[name2]
             if v then
-                for _, child in pairs({v:GetChildren()}) do
-                    child:SetMouseMotionEnabled(false)
-                end
+                SetViewerChildrenMouseMotion(false, v:GetChildren())
             end
         end
     end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -603,6 +603,7 @@ function CooldownCompanion.HideStandaloneDisplayVisuals(host)
     if host.textFrame then
         host.textFrame:Hide()
     end
+    host._indicatorBaseVisualsReady = nil
 end
 
 function CooldownCompanion.GetTriggerIconDimensions(settings)
@@ -875,6 +876,7 @@ function CooldownCompanion.ApplyTriggerIconVisual(host, settings)
     host._activeTextureSettings = nil
     host._activeTextureGeometry = nil
     host._activeDisplayType = "icon"
+    host._indicatorBaseVisualsReady = nil
     host._triggerTextBaseColor = nil
     host._triggerIconBaseColor = CopyColor(iconTint) or { 1, 1, 1, 1 }
 
@@ -926,6 +928,7 @@ function CooldownCompanion.ApplyTriggerTextVisual(host, settings)
     host._activeTextureSettings = nil
     host._activeTextureGeometry = nil
     host._activeDisplayType = "text"
+    host._indicatorBaseVisualsReady = nil
     host._triggerIconBaseColor = nil
     host._triggerTextBaseColor = CopyColor(textColor) or { 1, 1, 1, 1 }
 
@@ -1026,6 +1029,7 @@ function CooldownCompanion:RenderStandaloneDisplay(host, driverButton, group, se
             host._activeTextureSettings = settings
             host._activeTextureGeometry = geometry
             host._activeDisplayType = "texture"
+            host._indicatorBaseVisualsReady = nil
             SetTextureIndicatorBaseVisuals(host)
             if isTriggerPanel then
                 self:ApplyTriggerPanelEffects(host, driverButton, group, effectsActive)

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -26,6 +26,7 @@ local math_rad = math.rad
 local math_sin = math.sin
 local tonumber = tonumber
 local type = type
+local wipe = wipe
 
 local LOCATION_CENTER = AT.LOCATION_CENTER
 local LOCATION_DIMENSIONS = AT.LOCATION_DIMENSIONS
@@ -212,6 +213,7 @@ local function SetTextureIndicatorBaseVisuals(host)
 
         host._indicatorBaseAlpha = baseAlpha
         host._indicatorBaseColor = CopyColor(color) or { 1, 1, 1, 1 }
+        host._indicatorBaseVisualsReady = true
         return
     end
 
@@ -220,6 +222,7 @@ local function SetTextureIndicatorBaseVisuals(host)
         host.iconFrame.icon:SetVertexColor(color[1] or 1, color[2] or 1, color[3] or 1, color[4] or 1)
         host._indicatorBaseAlpha = Clamp(color[4] ~= nil and color[4] or 1, 0, 1)
         host._indicatorBaseColor = color
+        host._indicatorBaseVisualsReady = true
         return
     end
 
@@ -228,6 +231,7 @@ local function SetTextureIndicatorBaseVisuals(host)
         host.textFrame.text:SetTextColor(color[1] or 1, color[2] or 1, color[3] or 1, color[4] or 1)
         host._indicatorBaseAlpha = Clamp(color[4] ~= nil and color[4] or 1, 0, 1)
         host._indicatorBaseColor = color
+        host._indicatorBaseVisualsReady = true
     end
 end
 
@@ -301,7 +305,9 @@ TextureIndicatorOnUpdate = function(self)
     end
 
     local now = GetTime()
-    SetTextureIndicatorBaseVisuals(self)
+    if not self._indicatorBaseVisualsReady then
+        SetTextureIndicatorBaseVisuals(self)
+    end
     local baseColor = self._indicatorBaseColor or { 1, 1, 1, 1 }
     local baseAlpha = self._indicatorBaseAlpha or 1
 
@@ -713,7 +719,13 @@ local function DoesTriggerPanelMatch(frame)
         return false
     end
 
-    local runtimeButtonsByIndex = {}
+    local runtimeButtonsByIndex = frame._triggerRuntimeButtonsByIndex
+    if runtimeButtonsByIndex then
+        wipe(runtimeButtonsByIndex)
+    else
+        runtimeButtonsByIndex = {}
+        frame._triggerRuntimeButtonsByIndex = runtimeButtonsByIndex
+    end
     for _, button in ipairs(frame.buttons or {}) do
         if button and button.index then
             runtimeButtonsByIndex[button.index] = button
@@ -774,7 +786,13 @@ local function ApplyTextureIndicatorEffects(host, button, group)
         return
     end
 
-    local effectStates = {}
+    local effectStates = host._textureIndicatorEffectStates
+    if effectStates then
+        wipe(effectStates)
+    else
+        effectStates = {}
+        host._textureIndicatorEffectStates = effectStates
+    end
     for _, sectionKey in ipairs(TEXTURE_INDICATOR_SECTION_ORDER) do
         local config = indicators[sectionKey]
         if IsTextureIndicatorSectionActive(button, sectionKey, config) then

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -484,6 +484,7 @@ local function StopTextureColorShift(host)
     end
 
     host._textureColorShiftActive = nil
+    host._indicatorBaseVisualsReady = nil
     RefreshTextureIndicatorUpdater(host)
 end
 

--- a/Core/ClickThrough.lua
+++ b/Core/ClickThrough.lua
@@ -6,7 +6,7 @@
 local ADDON_NAME, ST = ...
 
 local InCombatLockdown = InCombatLockdown
-local ipairs = ipairs
+local select = select
 
 -- Helper function to make a frame click-through
 -- disableClicks: prevent LMB/RMB clicks (allows camera movement pass-through)
@@ -14,8 +14,16 @@ local ipairs = ipairs
 function ST.SetFrameClickThrough(frame, disableClicks, disableMotion)
     if not frame then return end
     local inCombat = InCombatLockdown()
+    local clickState = disableClicks == true
+    local motionState = disableMotion == true
 
-    if disableClicks then
+    if frame._cdcClickThroughClicks == clickState
+        and frame._cdcClickThroughMotion == motionState
+        and (inCombat or frame._cdcClickThroughProtectedApplied == true) then
+        return
+    end
+
+    if clickState then
         -- Disable mouse click interaction for camera pass-through
         -- SetMouseClickEnabled and SetPropagateMouseClicks are protected in combat
         if not inCombat then
@@ -45,7 +53,7 @@ function ST.SetFrameClickThrough(frame, disableClicks, disableMotion)
         end
     end
 
-    if disableMotion then
+    if motionState then
         -- Disable mouse motion (hover) events
         if not inCombat then
             if frame.SetMouseMotionEnabled then
@@ -71,7 +79,7 @@ function ST.SetFrameClickThrough(frame, disableClicks, disableMotion)
     -- EnableMouse must be true if we want motion events (tooltips)
     -- Only fully disable if both clicks and motion are disabled
     if not inCombat then
-        if disableClicks and disableMotion then
+        if clickState and motionState then
             frame:EnableMouse(false)
             if frame.SetHitRectInsets then
                 frame:SetHitRectInsets(10000, 10000, 10000, 10000)
@@ -84,13 +92,21 @@ function ST.SetFrameClickThrough(frame, disableClicks, disableMotion)
             end
         end
     end
+
+    frame._cdcClickThroughClicks = clickState
+    frame._cdcClickThroughMotion = motionState
+    frame._cdcClickThroughProtectedApplied = not inCombat
+end
+
+local function SetChildFramesClickThrough(disableClicks, disableMotion, ...)
+    for i = 1, select("#", ...) do
+        ST.SetFrameClickThroughRecursive(select(i, ...), disableClicks, disableMotion)
+    end
 end
 
 -- Recursively apply click-through to frame and all children
 function ST.SetFrameClickThroughRecursive(frame, disableClicks, disableMotion)
+    if not frame then return end
     ST.SetFrameClickThrough(frame, disableClicks, disableMotion)
-    -- Apply to all child frames
-    for _, child in ipairs({frame:GetChildren()}) do
-        ST.SetFrameClickThroughRecursive(child, disableClicks, disableMotion)
-    end
+    SetChildFramesClickThrough(disableClicks, disableMotion, frame:GetChildren())
 end

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -315,6 +315,13 @@ local function ResetButtonGlowTransitionState(button)
     end
 end
 
+local function ClearButtonCompactSlotCache(button)
+    if not button then return end
+    button._compactSlotAnchor = nil
+    button._compactSlotX = nil
+    button._compactSlotY = nil
+end
+
 -- Nudger constants
 local NUDGE_BTN_SIZE = 12
 local NUDGE_REPEAT_DELAY = 0.5
@@ -981,6 +988,7 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
                 end
             end
 
+            ClearButtonCompactSlotCache(button)
             if isTriggerMode then
                 button:SetPoint("CENTER", frame, "CENTER", 0, 0)
             else
@@ -1133,6 +1141,9 @@ function CooldownCompanion:UpdateGroupLayout(groupId)
     if not frame or not group then return end
 
     if not group.compactLayout then
+        for _, button in ipairs(frame.buttons) do
+            ClearButtonCompactSlotCache(button)
+        end
         frame._layoutDirty = false
         return
     end

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -16,6 +16,8 @@ local math_max = math.max
 local math_ceil = math.ceil
 local table_insert = table.insert
 local InCombatLockdown = InCombatLockdown
+local select = select
+local wipe = wipe
 
 -- Shared click-through and border helpers from Utils.lua
 local SetFrameClickThrough = ST.SetFrameClickThrough
@@ -321,15 +323,21 @@ local NUDGE_REPEAT_INTERVAL = 0.05
 local CreatePixelBorders = ST.CreatePixelBorders
 local GetEffectiveTextHeight = ST._GetEffectiveTextHeight
 
+local PropagateFrameStrata
+
+local function PropagateChildFrameStrata(strata, ...)
+    for i = 1, select("#", ...) do
+        PropagateFrameStrata(select(i, ...), strata)
+    end
+end
+
 -- Recursively set frame strata on a frame and all its child frames.
 -- Textures/FontStrings inherit from their parent frame automatically,
 -- but child Frame objects (cooldown widgets, overlay frames, glow containers)
 -- may not follow a parent strata change — so we force it explicitly.
-local function PropagateFrameStrata(frame, strata)
+function PropagateFrameStrata(frame, strata)
     frame:SetFrameStrata(strata)
-    for _, child in pairs({frame:GetChildren()}) do
-        PropagateFrameStrata(child, strata)
-    end
+    PropagateChildFrameStrata(strata, frame:GetChildren())
 end
 
 local function CreateNudger(frame, groupId)
@@ -1138,7 +1146,13 @@ function CooldownCompanion:UpdateGroupLayout(groupId)
 
     local maxVis = (group.maxVisibleButtons and group.maxVisibleButtons > 0) and group.maxVisibleButtons or #frame.buttons
 
-    local visibleButtons = {}
+    local visibleButtons = frame._compactVisibleButtons
+    if visibleButtons then
+        wipe(visibleButtons)
+    else
+        visibleButtons = {}
+        frame._compactVisibleButtons = visibleButtons
+    end
     for _, button in ipairs(frame.buttons) do
         local forceVisible = button._forceVisibleByConfig
         local shouldHide = (not forceVisible) and (button._visibilityHidden or #visibleButtons >= maxVis)
@@ -1158,7 +1172,6 @@ function CooldownCompanion:UpdateGroupLayout(groupId)
     local headerH = frame._textHeaderHeight or 0
     local xMul, yMul, growthAnchor = GetGrowthMultipliers(style.growthOrigin)
     for visibleIndex, button in ipairs(visibleButtons) do
-        button:ClearAllPoints()
         local row, col = GetCompactSlotForIndex(
             visibleIndex,
             visibleCount,
@@ -1166,7 +1179,17 @@ function CooldownCompanion:UpdateGroupLayout(groupId)
             orientation,
             compactGrowthDirection
         )
-        button:SetPoint(growthAnchor, frame, growthAnchor, xMul * col * (buttonWidth + spacing), yMul * (row * (buttonHeight + spacing) + headerH))
+        local x = xMul * col * (buttonWidth + spacing)
+        local y = yMul * (row * (buttonHeight + spacing) + headerH)
+        if button._compactSlotAnchor ~= growthAnchor
+            or button._compactSlotX ~= x
+            or button._compactSlotY ~= y then
+            button:ClearAllPoints()
+            button:SetPoint(growthAnchor, frame, growthAnchor, x, y)
+            button._compactSlotAnchor = growthAnchor
+            button._compactSlotX = x
+            button._compactSlotY = y
+        end
     end
 
     if frame.visibleButtonCount ~= visibleCount then

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1869,12 +1869,15 @@ function CooldownCompanion:UpdateAllCooldowns()
 
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = GetCVarBool("cooldownViewerEnabled")
+    self._cooldownUpdatePassActive = true
 
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
             frame:UpdateCooldowns()
         end
     end
+
+    self._cooldownUpdatePassActive = nil
 end
 
 function CooldownCompanion:UpdateAllGroupLayouts()

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -16,6 +16,7 @@ local type = type
 local UnitExists = UnitExists
 local UnitCanAttack = UnitCanAttack
 local InCombatLockdown = InCombatLockdown
+local C_CVar_GetCVarBool = C_CVar.GetCVarBool
 
 local LOAD_CONDITION_DEFAULTS = {
     raid = false,
@@ -1868,7 +1869,7 @@ function CooldownCompanion:UpdateAllCooldowns()
     self._assistedHighlightHasHostileTarget = hasHostileTarget
 
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
-    self._cdmViewerEnabled = GetCVarBool("cooldownViewerEnabled")
+    self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
     self._cooldownUpdatePassActive = true
 
     for groupId, frame in pairs(self.groupFrames) do

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -2336,26 +2336,31 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
         entry.independentVerticalFillDirection = nil
     end
 
-    local function EnsureNextId(settings, entry)
-        local function IdOwnedByOther(customBarId)
-            if type(customBarId) ~= "string" or customBarId == "" or type(settings.customBars) ~= "table" then
-                return false
-            end
-            for _, specBars in pairs(settings.customBars) do
-                if type(specBars) == "table" then
-                    for _, candidate in pairs(specBars) do
-                        if candidate ~= entry
-                            and type(candidate) == "table"
-                            and candidate.customBarId == customBarId then
-                            return true
-                        end
+    local function BuildCustomBarIdOwners(customBars)
+        local owners = {}
+        if type(customBars) ~= "table" then
+            return owners
+        end
+
+        for _, specBars in pairs(customBars) do
+            if type(specBars) == "table" then
+                for _, candidate in pairs(specBars) do
+                    local customBarId = type(candidate) == "table" and candidate.customBarId or nil
+                    if type(customBarId) == "string" and customBarId ~= "" and owners[customBarId] == nil then
+                        owners[customBarId] = candidate
                     end
                 end
             end
-            return false
         end
+        return owners
+    end
 
-        if type(entry.customBarId) == "string" and entry.customBarId ~= "" and not IdOwnedByOther(entry.customBarId) then
+    local function EnsureNextId(settings, entry, customBarIdOwners)
+        local entryId = entry.customBarId
+        if type(entryId) == "string"
+            and entryId ~= ""
+            and (customBarIdOwners[entryId] == nil or customBarIdOwners[entryId] == entry) then
+            customBarIdOwners[entryId] = entry
             return entry.customBarId
         end
         settings.nextCustomBarId = tonumber(settings.nextCustomBarId) or 1
@@ -2363,8 +2368,9 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
         repeat
             id = "custom_bar_" .. tostring(settings.nextCustomBarId)
             settings.nextCustomBarId = settings.nextCustomBarId + 1
-        until not IdOwnedByOther(id)
+        until customBarIdOwners[id] == nil
         entry.customBarId = id
+        customBarIdOwners[id] = entry
         return id
     end
 
@@ -2383,6 +2389,7 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
         if type(settings.customBars) ~= "table" then
             settings.customBars = {}
         end
+        local customBarIdOwners = BuildCustomBarIdOwners(settings.customBars)
 
         if type(settings.customAuraBars) == "table" then
             for specID, legacyBars in pairs(settings.customAuraBars) do
@@ -2422,7 +2429,7 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
                                 NormalizeCustomBarAttachedPlacement(entry)
                                 if HasCustomBarContent(entry) then
                                     entry.entryType = entry.entryType or "aura"
-                                    local id = EnsureNextId(settings, entry)
+                                    local id = EnsureNextId(settings, entry, customBarIdOwners)
                                     specBars[#specBars + 1] = entry
 
                                     if type(layout) == "table" then
@@ -2443,7 +2450,7 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
                         for _, entry in pairs(specBars) do
                             if type(entry) == "table" then
                                 entry.entryType = entry.entryType or "aura"
-                                EnsureNextId(settings, entry)
+                                EnsureNextId(settings, entry, customBarIdOwners)
                             end
                         end
                     end
@@ -2474,7 +2481,7 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
                         NormalizeCustomBarAttachedPlacement(entry)
                         if HasCustomBarContent(entry) then
                             entry.entryType = entry.entryType or "aura"
-                            EnsureNextId(settings, entry)
+                            EnsureNextId(settings, entry, customBarIdOwners)
                             target[#target + 1] = entry
                         end
                     end
@@ -2486,7 +2493,7 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
                         NormalizeCustomBarAttachedPlacement(entry)
                         if HasCustomBarContent(entry) then
                             entry.entryType = entry.entryType or "aura"
-                            EnsureNextId(settings, entry)
+                            EnsureNextId(settings, entry, customBarIdOwners)
                             target[#target + 1] = entry
                         end
                     end

--- a/Core/SoundAlerts.lua
+++ b/Core/SoundAlerts.lua
@@ -872,6 +872,14 @@ local function DidGainChargeSincePreviousState(state, cooldownActive, currentCha
     return false
 end
 
+local function PlayCustomBarTransitionSound(customBar, eventKey)
+    CooldownCompanion:PlayCustomBarSoundAlertEvent(customBar, eventKey)
+end
+
+local function PlayButtonTransitionSound(buttonData, eventKey)
+    CooldownCompanion:PlayButtonSoundAlertEvent(buttonData, eventKey)
+end
+
 local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
     local cooldownActive = opts.cooldownActive and true or false
     local auraActive = opts.auraActive and true or false
@@ -893,25 +901,25 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
 
     if opts.includeAuraEvents then
         if enabledEvents.onAuraApplied and auraActive and not state._sndPrevAuraActive then
-            opts.play("onAuraApplied")
+            opts.play(opts.playContext, "onAuraApplied")
         end
 
         if enabledEvents.onAuraRemoved and state._sndPrevAuraActive and not auraActive then
-            opts.play("onAuraRemoved")
+            opts.play(opts.playContext, "onAuraRemoved")
         end
     end
 
     if enabledEvents.onCooldown and cooldownActive and not state._sndPrevCooldownActive then
-        opts.play("onCooldown")
+        opts.play(opts.playContext, "onCooldown")
     end
 
     if enabledEvents.available then
         if opts.usesChargeBehavior then
             if DidGainChargeSincePreviousState(state, cooldownActive, currentCharges, chargeRecharging, chargeCooldownStartTime) then
-                opts.play("available")
+                opts.play(opts.playContext, "available")
             end
         elseif state._sndPrevCooldownActive and not cooldownActive then
-            opts.play("available")
+            opts.play(opts.playContext, "available")
         end
     end
 
@@ -947,28 +955,39 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, coold
             chargeCooldownStartTime = charges.cooldownStartTime
         end
 
-        UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, {
-            cooldownActive = cooldownActive,
-            auraActive = auraActive,
-            currentCharges = currentCharges,
-            chargeRecharging = chargeRecharging,
-            chargeCooldownStartTime = chargeCooldownStartTime,
-            includeAuraEvents = customBar.auraTracking == true,
-            usesChargeBehavior = cooldownResult and cooldownResult.hasCharges == true,
-            play = function(eventKey)
-                self:PlayCustomBarSoundAlertEvent(customBar, eventKey)
-            end,
-        })
+        local opts = barInfo._sndTransitionOptions
+        if not opts then
+            opts = {}
+            barInfo._sndTransitionOptions = opts
+        end
+        opts.cooldownActive = cooldownActive
+        opts.auraActive = auraActive
+        opts.currentCharges = currentCharges
+        opts.chargeRecharging = chargeRecharging
+        opts.chargeCooldownStartTime = chargeCooldownStartTime
+        opts.includeAuraEvents = customBar.auraTracking == true
+        opts.usesChargeBehavior = cooldownResult and cooldownResult.hasCharges == true
+        opts.play = PlayCustomBarTransitionSound
+        opts.playContext = customBar
+        UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, opts)
         return
     end
 
-    UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, {
-        auraActive = auraActive,
-        includeAuraEvents = true,
-        play = function(eventKey)
-            self:PlayCustomBarSoundAlertEvent(customBar, eventKey)
-        end,
-    })
+    local opts = barInfo._sndTransitionOptions
+    if not opts then
+        opts = {}
+        barInfo._sndTransitionOptions = opts
+    end
+    opts.cooldownActive = nil
+    opts.auraActive = auraActive
+    opts.currentCharges = nil
+    opts.chargeRecharging = nil
+    opts.chargeCooldownStartTime = nil
+    opts.includeAuraEvents = true
+    opts.usesChargeBehavior = nil
+    opts.play = PlayCustomBarTransitionSound
+    opts.playContext = customBar
+    UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, opts)
 end
 
 function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isOnGCD, cooldownActive, auraActive, currentCharges, _maxCharges, chargeRecharging, chargeCooldownStartTime)
@@ -990,18 +1009,21 @@ function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isO
         return
     end
 
-    UpdateCooldownSoundAlertTransitions(button, enabledEvents, {
-        cooldownActive = cooldownActive,
-        auraActive = auraActive,
-        currentCharges = currentCharges,
-        chargeRecharging = chargeRecharging,
-        chargeCooldownStartTime = chargeCooldownStartTime,
-        includeAuraEvents = true,
-        usesChargeBehavior = UsesChargeBehavior(buttonData),
-        play = function(eventKey)
-            self:PlayButtonSoundAlertEvent(buttonData, eventKey)
-        end,
-    })
+    local opts = button._sndTransitionOptions
+    if not opts then
+        opts = {}
+        button._sndTransitionOptions = opts
+    end
+    opts.cooldownActive = cooldownActive
+    opts.auraActive = auraActive
+    opts.currentCharges = currentCharges
+    opts.chargeRecharging = chargeRecharging
+    opts.chargeCooldownStartTime = chargeCooldownStartTime
+    opts.includeAuraEvents = true
+    opts.usesChargeBehavior = UsesChargeBehavior(buttonData)
+    opts.play = PlayButtonTransitionSound
+    opts.playContext = buttonData
+    UpdateCooldownSoundAlertTransitions(button, enabledEvents, opts)
 end
 
 function CooldownCompanion:UpdateTriggerPanelSoundAlerts(frame, group, triggerMatched)

--- a/Core/StyleOverrides.lua
+++ b/Core/StyleOverrides.lua
@@ -14,7 +14,17 @@ local CooldownCompanion = ST.Addon
 function CooldownCompanion:GetEffectiveStyle(groupStyle, buttonData)
     if buttonData and buttonData.styleOverrides
        and buttonData.overrideSections and next(buttonData.overrideSections) then
-        return setmetatable(buttonData.styleOverrides, { __index = groupStyle })
+        if buttonData._effectiveStyleGroupStyle ~= groupStyle
+            or buttonData._effectiveStyleOverrides ~= buttonData.styleOverrides then
+            setmetatable(buttonData.styleOverrides, { __index = groupStyle })
+            buttonData._effectiveStyleGroupStyle = groupStyle
+            buttonData._effectiveStyleOverrides = buttonData.styleOverrides
+        end
+        return buttonData.styleOverrides
+    end
+    if buttonData then
+        buttonData._effectiveStyleGroupStyle = nil
+        buttonData._effectiveStyleOverrides = nil
     end
     return groupStyle
 end

--- a/Core/StyleOverrides.lua
+++ b/Core/StyleOverrides.lua
@@ -4,6 +4,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local effectiveStyleCache = setmetatable({}, { __mode = "k" })
 
 ------------------------------------------------------------------------
 -- EFFECTIVE STYLE UTILITIES
@@ -14,17 +15,20 @@ local CooldownCompanion = ST.Addon
 function CooldownCompanion:GetEffectiveStyle(groupStyle, buttonData)
     if buttonData and buttonData.styleOverrides
        and buttonData.overrideSections and next(buttonData.overrideSections) then
-        if buttonData._effectiveStyleGroupStyle ~= groupStyle
-            or buttonData._effectiveStyleOverrides ~= buttonData.styleOverrides then
+        local cache = effectiveStyleCache[buttonData]
+        if not cache then
+            cache = {}
+            effectiveStyleCache[buttonData] = cache
+        end
+        if cache.groupStyle ~= groupStyle or cache.overrides ~= buttonData.styleOverrides then
             setmetatable(buttonData.styleOverrides, { __index = groupStyle })
-            buttonData._effectiveStyleGroupStyle = groupStyle
-            buttonData._effectiveStyleOverrides = buttonData.styleOverrides
+            cache.groupStyle = groupStyle
+            cache.overrides = buttonData.styleOverrides
         end
         return buttonData.styleOverrides
     end
     if buttonData then
-        buttonData._effectiveStyleGroupStyle = nil
-        buttonData._effectiveStyleOverrides = nil
+        effectiveStyleCache[buttonData] = nil
     end
     return groupStyle
 end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -160,6 +160,7 @@ local customAuraBarActivePreviewTokens = {}
 local customAuraBarPandemicPreviewTokens = {}
 local activeCustomAuraBarActivePreviews = {}
 local activeCustomAuraBarPandemicPreviews = {}
+local segmentedUpdateScratch = { auraActiveCache = {} }
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL = 0.65
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS = 3
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION = 12.3
@@ -1579,6 +1580,61 @@ end
 -- Update logic: Segmented resources (NOT secret — full Lua logic)
 ------------------------------------------------------------------------
 
+function segmentedUpdateScratch.GetFullSegments(holder)
+    if not holder._fullSegmentsScratch then
+        holder._fullSegmentsScratch = {}
+    else
+        wipe(holder._fullSegmentsScratch)
+    end
+    return holder._fullSegmentsScratch
+end
+
+function segmentedUpdateScratch.ClearValues(holder)
+    for _, seg in ipairs(holder.segments) do
+        seg:SetValue(0)
+    end
+end
+
+function segmentedUpdateScratch.ApplyAuraVisuals(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments)
+    if auraOverrideColor and not useAuraStackMode then
+        for i, seg in ipairs(holder.segments) do
+            if fullSegments[i] then
+                seg:SetStatusBarColor(auraOverrideColor[1], auraOverrideColor[2], auraOverrideColor[3], 1)
+            end
+        end
+    end
+
+    if useAuraStackMode then
+        ApplyResourceAuraStackSegments(holder, settings, auraApplications, auraMaxStacks, auraOverrideColor)
+    else
+        HideResourceAuraStackSegments(holder)
+    end
+end
+
+function segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, currentValue, maxValue, clearText)
+    segmentedUpdateScratch.ApplyAuraVisuals(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments)
+    if clearText then
+        ClearSegmentedText(holder)
+    else
+        SetSegmentedText(holder, currentValue, maxValue)
+    end
+end
+
+function segmentedUpdateScratch.SortRuneData(a, b)
+    if a.ready ~= b.ready then return a.ready end
+    return a.remaining < b.remaining
+end
+
+function segmentedUpdateScratch.GetRuneData(holder)
+    if not holder._runeDataScratch then
+        holder._runeDataScratch = {}
+        for i = 1, 6 do
+            holder._runeDataScratch[i] = {}
+        end
+    end
+    return holder._runeDataScratch
+end
+
 local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
     if not holder or not holder.segments then return end
     if not settings then
@@ -1592,57 +1648,27 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         and auraHasApplications
         and SupportsResourceAuraStackMode(powerType)
     local thresholdEnabled, thresholdValue, thresholdColor = GetSegmentedThresholdConfig(powerType, settings)
-    local fullSegments = {}
-
-    local function FinalizeAuraVisuals()
-        if auraOverrideColor and not useAuraStackMode then
-            for i, seg in ipairs(holder.segments) do
-                if fullSegments[i] then
-                    seg:SetStatusBarColor(auraOverrideColor[1], auraOverrideColor[2], auraOverrideColor[3], 1)
-                end
-            end
-        end
-
-        if useAuraStackMode then
-            ApplyResourceAuraStackSegments(holder, settings, auraApplications, auraMaxStacks, auraOverrideColor)
-        else
-            HideResourceAuraStackSegments(holder)
-        end
-    end
-
-    local function ClearForSecretMath()
-        for _, seg in ipairs(holder.segments) do
-            seg:SetValue(0)
-        end
-    end
-
-    local function FinalizeSegmentedUpdate(currentValue, maxValue, clearText)
-        FinalizeAuraVisuals()
-        if clearText then
-            ClearSegmentedText(holder)
-        else
-            SetSegmentedText(holder, currentValue, maxValue)
-        end
-    end
+    local fullSegments = segmentedUpdateScratch.GetFullSegments(holder)
 
     if powerType == 5 then
         -- DK Runes: sorted by readiness (ready left, longest CD right)
         local now = GetTime()
         local numSegs = math_min(#holder.segments, 6)
-        local runeData = {}
+        local runeData = segmentedUpdateScratch.GetRuneData(holder)
         for i = 1, 6 do
             local start, duration, ready = GetRuneCooldown(i)
             local remaining = 0
             if not ready and duration and duration > 0 then
                 remaining = math_max((start + duration) - now, 0)
             end
-            runeData[i] = { start = start, duration = duration, ready = ready, remaining = remaining }
+            local rune = runeData[i]
+            rune.start = start
+            rune.duration = duration
+            rune.ready = ready
+            rune.remaining = remaining
         end
         -- Sort: ready first, then by ascending remaining time
-        table.sort(runeData, function(a, b)
-            if a.ready ~= b.ready then return a.ready end
-            return a.remaining < b.remaining
-        end)
+        table.sort(runeData, segmentedUpdateScratch.SortRuneData)
         local readyColor, rechargingColor, maxColor = GetResourceColors(5, settings)
         local allReady = true
         local readyCount = 0
@@ -1676,14 +1702,14 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             end
             runeValueTotal = runeValueTotal + segValue
         end
-        FinalizeSegmentedUpdate(runeValueTotal, numSegs, false)
+        segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, runeValueTotal, numSegs, false)
         return
     end
 
     if powerType == 7 then
         if IsUnitPowerSecret("player", 7) or IsUnitPowerMaxSecret("player", 7) then
-            ClearForSecretMath()
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.ClearValues(holder)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
             return
         end
 
@@ -1692,8 +1718,8 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         local rawMax = UnitPowerMax("player", 7, true)
         local max = UnitPowerMax("player", 7)
         if issecretvalue and (issecretvalue(raw) or issecretvalue(rawMax) or issecretvalue(max)) then
-            ClearForSecretMath()
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.ClearValues(holder)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
             return
         end
 
@@ -1723,23 +1749,23 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                     end
                 end
             else
-                ClearForSecretMath()
+                segmentedUpdateScratch.ClearValues(holder)
             end
         else
-            ClearForSecretMath()
+            segmentedUpdateScratch.ClearValues(holder)
         end
         if type(displayCurrent) == "number" then
-            FinalizeSegmentedUpdate(displayCurrent, max, false)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, displayCurrent, max, false)
         else
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
         end
         return
     end
 
     if powerType == 19 then
         if IsUnitPowerSecret("player", 19) or IsUnitPowerMaxSecret("player", 19) then
-            ClearForSecretMath()
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.ClearValues(holder)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
             return
         end
 
@@ -1748,8 +1774,8 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         local max = UnitPowerMax("player", 19)
         local partialRaw = UnitPartialPower("player", 19)
         if issecretvalue and (issecretvalue(filled) or issecretvalue(max) or issecretvalue(partialRaw)) then
-            ClearForSecretMath()
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.ClearValues(holder)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
             return
         end
 
@@ -1773,23 +1799,23 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             end
         end
-        FinalizeSegmentedUpdate(displayCurrent, max, false)
+        segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, displayCurrent, max, false)
         return
     end
 
     -- Combo Points: color changes at max, charged coloring for Rogues
     if powerType == 4 then
         if IsUnitPowerSecret("player", 4) or IsUnitPowerMaxSecret("player", 4) then
-            ClearForSecretMath()
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.ClearValues(holder)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
             return
         end
 
         local current = UnitPower("player", 4)
         local max = UnitPowerMax("player", 4)
         if issecretvalue and (issecretvalue(current) or issecretvalue(max)) then
-            ClearForSecretMath()
-            FinalizeSegmentedUpdate(nil, nil, true)
+            segmentedUpdateScratch.ClearValues(holder)
+            segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
             return
         end
 
@@ -1818,22 +1844,22 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 seg:SetValue(0)
             end
         end
-        FinalizeSegmentedUpdate(current, max, false)
+        segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
         return
     end
 
     -- Generic segmented with max color: HolyPower, Chi, ArcaneCharges
     if IsUnitPowerSecret("player", powerType) or IsUnitPowerMaxSecret("player", powerType) then
-        ClearForSecretMath()
-        FinalizeSegmentedUpdate(nil, nil, true)
+        segmentedUpdateScratch.ClearValues(holder)
+        segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
         return
     end
 
     local current = UnitPower("player", powerType)
     local max = UnitPowerMax("player", powerType)
     if issecretvalue and (issecretvalue(current) or issecretvalue(max)) then
-        ClearForSecretMath()
-        FinalizeSegmentedUpdate(nil, nil, true)
+        segmentedUpdateScratch.ClearValues(holder)
+        segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
         return
     end
     local normalColor, maxColor
@@ -1856,7 +1882,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             seg:SetValue(0)
         end
     end
-    FinalizeSegmentedUpdate(current, max, false)
+    segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
 end
 
 ------------------------------------------------------------------------
@@ -3395,7 +3421,8 @@ local function OnUpdate(self, elapsed)
         return
     end
 
-    local auraActiveCache = {}
+    local auraActiveCache = segmentedUpdateScratch.auraActiveCache
+    wipe(auraActiveCache)
 
     for _, barInfo in ipairs(resourceBarFrames) do
         if barInfo.frame and (barInfo.frame:IsShown() or ShouldUpdateHiddenCustomAuraPandemicWake(barInfo)) then

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -260,10 +260,9 @@ local function HideResourceAuraStackSegments(holder)
     end
 end
 
-local function LayoutResourceAuraStackSegments(holder, settings, orientationOverride, reverseFillOverride)
-    if not holder or not holder.auraStackSegments or not holder.segments then return end
+local function GetResourceAuraStackLayoutInputs(holder, settings, orientationOverride, reverseFillOverride)
     local style = GetResourceDisplayStyle(settings)
-    local barTexture = CooldownCompanion:FetchStatusBar(style and style.barTexture or "Solid")
+    local barTextureName = style and style.barTexture or "Solid"
     local borderStyle = style and style.borderStyle or "pixel"
     local borderSize = style and style.borderSize or 1
     local isVertical
@@ -280,6 +279,53 @@ local function LayoutResourceAuraStackSegments(holder, settings, orientationOver
     elseif isVertical then
         reverseFill = IsVerticalFillReversed(settings)
     end
+
+    local baseSeg = holder and holder.segments and holder.segments[1]
+    local baseWidth = baseSeg and baseSeg:GetWidth() or 0
+    local baseHeight = baseSeg and baseSeg:GetHeight() or 0
+    local baseFrameLevel = baseSeg and baseSeg:GetFrameLevel() or 0
+
+    return barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel
+end
+
+local function UpdateResourceAuraStackLayoutState(holder, count, barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel)
+    holder._auraStackLayoutCount = count
+    holder._auraStackLayoutTexture = barTextureName
+    holder._auraStackLayoutBorderStyle = borderStyle
+    holder._auraStackLayoutBorderSize = borderSize
+    holder._auraStackLayoutVertical = isVertical
+    holder._auraStackLayoutReverseFill = reverseFill
+    holder._auraStackLayoutBaseWidth = baseWidth
+    holder._auraStackLayoutBaseHeight = baseHeight
+    holder._auraStackLayoutBaseFrameLevel = baseFrameLevel
+end
+
+local function ResourceAuraStackLayoutChanged(holder, settings)
+    local count = holder.auraStackSegments and #holder.auraStackSegments or 0
+    local barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel =
+        GetResourceAuraStackLayoutInputs(holder, settings)
+
+    if holder._auraStackLayoutCount ~= count
+        or holder._auraStackLayoutTexture ~= barTextureName
+        or holder._auraStackLayoutBorderStyle ~= borderStyle
+        or holder._auraStackLayoutBorderSize ~= borderSize
+        or holder._auraStackLayoutVertical ~= isVertical
+        or holder._auraStackLayoutReverseFill ~= reverseFill
+        or holder._auraStackLayoutBaseWidth ~= baseWidth
+        or holder._auraStackLayoutBaseHeight ~= baseHeight
+        or holder._auraStackLayoutBaseFrameLevel ~= baseFrameLevel then
+        return true
+    end
+
+    return false
+end
+
+local function LayoutResourceAuraStackSegments(holder, settings, orientationOverride, reverseFillOverride)
+    if not holder or not holder.auraStackSegments or not holder.segments then return end
+    local count = #holder.auraStackSegments
+    local barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel =
+        GetResourceAuraStackLayoutInputs(holder, settings, orientationOverride, reverseFillOverride)
+    local barTexture = CooldownCompanion:FetchStatusBar(barTextureName)
 
     for i, auraSeg in ipairs(holder.auraStackSegments) do
         local baseSeg = holder.segments[i]
@@ -313,6 +359,8 @@ local function LayoutResourceAuraStackSegments(holder, settings, orientationOver
             auraSeg:Hide()
         end
     end
+
+    UpdateResourceAuraStackLayoutState(holder, count, barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel)
 end
 
 local function EnsureResourceAuraStackSegments(holder, settings)
@@ -336,9 +384,12 @@ local function EnsureResourceAuraStackSegments(holder, settings)
             seg:Hide()
             holder.auraStackSegments[i] = seg
         end
+        holder._auraStackLayoutCount = nil
     end
 
-    LayoutResourceAuraStackSegments(holder, settings)
+    if ResourceAuraStackLayoutChanged(holder, settings) then
+        LayoutResourceAuraStackSegments(holder, settings)
+    end
     return holder.auraStackSegments
 end
 


### PR DESCRIPTION
## What Players Will Notice
- Cooldown Companion should spend less work on repeated display updates, especially in larger setups with many tracked cooldowns, resource bars, aura bars, texture panels, or trigger panels.
- Config interactions such as finder/search, autocomplete-backed resource aura rows, and Auto Add review refreshes should feel less wasteful on larger profiles.
- No tracking options, display modes, or saved settings are intentionally changed by this branch.

## Why This Changed
- A full Lua performance audit found steady allocation and redundant UI work in hot paths rather than one runaway bottleneck.
- The goal was to reduce garbage-collection pressure and repeated frame/widget setup without lowering cooldown, aura, resource, stack, charge, secret-value, combat, or restricted-content accuracy.

## What Changed
- Reused scratch tables and layout state in resource bars, segmented bars, rune data, trigger matching, text formatting, sound-alert transitions, and config search/preview paths.
- Avoided repeated structural work such as CDM child-list table allocation, recursive click-through allocation, compact-layout repointing, aura-stack segment relayout, icon-fill script reinstalling, and repeated style metatable setup.
- Preserved secret-value-sensitive paths by keeping live `SetFormattedText`/widget pass-through behavior where values may be secret.
- Added follow-up fixes from review loops for stale animation flags, texture color-shift base visuals, CVar cache API usage, and compact-layout slot cache invalidation.

## Validation
- Ran `luac -p` across every Lua file after implementation and after follow-up review fixes.
- Ran `git diff --check` after implementation and after follow-up review fixes.
- Ran repeated review-fix loops until no `safe_auto` review findings remained.
- Not yet verified in-game. Combat, restricted-content, secret-value behavior, and measured CPU/FPS impact still need runtime validation before this should leave draft.