### PR TITLE
Show the Blizzard CDM activation button only when needed

### DIFF
--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -977,21 +977,20 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
         scroll:AddChild(auraUnitSpacer)
     end
 
-    local cdmToggleBtn = AceGUI:Create("Button")
-    cdmToggleBtn:SetText(cdmEnabled and "Blizzard CDM: |cff00ff00Active|r" or "Blizzard CDM: |cffff0000Inactive|r")
-    cdmToggleBtn:SetFullWidth(true)
-    cdmToggleBtn:SetCallback("OnClick", function()
-        local current = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
-        C_CVar.SetCVar("cooldownViewerEnabled", current and "0" or "1")
-        CooldownCompanion:RefreshConfigPanel()
-        if not current then
+    if not cdmEnabled then
+        local cdmToggleBtn = AceGUI:Create("Button")
+        cdmToggleBtn:SetText("Blizzard CDM: |cffff0000Inactive|r")
+        cdmToggleBtn:SetFullWidth(true)
+        cdmToggleBtn:SetCallback("OnClick", function()
+            C_CVar.SetCVar("cooldownViewerEnabled", "1")
+            CooldownCompanion:RefreshConfigPanel()
             C_Timer.After(0.2, function()
                 CooldownCompanion:BuildViewerAuraMap()
                 CooldownCompanion:RefreshConfigPanel()
             end)
-        end
-    end)
-    scroll:AddChild(cdmToggleBtn)
+        end)
+        scroll:AddChild(cdmToggleBtn)
+    end
 
     local cdmRow = AceGUI:Create("SimpleGroup")
     cdmRow:SetFullWidth(true)


### PR DESCRIPTION
## What Players Will Notice
- In Aura Tracking settings, the Blizzard CDM button only appears when Blizzard CDM is disabled.
- Clicking the button still turns Blizzard CDM on, but the active-state button is no longer shown once CDM is already enabled.

## Why This Changed
- The addon should keep CDM setup help to the smallest safe action: enabling Blizzard CDM when it is off.
- Hiding the already-active button avoids presenting CDM as a toggle in this section and keeps the UI focused on the one setup step the addon can safely perform.

## What Changed
- Gated the `Blizzard CDM: Inactive` button behind the existing `cooldownViewerEnabled` CVar state.
- Simplified the click handler so it only sets `cooldownViewerEnabled` to `1`, refreshes the config panel, and rebuilds the viewer aura map after CDM has a moment to initialize.
- Removed the previous disable/toggle behavior from this Aura Tracking button.

## Validation
- Verified `C_CVar.SetCVar` and `C_CVar.GetCVarBool` signatures with the WoW API MCP.
- Ran `luac -p ConfigSettings\ButtonSettings.lua`.
- Ran `git diff --check origin/main...HEAD`.
- In-game, combat, and restricted-content validation are still pending.