### PR TITLE
Add fallback IDs for standalone aura tracking

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -505,6 +505,59 @@ local function GetConfiguredAuraUnit(buttonData)
     return buttonData.auraUnit or "player"
 end
 
+local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+    local unit = viewerFrame.auraDataUnit or auraUnit
+    if not (viewerFrame.auraInstanceID and unit == configUnit) then
+        return false
+    end
+
+    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerFrame.auraInstanceID)
+    if not auraData then
+        return false
+    end
+
+    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
+end
+
+local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+    local viewerCooldown = viewerFrame.Cooldown
+    if not (viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown()) then
+        return false
+    end
+
+    local vUnit = viewerFrame.auraDataUnit or auraUnit
+    if vUnit ~= configUnit then
+        return false
+    end
+
+    local startMs, durMs = viewerCooldown:GetCooldownTimes()
+    if issecretvalue(durMs) then
+        return true
+    end
+
+    return durMs > 0 and (startMs + durMs) > now * 1000
+end
+
+local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
+    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+        or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+end
+
+local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
+    local firstTrackedFrame
+    for _, spellID in ipairs(candidateIDs or {}) do
+        local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
+        if viewerFrame then
+            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
+                return viewerFrame, firstTrackedFrame
+            end
+            firstTrackedFrame = firstTrackedFrame or viewerFrame
+        end
+    end
+    return nil, firstTrackedFrame
+end
+CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+
 local function DispatchStandaloneTextureVisual(button)
     if not button then
         return
@@ -1304,17 +1357,31 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
         end
         local orderedStandaloneAuraIDs
+        local standaloneOriginalAuraIDs
+        local standaloneFallbackAuraIDs
         if buttonData.addedAs == "aura" then
             if not button._orderedStandaloneAuraIDs
                 or button._orderedStandaloneAuraIDsRaw ~= buttonData.auraSpellID
                 or button._orderedStandaloneAuraIDsButtonID ~= buttonData.id
                 or button._orderedStandaloneAuraIDsAuraSpellID ~= button._auraSpellID then
-                button._orderedStandaloneAuraIDs = CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
+                local originalAuraIDs, fallbackAuraIDs = CooldownCompanion:GetStandaloneAuraCandidateGroups(buttonData)
+                local allAuraIDs = {}
+                for _, spellID in ipairs(originalAuraIDs) do
+                    allAuraIDs[#allAuraIDs + 1] = spellID
+                end
+                for _, spellID in ipairs(fallbackAuraIDs) do
+                    allAuraIDs[#allAuraIDs + 1] = spellID
+                end
+                button._standaloneOriginalAuraIDs = originalAuraIDs
+                button._standaloneFallbackAuraIDs = fallbackAuraIDs
+                button._orderedStandaloneAuraIDs = allAuraIDs
                 button._orderedStandaloneAuraIDsRaw = buttonData.auraSpellID
                 button._orderedStandaloneAuraIDsButtonID = buttonData.id
                 button._orderedStandaloneAuraIDsAuraSpellID = button._auraSpellID
             end
             orderedStandaloneAuraIDs = button._orderedStandaloneAuraIDs
+            standaloneOriginalAuraIDs = button._standaloneOriginalAuraIDs
+            standaloneFallbackAuraIDs = button._standaloneFallbackAuraIDs
         end
 
         -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
@@ -1328,23 +1395,27 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 viewerFrame = allChildren[buttonData.cdmChildSlot]
             end
         end
-        -- Try configured/implicit aura IDs, prefer one with active aura.
+        -- Try standalone aura identity first; visible fallback IDs are only
+        -- considered after original candidates fail all active proofs.
         if not viewerFrame and orderedStandaloneAuraIDs then
-            local firstTrackedFrame
-            for _, numId in ipairs(orderedStandaloneAuraIDs) do
-                local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
-                if f then
-                    local unit = f.auraDataUnit or auraUnit
-                    if f.auraInstanceID and unit == configUnit
-                        and C_UnitAuras.GetAuraDataByAuraInstanceID(unit, f.auraInstanceID) then
-                        viewerFrame = f
-                        break
-                    elseif not firstTrackedFrame then
-                        firstTrackedFrame = f
-                    end
-                end
+            local originalActiveFrame, firstOriginalFrame = CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame(
+                standaloneOriginalAuraIDs,
+                configUnit,
+                auraUnit,
+                now,
+                barAuraStackConfigured
+            )
+            viewerFrame = originalActiveFrame
+            if not viewerFrame then
+                local fallbackActiveFrame, firstFallbackFrame = CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame(
+                    standaloneFallbackAuraIDs,
+                    configUnit,
+                    auraUnit,
+                    now,
+                    barAuraStackConfigured
+                )
+                viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
             end
-            viewerFrame = viewerFrame or firstTrackedFrame
         elseif not viewerFrame and buttonData.auraSpellID then
             -- Cache parsed IDs on the button to avoid per-tick gmatch allocation.
             local ids = button._parsedAuraIDs

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -538,9 +538,19 @@ local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraU
     return durMs > 0 and (startMs + durMs) > now * 1000
 end
 
+local function ViewerFrameHasActiveTotemDuration(viewerFrame)
+    local totemSlot = viewerFrame.preferredTotemUpdateSlot
+    if not (totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData) then
+        return false
+    end
+
+    return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
+end
+
 local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
     return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
         or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+        or ViewerFrameHasActiveTotemDuration(viewerFrame)
 end
 
 local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1303,6 +1303,19 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         else
             cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
         end
+        local orderedStandaloneAuraIDs
+        if buttonData.addedAs == "aura" then
+            if not button._orderedStandaloneAuraIDs
+                or button._orderedStandaloneAuraIDsRaw ~= buttonData.auraSpellID
+                or button._orderedStandaloneAuraIDsButtonID ~= buttonData.id
+                or button._orderedStandaloneAuraIDsAuraSpellID ~= button._auraSpellID then
+                button._orderedStandaloneAuraIDs = CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
+                button._orderedStandaloneAuraIDsRaw = buttonData.auraSpellID
+                button._orderedStandaloneAuraIDsButtonID = buttonData.id
+                button._orderedStandaloneAuraIDsAuraSpellID = button._auraSpellID
+            end
+            orderedStandaloneAuraIDs = button._orderedStandaloneAuraIDs
+        end
 
         -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
         -- untainted code that matches spell IDs to auras during combat and
@@ -1315,9 +1328,25 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 viewerFrame = allChildren[buttonData.cdmChildSlot]
             end
         end
-        -- Try each override ID (comma-separated), prefer one with active aura.
-        -- Cache parsed IDs on the button to avoid per-tick gmatch allocation.
-        if not viewerFrame and buttonData.auraSpellID then
+        -- Try configured/implicit aura IDs, prefer one with active aura.
+        if not viewerFrame and orderedStandaloneAuraIDs then
+            local firstTrackedFrame
+            for _, numId in ipairs(orderedStandaloneAuraIDs) do
+                local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
+                if f then
+                    local unit = f.auraDataUnit or auraUnit
+                    if f.auraInstanceID and unit == configUnit
+                        and C_UnitAuras.GetAuraDataByAuraInstanceID(unit, f.auraInstanceID) then
+                        viewerFrame = f
+                        break
+                    elseif not firstTrackedFrame then
+                        firstTrackedFrame = f
+                    end
+                end
+            end
+            viewerFrame = viewerFrame or firstTrackedFrame
+        elseif not viewerFrame and buttonData.auraSpellID then
+            -- Cache parsed IDs on the button to avoid per-tick gmatch allocation.
             local ids = button._parsedAuraIDs
             if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
                 ids = {}
@@ -1482,7 +1511,16 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
         if canUsePlayerAuraFallback and not auraOverrideActive then
             local auraData
-            if buttonData.auraSpellID then
+            if orderedStandaloneAuraIDs then
+                for _, numId in ipairs(orderedStandaloneAuraIDs) do
+                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
+                    if auraData then
+                        activeAuraSpellID = numId
+                        activeAuraSpellIDFromFallback = true
+                        break
+                    end
+                end
+            elseif buttonData.auraSpellID then
                 local ids = button._parsedAuraIDs
                 if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
                     ids = {}

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -344,6 +344,7 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
     local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
     local viewerFrame = cdmEnabled and CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData) or nil
     local hasViewerFrame = viewerFrame ~= nil
+    local isAuraEntry = buttonData.addedAs == "aura"
     local allowPassiveManualRecovery = options.allowPassiveManualRecovery == true
     local showAuraToggle = options.showAuraToggle == true
     local showAuraIconToggle = options.showAuraIconToggle == true
@@ -355,11 +356,15 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
     if hasViewerFrame and buttonData.auraTracking == nil then
         buttonData.auraTracking = true
         local overrideBuffs = CooldownCompanion.ABILITY_BUFF_OVERRIDES[buttonData.id]
-        if overrideBuffs and not buttonData.auraSpellID then
+        if overrideBuffs and not isAuraEntry and not buttonData.auraSpellID then
             buttonData.auraSpellID = overrideBuffs
         end
         EnsureAuraUnitChoice(buttonData, isHarmful)
         CooldownCompanion:RefreshGroupFrame(CS.selectedGroup)
+    end
+
+    if isAuraEntry then
+        buttonData.auraSpellID = CooldownCompanion:GetStandaloneAuraFallbackSpellIDText(buttonData)
     end
 
     local auraStatus = CooldownCompanion:ResolveAuraTrackingConfigStatus(
@@ -371,7 +376,10 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
     local auraFoundButUntracked = auraStatus.state == "associatedAuraNotTracked"
     local auraTrackedButUnavailable = auraStatus.state == "trackedAuraUnavailable"
     local auraInactiveColorCode = auraFoundButUntracked and "|cffffff00" or "|cffff0000"
-    local isAuraEntry = buttonData.addedAs == "aura"
+    local auraIdFieldLabel = isAuraEntry and "Fallback Aura IDs" or "Spell ID Override"
+    local auraIdFieldTooltip = isAuraEntry
+        and "The original aura entry is checked first. Add related buff/debuff spell IDs here as fallbacks for when the original aura is not present. Use commas only when one entry should intentionally watch multiple IDs.\n\nUse \"Pick CDM\" below to visually select a spell from the Cooldown Manager."
+        or "Most spells are tracked automatically, but some abilities apply a buff or debuff with a different spell ID than the ability itself. If tracking isn't working, enter the buff/debuff spell ID here. Use commas only when one entry should intentionally watch multiple IDs.\n\nUse \"Pick CDM\" below to visually select a spell from the Cooldown Manager."
 
     if showHeading then
         local auraHeading = AceGUI:Create("Heading")
@@ -467,7 +475,7 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
         return
     end
 
-    local allowManualAuraConfig = not buttonData.isPassive or allowPassiveManualRecovery
+    local allowManualAuraConfig = isAuraEntry or not buttonData.isPassive or allowPassiveManualRecovery
 
     local function StartAuraSpellOverridePicker()
         local grp = CS.selectedGroup
@@ -480,9 +488,14 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
                 local groups = CooldownCompanion.db.profile.groups
                 local selectedGroup = groups[grp]
                 if selectedGroup and selectedGroup.buttons and selectedGroup.buttons[btn] then
-                    selectedGroup.buttons[btn].auraSpellID = tostring(spellID)
-                    if selectedGroup.buttons[btn].auraTracking then
-                        EnsureAuraUnitChoice(selectedGroup.buttons[btn], isHarmful)
+                    local selectedButton = selectedGroup.buttons[btn]
+                    if isAuraEntry then
+                        selectedButton.auraSpellID = CooldownCompanion:GetStandaloneAuraFallbackSpellIDText(selectedButton, tostring(spellID))
+                    else
+                        selectedButton.auraSpellID = tostring(spellID)
+                    end
+                    if selectedButton.auraTracking then
+                        EnsureAuraUnitChoice(selectedButton, isHarmful)
                     end
                 end
             end
@@ -496,7 +509,7 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
         if auraEditBox.editbox.Instructions then
             auraEditBox.editbox.Instructions:Hide()
         end
-        auraEditBox:SetLabel("Spell ID Override")
+        auraEditBox:SetLabel(auraIdFieldLabel)
         auraEditBox:SetText(buttonData.auraSpellID and tostring(buttonData.auraSpellID) or "")
         auraEditBox:SetFullWidth(true)
         auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
@@ -510,7 +523,11 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
                     end
                 end
             end
-            buttonData.auraSpellID = text ~= "" and text or nil
+            if isAuraEntry then
+                buttonData.auraSpellID = CooldownCompanion:GetStandaloneAuraFallbackSpellIDText(buttonData, text)
+            else
+                buttonData.auraSpellID = text ~= "" and text or nil
+            end
             if buttonData.auraTracking then
                 EnsureAuraUnitChoice(buttonData, isHarmful)
             end
@@ -520,8 +537,8 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
         scroll:AddChild(auraEditBox)
 
         CreateInfoButton(auraEditBox.frame, auraEditBox.frame, "TOPLEFT", "TOPLEFT", auraEditBox.label:GetStringWidth() + 4, -2, {
-            "Spell ID Override",
-            {"Most spells are tracked automatically, but some abilities apply a buff or debuff with a different spell ID than the ability itself. If tracking isn't working, enter the buff/debuff spell ID here. Use commas only when one entry should intentionally watch multiple IDs.\n\nUse \"Pick CDM\" below to visually select a spell from the Cooldown Manager.", 1, 1, 1, true},
+            auraIdFieldLabel,
+            {auraIdFieldTooltip, 1, 1, 1, true},
         }, infoButtons)
 
         local overrideCdmSpacer = AceGUI:Create("Label")
@@ -599,7 +616,7 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
         pickCDMBtn:SetCallback("OnEnter", function(widget)
             GameTooltip:SetOwner(widget.frame, "ANCHOR_TOP")
             GameTooltip:AddLine("Pick from Cooldown Manager")
-            GameTooltip:AddLine("Shows a list of Tracked Buff/Tracked Bar auras currently tracked in the Cooldown Manager. Click one to populate the Spell ID Override.", 1, 1, 1, true)
+            GameTooltip:AddLine("Shows a list of Tracked Buff/Tracked Bar auras currently tracked in the Cooldown Manager. Click one to populate " .. auraIdFieldLabel .. ".", 1, 1, 1, true)
             GameTooltip:Show()
         end)
         pickCDMBtn:SetCallback("OnLeave", function()
@@ -638,7 +655,10 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
         scroll:AddChild(cdmDisabledSpacer)
     elseif auraStatus.state == "noAssociatedAura" then
         local noAuraLabel = AceGUI:Create("Label")
-        SetupWrappedStatusLabel(scroll, noAuraLabel, "|cff888888No associated aura was found for this spell. Use the Spell ID Override above if you want to link it to a specific CDM-trackable aura.|r")
+        local noAuraText = isAuraEntry
+            and "|cff888888No associated aura was found. Add a fallback aura ID above if you want this entry to use another CDM-trackable aura when the original is not present.|r"
+            or "|cff888888No associated aura was found for this spell. Use the Spell ID Override above if you want to link it to a specific CDM-trackable aura.|r"
+        SetupWrappedStatusLabel(scroll, noAuraLabel, noAuraText)
         scroll:AddChild(noAuraLabel)
         local noAuraSpacer = AceGUI:Create("Label")
         noAuraSpacer:SetText(" ")

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -236,6 +236,111 @@ local function ResolveDirectBuffViewerSpellID(spellID)
     return nil
 end
 
+local function BuildStandaloneOriginalAuraCandidateIDs(buttonData)
+    local candidateIDs = {}
+    local orderedCandidateSet = {}
+    local orderedCandidateIDs = {}
+
+    if not (buttonData and buttonData.type == "spell") then
+        return orderedCandidateIDs, candidateIDs, orderedCandidateSet
+    end
+
+    local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
+
+    local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
+    if directAuraID then
+        AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, directAuraID)
+    end
+
+    local resolvedAuraId = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
+    if resolvedAuraId then
+        AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, resolvedAuraId)
+    end
+
+    AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData.id)
+    AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, baseId)
+
+    return orderedCandidateIDs, candidateIDs, orderedCandidateSet
+end
+
+local function AppendStandaloneFallbackAuraCandidateIDs(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData, rawIDs)
+    local _, originalCandidateSet = BuildStandaloneOriginalAuraCandidateIDs(buttonData)
+    if not rawIDs then
+        return
+    end
+    for id in tostring(rawIDs):gmatch("%d+") do
+        local numericID = tonumber(id)
+        if numericID and not originalCandidateSet[numericID] then
+            AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, numericID)
+        end
+    end
+end
+
+local function BuildStandaloneAuraFallbackSpellIDText(buttonData, rawIDs)
+    local _, originalCandidateSet = BuildStandaloneOriginalAuraCandidateIDs(buttonData)
+    local fallbackIDs = {}
+    local seen = {}
+    if not rawIDs then
+        return nil
+    end
+    for id in tostring(rawIDs):gmatch("%d+") do
+        local numericID = tonumber(id)
+        if numericID and not originalCandidateSet[numericID] and not seen[numericID] then
+            seen[numericID] = true
+            fallbackIDs[#fallbackIDs + 1] = tostring(numericID)
+        end
+    end
+    return #fallbackIDs > 0 and table.concat(fallbackIDs, ",") or nil
+end
+
+local function BuildOrderedAuraCandidateIDs(buttonData)
+    local candidateIDs = {}
+    local orderedCandidateSet = {}
+    local orderedCandidateIDs = {}
+
+    if not (buttonData and buttonData.type == "spell") then
+        return orderedCandidateIDs, candidateIDs, orderedCandidateSet
+    end
+
+    local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
+
+    local function AppendSpellAssociationAuraIDs()
+        AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData.id)
+        AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, baseId)
+
+        local resolvedAuraId = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
+        if resolvedAuraId then
+            AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, resolvedAuraId)
+        end
+    end
+
+    if buttonData.addedAs == "aura" then
+        local originalAuraIDs = BuildStandaloneOriginalAuraCandidateIDs(buttonData)
+        for _, spellID in ipairs(originalAuraIDs) do
+            AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, spellID)
+        end
+        AppendStandaloneFallbackAuraCandidateIDs(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData, buttonData.auraSpellID)
+    else
+        AppendOrderedAuraCandidateIDsFromString(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData.auraSpellID)
+        AppendSpellAssociationAuraIDs()
+    end
+
+    local overrideBuffs = CooldownCompanion.ABILITY_BUFF_OVERRIDES and CooldownCompanion.ABILITY_BUFF_OVERRIDES[buttonData.id]
+    if overrideBuffs then
+        AppendOrderedAuraCandidateIDsFromString(candidateIDs, orderedCandidateSet, orderedCandidateIDs, overrideBuffs)
+    end
+
+    return orderedCandidateIDs, candidateIDs, orderedCandidateSet
+end
+
+function CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
+    return BuildOrderedAuraCandidateIDs(buttonData)
+end
+
+function CooldownCompanion:GetStandaloneAuraFallbackSpellIDText(buttonData, rawIDs)
+    return BuildStandaloneAuraFallbackSpellIDText(buttonData, rawIDs or (buttonData and buttonData.auraSpellID))
+end
+
 local function CooldownInfoMatchesCandidateSet(cooldownInfo, candidateSet)
     if type(cooldownInfo) ~= "table" then
         return false
@@ -443,9 +548,13 @@ end
 
 function CooldownCompanion:ResolveAuraSpellID(buttonData)
     if not buttonData.auraTracking then return nil end
-    if buttonData.auraSpellID then
+    if buttonData.addedAs ~= "aura" and buttonData.auraSpellID then
         local first = tostring(buttonData.auraSpellID):match("%d+")
         return first and tonumber(first)
+    end
+    if buttonData.addedAs == "aura" then
+        local orderedCandidateIDs = BuildOrderedAuraCandidateIDs(buttonData)
+        return orderedCandidateIDs[1]
     end
     if buttonData.type == "spell" then
         local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
@@ -552,7 +661,7 @@ function CooldownCompanion:ResolveStandaloneAuraDefaultSpellID(buttonData)
         return resolvedID
     end
 
-    local explicitAuraID = ResolveSingleSpellID(buttonData.auraSpellID)
+    local explicitAuraID = buttonData.addedAs ~= "aura" and ResolveSingleSpellID(buttonData.auraSpellID) or nil
     if explicitAuraID then
         return explicitAuraID
     end
@@ -622,23 +731,10 @@ function CooldownCompanion:ResolveAuraTrackingAssociationData(buttonData, viewer
     end
 
     local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
-    local candidateIDs = {}
-    local orderedCandidateSet = {}
-    local orderedCandidateIDs = {}
-
-    AppendOrderedAuraCandidateIDsFromString(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData.auraSpellID)
-    AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData.id)
-    AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, baseId)
-
+    local orderedCandidateIDs, candidateIDs, orderedCandidateSet = BuildOrderedAuraCandidateIDs(buttonData)
     local resolvedAuraId = C_UnitAuras.GetCooldownAuraBySpellID(baseId)
     if resolvedAuraId and resolvedAuraId ~= 0 then
         data.hasAssociatedAura = true
-        AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, resolvedAuraId)
-    end
-
-    local overrideBuffs = self.ABILITY_BUFF_OVERRIDES[buttonData.id]
-    if overrideBuffs then
-        AppendOrderedAuraCandidateIDsFromString(candidateIDs, orderedCandidateSet, orderedCandidateIDs, overrideBuffs)
     end
 
     local function MergeCooldownInfo(cooldownInfo)
@@ -761,7 +857,13 @@ function CooldownCompanion:NormalizeStandaloneAuraButtonData(buttonData, sibling
         changed = true
     end
 
-    if not buttonData.auraSpellID then
+    if buttonData.addedAs == "aura" then
+        local fallbackIDs = self:GetStandaloneAuraFallbackSpellIDText(buttonData)
+        if buttonData.auraSpellID ~= fallbackIDs then
+            buttonData.auraSpellID = fallbackIDs
+            changed = true
+        end
+    elseif not buttonData.auraSpellID then
         local inferredAuraSpellID = self:InferConfirmedAuraSpellIDString(buttonData)
         if inferredAuraSpellID then
             buttonData.auraSpellID = inferredAuraSpellID

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -281,6 +281,20 @@ local function AppendStandaloneFallbackAuraCandidateIDs(candidateIDs, orderedCan
     end
 end
 
+local function BuildStandaloneFallbackAuraCandidateIDs(buttonData, rawIDs)
+    local fallbackCandidateIDs = {}
+    local fallbackCandidateSet = {}
+    local fallbackOrderedSet = {}
+    AppendStandaloneFallbackAuraCandidateIDs(
+        fallbackCandidateSet,
+        fallbackOrderedSet,
+        fallbackCandidateIDs,
+        buttonData,
+        rawIDs
+    )
+    return fallbackCandidateIDs, fallbackCandidateSet, fallbackOrderedSet
+end
+
 local function BuildStandaloneAuraFallbackSpellIDText(buttonData, rawIDs)
     local _, originalCandidateSet = BuildStandaloneOriginalAuraCandidateIDs(buttonData)
     local fallbackIDs = {}
@@ -342,6 +356,12 @@ end
 
 function CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
     return BuildOrderedAuraCandidateIDs(buttonData)
+end
+
+function CooldownCompanion:GetStandaloneAuraCandidateGroups(buttonData)
+    local originalAuraIDs = BuildStandaloneOriginalAuraCandidateIDs(buttonData)
+    local fallbackAuraIDs = BuildStandaloneFallbackAuraCandidateIDs(buttonData, buttonData and buttonData.auraSpellID)
+    return originalAuraIDs, fallbackAuraIDs
 end
 
 function CooldownCompanion:GetStandaloneAuraFallbackSpellIDText(buttonData, rawIDs)

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -260,6 +260,11 @@ local function BuildStandaloneOriginalAuraCandidateIDs(buttonData)
     AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, buttonData.id)
     AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, baseId)
 
+    local overrideBuffs = CooldownCompanion.ABILITY_BUFF_OVERRIDES and CooldownCompanion.ABILITY_BUFF_OVERRIDES[buttonData.id]
+    if overrideBuffs then
+        AppendOrderedAuraCandidateIDsFromString(candidateIDs, orderedCandidateSet, orderedCandidateIDs, overrideBuffs)
+    end
+
     return orderedCandidateIDs, candidateIDs, orderedCandidateSet
 end
 
@@ -325,7 +330,9 @@ local function BuildOrderedAuraCandidateIDs(buttonData)
         AppendSpellAssociationAuraIDs()
     end
 
-    local overrideBuffs = CooldownCompanion.ABILITY_BUFF_OVERRIDES and CooldownCompanion.ABILITY_BUFF_OVERRIDES[buttonData.id]
+    local overrideBuffs = buttonData.addedAs ~= "aura"
+        and CooldownCompanion.ABILITY_BUFF_OVERRIDES
+        and CooldownCompanion.ABILITY_BUFF_OVERRIDES[buttonData.id]
     if overrideBuffs then
         AppendOrderedAuraCandidateIDsFromString(candidateIDs, orderedCandidateSet, orderedCandidateIDs, overrideBuffs)
     end

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -48,6 +48,16 @@ local function PlayerHasTrackedAuraForButton(button, buttonData)
         return true
     end
 
+    if buttonData.type == "spell" and buttonData.addedAs == "aura" then
+        local orderedAuraIDs = CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
+        for _, spellID in ipairs(orderedAuraIDs) do
+            if C_UnitAuras.GetPlayerAuraBySpellID(spellID) then
+                return true
+            end
+        end
+        return false
+    end
+
     if buttonData.auraSpellID then
         local includesButtonID
         for id in tostring(buttonData.auraSpellID):gmatch("%d+") do

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1390,7 +1390,7 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
                 newButton.auraTracking = true
                 newButton.auraIndicatorEnabled = true
                 local overrideBuffs = self.ABILITY_BUFF_OVERRIDES[id]
-                if overrideBuffs then
+                if overrideBuffs and newButton.addedAs ~= "aura" then
                     newButton.auraSpellID = overrideBuffs
                 end
             end

--- a/Core/SoundAlerts.lua
+++ b/Core/SoundAlerts.lua
@@ -273,21 +273,30 @@ local function BuildAuraSourceSpellIDs(self, buttonData, spellIDOverride)
     local spellIDs = {}
     local seen = {}
 
-    if buttonData and buttonData.auraSpellID then
-        for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-            AddUniqueSpellID(spellIDs, seen, tonumber(id))
+    if buttonData and buttonData.type == "spell" and buttonData.addedAs == "aura" then
+        local orderedAuraIDs = self.GetOrderedAuraCandidateIDs and self:GetOrderedAuraCandidateIDs(buttonData) or nil
+        if orderedAuraIDs then
+            for _, spellID in ipairs(orderedAuraIDs) do
+                AddUniqueSpellID(spellIDs, seen, spellID)
+            end
         end
-    end
-
-    if buttonData and buttonData.type == "spell" then
-        local auraID = C_UnitAuras.GetCooldownAuraBySpellID(buttonData.id)
-        AddUniqueSpellID(spellIDs, seen, auraID)
-        AddUniqueSpellID(spellIDs, seen, buttonData.id)
-
-        local overrideBuffs = self.ABILITY_BUFF_OVERRIDES and self.ABILITY_BUFF_OVERRIDES[buttonData.id]
-        if overrideBuffs then
-            for id in tostring(overrideBuffs):gmatch("%d+") do
+    elseif buttonData then
+        if buttonData.auraSpellID then
+            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
                 AddUniqueSpellID(spellIDs, seen, tonumber(id))
+            end
+        end
+
+        if buttonData.type == "spell" then
+            local auraID = C_UnitAuras.GetCooldownAuraBySpellID(buttonData.id)
+            AddUniqueSpellID(spellIDs, seen, auraID)
+            AddUniqueSpellID(spellIDs, seen, buttonData.id)
+
+            local overrideBuffs = self.ABILITY_BUFF_OVERRIDES and self.ABILITY_BUFF_OVERRIDES[buttonData.id]
+            if overrideBuffs then
+                for id in tostring(overrideBuffs):gmatch("%d+") do
+                    AddUniqueSpellID(spellIDs, seen, tonumber(id))
+                end
             end
         end
     end


### PR DESCRIPTION
## What Players Will Notice
- Standalone aura entries can now watch optional fallback aura IDs without showing or requiring the entry's own aura ID in the field.
- When both the original aura and a fallback aura are present, the original aura takes priority.
- The standalone aura settings now use `Fallback Aura IDs`, matching the spell + aura tracking flow while keeping fallback behavior clear.

## Why This Changed
- Standalone aura entries needed parity with spell-attached aura tracking for cases where one tracked entry may need to recognize related aura IDs.
- The visible field should only represent user-entered fallbacks; the aura chosen for the entry is already implied by the entry itself.

## What Changed
- Split standalone aura candidates into hidden original IDs and visible fallback IDs.
- Filtered standalone fallback text so self-matching IDs, resolved base IDs, and hardcoded original associations are not shown as user fallbacks.
- Updated runtime aura selection so original candidates are checked before fallback candidates across aura instance, viewer cooldown, and TrackedBar/totem duration paths.
- Updated config, event readiness, sound-alert source IDs, and add-time defaulting to honor standalone fallback semantics while preserving spell-attached `Spell ID Override` behavior.

## Validation
- `luac -p` on changed Lua files passed.
- Full repository Lua parse passed.
- `git diff --check origin/main...HEAD` passed.
- In-game fallback ordering was verified by the user.
- In-game combat behavior was verified by the user.
- Restricted-content verification was not separately confirmed.