### PR TITLE
Fix short cooldown icons flashing ready at high haste

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1670,6 +1670,10 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._lastOwnSpellCastAt = nil
+    button._lastRealCooldownSpellID = nil
+    button._lastRealCooldownDurationObj = nil
+    button._lastRealCooldownAt = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -53,6 +53,7 @@ local UpdateLossOfControl = ST._UpdateLossOfControl
 -- Imports from Tracking
 local UpdateIconTint = ST._UpdateIconTint
 local EvaluateDesaturation = ST._EvaluateDesaturation
+local ClearButtonVisualState = ST._ClearButtonVisualState
 
 -- Shared click-through helpers from Utils.lua
 local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
@@ -1063,11 +1064,18 @@ local function UpdateBarDisplay(button)
     local stackSegmentLayerActive = barAuraStackDisplay and button._barAuraStackMode ~= "continuous"
     local isChargeButton = UsesChargeBehavior(button.buttonData) and not barAuraStackDisplay
     local chargeState = button._chargeState
+    local visualState = button._visualState
     local auraTimerActive = barAuraStackDisplay or button._auraActive
         and (button._durationObj or button._viewerBar or button._conditionalPreviewRemaining)
     local onCooldown
     if itemUsesResolvedCooldownState then
         onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+    elseif visualState and isChargeButton then
+        chargeState = visualState.chargeState
+        onCooldown = chargeState == CHARGE_STATE_MISSING
+            or chargeState == CHARGE_STATE_ZERO
+    elseif visualState then
+        onCooldown = visualState.cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif isChargeButton then
         onCooldown = chargeState == CHARGE_STATE_MISSING
             or chargeState == CHARGE_STATE_ZERO
@@ -1662,6 +1670,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button:SetScript("OnUpdate", BarModeOnUpdate)
 
     -- Invalidate cached state
+    ClearButtonVisualState(button)
     button._desaturated = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
@@ -1674,6 +1683,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._lastRealCooldownSpellID = nil
     button._lastRealCooldownDurationObj = nil
     button._lastRealCooldownAt = nil
+    button._lastRealCooldownHoldGCDExpiresAt = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -68,6 +68,7 @@ local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
 local TARGET_SWITCH_SAFETY_CAP = 0.60
+local REAL_COOLDOWN_GCD_HOLD_WINDOW = 1.60
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
@@ -585,6 +586,8 @@ end
 
 local ProbeActionSlotCooldownForSpell
 
+-- Blizzard-style GCD sync is presentation-only: the real cooldown remains the
+-- canonical state, while the visible sweep may use the longer GCD duration.
 local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
     if not (result and realDurationObj and result.isOnGCD == true) then
         return false
@@ -594,11 +597,19 @@ local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
         return false
     end
 
-    result.state = COOLDOWN_STATE_GCD
+    local gcdDurationObj = CooldownCompanion._gcdDurationObj
+    if not gcdDurationObj then
+        return false
+    end
+
+    result.state = COOLDOWN_STATE_COOLDOWN
     result.source = source
-    result.realCooldownShown = false
-    result.durationObj = CooldownCompanion._gcdDurationObj
-    result.renderDurationObj = CooldownCompanion._gcdDurationObj
+    result.presentationState = COOLDOWN_STATE_GCD
+    result.presentationSource = source
+    result.realCooldownShown = true
+    result.realDurationObj = realDurationObj
+    result.durationObj = gcdDurationObj
+    result.renderDurationObj = gcdDurationObj
     result.gcdSyncUsed = true
     return true
 end
@@ -740,6 +751,87 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
         allowActionSlotRealFallback = allowActionSlotRealFallback,
     })
+end
+
+local function ClearRealCooldownContinuity(button)
+    button._lastRealCooldownSpellID = nil
+    button._lastRealCooldownDurationObj = nil
+    button._lastRealCooldownAt = nil
+end
+
+local function CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown)
+    return buttonData
+        and buttonData.type == "spell"
+        and buttonData.isPassive ~= true
+        and buttonData.hasCharges ~= true
+        and cooldownSpellId == buttonData.id
+        and noCooldown ~= true
+end
+
+function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, cooldownSpellId, noCooldown, result, now)
+    if not (button and result and result.fetchOk) then
+        return result
+    end
+
+    if not CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown) then
+        ClearRealCooldownContinuity(button)
+        return result
+    end
+
+    if result.state == COOLDOWN_STATE_COOLDOWN
+        and result.realCooldownShown == true
+        and result.realDurationObj then
+        button._lastRealCooldownSpellID = cooldownSpellId
+        button._lastRealCooldownDurationObj = result.realDurationObj
+        button._lastRealCooldownAt = now
+        return result
+    end
+
+    if result.state == COOLDOWN_STATE_READY then
+        ClearRealCooldownContinuity(button)
+        return result
+    end
+
+    local previousDurationObj = button._lastRealCooldownDurationObj
+    local previousAt = button._lastRealCooldownAt
+    local canReusePrevious = previousDurationObj
+        and previousAt
+        and button._lastRealCooldownSpellID == cooldownSpellId
+        and now - previousAt <= REAL_COOLDOWN_GCD_HOLD_WINDOW
+    local lastOwnCastAt = button._lastOwnSpellCastAt
+    local castAge = lastOwnCastAt and (now - lastOwnCastAt) or nil
+    local recentlyCastThisSpell = castAge and castAge <= REAL_COOLDOWN_GCD_HOLD_WINDOW
+
+    if canReusePrevious
+        and recentlyCastThisSpell
+        and result.state == COOLDOWN_STATE_GCD
+        and result.source == "spell-gcd"
+        and result.isOnGCD == true
+        and CooldownCompanion._gcdActive == true
+        and DurationObjectShowsCooldown(previousDurationObj) then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "held-real-cooldown-over-gcd"
+        result.realCooldownShown = true
+        result.realDurationObj = previousDurationObj
+        result.durationObj = previousDurationObj
+        result.renderDurationObj = previousDurationObj
+
+        if RealCooldownEndsInsideActiveGCD(previousDurationObj) then
+            result.presentationState = COOLDOWN_STATE_GCD
+            result.presentationSource = "continuity-gcd-sync"
+            result.durationObj = CooldownCompanion._gcdDurationObj
+            result.renderDurationObj = CooldownCompanion._gcdDurationObj
+            result.gcdSyncUsed = true
+        end
+
+        return result
+    end
+
+    if result.state == COOLDOWN_STATE_GCD and result.source == "spell-gcd" then
+        ClearRealCooldownContinuity(button)
+    end
+
+    return result
 end
 
 function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
@@ -1149,6 +1241,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._durationObj = nil
     button._cooldownDeferred = nil
     button._cooldownState = COOLDOWN_STATE_READY
+    button._cooldownPresentationState = COOLDOWN_STATE_READY
+    button._cooldownPresentationSource = nil
+    button._realCooldownDurationObj = nil
+    button._cooldownRenderDurationObj = nil
     button._chargeState = nil
     button._chargeCooldownVisualActive = nil
     button._barAuraStackDisplay = nil
@@ -1869,15 +1965,28 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if not auraOverrideActive and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
             spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
+            spellCooldownResult = self:ApplyRealCooldownContinuity(
+                button,
+                buttonData,
+                cooldownSpellId,
+                button._noCooldown,
+                spellCooldownResult,
+                now
+            )
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
+                button._cooldownPresentationState = spellCooldownResult.presentationState or button._cooldownState
+                button._cooldownPresentationSource = spellCooldownResult.presentationSource
+                button._realCooldownDurationObj = spellCooldownResult.realDurationObj
                 local renderDurationObj = spellCooldownResult.renderDurationObj
+                button._cooldownRenderDurationObj = renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
-                isGCDOnly = button._cooldownState == COOLDOWN_STATE_GCD
+                isGCDOnly = button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
+                    and button._cooldownPresentationState == COOLDOWN_STATE_GCD
 
                 if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                     if renderDurationObj then
@@ -1886,7 +1995,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     else
                         button.cooldown:SetCooldown(0, 0)
                     end
-                elseif button._cooldownState == COOLDOWN_STATE_GCD then
+                elseif button._cooldownPresentationState == COOLDOWN_STATE_GCD then
                     if style.showGCDSwipe == true and renderDurationObj then
                         button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
                     else

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -758,12 +758,22 @@ local function ClearRealCooldownContinuity(button)
     button._lastRealCooldownAt = nil
 end
 
-local function CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown)
+local function IsCurrentTrackedCooldownSpell(button, buttonData, cooldownSpellId)
+    if cooldownSpellId == buttonData.id then
+        return true
+    end
+
+    local liveOverrideId = button and button._liveOverrideSpellId
+    return liveOverrideId
+        and cooldownSpellId == liveOverrideId
+end
+
+local function CanHoldRealCooldown(button, buttonData, cooldownSpellId, noCooldown)
     return buttonData
         and buttonData.type == "spell"
         and buttonData.isPassive ~= true
         and buttonData.hasCharges ~= true
-        and cooldownSpellId == buttonData.id
+        and IsCurrentTrackedCooldownSpell(button, buttonData, cooldownSpellId)
         and noCooldown ~= true
 end
 
@@ -772,7 +782,7 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
         return result
     end
 
-    if not CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown) then
+    if not CanHoldRealCooldown(button, buttonData, cooldownSpellId, noCooldown) then
         ClearRealCooldownContinuity(button)
         return result
     end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1028,16 +1028,16 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
         and result.source == "spell-gcd"
         and result.isOnGCD == true
         and CooldownCompanion._gcdActive == true
-        and previousStillShown then
+        and (previousStillShown or gcdBridgeActive) then
         result.continuityDecision = "hold"
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "held-real-cooldown-over-gcd"
-        result.realCooldownShown = true
+        result.realCooldownShown = previousStillShown or false
         result.realDurationObj = previousDurationObj
         result.durationObj = previousDurationObj
         result.renderDurationObj = previousDurationObj
 
-        if RealCooldownEndsInsideActiveGCD(previousDurationObj) then
+        if not previousStillShown and gcdBridgeActive then
             result.presentationState = COOLDOWN_STATE_GCD
             result.durationObj = CooldownCompanion._gcdDurationObj
             result.renderDurationObj = CooldownCompanion._gcdDurationObj

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -605,7 +605,6 @@ local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
     result.state = COOLDOWN_STATE_COOLDOWN
     result.source = source
     result.presentationState = COOLDOWN_STATE_GCD
-    result.presentationSource = source
     result.realCooldownShown = true
     result.realDurationObj = realDurationObj
     result.durationObj = gcdDurationObj
@@ -818,7 +817,6 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
 
         if RealCooldownEndsInsideActiveGCD(previousDurationObj) then
             result.presentationState = COOLDOWN_STATE_GCD
-            result.presentationSource = "continuity-gcd-sync"
             result.durationObj = CooldownCompanion._gcdDurationObj
             result.renderDurationObj = CooldownCompanion._gcdDurationObj
             result.gcdSyncUsed = true
@@ -1241,10 +1239,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._durationObj = nil
     button._cooldownDeferred = nil
     button._cooldownState = COOLDOWN_STATE_READY
-    button._cooldownPresentationState = COOLDOWN_STATE_READY
-    button._cooldownPresentationSource = nil
-    button._realCooldownDurationObj = nil
-    button._cooldownRenderDurationObj = nil
     button._chargeState = nil
     button._chargeCooldownVisualActive = nil
     button._barAuraStackDisplay = nil
@@ -1979,14 +1973,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
-                button._cooldownPresentationState = spellCooldownResult.presentationState or button._cooldownState
-                button._cooldownPresentationSource = spellCooldownResult.presentationSource
-                button._realCooldownDurationObj = spellCooldownResult.realDurationObj
+                local cooldownPresentationState = spellCooldownResult.presentationState or button._cooldownState
                 local renderDurationObj = spellCooldownResult.renderDurationObj
-                button._cooldownRenderDurationObj = renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
                 isGCDOnly = button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
-                    and button._cooldownPresentationState == COOLDOWN_STATE_GCD
+                    and cooldownPresentationState == COOLDOWN_STATE_GCD
 
                 if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                     if renderDurationObj then
@@ -1995,7 +1986,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     else
                         button.cooldown:SetCooldown(0, 0)
                     end
-                elseif button._cooldownPresentationState == COOLDOWN_STATE_GCD then
+                elseif cooldownPresentationState == COOLDOWN_STATE_GCD then
                     if style.showGCDSwipe == true and renderDurationObj then
                         button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
                     else

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -69,6 +69,8 @@ local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
 local TARGET_SWITCH_SAFETY_CAP = 0.60
 local REAL_COOLDOWN_GCD_HOLD_WINDOW = 1.60
+local REAL_COOLDOWN_GCD_BRIDGE_START_WINDOW = 0.35
+local REAL_COOLDOWN_GCD_BRIDGE_EXPIRY_TOLERANCE = 0.05
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
@@ -586,6 +588,169 @@ end
 
 local ProbeActionSlotCooldownForSpell
 
+-- TEMPORARY DEBUG: narrow trace for intermittent Thrash high-haste cooldown gaps.
+-- Remove after the remaining Incarnation-window transition is understood.
+local THRASH_TRACE_SPELL_ID = 77758
+local THRASH_TRACE_VERSION = 8
+local THRASH_TRACE_LIMIT = 2400
+
+local function TraceCooldownValue(value)
+    if value ~= nil and issecretvalue(value) then
+        return "<secret>"
+    end
+    return value
+end
+
+local function BuildCooldownTraceForSpell(spellID)
+    if not spellID then
+        return nil
+    end
+
+    local info = C_Spell.GetSpellCooldown(spellID)
+    local normalDurationObj = C_Spell.GetSpellCooldownDuration(spellID)
+    local realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
+    local usable, noMana = C_Spell_IsSpellUsable(spellID)
+
+    return {
+        spellID = spellID,
+        infoPresent = info ~= nil,
+        isActive = info and TraceCooldownValue(info.isActive),
+        isEnabled = info and TraceCooldownValue(info.isEnabled),
+        isOnGCD = info and TraceCooldownValue(info.isOnGCD),
+        startTime = info and TraceCooldownValue(info.startTime),
+        duration = info and TraceCooldownValue(info.duration),
+        modRate = info and TraceCooldownValue(info.modRate),
+        normalShown = DurationObjectShowsCooldown(normalDurationObj),
+        realShown = DurationObjectShowsCooldown(realDurationObj),
+        normalRemaining = GetReadableDurationRemaining(normalDurationObj),
+        realRemaining = GetReadableDurationRemaining(realDurationObj),
+        usable = TraceCooldownValue(usable),
+        noMana = TraceCooldownValue(noMana),
+    }
+end
+
+function CooldownCompanion:RecordThrashCooldownTrace(button, buttonData, cooldownSpellId, result, phase)
+    if not (CooldownCompanion.db and CooldownCompanion.db.global) then
+        return
+    end
+
+    if not (buttonData and buttonData.type == "spell") then
+        return
+    end
+
+    if buttonData.id ~= THRASH_TRACE_SPELL_ID
+        and cooldownSpellId ~= THRASH_TRACE_SPELL_ID
+        and buttonData.name ~= "Thrash" then
+        return
+    end
+
+    local global = CooldownCompanion.db.global
+    local trace = global.thrashCooldownTrace
+    if type(trace) ~= "table" or trace.version ~= THRASH_TRACE_VERSION then
+        trace = {
+            version = THRASH_TRACE_VERSION,
+            spellID = THRASH_TRACE_SPELL_ID,
+            records = {},
+        }
+        global.thrashCooldownTrace = trace
+    end
+
+    local records = trace.records
+    if type(records) ~= "table" then
+        records = {}
+        trace.records = records
+    end
+
+    local liveOverrideID = C_Spell.GetOverrideSpell(buttonData.id)
+    local slotProbe = result and result.slotProbe
+    local directSlotProbe = ProbeActionSlotCooldownForSpell
+        and ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId) or nil
+
+    records[#records + 1] = {
+        t = GetTime(),
+        phase = phase,
+        groupId = button and button._groupId,
+        index = button and button.index,
+        buttonSpellID = buttonData.id,
+        buttonName = buttonData.name,
+        cooldownSpellID = cooldownSpellId,
+        liveOverrideID = liveOverrideID,
+        displaySpellID = button and button._displaySpellId,
+        noCooldown = button and button._noCooldown,
+        noCooldownSpellID = button and button._noCooldownSpellId,
+        showGCDSwipe = button and button.style and button.style.showGCDSwipe == true,
+        cooldownFrameShown = button and button.cooldown and button.cooldown:IsShown(),
+        currentButtonCooldownState = button and button._cooldownState,
+        currentButtonDesatCooldownActive = button and button._desatCooldownActive,
+        currentButtonDesaturated = button and button._desaturated,
+        currentButtonDesaturationReason = button and button._visualDesaturationReason,
+        currentButtonUnusableTintActive = button and button._unusableTintActive,
+        currentButtonTintReason = button and button._visualTintReason,
+        currentButtonSuppressedUnusableTintReason = button and button._visualSuppressedUnusableTintReason,
+        currentButtonVertexR = button and button._vertexR,
+        currentButtonVertexG = button and button._vertexG,
+        currentButtonVertexB = button and button._vertexB,
+        currentButtonVertexA = button and button._vertexA,
+        currentButtonIconFillActive = button and button._iconFillActive,
+        currentButtonIconFillMode = button and button._iconFillMode,
+        currentButtonIconFillReason = button and button._visualState and button._visualState.iconFillReason,
+        visualReady = button and button._visualState and button._visualState.ready,
+        visualCooldownActive = button and button._visualState and button._visualState.cooldownActive,
+        visualCooldownPresentationActive = button and button._visualState and button._visualState.cooldownPresentationActive,
+        visualCooldownVisualActive = button and button._visualState and button._visualState.cooldownVisualActive,
+        visualGCDActive = button and button._visualState and button._visualState.gcdActive,
+        visualUnusable = button and button._visualState and button._visualState.unusable,
+        visualOutOfRange = button and button._visualState and button._visualState.outOfRange,
+        currentButtonMainCDShown = button and button._mainCDShown,
+        lastOwnCastAge = button and button._lastOwnSpellCastAt and (GetTime() - button._lastOwnSpellCastAt) or nil,
+        lastRealCooldownSpellID = button and button._lastRealCooldownSpellID,
+        lastRealCooldownAge = button and button._lastRealCooldownAt and (GetTime() - button._lastRealCooldownAt) or nil,
+        lastRealCooldownStillShown = button and DurationObjectShowsCooldown(button._lastRealCooldownDurationObj) or nil,
+        lastRealCooldownGCDBridgeExpiresIn = button and button._lastRealCooldownHoldGCDExpiresAt
+            and (button._lastRealCooldownHoldGCDExpiresAt - GetTime()) or nil,
+        state = result and result.state,
+        source = result and result.source,
+        presentationState = result and result.presentationState,
+        fetchOk = result and result.fetchOk or false,
+        resultSpellID = result and result.spellID,
+        resultIsOnGCD = result and result.isOnGCD or false,
+        resultDeferred = result and result.deferred or false,
+        resultNormalShown = result and result.normalCooldownShown or false,
+        resultRealShown = result and result.realCooldownShown or false,
+        resultGcdSyncUsed = result and result.gcdSyncUsed or false,
+        resultContinuityDecision = result and result.continuityDecision,
+        resultContinuityReason = result and result.continuityReason,
+        resultContinuityCanReusePrevious = result and result.continuityCanReusePrevious,
+        resultContinuityRecentlyCast = result and result.continuityRecentlyCast,
+        resultContinuityFreshBridge = result and result.continuityFreshBridge,
+        resultContinuityCanHoldThroughGCD = result and result.continuityCanHoldThroughGCD,
+        resultContinuityPreviousStillShown = result and result.continuityPreviousStillShown,
+        resultContinuityGCDBridgeStarted = result and result.continuityGCDBridgeStarted,
+        resultContinuityGCDBridgeActive = result and result.continuityGCDBridgeActive,
+        resultContinuityGCDBridgeExpiresIn = result and result.continuityGCDBridgeExpiresIn,
+        resultContinuityGCDRemaining = result and result.continuityGCDRemaining,
+        resultNormalRemaining = result and GetReadableDurationRemaining(result.durationObj),
+        resultRealRemaining = result and GetReadableDurationRemaining(result.realDurationObj),
+        resultRenderRemaining = result and GetReadableDurationRemaining(result.renderDurationObj),
+        gcdActive = CooldownCompanion._gcdActive == true,
+        gcdRemaining = GetReadableDurationRemaining(CooldownCompanion._gcdDurationObj),
+        resultSlotShown = slotProbe and slotProbe.shown,
+        resultSlotRealShown = slotProbe and slotProbe.realShown,
+        resultSlotRemaining = slotProbe and GetReadableDurationRemaining(slotProbe.durationObj),
+        resultSlotRealRemaining = slotProbe and GetReadableDurationRemaining(slotProbe.realDurationObj),
+        directSlotShown = directSlotProbe and directSlotProbe.shown,
+        directSlotRealShown = directSlotProbe and directSlotProbe.realShown,
+        directSlotRemaining = directSlotProbe and GetReadableDurationRemaining(directSlotProbe.durationObj),
+        directSlotRealRemaining = directSlotProbe and GetReadableDurationRemaining(directSlotProbe.realDurationObj),
+        buttonSpell = BuildCooldownTraceForSpell(buttonData.id),
+        cooldownSpell = BuildCooldownTraceForSpell(cooldownSpellId),
+    }
+
+    while #records > THRASH_TRACE_LIMIT do
+        table.remove(records, 1)
+    end
+end
+
 -- Blizzard-style GCD sync is presentation-only: the real cooldown remains the
 -- canonical state, while the visible sweep may use the longer GCD duration.
 local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
@@ -756,6 +921,7 @@ local function ClearRealCooldownContinuity(button)
     button._lastRealCooldownSpellID = nil
     button._lastRealCooldownDurationObj = nil
     button._lastRealCooldownAt = nil
+    button._lastRealCooldownHoldGCDExpiresAt = nil
 end
 
 local function IsCurrentTrackedCooldownSpell(button, buttonData, cooldownSpellId)
@@ -783,6 +949,8 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
     end
 
     if not CanHoldRealCooldown(button, buttonData, cooldownSpellId, noCooldown) then
+        result.continuityDecision = "ineligible"
+        result.continuityReason = "not-current-tracked-real-cooldown"
         ClearRealCooldownContinuity(button)
         return result
     end
@@ -790,34 +958,78 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
     if result.state == COOLDOWN_STATE_COOLDOWN
         and result.realCooldownShown == true
         and result.realDurationObj then
+        result.continuityDecision = "store-real"
         button._lastRealCooldownSpellID = cooldownSpellId
         button._lastRealCooldownDurationObj = result.realDurationObj
         button._lastRealCooldownAt = now
+        button._lastRealCooldownHoldGCDExpiresAt = nil
         return result
     end
 
     if result.state == COOLDOWN_STATE_READY then
+        result.continuityDecision = "clear"
+        result.continuityReason = "ready"
         ClearRealCooldownContinuity(button)
         return result
     end
 
     local previousDurationObj = button._lastRealCooldownDurationObj
     local previousAt = button._lastRealCooldownAt
+    local previousAge = previousAt and (now - previousAt) or nil
+    local previousStillShown = previousDurationObj and DurationObjectShowsCooldown(previousDurationObj) or false
     local canReusePrevious = previousDurationObj
         and previousAt
         and button._lastRealCooldownSpellID == cooldownSpellId
-        and now - previousAt <= REAL_COOLDOWN_GCD_HOLD_WINDOW
+        and previousAge <= REAL_COOLDOWN_GCD_HOLD_WINDOW
     local lastOwnCastAt = button._lastOwnSpellCastAt
     local castAge = lastOwnCastAt and (now - lastOwnCastAt) or nil
     local recentlyCastThisSpell = castAge and castAge <= REAL_COOLDOWN_GCD_HOLD_WINDOW
+    local freshBridgeFromObservedReal = previousAge
+        and previousAge <= REAL_COOLDOWN_GCD_BRIDGE_START_WINDOW
+    local gcdRemaining = nil
+    local gcdBridgeExpiresAt = button._lastRealCooldownHoldGCDExpiresAt
+    local gcdBridgeActive = gcdBridgeExpiresAt
+        and now <= gcdBridgeExpiresAt + REAL_COOLDOWN_GCD_BRIDGE_EXPIRY_TOLERANCE
+    local gcdBridgeStarted = false
 
     if canReusePrevious
-        and recentlyCastThisSpell
+        and not recentlyCastThisSpell
+        and not gcdBridgeActive
         and result.state == COOLDOWN_STATE_GCD
         and result.source == "spell-gcd"
         and result.isOnGCD == true
         and CooldownCompanion._gcdActive == true
-        and DurationObjectShowsCooldown(previousDurationObj) then
+        and freshBridgeFromObservedReal then
+        gcdRemaining = GetReadableDurationRemaining(CooldownCompanion._gcdDurationObj)
+        if gcdRemaining and gcdRemaining > 0 then
+            gcdBridgeExpiresAt = now + gcdRemaining
+            button._lastRealCooldownHoldGCDExpiresAt = gcdBridgeExpiresAt
+            gcdBridgeActive = true
+            gcdBridgeStarted = true
+        end
+    elseif gcdBridgeActive then
+        gcdRemaining = GetReadableDurationRemaining(CooldownCompanion._gcdDurationObj)
+    end
+
+    local canHoldThroughGCD = recentlyCastThisSpell or gcdBridgeActive
+    result.continuityCanReusePrevious = canReusePrevious or false
+    result.continuityRecentlyCast = recentlyCastThisSpell or false
+    result.continuityFreshBridge = freshBridgeFromObservedReal or false
+    result.continuityCanHoldThroughGCD = canHoldThroughGCD or false
+    result.continuityPreviousStillShown = previousStillShown
+    result.continuityGCDBridgeStarted = gcdBridgeStarted or false
+    result.continuityGCDBridgeActive = gcdBridgeActive or false
+    result.continuityGCDBridgeExpiresIn = gcdBridgeExpiresAt and (gcdBridgeExpiresAt - now) or nil
+    result.continuityGCDRemaining = gcdRemaining
+
+    if canReusePrevious
+        and canHoldThroughGCD
+        and result.state == COOLDOWN_STATE_GCD
+        and result.source == "spell-gcd"
+        and result.isOnGCD == true
+        and CooldownCompanion._gcdActive == true
+        and previousStillShown then
+        result.continuityDecision = "hold"
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "held-real-cooldown-over-gcd"
         result.realCooldownShown = true
@@ -836,7 +1048,17 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
     end
 
     if result.state == COOLDOWN_STATE_GCD and result.source == "spell-gcd" then
+        result.continuityDecision = "clear"
+        if canReusePrevious and canHoldThroughGCD and not previousStillShown then
+            result.continuityReason = "previous-real-no-longer-shown"
+        elseif canReusePrevious and not canHoldThroughGCD then
+            result.continuityReason = "gcd-bridge-inactive"
+        else
+            result.continuityReason = "gcd-without-reusable-real-cooldown"
+        end
         ClearRealCooldownContinuity(button)
+    else
+        result.continuityDecision = "pass-through"
     end
 
     return result
@@ -1969,6 +2191,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if not auraOverrideActive and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
             spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
+            self:RecordThrashCooldownTrace(button, buttonData, cooldownSpellId, spellCooldownResult, "post-evaluate")
             spellCooldownResult = self:ApplyRealCooldownContinuity(
                 button,
                 buttonData,
@@ -1977,6 +2200,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellCooldownResult,
                 now
             )
+            self:RecordThrashCooldownTrace(button, buttonData, cooldownSpellId, spellCooldownResult, "post-continuity")
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
@@ -2005,7 +2229,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     end
                 else
                     button.cooldown:SetCooldown(0, 0)
+                    button.cooldown:Hide()
                 end
+                self:RecordThrashCooldownTrace(button, buttonData, cooldownSpellId, spellCooldownResult, "post-apply")
                 fetchOk = true
             elseif not fetchOk then
                 button.cooldown:SetCooldown(0, 0)
@@ -2233,7 +2459,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
     button._chargeState = ResolveChargeState(button, buttonData)
 
-    -- Cooldown desaturation follows the canonical cooldown state, never the GCD.
+    local cooldownDesaturationSuppressed = spellCooldownResult
+        and spellCooldownResult.source == "held-real-cooldown-over-gcd"
+
+    -- Cooldown desaturation follows real cooldown truth, not the bridged GCD
+    -- handoff used only to keep short-cooldown presentation from flashing ready.
     if buttonData.type == "item" then
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then
@@ -2242,7 +2472,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._desatCooldownActive = (auraProbeRealCooldownShown and not auraProbeIsGCDOnly) or false
     else
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+            and not cooldownDesaturationSuppressed
     end
+    self:RecordThrashCooldownTrace(button, buttonData, cooldownSpellId, spellCooldownResult, "post-desat")
     -- Track on-CD → off-CD transition for ready glow duration timer.
     -- desatWasActive is true only when the previous tick had an active cooldown,
     -- so nil → false (initial load) does NOT set a start time.
@@ -2561,6 +2793,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         usesChargeBehavior
     )
     ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)
+    CooldownCompanion.BuildButtonVisualState(button, buttonData, style, cooldownSpellId, fetchOk, isOnGCD, isGCDOnly)
 
     -- Mode-specific visual dispatch
     if button._isText then
@@ -2575,4 +2808,5 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end
+    self:RecordThrashCooldownTrace(button, buttonData, cooldownSpellId, spellCooldownResult, "post-visuals")
 end

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1239,6 +1239,10 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._lastOwnSpellCastAt = nil
+    button._lastRealCooldownSpellID = nil
+    button._lastRealCooldownDurationObj = nil
+    button._lastRealCooldownAt = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -45,6 +45,7 @@ local UpdateLossOfControl = ST._UpdateLossOfControl
 -- Imports from Tracking
 local UpdateIconTint = ST._UpdateIconTint
 local EvaluateDesaturation = ST._EvaluateDesaturation
+local ClearButtonVisualState = ST._ClearButtonVisualState
 
 -- Shared click-through helpers from Utils.lua
 local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
@@ -315,8 +316,18 @@ local function UpdateIconFill(button, buttonData, style)
     local cooldownPreview = button._conditionalPreviewDomain == "cooldown"
     local mode
     local color
+    local visualState = button._visualState
 
-    if button._auraActive == true or auraPreview then
+    if visualState and visualState.iconFillActive then
+        mode = visualState.iconFillMode
+        if mode == "aura" or mode == "aura_static" then
+            color = style.iconFillAuraColor or DEFAULT_ICON_FILL_AURA_COLOR
+        else
+            color = style.iconFillCooldownColor or DEFAULT_ICON_FILL_COOLDOWN_COLOR
+        end
+    elseif visualState then
+        mode = nil
+    elseif button._auraActive == true or auraPreview then
         color = style.iconFillAuraColor or DEFAULT_ICON_FILL_AURA_COLOR
         if button._auraHasTimer == false and not auraPreview then
             mode = "aura_static"
@@ -1180,8 +1191,10 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
                and not buttonData.isPassive
                and not button._noCooldown
                and (not style.readyGlowCombatOnly or inCombat)
-               and button._desatCooldownActive == false
-               and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
+               and ((button._visualState and button._visualState.readyGlowEligible == true)
+                    or (not button._visualState
+                        and button._desatCooldownActive == false
+                        and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN))
                and not (procOverlayActive and style.procGlowStyle ~= "none") then
             if style.readyGlowOnlyAtMaxCharges
                and buttonData.type == "spell"
@@ -1231,6 +1244,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button.style = style
 
     -- Invalidate cached widget state so next tick reapplies everything
+    ClearButtonVisualState(button)
     button._desaturated = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
@@ -1243,6 +1257,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._lastRealCooldownSpellID = nil
     button._lastRealCooldownDurationObj = nil
     button._lastRealCooldownAt = nil
+    button._lastRealCooldownHoldGCDExpiresAt = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -302,6 +302,9 @@ local function EvaluateTokenPresence(button, tokenName, timeRemaining, timeIsSec
     elseif tokenName == "oor" then
         return button._isOutOfRange == true
     elseif tokenName == "available" then
+        if button._visualState then
+            return button._visualState.ready == true
+        end
         return button._desatCooldownActive ~= true
     elseif tokenName == "incombat" then
         return UnitAffectingCombat("player") == true

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -166,6 +166,21 @@ end
 -- Icon tinting: out-of-range red > unusable dimming > aura tint > cooldown tint > base tint.
 -- Shared by icon-mode and bar-mode display paths.
 local function UpdateIconTint(button, buttonData, style)
+    local visualState = button and button._visualState
+    if visualState then
+        button._unusableTintActive = visualState.unusableTintActive == true
+        button._visualTintReason = visualState.tintReason
+        local r = visualState.tintR or 1
+        local g = visualState.tintG or 1
+        local b = visualState.tintB or 1
+        local a = visualState.tintA or 1
+        if button._vertexR ~= r or button._vertexG ~= g or button._vertexB ~= b or button._vertexA ~= a then
+            button._vertexR, button._vertexG, button._vertexB, button._vertexA = r, g, b, a
+            button.icon:SetVertexColor(r, g, b, a)
+        end
+        return
+    end
+
     button._unusableTintActive = false
     if buttonData.isPassive then
         local c
@@ -265,6 +280,17 @@ end
 -- equippable-but-not-equipped items always desaturate.
 -- Shared by icon-mode and bar-mode display paths.
 local function EvaluateDesaturation(button, buttonData, style)
+    local visualState = button and button._visualState
+    if visualState then
+        local wantDesat = visualState.desaturated == true
+        button._visualDesaturationReason = visualState.desaturationReason
+        if button._desaturated ~= wantDesat then
+            button._desaturated = wantDesat
+            button.icon:SetDesaturated(wantDesat)
+        end
+        return
+    end
+
     local wantDesat = false
     if button._auraTrackingReady == true then
         if buttonData.isPassive then

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -1,0 +1,296 @@
+--[[
+    CooldownCompanion - ButtonFrame/VisualState
+    Per-button visual-state snapshot shared by display consumers.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+
+local InCombatLockdown = InCombatLockdown
+local UnitCanAttack = UnitCanAttack
+local IsItemInRange = C_Item.IsItemInRange
+local IsUsableItem = C_Item.IsUsableItem
+local IsSpellUsable = C_Spell.IsSpellUsable
+
+local DEFAULT_WHITE = {1, 1, 1, 1}
+
+local function GetIconTintBaseAlpha(style)
+    local c = style and style.iconTintColor
+    return c and c[4] or 1
+end
+
+local function SetTint(state, r, g, b, a, reason, unusable)
+    state.tintR = r
+    state.tintG = g
+    state.tintB = b
+    state.tintA = a
+    state.tintReason = reason
+    state.unusableTintActive = unusable == true
+end
+
+local function ResolveUsability(button, buttonData)
+    if not buttonData or buttonData.isPassive then
+        return false
+    end
+
+    if button._conditionalUnusablePreview then
+        return true
+    end
+
+    if buttonData.type == "spell" then
+        local spellID = button._displaySpellId or buttonData.id
+        return not IsSpellUsable(spellID)
+    end
+
+    if buttonData.type == "item" or buttonData.type == "equipitem" then
+        return not IsUsableItem(button._resolvedItemId or buttonData.id)
+    end
+
+    return false
+end
+
+local function ResolveOutOfRange(button, buttonData, style)
+    if not (style and style.showOutOfRange) then
+        return false
+    end
+
+    if button._conditionalOutOfRangePreview then
+        return true
+    end
+
+    if buttonData.type == "spell" then
+        return button._spellOutOfRange == true
+    end
+
+    if buttonData.type == "item" or buttonData.type == "equipitem" then
+        if not InCombatLockdown() or UnitCanAttack("player", "target") then
+            local inRange = IsItemInRange(button._resolvedItemId or buttonData.id, "target")
+            return inRange == false
+        end
+    end
+
+    return false
+end
+
+local function ResolveDesaturation(button, buttonData, style, cooldownVisualActive)
+    local wantDesat = false
+    local reason = "base"
+
+    if button._auraTrackingReady == true then
+        if buttonData.isPassive then
+            if buttonData.neverDesaturate then
+                wantDesat = false
+                reason = "passive-never-desaturate"
+            elseif buttonData.invertAuraDesaturationLogic then
+                wantDesat = button._auraActive == true
+                reason = wantDesat and "passive-aura-active-inverted" or "passive-aura-missing-inverted"
+            else
+                wantDesat = not button._auraActive
+                reason = wantDesat and "passive-aura-missing" or "passive-aura-active"
+            end
+        else
+            wantDesat = buttonData.desaturateWhileAuraNotActive and not button._auraActive
+            reason = wantDesat and "aura-missing" or "aura-tracked"
+        end
+
+        if not wantDesat and not button._auraActive
+            and style.desaturateOnCooldown and cooldownVisualActive then
+            wantDesat = true
+            reason = "cooldown-presentation-while-aura-missing"
+        end
+    elseif style.desaturateOnCooldown or buttonData.desaturateWhileZeroCharges
+        or buttonData.desaturateWhileZeroStacks or button._isEquippableNotEquipped then
+        if style.desaturateOnCooldown and cooldownVisualActive then
+            wantDesat = true
+            reason = "cooldown-presentation"
+        end
+
+        if not wantDesat and buttonData.desaturateWhileZeroCharges
+                and not CooldownCompanion.HasItemFallbacks(buttonData)
+                and button._chargeState == CHARGE_STATE_ZERO then
+            wantDesat = true
+            reason = "zero-charges"
+        end
+
+        local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
+            and button._resolvedItemAvailableQuantity
+            or button._itemCount
+        if not wantDesat and buttonData.desaturateWhileZeroStacks and (itemUseCount or 0) == 0 then
+            wantDesat = true
+            reason = "zero-stacks"
+        end
+    end
+
+    if not wantDesat and button._isEquippableNotEquipped then
+        wantDesat = true
+        reason = "not-equipped"
+    end
+
+    return wantDesat, reason
+end
+
+local function ResolveTint(button, buttonData, style, state)
+    state.outOfRange = ResolveOutOfRange(button, buttonData, style)
+    state.unusable = ResolveUsability(button, buttonData)
+
+    if buttonData.isPassive then
+        local c
+        local reason = "base"
+        if style.iconAuraTintEnabled and buttonData.auraTracking and button._auraActive then
+            c = style.iconAuraTintColor
+            reason = "aura"
+        end
+        c = c or style.iconTintColor or DEFAULT_WHITE
+        SetTint(state, c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1, reason, false)
+        return
+    end
+
+    local base = style.iconTintColor
+    local r, g, b, a = 1, 1, 1, GetIconTintBaseAlpha(style)
+
+    if state.outOfRange then
+        SetTint(state, 1, 0.2, 0.2, a, "out-of-range", false)
+        return
+    end
+
+    if style.showUnusable and state.unusable then
+        local apiUnusableDuringCooldown = not button._conditionalUnusablePreview
+            and (state.cooldownPresentationActive == true or state.gcdActive == true)
+        if not apiUnusableDuringCooldown then
+            local c = style.iconUnusableTintColor
+            SetTint(
+                state,
+                c and c[1] or 0.4,
+                c and c[2] or 0.4,
+                c and c[3] or 0.4,
+                c and c[4] or a,
+                "unusable",
+                true
+            )
+            return
+        end
+        state.suppressedUnusableTintReason = "cooldown-or-gcd"
+    end
+
+    if style.iconAuraTintEnabled and buttonData.auraTracking and button._auraActive then
+        local c = style.iconAuraTintColor
+        if c then
+            SetTint(state, c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1, "aura", false)
+            return
+        end
+    end
+
+    if style.iconCooldownTintEnabled and state.cooldownVisualActive then
+        local c = style.iconCooldownTintColor
+        if c then
+            SetTint(state, c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1, "cooldown", false)
+            return
+        end
+    end
+
+    if base then
+        SetTint(state, base[1] or 1, base[2] or 1, base[3] or 1, base[4] or 1, "base", false)
+    else
+        SetTint(state, r, g, b, a, "base", false)
+    end
+end
+
+local function ResolveIconFill(button, buttonData, state)
+    local auraPreview = button._conditionalAuraPreview == true
+        or button._conditionalAuraDurationTextPreview == true
+    local cooldownPreview = button._conditionalPreviewDomain == "cooldown"
+
+    if button._auraActive == true or auraPreview then
+        state.iconFillActive = true
+        state.iconFillMode = (button._auraHasTimer == false and not auraPreview) and "aura_static" or "aura"
+        state.iconFillReason = auraPreview and "aura-preview" or "aura"
+        return
+    end
+
+    if cooldownPreview
+        or state.cooldownState == COOLDOWN_STATE_COOLDOWN
+        or (CooldownCompanion.UsesChargeBehavior(buttonData)
+            and button._chargeRecharging == true
+            and button._hideCooldownChargesActive ~= true) then
+        state.iconFillActive = true
+        state.iconFillMode = "cooldown"
+        state.iconFillReason = cooldownPreview and "cooldown-preview" or "cooldown"
+        return
+    end
+
+    state.iconFillActive = false
+    state.iconFillMode = nil
+    state.iconFillReason = "inactive"
+end
+
+local function BuildButtonVisualState(button, buttonData, style, cooldownSpellId, fetchOk, isOnGCD, isGCDOnly)
+    if not (button and buttonData and style) then
+        return nil
+    end
+
+    local state = button._visualState
+    if not state then
+        state = {}
+        button._visualState = state
+    end
+
+    state.version = 1
+    state.spellID = cooldownSpellId or buttonData.id
+    state.cooldownState = button._cooldownState
+    state.cooldownActive = button._desatCooldownActive == true
+    state.cooldownPresentationActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        or (button._cooldownState == COOLDOWN_STATE_GCD and style.showGCDSwipe == true)
+    state.cooldownVisualActive = state.cooldownPresentationActive == true
+    state.gcdActive = isOnGCD == true or button._cooldownState == COOLDOWN_STATE_GCD
+    state.gcdOnly = isGCDOnly == true
+    state.fetchOk = fetchOk == true
+    state.noCooldown = button._noCooldown == true
+    state.chargeState = button._chargeState
+    state.chargeCooldownActive = button._chargeState == CHARGE_STATE_ZERO
+    state.chargeRecharging = button._chargeRecharging == true
+    state.barCooldownActive = button._chargeState == CHARGE_STATE_MISSING
+        or button._chargeState == CHARGE_STATE_ZERO
+        or button._cooldownState == COOLDOWN_STATE_COOLDOWN
+    state.ready = not buttonData.isPassive
+        and button._noCooldown ~= true
+        and button._desatCooldownActive == false
+        and state.cooldownPresentationActive ~= true
+    state.readyGlowEligible = state.ready
+    state.visibilityHidden = button._visibilityHidden == true
+    state.visibilityAlpha = button._visibilityAlphaOverride or 1
+    state.suppressedUnusableTintReason = nil
+
+    state.desaturated, state.desaturationReason = ResolveDesaturation(button, buttonData, style, state.cooldownVisualActive)
+    state.desaturatedByCooldown = state.desaturated == true
+        and (state.desaturationReason == "cooldown-presentation"
+            or state.desaturationReason == "cooldown-presentation-while-aura-missing")
+
+    ResolveTint(button, buttonData, style, state)
+    ResolveIconFill(button, buttonData, state)
+
+    button._visualDesaturationReason = state.desaturationReason
+    button._visualTintReason = state.tintReason
+    button._visualSuppressedUnusableTintReason = state.suppressedUnusableTintReason
+    button._isUnusable = state.unusable == true
+    button._isOutOfRange = state.outOfRange == true
+
+    return state
+end
+
+local function ClearButtonVisualState(button)
+    if not button then return end
+    button._visualState = nil
+    button._visualDesaturationReason = nil
+    button._visualTintReason = nil
+    button._visualSuppressedUnusableTintReason = nil
+end
+
+ST._BuildButtonVisualState = BuildButtonVisualState
+ST._ClearButtonVisualState = ClearButtonVisualState
+CooldownCompanion.BuildButtonVisualState = BuildButtonVisualState
+CooldownCompanion.ClearButtonVisualState = ClearButtonVisualState

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -70,6 +70,7 @@ Core\GroupOperations.lua
 ButtonFrame\Helpers.lua
 ButtonFrame\Glows.lua
 ButtonFrame\Visibility.lua
+ButtonFrame\VisualState.lua
 ButtonFrame\Tracking.lua
 ButtonFrame\IconMode.lua
 ButtonFrame\BarMode.lua

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -572,6 +572,9 @@ local function IsTextureIndicatorSectionActive(button, sectionKey, config)
         if not buttonData or buttonData.isPassive or button._noCooldown then
             return false
         end
+        if button._visualState then
+            return button._visualState.ready == true
+        end
         return button._desatCooldownActive == false
     end
 
@@ -579,6 +582,9 @@ local function IsTextureIndicatorSectionActive(button, sectionKey, config)
         local buttonData = button.buttonData
         if not buttonData or buttonData.isPassive then
             return false
+        end
+        if button._visualState then
+            return button._visualState.unusable == true
         end
         if buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
@@ -599,6 +605,9 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
     end
 
     if conditionKey == "cooldownActive" then
+        if button._visualState then
+            return button._visualState.cooldownActive == true
+        end
         return button._desatCooldownActive == true
     end
 

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1492,10 +1492,15 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
             if buttonData and buttonData.type == "spell" then
                 button._noCooldown = nil
                 button._noCooldownSpellId = nil
+                button._visualState = nil
+                button._visualDesaturationReason = nil
+                button._visualTintReason = nil
+                button._visualSuppressedUnusableTintReason = nil
                 button._lastOwnSpellCastAt = nil
                 button._lastRealCooldownSpellID = nil
                 button._lastRealCooldownDurationObj = nil
                 button._lastRealCooldownAt = nil
+                button._lastRealCooldownHoldGCDExpiresAt = nil
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1492,6 +1492,10 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
             if buttonData and buttonData.type == "spell" then
                 button._noCooldown = nil
                 button._noCooldownSpellId = nil
+                button._lastOwnSpellCastAt = nil
+                button._lastRealCooldownSpellID = nil
+                button._lastRealCooldownDurationObj = nil
+                button._lastRealCooldownAt = nil
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -415,9 +415,10 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
     if unit == "player" then
         self:ForEachButton(function(button, buttonData)
             if buttonData.type == "spell"
-               and not buttonData.isPassive then
+                and not buttonData.isPassive then
                 local displaySpellID = button._displaySpellId or buttonData.id
                 if spellID == buttonData.id or spellID == displaySpellID then
+                    button._lastOwnSpellCastAt = GetTime()
                     if self.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
                         -- Track charge consumption for restricted-mode color heuristic.
                         -- _chargeRecharging at event time reflects the PRE-cast state:


### PR DESCRIPTION
## What Players Will Notice
- Short real-cooldown abilities should no longer briefly look ready/available when extreme haste causes their cooldown to overlap tightly with the GCD.
- This specifically improves cases validated in game with Thrash during Incarnation and Execute on Fury Warrior, where the icon could briefly lose its cooldown state before returning to the correct display.

## Why This Changed
- At very high haste, Blizzard can briefly report a short real cooldown as GCD-only even though the ability is still on its real cooldown.
- Execute adds an extra wrinkle because the saved button is base Execute while the active cooldown truth can live on its current override spell.

## What Changed
- Keeps real cooldown state canonical when GCD sync is only a presentation concern, matching Blizzard-style behavior without treating the real cooldown as gone.
- Adds narrow real-cooldown continuity for direct non-charge spell buttons: if a previously confirmed real cooldown briefly downgrades to spell-GCD after the player cast the spell, CDC preserves the active real cooldown object instead of flashing ready.
- Makes that continuity override-aware, so a base spell button can treat its current live override as the same tracked ability.
- Clears the continuity runtime state during existing button/style/spell-availability resets so stale runtime state does not survive button refreshes.

## Validation
- `luac -p ButtonFrame\CooldownUpdate.lua ButtonFrame\IconMode.lua ButtonFrame\BarMode.lua Core\Lifecycle.lua Core\GroupOperations.lua`
- `git diff --check`
- In-game validation: Thrash during Incarnation/high haste and Fury Warrior Execute high-haste repro both stopped showing the false-ready cooldown flash after the fix.
- Code review/fix loop run; remaining concerns are advisory validation/residual-risk notes rather than safe auto-fix items.
- Combat/restricted-content validation has not been separately verified beyond the in-game combat repros above.