### PR TITLE
Add duration format choices for cooldown timers

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -31,6 +31,7 @@ local ApplyEdgePositions = ST._ApplyEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
+local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 local DEFAULT_BAR_AURA_COLOR = ST._DEFAULT_BAR_AURA_COLOR
 local DEFAULT_BAR_PANDEMIC_COLOR = ST._DEFAULT_BAR_PANDEMIC_COLOR
 local DEFAULT_BAR_CHARGE_COLOR = ST._DEFAULT_BAR_CHARGE_COLOR
@@ -952,21 +953,22 @@ local function UpdateBarFill(button)
                 button.timeText:SetTextColor(cc[1], cc[2], cc[3], cc[4])
             end
             -- Time text: HasSecretValues() returns a non-secret boolean.
-            -- Non-secret: full FormatTime formatting ("1:30:00", "1:30", "45", etc.)
-            -- Secret: pass secret number to C++ SetFormattedText ("%.1f" / "%.0f" format)
-            local decimal = button.style.decimalTimers
+            -- Non-secret: full duration-format examples ("1:30", "45", "8.7", etc.)
+            -- Secret: pass the secret number through C++ SetFormattedText with the closest specifier.
+            local durationStyle = button.style
+            local secretFormatSpec = GetDurationSecretFormatSpec(durationStyle)
             if previewRemaining and previewRemaining > 0 then
-                SetBarTimeText(button, FormatTime(previewRemaining, decimal))
+                SetBarTimeText(button, FormatTime(previewRemaining, durationStyle))
             elseif button._durationObj then
                 local remaining = button._durationObj:GetRemainingDuration()
                 if not button._durationObj:HasSecretValues() then
                     if remaining > 0 then
-                        SetBarTimeText(button, FormatTime(remaining, decimal))
+                        SetBarTimeText(button, FormatTime(remaining, durationStyle))
                     else
                         SetBarTimeText(button, "")
                     end
                 else
-                    SetBarTimeFormattedText(button, decimal and "%.1f" or "%.0f", remaining)
+                    SetBarTimeFormattedText(button, secretFormatSpec, remaining)
                 end
             elseif button._viewerBar then
                 -- Totem: viewer bar values may be secret (set by Blizzard's internal totem tracking).
@@ -974,10 +976,10 @@ local function UpdateBarFill(button)
                 -- secure code sets it, so the widget reports plain — but the actual
                 -- number returned by GetValue() is a secret wrapper).
                 -- Always use SetFormattedText for secret-safe pass-through.
-                SetBarTimeFormattedText(button, decimal and "%.1f" or "%.0f", button._viewerBar:GetValue())
+                SetBarTimeFormattedText(button, secretFormatSpec, button._viewerBar:GetValue())
             else
                 if itemRemaining > 0 then
-                    SetBarTimeText(button, FormatTime(itemRemaining, decimal))
+                    SetBarTimeText(button, FormatTime(itemRemaining, durationStyle))
                 else
                     SetBarTimeText(button, "")
                 end

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -156,8 +156,7 @@ CooldownCompanion.FormatTime = FormatTime
 
 local function GetDurationSecretFormatSpec(source)
     local formatKey = GetDurationFormat(source)
-    if formatKey == DURATION_FORMAT_DECIMAL_UNDER_60
-        or formatKey == DURATION_FORMAT_DECIMAL_UNDER_10 then
+    if formatKey == DURATION_FORMAT_DECIMAL_UNDER_60 then
         return "%.1f"
     end
     return "%.0f"

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -116,6 +116,9 @@ local function FormatUnitsTime(seconds)
     elseif total > 0 then
         return string_format("%ds", total)
     end
+    if seconds > 0 then
+        return "0s"
+    end
     return ""
 end
 

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -21,17 +21,169 @@ local DEFAULT_BAR_CHARGE_COLOR = {1.0, 0.82, 0.0, 1.0}
 local HEALTHSTONE_ITEM_ID = 5512
 
 -- Format remaining seconds for time display (shared across bar, text, and preview modes).
-local function FormatTime(seconds, decimal)
+local DURATION_FORMAT_CLOCK = "clock"
+local DURATION_FORMAT_UNITS = "units"
+local DURATION_FORMAT_DECIMAL_UNDER_10 = "decimal_under_10"
+local DURATION_FORMAT_DECIMAL_UNDER_60 = "decimal_under_60"
+
+local DURATION_FORMAT_LABELS = {
+    [DURATION_FORMAT_CLOCK] = "1:30 / 45 / 8",
+    [DURATION_FORMAT_UNITS] = "1m 30s / 45s / 8s",
+    [DURATION_FORMAT_DECIMAL_UNDER_10] = "1:30 / 45 / 8.7",
+    [DURATION_FORMAT_DECIMAL_UNDER_60] = "1:30 / 45.0 / 8.7",
+}
+
+local DURATION_FORMAT_ORDER = {
+    DURATION_FORMAT_CLOCK,
+    DURATION_FORMAT_UNITS,
+    DURATION_FORMAT_DECIMAL_UNDER_10,
+    DURATION_FORMAT_DECIMAL_UNDER_60,
+}
+
+local DURATION_FORMAT_SET = {
+    [DURATION_FORMAT_CLOCK] = true,
+    [DURATION_FORMAT_UNITS] = true,
+    [DURATION_FORMAT_DECIMAL_UNDER_10] = true,
+    [DURATION_FORMAT_DECIMAL_UNDER_60] = true,
+}
+
+CooldownCompanion.DURATION_FORMAT_CLOCK = DURATION_FORMAT_CLOCK
+CooldownCompanion.DURATION_FORMAT_UNITS = DURATION_FORMAT_UNITS
+CooldownCompanion.DURATION_FORMAT_DECIMAL_UNDER_10 = DURATION_FORMAT_DECIMAL_UNDER_10
+CooldownCompanion.DURATION_FORMAT_DECIMAL_UNDER_60 = DURATION_FORMAT_DECIMAL_UNDER_60
+
+local secondsFormatterCache = {}
+
+local function NormalizeDurationFormat(value, decimalTimers)
+    if DURATION_FORMAT_SET[value] then
+        return value
+    end
+    if decimalTimers == true then
+        return DURATION_FORMAT_DECIMAL_UNDER_60
+    end
+    return DURATION_FORMAT_CLOCK
+end
+CooldownCompanion.NormalizeDurationFormat = NormalizeDurationFormat
+
+local function GetDurationFormat(source, decimalTimers)
+    if type(source) == "table" then
+        return NormalizeDurationFormat(source.durationFormat, source.decimalTimers)
+    end
+    return NormalizeDurationFormat(source, decimalTimers)
+end
+CooldownCompanion.GetDurationFormat = GetDurationFormat
+
+function CooldownCompanion:GetDurationFormatOptions()
+    return DURATION_FORMAT_LABELS, DURATION_FORMAT_ORDER
+end
+
+local function GetEnumValue(enumName, valueName, fallback)
+    local enumTable = Enum and Enum[enumName]
+    if enumTable and enumTable[valueName] ~= nil then
+        return enumTable[valueName]
+    end
+    return fallback
+end
+
+local function GetUnitsSecondsFormatter()
+    if secondsFormatterCache[DURATION_FORMAT_UNITS] ~= nil then
+        return secondsFormatterCache[DURATION_FORMAT_UNITS]
+    end
+
+    local formatter
+    if C_StringUtil and C_StringUtil.CreateSecondsFormatter then
+        formatter = C_StringUtil.CreateSecondsFormatter()
+        formatter:SetDefaultAbbreviation(GetEnumValue("SecondsFormatterAbbrevation", "OneLetter", 2))
+        formatter:SetDesiredUnitCount(2)
+        formatter:SetMinInterval(GetEnumValue("SecondsFormatterInterval", "Seconds", 0))
+        formatter:SetMillisecondsThreshold(0)
+        formatter:SetCanRoundUpLastUnit(false)
+        formatter:SetCanRoundUpIntervals(false)
+        formatter:SetConvertToLower(true)
+        formatter:SetStripIntervalWhitespace(GetEnumValue("SecondsFormatterIntervalWhitespace", "Preserve", 0))
+    end
+
+    secondsFormatterCache[DURATION_FORMAT_UNITS] = formatter or false
+    return formatter
+end
+
+local function FormatUnitsTime(seconds)
+    local total = math_floor(seconds)
+    if total >= 3600 then
+        return string_format("%dh %dm", math_floor(total / 3600), math_floor(total / 60) % 60)
+    elseif total >= 60 then
+        return string_format("%dm %ds", math_floor(total / 60), total % 60)
+    elseif total > 0 then
+        return string_format("%ds", total)
+    end
+    return ""
+end
+
+local function FormatTime(seconds, formatOrDecimal)
     if seconds >= 3600 then
+        local formatKey = GetDurationFormat(formatOrDecimal)
+        if formatKey == DURATION_FORMAT_UNITS then
+            return FormatUnitsTime(seconds)
+        end
         return string_format("%d:%02d:%02d", math_floor(seconds / 3600), math_floor(seconds / 60) % 60, math_floor(seconds % 60))
     elseif seconds >= 60 then
+        local formatKey = GetDurationFormat(formatOrDecimal)
+        if formatKey == DURATION_FORMAT_UNITS then
+            return FormatUnitsTime(seconds)
+        end
         return string_format("%d:%02d", math_floor(seconds / 60), math_floor(seconds % 60))
     elseif seconds > 0 then
-        return string_format(decimal and "%.1f" or "%d", decimal and seconds or math_floor(seconds))
+        local formatKey
+        if type(formatOrDecimal) == "boolean" then
+            formatKey = NormalizeDurationFormat(nil, formatOrDecimal)
+        else
+            formatKey = GetDurationFormat(formatOrDecimal)
+        end
+        if formatKey == DURATION_FORMAT_UNITS then
+            return FormatUnitsTime(seconds)
+        elseif formatKey == DURATION_FORMAT_DECIMAL_UNDER_60
+            or (formatKey == DURATION_FORMAT_DECIMAL_UNDER_10 and seconds < 10) then
+            return string_format("%.1f", seconds)
+        end
+        return string_format("%d", math_floor(seconds))
     end
     return ""
 end
 CooldownCompanion.FormatTime = FormatTime
+
+local function GetDurationSecretFormatSpec(source)
+    local formatKey = GetDurationFormat(source)
+    if formatKey == DURATION_FORMAT_DECIMAL_UNDER_60
+        or formatKey == DURATION_FORMAT_DECIMAL_UNDER_10 then
+        return "%.1f"
+    end
+    return "%.0f"
+end
+CooldownCompanion.GetDurationSecretFormatSpec = GetDurationSecretFormatSpec
+
+local function ApplyDurationFormatToCooldown(cooldown, source)
+    if not cooldown then return end
+
+    local formatKey = GetDurationFormat(source)
+    local formatter
+    if formatKey == DURATION_FORMAT_UNITS then
+        formatter = GetUnitsSecondsFormatter()
+    end
+
+    if cooldown.SetCountdownFormatter then
+        cooldown:SetCountdownFormatter(formatter or nil)
+    end
+    if cooldown.SetCountdownMillisecondsThreshold then
+        local threshold = 0
+        if formatKey == DURATION_FORMAT_DECIMAL_UNDER_10 then
+            threshold = 10
+        elseif formatKey == DURATION_FORMAT_DECIMAL_UNDER_60 then
+            threshold = 60
+        end
+        cooldown:SetCountdownMillisecondsThreshold(threshold)
+    end
+end
+CooldownCompanion.ApplyDurationFormatToCooldown = ApplyDurationFormatToCooldown
 
 -- Apply font, size, outline, and text color to a FontString from a style table.
 -- Keys are derived from prefix: e.g. prefix="charge" reads chargeFont, chargeFontSize,

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -100,7 +100,7 @@ local function GetUnitsSecondsFormatter()
         formatter:SetCanRoundUpLastUnit(false)
         formatter:SetCanRoundUpIntervals(false)
         formatter:SetConvertToLower(true)
-        formatter:SetStripIntervalWhitespace(GetEnumValue("SecondsFormatterIntervalWhitespace", "Preserve", 0))
+        formatter:SetStripIntervalWhitespace(GetEnumValue("SecondsFormatterIntervalWhitespace", "StripIgnoreLocale", 2))
     end
 
     secondsFormatterCache[DURATION_FORMAT_UNITS] = formatter or false

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -52,6 +52,7 @@ local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
 -- Shared helpers from ButtonFrame/Helpers.lua
 local IsItemEquippable = CooldownCompanion.IsItemEquippable
 local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
+local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCooldown
 
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
@@ -535,6 +536,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.cooldown:SetAllPoints(button.icon)
     ApplyDefaultCooldownSwipeStyle(button, style)
     button.cooldown:SetHideCountdownNumbers(false) -- Always allow; visibility controlled via text alpha
+    ApplyDurationFormatToCooldown(button.cooldown, style)
     -- Recursively disable mouse on cooldown and all its children (CooldownFrameTemplate has children)
     -- Always fully non-interactive: disable both clicks and motion
     SetFrameClickThroughRecursive(button.cooldown, true, true)
@@ -600,6 +602,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
         secCd:SetSize(1, 1)
         secCd:SetPoint("CENTER")
         secCd:SetHideCountdownNumbers(false)
+        ApplyDurationFormatToCooldown(secCd, style)
         SetFrameClickThroughRecursive(secCd, true, true)
         button.secondaryCooldown = secCd
 
@@ -1322,6 +1325,10 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Countdown number visibility is controlled per-tick via SetHideCountdownNumbers
     button.cooldown:SetHideCountdownNumbers(false)
+    ApplyDurationFormatToCooldown(button.cooldown, style)
+    if button.secondaryCooldown then
+        ApplyDurationFormatToCooldown(button.secondaryCooldown, style)
+    end
     ApplyDefaultCooldownSwipeStyle(button, style)
     if button.auraBlizzardCooldown then
         AnchorAuraBlizzardCooldown(button)

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -37,6 +37,7 @@ local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
 -- Shared helpers from ButtonFrame/Helpers.lua
 local IsItemEquippable = CooldownCompanion.IsItemEquippable
 local FormatTime = CooldownCompanion.FormatTime
+local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- These are used as fallbacks when style keys are nil (user hasn't customized).
@@ -493,7 +494,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                     end
                     parts[#parts + 1] = WrapColor("%TIME%", colorOverride or cdColor)
                 elseif timeRemaining then
-                    parts[#parts + 1] = WrapColor(FormatTime(timeRemaining, style.decimalTimers), colorOverride or cdColor)
+                    parts[#parts + 1] = WrapColor(FormatTime(timeRemaining, style), colorOverride or cdColor)
                 end
 
             elseif token == "charges" then
@@ -534,7 +535,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                     end
                     parts[#parts + 1] = WrapColor("%AURA%", colorOverride or auraColor)
                 elseif auraHasTimer and auraRemaining then
-                    parts[#parts + 1] = WrapColor(FormatTime(auraRemaining, style.decimalTimers), colorOverride or auraColor)
+                    parts[#parts + 1] = WrapColor(FormatTime(auraRemaining, style), colorOverride or auraColor)
                 end
 
             elseif token == "keybind" then
@@ -554,7 +555,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                         end
                         parts[#parts + 1] = WrapColor("%STATUS%", colorOverride or auraColor)
                     elseif auraRemaining then
-                        parts[#parts + 1] = WrapColor(FormatTime(auraRemaining, style.decimalTimers), colorOverride or auraColor)
+                        parts[#parts + 1] = WrapColor(FormatTime(auraRemaining, style), colorOverride or auraColor)
                     else
                         parts[#parts + 1] = WrapColor("Active", colorOverride or auraColor)
                     end
@@ -567,7 +568,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                     end
                     parts[#parts + 1] = WrapColor("%STATUS%", colorOverride or cdColor)
                 elseif timeRemaining and timeRemaining > 0 then
-                    parts[#parts + 1] = WrapColor(FormatTime(timeRemaining, style.decimalTimers), colorOverride or cdColor)
+                    parts[#parts + 1] = WrapColor(FormatTime(timeRemaining, style), colorOverride or cdColor)
                 elseif button._cooldownDeferred then
                     -- Deferred cooldown: timer hasn't started yet, show cooldown
                     -- color with placeholder instead of "Ready".
@@ -622,8 +623,8 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
         local fmtStr = text
 
         -- Sentinel placeholders and their format specifiers / secret values
-        -- Numeric secrets (cooldown/aura times) use %.1f or %.0f, string secrets (stacks) use %s
-        local timeFmt = style.decimalTimers and "%.1f" or "%.0f"
+        -- Numeric secrets (cooldown/aura times) use the closest pass-through format; string secrets use %s.
+        local timeFmt = GetDurationSecretFormatSpec(style)
         local allPlaceholders = {
             {text = "%TIME%",   val = secretValue,      fmt = timeFmt},
             {text = "%AURA%",   val = secretValue,      fmt = timeFmt},

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -33,6 +33,7 @@ local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildShowTooltipsControls = ST._BuildShowTooltipsControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
+local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -399,25 +400,10 @@ local function BuildBarAppearanceTab(container, group, style)
         AddFontControls(container, style, "barReady", {sizeMin = 6, sizeMax = 24}, refreshStyle)
     end
 
-    -- Show Decimal Point toggle (affects both cooldown and aura duration text)
-    local decimalCheck = AceGUI:Create("CheckBox")
-    decimalCheck:SetLabel("Show Decimal Point")
-    decimalCheck:SetValue(style.decimalTimers or false)
-    decimalCheck:SetFullWidth(true)
-    decimalCheck:SetCallback("OnValueChanged", function(widget, event, val)
-        style.decimalTimers = val or nil
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(decimalCheck)
-
-    CreateInfoButton(decimalCheck.frame, decimalCheck.checkbg, "LEFT", "RIGHT", decimalCheck.text:GetStringWidth() + 4, 0, {
-        "Show Decimal Point",
-        {"Shows one decimal place on duration text", 1, 1, 1, true},
-        {"(e.g. \"4.5\" instead of \"5\").", 1, 1, 1, true},
-    }, decimalCheck)
-
     -- Compact Mode toggle + Max Visible Buttons slider
     BuildCompactModeControls(container, group, tabInfoButtons)
+    AddDurationFormatDropdown(container, style, refreshStyle)
+
     BuildGroupSettingPresetControls(container, group, "bars", tabInfoButtons)
 
     -- Apply "Hide CDC Tooltips" to tab info buttons (skip advanced toggles)

--- a/ConfigSettings/FormatEditor.lua
+++ b/ConfigSettings/FormatEditor.lua
@@ -405,7 +405,7 @@ local function PreviewSubstitute(segments, style, mockState)
                 parts[#parts + 1] = WrapPreviewColor(mockState.name or "Fireball", colorOverride or baseColor)
             elseif token == "time" then
                 if timeVal and timeVal > 0 then
-                    parts[#parts + 1] = WrapPreviewColor(FormatTime(timeVal, style.decimalTimers), colorOverride or cdColor)
+                    parts[#parts + 1] = WrapPreviewColor(FormatTime(timeVal, style), colorOverride or cdColor)
                 end
             elseif token == "charges" then
                 if mockState.charges then
@@ -425,7 +425,7 @@ local function PreviewSubstitute(segments, style, mockState)
                 end
             elseif token == "aura" then
                 if auraVal and auraVal > 0 then
-                    parts[#parts + 1] = WrapPreviewColor(FormatTime(auraVal, style.decimalTimers), colorOverride or auraColor)
+                    parts[#parts + 1] = WrapPreviewColor(FormatTime(auraVal, style), colorOverride or auraColor)
                 end
             elseif token == "keybind" then
                 if mockState.keybind and mockState.keybind ~= "" then
@@ -434,14 +434,14 @@ local function PreviewSubstitute(segments, style, mockState)
             elseif token == "status" then
                 if auraActive then
                     if auraVal and auraVal > 0 then
-                        parts[#parts + 1] = WrapPreviewColor(FormatTime(auraVal, style.decimalTimers), colorOverride or auraColor)
+                        parts[#parts + 1] = WrapPreviewColor(FormatTime(auraVal, style), colorOverride or auraColor)
                     else
                         parts[#parts + 1] = WrapPreviewColor("Active", colorOverride or auraColor)
                     end
                 elseif auraOnly then
                     -- Aura-only entries do not have a ready/cooldown fallback.
                 elseif timeVal and timeVal > 0 then
-                    parts[#parts + 1] = WrapPreviewColor(FormatTime(timeVal, style.decimalTimers), colorOverride or cdColor)
+                    parts[#parts + 1] = WrapPreviewColor(FormatTime(timeVal, style), colorOverride or cdColor)
                 else
                     parts[#parts + 1] = WrapPreviewColor(style.textReadyText or "Ready", colorOverride or readyColor)
                 end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -52,6 +52,7 @@ local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
+local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
 local BuildKeyPressHighlightControls = ST._BuildKeyPressHighlightControls
@@ -2842,6 +2843,10 @@ local function BuildAppearanceTab(container)
 
     -- Compact Mode toggle + Max Visible Buttons slider
     BuildCompactModeControls(container, group, tabInfoButtons)
+
+    if style.showCooldownText or style.showAuraText ~= false then
+        AddDurationFormatDropdown(container, style, refreshStyle)
+    end
 
     -- Border heading
     local borderHeading = AceGUI:Create("Heading")

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -33,6 +33,7 @@ local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
+local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 local tabInfoButtons = CS.tabInfoButtons
 
 local function RefreshLayoutOrderPreview()
@@ -3596,21 +3597,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
 
                         AddColorPicker(container, customBars[cabIdx], "durationTextFontColor", "Duration Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
 
-                        local decimalCheck = AceGUI:Create("CheckBox")
-                        decimalCheck:SetLabel("Show Decimal Point")
-                        decimalCheck:SetValue(cab.decimalTimers or false)
-                        decimalCheck:SetFullWidth(true)
-                        decimalCheck:SetCallback("OnValueChanged", function(widget, event, val)
-                            customBars[cabIdx].decimalTimers = val or nil
-                            CooldownCompanion:ApplyResourceBars()
-                        end)
-                        container:AddChild(decimalCheck)
-
-                        CreateInfoButton(decimalCheck.frame, decimalCheck.checkbg, "LEFT", "RIGHT", decimalCheck.text:GetStringWidth() + 4, 0, {
-                            "Show Decimal Point",
-                            {"Shows one decimal place on duration text", 1, 1, 1, true},
-                            {"(e.g. \"4.5\" instead of \"5\").", 1, 1, 1, true},
-                        }, decimalCheck)
+                        AddDurationFormatDropdown(container, customBars[cabIdx], cabApplyBars)
                     end
 
                     local stackAdvExpanded = AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack)

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -59,18 +59,11 @@ local function AddDurationFormatDropdown(container, settings, refreshCallback, o
         return nil
     end
 
-    local valueSource = settings
-    if opts and type(opts.fallbackStyle) == "table"
-        and settings.durationFormat == nil
-        and settings.decimalTimers == nil then
-        valueSource = opts.fallbackStyle
-    end
-
     local formatOptions, formatOrder = CooldownCompanion:GetDurationFormatOptions()
     local durationDrop = AceGUI:Create("Dropdown")
     durationDrop:SetLabel("Duration Format")
     durationDrop:SetList(formatOptions, formatOrder)
-    durationDrop:SetValue(CooldownCompanion:GetDurationFormat(valueSource))
+    durationDrop:SetValue(CooldownCompanion.GetDurationFormat(settings))
     durationDrop:SetFullWidth(true)
     durationDrop:SetCallback("OnValueChanged", function(widget, event, val)
         settings.durationFormat = CooldownCompanion.NormalizeDurationFormat(val)
@@ -161,7 +154,7 @@ local function BuildCooldownTextControls(container, styleTable, refreshCallback,
     end)
     container:AddChild(cdTextCb)
 
-    if showCooldownText or showAuraText ~= false then
+    if not (opts and opts.isOverride) and (showCooldownText or showAuraText ~= false) then
         AddDurationFormatDropdown(container, styleTable, refreshCallback, opts)
     end
 

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -54,6 +54,35 @@ local function RefreshConfigPanelForPreviewToggle()
     return true
 end
 
+local function AddDurationFormatDropdown(container, settings, refreshCallback, opts)
+    if not (container and settings and CooldownCompanion.GetDurationFormatOptions) then
+        return nil
+    end
+
+    local valueSource = settings
+    if opts and type(opts.fallbackStyle) == "table"
+        and settings.durationFormat == nil
+        and settings.decimalTimers == nil then
+        valueSource = opts.fallbackStyle
+    end
+
+    local formatOptions, formatOrder = CooldownCompanion:GetDurationFormatOptions()
+    local durationDrop = AceGUI:Create("Dropdown")
+    durationDrop:SetLabel("Duration Format")
+    durationDrop:SetList(formatOptions, formatOrder)
+    durationDrop:SetValue(CooldownCompanion:GetDurationFormat(valueSource))
+    durationDrop:SetFullWidth(true)
+    durationDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        settings.durationFormat = CooldownCompanion.NormalizeDurationFormat(val)
+        settings.decimalTimers = nil
+        if refreshCallback then
+            refreshCallback()
+        end
+    end)
+    container:AddChild(durationDrop)
+    return durationDrop
+end
+
 local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActiveFn)
     if not (container and isActiveFn and setActiveFn) then
         return nil
@@ -110,10 +139,20 @@ local function AddConditionalPreviewButton(container, label, previewKind, opts)
     end)
 end
 
-local function BuildCooldownTextControls(container, styleTable, refreshCallback)
+local function BuildCooldownTextControls(container, styleTable, refreshCallback, opts)
+    local fallbackStyle = opts and opts.fallbackStyle
+    local showCooldownText = styleTable.showCooldownText
+    if showCooldownText == nil and type(fallbackStyle) == "table" then
+        showCooldownText = fallbackStyle.showCooldownText
+    end
+    local showAuraText = styleTable.showAuraText
+    if showAuraText == nil and type(fallbackStyle) == "table" then
+        showAuraText = fallbackStyle.showAuraText
+    end
+
     local cdTextCb = AceGUI:Create("CheckBox")
     cdTextCb:SetLabel("Show Cooldown Text")
-    cdTextCb:SetValue(styleTable.showCooldownText or false)
+    cdTextCb:SetValue(showCooldownText or false)
     cdTextCb:SetFullWidth(true)
     cdTextCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showCooldownText = val
@@ -122,27 +161,13 @@ local function BuildCooldownTextControls(container, styleTable, refreshCallback)
     end)
     container:AddChild(cdTextCb)
 
-    if styleTable.showCooldownText then
+    if showCooldownText or showAuraText ~= false then
+        AddDurationFormatDropdown(container, styleTable, refreshCallback, opts)
+    end
+
+    if showCooldownText then
         AddFontControls(container, styleTable, "cooldown", {}, refreshCallback)
         AddColorPicker(container, styleTable, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshCallback, refreshCallback)
-
-        local decimalCheck = AceGUI:Create("CheckBox")
-        decimalCheck:SetLabel("Show Decimal Point")
-        decimalCheck:SetValue(styleTable.decimalTimers or false)
-        decimalCheck:SetFullWidth(true)
-        decimalCheck:SetCallback("OnValueChanged", function(widget, event, val)
-            styleTable.decimalTimers = val or nil
-            refreshCallback()
-        end)
-        container:AddChild(decimalCheck)
-
-        CreateInfoButton(decimalCheck.frame, decimalCheck.checkbg, "LEFT", "RIGHT", decimalCheck.text:GetStringWidth() + 4, 0, {
-            "Show Decimal Point",
-            {"Shows one decimal place on duration text", 1, 1, 1, true},
-            {"(e.g. \"4.5\" instead of \"5\").", 1, 1, 1, true},
-            " ",
-            {"Bar and text mode only.", 0.7, 0.7, 0.7, true},
-        }, decimalCheck)
 
         local cdAnchorDrop = AddAnchorDropdown(container, styleTable, "cooldownTextAnchor", "CENTER", refreshCallback)
 
@@ -1269,6 +1294,7 @@ end
 -- EXPORTS
 ------------------------------------------------------------------------
 ST._BuildCooldownTextControls = BuildCooldownTextControls
+ST._AddDurationFormatDropdown = AddDurationFormatDropdown
 ST._AddPreviewToggleButton = AddPreviewToggleButton
 ST._RefreshConfigPanelForPreviewToggle = RefreshConfigPanelForPreviewToggle
 ST._AddConditionalPreviewButton = AddConditionalPreviewButton

--- a/ConfigSettings/TextModeTabs.lua
+++ b/ConfigSettings/TextModeTabs.lua
@@ -21,6 +21,7 @@ local AddColorPicker = ST._AddColorPicker
 local RenderFormatPreview = ST._RenderFormatPreview
 local ParseFormatString = ST._ParseFormatString
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
+local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -29,7 +30,7 @@ local TOKEN_HELP_TEXT = table.concat({
     "|cffffffffAvailable Tokens:|r",
     "",
     "|cff00ff00{name}|r  Spell/item display name",
-    "|cff00ff00{time}|r  Cooldown time remaining (1:23, 4.5)",
+    "|cff00ff00{time}|r  Cooldown time remaining",
     "|cff00ff00{charges}|r  Current charges (if spell has charges)",
     "|cff00ff00{maxcharges}|r  Maximum charges (if spell has charges)",
     "|cff00ff00{stacks}|r  Aura stacks or item count",
@@ -164,21 +165,7 @@ local function BuildTextAppearanceTab(container, group, style)
         container:AddChild(spacingSlider)
     end
 
-    local decimalCheck = AceGUI:Create("CheckBox")
-    decimalCheck:SetLabel("Show Decimal Point")
-    decimalCheck:SetValue(style.decimalTimers or false)
-    decimalCheck:SetFullWidth(true)
-    decimalCheck:SetCallback("OnValueChanged", function(widget, event, val)
-        style.decimalTimers = val or nil
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(decimalCheck)
-
-    CreateInfoButton(decimalCheck.frame, decimalCheck.checkbg, "LEFT", "RIGHT", decimalCheck.text:GetStringWidth() + 4, 0, {
-        "Show Decimal Point",
-        {"Shows one decimal place on duration text", 1, 1, 1, true},
-        {"(e.g. \"4.5\" instead of \"5\").", 1, 1, 1, true},
-    }, decimalCheck)
+    AddDurationFormatDropdown(container, style, refreshStyle)
 
     local headerCb = AceGUI:Create("CheckBox")
     headerCb:SetLabel("Show Group Header")

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -420,7 +420,7 @@ local defaults = {
             textBorderSize = 0,
             textBorderColor = {0, 0, 0, 1},
             textShadow = false,
-            decimalTimers = false,
+            durationFormat = "clock",
             showTextGroupHeader = false,
             textHeaderFontSize = 12,
             textHeaderFontColor = {1, 1, 1, 1},
@@ -624,7 +624,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     cooldownText = {
         label = "Cooldown Text",
-        keys = {"showCooldownText", "decimalTimers", "cooldownFont", "cooldownFontSize", "cooldownFontOutline", "cooldownFontColor", "cooldownTextAnchor", "cooldownTextXOffset", "cooldownTextYOffset"},
+        keys = {"showCooldownText", "durationFormat", "cooldownFont", "cooldownFontSize", "cooldownFontOutline", "cooldownFontColor", "cooldownTextAnchor", "cooldownTextXOffset", "cooldownTextYOffset"},
         modes = {icons = true, bars = true},
     },
     auraText = {

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -624,7 +624,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     cooldownText = {
         label = "Cooldown Text",
-        keys = {"showCooldownText", "durationFormat", "cooldownFont", "cooldownFontSize", "cooldownFontOutline", "cooldownFontColor", "cooldownTextAnchor", "cooldownTextXOffset", "cooldownTextYOffset"},
+        keys = {"showCooldownText", "cooldownFont", "cooldownFontSize", "cooldownFontOutline", "cooldownFontColor", "cooldownTextAnchor", "cooldownTextXOffset", "cooldownTextYOffset"},
         modes = {icons = true, bars = true},
     },
     auraText = {

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -1489,12 +1489,6 @@ local function MigrateDurationFormatForGroup(group)
     end
 
     MigrateDurationFormatTable(group.style)
-
-    if type(group.buttons) == "table" then
-        for _, buttonData in pairs(group.buttons) do
-            MigrateDurationFormatTable(buttonData and buttonData.styleOverrides)
-        end
-    end
 end
 
 local function MigrateDurationFormatCustomBars(container)

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -1502,16 +1502,23 @@ local function MigrateDurationFormatCustomBars(container)
         return
     end
 
-    if type(container.customBars) == "table" then
-        for _, customBar in pairs(container.customBars) do
-            MigrateDurationFormatTable(customBar)
+    local function migrateCollection(collection)
+        if type(collection) ~= "table" then
+            return
+        end
+
+        for _, entry in pairs(collection) do
+            MigrateDurationFormatTable(entry)
+            if type(entry) == "table" then
+                for _, nestedEntry in pairs(entry) do
+                    MigrateDurationFormatTable(nestedEntry)
+                end
+            end
         end
     end
-    if type(container.customAuraBars) == "table" then
-        for _, customBar in pairs(container.customAuraBars) do
-            MigrateDurationFormatTable(customBar)
-        end
-    end
+
+    migrateCollection(container.customBars)
+    migrateCollection(container.customAuraBars)
 end
 
 function CooldownCompanion:MigrateDurationFormatSettings()

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -121,6 +121,7 @@ function CooldownCompanion:RunAllMigrations()
     self:MigrateSpecColorsToSpecOverrides()
     self:MigrateResourceBarDisplayProfiles()
     self:MigrateCustomAuraBarsToCustomBars()
+    self:MigrateDurationFormatSettings()
     return true
 end
 
@@ -161,6 +162,7 @@ function CooldownCompanion:ClearMigrationSentinels()
     profile._migratedResourceBarDisplayProfilesV2 = nil
     profile._migratedCustomBarsDynamic = nil
     profile._migratedCustomBarsDynamicV2 = nil
+    profile._migratedDurationFormatSettings = nil
 end
 
 function CooldownCompanion:MigrateGroupOwnership()
@@ -1464,6 +1466,79 @@ function CooldownCompanion:MigrateNewDefaults()
     profile.newDefaultsMigrated = true
 end
 
+local DURATION_FORMAT_CLOCK = "clock"
+local DURATION_FORMAT_DECIMAL_UNDER_60 = "decimal_under_60"
+
+local function MigrateDurationFormatTable(settings)
+    if type(settings) ~= "table" then
+        return
+    end
+
+    local legacyDecimal = rawget(settings, "decimalTimers")
+    if rawget(settings, "durationFormat") == nil and legacyDecimal ~= nil then
+        settings.durationFormat = legacyDecimal and DURATION_FORMAT_DECIMAL_UNDER_60 or DURATION_FORMAT_CLOCK
+    end
+    if legacyDecimal ~= nil then
+        settings.decimalTimers = nil
+    end
+end
+
+local function MigrateDurationFormatForGroup(group)
+    if type(group) ~= "table" then
+        return
+    end
+
+    MigrateDurationFormatTable(group.style)
+
+    if type(group.buttons) == "table" then
+        for _, buttonData in pairs(group.buttons) do
+            MigrateDurationFormatTable(buttonData and buttonData.styleOverrides)
+        end
+    end
+end
+
+local function MigrateDurationFormatCustomBars(container)
+    if type(container) ~= "table" then
+        return
+    end
+
+    if type(container.customBars) == "table" then
+        for _, customBar in pairs(container.customBars) do
+            MigrateDurationFormatTable(customBar)
+        end
+    end
+    if type(container.customAuraBars) == "table" then
+        for _, customBar in pairs(container.customAuraBars) do
+            MigrateDurationFormatTable(customBar)
+        end
+    end
+end
+
+function CooldownCompanion:MigrateDurationFormatSettings()
+    local profile = self.db and self.db.profile
+    if not profile or profile._migratedDurationFormatSettings then return end
+
+    MigrateDurationFormatTable(rawget(profile, "globalStyle"))
+
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            MigrateDurationFormatForGroup(group)
+        end
+    end
+
+    MigrateDurationFormatCustomBars(rawget(profile, "resourceBars"))
+    MigrateDurationFormatCustomBars(rawget(profile, "legacyResourceBarsSeed"))
+
+    local store = rawget(profile, "resourceBarsByChar")
+    if type(store) == "table" then
+        for _, charSettings in pairs(store) do
+            MigrateDurationFormatCustomBars(charSettings)
+        end
+    end
+
+    profile._migratedDurationFormatSettings = true
+end
+
 local ICON_FILL_COOLDOWN_COLOR_DEFAULT = {0.6, 0.13, 0.18, 0.55}
 local ICON_FILL_AURA_COLOR_DEFAULT = {0.2, 1.0, 0.2, 0.55}
 
@@ -2284,6 +2359,7 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
         "durationTextFontSize",
         "durationTextFontOutline",
         "durationTextFontColor",
+        "durationFormat",
         "decimalTimers",
         "showStackText",
         "showText",

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -118,6 +118,7 @@ local GetActiveResourceAuraEntry = RB.GetActiveResourceAuraEntry
 
 -- Shared helper from ButtonFrame/Helpers.lua
 local FormatTime = CooldownCompanion.FormatTime
+local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 -- Other ST imports
 local CreateGlowContainer = ST._CreateGlowContainer
 local ShowGlowStyle = ST._ShowGlowStyle
@@ -2205,15 +2206,15 @@ local function UpdateCustomAuraBar(barInfo)
                 local remaining = durationObj:GetRemainingDuration()
                 if not durationObj:HasSecretValues() then
                     if remaining > 0 then
-                        bar.text:SetText(FormatTime(remaining, cabConfig.decimalTimers))
+                        bar.text:SetText(FormatTime(remaining, cabConfig))
                     else
                         bar.text:SetText("")
                     end
                 else
-                    bar.text:SetFormattedText(cabConfig.decimalTimers and "%.1f" or "%.0f", remaining)
+                    bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
                 end
             elseif indicatorPreview then
-                bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig.decimalTimers))
+                bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig))
             else
                 bar.text:SetText("")
             end
@@ -2660,14 +2661,14 @@ function RB.UpdateCustomCooldownBar(barInfo)
             if auraDurationObj then
                 local remaining = auraDurationObj:GetRemainingDuration()
                 if auraDurationObj:HasSecretValues() then
-                    bar.text:SetFormattedText(cabConfig.decimalTimers and "%.1f" or "%.0f", remaining)
+                    bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
                 elseif remaining and remaining > 0 then
-                    bar.text:SetText(FormatTime(remaining, cabConfig.decimalTimers))
+                    bar.text:SetText(FormatTime(remaining, cabConfig))
                 else
                     bar.text:SetText("")
                 end
             elseif auraPreview or pandemicPreview then
-                bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig.decimalTimers))
+                bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig))
             else
                 bar.text:SetText("")
             end
@@ -2705,9 +2706,9 @@ function RB.UpdateCustomCooldownBar(barInfo)
         if cooldownActive and durationObj then
             local remaining = durationObj:GetRemainingDuration()
             if durationObj:HasSecretValues() then
-                bar.text:SetFormattedText(cabConfig.decimalTimers and "%.1f" or "%.0f", remaining)
+                bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
             elseif remaining and remaining > 0 then
-                bar.text:SetText(FormatTime(remaining, cabConfig.decimalTimers))
+                bar.text:SetText(FormatTime(remaining, cabConfig))
             else
                 bar.text:SetText("")
             end
@@ -4788,7 +4789,7 @@ local function ApplyPreviewDataToBar(barInfo, settings)
             if isSpellAuraStackDisplay then
                 barInfo.frame.text:SetText("")
             else
-                barInfo.frame.text:SetText(FormatTime(12.3, cabConfig and cabConfig.decimalTimers))
+                barInfo.frame.text:SetText(FormatTime(12.3, cabConfig))
             end
         end
         if barInfo.frame.stackText and barInfo.frame.stackText:IsShown() then
@@ -4830,7 +4831,7 @@ local function ApplyPreviewDataToBar(barInfo, settings)
             end
         end
         if barInfo.frame.text and barInfo.frame.text:IsShown() then
-            barInfo.frame.text:SetText(FormatTime(12.3, cabConfig and cabConfig.decimalTimers))
+            barInfo.frame.text:SetText(FormatTime(12.3, cabConfig))
         end
         if barInfo.frame.stackText and barInfo.frame.stackText:IsShown() then
             if isActive then

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -250,6 +250,7 @@ local customBarContentFields = {
     "durationTextFontSize",
     "durationTextFontOutline",
     "durationTextFontColor",
+    "durationFormat",
     "decimalTimers",
     "showStackText",
     "showText",


### PR DESCRIPTION
## What Players Will Notice
- Duration text now has four formatting choices instead of the old single decimal toggle: `1:30 / 45 / 8`, `1m 30s / 45s / 8s`, `1:30 / 45 / 8.7`, and `1:30 / 45.0 / 8.7`.
- The setting applies panel-wide to cooldown, aura duration, bar, text-mode, and Custom Bar duration displays so users get consistent timer formatting without per-button override confusion.
- Icon cooldown numbers use Blizzard's native countdown formatter where available, including unit formatting and decimal thresholds.

## Why This Changed
- The previous `Show Decimal Point` option was too narrow and did not clearly describe what users would see across the important timing windows above 1 minute, between 1 minute and 10 seconds, and below 10 seconds.
- The new UI presents examples directly so the choice is based on visible output rather than internal format names.

## What Changed
- Added shared duration format helpers for clock, units, decimal-below-10, and decimal-below-60 formats.
- Replaced the old decimal checkbox with a Duration Format dropdown near existing text settings for icon, bar, text, and Custom Bar panels.
- Migrated existing `decimalTimers` settings to the matching new `durationFormat` value for group styles and Custom Bar settings.
- Updated bar, text-mode, Custom Bar, preview, and native cooldown render paths to consume the selected format.
- Kept duration formatting panel-wide by removing it from per-button cooldown text override keys.

## Validation
- Ran `luac -p` on the changed Lua files.
- Ran `git diff --check origin/main...HEAD`.
- Ran review/fix passes against the branch and fixed the safe findings found there.
- Combat behavior was checked in-game and reported safe.
- Restricted-content validation was not separately confirmed in this session.