### PR TITLE
Improve short cooldown display during high haste

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1680,6 +1680,10 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._nilConfirmPending = nil
     button._displaySpellId = nil
     button._liveOverrideSpellId = nil
+    button._lastRealCooldownSpellID = nil
+    button._lastRealCooldownDurationObj = nil
+    button._lastRealCooldownAt = nil
+    button._lastOwnSpellCastAt = nil
     button._itemCount = nil
     button._auraActive = nil
     button._showingAuraIcon = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -68,6 +68,7 @@ local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
 local TARGET_SWITCH_SAFETY_CAP = 0.60
+local REAL_COOLDOWN_GCD_HOLD_WINDOW = 1.60
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
@@ -585,6 +586,8 @@ end
 
 local ProbeActionSlotCooldownForSpell
 
+-- Blizzard-style GCD sync is presentation-only: the real cooldown remains the
+-- canonical state, while the visible sweep may use the longer GCD duration.
 local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
     if not (result and realDurationObj and result.isOnGCD == true) then
         return false
@@ -594,11 +597,19 @@ local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
         return false
     end
 
-    result.state = COOLDOWN_STATE_GCD
+    local gcdDurationObj = CooldownCompanion._gcdDurationObj
+    if not gcdDurationObj then
+        return false
+    end
+
+    result.state = COOLDOWN_STATE_COOLDOWN
     result.source = source
-    result.realCooldownShown = false
-    result.durationObj = CooldownCompanion._gcdDurationObj
-    result.renderDurationObj = CooldownCompanion._gcdDurationObj
+    result.presentationState = COOLDOWN_STATE_GCD
+    result.presentationSource = source
+    result.realCooldownShown = true
+    result.realDurationObj = realDurationObj
+    result.durationObj = gcdDurationObj
+    result.renderDurationObj = gcdDurationObj
     result.gcdSyncUsed = true
     return true
 end
@@ -740,6 +751,87 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
         allowActionSlotRealFallback = allowActionSlotRealFallback,
     })
+end
+
+local function ClearRealCooldownContinuity(button)
+    button._lastRealCooldownSpellID = nil
+    button._lastRealCooldownDurationObj = nil
+    button._lastRealCooldownAt = nil
+end
+
+local function CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown)
+    return buttonData
+        and buttonData.type == "spell"
+        and buttonData.isPassive ~= true
+        and buttonData.hasCharges ~= true
+        and cooldownSpellId == buttonData.id
+        and noCooldown ~= true
+end
+
+function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, cooldownSpellId, noCooldown, result, now)
+    if not (button and result and result.fetchOk) then
+        return result
+    end
+
+    if not CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown) then
+        ClearRealCooldownContinuity(button)
+        return result
+    end
+
+    if result.state == COOLDOWN_STATE_COOLDOWN
+        and result.realCooldownShown == true
+        and result.realDurationObj then
+        button._lastRealCooldownSpellID = cooldownSpellId
+        button._lastRealCooldownDurationObj = result.realDurationObj
+        button._lastRealCooldownAt = now
+        return result
+    end
+
+    if result.state == COOLDOWN_STATE_READY then
+        ClearRealCooldownContinuity(button)
+        return result
+    end
+
+    local previousDurationObj = button._lastRealCooldownDurationObj
+    local previousAt = button._lastRealCooldownAt
+    local canReusePrevious = previousDurationObj
+        and previousAt
+        and button._lastRealCooldownSpellID == cooldownSpellId
+        and now - previousAt <= REAL_COOLDOWN_GCD_HOLD_WINDOW
+    local lastOwnCastAt = button._lastOwnSpellCastAt
+    local castAge = lastOwnCastAt and (now - lastOwnCastAt) or nil
+    local recentlyCastThisSpell = castAge and castAge <= REAL_COOLDOWN_GCD_HOLD_WINDOW
+
+    if canReusePrevious
+        and recentlyCastThisSpell
+        and result.state == COOLDOWN_STATE_GCD
+        and result.source == "spell-gcd"
+        and result.isOnGCD == true
+        and CooldownCompanion._gcdActive == true
+        and DurationObjectShowsCooldown(previousDurationObj) then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "held-real-cooldown-over-gcd"
+        result.realCooldownShown = true
+        result.realDurationObj = previousDurationObj
+        result.durationObj = previousDurationObj
+        result.renderDurationObj = previousDurationObj
+
+        if RealCooldownEndsInsideActiveGCD(previousDurationObj) then
+            result.presentationState = COOLDOWN_STATE_GCD
+            result.presentationSource = "continuity-gcd-sync"
+            result.durationObj = CooldownCompanion._gcdDurationObj
+            result.renderDurationObj = CooldownCompanion._gcdDurationObj
+            result.gcdSyncUsed = true
+        end
+
+        return result
+    end
+
+    if result.state == COOLDOWN_STATE_GCD and result.source == "spell-gcd" then
+        ClearRealCooldownContinuity(button)
+    end
+
+    return result
 end
 
 function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
@@ -1149,6 +1241,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._durationObj = nil
     button._cooldownDeferred = nil
     button._cooldownState = COOLDOWN_STATE_READY
+    button._cooldownPresentationState = COOLDOWN_STATE_READY
+    button._cooldownPresentationSource = nil
+    button._realCooldownDurationObj = nil
+    button._cooldownRenderDurationObj = nil
     button._chargeState = nil
     button._chargeCooldownVisualActive = nil
     button._barAuraStackDisplay = nil
@@ -1869,15 +1965,28 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if not auraOverrideActive and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
             spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
+            spellCooldownResult = self:ApplyRealCooldownContinuity(
+                button,
+                buttonData,
+                cooldownSpellId,
+                button._noCooldown,
+                spellCooldownResult,
+                now
+            )
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
+                button._cooldownPresentationState = spellCooldownResult.presentationState or button._cooldownState
+                button._cooldownPresentationSource = spellCooldownResult.presentationSource
+                button._realCooldownDurationObj = spellCooldownResult.realDurationObj
                 local renderDurationObj = spellCooldownResult.renderDurationObj
+                button._cooldownRenderDurationObj = renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
-                isGCDOnly = button._cooldownState == COOLDOWN_STATE_GCD
+                isGCDOnly = button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
+                    and button._cooldownPresentationState == COOLDOWN_STATE_GCD
 
                 if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                     if renderDurationObj then
@@ -1886,7 +1995,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     else
                         button.cooldown:SetCooldown(0, 0)
                     end
-                elseif button._cooldownState == COOLDOWN_STATE_GCD then
+                elseif button._cooldownPresentationState == COOLDOWN_STATE_GCD then
                     if style.showGCDSwipe == true and renderDurationObj then
                         button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
                     else

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -756,7 +756,6 @@ local function ClearRealCooldownContinuity(button)
     button._lastRealCooldownSpellID = nil
     button._lastRealCooldownDurationObj = nil
     button._lastRealCooldownAt = nil
-    button._lastOwnSpellCastAt = nil
 end
 
 local function MatchesButtonCooldownSpell(button, buttonData, spellID)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -605,7 +605,6 @@ local function ApplyGCDSyncIfRealEndsInside(result, realDurationObj, source)
     result.state = COOLDOWN_STATE_COOLDOWN
     result.source = source
     result.presentationState = COOLDOWN_STATE_GCD
-    result.presentationSource = source
     result.realCooldownShown = true
     result.realDurationObj = realDurationObj
     result.durationObj = gcdDurationObj
@@ -757,14 +756,21 @@ local function ClearRealCooldownContinuity(button)
     button._lastRealCooldownSpellID = nil
     button._lastRealCooldownDurationObj = nil
     button._lastRealCooldownAt = nil
+    button._lastOwnSpellCastAt = nil
 end
 
-local function CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown)
+local function MatchesButtonCooldownSpell(button, buttonData, spellID)
+    return buttonData
+        and (spellID == buttonData.id
+            or (button and button._liveOverrideSpellId and spellID == button._liveOverrideSpellId))
+end
+
+local function CanHoldRealCooldown(button, buttonData, cooldownSpellId, noCooldown)
     return buttonData
         and buttonData.type == "spell"
         and buttonData.isPassive ~= true
         and buttonData.hasCharges ~= true
-        and cooldownSpellId == buttonData.id
+        and MatchesButtonCooldownSpell(button, buttonData, cooldownSpellId)
         and noCooldown ~= true
 end
 
@@ -773,7 +779,7 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
         return result
     end
 
-    if not CanHoldRealCooldown(buttonData, cooldownSpellId, noCooldown) then
+    if not CanHoldRealCooldown(button, buttonData, cooldownSpellId, noCooldown) then
         ClearRealCooldownContinuity(button)
         return result
     end
@@ -794,9 +800,13 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
 
     local previousDurationObj = button._lastRealCooldownDurationObj
     local previousAt = button._lastRealCooldownAt
+    local previousSpellID = button._lastRealCooldownSpellID
+    local previousMatchesCurrent = previousSpellID == cooldownSpellId
+        or (MatchesButtonCooldownSpell(button, buttonData, previousSpellID)
+            and MatchesButtonCooldownSpell(button, buttonData, cooldownSpellId))
     local canReusePrevious = previousDurationObj
         and previousAt
-        and button._lastRealCooldownSpellID == cooldownSpellId
+        and previousMatchesCurrent
         and now - previousAt <= REAL_COOLDOWN_GCD_HOLD_WINDOW
     local lastOwnCastAt = button._lastOwnSpellCastAt
     local castAge = lastOwnCastAt and (now - lastOwnCastAt) or nil
@@ -818,7 +828,6 @@ function CooldownCompanion:ApplyRealCooldownContinuity(button, buttonData, coold
 
         if RealCooldownEndsInsideActiveGCD(previousDurationObj) then
             result.presentationState = COOLDOWN_STATE_GCD
-            result.presentationSource = "continuity-gcd-sync"
             result.durationObj = CooldownCompanion._gcdDurationObj
             result.renderDurationObj = CooldownCompanion._gcdDurationObj
             result.gcdSyncUsed = true
@@ -1241,10 +1250,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._durationObj = nil
     button._cooldownDeferred = nil
     button._cooldownState = COOLDOWN_STATE_READY
-    button._cooldownPresentationState = COOLDOWN_STATE_READY
-    button._cooldownPresentationSource = nil
-    button._realCooldownDurationObj = nil
-    button._cooldownRenderDurationObj = nil
     button._chargeState = nil
     button._chargeCooldownVisualActive = nil
     button._barAuraStackDisplay = nil
@@ -1979,14 +1984,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
-                button._cooldownPresentationState = spellCooldownResult.presentationState or button._cooldownState
-                button._cooldownPresentationSource = spellCooldownResult.presentationSource
-                button._realCooldownDurationObj = spellCooldownResult.realDurationObj
                 local renderDurationObj = spellCooldownResult.renderDurationObj
-                button._cooldownRenderDurationObj = renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
+                local cooldownPresentationState = spellCooldownResult.presentationState or button._cooldownState
                 isGCDOnly = button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
-                    and button._cooldownPresentationState == COOLDOWN_STATE_GCD
+                    and cooldownPresentationState == COOLDOWN_STATE_GCD
 
                 if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                     if renderDurationObj then
@@ -1995,7 +1997,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                     else
                         button.cooldown:SetCooldown(0, 0)
                     end
-                elseif button._cooldownPresentationState == COOLDOWN_STATE_GCD then
+                elseif cooldownPresentationState == COOLDOWN_STATE_GCD then
                     if style.showGCDSwipe == true and renderDurationObj then
                         button.cooldown:SetCooldownFromDurationObject(renderDurationObj)
                     else

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1254,6 +1254,10 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._keyPressHighlightActive = nil
     button._displaySpellId = nil
     button._liveOverrideSpellId = nil
+    button._lastRealCooldownSpellID = nil
+    button._lastRealCooldownDurationObj = nil
+    button._lastRealCooldownAt = nil
+    button._lastOwnSpellCastAt = nil
     button._spellOutOfRange = nil
     button._itemCount = nil
     button._auraActive = nil

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1494,6 +1494,10 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._noCooldownSpellId = nil
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
+                button._lastRealCooldownSpellID = nil
+                button._lastRealCooldownDurationObj = nil
+                button._lastRealCooldownAt = nil
+                button._lastOwnSpellCastAt = nil
                 button._lastSpellTexture = nil
                 button._iconDirty = true
                 button._cooldownDeferred = nil

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -415,9 +415,10 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
     if unit == "player" then
         self:ForEachButton(function(button, buttonData)
             if buttonData.type == "spell"
-               and not buttonData.isPassive then
+                and not buttonData.isPassive then
                 local displaySpellID = button._displaySpellId or buttonData.id
                 if spellID == buttonData.id or spellID == displaySpellID then
+                    button._lastOwnSpellCastAt = GetTime()
                     if self.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
                         -- Track charge consumption for restricted-mode color heuristic.
                         -- _chargeRecharging at event time reflects the PRE-cast state:


### PR DESCRIPTION
## What Players Will Notice
- Short real cooldown spells that shrink under very high haste should be less likely to flash as ready while the ability is still recovering behind the active GCD.
- The visible cooldown sweep is kept aligned with the real cooldown state instead of letting a temporary GCD-only API response make the icon look available too early.

## Why This Changed
- Some very short real cooldowns can briefly report through the spell cooldown lane as GCD-only during high-haste windows, even though the player-facing action button still behaves like the real cooldown is active.
- That transient downgrade could make Cooldown Companion briefly clear cooldown presentation before the real cooldown was reliably complete.

## What Changed
- Treat GCD sync as presentation-only: the canonical state can remain a real cooldown while the visible sweep may use the active GCD when the real cooldown ends inside it.
- Preserve the last confirmed real cooldown duration object for a short, bounded window after the player's own cast, so temporary `spell-gcd` readings do not immediately clear the cooldown display.
- Record the player cast timestamp needed for that bounded continuity path.

## Validation
- Ran Lua syntax validation on the touched files: `ButtonFrame/CooldownUpdate.lua` and `Core/Lifecycle.lua`.
- Ran a full addon Lua syntax pass across all `.lua` files.
- Ran `git diff --check` against `origin/main`.
- In-game combat/restricted-content validation is still required before treating this as fully verified.