### PR TITLE
Add optional one-pixel border thickness

### DIFF
--- a/BORDER_RENDERING.md
+++ b/BORDER_RENDERING.md
@@ -1,16 +1,16 @@
-# Border Rendering
+# Border Thickness Modes
 
-Cooldown Companion supports two border rendering modes:
+Cooldown Companion supports two border thickness modes:
 
 - `custom`: preserves the existing UI-unit border thickness behavior, including fractional values from `0.1`-step sliders.
-- `crisp`: renders the border as one physical pixel using Blizzard `PixelUtil`.
+- `crisp`: the internal value for the user-facing `One-pixel` option, which renders the border as one physical pixel using Blizzard `PixelUtil`.
 
 The shared implementation lives in `Core/Utils.lua`. Runtime and preview callers should use the CC helpers there instead of adding local pixel conversion math.
 
 ## Audit Checklist
 
-- Crisp borders call Blizzard `PixelUtil` through `Core/Utils.lua`.
+- One-pixel borders call Blizzard `PixelUtil` through `Core/Utils.lua`.
 - Custom thickness remains a separate path and keeps existing `borderSize` values as UI-unit thickness.
 - Missing render-mode settings resolve to `custom`, so existing profiles are not reinterpreted.
 - The code does not add a custom UI scale multiplier or a general layout toolkit.
-- Feature text should describe this as an optional crisp one-pixel border mode, not as a broad UI scaling system.
+- Feature text should describe this as an optional one-pixel border thickness mode, not as a broad UI scaling system.

--- a/BORDER_RENDERING.md
+++ b/BORDER_RENDERING.md
@@ -1,0 +1,16 @@
+# Border Rendering
+
+Cooldown Companion supports two border rendering modes:
+
+- `custom`: preserves the existing UI-unit border thickness behavior, including fractional values from `0.1`-step sliders.
+- `crisp`: renders the border as one physical pixel using Blizzard `PixelUtil`.
+
+The shared implementation lives in `Core/Utils.lua`. Runtime and preview callers should use the CC helpers there instead of adding local pixel conversion math.
+
+## Audit Checklist
+
+- Crisp borders call Blizzard `PixelUtil` through `Core/Utils.lua`.
+- Custom thickness remains a separate path and keeps existing `borderSize` values as UI-unit thickness.
+- Missing render-mode settings resolve to `custom`, so existing profiles are not reinterpreted.
+- The code does not add a custom UI scale multiplier or a general layout toolkit.
+- Feature text should describe this as an optional crisp one-pixel border mode, not as a broad UI scaling system.

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -28,6 +28,7 @@ local SetIconAreaPoints = ST._SetIconAreaPoints
 local SetBarAreaPoints = ST._SetBarAreaPoints
 local AnchorBarCountText = ST._AnchorBarCountText
 local ApplyEdgePositions = ST._ApplyEdgePositions
+local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
@@ -481,6 +482,7 @@ local function BuildBarAuraStackLayoutKey(button, mode, maxStacks, width, height
         tostring(style.barTexture or "Solid"),
         tostring(style.borderStyle or "pixel"),
         tostring(style.borderSize or ST.DEFAULT_BORDER_SIZE or 1),
+        tostring(ST.GetBorderRenderMode(style)),
         BarAuraColorKey(style.barBgColor),
         BarAuraColorKey(style.borderColor),
         BarAuraColorKey(auraBar and auraBar.thresholdMaxColor),
@@ -540,6 +542,7 @@ local function GetBarAuraStackVisualDirtyState(button, mode, maxStacks, stackVal
         or state.barTexture ~= (style.barTexture or "Solid")
         or state.borderStyle ~= (style.borderStyle or "pixel")
         or state.borderSize ~= (style.borderSize or ST.DEFAULT_BORDER_SIZE or 1)
+        or state.borderRenderMode ~= ST.GetBorderRenderMode(style)
         or state.showThreshold ~= showThreshold
         or state.maxStacksGlowEnabled ~= (auraBar and auraBar.maxStacksGlowEnabled == true)
         or state.maxStacksGlowStyle ~= (auraBar and auraBar.maxStacksGlowStyle or nil)
@@ -576,6 +579,7 @@ local function GetBarAuraStackVisualDirtyState(button, mode, maxStacks, stackVal
         state.barTexture = style.barTexture or "Solid"
         state.borderStyle = style.borderStyle or "pixel"
         state.borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+        state.borderRenderMode = ST.GetBorderRenderMode(style)
         state.showThreshold = showThreshold
         state.maxStacksGlowEnabled = auraBar and auraBar.maxStacksGlowEnabled == true
         state.maxStacksGlowStyle = auraBar and auraBar.maxStacksGlowStyle or nil
@@ -623,6 +627,7 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
     local barTexture = CooldownCompanion:FetchStatusBar(button.style and button.style.barTexture or "Solid")
     local borderStyle = button.style and button.style.borderStyle or "pixel"
     local borderSize = button.style and button.style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+    local borderRenderMode = ST.GetBorderRenderMode(button.style)
     local layoutKey = BuildBarAuraStackLayoutKey(button, mode, maxStacks, width, height, gap, showThreshold)
     local layoutChanged = button._barAuraStackLayoutKey ~= layoutKey
 
@@ -639,7 +644,7 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
         if showThreshold and RB.EnsureCustomAuraContinuousThresholdOverlay and RB.LayoutCustomAuraContinuousThresholdOverlay then
             RB.EnsureCustomAuraContinuousThresholdOverlay(button.statusBar)
             if layoutChanged then
-                RB.LayoutCustomAuraContinuousThresholdOverlay(button.statusBar, barTexture, borderStyle, borderSize)
+                RB.LayoutCustomAuraContinuousThresholdOverlay(button.statusBar, barTexture, borderStyle, borderSize, borderRenderMode)
             end
             local overlay = button.statusBar.thresholdOverlay
             if overlay then
@@ -723,6 +728,7 @@ local function BuildBarAuraStackIndicatorKey(button, info, glowConfig, mode, max
         tostring(style.barTexture or "Solid"),
         tostring(style.borderStyle or "pixel"),
         tostring(style.borderSize or ST.DEFAULT_BORDER_SIZE or 1),
+        tostring(ST.GetBorderRenderMode(style)),
     }, "|")
 end
 
@@ -790,7 +796,8 @@ local function UpdateBarAuraStackIndicator(button, mode, maxStacks, stackValue, 
             maxStacks,
             CooldownCompanion:FetchStatusBar(button.style and button.style.barTexture or "Solid"),
             button.style and button.style.borderStyle or "pixel",
-            button.style and button.style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+            button.style and button.style.borderSize or ST.DEFAULT_BORDER_SIZE or 1,
+            ST.GetBorderRenderMode(button.style)
         )
         info._barAuraStackIndicatorKey = indicatorKey
     end
@@ -1313,6 +1320,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     local barLength = style.barLength or 180
     local barHeight = style.barHeight or 20
     local borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE
+    local borderRenderMode = ST.GetBorderRenderMode(style)
     local showIcon = style.showBarIcon ~= false
     local isVertical = style.barFillVertical or false
     local iconReverse = showIcon and (style.barIconReverse or false)
@@ -1345,7 +1353,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     -- Icon
     button.icon = button:CreateTexture(nil, "ARTWORK")
     if showIcon then
-        SetIconAreaPoints(button.icon, button, isVertical, iconReverse, iconSize, borderSize)
+        SetIconAreaPoints(button.icon, button, isVertical, iconReverse, iconSize, ST.GetBorderLayoutSize(button, borderSize, borderRenderMode))
         button.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
     else
         -- Hidden 1x1 icon (still needed for UpdateButtonIcon)
@@ -1372,7 +1380,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
         if not showIcon then tex:Hide() end
         button.iconBorderTextures[i] = tex
     end
-    ApplyEdgePositions(button.iconBorderTextures, button._iconBounds, borderSize)
+    ApplyBorderEdgePositions(button.iconBorderTextures, button._iconBounds, borderSize, borderRenderMode)
 
     -- Bar area bounds (for border positioning separate from icon)
     button._barBounds = CreateFrame("Frame", nil, button)
@@ -1385,7 +1393,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
 
     -- StatusBar
     button.statusBar = CreateFrame("StatusBar", nil, button)
-    SetBarAreaPoints(button.statusBar, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderSize)
+    SetBarAreaPoints(button.statusBar, button, isVertical, iconReverse, barAreaLeft, barAreaTop, ST.GetBorderLayoutSize(button, borderSize, borderRenderMode))
     if isVertical then
         button.statusBar:SetOrientation("VERTICAL")
     end
@@ -1399,7 +1407,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
 
     -- Dedicated text layer above custom segment holders.
     button.barTextFrame = CreateFrame("Frame", nil, button)
-    SetBarAreaPoints(button.barTextFrame, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderSize)
+    SetBarAreaPoints(button.barTextFrame, button, isVertical, iconReverse, barAreaLeft, barAreaTop, ST.GetBorderLayoutSize(button, borderSize, borderRenderMode))
     button.barTextFrame:SetFrameLevel(button.statusBar:GetFrameLevel() + 20)
     button.barTextFrame:EnableMouse(false)
 
@@ -1470,7 +1478,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
         tex:SetColorTexture(unpack(borderColor))
         button.borderTextures[i] = tex
     end
-    ApplyEdgePositions(button.borderTextures, button._barBounds, borderSize)
+    ApplyBorderEdgePositions(button.borderTextures, button._barBounds, borderSize, borderRenderMode)
 
     -- Loss of control cooldown frame (red swipe over the bar icon)
     button.locCooldown = CreateFrame("Cooldown", button:GetName() .. "LocCooldown", button, "CooldownFrameTemplate")
@@ -1647,6 +1655,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     local barLength = newStyle.barLength or 180
     local barHeight = newStyle.barHeight or 20
     local borderSize = newStyle.borderSize or ST.DEFAULT_BORDER_SIZE
+    local borderRenderMode = ST.GetBorderRenderMode(newStyle)
+    local borderLayoutSize = ST.GetBorderLayoutSize(button, borderSize, borderRenderMode)
     local showIcon = newStyle.showBarIcon ~= false
     local isVertical = newStyle.barFillVertical or false
     local iconReverse = showIcon and (newStyle.barIconReverse or false)
@@ -1732,7 +1742,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     -- Update icon
     button.icon:ClearAllPoints()
     if showIcon then
-        SetIconAreaPoints(button.icon, button, isVertical, iconReverse, iconSize, borderSize)
+        SetIconAreaPoints(button.icon, button, isVertical, iconReverse, iconSize, borderLayoutSize)
         button.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
         button.icon:SetAlpha(1)
     else
@@ -1766,7 +1776,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
         SetIconAreaPoints(button._iconBounds, button, isVertical, iconReverse, iconSize, 0)
     end
     if button.iconBorderTextures then
-        ApplyEdgePositions(button.iconBorderTextures, button._iconBounds, borderSize)
+        ApplyBorderEdgePositions(button.iconBorderTextures, button._iconBounds, borderSize, borderRenderMode)
         for _, tex in ipairs(button.iconBorderTextures) do
             if showIcon then tex:Show() else tex:Hide() end
         end
@@ -1783,7 +1793,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     end
 
     -- Update status bar
-    SetBarAreaPoints(button.statusBar, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderSize)
+    SetBarAreaPoints(button.statusBar, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderLayoutSize)
     if isVertical then
         button.statusBar:SetOrientation("VERTICAL")
     else
@@ -1796,7 +1806,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
 
     if button.barTextFrame then
         button.barTextFrame:ClearAllPoints()
-        SetBarAreaPoints(button.barTextFrame, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderSize)
+        SetBarAreaPoints(button.barTextFrame, button, isVertical, iconReverse, barAreaLeft, barAreaTop, borderLayoutSize)
         button.barTextFrame:SetFrameLevel(button.statusBar:GetFrameLevel() + 20)
     end
 
@@ -1810,7 +1820,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     -- Update border
     local borderColor = newStyle.borderColor or {0, 0, 0, 1}
     if button.borderTextures then
-        ApplyEdgePositions(button.borderTextures, button._barBounds or button, borderSize)
+        ApplyBorderEdgePositions(button.borderTextures, button._barBounds or button, borderSize, borderRenderMode)
         for _, tex in ipairs(button.borderTextures) do
             tex:SetColorTexture(unpack(borderColor))
             tex:Show()

--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -27,7 +27,6 @@ local InCombatLockdown = InCombatLockdown
 local SetIconAreaPoints = ST._SetIconAreaPoints
 local SetBarAreaPoints = ST._SetBarAreaPoints
 local AnchorBarCountText = ST._AnchorBarCountText
-local ApplyEdgePositions = ST._ApplyEdgePositions
 local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
@@ -144,6 +143,7 @@ local function GetBarAuraVisualSettings(button)
     settings.borderStyle = style.borderStyle or "pixel"
     settings.borderColor = style.borderColor or {0, 0, 0, 1}
     settings.borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
+    settings.borderRenderMode = ST.GetBorderRenderMode(style)
 
     local RB = GetResourceBarVisuals()
     local specID = RB and RB.GetCurrentSpecID and RB.GetCurrentSpecID()
@@ -158,6 +158,7 @@ local function GetBarAuraVisualSettings(button)
         profile.borderStyle = settings.borderStyle
         profile.borderColor = settings.borderColor
         profile.borderSize = settings.borderSize
+        profile.borderRenderMode = settings.borderRenderMode
     end
 
     return settings

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -645,31 +645,13 @@ local function ApplyStrataOrder(button, order)
     end
 end
 
--- Shared edge anchor spec from Utils.lua
-local EDGE_ANCHOR_SPEC = ST.EDGE_ANCHOR_SPEC
-
 -- Apply edge positions to 4 border/highlight textures using the shared spec
 local function ApplyEdgePositions(textures, button, size)
-    if ST.PositionBorderTextures then
-        ST.PositionBorderTextures(textures, button, size, ST.BORDER_RENDER_MODE_CUSTOM)
-        return
-    end
-
-    for i, spec in ipairs(EDGE_ANCHOR_SPEC) do
-        local tex = textures[i]
-        tex:ClearAllPoints()
-        tex:SetPoint(spec[1], button, spec[2], spec[5] * size, spec[6] * size)
-        tex:SetPoint(spec[3], button, spec[4], spec[7] * size, spec[8] * size)
-    end
+    ST.PositionBorderTextures(textures, button, size, ST.BORDER_RENDER_MODE_CUSTOM)
 end
 
 local function ApplyBorderEdgePositions(textures, button, size, renderMode)
-    if ST.PositionBorderTextures then
-        ST.PositionBorderTextures(textures, button, size, renderMode)
-        return
-    end
-
-    ApplyEdgePositions(textures, button, size)
+    ST.PositionBorderTextures(textures, button, size, renderMode)
 end
 
 -- Apply aspect-ratio-aware texture cropping to an icon.

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -650,12 +650,26 @@ local EDGE_ANCHOR_SPEC = ST.EDGE_ANCHOR_SPEC
 
 -- Apply edge positions to 4 border/highlight textures using the shared spec
 local function ApplyEdgePositions(textures, button, size)
+    if ST.PositionBorderTextures then
+        ST.PositionBorderTextures(textures, button, size, ST.BORDER_RENDER_MODE_CUSTOM)
+        return
+    end
+
     for i, spec in ipairs(EDGE_ANCHOR_SPEC) do
         local tex = textures[i]
         tex:ClearAllPoints()
         tex:SetPoint(spec[1], button, spec[2], spec[5] * size, spec[6] * size)
         tex:SetPoint(spec[3], button, spec[4], spec[7] * size, spec[8] * size)
     end
+end
+
+local function ApplyBorderEdgePositions(textures, button, size, renderMode)
+    if ST.PositionBorderTextures then
+        ST.PositionBorderTextures(textures, button, size, renderMode)
+        return
+    end
+
+    ApplyEdgePositions(textures, button, size)
 end
 
 -- Apply aspect-ratio-aware texture cropping to an icon.
@@ -726,5 +740,6 @@ ST._SetBarAreaPoints = SetBarAreaPoints
 ST._AnchorBarCountText = AnchorBarCountText
 ST._ApplyStrataOrder = ApplyStrataOrder
 ST._ApplyEdgePositions = ApplyEdgePositions
+ST._ApplyBorderEdgePositions = ApplyBorderEdgePositions
 ST._ApplyIconTexCoord = ApplyIconTexCoord
 ST._FitHighlightFrame = FitHighlightFrame

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -21,6 +21,7 @@ local GetTime = GetTime
 -- Imports from Helpers
 local ApplyStrataOrder = ST._ApplyStrataOrder
 local ApplyEdgePositions = ST._ApplyEdgePositions
+local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local FitHighlightFrame = ST._FitHighlightFrame
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
@@ -490,8 +491,10 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Icon
     button.icon = button:CreateTexture(nil, "ARTWORK")
     local borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE
-    button.icon:SetPoint("TOPLEFT", borderSize, -borderSize)
-    button.icon:SetPoint("BOTTOMRIGHT", -borderSize, borderSize)
+    local borderRenderMode = ST.GetBorderRenderMode(style)
+    local borderLayoutSize = ST.GetBorderLayoutSize(button, borderSize, borderRenderMode)
+    button.icon:SetPoint("TOPLEFT", borderLayoutSize, -borderLayoutSize)
+    button.icon:SetPoint("BOTTOMRIGHT", -borderLayoutSize, borderLayoutSize)
 
     ApplyIconTexCoord(button.icon, width, height)
 
@@ -515,7 +518,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
         tex:SetColorTexture(unpack(borderColor))
         button.borderTextures[i] = tex
     end
-    ApplyEdgePositions(button.borderTextures, button, borderSize)
+    ApplyBorderEdgePositions(button.borderTextures, button, borderSize, borderRenderMode)
 
     -- Assisted highlight overlays (multiple styles, all hidden by default)
     button.assistedHighlight = CreateAssistedHighlight(button, style)
@@ -1240,6 +1243,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     end
 
     local borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE
+    local borderRenderMode = ST.GetBorderRenderMode(style)
+    local borderLayoutSize = ST.GetBorderLayoutSize(button, borderSize, borderRenderMode)
 
     -- Store updated style reference
     button.style = style
@@ -1302,8 +1307,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Update icon position
     button.icon:ClearAllPoints()
-    button.icon:SetPoint("TOPLEFT", borderSize, -borderSize)
-    button.icon:SetPoint("BOTTOMRIGHT", -borderSize, borderSize)
+    button.icon:SetPoint("TOPLEFT", borderLayoutSize, -borderLayoutSize)
+    button.icon:SetPoint("BOTTOMRIGHT", -borderLayoutSize, borderLayoutSize)
 
     ApplyIconTexCoord(button.icon, width, height)
 
@@ -1321,7 +1326,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Update border textures
     local borderColor = style.borderColor or {0, 0, 0, 1}
     if button.borderTextures then
-        ApplyEdgePositions(button.borderTextures, button, borderSize)
+        ApplyBorderEdgePositions(button.borderTextures, button, borderSize, borderRenderMode)
         for _, tex in ipairs(button.borderTextures) do
             tex:SetColorTexture(unpack(borderColor))
         end

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -26,7 +26,6 @@ local C_UnitAuras_GetAuraApplicationDisplayCount = C_UnitAuras.GetAuraApplicatio
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
 -- Imports from Helpers
-local ApplyEdgePositions = ST._ApplyEdgePositions
 local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 
 -- Imports from Glows

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -27,6 +27,7 @@ local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
 -- Imports from Helpers
 local ApplyEdgePositions = ST._ApplyEdgePositions
+local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 
 -- Imports from Glows
 
@@ -748,11 +749,12 @@ local function UpdateTextStyle(button, newStyle)
 
     -- Border
     local borderSize = newStyle.textBorderSize or 0
+    local borderRenderMode = ST.GetBorderRenderMode(newStyle, "textBorderRenderMode")
     local borderColor = newStyle.textBorderColor or {0, 0, 0, 1}
     for i = 1, 4 do
         button.borderTextures[i]:SetColorTexture(unpack(borderColor))
     end
-    ApplyEdgePositions(button.borderTextures, button, borderSize)
+    ApplyBorderEdgePositions(button.borderTextures, button, borderSize, borderRenderMode)
 
     -- Font
     local font = CooldownCompanion:FetchFont(newStyle.textFont or "Friz Quadrata TT")
@@ -775,7 +777,8 @@ local function UpdateTextStyle(button, newStyle)
 
     -- Anchor text within frame respecting border
     button.textString:ClearAllPoints()
-    local inset = (borderSize > 0 and borderSize or 0) + 2
+    local borderLayoutSize = ST.GetBorderLayoutSize(button, borderSize, borderRenderMode)
+    local inset = ((borderSize > 0 or ST.IsCrispBorderRenderMode(borderRenderMode)) and borderLayoutSize or 0) + 2
     button.textString:SetPoint("TOPLEFT", inset, -1)
     button.textString:SetPoint("BOTTOMRIGHT", -inset, 1)
 
@@ -810,6 +813,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
 
     -- Border textures
     local borderSize = style.textBorderSize or 0
+    local borderRenderMode = ST.GetBorderRenderMode(style, "textBorderRenderMode")
     local borderColor = style.textBorderColor or {0, 0, 0, 1}
     button.borderTextures = {}
     for i = 1, 4 do
@@ -817,7 +821,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
         tex:SetColorTexture(unpack(borderColor))
         button.borderTextures[i] = tex
     end
-    ApplyEdgePositions(button.borderTextures, button, borderSize)
+    ApplyBorderEdgePositions(button.borderTextures, button, borderSize, borderRenderMode)
 
     -- Main text FontString
     button.textString = button:CreateFontString(nil, "OVERLAY")
@@ -840,7 +844,8 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
         button.textString:SetShadowOffset(0, 0)
     end
 
-    local inset = (borderSize > 0 and borderSize or 0) + 2
+    local borderLayoutSize = ST.GetBorderLayoutSize(button, borderSize, borderRenderMode)
+    local inset = ((borderSize > 0 or ST.IsCrispBorderRenderMode(borderRenderMode)) and borderLayoutSize or 0) + 2
     button.textString:SetPoint("TOPLEFT", inset, -1)
     button.textString:SetPoint("BOTTOMRIGHT", -inset, 1)
 

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -22,6 +22,7 @@ local AddColorPicker = ST._AddColorPicker
 local AddAnchorDropdown = ST._AddAnchorDropdown
 local AddFontControls = ST._AddFontControls
 local AddOffsetSliders = ST._AddOffsetSliders
+local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 
 -- Imports from SectionBuilders.lua
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
@@ -86,16 +87,23 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(heightSlider)
 
-    local borderSlider = AceGUI:Create("Slider")
-    borderSlider:SetLabel("Border Size")
-    borderSlider:SetSliderValues(0, 5, 0.1)
-    borderSlider:SetValue(style.borderSize or ST.DEFAULT_BORDER_SIZE)
-    borderSlider:SetFullWidth(true)
-    borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        style.borderSize = val
+    local renderMode = AddBorderRenderModeDropdown(container, style, "borderRenderMode", function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    container:AddChild(borderSlider)
+
+    if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+        local borderSlider = AceGUI:Create("Slider")
+        borderSlider:SetLabel("Border Size")
+        borderSlider:SetSliderValues(0, 5, 0.1)
+        borderSlider:SetValue(style.borderSize or ST.DEFAULT_BORDER_SIZE)
+        borderSlider:SetFullWidth(true)
+        borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            style.borderSize = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        container:AddChild(borderSlider)
+    end
 
     if group.buttons and #group.buttons > 1 then
         local spacingSlider = AceGUI:Create("Slider")

--- a/ConfigSettings/CastBarPanels.lua
+++ b/ConfigSettings/CastBarPanels.lua
@@ -14,6 +14,7 @@ local AddAnchorDropdown = ST._AddAnchorDropdown
 local HookSliderEditBox = ST._HookSliderEditBox
 local BuildIndependentAnchorTargetRow = ST._BuildIndependentAnchorTargetRow
 local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
+local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 
 ------------------------------------------------------------------------
 -- CAST BAR SETTINGS PANEL
@@ -342,16 +343,23 @@ local function BuildCastBarStylingPanel(container)
     if settings.borderStyle == "pixel" then
         AddColorPicker(container, settings, "borderColor", "Border Color", {0, 0, 0, 1}, true, applyCastBar)
 
-        local borderSizeSlider = AceGUI:Create("Slider")
-        borderSizeSlider:SetLabel("Border Size")
-        borderSizeSlider:SetSliderValues(0, 5, 0.1)
-        borderSizeSlider:SetValue(settings.borderSize or 1)
-        borderSizeSlider:SetFullWidth(true)
-        borderSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            settings.borderSize = val
+        local renderMode = AddBorderRenderModeDropdown(container, settings, "borderRenderMode", function()
             CooldownCompanion:ApplyCastBarSettings()
+            CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(borderSizeSlider)
+
+        if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+            local borderSizeSlider = AceGUI:Create("Slider")
+            borderSizeSlider:SetLabel("Border Size")
+            borderSizeSlider:SetSliderValues(0, 5, 0.1)
+            borderSizeSlider:SetValue(settings.borderSize or 1)
+            borderSizeSlider:SetFullWidth(true)
+            borderSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
+                settings.borderSize = val
+                CooldownCompanion:ApplyCastBarSettings()
+            end)
+            container:AddChild(borderSizeSlider)
+        end
     end
 
     -- ============ Size ============
@@ -448,16 +456,23 @@ local function BuildCastBarStylingPanel(container)
             container:AddChild(iconYSlider)
 
             -- Icon Border Size slider (offset mode only)
-            local iconBorderSlider = AceGUI:Create("Slider")
-            iconBorderSlider:SetLabel("Icon Border Size")
-            iconBorderSlider:SetSliderValues(0, 4, 0.1)
-            iconBorderSlider:SetValue(settings.iconBorderSize or 1)
-            iconBorderSlider:SetFullWidth(true)
-            iconBorderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                settings.iconBorderSize = val
+            local iconRenderMode = AddBorderRenderModeDropdown(container, settings, "iconBorderRenderMode", function()
                 CooldownCompanion:ApplyCastBarSettings()
+                CooldownCompanion:RefreshConfigPanel()
             end)
-            container:AddChild(iconBorderSlider)
+
+            if iconRenderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+                local iconBorderSlider = AceGUI:Create("Slider")
+                iconBorderSlider:SetLabel("Icon Border Size")
+                iconBorderSlider:SetSliderValues(0, 4, 0.1)
+                iconBorderSlider:SetValue(settings.iconBorderSize or 1)
+                iconBorderSlider:SetFullWidth(true)
+                iconBorderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+                    settings.iconBorderSize = val
+                    CooldownCompanion:ApplyCastBarSettings()
+                end)
+                container:AddChild(iconBorderSlider)
+            end
         end
     end
 

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -25,7 +25,9 @@ local HookSliderEditBox = ST._HookSliderEditBox
 local BuildAlphaControls = ST._BuildAlphaControls
 local OpenTriggerPanelIconPicker = ST._OpenTriggerPanelIconPicker
 local ApplyEdgePositions = ST._ApplyEdgePositions
+local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
+local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
 
 -- Imports from SectionBuilders.lua
@@ -617,6 +619,8 @@ local function BuildTriggerIconAppearanceTab(container, group)
         local height = settings.maintainAspectRatio and (settings.buttonSize or ST.BUTTON_SIZE)
             or (settings.iconHeight or settings.buttonSize or ST.BUTTON_SIZE)
         local borderSize = settings.borderSize or ST.DEFAULT_BORDER_SIZE
+        local borderRenderMode = ST.GetBorderRenderMode(settings)
+        local borderLayoutSize = ST.GetBorderLayoutSize(iconHolder, borderSize, borderRenderMode)
         local bgColor = settings.backgroundColor or { 0, 0, 0, 0.5 }
         local borderColor = settings.borderColor or { 0, 0, 0, 1 }
         local tintColor = settings.iconTintColor or { 1, 1, 1, 1 }
@@ -624,8 +628,8 @@ local function BuildTriggerIconAppearanceTab(container, group)
 
         iconHolder:SetSize(width, height)
         previewIcon:ClearAllPoints()
-        previewIcon:SetPoint("TOPLEFT", borderSize, -borderSize)
-        previewIcon:SetPoint("BOTTOMRIGHT", -borderSize, borderSize)
+        previewIcon:SetPoint("TOPLEFT", borderLayoutSize, -borderLayoutSize)
+        previewIcon:SetPoint("BOTTOMRIGHT", -borderLayoutSize, borderLayoutSize)
 
         if hasIcon then
             previewBg:SetColorTexture(bgColor[1] or 0, bgColor[2] or 0, bgColor[3] or 0, bgColor[4] ~= nil and bgColor[4] or 0.5)
@@ -634,7 +638,7 @@ local function BuildTriggerIconAppearanceTab(container, group)
                 border:SetColorTexture(borderColor[1] or 0, borderColor[2] or 0, borderColor[3] or 0, borderColor[4] ~= nil and borderColor[4] or 1)
                 border:Show()
             end
-            ApplyEdgePositions(previewBorders, iconHolder, borderSize)
+            ApplyBorderEdgePositions(previewBorders, iconHolder, borderSize, borderRenderMode)
             previewIcon:SetTexture(settings.manualIcon)
             previewIcon:SetVertexColor(tintColor[1] or 1, tintColor[2] or 1, tintColor[3] or 1, tintColor[4] ~= nil and tintColor[4] or 1)
             ApplyIconTexCoord(previewIcon, width, height)
@@ -736,17 +740,24 @@ local function BuildTriggerIconAppearanceTab(container, group)
         container:AddChild(heightSlider)
     end
 
-    local borderSlider = AceGUI:Create("Slider")
-    borderSlider:SetLabel("Border Size")
-    borderSlider:SetSliderValues(0, 5, 0.1)
-    borderSlider:SetValue(settings.borderSize or ST.DEFAULT_BORDER_SIZE)
-    borderSlider:SetFullWidth(true)
-    borderSlider:SetCallback("OnValueChanged", function(_, _, value)
-        settings.borderSize = value
+    local renderMode = AddBorderRenderModeDropdown(container, settings, "borderRenderMode", function()
         RefreshIconPreview()
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    HookSliderEditBox(borderSlider)
-    container:AddChild(borderSlider)
+
+    if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+        local borderSlider = AceGUI:Create("Slider")
+        borderSlider:SetLabel("Border Size")
+        borderSlider:SetSliderValues(0, 5, 0.1)
+        borderSlider:SetValue(settings.borderSize or ST.DEFAULT_BORDER_SIZE)
+        borderSlider:SetFullWidth(true)
+        borderSlider:SetCallback("OnValueChanged", function(_, _, value)
+            settings.borderSize = value
+            RefreshIconPreview()
+        end)
+        HookSliderEditBox(borderSlider)
+        container:AddChild(borderSlider)
+    end
 
     AddColorPicker(container, settings, "borderColor", "Border Color", { 0, 0, 0, 1 }, true, RefreshIconPreview, RefreshIconPreview)
     AddColorPicker(container, settings, "iconTintColor", "Base Icon Color", { 1, 1, 1, 1 }, true, RefreshIconPreview, RefreshIconPreview)
@@ -2631,19 +2642,26 @@ local function BuildAppearanceTab(container)
         container:AddChild(hSlider)
     end
 
-    local borderSlider = AceGUI:Create("Slider")
-    borderSlider:SetLabel("Border Size")
-    borderSlider:SetSliderValues(0, 5, 0.1)
-    borderSlider:SetValue(style.borderSize or ST.DEFAULT_BORDER_SIZE)
-    borderSlider:SetFullWidth(true)
-    if group.masqueEnabled then
-        borderSlider:SetDisabled(true)
-    end
-    borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        style.borderSize = val
+    local renderMode = AddBorderRenderModeDropdown(container, style, "borderRenderMode", function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(borderSlider)
+        CooldownCompanion:RefreshConfigPanel()
+    end, group.masqueEnabled)
+
+    if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+        local borderSlider = AceGUI:Create("Slider")
+        borderSlider:SetLabel("Border Size")
+        borderSlider:SetSliderValues(0, 5, 0.1)
+        borderSlider:SetValue(style.borderSize or ST.DEFAULT_BORDER_SIZE)
+        borderSlider:SetFullWidth(true)
+        if group.masqueEnabled then
+            borderSlider:SetDisabled(true)
+        end
+        borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            style.borderSize = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        container:AddChild(borderSlider)
+    end
 
     if group.buttons and #group.buttons > 1 then
         local spacingSlider = AceGUI:Create("Slider")
@@ -2960,7 +2978,7 @@ local function BuildAppearanceTab(container)
             {"Uses the Masque addon to apply custom button skins to this group. Configure skins via /masque or the Masque config panel.", 1, 1, 1, true},
             " ",
             {"Overridden Settings:", 1, 0.82, 0},
-            {"Border Size, Border Color, Square Icons (forced on)", 0.7, 0.7, 0.7, true},
+            {"Border Rendering, Border Size, Border Color, Square Icons (forced on)", 0.7, 0.7, 0.7, true},
         }, tabInfoButtons)
         end -- not masqueCollapsed
     end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -24,7 +24,6 @@ local AddOffsetSliders = ST._AddOffsetSliders
 local HookSliderEditBox = ST._HookSliderEditBox
 local BuildAlphaControls = ST._BuildAlphaControls
 local OpenTriggerPanelIconPicker = ST._OpenTriggerPanelIconPicker
-local ApplyEdgePositions = ST._ApplyEdgePositions
 local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2977,7 +2977,7 @@ local function BuildAppearanceTab(container)
             {"Uses the Masque addon to apply custom button skins to this group. Configure skins via /masque or the Masque config panel.", 1, 1, 1, true},
             " ",
             {"Overridden Settings:", 1, 0.82, 0},
-            {"Border Rendering, Border Size, Border Color, Square Icons (forced on)", 0.7, 0.7, 0.7, true},
+            {"Border Thickness, Border Size, Border Color, Square Icons (forced on)", 0.7, 0.7, 0.7, true},
         }, tabInfoButtons)
         end -- not masqueCollapsed
     end

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -1057,10 +1057,10 @@ local function AddBorderRenderModeDropdown(container, tbl, key, refreshFn, disab
     key = key or "borderRenderMode"
 
     local modeDrop = AceGUI:Create("Dropdown")
-    modeDrop:SetLabel("Border Rendering")
+    modeDrop:SetLabel("Border Thickness")
     modeDrop:SetList({
         [ST.BORDER_RENDER_MODE_CUSTOM] = "Custom Thickness",
-        [ST.BORDER_RENDER_MODE_CRISP] = "Crisp 1 Pixel",
+        [ST.BORDER_RENDER_MODE_CRISP] = "One-pixel",
     }, { ST.BORDER_RENDER_MODE_CUSTOM, ST.BORDER_RENDER_MODE_CRISP })
     modeDrop:SetValue(ST.GetBorderRenderMode(tbl, key))
     if modeDrop.SetDisabled then

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -1053,6 +1053,31 @@ local function AddOffsetSliders(container, tbl, xKey, yKey, defaults, refreshFn)
     container:AddChild(ySlider)
 end
 
+local function AddBorderRenderModeDropdown(container, tbl, key, refreshFn, disabled)
+    key = key or "borderRenderMode"
+
+    local modeDrop = AceGUI:Create("Dropdown")
+    modeDrop:SetLabel("Border Rendering")
+    modeDrop:SetList({
+        [ST.BORDER_RENDER_MODE_CUSTOM] = "Custom Thickness",
+        [ST.BORDER_RENDER_MODE_CRISP] = "Crisp 1 Pixel",
+    }, { ST.BORDER_RENDER_MODE_CUSTOM, ST.BORDER_RENDER_MODE_CRISP })
+    modeDrop:SetValue(ST.GetBorderRenderMode(tbl, key))
+    if modeDrop.SetDisabled then
+        modeDrop:SetDisabled(disabled == true)
+    end
+    modeDrop:SetFullWidth(true)
+    modeDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        tbl[key] = ST.GetBorderRenderMode(val)
+        if refreshFn then
+            refreshFn()
+        end
+    end)
+    container:AddChild(modeDrop)
+
+    return ST.GetBorderRenderMode(tbl, key)
+end
+
 -- Expose helpers for other ConfigSettings files
 ST._ColorHeading = ColorHeading
 ST._AttachCollapseButton = AttachCollapseButton
@@ -1316,3 +1341,4 @@ ST._BuildIndependentAnchorTargetRow = BuildIndependentAnchorTargetRow
 
 ST._AddFontControls = AddFontControls
 ST._AddOffsetSliders = AddOffsetSliders
+ST._AddBorderRenderModeDropdown = AddBorderRenderModeDropdown

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -1053,6 +1053,37 @@ local function AddOffsetSliders(container, tbl, xKey, yKey, defaults, refreshFn)
     container:AddChild(ySlider)
 end
 
+local BORDER_THICKNESS_MODE_TOOLTIPS = {
+    [ST.BORDER_RENDER_MODE_CUSTOM] = {
+        "Custom Thickness",
+        "Uses the Border Size slider, including fractional values.",
+    },
+    [ST.BORDER_RENDER_MODE_CRISP] = {
+        "One-pixel",
+        "Uses a stable one-pixel border for your current UI scale.",
+    },
+}
+
+local function AddDropdownItemTooltips(dropdown, tooltipByValue)
+    if not (dropdown and dropdown.pullout and tooltipByValue) then return end
+
+    for _, item in dropdown.pullout:IterateItems() do
+        local value = item.userdata and item.userdata.value
+        local tooltip = tooltipByValue[value]
+        if tooltip then
+            item:SetCallback("OnEnter", function(widget)
+                GameTooltip:SetOwner(widget.frame, "ANCHOR_RIGHT")
+                GameTooltip:AddLine(tooltip[1], 1, 0.82, 0, true)
+                GameTooltip:AddLine(tooltip[2], 1, 1, 1, true)
+                GameTooltip:Show()
+            end)
+            item:SetCallback("OnLeave", function()
+                GameTooltip:Hide()
+            end)
+        end
+    end
+end
+
 local function AddBorderRenderModeDropdown(container, tbl, key, refreshFn, disabled)
     key = key or "borderRenderMode"
 
@@ -1062,10 +1093,14 @@ local function AddBorderRenderModeDropdown(container, tbl, key, refreshFn, disab
         [ST.BORDER_RENDER_MODE_CUSTOM] = "Custom Thickness",
         [ST.BORDER_RENDER_MODE_CRISP] = "One-pixel",
     }, { ST.BORDER_RENDER_MODE_CUSTOM, ST.BORDER_RENDER_MODE_CRISP })
+    AddDropdownItemTooltips(modeDrop, BORDER_THICKNESS_MODE_TOOLTIPS)
     modeDrop:SetValue(ST.GetBorderRenderMode(tbl, key))
     if modeDrop.SetDisabled then
         modeDrop:SetDisabled(disabled == true)
     end
+    modeDrop:SetCallback("OnClosed", function()
+        GameTooltip:Hide()
+    end)
     modeDrop:SetFullWidth(true)
     modeDrop:SetCallback("OnValueChanged", function(widget, event, val)
         tbl[key] = ST.GetBorderRenderMode(val)

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -276,38 +276,7 @@ end
 
 local function ApplyPreviewEdgeBorder(frame, size, color)
     if not (frame and frame.borderTextures) then return end
-    size = math_max(1, math_floor(size or 1))
-    color = color or { 0, 0, 0, 1 }
-
-    local top = frame.borderTextures[1]
-    local bottom = frame.borderTextures[2]
-    local left = frame.borderTextures[3]
-    local right = frame.borderTextures[4]
-
-    top:ClearAllPoints()
-    top:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, 0)
-    top:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 0, 0)
-    top:SetHeight(size)
-
-    bottom:ClearAllPoints()
-    bottom:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    bottom:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, 0)
-    bottom:SetHeight(size)
-
-    left:ClearAllPoints()
-    left:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, 0)
-    left:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    left:SetWidth(size)
-
-    right:ClearAllPoints()
-    right:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 0, 0)
-    right:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, 0)
-    right:SetWidth(size)
-
-    for i = 1, 4 do
-        frame.borderTextures[i]:SetColorTexture(color[1] or 0, color[2] or 0, color[3] or 0, color[4] ~= nil and color[4] or 1)
-        frame.borderTextures[i]:Show()
-    end
+    ST.ApplyBorderTextures(frame.borderTextures, frame, color or { 0, 0, 0, 1 }, size or 1, frame._previewBorderRenderMode)
 end
 
 local function HidePreviewEdgeBorder(frame)
@@ -333,9 +302,11 @@ local function StyleMirroredIconFrame(iconFrame, button, group)
     end
 
     local borderSize = GetSourceIconBorderSize(button, style.borderSize or ST.DEFAULT_BORDER_SIZE or 1)
+    local borderRenderMode = ST.GetBorderRenderMode(style)
+    local borderLayoutSize = ST.GetBorderLayoutSize(iconFrame, borderSize, borderRenderMode)
     local bgColor = CloneColor(style.backgroundColor, { 0, 0, 0, 0.5 })
     local borderColor = CloneColor(style.borderColor, { 0, 0, 0, 1 })
-    local showBorder = borderSize > 0 and ((borderColor[4] ~= nil and borderColor[4] > 0) or borderColor[4] == nil)
+    local showBorder = (borderSize > 0 or ST.IsCrispBorderRenderMode(borderRenderMode)) and ((borderColor[4] ~= nil and borderColor[4] > 0) or borderColor[4] == nil)
 
     if button and button.borderTextures then
         local anyShown = false
@@ -351,8 +322,8 @@ local function StyleMirroredIconFrame(iconFrame, button, group)
 
     iconFrame.bg:SetColorTexture(bgColor[1] or 0, bgColor[2] or 0, bgColor[3] or 0, bgColor[4] ~= nil and bgColor[4] or 1)
     iconFrame.icon:ClearAllPoints()
-    iconFrame.icon:SetPoint("TOPLEFT", iconFrame, "TOPLEFT", borderSize, -borderSize)
-    iconFrame.icon:SetPoint("BOTTOMRIGHT", iconFrame, "BOTTOMRIGHT", -borderSize, borderSize)
+    iconFrame.icon:SetPoint("TOPLEFT", iconFrame, "TOPLEFT", borderLayoutSize, -borderLayoutSize)
+    iconFrame.icon:SetPoint("BOTTOMRIGHT", iconFrame, "BOTTOMRIGHT", -borderLayoutSize, borderLayoutSize)
     iconFrame.icon:SetTexture((button and button.icon and button.icon:GetTexture()) or GetLayoutPreviewIcon(button and button.buttonData))
     iconFrame.icon:Show()
     iconFrame.countText:Hide()
@@ -364,6 +335,7 @@ local function StyleMirroredIconFrame(iconFrame, button, group)
     end
 
     if showBorder then
+        iconFrame._previewBorderRenderMode = borderRenderMode
         ApplyPreviewEdgeBorder(iconFrame, borderSize, borderColor)
     else
         HidePreviewEdgeBorder(iconFrame)
@@ -1340,9 +1312,9 @@ local function ConfigureCastPreview(frame, slot, preview, width, height)
 
     local borderStyle = settings.borderStyle or "pixel"
     if borderStyle == "pixel" then
-        ApplyPixelBorders(castPreview.pixelBorders, bar, settings.borderColor or { 0, 0, 0, 1 }, settings.borderSize or 1)
+        ApplyPixelBorders(castPreview.pixelBorders, bar, settings.borderColor or { 0, 0, 0, 1 }, settings.borderSize or 1, ST.GetBorderRenderMode(settings))
         if iconFrame:IsShown() and settings.iconOffset then
-            ApplyPixelBorders(castPreview.iconBorders, iconFrame, settings.borderColor or { 0, 0, 0, 1 }, settings.iconBorderSize or 1)
+            ApplyPixelBorders(castPreview.iconBorders, iconFrame, settings.borderColor or { 0, 0, 0, 1 }, settings.iconBorderSize or 1, ST.GetBorderRenderMode(settings, "iconBorderRenderMode"))
         else
             HidePixelBorders(castPreview.iconBorders)
         end

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -1237,17 +1237,24 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
     if (displayProfile.borderStyle or settings.borderStyle or "pixel") == "pixel" then
         AddColorPicker(container, displayProfile, "borderColor", "Border Color", { 0, 0, 0, 1 }, true, applyBars)
 
-        local borderSizeSlider = AceGUI:Create("Slider")
-        borderSizeSlider:SetLabel("Border Size")
-        borderSizeSlider:SetSliderValues(0, 4, 0.1)
-        borderSizeSlider:SetValue(displayProfile.borderSize or settings.borderSize or 1)
-        borderSizeSlider:SetIsPercent(false)
-        borderSizeSlider:SetFullWidth(true)
-        borderSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            displayProfile.borderSize = val
+        local renderMode = ST._AddBorderRenderModeDropdown(container, displayProfile, "borderRenderMode", function()
             CooldownCompanion:ApplyResourceBars()
+            CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(borderSizeSlider)
+
+        if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+            local borderSizeSlider = AceGUI:Create("Slider")
+            borderSizeSlider:SetLabel("Border Size")
+            borderSizeSlider:SetSliderValues(0, 4, 0.1)
+            borderSizeSlider:SetValue(displayProfile.borderSize or settings.borderSize or 1)
+            borderSizeSlider:SetIsPercent(false)
+            borderSizeSlider:SetFullWidth(true)
+            borderSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
+                displayProfile.borderSize = val
+                CooldownCompanion:ApplyResourceBars()
+            end)
+            container:AddChild(borderSizeSlider)
+        end
     end
 
     -- ============ Text Section ============

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -16,6 +16,7 @@ local AddColorPicker = ST._AddColorPicker
 local AddAnchorDropdown = ST._AddAnchorDropdown
 local AddFontControls = ST._AddFontControls
 local AddOffsetSliders = ST._AddOffsetSliders
+local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 
 -- Module-level aliases
 local tabInfoButtons = CS.tabInfoButtons
@@ -285,16 +286,23 @@ local function BuildChargeTextControls(container, styleTable, refreshCallback)
 end
 
 local function BuildBorderControls(container, styleTable, refreshCallback)
-    local borderSlider = AceGUI:Create("Slider")
-    borderSlider:SetLabel("Border Size")
-    borderSlider:SetSliderValues(0, 5, 0.1)
-    borderSlider:SetValue(styleTable.borderSize or ST.DEFAULT_BORDER_SIZE)
-    borderSlider:SetFullWidth(true)
-    borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        styleTable.borderSize = val
+    local renderMode = AddBorderRenderModeDropdown(container, styleTable, "borderRenderMode", function()
         refreshCallback()
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    container:AddChild(borderSlider)
+
+    if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+        local borderSlider = AceGUI:Create("Slider")
+        borderSlider:SetLabel("Border Size")
+        borderSlider:SetSliderValues(0, 5, 0.1)
+        borderSlider:SetValue(styleTable.borderSize or ST.DEFAULT_BORDER_SIZE)
+        borderSlider:SetFullWidth(true)
+        borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            styleTable.borderSize = val
+            refreshCallback()
+        end)
+        container:AddChild(borderSlider)
+    end
 
     AddColorPicker(container, styleTable, "borderColor", "Border Color", {0, 0, 0, 1}, true, refreshCallback, refreshCallback)
 end
@@ -1220,16 +1228,23 @@ end
 local function BuildTextBackgroundControls(container, styleTable, refreshCallback)
     AddColorPicker(container, styleTable, "textBgColor", "Background Color", {0, 0, 0, 0}, true, refreshCallback, refreshCallback)
 
-    local borderSlider = AceGUI:Create("Slider")
-    borderSlider:SetLabel("Border Size")
-    borderSlider:SetSliderValues(0, 5, 0.1)
-    borderSlider:SetValue(styleTable.textBorderSize or 0)
-    borderSlider:SetFullWidth(true)
-    borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        styleTable.textBorderSize = val
+    local renderMode = AddBorderRenderModeDropdown(container, styleTable, "textBorderRenderMode", function()
         refreshCallback()
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    container:AddChild(borderSlider)
+
+    if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+        local borderSlider = AceGUI:Create("Slider")
+        borderSlider:SetLabel("Border Size")
+        borderSlider:SetSliderValues(0, 5, 0.1)
+        borderSlider:SetValue(styleTable.textBorderSize or 0)
+        borderSlider:SetFullWidth(true)
+        borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            styleTable.textBorderSize = val
+            refreshCallback()
+        end)
+        container:AddChild(borderSlider)
+    end
 
     AddColorPicker(container, styleTable, "textBorderColor", "Border Color", {0, 0, 0, 1}, true, refreshCallback, refreshCallback)
 end

--- a/ConfigSettings/TextModeTabs.lua
+++ b/ConfigSettings/TextModeTabs.lua
@@ -22,6 +22,7 @@ local RenderFormatPreview = ST._RenderFormatPreview
 local ParseFormatString = ST._ParseFormatString
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
+local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -405,16 +406,23 @@ local function BuildTextAppearanceTab(container, group, style)
     if not bgCollapsed then
     AddColorPicker(container, style, "textBgColor", "Background Color", {0, 0, 0, 0}, true, refreshStyle, refreshStyle)
 
-    local borderSlider = AceGUI:Create("Slider")
-    borderSlider:SetLabel("Border Size")
-    borderSlider:SetSliderValues(0, 5, 0.1)
-    borderSlider:SetValue(style.textBorderSize or 0)
-    borderSlider:SetFullWidth(true)
-    borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        style.textBorderSize = val
+    local renderMode = AddBorderRenderModeDropdown(container, style, "textBorderRenderMode", function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
     end)
-    container:AddChild(borderSlider)
+
+    if renderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+        local borderSlider = AceGUI:Create("Slider")
+        borderSlider:SetLabel("Border Size")
+        borderSlider:SetSliderValues(0, 5, 0.1)
+        borderSlider:SetValue(style.textBorderSize or 0)
+        borderSlider:SetFullWidth(true)
+        borderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            style.textBorderSize = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        container:AddChild(borderSlider)
+    end
 
     AddColorPicker(container, style, "textBorderColor", "Border Color", {0, 0, 0, 1}, true, refreshStyle, refreshStyle)
 

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -880,6 +880,7 @@ function CooldownCompanion.NormalizeTriggerIconSettings(settings)
     settings.iconWidth = Clamp(tonumber(settings.iconWidth) or settings.buttonSize, 10, 150)
     settings.iconHeight = Clamp(tonumber(settings.iconHeight) or settings.buttonSize, 10, 150)
     settings.borderSize = Clamp(tonumber(settings.borderSize) or 1, 0, 5)
+    settings.borderRenderMode = ST.GetBorderRenderMode(settings)
     settings.borderColor = CopyColor(settings.borderColor) or { 0, 0, 0, 1 }
     settings.backgroundColor = CopyColor(settings.backgroundColor) or { 0, 0, 0, 0.5 }
     settings.iconTintColor = CopyColor(settings.iconTintColor) or { 1, 1, 1, 1 }
@@ -996,6 +997,7 @@ function CooldownCompanion:GetTriggerPanelIconSettings(groupOrId, createIfMissin
             iconWidth = 36,
             iconHeight = 36,
             borderSize = 1,
+            borderRenderMode = ST.BORDER_RENDER_MODE_CUSTOM,
             borderColor = { 0, 0, 0, 1 },
             backgroundColor = { 0, 0, 0, 0.5 },
             iconTintColor = { 1, 1, 1, 1 },

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -866,6 +866,8 @@ function CooldownCompanion.ApplyTriggerIconVisual(host, settings)
     local iconFrame = CooldownCompanion.EnsureTriggerIconVisual(host)
     local width, height = CooldownCompanion.GetTriggerIconDimensions(settings)
     local borderSize = settings.borderSize or 0
+    local borderRenderMode = ST.GetBorderRenderMode(settings)
+    local borderLayoutSize = ST.GetBorderLayoutSize(iconFrame, borderSize, borderRenderMode)
     local iconTint = settings.iconTintColor or { 1, 1, 1, 1 }
     local backgroundColor = settings.backgroundColor or { 0, 0, 0, 0.5 }
     local borderColor = settings.borderColor or { 0, 0, 0, 1 }
@@ -891,8 +893,8 @@ function CooldownCompanion.ApplyTriggerIconVisual(host, settings)
         backgroundColor[4] ~= nil and backgroundColor[4] or 0.5
     )
     iconFrame.icon:ClearAllPoints()
-    iconFrame.icon:SetPoint("TOPLEFT", borderSize, -borderSize)
-    iconFrame.icon:SetPoint("BOTTOMRIGHT", -borderSize, borderSize)
+    iconFrame.icon:SetPoint("TOPLEFT", borderLayoutSize, -borderLayoutSize)
+    iconFrame.icon:SetPoint("BOTTOMRIGHT", -borderLayoutSize, borderLayoutSize)
     iconFrame.icon:SetTexture(settings.manualIcon)
     iconFrame.icon:SetVertexColor(
         iconTint[1] or 1,
@@ -910,7 +912,7 @@ function CooldownCompanion.ApplyTriggerIconVisual(host, settings)
             borderColor[4] ~= nil and borderColor[4] or 1
         )
     end
-    ST._ApplyEdgePositions(iconFrame.borderTextures, iconFrame, borderSize)
+    ST._ApplyBorderEdgePositions(iconFrame.borderTextures, iconFrame, borderSize, borderRenderMode)
     iconFrame:Show()
 
     return true

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -63,6 +63,7 @@ local defaults = {
                         buttonSize = 36,
                         buttonSpacing = 2,
                         borderSize = 1,
+                        borderRenderMode = "custom",
                         borderColor = {0, 0, 0, 1},
                         backgroundColor = {0, 0, 0, 0.5},
                         orientation = "horizontal", -- "horizontal" or "vertical"
@@ -245,6 +246,7 @@ local defaults = {
             buttonSize = 36,
             buttonSpacing = 2,
             borderSize = 1,
+            borderRenderMode = "custom",
             borderColor = {0, 0, 0, 1},
             cooldownFontSize = 12,
             cooldownFontOutline = "OUTLINE",
@@ -418,6 +420,7 @@ local defaults = {
             textCustomColor = {1, 0.82, 0, 1},
             textBgColor = {0, 0, 0, 0},
             textBorderSize = 0,
+            textBorderRenderMode = "custom",
             textBorderColor = {0, 0, 0, 1},
             textShadow = false,
             durationFormat = "clock",
@@ -443,6 +446,7 @@ local defaults = {
             borderStyle = "pixel",
             borderColor = { 0, 0, 0, 1 },
             borderSize = 1,
+            borderRenderMode = "custom",
             segmentGap = 4,
             hideManaForNonHealer = true,
             resources = {
@@ -559,6 +563,7 @@ local defaults = {
             iconOffsetX = 0,
             iconOffsetY = 0,
             iconBorderSize = 1,
+            iconBorderRenderMode = "custom",
             showSpark = true,
             showSparkTrail = true,
             showInterruptShake = true,
@@ -567,6 +572,7 @@ local defaults = {
             borderStyle = "pixel",
             borderColor = { 0, 0, 0, 1 },
             borderSize = 1,
+            borderRenderMode = "custom",
             showNameText = true,
             nameFont = "Friz Quadrata TT",
             nameFontSize = 10,
@@ -619,7 +625,7 @@ ST.OVERRIDE_SECTIONS = {
     -- Icon Mode — Appearance Tab
     borderSettings = {
         label = "Border",
-        keys = {"borderSize", "borderColor"},
+        keys = {"borderSize", "borderRenderMode", "borderColor"},
         modes = {icons = true, bars = true},
     },
     cooldownText = {
@@ -797,7 +803,7 @@ ST.OVERRIDE_SECTIONS = {
     },
     textBackground = {
         label = "Text Background",
-        keys = {"textBgColor", "textBorderSize", "textBorderColor"},
+        keys = {"textBgColor", "textBorderSize", "textBorderRenderMode", "textBorderColor"},
         modes = {text = true},
     },
 }

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -108,6 +108,7 @@ function CooldownCompanion:RunAllMigrations()
     self:MigrateTalentConditions()
     self:MigrateChoiceTalentConditions()
     self:MigrateNewDefaults()
+    self:MigrateBorderRenderModeOverrides()
     self:MigrateIconFillTimerDefaults()
     self:MigrateCharacterScopedBarSettings()
     self:MigratePanelAnchorCenter()
@@ -146,6 +147,7 @@ function CooldownCompanion:ClearMigrationSentinels()
     profile.talentConditionsMigrated = nil
     profile.choiceTalentConditionsMigrated = nil
     profile.newDefaultsMigrated = nil
+    profile.borderRenderModeOverridesMigrated = nil
     profile._migratedContainerAnchorsToScreenOffsets = nil
     profile._migratedContainerAlphaToPanel = nil
     profile._migratedContainerHeroTalentStamps = nil
@@ -1464,6 +1466,34 @@ function CooldownCompanion:MigrateNewDefaults()
     end
 
     profile.newDefaultsMigrated = true
+end
+
+function CooldownCompanion:MigrateBorderRenderModeOverrides()
+    local profile = self.db.profile
+    if profile.borderRenderModeOverridesMigrated then return end
+
+    for _, group in pairs(profile.groups) do
+        if group.buttons then
+            for _, bd in ipairs(group.buttons) do
+                if bd.overrideSections then
+                    if bd.overrideSections.borderSettings then
+                        if not bd.styleOverrides then bd.styleOverrides = {} end
+                        if rawget(bd.styleOverrides, "borderRenderMode") == nil then
+                            bd.styleOverrides.borderRenderMode = ST.BORDER_RENDER_MODE_CUSTOM
+                        end
+                    end
+                    if bd.overrideSections.textBackground then
+                        if not bd.styleOverrides then bd.styleOverrides = {} end
+                        if rawget(bd.styleOverrides, "textBorderRenderMode") == nil then
+                            bd.styleOverrides.textBorderRenderMode = ST.BORDER_RENDER_MODE_CUSTOM
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    profile.borderRenderModeOverridesMigrated = true
 end
 
 local DURATION_FORMAT_CLOCK = "clock"

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -54,9 +54,7 @@ local function GetBorderSize(size, fallback)
 end
 
 function ST.GetBorderLayoutSize(region, size, mode)
-    if ST.IsCrispBorderRenderMode(mode)
-        and PixelUtil and PixelUtil.GetNearestPixelSize
-        and region and region.GetEffectiveScale then
+    if ST.IsCrispBorderRenderMode(mode) then
         return PixelUtil.GetNearestPixelSize(1, region:GetEffectiveScale(), 1)
     end
     return GetBorderSize(size, 1)
@@ -89,7 +87,7 @@ function ST.HideBorderTextures(textures)
 end
 
 local function ApplyBorderPoint(tex, point, relativeTo, relativePoint, offsetX, offsetY, crisp)
-    if crisp and PixelUtil and PixelUtil.SetPoint then
+    if crisp then
         PixelUtil.SetPoint(
             tex,
             point,

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -53,9 +53,13 @@ local function GetBorderSize(size, fallback)
     return tonumber(size) or fallback or 1
 end
 
+local function GetOnePhysicalPixelSize(region)
+    return PixelUtil.GetNearestPixelSize(0, region:GetEffectiveScale(), 1)
+end
+
 function ST.GetBorderLayoutSize(region, size, mode)
     if ST.IsCrispBorderRenderMode(mode) then
-        return PixelUtil.GetNearestPixelSize(1, region:GetEffectiveScale(), 1)
+        return GetOnePhysicalPixelSize(region)
     end
     return GetBorderSize(size, 1)
 end
@@ -107,11 +111,12 @@ function ST.PositionBorderTexturesBetween(textures, leftFrame, rightFrame, size,
     if not (textures and leftFrame and rightFrame) then return end
 
     local crisp = ST.IsCrispBorderRenderMode(mode)
-    local edgeSize = crisp and 1 or GetBorderSize(size, 1)
+    local customEdgeSize = GetBorderSize(size, 1)
 
     for index, spec in ipairs(ST.EDGE_ANCHOR_SPEC) do
         local tex = GetEdgeTexture(textures, index)
         if tex then
+            local edgeSize = crisp and GetOnePhysicalPixelSize(tex) or customEdgeSize
             local firstFrame, secondFrame
             if index == 1 or index == 2 then
                 firstFrame, secondFrame = leftFrame, rightFrame

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -6,6 +6,8 @@
 local ADDON_NAME, ST = ...
 
 local string_format = string.format
+local tonumber = tonumber
+local type = type
 
 --------------------------------------------------------------------------------
 -- Constants
@@ -15,6 +17,8 @@ ST.DEFAULT_OVERHANG_PCT = 32
 ST.DEFAULT_GLOW_COLOR = {1, 1, 1, 1}
 ST.DEFAULT_BG_COLOR = {0.2, 0.2, 0.2, 0.8}
 ST.NUM_GLOW_STYLES = 3
+ST.BORDER_RENDER_MODE_CUSTOM = "custom"
+ST.BORDER_RENDER_MODE_CRISP = "crisp"
 
 -- Shared edge anchor spec: {point1, relPoint1, point2, relPoint2, x1sign, y1sign, x2sign, y2sign}
 -- Signs: 0 = zero offset, 1 = +size, -1 = -size
@@ -29,35 +33,152 @@ ST.EDGE_ANCHOR_SPEC = {
 -- Border Helpers
 --------------------------------------------------------------------------------
 
--- Create 4 pixel-perfect border textures using PixelUtil (replaces backdrop edgeFile)
+local BORDER_EDGE_NAMES = { "TOP", "BOTTOM", "LEFT", "RIGHT" }
+
+function ST.GetBorderRenderMode(source, key)
+    if type(source) == "table" then
+        source = source[key or "borderRenderMode"]
+    end
+    if source == ST.BORDER_RENDER_MODE_CRISP then
+        return ST.BORDER_RENDER_MODE_CRISP
+    end
+    return ST.BORDER_RENDER_MODE_CUSTOM
+end
+
+function ST.IsCrispBorderRenderMode(source, key)
+    return ST.GetBorderRenderMode(source, key) == ST.BORDER_RENDER_MODE_CRISP
+end
+
+local function GetBorderSize(size, fallback)
+    return tonumber(size) or fallback or 1
+end
+
+function ST.GetBorderLayoutSize(region, size, mode)
+    if ST.IsCrispBorderRenderMode(mode)
+        and PixelUtil and PixelUtil.GetNearestPixelSize
+        and region and region.GetEffectiveScale then
+        return PixelUtil.GetNearestPixelSize(1, region:GetEffectiveScale(), 1)
+    end
+    return GetBorderSize(size, 1)
+end
+
+local function GetEdgeTexture(textures, index)
+    return textures[index] or textures[BORDER_EDGE_NAMES[index]]
+end
+
+function ST.CreateBorderTextureSet(parent, layer, sublevel)
+    local textures = {}
+    for index, side in ipairs(BORDER_EDGE_NAMES) do
+        local tex = parent:CreateTexture(nil, layer or "OVERLAY", nil, sublevel)
+        tex:SetColorTexture(0, 0, 0, 1)
+        tex:Hide()
+        textures[index] = tex
+        textures[side] = tex
+    end
+    return textures
+end
+
+function ST.HideBorderTextures(textures)
+    if not textures then return end
+    for index = 1, 4 do
+        local tex = GetEdgeTexture(textures, index)
+        if tex then
+            tex:Hide()
+        end
+    end
+end
+
+local function ApplyBorderPoint(tex, point, relativeTo, relativePoint, offsetX, offsetY, crisp)
+    if crisp and PixelUtil and PixelUtil.SetPoint then
+        PixelUtil.SetPoint(
+            tex,
+            point,
+            relativeTo,
+            relativePoint,
+            offsetX,
+            offsetY,
+            offsetX ~= 0 and 1 or nil,
+            offsetY ~= 0 and 1 or nil
+        )
+    else
+        tex:SetPoint(point, relativeTo, relativePoint, offsetX, offsetY)
+    end
+end
+
+function ST.PositionBorderTexturesBetween(textures, leftFrame, rightFrame, size, mode)
+    if not (textures and leftFrame and rightFrame) then return end
+
+    local crisp = ST.IsCrispBorderRenderMode(mode)
+    local edgeSize = crisp and 1 or GetBorderSize(size, 1)
+
+    for index, spec in ipairs(ST.EDGE_ANCHOR_SPEC) do
+        local tex = GetEdgeTexture(textures, index)
+        if tex then
+            local firstFrame, secondFrame
+            if index == 1 or index == 2 then
+                firstFrame, secondFrame = leftFrame, rightFrame
+            elseif index == 3 then
+                firstFrame, secondFrame = leftFrame, leftFrame
+            else
+                firstFrame, secondFrame = rightFrame, rightFrame
+            end
+
+            tex:ClearAllPoints()
+            ApplyBorderPoint(tex, spec[1], firstFrame, spec[2], spec[5] * edgeSize, spec[6] * edgeSize, crisp)
+            ApplyBorderPoint(tex, spec[3], secondFrame, spec[4], spec[7] * edgeSize, spec[8] * edgeSize, crisp)
+        end
+    end
+end
+
+function ST.PositionBorderTextures(textures, frame, size, mode)
+    ST.PositionBorderTexturesBetween(textures, frame, frame, size, mode)
+end
+
+function ST.ApplyBorderTexturesBetween(textures, leftFrame, rightFrame, color, size, mode)
+    if not (textures and leftFrame and rightFrame) then return end
+
+    if not ST.IsCrispBorderRenderMode(mode) and GetBorderSize(size, 1) <= 0 then
+        ST.HideBorderTextures(textures)
+        return
+    end
+
+    local r, g, b, a = 0, 0, 0, 1
+    if color then
+        r = color[1] or r
+        g = color[2] or g
+        b = color[3] or b
+        if color[4] ~= nil then
+            a = color[4]
+        end
+    end
+
+    for index = 1, 4 do
+        local tex = GetEdgeTexture(textures, index)
+        if tex then
+            tex:SetColorTexture(r, g, b, a)
+        end
+    end
+
+    ST.PositionBorderTexturesBetween(textures, leftFrame, rightFrame, size, mode)
+
+    for index = 1, 4 do
+        local tex = GetEdgeTexture(textures, index)
+        if tex then
+            tex:Show()
+        end
+    end
+end
+
+function ST.ApplyBorderTextures(textures, frame, color, size, mode)
+    ST.ApplyBorderTexturesBetween(textures, frame, frame, color, size, mode)
+end
+
+-- Create 4 one-physical-pixel border textures using Blizzard PixelUtil.
 function ST.CreatePixelBorders(frame, r, g, b, a)
-    r, g, b, a = r or 0, g or 0, b or 0, a or 1
-
-    local top = frame:CreateTexture(nil, "BORDER")
-    top:SetColorTexture(r, g, b, a)
-    PixelUtil.SetPoint(top, "TOPLEFT", frame, "TOPLEFT", 0, 0)
-    PixelUtil.SetPoint(top, "TOPRIGHT", frame, "TOPRIGHT", 0, 0)
-    PixelUtil.SetHeight(top, 1, 1)
-
-    local bottom = frame:CreateTexture(nil, "BORDER")
-    bottom:SetColorTexture(r, g, b, a)
-    PixelUtil.SetPoint(bottom, "BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    PixelUtil.SetPoint(bottom, "BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, 0)
-    PixelUtil.SetHeight(bottom, 1, 1)
-
-    local left = frame:CreateTexture(nil, "BORDER")
-    left:SetColorTexture(r, g, b, a)
-    PixelUtil.SetPoint(left, "TOPLEFT", frame, "TOPLEFT", 0, 0)
-    PixelUtil.SetPoint(left, "BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    PixelUtil.SetWidth(left, 1, 1)
-
-    local right = frame:CreateTexture(nil, "BORDER")
-    right:SetColorTexture(r, g, b, a)
-    PixelUtil.SetPoint(right, "TOPRIGHT", frame, "TOPRIGHT", 0, 0)
-    PixelUtil.SetPoint(right, "BOTTOMRIGHT", frame, "BOTTOMRIGHT", 0, 0)
-    PixelUtil.SetWidth(right, 1, 1)
-
-    frame.borderTextures = { top, bottom, left, right }
+    local textures = ST.CreateBorderTextureSet(frame, "BORDER")
+    ST.ApplyBorderTextures(textures, frame, { r or 0, g or 0, b or 0, a or 1 }, 1, ST.BORDER_RENDER_MODE_CRISP)
+    frame.borderTextures = textures
+    return textures
 end
 
 --------------------------------------------------------------------------------

--- a/OtherBars/CastBar.lua
+++ b/OtherBars/CastBar.lua
@@ -359,57 +359,21 @@ end
 --- Create or return the pixel border textures for the cast bar
 local function GetPixelBorders(cb)
     if pixelBorders then return pixelBorders end
-    pixelBorders = {}
-    local names = { "TOP", "BOTTOM", "LEFT", "RIGHT" }
-    for _, side in ipairs(names) do
-        local tex = cb:CreateTexture(nil, "OVERLAY", nil, 7)
-        tex:SetColorTexture(0, 0, 0, 1)
-        tex:Hide()
-        pixelBorders[side] = tex
-    end
+    pixelBorders = ST.CreateBorderTextureSet(cb, "OVERLAY", 7)
     return pixelBorders
 end
 
 --- Optional iconFrame + iconOnRight: extends the border to wrap both bar+icon.
-local function ShowPixelBorders(cb, color, size, iconFrame, iconOnRight)
+local function ShowPixelBorders(cb, color, size, renderMode, iconFrame, iconOnRight)
     local borders = GetPixelBorders(cb)
-    local r, g, b, a = color[1], color[2], color[3], color[4]
-    size = size or 1
-
-    for _, tex in pairs(borders) do
-        tex:SetColorTexture(r, g, b, a)
-        tex:Show()
-    end
-
     local leftFrame = (iconFrame and not iconOnRight) and iconFrame or cb
     local rightFrame = (iconFrame and iconOnRight) and iconFrame or cb
-
-    borders.TOP:SetHeight(size)
-    borders.TOP:ClearAllPoints()
-    borders.TOP:SetPoint("TOPLEFT", leftFrame, "TOPLEFT", 0, 0)
-    borders.TOP:SetPoint("TOPRIGHT", rightFrame, "TOPRIGHT", 0, 0)
-
-    borders.BOTTOM:SetHeight(size)
-    borders.BOTTOM:ClearAllPoints()
-    borders.BOTTOM:SetPoint("BOTTOMLEFT", leftFrame, "BOTTOMLEFT", 0, 0)
-    borders.BOTTOM:SetPoint("BOTTOMRIGHT", rightFrame, "BOTTOMRIGHT", 0, 0)
-
-    borders.LEFT:SetWidth(size)
-    borders.LEFT:ClearAllPoints()
-    borders.LEFT:SetPoint("TOPLEFT", leftFrame, "TOPLEFT", 0, -size)
-    borders.LEFT:SetPoint("BOTTOMLEFT", leftFrame, "BOTTOMLEFT", 0, size)
-
-    borders.RIGHT:SetWidth(size)
-    borders.RIGHT:ClearAllPoints()
-    borders.RIGHT:SetPoint("TOPRIGHT", rightFrame, "TOPRIGHT", 0, -size)
-    borders.RIGHT:SetPoint("BOTTOMRIGHT", rightFrame, "BOTTOMRIGHT", 0, size)
+    ST.ApplyBorderTexturesBetween(borders, leftFrame, rightFrame, color, size, renderMode)
 end
 
 local function HidePixelBorders()
     if not pixelBorders then return end
-    for _, tex in pairs(pixelBorders) do
-        tex:Hide()
-    end
+    ST.HideBorderTextures(pixelBorders)
 end
 
 --- Icon pixel borders (inline mode — matches bar border style)
@@ -417,53 +381,18 @@ local iconPixelBorders = nil
 
 local function GetIconPixelBorders(cb)
     if iconPixelBorders then return iconPixelBorders end
-    iconPixelBorders = {}
-    local names = { "TOP", "BOTTOM", "LEFT", "RIGHT" }
-    for _, side in ipairs(names) do
-        local tex = cb:CreateTexture(nil, "OVERLAY", nil, 7)
-        tex:SetColorTexture(0, 0, 0, 1)
-        tex:Hide()
-        iconPixelBorders[side] = tex
-    end
+    iconPixelBorders = ST.CreateBorderTextureSet(cb, "OVERLAY", 7)
     return iconPixelBorders
 end
 
-local function ShowIconPixelBorders(cb, color, size)
+local function ShowIconPixelBorders(cb, color, size, renderMode)
     local borders = GetIconPixelBorders(cb)
-    local r, g, b, a = color[1], color[2], color[3], color[4]
-    size = size or 1
-
-    for _, tex in pairs(borders) do
-        tex:SetColorTexture(r, g, b, a)
-        tex:Show()
-    end
-
-    borders.TOP:SetHeight(size)
-    borders.TOP:ClearAllPoints()
-    borders.TOP:SetPoint("TOPLEFT", cb.Icon, "TOPLEFT", 0, 0)
-    borders.TOP:SetPoint("TOPRIGHT", cb.Icon, "TOPRIGHT", 0, 0)
-
-    borders.BOTTOM:SetHeight(size)
-    borders.BOTTOM:ClearAllPoints()
-    borders.BOTTOM:SetPoint("BOTTOMLEFT", cb.Icon, "BOTTOMLEFT", 0, 0)
-    borders.BOTTOM:SetPoint("BOTTOMRIGHT", cb.Icon, "BOTTOMRIGHT", 0, 0)
-
-    borders.LEFT:SetWidth(size)
-    borders.LEFT:ClearAllPoints()
-    borders.LEFT:SetPoint("TOPLEFT", cb.Icon, "TOPLEFT", 0, -size)
-    borders.LEFT:SetPoint("BOTTOMLEFT", cb.Icon, "BOTTOMLEFT", 0, size)
-
-    borders.RIGHT:SetWidth(size)
-    borders.RIGHT:ClearAllPoints()
-    borders.RIGHT:SetPoint("TOPRIGHT", cb.Icon, "TOPRIGHT", 0, -size)
-    borders.RIGHT:SetPoint("BOTTOMRIGHT", cb.Icon, "BOTTOMRIGHT", 0, size)
+    ST.ApplyBorderTextures(borders, cb.Icon, color, size, renderMode)
 end
 
 local function HideIconPixelBorders()
     if not iconPixelBorders then return end
-    for _, tex in pairs(iconPixelBorders) do
-        tex:Hide()
-    end
+    ST.HideBorderTextures(iconPixelBorders)
 end
 
 --- Fill edge masks: thin opaque strips at the left/right edges of the StatusBar
@@ -915,13 +844,14 @@ local function DeferredReapply()
         if bStyle == "pixel" then
             local bColor = s.borderColor or {0,0,0,1}
             local bSize = s.borderSize or 1
+            local bRenderMode = ST.GetBorderRenderMode(s)
             if s.showIcon and not s.iconOffset then
-                ShowPixelBorders(cb, bColor, bSize, cb.Icon, s.iconFlipSide)
+                ShowPixelBorders(cb, bColor, bSize, bRenderMode, cb.Icon, s.iconFlipSide)
             else
-                ShowPixelBorders(cb, bColor, bSize)
+                ShowPixelBorders(cb, bColor, bSize, bRenderMode)
             end
             if s.showIcon and s.iconOffset then
-                ShowIconPixelBorders(cb, bColor, s.iconBorderSize or 1)
+                ShowIconPixelBorders(cb, bColor, s.iconBorderSize or 1, ST.GetBorderRenderMode(s, "iconBorderRenderMode"))
             else
                 HideIconPixelBorders()
             end
@@ -1297,14 +1227,15 @@ function CooldownCompanion:ApplyCastBarSettings()
             end
             local bColor = settings.borderColor or { 0, 0, 0, 1 }
             local bSize = settings.borderSize or 1
+            local bRenderMode = ST.GetBorderRenderMode(settings)
             if settings.showIcon and not settings.iconOffset then
-                ShowPixelBorders(cb, bColor, bSize, cb.Icon, settings.iconFlipSide)
+                ShowPixelBorders(cb, bColor, bSize, bRenderMode, cb.Icon, settings.iconFlipSide)
             else
-                ShowPixelBorders(cb, bColor, bSize)
+                ShowPixelBorders(cb, bColor, bSize, bRenderMode)
             end
             -- Icon border (offset mode only)
             if settings.showIcon and settings.iconOffset then
-                ShowIconPixelBorders(cb, bColor, settings.iconBorderSize or 1)
+                ShowIconPixelBorders(cb, bColor, settings.iconBorderSize or 1, ST.GetBorderRenderMode(settings, "iconBorderRenderMode"))
             else
                 HideIconPixelBorders()
             end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -1170,15 +1170,15 @@ function HealthBar.LayoutReverseEdgeEffectBar(bar, effectBar)
     end
 end
 
-function HealthBar.LayoutEffectBars(bar, borderStyle, borderSize, config)
+function HealthBar.LayoutEffectBars(bar, borderStyle, borderSize, borderRenderMode, config)
     if not bar then return end
     if bar.healthEffectClip then
         bar.healthEffectClip:SetFrameLevel(bar:GetFrameLevel() + 1)
         bar.healthEffectClip:ClearAllPoints()
         if borderStyle == "pixel" then
-            borderSize = tonumber(borderSize) or 1
-            bar.healthEffectClip:SetPoint("TOPLEFT", bar, "TOPLEFT", borderSize, -borderSize)
-            bar.healthEffectClip:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -borderSize, borderSize)
+            local inset = ST.GetBorderLayoutSize(bar, borderSize, borderRenderMode)
+            bar.healthEffectClip:SetPoint("TOPLEFT", bar, "TOPLEFT", inset, -inset)
+            bar.healthEffectClip:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -inset, inset)
         else
             bar.healthEffectClip:SetAllPoints(bar)
         end
@@ -3290,12 +3290,13 @@ local function PrepareCustomAuraBar(
         local borderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
         local borderColor = GetResourceDisplayValue(settings, "borderColor", { 0, 0, 0, 1 })
         local borderSize = GetResourceDisplayValue(settings, "borderSize", 1)
+        local borderRenderMode = GetResourceDisplayValue(settings, "borderRenderMode", ST.BORDER_RENDER_MODE_CUSTOM)
         if borderStyle == "pixel" then
-            ApplyPixelBorders(barInfo.frame.borders, barInfo.frame, borderColor, borderSize)
+            ApplyPixelBorders(barInfo.frame.borders, barInfo.frame, borderColor, borderSize, borderRenderMode)
         else
             HidePixelBorders(barInfo.frame.borders)
         end
-        LayoutCustomAuraContinuousThresholdOverlay(barInfo.frame, barTexture, borderStyle, borderSize)
+        LayoutCustomAuraContinuousThresholdOverlay(barInfo.frame, barTexture, borderStyle, borderSize, borderRenderMode)
         local durationTextFontName = cabConfig.durationTextFont or DEFAULT_RESOURCE_TEXT_FONT
         local durationTextSize = tonumber(cabConfig.durationTextFontSize) or DEFAULT_RESOURCE_TEXT_SIZE
         local durationTextOutline = cabConfig.durationTextFontOutline or DEFAULT_RESOURCE_TEXT_OUTLINE
@@ -3331,8 +3332,9 @@ local function PrepareCustomAuraBar(
             EnsureMaxStacksIndicator(barInfo)
             local indBorderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
             local indBorderSize = GetResourceDisplayValue(settings, "borderSize", 1)
+            local indBorderRenderMode = GetResourceDisplayValue(settings, "borderRenderMode", ST.BORDER_RENDER_MODE_CUSTOM)
             local indBarTexture = CooldownCompanion:FetchStatusBar(GetResourceDisplayValue(settings, "barTexture", "Solid"))
-            LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, indBarTexture, indBorderStyle, indBorderSize)
+            LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, indBarTexture, indBorderStyle, indBorderSize, indBorderRenderMode)
         end
     else
         ClearMaxStacksIndicator(barInfo)
@@ -3706,9 +3708,10 @@ local function StyleContinuousBar(bar, powerType, settings)
     local borderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
     local borderColor = GetResourceDisplayValue(settings, "borderColor", { 0, 0, 0, 1 })
     local borderSize = GetResourceDisplayValue(settings, "borderSize", 1)
+    local borderRenderMode = GetResourceDisplayValue(settings, "borderRenderMode", ST.BORDER_RENDER_MODE_CUSTOM)
 
     if borderStyle == "pixel" then
-        ApplyPixelBorders(bar.borders, bar, borderColor, borderSize)
+        ApplyPixelBorders(bar.borders, bar, borderColor, borderSize, borderRenderMode)
     else
         HidePixelBorders(bar.borders)
     end
@@ -3787,13 +3790,14 @@ function HealthBar.Style(bar, settings)
     local borderStyle = GetResourceDisplayValue(settings, "borderStyle", "pixel")
     local borderColor = GetResourceDisplayValue(settings, "borderColor", { 0, 0, 0, 1 })
     local borderSize = GetResourceDisplayValue(settings, "borderSize", 1)
+    local borderRenderMode = GetResourceDisplayValue(settings, "borderRenderMode", ST.BORDER_RENDER_MODE_CUSTOM)
 
     if borderStyle == "pixel" then
-        ApplyPixelBorders(bar.borders, bar, borderColor, borderSize)
+        ApplyPixelBorders(bar.borders, bar, borderColor, borderSize, borderRenderMode)
     else
         HidePixelBorders(bar.borders)
     end
-    HealthBar.LayoutEffectBars(bar, borderStyle, borderSize, resourceConfig)
+    HealthBar.LayoutEffectBars(bar, borderStyle, borderSize, borderRenderMode, resourceConfig)
 
     local textFormat = resourceConfig and resourceConfig.textFormat or "percent"
     if textFormat ~= "percent"

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -44,6 +44,7 @@ local RESOURCE_DISPLAY_PROFILE_KEYS = {
     "borderStyle",
     "borderColor",
     "borderSize",
+    "borderRenderMode",
 }
 
 local RESOURCE_TEXT_DISPLAY_KEYS = {
@@ -832,6 +833,7 @@ local function SeedResourceDisplayProfileFromGlobal(profile, settings)
     if profile.borderStyle == nil then profile.borderStyle = "pixel" end
     if profile.borderColor == nil then profile.borderColor = { 0, 0, 0, 1 } end
     if profile.borderSize == nil then profile.borderSize = 1 end
+    if profile.borderRenderMode == nil then profile.borderRenderMode = ST.BORDER_RENDER_MODE_CUSTOM end
     if profile.classBarBrightness == nil then profile.classBarBrightness = 1.3 end
     return profile
 end

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -265,6 +265,7 @@ local function GetResourceAuraStackLayoutInputs(holder, settings, orientationOve
     local barTextureName = style and style.barTexture or "Solid"
     local borderStyle = style and style.borderStyle or "pixel"
     local borderSize = style and style.borderSize or 1
+    local borderRenderMode = ST.GetBorderRenderMode(style)
     local isVertical
     if orientationOverride == "vertical" then
         isVertical = true
@@ -285,14 +286,15 @@ local function GetResourceAuraStackLayoutInputs(holder, settings, orientationOve
     local baseHeight = baseSeg and baseSeg:GetHeight() or 0
     local baseFrameLevel = baseSeg and baseSeg:GetFrameLevel() or 0
 
-    return barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel
+    return barTextureName, borderStyle, borderSize, borderRenderMode, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel
 end
 
-local function UpdateResourceAuraStackLayoutState(holder, count, barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel)
+local function UpdateResourceAuraStackLayoutState(holder, count, barTextureName, borderStyle, borderSize, borderRenderMode, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel)
     holder._auraStackLayoutCount = count
     holder._auraStackLayoutTexture = barTextureName
     holder._auraStackLayoutBorderStyle = borderStyle
     holder._auraStackLayoutBorderSize = borderSize
+    holder._auraStackLayoutBorderRenderMode = borderRenderMode
     holder._auraStackLayoutVertical = isVertical
     holder._auraStackLayoutReverseFill = reverseFill
     holder._auraStackLayoutBaseWidth = baseWidth
@@ -302,13 +304,14 @@ end
 
 local function ResourceAuraStackLayoutChanged(holder, settings)
     local count = holder.auraStackSegments and #holder.auraStackSegments or 0
-    local barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel =
+    local barTextureName, borderStyle, borderSize, borderRenderMode, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel =
         GetResourceAuraStackLayoutInputs(holder, settings)
 
     if holder._auraStackLayoutCount ~= count
         or holder._auraStackLayoutTexture ~= barTextureName
         or holder._auraStackLayoutBorderStyle ~= borderStyle
         or holder._auraStackLayoutBorderSize ~= borderSize
+        or holder._auraStackLayoutBorderRenderMode ~= borderRenderMode
         or holder._auraStackLayoutVertical ~= isVertical
         or holder._auraStackLayoutReverseFill ~= reverseFill
         or holder._auraStackLayoutBaseWidth ~= baseWidth
@@ -323,14 +326,14 @@ end
 local function LayoutResourceAuraStackSegments(holder, settings, orientationOverride, reverseFillOverride)
     if not holder or not holder.auraStackSegments or not holder.segments then return end
     local count = #holder.auraStackSegments
-    local barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel =
+    local barTextureName, borderStyle, borderSize, borderRenderMode, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel =
         GetResourceAuraStackLayoutInputs(holder, settings, orientationOverride, reverseFillOverride)
     local barTexture = CooldownCompanion:FetchStatusBar(barTextureName)
 
     for i, auraSeg in ipairs(holder.auraStackSegments) do
         local baseSeg = holder.segments[i]
         if baseSeg then
-            local inset = (borderStyle == "pixel") and borderSize or 0
+            local inset = (borderStyle == "pixel") and ST.GetBorderLayoutSize(baseSeg, borderSize, borderRenderMode) or 0
             if inset < 0 then inset = 0 end
 
             auraSeg:ClearAllPoints()
@@ -360,7 +363,7 @@ local function LayoutResourceAuraStackSegments(holder, settings, orientationOver
         end
     end
 
-    UpdateResourceAuraStackLayoutState(holder, count, barTextureName, borderStyle, borderSize, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel)
+    UpdateResourceAuraStackLayoutState(holder, count, barTextureName, borderStyle, borderSize, borderRenderMode, isVertical, reverseFill, baseWidth, baseHeight, baseFrameLevel)
 end
 
 local function EnsureResourceAuraStackSegments(holder, settings)
@@ -463,7 +466,8 @@ local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, ma
 
     local style = GetResourceDisplayStyle(settings)
     local borderStyle = style and style.borderStyle or "pixel"
-    local borderSize = (borderStyle == "pixel") and (style and style.borderSize or 1) or 0
+    local borderRenderMode = ST.GetBorderRenderMode(style)
+    local borderSize = (borderStyle == "pixel") and ST.GetBorderLayoutSize(bar, style and style.borderSize or 1, borderRenderMode) or 0
     local width = bar:GetWidth() or 0
     local height = bar:GetHeight() or 0
     if width <= 0 or height <= 0 then
@@ -534,53 +538,15 @@ end
 ------------------------------------------------------------------------
 
 local function CreatePixelBorders(parent)
-    local borders = {}
-    local names = { "TOP", "BOTTOM", "LEFT", "RIGHT" }
-    for _, side in ipairs(names) do
-        local tex = parent:CreateTexture(nil, "OVERLAY", nil, 7)
-        tex:SetColorTexture(0, 0, 0, 1)
-        tex:Hide()
-        borders[side] = tex
-    end
-    return borders
+    return ST.CreateBorderTextureSet(parent, "OVERLAY", 7)
 end
 
-local function ApplyPixelBorders(borders, parent, color, size)
-    if not borders then return end
-    local r, g, b, a = color[1], color[2], color[3], color[4]
-    size = size or 1
-
-    for _, tex in pairs(borders) do
-        tex:SetColorTexture(r, g, b, a)
-        tex:Show()
-    end
-
-    borders.TOP:ClearAllPoints()
-    borders.TOP:SetPoint("TOPLEFT", parent, "TOPLEFT", 0, 0)
-    borders.TOP:SetPoint("TOPRIGHT", parent, "TOPRIGHT", 0, 0)
-    borders.TOP:SetHeight(size)
-
-    borders.BOTTOM:ClearAllPoints()
-    borders.BOTTOM:SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", 0, 0)
-    borders.BOTTOM:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", 0, 0)
-    borders.BOTTOM:SetHeight(size)
-
-    borders.LEFT:ClearAllPoints()
-    borders.LEFT:SetPoint("TOPLEFT", parent, "TOPLEFT", 0, -size)
-    borders.LEFT:SetPoint("BOTTOMLEFT", parent, "BOTTOMLEFT", 0, size)
-    borders.LEFT:SetWidth(size)
-
-    borders.RIGHT:ClearAllPoints()
-    borders.RIGHT:SetPoint("TOPRIGHT", parent, "TOPRIGHT", 0, -size)
-    borders.RIGHT:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", 0, size)
-    borders.RIGHT:SetWidth(size)
+local function ApplyPixelBorders(borders, parent, color, size, renderMode)
+    ST.ApplyBorderTextures(borders, parent, color, size, renderMode)
 end
 
 local function HidePixelBorders(borders)
-    if not borders then return end
-    for _, tex in pairs(borders) do
-        tex:Hide()
-    end
+    ST.HideBorderTextures(borders)
 end
 
 ------------------------------------------------------------------------
@@ -621,7 +587,7 @@ local function EnsureMaxStacksIndicator(barInfo)
     return indicator
 end
 
-local function LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, barTexture, borderStyle, borderSize)
+local function LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, barTexture, borderStyle, borderSize, borderRenderMode)
     local indicator = barInfo._maxStacksIndicator
     if not indicator then return end
 
@@ -636,8 +602,9 @@ local function LayoutMaxStacksIndicator(barInfo, cabConfig, maxStacks, barTextur
     if style == "pulsingOverlay" then
         indicator:SetFrameLevel(frame:GetFrameLevel() + 3)
         if borderStyle == "pixel" then
-            indicator:SetPoint("TOPLEFT", frame, "TOPLEFT", borderSize, -borderSize)
-            indicator:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -borderSize, borderSize)
+            local inset = ST.GetBorderLayoutSize(frame, borderSize, borderRenderMode)
+            indicator:SetPoint("TOPLEFT", frame, "TOPLEFT", inset, -inset)
+            indicator:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -inset, inset)
         else
             indicator:SetAllPoints(frame)
         end
@@ -756,7 +723,7 @@ local function EnsureCustomAuraOverlayThresholdOverlays(holder, halfSegments)
     end
 end
 
-local function LayoutCustomAuraContinuousThresholdOverlay(bar, barTexture, borderStyle, borderSize)
+local function LayoutCustomAuraContinuousThresholdOverlay(bar, barTexture, borderStyle, borderSize, borderRenderMode)
     if not bar or not bar.thresholdOverlay then return end
     local overlay = bar.thresholdOverlay
     local isVertical = bar._isVertical == true
@@ -767,8 +734,9 @@ local function LayoutCustomAuraContinuousThresholdOverlay(bar, barTexture, borde
     end
     overlay:ClearAllPoints()
     if borderStyle == "pixel" then
-        overlay:SetPoint("TOPLEFT", bar, "TOPLEFT", borderSize, -borderSize)
-        overlay:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -borderSize, borderSize)
+        local inset = ST.GetBorderLayoutSize(bar, borderSize, borderRenderMode)
+        overlay:SetPoint("TOPLEFT", bar, "TOPLEFT", inset, -inset)
+        overlay:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -inset, inset)
     else
         overlay:SetAllPoints(bar)
     end
@@ -869,6 +837,7 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
     local borderStyle = style and style.borderStyle or "pixel"
     local borderColor = style and style.borderColor or { 0, 0, 0, 1 }
     local borderSize = style and style.borderSize or 1
+    local borderRenderMode = ST.GetBorderRenderMode(style)
     local isVertical
     if orientationOverride == "vertical" then
         isVertical = true
@@ -933,7 +902,7 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
             seg.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])
 
             if borderStyle == "pixel" then
-                ApplyPixelBorders(seg.borders, seg, borderColor, borderSize)
+                ApplyPixelBorders(seg.borders, seg, borderColor, borderSize, borderRenderMode)
             else
                 HidePixelBorders(seg.borders)
             end
@@ -942,8 +911,9 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
                 local thresholdSeg = holder.thresholdSegments[i]
                 thresholdSeg:ClearAllPoints()
                 if borderStyle == "pixel" then
-                    thresholdSeg:SetPoint("TOPLEFT", seg, "TOPLEFT", borderSize, -borderSize)
-                    thresholdSeg:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -borderSize, borderSize)
+                    local inset = ST.GetBorderLayoutSize(seg, borderSize, borderRenderMode)
+                    thresholdSeg:SetPoint("TOPLEFT", seg, "TOPLEFT", inset, -inset)
+                    thresholdSeg:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -inset, inset)
                 else
                     thresholdSeg:SetAllPoints(seg)
                 end
@@ -1019,6 +989,7 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
     local borderStyle = style and style.borderStyle or "pixel"
     local borderColor = style and style.borderColor or { 0, 0, 0, 1 }
     local borderSize = style and style.borderSize or 1
+    local borderRenderMode = ST.GetBorderRenderMode(style)
     local isVertical
     if orientationOverride == "vertical" then
         isVertical = true
@@ -1074,7 +1045,7 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
         seg.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])
 
         if borderStyle == "pixel" then
-            ApplyPixelBorders(seg.borders, seg, borderColor, borderSize)
+            ApplyPixelBorders(seg.borders, seg, borderColor, borderSize, borderRenderMode)
         else
             HidePixelBorders(seg.borders)
         end
@@ -1083,8 +1054,9 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
         local ov = holder.overlaySegments[i]
         ov:ClearAllPoints()
         if borderStyle == "pixel" then
-            ov:SetPoint("TOPLEFT", seg, "TOPLEFT", borderSize, -borderSize)
-            ov:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -borderSize, borderSize)
+            local inset = ST.GetBorderLayoutSize(seg, borderSize, borderRenderMode)
+            ov:SetPoint("TOPLEFT", seg, "TOPLEFT", inset, -inset)
+            ov:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -inset, inset)
         else
             ov:SetAllPoints(seg)
         end
@@ -1096,8 +1068,9 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
             local thresholdSeg = holder.thresholdSegments[i]
             thresholdSeg:ClearAllPoints()
             if borderStyle == "pixel" then
-                thresholdSeg:SetPoint("TOPLEFT", seg, "TOPLEFT", borderSize, -borderSize)
-                thresholdSeg:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -borderSize, borderSize)
+                local inset = ST.GetBorderLayoutSize(seg, borderSize, borderRenderMode)
+                thresholdSeg:SetPoint("TOPLEFT", seg, "TOPLEFT", inset, -inset)
+                thresholdSeg:SetPoint("BOTTOMRIGHT", seg, "BOTTOMRIGHT", -inset, inset)
             else
                 thresholdSeg:SetAllPoints(seg)
             end

--- a/tests/border-rendering.lua
+++ b/tests/border-rendering.lua
@@ -1,0 +1,117 @@
+local ST = {}
+
+PixelUtil = {
+    nearestCalls = {},
+    pointCalls = {},
+}
+
+function PixelUtil.GetNearestPixelSize(uiUnitSize, layoutScale, minPixels)
+    table.insert(PixelUtil.nearestCalls, {
+        uiUnitSize = uiUnitSize,
+        layoutScale = layoutScale,
+        minPixels = minPixels,
+    })
+    return 0.5
+end
+
+function PixelUtil.SetPoint(region, point, relativeTo, relativePoint, offsetX, offsetY, minOffsetXPixels, minOffsetYPixels)
+    table.insert(PixelUtil.pointCalls, {
+        region = region,
+        point = point,
+        relativeTo = relativeTo,
+        relativePoint = relativePoint,
+        offsetX = offsetX,
+        offsetY = offsetY,
+        minOffsetXPixels = minOffsetXPixels,
+        minOffsetYPixels = minOffsetYPixels,
+    })
+    region:SetPoint(point, relativeTo, relativePoint, offsetX, offsetY)
+end
+
+local function assertEquals(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s: expected %s, got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function NewTexture()
+    return {
+        shown = false,
+        points = {},
+        color = nil,
+        SetColorTexture = function(self, r, g, b, a)
+            self.color = { r, g, b, a }
+        end,
+        Hide = function(self)
+            self.shown = false
+        end,
+        Show = function(self)
+            self.shown = true
+        end,
+        ClearAllPoints = function(self)
+            self.points = {}
+        end,
+        SetPoint = function(self, point, relativeTo, relativePoint, offsetX, offsetY)
+            table.insert(self.points, {
+                point = point,
+                relativeTo = relativeTo,
+                relativePoint = relativePoint,
+                offsetX = offsetX,
+                offsetY = offsetY,
+            })
+        end,
+    }
+end
+
+local function NewRegion()
+    local region = {
+        textures = {},
+        scale = 2,
+    }
+    function region:GetEffectiveScale()
+        return self.scale
+    end
+    function region:CreateTexture()
+        local texture = NewTexture()
+        table.insert(self.textures, texture)
+        return texture
+    end
+    return region
+end
+
+local chunk = assert(loadfile("Core/Utils.lua"))
+chunk("CooldownCompanion", ST)
+
+assertEquals(ST.GetBorderRenderMode(nil), ST.BORDER_RENDER_MODE_CUSTOM, "nil render mode defaults to custom")
+assertEquals(ST.GetBorderRenderMode("unexpected"), ST.BORDER_RENDER_MODE_CUSTOM, "invalid render mode defaults to custom")
+assertEquals(ST.GetBorderRenderMode(ST.BORDER_RENDER_MODE_CRISP), ST.BORDER_RENDER_MODE_CRISP, "crisp render mode is preserved")
+assertEquals(ST.GetBorderRenderMode({ textBorderRenderMode = ST.BORDER_RENDER_MODE_CRISP }, "textBorderRenderMode"), ST.BORDER_RENDER_MODE_CRISP, "table render mode key is supported")
+
+local region = NewRegion()
+assertEquals(ST.GetBorderLayoutSize(region, 2.25, ST.BORDER_RENDER_MODE_CUSTOM), 2.25, "custom layout size uses configured value")
+assertEquals(ST.GetBorderLayoutSize(region, 2.25, ST.BORDER_RENDER_MODE_CRISP), 0.5, "crisp layout size uses PixelUtil")
+assertEquals(PixelUtil.nearestCalls[#PixelUtil.nearestCalls].layoutScale, 2, "crisp layout uses effective scale")
+
+local textures = ST.CreateBorderTextureSet(region)
+assertEquals(#textures, 4, "border texture set has numeric entries")
+assertTrue(textures[1] == textures.TOP, "border texture set exposes named top alias")
+assertTrue(textures[4] == textures.RIGHT, "border texture set exposes named right alias")
+
+ST.ApplyBorderTextures(textures, region, { 1, 0.5, 0.25, 0.75 }, 0, ST.BORDER_RENDER_MODE_CUSTOM)
+for index = 1, 4 do
+    assertEquals(textures[index].shown, false, "custom zero border hides texture " .. index)
+end
+
+ST.ApplyBorderTextures(textures, region, { 0, 1, 0, 1 }, 0, ST.BORDER_RENDER_MODE_CRISP)
+for index = 1, 4 do
+    assertEquals(textures[index].shown, true, "crisp border shows texture " .. index)
+end
+assertTrue(#PixelUtil.pointCalls > 0, "crisp positioning uses PixelUtil.SetPoint")
+
+print("border rendering helper tests passed")

--- a/tests/border-rendering.lua
+++ b/tests/border-rendering.lua
@@ -1,9 +1,18 @@
 local ST = {}
 
 PixelUtil = {
+    pixelFactor = 0.5,
     nearestCalls = {},
     pointCalls = {},
 }
+
+function PixelUtil.GetPixelToUIUnitFactor()
+    return PixelUtil.pixelFactor
+end
+
+local function Round(value)
+    return math.floor(value + 0.5)
+end
 
 function PixelUtil.GetNearestPixelSize(uiUnitSize, layoutScale, minPixels)
     table.insert(PixelUtil.nearestCalls, {
@@ -11,21 +20,37 @@ function PixelUtil.GetNearestPixelSize(uiUnitSize, layoutScale, minPixels)
         layoutScale = layoutScale,
         minPixels = minPixels,
     })
-    return 0.5
+    if uiUnitSize == 0 and (not minPixels or minPixels == 0) then
+        return 0
+    end
+
+    local numPixels = Round((uiUnitSize * layoutScale) / PixelUtil.GetPixelToUIUnitFactor())
+    if minPixels then
+        if uiUnitSize < 0 then
+            if numPixels > -minPixels then
+                numPixels = -minPixels
+            end
+        elseif numPixels < minPixels then
+            numPixels = minPixels
+        end
+    end
+    return numPixels * PixelUtil.GetPixelToUIUnitFactor() / layoutScale
 end
 
 function PixelUtil.SetPoint(region, point, relativeTo, relativePoint, offsetX, offsetY, minOffsetXPixels, minOffsetYPixels)
+    local snappedX = PixelUtil.GetNearestPixelSize(offsetX, region:GetEffectiveScale(), minOffsetXPixels)
+    local snappedY = PixelUtil.GetNearestPixelSize(offsetY, region:GetEffectiveScale(), minOffsetYPixels)
     table.insert(PixelUtil.pointCalls, {
         region = region,
         point = point,
         relativeTo = relativeTo,
         relativePoint = relativePoint,
-        offsetX = offsetX,
-        offsetY = offsetY,
+        offsetX = snappedX,
+        offsetY = snappedY,
         minOffsetXPixels = minOffsetXPixels,
         minOffsetYPixels = minOffsetYPixels,
     })
-    region:SetPoint(point, relativeTo, relativePoint, offsetX, offsetY)
+    region:SetPoint(point, relativeTo, relativePoint, snappedX, snappedY)
 end
 
 local function assertEquals(actual, expected, label)
@@ -45,6 +70,10 @@ local function NewTexture()
         shown = false,
         points = {},
         color = nil,
+        scale = 1,
+        GetEffectiveScale = function(self)
+            return self.scale
+        end,
         SetColorTexture = function(self, r, g, b, a)
             self.color = { r, g, b, a }
         end,
@@ -79,6 +108,7 @@ local function NewRegion()
     end
     function region:CreateTexture()
         local texture = NewTexture()
+        texture.scale = self.scale
         table.insert(self.textures, texture)
         return texture
     end
@@ -95,8 +125,13 @@ assertEquals(ST.GetBorderRenderMode({ textBorderRenderMode = ST.BORDER_RENDER_MO
 
 local region = NewRegion()
 assertEquals(ST.GetBorderLayoutSize(region, 2.25, ST.BORDER_RENDER_MODE_CUSTOM), 2.25, "custom layout size uses configured value")
-assertEquals(ST.GetBorderLayoutSize(region, 2.25, ST.BORDER_RENDER_MODE_CRISP), 0.5, "crisp layout size uses PixelUtil")
+assertEquals(ST.GetBorderLayoutSize(region, 2.25, ST.BORDER_RENDER_MODE_CRISP), 0.25, "crisp layout size is one physical pixel")
 assertEquals(PixelUtil.nearestCalls[#PixelUtil.nearestCalls].layoutScale, 2, "crisp layout uses effective scale")
+
+local scaleOneRegion = NewRegion()
+scaleOneRegion.scale = 1
+local crispSize = ST.GetBorderLayoutSize(scaleOneRegion, 2.25, ST.BORDER_RENDER_MODE_CRISP)
+assertEquals(crispSize * scaleOneRegion.scale / PixelUtil.GetPixelToUIUnitFactor(), 1, "scale 1 crisp size is one physical pixel")
 
 local textures = ST.CreateBorderTextureSet(region)
 assertEquals(#textures, 4, "border texture set has numeric entries")
@@ -113,5 +148,6 @@ for index = 1, 4 do
     assertEquals(textures[index].shown, true, "crisp border shows texture " .. index)
 end
 assertTrue(#PixelUtil.pointCalls > 0, "crisp positioning uses PixelUtil.SetPoint")
+assertEquals(PixelUtil.pointCalls[#PixelUtil.pointCalls].offsetY * region.scale / PixelUtil.GetPixelToUIUnitFactor(), 1, "crisp offset is one physical pixel")
 
 print("border rendering helper tests passed")


### PR DESCRIPTION
## What Players Will Notice
- Border settings now support a separate `One-pixel` thickness option for icon, bar, text, cast bar, and resource-style borders.
- Existing `Custom Thickness` borders keep their current fractional sizing behavior, including 0.1-step adjustments.
- Existing per-button border overrides continue to behave like custom-thickness overrides after migration.

## Why This Changed
- Fractional UI-unit border sizes can look inconsistent at different UI scales or frame sizes.
- Players who want a stable one-pixel border needed a dedicated option that does not reinterpret existing custom border settings.

## What Changed
- Added shared Cooldown Companion border helpers in `Core/Utils.lua` with two explicit modes: `custom` and the internal one-pixel mode.
- The one-pixel option derives one physical pixel through Blizzard `PixelUtil`, while custom thickness preserves the previous UI-unit sizing path.
- Added config dropdowns under `Border Thickness` and hid the thickness slider when `One-pixel` is selected.
- Routed button, bar, text, cast bar, resource bar, and preview border drawing through the shared helpers.
- Added a migration so old per-button border/text-background overrides default to custom thickness instead of inheriting a new group-level one-pixel setting.
- Added a small repository note documenting the rendering boundary and audit checklist.

## Validation
- `lua tests\border-rendering.lua`
- `luac -p ConfigSettings\Helpers.lua ConfigSettings\GroupTabs.lua`
- `git diff --check`
- Earlier branch validation also included the broader changed-file `luac -p` pass and `git diff --check origin/main...HEAD`.
- In-game visual testing before the final sizing correction confirmed stable one-pixel borders across tested width/height ratios, and combat behavior was confirmed. A final in-game sanity pass is still recommended after the last PixelUtil sizing adjustment.