### PR TITLE
Fade config windows while dragging

### DIFF
--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -548,7 +548,9 @@ local function CreateConfigPanel()
 
     local configDragAlphaFrames = setmetatable({}, { __mode = "k" })
     local configDragAlphaBeforeMove = setmetatable({}, { __mode = "k" })
+    local configDragAlphaHandles = setmetatable({}, { __mode = "k" })
     local configDragAlphaActive = false
+    local SetMainConfigDragAlpha
 
     local function SetConfigDragAlphaFrame(targetFrame, active)
         if not (targetFrame and targetFrame.SetAlpha) then
@@ -566,12 +568,39 @@ local function CreateConfigPanel()
         end
     end
 
+    local function GetConfigDragAlphaHandle(targetFrame)
+        return targetFrame and targetFrame.obj and targetFrame.obj.title
+    end
+
+    local function HookConfigDragAlphaHandle(handle)
+        if not (handle and handle.HookScript) or handle._cdcConfigDragAlphaHooked then
+            return
+        end
+
+        handle._cdcConfigDragAlphaHooked = true
+        handle:HookScript("OnMouseDown", function(self)
+            if configDragAlphaHandles[self] and SetMainConfigDragAlpha then
+                SetMainConfigDragAlpha(true)
+            end
+        end)
+        handle:HookScript("OnMouseUp", function(self)
+            if configDragAlphaHandles[self] and SetMainConfigDragAlpha then
+                SetMainConfigDragAlpha(false)
+            end
+        end)
+    end
+
     CS.RegisterConfigDragAlphaFrame = function(targetFrame)
         if not targetFrame then
             return
         end
 
         configDragAlphaFrames[targetFrame] = true
+        local dragHandle = GetConfigDragAlphaHandle(targetFrame)
+        if dragHandle then
+            configDragAlphaHandles[dragHandle] = true
+            HookConfigDragAlphaHandle(dragHandle)
+        end
         if configDragAlphaActive then
             SetConfigDragAlphaFrame(targetFrame, true)
         end
@@ -582,11 +611,19 @@ local function CreateConfigPanel()
             return
         end
 
-        SetConfigDragAlphaFrame(targetFrame, false)
+        local dragHandle = GetConfigDragAlphaHandle(targetFrame)
+        if dragHandle then
+            configDragAlphaHandles[dragHandle] = nil
+        end
+        if configDragAlphaActive then
+            SetMainConfigDragAlpha(false)
+        else
+            SetConfigDragAlphaFrame(targetFrame, false)
+        end
         configDragAlphaFrames[targetFrame] = nil
     end
 
-    local function SetMainConfigDragAlpha(active)
+    SetMainConfigDragAlpha = function(active)
         if active then
             configDragAlphaActive = true
             SetConfigDragAlphaFrame(content, true)
@@ -604,12 +641,8 @@ local function CreateConfigPanel()
 
     local titleMover = frame.titletext and frame.titletext:GetParent()
     if titleMover then
-        titleMover:HookScript("OnMouseDown", function()
-            SetMainConfigDragAlpha(true)
-        end)
-        titleMover:HookScript("OnMouseUp", function()
-            SetMainConfigDragAlpha(false)
-        end)
+        configDragAlphaHandles[titleMover] = true
+        HookConfigDragAlphaHandle(titleMover)
     end
 
     -- Hide AceGUI's default sizer grips (replaced by custom resize grip below)

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -68,6 +68,7 @@ local CONFIG_FINDER_BUTTON_GAP = 6
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
 local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
 local CONFIG_NESTED_INLINE_GROUP_INSET = 20
+local CONFIG_DRAG_ALPHA = 0.40
 
 if not AceGUI:GetLayout(MANUAL_COLUMN_LAYOUT) then
     -- These columns are positioned and sized manually, so their layout should
@@ -545,6 +546,72 @@ local function CreateConfigPanel()
     -- Get the content area (below the title bar)
     local contentFrame = frame.content
 
+    local configDragAlphaFrames = setmetatable({}, { __mode = "k" })
+    local configDragAlphaBeforeMove = setmetatable({}, { __mode = "k" })
+    local configDragAlphaActive = false
+
+    local function SetConfigDragAlphaFrame(targetFrame, active)
+        if not (targetFrame and targetFrame.SetAlpha) then
+            return
+        end
+
+        if active then
+            if configDragAlphaBeforeMove[targetFrame] == nil then
+                configDragAlphaBeforeMove[targetFrame] = targetFrame.GetAlpha and targetFrame:GetAlpha() or 1
+            end
+            targetFrame:SetAlpha(math.min(configDragAlphaBeforeMove[targetFrame] or 1, CONFIG_DRAG_ALPHA))
+        elseif configDragAlphaBeforeMove[targetFrame] ~= nil then
+            targetFrame:SetAlpha(configDragAlphaBeforeMove[targetFrame])
+            configDragAlphaBeforeMove[targetFrame] = nil
+        end
+    end
+
+    CS.RegisterConfigDragAlphaFrame = function(targetFrame)
+        if not targetFrame then
+            return
+        end
+
+        configDragAlphaFrames[targetFrame] = true
+        if configDragAlphaActive then
+            SetConfigDragAlphaFrame(targetFrame, true)
+        end
+    end
+
+    CS.UnregisterConfigDragAlphaFrame = function(targetFrame)
+        if not targetFrame then
+            return
+        end
+
+        SetConfigDragAlphaFrame(targetFrame, false)
+        configDragAlphaFrames[targetFrame] = nil
+    end
+
+    local function SetMainConfigDragAlpha(active)
+        if active then
+            configDragAlphaActive = true
+            SetConfigDragAlphaFrame(content, true)
+            for targetFrame in pairs(configDragAlphaFrames) do
+                SetConfigDragAlphaFrame(targetFrame, true)
+            end
+        else
+            configDragAlphaActive = false
+            SetConfigDragAlphaFrame(content, false)
+            for targetFrame in pairs(configDragAlphaFrames) do
+                SetConfigDragAlphaFrame(targetFrame, false)
+            end
+        end
+    end
+
+    local titleMover = frame.titletext and frame.titletext:GetParent()
+    if titleMover then
+        titleMover:HookScript("OnMouseDown", function()
+            SetMainConfigDragAlpha(true)
+        end)
+        titleMover:HookScript("OnMouseUp", function()
+            SetMainConfigDragAlpha(false)
+        end)
+    end
+
     -- Hide AceGUI's default sizer grips (replaced by custom resize grip below)
     if frame.sizer_se then
         frame.sizer_se:Hide()
@@ -601,6 +668,7 @@ local function CreateConfigPanel()
     -- isCollapsing flag prevents cleanup when collapsing (vs truly closing)
     local isCollapsing = false
     content:HookScript("OnHide", function()
+        SetMainConfigDragAlpha(false)
         if CancelFirstIconPanelTutorial then
             CancelFirstIconPanelTutorial(isCollapsing and "config_collapsed" or "config_hidden")
         end

--- a/ConfigSettings/AuraTexturePicker.lua
+++ b/ConfigSettings/AuraTexturePicker.lua
@@ -115,6 +115,9 @@ local function OpenAuraTexturePicker(opts)
     window:EnableResize(false)
     pickerWindow = window
     CS.auraTexturePickerWindow = window
+    if CS.RegisterConfigDragAlphaFrame then
+        CS.RegisterConfigDragAlphaFrame(window.frame)
+    end
 
     local configFrame = CS.configFrame
     if configFrame and configFrame.frame and configFrame.frame:IsShown() then
@@ -670,6 +673,9 @@ local function OpenAuraTexturePicker(opts)
         ClearStagedPreview()
         GameTooltip:Hide()
         CleanupRawGrid()
+        if CS.UnregisterConfigDragAlphaFrame then
+            CS.UnregisterConfigDragAlphaFrame(widget.frame)
+        end
         widget._rebind = nil
         widget._refreshEntries = nil
         widget._targetGroupId = nil

--- a/ConfigSettings/FormatEditor.lua
+++ b/ConfigSettings/FormatEditor.lua
@@ -654,6 +654,9 @@ local function OpenFormatEditor(style, groupId, opts)
     window:PauseLayout()
     formatEditorFrame = window
     CS.formatEditorFrame = window
+    if CS.RegisterConfigDragAlphaFrame then
+        CS.RegisterConfigDragAlphaFrame(window.frame)
+    end
 
     -- Anchor to the right of the config panel
     local configFrame = CS.configFrame
@@ -1104,6 +1107,9 @@ local function OpenFormatEditor(style, groupId, opts)
     window:SetCallback("OnClose", function(widget)
         -- Stop pulse animation
         widget.frame:SetScript("OnUpdate", nil)
+        if CS.UnregisterConfigDragAlphaFrame then
+            CS.UnregisterConfigDragAlphaFrame(widget.frame)
+        end
         -- Release save button (not part of AceGUI layout)
         if widget._saveBtn then
             AceGUI:Release(widget._saveBtn)


### PR DESCRIPTION
## What Players Will Notice
- The Cooldown Companion config window now fades to 40% opacity while it is being dragged, making it easier to see the game world and addon layout behind it.
- Attached config tools like the texture picker and format editor fade with the main config while they remain attached, including when those attached windows are dragged directly.

## Why This Changed
- Moving the config could fully cover the screen area players were trying to line up or inspect.
- The first pass faded only the main config frame, so attached config windows could remain visually in the way while the config was being repositioned.

## What Changed
- Added a shared config drag-alpha helper that stores and restores each participating frame's original alpha.
- Registered attached AceGUI config windows, currently the aura texture picker and format editor, so they fade with the main config and clean up on close.
- Hooked registered title handles so direct dragging on attached windows uses the same fade and restore lifecycle as dragging the main config title.

## Validation
- Ran `luac -p Config\Panel.lua ConfigSettings\AuraTexturePicker.lua ConfigSettings\FormatEditor.lua`.
- Ran `git diff --check`; only the usual LF-to-CRLF warnings were reported.
- Ran `review-fix-loop` after the direct-drag fix; no P2+ findings and no `safe_auto` fixes remained.
- In-game combat/restricted-content verification has not been completed in this Codex session. Before merge, verify dragging the main config, the texture picker, and the format editor in-game restores alpha after release/close/reopen, including restricted-content/combat-safe behavior where applicable.
