### PR TITLE
Clean up advanced config controls with a focused side editor

### DIFF
--- a/ButtonFrame/Glows.lua
+++ b/ButtonFrame/Glows.lua
@@ -213,6 +213,37 @@ local function TintProcGlowFrame(frame, color)
     end
 end
 
+local function PrepareProcGlowLoop(frame, color, resetLoopAlpha)
+    if not frame then return end
+
+    TintProcGlowFrame(frame, color)
+    if frame.ProcAltGlow then
+        frame.ProcAltGlow:Hide()
+    end
+    if frame.ProcStartAnim then
+        frame.ProcStartAnim:Stop()
+    end
+    if frame.ProcStartFlipbook then
+        frame.ProcStartFlipbook:Show()
+        frame.ProcStartFlipbook:SetAlpha(0)
+    end
+    if frame.ProcLoopFlipbook then
+        frame.ProcLoopFlipbook:Show()
+        frame.ProcLoopFlipbook:SetAlpha(resetLoopAlpha and 0 or 1)
+    end
+end
+
+local function PlayProcGlowLoop(frame)
+    if not frame then return end
+    if frame.ProcLoop then
+        if not frame.ProcLoop:IsPlaying() then
+            frame.ProcLoop:Play()
+        end
+    elseif frame.ProcLoopFlipbook then
+        frame.ProcLoopFlipbook:SetAlpha(1)
+    end
+end
+
 -- Hide all glow sub-styles in a container table (solidTextures, procFrame, overlayTexture).
 -- Works for procGlow, auraGlow, barAuraEffect, assistedHighlight, and keyPressHighlight containers.
 -- LCG pixel glow is stopped via StopLibCustomGlow.
@@ -284,18 +315,9 @@ local function ShowGlowStyle(container, style, button, color, params)
         end
     elseif style == "glow" then
         FitHighlightFrame(container.procFrame, button, size or 32)
-        TintProcGlowFrame(container.procFrame, color)
+        PrepareProcGlowLoop(container.procFrame, color, true)
         container.procFrame:Show()
-        -- Skip intro burst, go straight to loop
-        if container.procFrame.ProcStartFlipbook then
-            container.procFrame.ProcStartFlipbook:SetAlpha(0)
-        end
-        if container.procFrame.ProcLoopFlipbook then
-            container.procFrame.ProcLoopFlipbook:SetAlpha(1)
-        end
-        if container.procFrame.ProcLoop then
-            container.procFrame.ProcLoop:Play()
-        end
+        PlayProcGlowLoop(container.procFrame)
     elseif style == "overlay" then
         if container.overlayTexture then
             container.overlayTexture:SetColorTexture(color[1], color[2], color[3], color[4] or defaultAlpha)
@@ -358,6 +380,29 @@ local function IsGlowAnimationAlive(container)
         return true
     end
     -- No recognized sub-style matched — assume dead to force restart.
+    return false
+end
+
+local function TryUpdateGlowStyleInPlace(container, style, button, color, params)
+    if style == "solid" then
+        ApplyEdgePositions(container.solidTextures, button, params.size or 2)
+        for _, tex in ipairs(container.solidTextures) do
+            tex:SetColorTexture(color[1], color[2], color[3], color[4] or params.defaultAlpha or 1)
+            tex:Show()
+        end
+        return true
+    elseif style == "glow" and container.procFrame and container.procFrame:IsShown() then
+        FitHighlightFrame(container.procFrame, button, params.size or 32)
+        PrepareProcGlowLoop(container.procFrame, color, false)
+        container.procFrame:Show()
+        PlayProcGlowLoop(container.procFrame)
+        return true
+    elseif style == "overlay" and container.overlayTexture and container.overlayTexture:IsShown() then
+        container.overlayTexture:SetColorTexture(color[1], color[2], color[3], color[4] or params.defaultAlpha or 1)
+        container.overlayTexture:Show()
+        return true
+    end
+
     return false
 end
 
@@ -548,21 +593,6 @@ local function MakeGlowSetter(cfg)
             return
         end
 
-        -- Update cache
-        button[cActive] = true
-        button[cStyle] = glowStyle
-        button[cR] = color[1]
-        button[cG] = color[2]
-        button[cB] = color[3]
-        button[cA] = ca
-        if cSz then button[cSz] = sz end
-        if cTh then button[cTh] = th end
-        if cSpd then button[cSpd] = spd end
-        if cLn then button[cLn] = ln end
-        if cPandemic then button[cPandemic] = pandemicOverride end
-
-        HideGlowStyles(container)
-
         -- Build opts table (state-change path only, so allocation is OK)
         local opts = { size = sz, key = resolvedLcgKey }
         if fullParams then
@@ -578,6 +608,28 @@ local function MakeGlowSetter(cfg)
             opts.defaultAlpha = optsDefaultAlpha
         end
 
+        local updateInPlace = button[cActive]
+            and button[cStyle] == glowStyle
+            and IsGlowAnimationAlive(container)
+
+        -- Update cache
+        button[cActive] = true
+        button[cStyle] = glowStyle
+        button[cR] = color[1]
+        button[cG] = color[2]
+        button[cB] = color[3]
+        button[cA] = ca
+        if cSz then button[cSz] = sz end
+        if cTh then button[cTh] = th end
+        if cSpd then button[cSpd] = spd end
+        if cLn then button[cLn] = ln end
+        if cPandemic then button[cPandemic] = pandemicOverride end
+
+        if updateInPlace and TryUpdateGlowStyleInPlace(container, glowStyle, button, color, opts) then
+            return
+        end
+
+        HideGlowStyles(container)
         ShowGlowStyle(container, glowStyle, button, color, opts)
     end
 end

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -1082,4 +1082,10 @@ function CooldownCompanion:ClearAllConfigPreviews()
     if self.StopResourceBarPreview then
         self:StopResourceBarPreview()
     end
+    if ST._ClearActivePreviewBadgeButton then
+        ST._ClearActivePreviewBadgeButton()
+    end
+    if ST._RefreshAdvancedSettingsPreviewButtons then
+        ST._RefreshAdvancedSettingsPreviewButtons()
+    end
 end

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1146,14 +1146,22 @@ local function CreateConfigPanel()
             info.func = function()
                 local val = not CooldownCompanion.db.profile.hideInfoButtons
                 CooldownCompanion.db.profile.hideInfoButtons = val
-                for _, btn in ipairs(CS.columnInfoButtons) do
-                    if val then btn:Hide() else btn:Show() end
+                local function applyInfoButtonVisibility(buttons)
+                    if type(buttons) ~= "table" then return end
+                    for _, btn in ipairs(buttons) do
+                        if btn and not btn._isAdvancedToggle then
+                            if val then btn:Hide() else btn:Show() end
+                        end
+                    end
                 end
-                for _, btn in ipairs(CS.tabInfoButtons) do
-                    if val then btn:Hide() else btn:Show() end
-                end
-                for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                    if val then btn:Hide() else btn:Show() end
+                for _, buttons in ipairs({
+                    CS.columnInfoButtons,
+                    CS.tabInfoButtons,
+                    CS.customBarInfoButtons,
+                    CS.buttonSettingsInfoButtons,
+                    CS.advancedSettingsInfoButtons,
+                }) do
+                    applyInfoButtonVisibility(buttons)
                 end
             end
             UIDropDownMenu_AddButton(info, level)
@@ -1265,6 +1273,9 @@ local function CreateConfigPanel()
 
     -- Reset collapse state whenever mini frame is hidden (ESC, /cdc toggle, expand)
     miniFrame:SetScript("OnHide", function()
+        if CS.CloseAdvancedSettingsPanel then
+            CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+        end
         isMinimized = false
         collapseIcon:SetAtlas("common-icon-minus")
         collapseBtn:SetParent(content)
@@ -1315,6 +1326,9 @@ local function CreateConfigPanel()
         else
             -- Collapse: save main frame position, then show mini frame at collapse button position
             CloseDropDownMenus()
+            if CS.CloseAdvancedSettingsPanel then
+                CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+            end
 
             savedFrameRight = content:GetRight()
             savedFrameTop = content:GetTop()
@@ -2274,6 +2288,9 @@ function CooldownCompanion:ToggleConfig()
     if CS.configFrame._miniFrame and CS.configFrame._miniFrame:IsShown() then
         if CS.configFrame.HideChangelogOverlay then
             CS.configFrame.HideChangelogOverlay()
+        end
+        if CS.CloseAdvancedSettingsPanel then
+            CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
         end
         CS.configFrame._miniFrame:Hide()
         return

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -1828,7 +1828,9 @@ local function CreateConfigPanel()
         -- Apply hideInfoButtons setting
         if CooldownCompanion.db.profile.hideInfoButtons then
             for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                btn:Hide()
+                if btn and not btn._isAdvancedToggle then
+                    btn:Hide()
+                end
             end
         end
     end)

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -717,6 +717,9 @@ local function CreateConfigPanel()
         if CS.CancelPickAuraTexture then
             CS.CancelPickAuraTexture()
         end
+        if CS.CloseAdvancedSettingsPanel then
+            CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+        end
         if not CS.previewToggleRefreshActive then
             CooldownCompanion:ClearAllConfigPreviews()
         end
@@ -2109,6 +2112,8 @@ function CooldownCompanion:RefreshConfigPanel()
     if not CS.configFrame then return end
     if not CS.configFrame.frame:IsShown() then return end
     if CS.talentPickerMode then return end
+    if CS.configRefreshInProgress or CS.advancedSettingsPanelRefreshing then return end
+    CS.configRefreshInProgress = true
     if IsConfigFinderAvailable and not IsConfigFinderAvailable() and ClearConfigFinderText then
         ClearConfigFinderText()
     elseif SetConfigFinderText then
@@ -2230,6 +2235,10 @@ function CooldownCompanion:RefreshConfigPanel()
     end
     if RefreshTutorialPlacement then
         RefreshTutorialPlacement()
+    end
+    CS.configRefreshInProgress = false
+    if CS.RefreshAdvancedSettingsPanel then
+        CS.RefreshAdvancedSettingsPanel()
     end
 
 end

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -99,7 +99,7 @@ local STEP_DATA = {
     },
     panel_settings_intro = {
         title = "Panel Settings",
-        text = "This column is dedicated to editing and styling all entries in a panel. Panel layout, text elements, and indicators are all found here.\n\nImportant:\n\n|A:Crosshair_VehichleCursor_32:14:14|a: Whenever you see the |A:Crosshair_VehichleCursor_32:14:14|a next to a setting, that means you can override a panel-wide setting for a specific entry.\n\n|A:QuestLog-icon-setting:14:14|a: Whenever you see the |A:QuestLog-icon-setting:14:14|a next to a setting, that means you can expand advanced settings for it.",
+        text = "This column is dedicated to editing and styling all entries in a panel. Panel layout, text elements, and indicators are all found here.\n\nImportant:\n\n|A:Crosshair_VehichleCursor_32:14:14|a: Whenever you see the |A:Crosshair_VehichleCursor_32:14:14|a next to a setting, that means you can override a panel-wide setting for a specific entry.\n\n|A:QuestLog-icon-setting:14:14|a: Whenever you see the |A:QuestLog-icon-setting:14:14|a next to a setting, that opens advanced settings for it.",
         anchor = "col4_area",
         placement = "left",
     },

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -210,6 +210,7 @@ local function BuildWindowContents()
     local scroll = AceGUI:Create("ScrollFrame")
     scroll:SetLayout("List")
     scroll._isAdvancedSettingsPanel = true
+    CS.advancedSettingsPreviewToggleButtons = nil
     if scroll.PauseLayout then
         scroll:PauseLayout()
     end
@@ -253,6 +254,7 @@ local function CleanupWindow(widget)
     end
 
     ClearAdvancedSettingsInfoButtons()
+    CS.advancedSettingsPreviewToggleButtons = nil
     widget:ReleaseChildren()
     AceGUI:Release(widget)
     advancedWindow = nil

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -1,0 +1,332 @@
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+local AceGUI = LibStub("AceGUI-3.0")
+local CS = ST._configState
+
+local PANEL_WIDTH = 430
+local PANEL_HEIGHT = 610
+
+local advancedWindow = nil
+local activeDescriptor = nil
+local queuedOpen = nil
+local refreshingAdvancedPanel = false
+
+local function BoolValue(value)
+    return value == true
+end
+
+local function SortedKeyString(selection)
+    if type(selection) ~= "table" then
+        return ""
+    end
+
+    local keys = {}
+    for key, selected in pairs(selection) do
+        if selected then
+            keys[#keys + 1] = tostring(key)
+        end
+    end
+    table.sort(keys)
+    return table.concat(keys, ",")
+end
+
+local function BuildContext(extra)
+    local context = {
+        selectedFolder = CS.selectedFolder,
+        selectedContainer = CS.selectedContainer,
+        selectedGroup = CS.selectedGroup,
+        selectedButton = CS.selectedButton,
+        selectedButtons = SortedKeyString(CS.selectedButtons),
+        selectedPanels = SortedKeyString(CS.selectedPanels),
+        selectedGroups = SortedKeyString(CS.selectedGroups),
+        selectedTab = CS.selectedTab,
+        buttonSettingsTab = CS.buttonSettingsTab,
+        panelSettingsTab = CS.panelSettingsTab,
+        resourceBarPanelActive = BoolValue(CS.resourceBarPanelActive),
+        barPanelTab = CS.barPanelTab,
+        resourceStylingTab = CS.resourceStylingTab,
+        castBarStylingTab = CS.castBarStylingTab,
+        customBarSettingsTab = CS.customBarSettingsTab,
+        selectedCustomBarId = CS.selectedCustomBarId,
+        browseMode = BoolValue(CS.browseMode),
+        browseCharKey = CS.browseCharKey,
+        autoAddFlowActive = BoolValue(CS.autoAddFlowActive),
+        talentPickerMode = BoolValue(CS.talentPickerMode),
+    }
+
+    if type(extra) == "table" then
+        for key, value in pairs(extra) do
+            context[key] = value
+        end
+    end
+
+    return context
+end
+
+local function ContextMatches(left, right)
+    if type(left) ~= "table" or type(right) ~= "table" then
+        return false
+    end
+
+    for key, value in pairs(left) do
+        if right[key] ~= value then
+            return false
+        end
+    end
+    for key, value in pairs(right) do
+        if left[key] ~= value then
+            return false
+        end
+    end
+    return true
+end
+
+local function NormalizeDescriptor(opts)
+    if type(opts) ~= "table" then
+        return nil
+    end
+    if type(opts.settingKey) ~= "string" or opts.settingKey == "" then
+        return nil
+    end
+    if type(opts.build) ~= "function" then
+        return nil
+    end
+
+    return {
+        settingKey = opts.settingKey,
+        title = opts.title or "Advanced Settings",
+        build = opts.build,
+        context = BuildContext(opts.context),
+        deferBuild = opts.deferBuild == true,
+    }
+end
+
+local function CurrentContextMatches(descriptor)
+    return descriptor and ContextMatches(descriptor.context, BuildContext())
+end
+
+local function AnchorWindowToConfig()
+    local configFrame = CS.configFrame
+    if advancedWindow and configFrame and configFrame.frame and configFrame.frame:IsShown() then
+        advancedWindow.frame:ClearAllPoints()
+        advancedWindow.frame:SetPoint("TOPLEFT", configFrame.frame, "TOPRIGHT", 4, 0)
+    end
+end
+
+local function BuildWindowContents()
+    if not (advancedWindow and activeDescriptor) then
+        return
+    end
+    if refreshingAdvancedPanel then
+        return
+    end
+
+    refreshingAdvancedPanel = true
+    CS.advancedSettingsPanelRefreshing = true
+    advancedWindow:SetTitle(activeDescriptor.title or "Advanced Settings")
+    advancedWindow:ReleaseChildren()
+    if advancedWindow.PauseLayout then
+        advancedWindow:PauseLayout()
+    end
+
+    local scroll = AceGUI:Create("ScrollFrame")
+    scroll:SetLayout("List")
+    if scroll.PauseLayout then
+        scroll:PauseLayout()
+    end
+    advancedWindow:AddChild(scroll)
+    activeDescriptor.build(scroll, activeDescriptor)
+
+    if CooldownCompanion.db.profile.hideInfoButtons then
+        for _, buttons in ipairs({ CS.tabInfoButtons, CS.customBarInfoButtons, CS.buttonSettingsInfoButtons }) do
+            if type(buttons) == "table" then
+                for _, btn in ipairs(buttons) do
+                    if btn and not btn._isAdvancedToggle then
+                        btn:Hide()
+                    end
+                end
+            end
+        end
+    end
+
+    if scroll.ResumeLayout then
+        scroll:ResumeLayout()
+    end
+    if scroll.DoLayout then
+        scroll:DoLayout()
+    end
+    if advancedWindow.ResumeLayout then
+        advancedWindow:ResumeLayout()
+    end
+    if advancedWindow.DoLayout then
+        advancedWindow:DoLayout()
+    end
+
+    CS.advancedSettingsPanelRefreshing = false
+    refreshingAdvancedPanel = false
+end
+
+local function CleanupWindow(widget)
+    if CS.UnregisterConfigDragAlphaFrame then
+        CS.UnregisterConfigDragAlphaFrame(widget.frame)
+    end
+
+    widget:ReleaseChildren()
+    AceGUI:Release(widget)
+    advancedWindow = nil
+    CS.advancedSettingsPanelWindow = nil
+    activeDescriptor = nil
+    if CS.SetActiveAdvancedSettingsToggleButton then
+        CS.SetActiveAdvancedSettingsToggleButton(nil)
+    end
+
+end
+
+local function CloseAdvancedSettingsPanel()
+    if advancedWindow then
+        advancedWindow:Fire("OnClose")
+        return true
+    else
+        local hadActiveDescriptor = activeDescriptor ~= nil
+        activeDescriptor = nil
+        if hadActiveDescriptor and CS.SetActiveAdvancedSettingsToggleButton then
+            CS.SetActiveAdvancedSettingsToggleButton(nil)
+        end
+        return hadActiveDescriptor
+    end
+end
+
+local function OpenAdvancedSettingsPanel(opts)
+    local descriptor = NormalizeDescriptor(opts)
+    if not descriptor then
+        return false
+    end
+
+    if activeDescriptor
+        and activeDescriptor.settingKey == descriptor.settingKey
+        and ContextMatches(activeDescriptor.context, descriptor.context)
+    then
+        CloseAdvancedSettingsPanel({ skipRefresh = true })
+        return false
+    end
+
+    if CS.CancelPickAuraTexture then
+        CS.CancelPickAuraTexture()
+    end
+    if ST._CloseFormatEditor then
+        ST._CloseFormatEditor()
+    end
+
+    activeDescriptor = descriptor
+
+    if not advancedWindow then
+        local window = AceGUI:Create("Window")
+        window:SetTitle(descriptor.title or "Advanced Settings")
+        window:SetWidth(PANEL_WIDTH)
+        window:SetHeight(PANEL_HEIGHT)
+        window:SetLayout("Fill")
+        window:EnableResize(false)
+        window:SetCallback("OnClose", CleanupWindow)
+        advancedWindow = window
+        CS.advancedSettingsPanelWindow = window
+        if CS.RegisterConfigDragAlphaFrame then
+            CS.RegisterConfigDragAlphaFrame(window.frame)
+        end
+    else
+        advancedWindow:Show()
+        advancedWindow.frame:Raise()
+    end
+
+    AnchorWindowToConfig()
+    if not descriptor.deferBuild and not CS.configRefreshInProgress then
+        BuildWindowContents()
+    end
+    return true
+end
+
+local function RebindAdvancedSettingsPanel(opts)
+    if not activeDescriptor then
+        return false
+    end
+
+    local descriptor = NormalizeDescriptor(opts)
+    if not descriptor then
+        return false
+    end
+
+    if activeDescriptor.settingKey == descriptor.settingKey
+        and ContextMatches(activeDescriptor.context, descriptor.context)
+    then
+        activeDescriptor = descriptor
+        return true
+    end
+
+    return false
+end
+
+local function QueueAdvancedSettingsPanelOpen(settingKey, extraContext)
+    if type(settingKey) ~= "string" or settingKey == "" then
+        return
+    end
+    queuedOpen = {
+        settingKey = settingKey,
+        context = BuildContext(extraContext),
+    }
+end
+
+local function ConsumeQueuedAdvancedSettingsPanelOpen(opts)
+    if not queuedOpen then
+        return false
+    end
+
+    if not ContextMatches(queuedOpen.context, BuildContext()) then
+        queuedOpen = nil
+        return false
+    end
+
+    local descriptor = NormalizeDescriptor(opts)
+    if not descriptor then
+        return false
+    end
+
+    if queuedOpen.settingKey ~= descriptor.settingKey
+        or not ContextMatches(queuedOpen.context, descriptor.context)
+    then
+        return false
+    end
+
+    queuedOpen = nil
+    return OpenAdvancedSettingsPanel(descriptor)
+end
+
+local function RefreshAdvancedSettingsPanel()
+    if not activeDescriptor then
+        return
+    end
+
+    if not CurrentContextMatches(activeDescriptor) then
+        CloseAdvancedSettingsPanel({ skipRefresh = true })
+        return
+    end
+
+    if advancedWindow then
+        AnchorWindowToConfig()
+        BuildWindowContents()
+    end
+end
+
+local function IsAdvancedSettingsPanelOpen(settingKey, extraContext)
+    if not (activeDescriptor and activeDescriptor.settingKey == settingKey) then
+        return false
+    end
+    return ContextMatches(activeDescriptor.context, BuildContext(extraContext))
+end
+
+CS.BuildAdvancedSettingsContext = BuildContext
+CS.OpenAdvancedSettingsPanel = OpenAdvancedSettingsPanel
+CS.CloseAdvancedSettingsPanel = CloseAdvancedSettingsPanel
+CS.RefreshAdvancedSettingsPanel = RefreshAdvancedSettingsPanel
+CS.RebindAdvancedSettingsPanel = RebindAdvancedSettingsPanel
+CS.QueueAdvancedSettingsPanelOpen = QueueAdvancedSettingsPanelOpen
+CS.ConsumeQueuedAdvancedSettingsPanelOpen = ConsumeQueuedAdvancedSettingsPanelOpen
+CS.IsAdvancedSettingsPanelOpen = IsAdvancedSettingsPanelOpen

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -3,8 +3,11 @@ local CooldownCompanion = ST.Addon
 local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 
-local PANEL_WIDTH = 430
-local PANEL_HEIGHT = 610
+local FALLBACK_PANEL_WIDTH = 330
+local MIN_PANEL_HEIGHT = 220
+local MAX_PANEL_HEIGHT = 610
+local FRAME_CHROME_HEIGHT = 57
+local CONTENT_HEIGHT_PADDING = 24
 
 local advancedWindow = nil
 local activeDescriptor = nil
@@ -113,6 +116,46 @@ local function AnchorWindowToConfig()
     end
 end
 
+local function GetAdvancedPanelWidth()
+    local configFrame = CS.configFrame
+    local narrowestWidth
+
+    for _, columnKey in ipairs({ "col1", "col2", "col3", "col4" }) do
+        local column = configFrame and configFrame[columnKey]
+        local frame = column and column.frame
+        local visible = frame and (frame:IsVisible() or frame:IsShown())
+        if visible then
+            local width = frame:GetWidth()
+            if width and width > 0 then
+                narrowestWidth = narrowestWidth and math.min(narrowestWidth, width) or width
+            end
+        end
+    end
+
+    return math.floor((narrowestWidth or FALLBACK_PANEL_WIDTH) + 0.5)
+end
+
+local function GetAdvancedPanelHeight(contentHeight)
+    local desiredHeight = (contentHeight or 0) + FRAME_CHROME_HEIGHT + CONTENT_HEIGHT_PADDING
+    return math.min(MAX_PANEL_HEIGHT, math.max(MIN_PANEL_HEIGHT, math.floor(desiredHeight + 0.5)))
+end
+
+local function ResizeAdvancedPanelToContent(scroll)
+    if not advancedWindow then
+        return
+    end
+
+    advancedWindow:SetWidth(GetAdvancedPanelWidth())
+
+    local contentHeight = scroll and scroll.content and scroll.content:GetHeight()
+    advancedWindow:SetHeight(GetAdvancedPanelHeight(contentHeight))
+
+    if advancedWindow.DoLayout then
+        advancedWindow:DoLayout()
+    end
+    AnchorWindowToConfig()
+end
+
 local function BuildWindowContents()
     if not (advancedWindow and activeDescriptor) then
         return
@@ -124,6 +167,7 @@ local function BuildWindowContents()
     refreshingAdvancedPanel = true
     CS.advancedSettingsPanelRefreshing = true
     advancedWindow:SetTitle(activeDescriptor.title or "Advanced Settings")
+    advancedWindow:SetWidth(GetAdvancedPanelWidth())
     advancedWindow:ReleaseChildren()
     if advancedWindow.PauseLayout then
         advancedWindow:PauseLayout()
@@ -161,6 +205,8 @@ local function BuildWindowContents()
     if advancedWindow.DoLayout then
         advancedWindow:DoLayout()
     end
+
+    ResizeAdvancedPanelToContent(scroll)
 
     CS.advancedSettingsPanelRefreshing = false
     refreshingAdvancedPanel = false
@@ -222,8 +268,8 @@ local function OpenAdvancedSettingsPanel(opts)
     if not advancedWindow then
         local window = AceGUI:Create("Window")
         window:SetTitle(descriptor.title or "Advanced Settings")
-        window:SetWidth(PANEL_WIDTH)
-        window:SetHeight(PANEL_HEIGHT)
+        window:SetWidth(GetAdvancedPanelWidth())
+        window:SetHeight(MAX_PANEL_HEIGHT)
         window:SetLayout("Fill")
         window:EnableResize(false)
         window:SetCallback("OnClose", CleanupWindow)

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -13,6 +13,7 @@ local advancedWindow = nil
 local activeDescriptor = nil
 local queuedOpen = nil
 local refreshingAdvancedPanel = false
+CS.advancedSettingsInfoButtons = CS.advancedSettingsInfoButtons or {}
 
 local function BoolValue(value)
     return value == true
@@ -34,10 +35,18 @@ local function SortedKeyString(selection)
 end
 
 local function BuildContext(extra)
+    local group = CS.selectedGroup
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[CS.selectedGroup]
+
     local context = {
         selectedFolder = CS.selectedFolder,
         selectedContainer = CS.selectedContainer,
         selectedGroup = CS.selectedGroup,
+        selectedGroupDisplayMode = group and (group.displayMode or "icons") or "",
+        selectedGroupTriggerDisplayType = group and group.displayMode == "trigger" and CooldownCompanion.GetTriggerPanelDisplayType and CooldownCompanion:GetTriggerPanelDisplayType(group, false) or "",
         selectedButton = CS.selectedButton,
         selectedButtons = SortedKeyString(CS.selectedButtons),
         selectedPanels = SortedKeyString(CS.selectedPanels),
@@ -99,13 +108,37 @@ local function NormalizeDescriptor(opts)
         settingKey = opts.settingKey,
         title = opts.title or "Advanced Settings",
         build = opts.build,
+        isAvailable = type(opts.isAvailable) == "function" and opts.isAvailable or nil,
+        contextExtra = opts.context,
         context = BuildContext(opts.context),
         deferBuild = opts.deferBuild == true,
     }
 end
 
 local function CurrentContextMatches(descriptor)
-    return descriptor and ContextMatches(descriptor.context, BuildContext())
+    if not descriptor then
+        return false
+    end
+    if descriptor.isAvailable and not descriptor.isAvailable() then
+        return false
+    end
+    return ContextMatches(descriptor.context, BuildContext(descriptor.contextExtra))
+end
+
+local function ClearAdvancedSettingsInfoButtons()
+    local buttons = CS.advancedSettingsInfoButtons
+    if type(buttons) ~= "table" then
+        return
+    end
+
+    for _, btn in ipairs(buttons) do
+        if btn then
+            btn:ClearAllPoints()
+            btn:Hide()
+            btn:SetParent(nil)
+        end
+    end
+    wipe(buttons)
 end
 
 local function AnchorWindowToConfig()
@@ -168,6 +201,7 @@ local function BuildWindowContents()
     CS.advancedSettingsPanelRefreshing = true
     advancedWindow:SetTitle(activeDescriptor.title or "Advanced Settings")
     advancedWindow:SetWidth(GetAdvancedPanelWidth())
+    ClearAdvancedSettingsInfoButtons()
     advancedWindow:ReleaseChildren()
     if advancedWindow.PauseLayout then
         advancedWindow:PauseLayout()
@@ -175,6 +209,7 @@ local function BuildWindowContents()
 
     local scroll = AceGUI:Create("ScrollFrame")
     scroll:SetLayout("List")
+    scroll._isAdvancedSettingsPanel = true
     if scroll.PauseLayout then
         scroll:PauseLayout()
     end
@@ -182,7 +217,7 @@ local function BuildWindowContents()
     activeDescriptor.build(scroll, activeDescriptor)
 
     if CooldownCompanion.db.profile.hideInfoButtons then
-        for _, buttons in ipairs({ CS.tabInfoButtons, CS.customBarInfoButtons, CS.buttonSettingsInfoButtons }) do
+        for _, buttons in ipairs({ CS.tabInfoButtons, CS.customBarInfoButtons, CS.buttonSettingsInfoButtons, CS.advancedSettingsInfoButtons }) do
             if type(buttons) == "table" then
                 for _, btn in ipairs(buttons) do
                     if btn and not btn._isAdvancedToggle then
@@ -217,6 +252,7 @@ local function CleanupWindow(widget)
         CS.UnregisterConfigDragAlphaFrame(widget.frame)
     end
 
+    ClearAdvancedSettingsInfoButtons()
     widget:ReleaseChildren()
     AceGUI:Release(widget)
     advancedWindow = nil
@@ -229,6 +265,7 @@ local function CleanupWindow(widget)
 end
 
 local function CloseAdvancedSettingsPanel()
+    queuedOpen = nil
     if advancedWindow then
         advancedWindow:Fire("OnClose")
         return true
@@ -342,7 +379,7 @@ local function ConsumeQueuedAdvancedSettingsPanelOpen(opts)
     end
 
     queuedOpen = nil
-    return OpenAdvancedSettingsPanel(descriptor)
+    return OpenAdvancedSettingsPanel(opts)
 end
 
 local function RefreshAdvancedSettingsPanel()
@@ -368,7 +405,6 @@ local function IsAdvancedSettingsPanelOpen(settingKey, extraContext)
     return ContextMatches(activeDescriptor.context, BuildContext(extraContext))
 end
 
-CS.BuildAdvancedSettingsContext = BuildContext
 CS.OpenAdvancedSettingsPanel = OpenAdvancedSettingsPanel
 CS.CloseAdvancedSettingsPanel = CloseAdvancedSettingsPanel
 CS.RefreshAdvancedSettingsPanel = RefreshAdvancedSettingsPanel

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -271,7 +271,7 @@ end
 local function CloseAdvancedSettingsPanel()
     queuedOpen = nil
     if advancedWindow then
-        advancedWindow:Fire("OnClose")
+        advancedWindow:Hide()
         return true
     else
         local hadActiveDescriptor = activeDescriptor ~= nil

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -4,10 +4,10 @@ local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 
 local FALLBACK_PANEL_WIDTH = 330
-local MIN_PANEL_HEIGHT = 220
+local MIN_PANEL_HEIGHT = 105
 local MAX_PANEL_HEIGHT = 610
 local FRAME_CHROME_HEIGHT = 57
-local CONTENT_HEIGHT_PADDING = 24
+local CONTENT_HEIGHT_PADDING = 6
 
 local advancedWindow = nil
 local activeDescriptor = nil

--- a/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/ConfigSettings/AdvancedSettingsPanel.lua
@@ -51,6 +51,8 @@ local function BuildContext(extra)
         selectedButtons = SortedKeyString(CS.selectedButtons),
         selectedPanels = SortedKeyString(CS.selectedPanels),
         selectedGroups = SortedKeyString(CS.selectedGroups),
+        currentSpecId = CooldownCompanion._currentSpecId,
+        currentHeroSpecId = CooldownCompanion._currentHeroSpecId,
         selectedTab = CS.selectedTab,
         buttonSettingsTab = CS.buttonSettingsTab,
         panelSettingsTab = CS.panelSettingsTab,

--- a/ConfigSettings/AuraTexturePicker.lua
+++ b/ConfigSettings/AuraTexturePicker.lua
@@ -98,6 +98,10 @@ end
 local function OpenAuraTexturePicker(opts)
     opts = opts or {}
 
+    if CS.CloseAdvancedSettingsPanel then
+        CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+    end
+
     if pickerWindow then
         pickerWindow:Show()
         pickerWindow.frame:Raise()

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -58,7 +58,24 @@ local function BuildBarAppearanceTab(container, group, style)
         CooldownCompanion:RefreshConfigPanel()
     end)
 
-    local barAdvExpanded, barAdvBtn = AddAdvancedToggle(barHeading, "barSettings", tabInfoButtons)
+    local function BuildBarSettingsAdvanced(panel)
+        local updateFreqSlider = AceGUI:Create("Slider")
+        updateFreqSlider:SetLabel("Update Frequency (Hz)")
+        updateFreqSlider:SetSliderValues(10, 60, 0.1)
+        local curInterval = style.barUpdateInterval or 0.025
+        updateFreqSlider:SetValue(math.floor(1 / curInterval + 0.5))
+        updateFreqSlider:SetFullWidth(true)
+        updateFreqSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            style.barUpdateInterval = 1 / val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        panel:AddChild(updateFreqSlider)
+    end
+
+    local barAdvExpanded, barAdvBtn = AddAdvancedToggle(barHeading, "barSettings", tabInfoButtons, nil, {
+        title = "Bar Settings Advanced",
+        build = BuildBarSettingsAdvanced,
+    })
     barAdvBtn:SetPoint("LEFT", collapseBtn, "RIGHT", 4, 0)
     barHeading.right:ClearAllPoints()
     barHeading.right:SetPoint("RIGHT", barHeading.frame, "RIGHT", -3, 0)
@@ -137,19 +154,6 @@ local function BuildBarAppearanceTab(container, group, style)
     local barColorPicker = AddColorPicker(container, style, "barColor", "Bar Color", {0.2, 0.6, 1.0, 1.0}, true, refreshStyle, refreshStyle)
     CreateColorPickerPromoteButton(barColorPicker, "barColor", group, style)
 
-    if barAdvExpanded then
-    local updateFreqSlider = AceGUI:Create("Slider")
-    updateFreqSlider:SetLabel("Update Frequency (Hz)")
-    updateFreqSlider:SetSliderValues(10, 60, 0.1)
-    local curInterval = style.barUpdateInterval or 0.025
-    updateFreqSlider:SetValue(math.floor(1 / curInterval + 0.5))
-    updateFreqSlider:SetFullWidth(true)
-    updateFreqSlider:SetCallback("OnValueChanged", function(widget, event, val)
-        style.barUpdateInterval = 1 / val
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(updateFreqSlider)
-    end -- barAdvExpanded (update freq)
     end -- not barSettingsCollapsed
 
     -- Contextual color pickers (no heading/collapse/promote)
@@ -179,10 +183,7 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(showIconCb)
 
-    local iconAdvExpanded, iconAdvBtn = AddAdvancedToggle(showIconCb, "barIcon", tabInfoButtons, style.showBarIcon ~= false)
-    CreateCheckboxPromoteButton(showIconCb, iconAdvBtn, "barIcon", group, style)
-
-    if iconAdvExpanded and style.showBarIcon ~= false then
+    local function BuildBarIconAdvanced(panel)
         local flipIconCheck = AceGUI:Create("CheckBox")
         flipIconCheck:SetLabel("Flip Icon Side")
         flipIconCheck:SetValue(style.barIconReverse or false)
@@ -192,7 +193,7 @@ local function BuildBarAppearanceTab(container, group, style)
             CooldownCompanion:RefreshGroupFrame(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(flipIconCheck)
+        panel:AddChild(flipIconCheck)
 
         local iconOffsetSlider = AceGUI:Create("Slider")
         iconOffsetSlider:SetLabel("Icon Offset")
@@ -203,7 +204,7 @@ local function BuildBarAppearanceTab(container, group, style)
             style.barIconOffset = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(iconOffsetSlider)
+        panel:AddChild(iconOffsetSlider)
 
         local customIconSizeCb = AceGUI:Create("CheckBox")
         customIconSizeCb:SetLabel("Custom Icon Size")
@@ -214,7 +215,7 @@ local function BuildBarAppearanceTab(container, group, style)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(customIconSizeCb)
+        panel:AddChild(customIconSizeCb)
 
         if style.barIconSizeOverride then
             local iconSizeSlider = AceGUI:Create("Slider")
@@ -226,9 +227,15 @@ local function BuildBarAppearanceTab(container, group, style)
                 style.barIconSize = val
                 CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             end)
-            container:AddChild(iconSizeSlider)
+            panel:AddChild(iconSizeSlider)
         end
     end
+
+    local iconAdvExpanded, iconAdvBtn = AddAdvancedToggle(showIconCb, "barIcon", tabInfoButtons, style.showBarIcon ~= false, {
+        title = "Bar Icon Advanced",
+        build = BuildBarIconAdvanced,
+    })
+    CreateCheckboxPromoteButton(showIconCb, iconAdvBtn, "barIcon", group, style)
 
     -- Show Name Text toggle
     local showNameCbBasic = AceGUI:Create("CheckBox")
@@ -242,10 +249,7 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(showNameCbBasic)
 
-    local nameAdvExpanded, nameAdvBtn = AddAdvancedToggle(showNameCbBasic, "barNameText", tabInfoButtons, style.showBarNameText ~= false)
-    CreateCheckboxPromoteButton(showNameCbBasic, nameAdvBtn, "barNameText", group, style)
-
-    if nameAdvExpanded and style.showBarNameText ~= false then
+    local function BuildBarNameTextAdvanced(panel)
         local flipNameCheck = AceGUI:Create("CheckBox")
         flipNameCheck:SetLabel("Flip Name Text")
         flipNameCheck:SetValue(style.barNameTextReverse or false)
@@ -254,12 +258,18 @@ local function BuildBarAppearanceTab(container, group, style)
             style.barNameTextReverse = val or nil
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(flipNameCheck)
+        panel:AddChild(flipNameCheck)
 
-        AddFontControls(container, style, "barName", {sizeMin = 6, sizeMax = 24, size = 10}, refreshStyle)
-        AddColorPicker(container, style, "barNameFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddOffsetSliders(container, style, "barNameTextOffsetX", "barNameTextOffsetY", {range = 50}, refreshStyle)
+        AddFontControls(panel, style, "barName", {sizeMin = 6, sizeMax = 24, size = 10}, refreshStyle)
+        AddColorPicker(panel, style, "barNameFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddOffsetSliders(panel, style, "barNameTextOffsetX", "barNameTextOffsetY", {range = 50}, refreshStyle)
     end
+
+    local nameAdvExpanded, nameAdvBtn = AddAdvancedToggle(showNameCbBasic, "barNameText", tabInfoButtons, style.showBarNameText ~= false, {
+        title = "Name Text Advanced",
+        build = BuildBarNameTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(showNameCbBasic, nameAdvBtn, "barNameText", group, style)
 
     -- Show Cooldown Text toggle
     local showTimeCbBasic = AceGUI:Create("CheckBox")
@@ -273,10 +283,7 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(showTimeCbBasic)
 
-    local timeAdvExpanded, timeAdvBtn = AddAdvancedToggle(showTimeCbBasic, "barCooldownText", tabInfoButtons, style.showCooldownText)
-    CreateCheckboxPromoteButton(showTimeCbBasic, timeAdvBtn, "cooldownText", group, style)
-
-    if timeAdvExpanded and style.showCooldownText then
+    local function BuildBarCooldownTextAdvanced(panel)
         local flipTimeCheck = AceGUI:Create("CheckBox")
         flipTimeCheck:SetLabel("Flip Time Text")
         flipTimeCheck:SetValue(style.barTimeTextReverse or false)
@@ -285,7 +292,7 @@ local function BuildBarAppearanceTab(container, group, style)
             style.barTimeTextReverse = val or nil
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(flipTimeCheck)
+        panel:AddChild(flipTimeCheck)
 
         -- (?) tooltip for Flip Time Text
         CreateInfoButton(flipTimeCheck.frame, flipTimeCheck.checkbg, "LEFT", "RIGHT", flipTimeCheck.text:GetStringWidth() + 4, 0, {
@@ -293,14 +300,20 @@ local function BuildBarAppearanceTab(container, group, style)
             {"Applies to all time-based text, including cooldown time, aura time, and ready text.", 1, 1, 1, true},
         }, flipTimeCheck)
 
-        AddFontControls(container, style, "cooldown", {sizeMin = 6, sizeMax = 24}, refreshStyle)
-        AddColorPicker(container, style, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshStyle, refreshStyle)
-        AddOffsetSliders(container, style, "barCdTextOffsetX", "barCdTextOffsetY", {range = 50}, refreshStyle)
+        AddFontControls(panel, style, "cooldown", {sizeMin = 6, sizeMax = 24}, refreshStyle)
+        AddColorPicker(panel, style, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshStyle, refreshStyle)
+        AddOffsetSliders(panel, style, "barCdTextOffsetX", "barCdTextOffsetY", {range = 50}, refreshStyle)
 
         if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Cooldown Text", "cooldown")
+            AddConditionalPreviewButton(panel, "Preview Cooldown Text", "cooldown")
         end
     end
+
+    local timeAdvExpanded, timeAdvBtn = AddAdvancedToggle(showTimeCbBasic, "barCooldownText", tabInfoButtons, style.showCooldownText, {
+        title = "Cooldown Text Advanced",
+        build = BuildBarCooldownTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(showTimeCbBasic, timeAdvBtn, "cooldownText", group, style)
 
     -- Show Charge Text toggle
     local chargeTextCb = AceGUI:Create("CheckBox")
@@ -314,17 +327,20 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(chargeTextCb)
 
-    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false)
-    CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
-
-    if chargeAdvExpanded and style.showChargeText ~= false then
-        AddFontControls(container, style, "charge", {}, refreshStyle)
-        AddColorPicker(container, style, "chargeFontColor", "Font Color (Max Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddColorPicker(container, style, "chargeFontColorMissing", "Font Color (Missing Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddColorPicker(container, style, "chargeFontColorZero", "Font Color (Zero Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddAnchorDropdown(container, style, "chargeAnchor", "BOTTOMRIGHT", refreshStyle)
-        AddOffsetSliders(container, style, "chargeXOffset", "chargeYOffset", {x = -2, y = 2}, refreshStyle)
+    local function BuildBarChargeTextAdvanced(panel)
+        AddFontControls(panel, style, "charge", {}, refreshStyle)
+        AddColorPicker(panel, style, "chargeFontColor", "Font Color (Max Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddColorPicker(panel, style, "chargeFontColorMissing", "Font Color (Missing Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddColorPicker(panel, style, "chargeFontColorZero", "Font Color (Zero Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddAnchorDropdown(panel, style, "chargeAnchor", "BOTTOMRIGHT", refreshStyle)
+        AddOffsetSliders(panel, style, "chargeXOffset", "chargeYOffset", {x = -2, y = 2}, refreshStyle)
     end
+
+    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false, {
+        title = "Count Text Advanced",
+        build = BuildBarChargeTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
 
     -- ================================================================
     -- Aura Duration Text
@@ -340,17 +356,20 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(auraTextCb)
 
-    local barAuraTextAdvExpanded, barAuraTextAdvBtn = AddAdvancedToggle(auraTextCb, "barAuraText", tabInfoButtons, style.showAuraText ~= false)
-    CreateCheckboxPromoteButton(auraTextCb, barAuraTextAdvBtn, "auraText", group, style)
-
-    if barAuraTextAdvExpanded and style.showAuraText ~= false then
-        AddFontControls(container, style, "auraText", {sizeMin = 6, sizeMax = 24}, refreshStyle)
-        AddColorPicker(container, style, "auraTextFontColor", "Font Color", {0, 0.925, 1, 1}, false, refreshStyle, refreshStyle)
+    local function BuildBarAuraTextAdvanced(panel)
+        AddFontControls(panel, style, "auraText", {sizeMin = 6, sizeMax = 24}, refreshStyle)
+        AddColorPicker(panel, style, "auraTextFontColor", "Font Color", {0, 0.925, 1, 1}, false, refreshStyle, refreshStyle)
 
         if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Aura Duration Text", "aura_duration_text")
+            AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text")
         end
-    end -- barAuraTextAdvExpanded
+    end
+
+    local barAuraTextAdvExpanded, barAuraTextAdvBtn = AddAdvancedToggle(auraTextCb, "barAuraText", tabInfoButtons, style.showAuraText ~= false, {
+        title = "Aura Duration Text Advanced",
+        build = BuildBarAuraTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(auraTextCb, barAuraTextAdvBtn, "auraText", group, style)
 
     -- ================================================================
     -- Aura Stack Text
@@ -366,19 +385,22 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(barAuraStackCb)
 
-    local barAuraStackAdvExpanded, barAuraStackAdvBtn = AddAdvancedToggle(barAuraStackCb, "barAuraStackText", tabInfoButtons, style.showAuraStackText ~= false)
-    CreateCheckboxPromoteButton(barAuraStackCb, barAuraStackAdvBtn, "auraStackText", group, style)
-
-    if barAuraStackAdvExpanded and style.showAuraStackText ~= false then
-        AddFontControls(container, style, "auraStack", {}, refreshStyle)
-        AddColorPicker(container, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddAnchorDropdown(container, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
-        AddOffsetSliders(container, style, "auraStackXOffset", "auraStackYOffset", {x = 2, y = 2}, refreshStyle)
+    local function BuildBarAuraStackAdvanced(panel)
+        AddFontControls(panel, style, "auraStack", {}, refreshStyle)
+        AddColorPicker(panel, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddAnchorDropdown(panel, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
+        AddOffsetSliders(panel, style, "auraStackXOffset", "auraStackYOffset", {x = 2, y = 2}, refreshStyle)
 
         if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
+            AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text")
         end
-    end -- barAuraStackAdvExpanded
+    end
+
+    local barAuraStackAdvExpanded, barAuraStackAdvBtn = AddAdvancedToggle(barAuraStackCb, "barAuraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
+        title = "Aura Stack Text Advanced",
+        build = BuildBarAuraStackAdvanced,
+    })
+    CreateCheckboxPromoteButton(barAuraStackCb, barAuraStackAdvBtn, "auraStackText", group, style)
 
     -- Show Ready Text toggle
     local showReadyCb = AceGUI:Create("CheckBox")
@@ -392,10 +414,7 @@ local function BuildBarAppearanceTab(container, group, style)
     end)
     container:AddChild(showReadyCb)
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(showReadyCb, "barReadyText", tabInfoButtons, style.showBarReadyText)
-    CreateCheckboxPromoteButton(showReadyCb, readyAdvBtn, "barReadyText", group, style)
-
-    if readyAdvExpanded and style.showBarReadyText then
+    local function BuildBarReadyTextAdvanced(panel)
         local readyTextBox = AceGUI:Create("EditBox")
         if readyTextBox.editbox.Instructions then readyTextBox.editbox.Instructions:Hide() end
         readyTextBox:SetLabel("Ready Text")
@@ -405,11 +424,17 @@ local function BuildBarAppearanceTab(container, group, style)
             style.barReadyText = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(readyTextBox)
+        panel:AddChild(readyTextBox)
 
-        AddColorPicker(container, style, "barReadyTextColor", "Ready Text Color", {0.2, 1.0, 0.2, 1.0}, true, refreshStyle, refreshStyle)
-        AddFontControls(container, style, "barReady", {sizeMin = 6, sizeMax = 24}, refreshStyle)
+        AddColorPicker(panel, style, "barReadyTextColor", "Ready Text Color", {0.2, 1.0, 0.2, 1.0}, true, refreshStyle, refreshStyle)
+        AddFontControls(panel, style, "barReady", {sizeMin = 6, sizeMax = 24}, refreshStyle)
     end
+
+    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(showReadyCb, "barReadyText", tabInfoButtons, style.showBarReadyText, {
+        title = "Ready Text Advanced",
+        build = BuildBarReadyTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(showReadyCb, readyAdvBtn, "barReadyText", group, style)
 
     -- Compact Mode toggle + Max Visible Buttons slider
     BuildCompactModeControls(container, group, tabInfoButtons)
@@ -443,39 +468,44 @@ local function BuildBarEffectsTab(container, group, style)
     end)
     container:AddChild(barAuraEnableCb)
 
-    local barAuraAdvExpanded, barAuraAdvBtn = AddAdvancedToggle(barAuraEnableCb, "barActiveAura", tabInfoButtons, style.barAuraEffect ~= "none")
+    local function BuildBarActiveAuraAdvanced(panel)
+        local barAuraCombatCb = AceGUI:Create("CheckBox")
+        barAuraCombatCb:SetLabel("Show Only In Combat")
+        barAuraCombatCb:SetValue(style.auraGlowCombatOnly or false)
+        barAuraCombatCb:SetFullWidth(true)
+        barAuraCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.auraGlowCombatOnly = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        panel:AddChild(barAuraCombatCb)
+        ApplyCheckboxIndent(barAuraCombatCb, 20)
+
+        BuildBarActiveAuraControls(panel, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+
+        BuildBarAuraPulseControls(panel, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Active Aura Effects", function()
+                return CS.selectedGroup and CooldownCompanion:IsBarAuraActivePreviewActive(CS.selectedGroup, nil)
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, show)
+                end
+            end)
+        end
+    end
+
+    local barAuraAdvExpanded, barAuraAdvBtn = AddAdvancedToggle(barAuraEnableCb, "barActiveAura", tabInfoButtons, style.barAuraEffect ~= "none", {
+        title = "Active Aura Indicator Advanced",
+        build = BuildBarActiveAuraAdvanced,
+    })
     CreateCheckboxPromoteButton(barAuraEnableCb, barAuraAdvBtn, "barActiveAura", group, style)
 
-    if barAuraAdvExpanded and style.barAuraEffect ~= "none" then
-    local barAuraCombatCb = AceGUI:Create("CheckBox")
-    barAuraCombatCb:SetLabel("Show Only In Combat")
-    barAuraCombatCb:SetValue(style.auraGlowCombatOnly or false)
-    barAuraCombatCb:SetFullWidth(true)
-    barAuraCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.auraGlowCombatOnly = val
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(barAuraCombatCb)
-    ApplyCheckboxIndent(barAuraCombatCb, 20)
-
-    BuildBarActiveAuraControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-
-    BuildBarAuraPulseControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Active Aura Effects", function()
-            return CS.selectedGroup and CooldownCompanion:IsBarAuraActivePreviewActive(CS.selectedGroup, nil)
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, show)
-            end
-        end)
-    end
-    elseif CS.selectedGroup then
+    if not (barAuraAdvExpanded and style.barAuraEffect ~= "none") and CS.selectedGroup then
         CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, false)
     end -- barAuraAdvExpanded
 
@@ -493,39 +523,44 @@ local function BuildBarEffectsTab(container, group, style)
     end)
     container:AddChild(pandemicIndicatorCb)
 
-    local barPandemicAdvExpanded, barPandemicAdvBtn = AddAdvancedToggle(pandemicIndicatorCb, "barPandemicIndicator", tabInfoButtons, style.showPandemicGlow ~= false)
+    local function BuildBarPandemicAdvanced(panel)
+        local barPandemicCombatCb = AceGUI:Create("CheckBox")
+        barPandemicCombatCb:SetLabel("Show Only In Combat")
+        barPandemicCombatCb:SetValue(style.pandemicGlowCombatOnly or false)
+        barPandemicCombatCb:SetFullWidth(true)
+        barPandemicCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.pandemicGlowCombatOnly = val
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        panel:AddChild(barPandemicCombatCb)
+        ApplyCheckboxIndent(barPandemicCombatCb, 20)
+
+        BuildPandemicBarControls(panel, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+
+        BuildPandemicBarPulseControls(panel, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Pandemic Effects", function()
+                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
+    local barPandemicAdvExpanded, barPandemicAdvBtn = AddAdvancedToggle(pandemicIndicatorCb, "barPandemicIndicator", tabInfoButtons, style.showPandemicGlow ~= false, {
+        title = "Pandemic Indicator Advanced",
+        build = BuildBarPandemicAdvanced,
+    })
     CreateCheckboxPromoteButton(pandemicIndicatorCb, barPandemicAdvBtn, "pandemicBar", group, style)
 
-    if barPandemicAdvExpanded and style.showPandemicGlow ~= false then
-    local barPandemicCombatCb = AceGUI:Create("CheckBox")
-    barPandemicCombatCb:SetLabel("Show Only In Combat")
-    barPandemicCombatCb:SetValue(style.pandemicGlowCombatOnly or false)
-    barPandemicCombatCb:SetFullWidth(true)
-    barPandemicCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.pandemicGlowCombatOnly = val
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-    container:AddChild(barPandemicCombatCb)
-    ApplyCheckboxIndent(barPandemicCombatCb, 20)
-
-    BuildPandemicBarControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-
-    BuildPandemicBarPulseControls(container, style, function()
-        CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-    end)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Pandemic Effects", function()
-            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
-            end
-        end)
-    end
-    elseif CS.selectedGroup then
+    if not (barPandemicAdvExpanded and style.showPandemicGlow ~= false) and CS.selectedGroup then
         CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, false)
     end -- barPandemicAdvExpanded
 
@@ -570,11 +605,17 @@ local function BuildBarEffectsTab(container, group, style)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "barUnusableDimming", tabInfoButtons, style.showUnusable)
-        CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
-        if unusableAdvExpanded and style.showUnusable and AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
+        local function BuildBarUnusableAdvanced(panel)
+            if AddConditionalPreviewButton then
+                AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable")
+            end
         end
+
+        local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "barUnusableDimming", tabInfoButtons, style.showUnusable, {
+            title = "Unusable Dimming Advanced",
+            build = BuildBarUnusableAdvanced,
+        })
+        CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
 
         -- Show Tooltips
         local tooltipCb = BuildShowTooltipsControls(container, style, function()

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -17,7 +17,6 @@ local CreateInfoButton = ST._CreateInfoButton
 local BuildCompactModeControls = ST._BuildCompactModeControls
 local BuildGroupSettingPresetControls = ST._BuildGroupSettingPresetControls
 local GetBarTextureOptions = ST._GetBarTextureOptions
-local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
 local AddAnchorDropdown = ST._AddAnchorDropdown
 local AddFontControls = ST._AddFontControls
@@ -478,7 +477,6 @@ local function BuildBarEffectsTab(container, group, style)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
         panel:AddChild(barAuraCombatCb)
-        ApplyCheckboxIndent(barAuraCombatCb, 20)
 
         BuildBarActiveAuraControls(panel, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
@@ -533,7 +531,6 @@ local function BuildBarEffectsTab(container, group, style)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
         panel:AddChild(barPandemicCombatCb)
-        ApplyCheckboxIndent(barPandemicCombatCb, 20)
 
         BuildPandemicBarControls(panel, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -31,8 +31,8 @@ local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
 local BuildLossOfControlControls = ST._BuildLossOfControlControls
 local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildShowTooltipsControls = ST._BuildShowTooltipsControls
-local AddPreviewToggleButton = ST._AddPreviewToggleButton
-local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
+local AddPreviewBadge = ST._AddPreviewBadge
+local AddConditionalPreviewBadge = ST._AddConditionalPreviewBadge
 local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 
 local tabInfoButtons = CS.tabInfoButtons
@@ -302,17 +302,14 @@ local function BuildBarAppearanceTab(container, group, style)
         AddFontControls(panel, style, "cooldown", {sizeMin = 6, sizeMax = 24}, refreshStyle)
         AddColorPicker(panel, style, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshStyle, refreshStyle)
         AddOffsetSliders(panel, style, "barCdTextOffsetX", "barCdTextOffsetY", {range = 50}, refreshStyle)
-
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Cooldown Text", "cooldown")
-        end
     end
 
-    local timeAdvExpanded, timeAdvBtn = AddAdvancedToggle(showTimeCbBasic, "barCooldownText", tabInfoButtons, style.showCooldownText, {
+    local _, timeAdvBtn = AddAdvancedToggle(showTimeCbBasic, "barCooldownText", tabInfoButtons, style.showCooldownText, {
         title = "Cooldown Text Advanced",
         build = BuildBarCooldownTextAdvanced,
     })
-    CreateCheckboxPromoteButton(showTimeCbBasic, timeAdvBtn, "cooldownText", group, style)
+    local timePromoteBtn = CreateCheckboxPromoteButton(showTimeCbBasic, timeAdvBtn, "cooldownText", group, style)
+    AddConditionalPreviewBadge(showTimeCbBasic, timePromoteBtn or timeAdvBtn, "Preview Cooldown Text", "cooldown", style.showCooldownText)
 
     -- Show Charge Text toggle
     local chargeTextCb = AceGUI:Create("CheckBox")
@@ -358,17 +355,14 @@ local function BuildBarAppearanceTab(container, group, style)
     local function BuildBarAuraTextAdvanced(panel)
         AddFontControls(panel, style, "auraText", {sizeMin = 6, sizeMax = 24}, refreshStyle)
         AddColorPicker(panel, style, "auraTextFontColor", "Font Color", {0, 0.925, 1, 1}, false, refreshStyle, refreshStyle)
-
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text")
-        end
     end
 
-    local barAuraTextAdvExpanded, barAuraTextAdvBtn = AddAdvancedToggle(auraTextCb, "barAuraText", tabInfoButtons, style.showAuraText ~= false, {
+    local _, barAuraTextAdvBtn = AddAdvancedToggle(auraTextCb, "barAuraText", tabInfoButtons, style.showAuraText ~= false, {
         title = "Aura Duration Text Advanced",
         build = BuildBarAuraTextAdvanced,
     })
-    CreateCheckboxPromoteButton(auraTextCb, barAuraTextAdvBtn, "auraText", group, style)
+    local barAuraTextPromoteBtn = CreateCheckboxPromoteButton(auraTextCb, barAuraTextAdvBtn, "auraText", group, style)
+    AddConditionalPreviewBadge(auraTextCb, barAuraTextPromoteBtn or barAuraTextAdvBtn, "Preview Aura Duration Text", "aura_duration_text", style.showAuraText ~= false)
 
     -- ================================================================
     -- Aura Stack Text
@@ -389,17 +383,14 @@ local function BuildBarAppearanceTab(container, group, style)
         AddColorPicker(panel, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
         AddAnchorDropdown(panel, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
         AddOffsetSliders(panel, style, "auraStackXOffset", "auraStackYOffset", {x = 2, y = 2}, refreshStyle)
-
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text")
-        end
     end
 
-    local barAuraStackAdvExpanded, barAuraStackAdvBtn = AddAdvancedToggle(barAuraStackCb, "barAuraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
+    local _, barAuraStackAdvBtn = AddAdvancedToggle(barAuraStackCb, "barAuraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
         title = "Aura Stack Text Advanced",
         build = BuildBarAuraStackAdvanced,
     })
-    CreateCheckboxPromoteButton(barAuraStackCb, barAuraStackAdvBtn, "auraStackText", group, style)
+    local barAuraStackPromoteBtn = CreateCheckboxPromoteButton(barAuraStackCb, barAuraStackAdvBtn, "auraStackText", group, style)
+    AddConditionalPreviewBadge(barAuraStackCb, barAuraStackPromoteBtn or barAuraStackAdvBtn, "Preview Aura Stack Text", "aura_stack_text", style.showAuraStackText ~= false)
 
     -- Show Ready Text toggle
     local showReadyCb = AceGUI:Create("CheckBox")
@@ -485,25 +476,22 @@ local function BuildBarEffectsTab(container, group, style)
         BuildBarAuraPulseControls(panel, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Active Aura Effects", function()
-                return CS.selectedGroup and CooldownCompanion:IsBarAuraActivePreviewActive(CS.selectedGroup, nil)
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, show)
-                end
-            end)
-        end
     end
 
-    local barAuraAdvExpanded, barAuraAdvBtn = AddAdvancedToggle(barAuraEnableCb, "barActiveAura", tabInfoButtons, style.barAuraEffect ~= "none", {
+    local _, barAuraAdvBtn = AddAdvancedToggle(barAuraEnableCb, "barActiveAura", tabInfoButtons, style.barAuraEffect ~= "none", {
         title = "Active Aura Indicator Advanced",
         build = BuildBarActiveAuraAdvanced,
     })
-    CreateCheckboxPromoteButton(barAuraEnableCb, barAuraAdvBtn, "barActiveAura", group, style)
+    local barAuraPromoteBtn = CreateCheckboxPromoteButton(barAuraEnableCb, barAuraAdvBtn, "barActiveAura", group, style)
+    AddPreviewBadge(barAuraEnableCb, barAuraPromoteBtn or barAuraAdvBtn, "Preview Active Aura Effects", function()
+        return CS.selectedGroup and CooldownCompanion:IsBarAuraActivePreviewActive(CS.selectedGroup, nil)
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, show)
+        end
+    end, style.barAuraEffect ~= "none")
 
-    if not (barAuraAdvExpanded and style.barAuraEffect ~= "none") and CS.selectedGroup then
+    if style.barAuraEffect == "none" and CS.selectedGroup then
         CooldownCompanion:SetBarAuraActivePreview(CS.selectedGroup, nil, false)
     end -- barAuraAdvExpanded
 
@@ -539,25 +527,22 @@ local function BuildBarEffectsTab(container, group, style)
         BuildPandemicBarPulseControls(panel, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Pandemic Effects", function()
-                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
-    local barPandemicAdvExpanded, barPandemicAdvBtn = AddAdvancedToggle(pandemicIndicatorCb, "barPandemicIndicator", tabInfoButtons, style.showPandemicGlow ~= false, {
+    local _, barPandemicAdvBtn = AddAdvancedToggle(pandemicIndicatorCb, "barPandemicIndicator", tabInfoButtons, style.showPandemicGlow ~= false, {
         title = "Pandemic Indicator Advanced",
         build = BuildBarPandemicAdvanced,
     })
-    CreateCheckboxPromoteButton(pandemicIndicatorCb, barPandemicAdvBtn, "pandemicBar", group, style)
+    local barPandemicPromoteBtn = CreateCheckboxPromoteButton(pandemicIndicatorCb, barPandemicAdvBtn, "pandemicBar", group, style)
+    AddPreviewBadge(pandemicIndicatorCb, barPandemicPromoteBtn or barPandemicAdvBtn, "Preview Pandemic Effects", function()
+        return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
+        end
+    end, style.showPandemicGlow ~= false)
 
-    if not (barPandemicAdvExpanded and style.showPandemicGlow ~= false) and CS.selectedGroup then
+    if style.showPandemicGlow == false and CS.selectedGroup then
         CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, false)
     end -- barPandemicAdvExpanded
 
@@ -602,17 +587,8 @@ local function BuildBarEffectsTab(container, group, style)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        local function BuildBarUnusableAdvanced(panel)
-            if AddConditionalPreviewButton then
-                AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable")
-            end
-        end
-
-        local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "barUnusableDimming", tabInfoButtons, style.showUnusable, {
-            title = "Unusable Dimming Advanced",
-            build = BuildBarUnusableAdvanced,
-        })
-        CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
+        local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
+        AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn, "Preview Unusable State", "unusable", style.showUnusable)
 
         -- Show Tooltips
         local tooltipCb = BuildShowTooltipsControls(container, style, function()

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1274,17 +1274,7 @@ local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
     end)
     scroll:AddChild(indicatorCb)
 
-    local indicatorAdvExpanded, indicatorAdvBtn = AddAdvancedToggle(indicatorCb, "barPanelAuraMaxStacksIndicator_" .. CS.selectedGroup .. "_" .. CS.selectedButton, infoButtons, auraBar.maxStacksGlowEnabled == true)
-    CreateInfoButton(indicatorCb.frame, indicatorAdvBtn, "LEFT", "RIGHT", 4, 0, {
-        "Max Stack Indicator",
-        {"Due to combat restrictions, individual bar segments cannot be highlighted independently.", 1, 1, 1, true},
-        " ",
-        {"The indicator covers the whole bar entry and appears automatically when the aura reaches its maximum stack count.", 1, 1, 1, true},
-        " ",
-        {"The Pulsing Overlay style is only available for continuous display mode.", 1, 1, 1, true},
-    }, indicatorCb)
-
-    if indicatorAdvExpanded and auraBar.maxStacksGlowEnabled == true then
+    local function BuildMaxStackIndicatorAdvanced(panel)
         local currentStyle = auraBar.maxStacksGlowStyle or "solidBorder"
         local isContinuousDisplay = stackDisplayMode == "continuous"
         if currentStyle == "pulsingOverlay" and not isContinuousDisplay then
@@ -1310,9 +1300,9 @@ local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
             auraBar.maxStacksGlowStyle = value
             RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true, refreshConfig = true })
         end)
-        scroll:AddChild(indicatorStyleDrop)
+        panel:AddChild(indicatorStyleDrop)
 
-        AddColorPicker(scroll, auraBar, "maxStacksGlowColor", "Indicator Color", {1, 0.84, 0, 0.9}, true,
+        AddColorPicker(panel, auraBar, "maxStacksGlowColor", "Indicator Color", {1, 0.84, 0, 0.9}, true,
             function() RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true }) end)
 
         if currentStyle ~= "pulsingOverlay" then
@@ -1325,7 +1315,7 @@ local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
                 auraBar.maxStacksGlowSize = value
                 RefreshSelectedBarPanelAuraButton()
             end)
-            scroll:AddChild(sizeSlider)
+            panel:AddChild(sizeSlider)
         end
 
         if currentStyle == "pulsingBorder" or currentStyle == "pulsingOverlay" then
@@ -1338,9 +1328,23 @@ local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
                 auraBar.maxStacksGlowSpeed = value
                 RefreshSelectedBarPanelAuraButton()
             end)
-            scroll:AddChild(speedSlider)
+            panel:AddChild(speedSlider)
         end
     end
+
+    local indicatorAdvExpanded, indicatorAdvBtn = AddAdvancedToggle(indicatorCb, "barPanelAuraMaxStacksIndicator_" .. CS.selectedGroup .. "_" .. CS.selectedButton, infoButtons, auraBar.maxStacksGlowEnabled == true, {
+        title = "Max Stack Indicator Advanced",
+        build = BuildMaxStackIndicatorAdvanced,
+    })
+    CreateInfoButton(indicatorCb.frame, indicatorAdvBtn, "LEFT", "RIGHT", 4, 0, {
+        "Max Stack Indicator",
+        {"Due to combat restrictions, individual bar segments cannot be highlighted independently.", 1, 1, 1, true},
+        " ",
+        {"The indicator covers the whole bar entry and appears automatically when the aura reaches its maximum stack count.", 1, 1, 1, true},
+        " ",
+        {"The Pulsing Overlay style is only available for continuous display mode.", 1, 1, 1, true},
+    }, indicatorCb)
+
 end
 
 local function BuildSpellSoundAlertsSection(scroll, buttonData, infoButtons)

--- a/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -195,7 +195,9 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
             })
             if CooldownCompanion.db.profile.hideInfoButtons then
                 for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                    btn:Hide()
+                    if btn and not btn._isAdvancedToggle then
+                        btn:Hide()
+                    end
                 end
             end
         end

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -134,7 +134,22 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
     fmtHeading:SetFullWidth(true)
     scroll:AddChild(fmtHeading)
 
-    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons)
+    local function BuildFormatOverridePreviewAdvanced(panel)
+        if AddConditionalPreviewButton then
+            local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
+            AddConditionalPreviewButton(panel, "Preview Cooldown State", "cooldown", target)
+            AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text", target)
+            AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text", target)
+            AddConditionalPreviewButton(panel, "Preview Pandemic State", "pandemic", target)
+            AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable", target)
+            AddConditionalPreviewButton(panel, "Preview Out of Range State", "out_of_range", target)
+        end
+    end
+
+    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons, nil, {
+        title = "Format Override Advanced",
+        build = BuildFormatOverridePreviewAdvanced,
+    })
     fmtPreviewAdvBtn:SetPoint("LEFT", fmtHeading.label, "RIGHT", 4, 0)
 
     local fmtInfo = CreateInfoButton(fmtHeading.frame, fmtPreviewAdvBtn, "LEFT", "RIGHT", 4, 0, {
@@ -214,15 +229,6 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
         scroll:AddChild(clearBtn)
     end
 
-    if fmtPreviewAdvExpanded and AddConditionalPreviewButton then
-        local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
-        AddConditionalPreviewButton(scroll, "Preview Cooldown State", "cooldown", target)
-        AddConditionalPreviewButton(scroll, "Preview Aura Duration Text", "aura_duration_text", target)
-        AddConditionalPreviewButton(scroll, "Preview Aura Stack Text", "aura_stack_text", target)
-        AddConditionalPreviewButton(scroll, "Preview Pandemic State", "pandemic", target)
-        AddConditionalPreviewButton(scroll, "Preview Unusable State", "unusable", target)
-        AddConditionalPreviewButton(scroll, "Preview Out of Range State", "out_of_range", target)
-    end
 end
 
 local function BuildSingleBarColorControl(key, label, defaultColor)
@@ -365,7 +371,49 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                 local previewAdvExpanded
                 if PREVIEWABLE_OVERRIDE_SECTIONS[sectionId] then
                     local previewAdvBtn
-                    previewAdvExpanded, previewAdvBtn = AddAdvancedToggle(heading, "overridePreview_" .. sectionId, infoButtons)
+                    local function BuildOverridePreviewAdvanced(panel)
+                        if sectionId == "procGlow" and overrides.procGlowStyle ~= "none" then
+                            AddSelectedButtonPreviewToggle(panel, "Preview Proc Glow", "_procGlowPreview", CooldownCompanion.SetProcGlowPreview)
+                        elseif sectionId == "auraIndicator" and overrides.auraGlowStyle ~= "none" then
+                            AddSelectedButtonPreviewToggle(panel, "Preview Aura Glow", "_auraGlowPreview", CooldownCompanion.SetAuraGlowPreview)
+                        elseif sectionId == "pandemicGlow" and GetEffectiveOverrideValue("showPandemicGlow") ~= false then
+                            AddSelectedButtonPreviewToggle(panel, "Preview Pandemic Glow", "_pandemicPreview", CooldownCompanion.SetPandemicPreview)
+                        elseif sectionId == "barActiveAura" then
+                            AddSelectedBarAuraActivePreviewToggle(panel, "Preview Active Aura Effects")
+                        elseif sectionId == "pandemicBar" then
+                            AddSelectedButtonPreviewToggle(panel, "Preview Pandemic Effects", "_pandemicPreview", CooldownCompanion.SetPandemicPreview)
+                        elseif sectionId == "readyGlow" and overrides.readyGlowStyle and overrides.readyGlowStyle ~= "none" then
+                            AddSelectedButtonPreviewToggle(panel, "Preview Ready Glow Style", "_readyGlowPreview", CooldownCompanion.SetReadyGlowPreview)
+                        end
+
+                        if AddConditionalPreviewButton then
+                            local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
+                            if sectionId == "cooldownText" or sectionId == "cooldownSwipe" or sectionId == "desaturation" then
+                                AddConditionalPreviewButton(panel, "Preview Cooldown State", "cooldown", target)
+                            elseif sectionId == "iconFillTimer" and overrides.iconFillEnabled == true and group.masqueEnabled ~= true then
+                                AddConditionalPreviewButton(panel, "Preview Cooldown Fill", "cooldown", target)
+                                AddConditionalPreviewButton(panel, "Preview Aura Fill", "aura_duration_text", target)
+                            elseif sectionId == "auraText" or sectionId == "auraDurationSwipe" then
+                                AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text", target)
+                            elseif sectionId == "auraStackText" then
+                                AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text", target)
+                            elseif sectionId == "showOutOfRange" then
+                                AddConditionalPreviewButton(panel, "Preview Out of Range State", "out_of_range", target)
+                            elseif sectionId == "unusableDimming" then
+                                AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable", target)
+                            elseif sectionId == "iconTint" then
+                                AddConditionalPreviewButton(panel, "Preview Cooldown Tint", "cooldown", target)
+                                AddConditionalPreviewButton(panel, "Preview Aura Tint", "aura", target)
+                                AddConditionalPreviewButton(panel, "Preview Unusable Tint", "unusable", target)
+                                AddConditionalPreviewButton(panel, "Preview Out of Range Tint", "out_of_range", target)
+                            end
+                        end
+                    end
+
+                    previewAdvExpanded, previewAdvBtn = AddAdvancedToggle(heading, "overridePreview_" .. sectionId, infoButtons, nil, {
+                        title = sectionDef.label .. " Advanced",
+                        build = BuildOverridePreviewAdvanced,
+                    })
                     previewAdvBtn:SetPoint("LEFT", revertBtn, "RIGHT", 4, 0)
                     heading.right:ClearAllPoints()
                     heading.right:SetPoint("RIGHT", heading.frame, "RIGHT", -3, 0)
@@ -499,42 +547,6 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                             masqueEnabled = group.masqueEnabled == true,
                         })
 
-                        if previewAdvExpanded and sectionId == "procGlow" and overrides.procGlowStyle ~= "none" then
-                            AddSelectedButtonPreviewToggle(scroll, "Preview Proc Glow", "_procGlowPreview", CooldownCompanion.SetProcGlowPreview)
-                        elseif previewAdvExpanded and sectionId == "auraIndicator" and overrides.auraGlowStyle ~= "none" then
-                            AddSelectedButtonPreviewToggle(scroll, "Preview Aura Glow", "_auraGlowPreview", CooldownCompanion.SetAuraGlowPreview)
-                        elseif previewAdvExpanded and sectionId == "pandemicGlow" and GetEffectiveOverrideValue("showPandemicGlow") ~= false then
-                            AddSelectedButtonPreviewToggle(scroll, "Preview Pandemic Glow", "_pandemicPreview", CooldownCompanion.SetPandemicPreview)
-                        elseif previewAdvExpanded and sectionId == "barActiveAura" then
-                            AddSelectedBarAuraActivePreviewToggle(scroll, "Preview Active Aura Effects")
-                        elseif previewAdvExpanded and sectionId == "pandemicBar" then
-                            AddSelectedButtonPreviewToggle(scroll, "Preview Pandemic Effects", "_pandemicPreview", CooldownCompanion.SetPandemicPreview)
-                        elseif previewAdvExpanded and sectionId == "readyGlow" and overrides.readyGlowStyle and overrides.readyGlowStyle ~= "none" then
-                            AddSelectedButtonPreviewToggle(scroll, "Preview Ready Glow Style", "_readyGlowPreview", CooldownCompanion.SetReadyGlowPreview)
-                        end
-
-                        if previewAdvExpanded and AddConditionalPreviewButton then
-                            local target = { buttonIndex = function() return CS.selectedButton end, requireButton = true }
-                            if sectionId == "cooldownText" or sectionId == "cooldownSwipe" or sectionId == "desaturation" then
-                                AddConditionalPreviewButton(scroll, "Preview Cooldown State", "cooldown", target)
-                            elseif sectionId == "iconFillTimer" and overrides.iconFillEnabled == true and group.masqueEnabled ~= true then
-                                AddConditionalPreviewButton(scroll, "Preview Cooldown Fill", "cooldown", target)
-                                AddConditionalPreviewButton(scroll, "Preview Aura Fill", "aura_duration_text", target)
-                            elseif sectionId == "auraText" or sectionId == "auraDurationSwipe" then
-                                AddConditionalPreviewButton(scroll, "Preview Aura Duration Text", "aura_duration_text", target)
-                            elseif sectionId == "auraStackText" then
-                                AddConditionalPreviewButton(scroll, "Preview Aura Stack Text", "aura_stack_text", target)
-                            elseif sectionId == "showOutOfRange" then
-                                AddConditionalPreviewButton(scroll, "Preview Out of Range State", "out_of_range", target)
-                            elseif sectionId == "unusableDimming" then
-                                AddConditionalPreviewButton(scroll, "Preview Unusable State", "unusable", target)
-                            elseif sectionId == "iconTint" then
-                                AddConditionalPreviewButton(scroll, "Preview Cooldown Tint", "cooldown", target)
-                                AddConditionalPreviewButton(scroll, "Preview Aura Tint", "aura", target)
-                                AddConditionalPreviewButton(scroll, "Preview Unusable Tint", "unusable", target)
-                                AddConditionalPreviewButton(scroll, "Preview Out of Range Tint", "out_of_range", target)
-                            end
-                        end
                     end
                 end
             end

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -413,6 +413,9 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                     previewAdvExpanded, previewAdvBtn = AddAdvancedToggle(heading, "overridePreview_" .. sectionId, infoButtons, nil, {
                         title = sectionDef.label .. " Advanced",
                         build = BuildOverridePreviewAdvanced,
+                        isAvailable = function()
+                            return buttonData.overrideSections and buttonData.overrideSections[sectionId]
+                        end,
                     })
                     previewAdvBtn:SetPoint("LEFT", revertBtn, "RIGHT", 4, 0)
                     heading.right:ClearAllPoints()

--- a/ConfigSettings/CastBarPanels.lua
+++ b/ConfigSettings/CastBarPanels.lua
@@ -433,7 +433,9 @@ local function BuildCastBarStylingPanel(container)
         -- Icon Border Size slider (offset mode only)
         local iconRenderMode = AddBorderRenderModeDropdown(panel, settings, "iconBorderRenderMode", function()
             CooldownCompanion:ApplyCastBarSettings()
-            CooldownCompanion:RefreshConfigPanel()
+            if CS.RefreshAdvancedSettingsPanel then
+                CS.RefreshAdvancedSettingsPanel()
+            end
         end)
         local borderThicknessLocked = ST.IsBorderThicknessLocked()
 
@@ -473,14 +475,15 @@ local function BuildCastBarStylingPanel(container)
         iconOffsetCb:SetCallback("OnValueChanged", function(widget, event, val)
             settings.iconOffset = val
             CooldownCompanion:ApplyCastBarSettings()
-            CooldownCompanion:RefreshConfigPanel()
+            if CS.RefreshAdvancedSettingsPanel then
+                CS.RefreshAdvancedSettingsPanel()
+            end
         end)
         panel:AddChild(iconOffsetCb)
 
-        AddAdvancedToggle(iconOffsetCb, "castbarIconOffset", cbAdvBtns, settings.iconOffset or false, {
-            title = "Icon Offset Advanced",
-            build = BuildIconOffsetAdvanced,
-        })
+        if settings.iconOffset then
+            BuildIconOffsetAdvanced(panel)
+        end
     end
 
     AddAdvancedToggle(iconCb, "castbarIcon", cbAdvBtns, settings.showIcon ~= false, {

--- a/ConfigSettings/CastBarPanels.lua
+++ b/ConfigSettings/CastBarPanels.lua
@@ -393,9 +393,67 @@ local function BuildCastBarStylingPanel(container)
     end)
     container:AddChild(iconCb)
 
-    local iconAdvExpanded = AddAdvancedToggle(iconCb, "castbarIcon", cbAdvBtns, settings.showIcon ~= false)
+    local function BuildIconOffsetAdvanced(panel)
+        -- Icon Size slider (offset mode only)
+        local iconSizeSlider = AceGUI:Create("Slider")
+        iconSizeSlider:SetLabel("Icon Size")
+        iconSizeSlider:SetSliderValues(8, 64, 0.1)
+        iconSizeSlider:SetValue(settings.iconSize or 16)
+        iconSizeSlider:SetFullWidth(true)
+        iconSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            settings.iconSize = val
+            CooldownCompanion:ApplyCastBarSettings()
+        end)
+        panel:AddChild(iconSizeSlider)
 
-    if iconAdvExpanded and settings.showIcon ~= false then
+        -- Icon X Offset slider
+        local iconXSlider = AceGUI:Create("Slider")
+        iconXSlider:SetLabel("Icon X Offset")
+        iconXSlider:SetSliderValues(-50, 50, 0.1)
+        iconXSlider:SetValue(settings.iconOffsetX or 0)
+        iconXSlider:SetFullWidth(true)
+        iconXSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            settings.iconOffsetX = val
+            CooldownCompanion:ApplyCastBarSettings()
+        end)
+        panel:AddChild(iconXSlider)
+
+        -- Icon Y Offset slider
+        local iconYSlider = AceGUI:Create("Slider")
+        iconYSlider:SetLabel("Icon Y Offset")
+        iconYSlider:SetSliderValues(-50, 50, 0.1)
+        iconYSlider:SetValue(settings.iconOffsetY or 0)
+        iconYSlider:SetFullWidth(true)
+        iconYSlider:SetCallback("OnValueChanged", function(widget, event, val)
+            settings.iconOffsetY = val
+            CooldownCompanion:ApplyCastBarSettings()
+        end)
+        panel:AddChild(iconYSlider)
+
+        -- Icon Border Size slider (offset mode only)
+        local iconRenderMode = AddBorderRenderModeDropdown(panel, settings, "iconBorderRenderMode", function()
+            CooldownCompanion:ApplyCastBarSettings()
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        local borderThicknessLocked = ST.IsBorderThicknessLocked()
+
+        if iconRenderMode ~= ST.BORDER_RENDER_MODE_CRISP then
+            local iconBorderSlider = AceGUI:Create("Slider")
+            iconBorderSlider:SetLabel("Icon Border Size")
+            iconBorderSlider:SetSliderValues(0, 4, 0.1)
+            iconBorderSlider:SetValue(settings.iconBorderSize or 1)
+            iconBorderSlider:SetFullWidth(true)
+            iconBorderSlider:SetDisabled(borderThicknessLocked)
+            iconBorderSlider:SetCallback("OnValueChanged", function(widget, event, val)
+                if borderThicknessLocked then return end
+                settings.iconBorderSize = val
+                CooldownCompanion:ApplyCastBarSettings()
+            end)
+            panel:AddChild(iconBorderSlider)
+        end
+    end
+
+    local function BuildIconAdvanced(panel)
         -- Icon on Right Side
         local iconFlipCb = AceGUI:Create("CheckBox")
         iconFlipCb:SetLabel("Icon on Right Side")
@@ -405,7 +463,7 @@ local function BuildCastBarStylingPanel(container)
             settings.iconFlipSide = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(iconFlipCb)
+        panel:AddChild(iconFlipCb)
 
         -- Icon Offset toggle
         local iconOffsetCb = AceGUI:Create("CheckBox")
@@ -417,70 +475,18 @@ local function BuildCastBarStylingPanel(container)
             CooldownCompanion:ApplyCastBarSettings()
             CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(iconOffsetCb)
+        panel:AddChild(iconOffsetCb)
 
-        local iconOffsetAdvExpanded = AddAdvancedToggle(iconOffsetCb, "castbarIconOffset", cbAdvBtns, settings.iconOffset or false)
-
-        if iconOffsetAdvExpanded and settings.iconOffset then
-            -- Icon Size slider (offset mode only)
-            local iconSizeSlider = AceGUI:Create("Slider")
-            iconSizeSlider:SetLabel("Icon Size")
-            iconSizeSlider:SetSliderValues(8, 64, 0.1)
-            iconSizeSlider:SetValue(settings.iconSize or 16)
-            iconSizeSlider:SetFullWidth(true)
-            iconSizeSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                settings.iconSize = val
-                CooldownCompanion:ApplyCastBarSettings()
-            end)
-            container:AddChild(iconSizeSlider)
-
-            -- Icon X Offset slider
-            local iconXSlider = AceGUI:Create("Slider")
-            iconXSlider:SetLabel("Icon X Offset")
-            iconXSlider:SetSliderValues(-50, 50, 0.1)
-            iconXSlider:SetValue(settings.iconOffsetX or 0)
-            iconXSlider:SetFullWidth(true)
-            iconXSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                settings.iconOffsetX = val
-                CooldownCompanion:ApplyCastBarSettings()
-            end)
-            container:AddChild(iconXSlider)
-
-            -- Icon Y Offset slider
-            local iconYSlider = AceGUI:Create("Slider")
-            iconYSlider:SetLabel("Icon Y Offset")
-            iconYSlider:SetSliderValues(-50, 50, 0.1)
-            iconYSlider:SetValue(settings.iconOffsetY or 0)
-            iconYSlider:SetFullWidth(true)
-            iconYSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                settings.iconOffsetY = val
-                CooldownCompanion:ApplyCastBarSettings()
-            end)
-            container:AddChild(iconYSlider)
-
-            -- Icon Border Size slider (offset mode only)
-            local iconRenderMode = AddBorderRenderModeDropdown(container, settings, "iconBorderRenderMode", function()
-                CooldownCompanion:ApplyCastBarSettings()
-                CooldownCompanion:RefreshConfigPanel()
-            end)
-            local borderThicknessLocked = ST.IsBorderThicknessLocked()
-
-            if iconRenderMode ~= ST.BORDER_RENDER_MODE_CRISP then
-                local iconBorderSlider = AceGUI:Create("Slider")
-                iconBorderSlider:SetLabel("Icon Border Size")
-                iconBorderSlider:SetSliderValues(0, 4, 0.1)
-                iconBorderSlider:SetValue(settings.iconBorderSize or 1)
-                iconBorderSlider:SetFullWidth(true)
-                iconBorderSlider:SetDisabled(borderThicknessLocked)
-                iconBorderSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                    if borderThicknessLocked then return end
-                    settings.iconBorderSize = val
-                    CooldownCompanion:ApplyCastBarSettings()
-                end)
-                container:AddChild(iconBorderSlider)
-            end
-        end
+        AddAdvancedToggle(iconOffsetCb, "castbarIconOffset", cbAdvBtns, settings.iconOffset or false, {
+            title = "Icon Offset Advanced",
+            build = BuildIconOffsetAdvanced,
+        })
     end
+
+    AddAdvancedToggle(iconCb, "castbarIcon", cbAdvBtns, settings.showIcon ~= false, {
+        title = "Spell Icon Advanced",
+        build = BuildIconAdvanced,
+    })
 
     -- Show Spark
     local sparkCb = AceGUI:Create("CheckBox")
@@ -505,9 +511,7 @@ local function BuildCastBarStylingPanel(container)
     end)
     container:AddChild(nameCb)
 
-    local nameAdvExpanded = AddAdvancedToggle(nameCb, "castbarNameText", cbAdvBtns, settings.showNameText ~= false)
-
-    if nameAdvExpanded and settings.showNameText ~= false then
+    local function BuildNameTextAdvanced(panel)
         -- Font
         local nameFontDrop = AceGUI:Create("Dropdown")
         nameFontDrop:SetLabel("Font")
@@ -518,7 +522,7 @@ local function BuildCastBarStylingPanel(container)
             settings.nameFont = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(nameFontDrop)
+        panel:AddChild(nameFontDrop)
 
         -- Size
         local nameSizeSlider = AceGUI:Create("Slider")
@@ -530,7 +534,7 @@ local function BuildCastBarStylingPanel(container)
             settings.nameFontSize = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(nameSizeSlider)
+        panel:AddChild(nameSizeSlider)
 
         -- Outline
         local nameOutlineDrop = AceGUI:Create("Dropdown")
@@ -542,11 +546,16 @@ local function BuildCastBarStylingPanel(container)
             settings.nameFontOutline = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(nameOutlineDrop)
+        panel:AddChild(nameOutlineDrop)
 
         -- Color
-        AddColorPicker(container, settings, "nameFontColor", "Font Color", {1, 1, 1, 1}, true, applyCastBar)
+        AddColorPicker(panel, settings, "nameFontColor", "Font Color", {1, 1, 1, 1}, true, applyCastBar)
     end
+
+    AddAdvancedToggle(nameCb, "castbarNameText", cbAdvBtns, settings.showNameText ~= false, {
+        title = "Spell Name Advanced",
+        build = BuildNameTextAdvanced,
+    })
 
     -- Show Cast Time
     local ctCb = AceGUI:Create("CheckBox")
@@ -560,9 +569,7 @@ local function BuildCastBarStylingPanel(container)
     end)
     container:AddChild(ctCb)
 
-    local ctAdvExpanded = AddAdvancedToggle(ctCb, "castbarCastTime", cbAdvBtns, settings.showCastTimeText ~= false)
-
-    if ctAdvExpanded and settings.showCastTimeText ~= false then
+    local function BuildCastTimeAdvanced(panel)
         -- Font
         local ctFontDrop = AceGUI:Create("Dropdown")
         ctFontDrop:SetLabel("Font")
@@ -573,7 +580,7 @@ local function BuildCastBarStylingPanel(container)
             settings.castTimeFont = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(ctFontDrop)
+        panel:AddChild(ctFontDrop)
 
         -- Size
         local ctSizeSlider = AceGUI:Create("Slider")
@@ -585,7 +592,7 @@ local function BuildCastBarStylingPanel(container)
             settings.castTimeFontSize = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(ctSizeSlider)
+        panel:AddChild(ctSizeSlider)
 
         -- Outline
         local ctOutlineDrop = AceGUI:Create("Dropdown")
@@ -597,10 +604,10 @@ local function BuildCastBarStylingPanel(container)
             settings.castTimeFontOutline = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(ctOutlineDrop)
+        panel:AddChild(ctOutlineDrop)
 
         -- Color
-        AddColorPicker(container, settings, "castTimeFontColor", "Font Color", {1, 1, 1, 1}, true, applyCastBar)
+        AddColorPicker(panel, settings, "castTimeFontColor", "Font Color", {1, 1, 1, 1}, true, applyCastBar)
 
         -- X Offset
         local ctXSlider = AceGUI:Create("Slider")
@@ -612,7 +619,7 @@ local function BuildCastBarStylingPanel(container)
             settings.castTimeXOffset = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(ctXSlider)
+        panel:AddChild(ctXSlider)
 
         -- Y Offset
         local ctYSlider = AceGUI:Create("Slider")
@@ -624,8 +631,13 @@ local function BuildCastBarStylingPanel(container)
             settings.castTimeYOffset = val
             CooldownCompanion:ApplyCastBarSettings()
         end)
-        container:AddChild(ctYSlider)
+        panel:AddChild(ctYSlider)
     end
+
+    AddAdvancedToggle(ctCb, "castbarCastTime", cbAdvBtns, settings.showCastTimeText ~= false, {
+        title = "Cast Time Advanced",
+        build = BuildCastTimeAdvanced,
+    })
 end
 
 -- Expose for ButtonSettings.lua and Config.lua

--- a/ConfigSettings/FormatEditor.lua
+++ b/ConfigSettings/FormatEditor.lua
@@ -635,6 +635,10 @@ end
 -- OPEN FORMAT EDITOR
 ------------------------------------------------------------------------
 local function OpenFormatEditor(style, groupId, opts)
+    if CS.CloseAdvancedSettingsPanel then
+        CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+    end
+
     -- If already open, bring to front and refresh
     if formatEditorFrame then
         formatEditorFrame:Show()

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -51,9 +51,9 @@ local BuildProcGlowControls = ST._BuildProcGlowControls
 local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
-local AddPreviewToggleButton = ST._AddPreviewToggleButton
-local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
+local AddPreviewBadge = ST._AddPreviewBadge
+local AddConditionalPreviewBadge = ST._AddConditionalPreviewBadge
 local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
@@ -110,78 +110,6 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     " ",
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
-
-local function SetPreviewBadgeActive(btn, active)
-    if btn and btn._icon then
-        if active then
-            btn._icon:SetVertexColor(1, 0.82, 0, 1)
-        else
-            btn._icon:SetVertexColor(0.72, 0.72, 0.72, 0.85)
-        end
-    end
-end
-
-local function AddConditionalPreviewBadge(parentWidget, anchorAfterFrame, label, previewKind, enabled)
-    if not enabled
-        or not (parentWidget and parentWidget.frame and parentWidget.checkbg and parentWidget.text)
-        or not (CooldownCompanion.SetConditionalVisualPreviewActive and CooldownCompanion.IsConditionalVisualPreviewActive)
-    then
-        return nil
-    end
-
-    local frame = parentWidget.frame
-    local btn = frame._cdcPreviewBtn
-    if not btn then
-        btn = CreateFrame("Button", nil, frame)
-        btn:SetSize(14, 14)
-        btn._icon = btn:CreateTexture(nil, "ARTWORK")
-        btn._icon:SetSize(13, 13)
-        btn._icon:SetPoint("CENTER")
-        btn._icon:SetAtlas("GM-icon-visible", false)
-        frame._cdcPreviewBtn = btn
-    end
-
-    btn:SetParent(frame)
-    btn:ClearAllPoints()
-    if anchorAfterFrame and anchorAfterFrame:IsShown() then
-        btn:SetPoint("LEFT", anchorAfterFrame, "RIGHT", 4, 0)
-    else
-        btn:SetPoint("LEFT", parentWidget.checkbg, "RIGHT", parentWidget.text:GetStringWidth() + 6, 0)
-    end
-    btn:Show()
-    btn._icon:Show()
-
-    local function IsActive()
-        return CooldownCompanion:IsConditionalVisualPreviewActive(CS.selectedGroup, nil, previewKind)
-    end
-
-    SetPreviewBadgeActive(btn, IsActive())
-    btn:SetScript("OnClick", function()
-        local showPreview = not IsActive()
-        if showPreview and CooldownCompanion.ClearAllConfigPreviews then
-            CooldownCompanion:ClearAllConfigPreviews()
-        end
-        CooldownCompanion:SetConditionalVisualPreviewActive(CS.selectedGroup, nil, previewKind, showPreview)
-        if not (RefreshConfigPanelForPreviewToggle and RefreshConfigPanelForPreviewToggle()) then
-            SetPreviewBadgeActive(btn, IsActive())
-        end
-    end)
-    btn:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-        GameTooltip:AddLine(label)
-        GameTooltip:Show()
-    end)
-    btn:SetScript("OnLeave", function()
-        GameTooltip:Hide()
-    end)
-    parentWidget:SetCallback("OnRelease", function()
-        btn:ClearAllPoints()
-        btn:Hide()
-        btn:SetParent(nil)
-    end)
-
-    return btn
-end
 
 local function AddIndicatorsHeading(container, text)
     local heading = AceGUI:Create("Heading")
@@ -1620,25 +1548,23 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
             BuildTextureIndicatorSpeedSlider(panel, config, "Bounce Duration")
         end
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, sectionDef.previewText, function()
-                return CS.selectedGroup
-                    and CooldownCompanion:IsGroupTextureIndicatorPreviewActive(CS.selectedGroup, sectionKey)
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, show)
-                end
-            end)
-        end
     end
 
     local advKey = "textureIndicator_" .. sectionKey
-    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
+    local _, advBtn = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
         title = sectionDef.label .. " Advanced",
         build = BuildTextureIndicatorAdvanced,
     })
+    AddPreviewBadge(enableCb, advBtn, sectionDef.previewText, function()
+        return CS.selectedGroup
+            and CooldownCompanion:IsGroupTextureIndicatorPreviewActive(CS.selectedGroup, sectionKey)
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, show)
+        end
+    end, config.enabled)
 
-    if (not advExpanded or not config.enabled) and CS.selectedGroup then
+    if not config.enabled and CS.selectedGroup then
         CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, false)
     end
 end
@@ -1677,22 +1603,20 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
 
         BuildTextureIndicatorSpeedSlider(panel, config, def.speedLabel)
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Effects", function()
-                return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
     local advKey = "triggerEffect_" .. effectKey
-    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
+    local advExpanded, advBtn = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
         title = def.label .. " Advanced",
         build = BuildTriggerEffectAdvanced,
     })
+    AddPreviewBadge(enableCb, advBtn, "Preview Effects", function()
+        return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
+        end
+    end, config.enabled)
     return advExpanded and config.enabled
 end
 
@@ -1809,27 +1733,26 @@ local function BuildProcGlowSection(container, group, style)
 
         BuildProcGlowControls(panel, style, UpdateSelectedGroupStyle)
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Proc Glow", function()
-                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_procGlowPreview")
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
-    local procAdvExpanded, procAdvBtn = AddAdvancedToggle(procEnableCb, "procGlow", tabInfoButtons, style.procGlowStyle ~= "none", {
+    local _, procAdvBtn = AddAdvancedToggle(procEnableCb, "procGlow", tabInfoButtons, style.procGlowStyle ~= "none", {
         title = "Proc Glow Advanced",
         build = BuildProcGlowAdvanced,
     })
     local procBtnData = CS.selectedButton and group.buttons[CS.selectedButton]
+    local procPromoteBtn
     if not (procBtnData and procBtnData.isPassive) then
-        CreateCheckboxPromoteButton(procEnableCb, procAdvBtn, "procGlow", group, style)
+        procPromoteBtn = CreateCheckboxPromoteButton(procEnableCb, procAdvBtn, "procGlow", group, style)
     end
+    AddPreviewBadge(procEnableCb, procPromoteBtn or procAdvBtn, "Preview Proc Glow", function()
+        return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_procGlowPreview")
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, show)
+        end
+    end, style.procGlowStyle ~= "none")
 
-    if not (procAdvExpanded and style.procGlowStyle ~= "none") then
+    if style.procGlowStyle == "none" then
         CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, false)
         return
     end
@@ -1869,24 +1792,22 @@ local function BuildAuraGlowSection(container, group, style)
 
         BuildAuraIndicatorControls(panel, style, UpdateSelectedGroupStyle)
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Aura Glow", function()
-                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_auraGlowPreview")
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
-    local auraAdvExpanded, auraAdvBtn = AddAdvancedToggle(auraEnableCb, "auraGlow", tabInfoButtons, style.auraGlowStyle ~= "none", {
+    local _, auraAdvBtn = AddAdvancedToggle(auraEnableCb, "auraGlow", tabInfoButtons, style.auraGlowStyle ~= "none", {
         title = "Aura Glow Advanced",
         build = BuildAuraGlowAdvanced,
     })
-    CreateCheckboxPromoteButton(auraEnableCb, auraAdvBtn, "auraIndicator", group, style)
+    local auraPromoteBtn = CreateCheckboxPromoteButton(auraEnableCb, auraAdvBtn, "auraIndicator", group, style)
+    AddPreviewBadge(auraEnableCb, auraPromoteBtn or auraAdvBtn, "Preview Aura Glow", function()
+        return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_auraGlowPreview")
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, show)
+        end
+    end, style.auraGlowStyle ~= "none")
 
-    if not (auraAdvExpanded and style.auraGlowStyle ~= "none") then
+    if style.auraGlowStyle == "none" then
         CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, false)
         return
     end
@@ -1916,24 +1837,22 @@ local function BuildPandemicGlowSection(container, group, style)
 
         BuildPandemicGlowControls(panel, style, UpdateSelectedGroupStyle)
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Pandemic Glow", function()
-                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
-    local pandemicAdvExpanded, pandemicAdvBtn = AddAdvancedToggle(pandemicGlowCb, "pandemicGlow", tabInfoButtons, style.showPandemicGlow ~= false, {
+    local _, pandemicAdvBtn = AddAdvancedToggle(pandemicGlowCb, "pandemicGlow", tabInfoButtons, style.showPandemicGlow ~= false, {
         title = "Pandemic Glow Advanced",
         build = BuildPandemicGlowAdvanced,
     })
-    CreateCheckboxPromoteButton(pandemicGlowCb, pandemicAdvBtn, "pandemicGlow", group, style)
+    local pandemicPromoteBtn = CreateCheckboxPromoteButton(pandemicGlowCb, pandemicAdvBtn, "pandemicGlow", group, style)
+    AddPreviewBadge(pandemicGlowCb, pandemicPromoteBtn or pandemicAdvBtn, "Preview Pandemic Glow", function()
+        return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
+        end
+    end, style.showPandemicGlow ~= false)
 
-    if not (pandemicAdvExpanded and style.showPandemicGlow ~= false) then
+    if style.showPandemicGlow == false then
         CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, false)
         return
     end
@@ -2017,28 +1936,26 @@ local function BuildReadyGlowSection(container, group, style)
 
         BuildReadyGlowControls(panel, style, UpdateSelectedGroupStyle)
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Ready Glow Style", function()
-                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_readyGlowPreview")
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyEnableCb, "readyGlow", tabInfoButtons, style.readyGlowStyle and style.readyGlowStyle ~= "none", {
+    local _, readyAdvBtn = AddAdvancedToggle(readyEnableCb, "readyGlow", tabInfoButtons, style.readyGlowStyle and style.readyGlowStyle ~= "none", {
         title = "Ready Glow Advanced",
         build = BuildReadyGlowAdvanced,
     })
     local readyPromoteBtn = CreateCheckboxPromoteButton(readyEnableCb, readyAdvBtn, "readyGlow", group, style)
-    CreateInfoButton(readyEnableCb.frame, readyPromoteBtn, "LEFT", "RIGHT", 4, 0, {
+    local readyPreviewBtn = AddPreviewBadge(readyEnableCb, readyPromoteBtn or readyAdvBtn, "Preview Ready Glow Style", function()
+        return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_readyGlowPreview")
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, show)
+        end
+    end, style.readyGlowStyle and style.readyGlowStyle ~= "none")
+    CreateInfoButton(readyEnableCb.frame, readyPreviewBtn or readyPromoteBtn or readyAdvBtn, "LEFT", "RIGHT", 4, 0, {
         "Ready Glow",
         {"Adds a glow to spells/items that are not on cooldown.", 1, 1, 1, true},
     }, tabInfoButtons)
 
-    if not (readyAdvExpanded and style.readyGlowStyle and style.readyGlowStyle ~= "none") then
+    if not (style.readyGlowStyle and style.readyGlowStyle ~= "none") then
         CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, false)
         return
     end
@@ -2068,28 +1985,26 @@ local function BuildKeyPressHighlightSection(container, group, style)
 
         BuildKeyPressHighlightControls(panel, style, UpdateSelectedGroupStyle)
 
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(panel, "Preview Key Press Highlight", function()
-                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_keyPressHighlightPreview")
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
     end
 
-    local kphAdvExpanded, kphAdvBtn = AddAdvancedToggle(kphEnableCb, "keyPressHighlight", tabInfoButtons, style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none", {
+    local _, kphAdvBtn = AddAdvancedToggle(kphEnableCb, "keyPressHighlight", tabInfoButtons, style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none", {
         title = "Key Press Highlight Advanced",
         build = BuildKeyPressHighlightAdvanced,
     })
     local kphPromoteBtn = CreateCheckboxPromoteButton(kphEnableCb, kphAdvBtn, "keyPressHighlight", group, style)
-    CreateInfoButton(kphEnableCb.frame, kphPromoteBtn, "LEFT", "RIGHT", 4, 0, {
+    local kphPreviewBtn = AddPreviewBadge(kphEnableCb, kphPromoteBtn or kphAdvBtn, "Preview Key Press Highlight", function()
+        return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_keyPressHighlightPreview")
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, show)
+        end
+    end, style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none")
+    CreateInfoButton(kphEnableCb.frame, kphPreviewBtn or kphPromoteBtn or kphAdvBtn, "LEFT", "RIGHT", 4, 0, {
         "Key Press Highlight",
         {"Shows a glow overlay on buttons while their action bar keybind is physically held down.", 1, 1, 1, true},
     }, tabInfoButtons)
 
-    if not (kphAdvExpanded and style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none") then
+    if not (style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none") then
         CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, false)
         return
     end
@@ -2812,16 +2727,14 @@ local function BuildAppearanceTab(container)
 
         AddOffsetSliders(panel, style, "cooldownTextXOffset", "cooldownTextYOffset", { x = 0, y = 0 }, refreshStyle)
 
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Cooldown Text", "cooldown")
-        end
     end
 
     local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText, {
         title = "Cooldown Text Advanced",
         build = BuildCooldownTextAdvanced,
     })
-    CreateCheckboxPromoteButton(cdTextCb, cdTextAdvBtn, "cooldownText", group, style)
+    local cdTextPromoteBtn = CreateCheckboxPromoteButton(cdTextCb, cdTextAdvBtn, "cooldownText", group, style)
+    AddConditionalPreviewBadge(cdTextCb, cdTextPromoteBtn or cdTextAdvBtn, "Preview Cooldown Text", "cooldown", style.showCooldownText)
 
     -- Show Charge Text toggle
     local chargeTextCb = AceGUI:Create("CheckBox")
@@ -2887,9 +2800,6 @@ local function BuildAppearanceTab(container)
             AddOffsetSliders(panel, style, "auraTextXOffset", "auraTextYOffset", { x = 2, y = -2 }, refreshStyle)
         end
 
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text")
-        end
     end
 
     local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false, {
@@ -2897,8 +2807,9 @@ local function BuildAppearanceTab(container)
         build = BuildAuraDurationTextAdvanced,
     })
     local auraTextPromoteBtn = CreateCheckboxPromoteButton(auraTextCb, auraTextAdvBtn, "auraText", group, style)
+    local auraTextPreviewBtn = AddConditionalPreviewBadge(auraTextCb, auraTextPromoteBtn or auraTextAdvBtn, "Preview Aura Duration Text", "aura_duration_text", style.showAuraText ~= false)
 
-    local auraPosInfo = CreateInfoButton(auraTextCb.frame, auraTextPromoteBtn, "LEFT", "RIGHT", 4, 0, {
+    local auraPosInfo = CreateInfoButton(auraTextCb.frame, auraTextPreviewBtn or auraTextPromoteBtn or auraTextAdvBtn, "LEFT", "RIGHT", 4, 0, {
         "Shared Position",
         {"Position is shared with Cooldown Text by default. Enable 'Separate Text Positions' in advanced settings to use independent positions.", 1, 1, 1, true},
     }, auraTextCb)
@@ -2925,16 +2836,14 @@ local function BuildAppearanceTab(container)
         AddAnchorDropdown(panel, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
         AddOffsetSliders(panel, style, "auraStackXOffset", "auraStackYOffset", { x = 2, y = 2 }, refreshStyle)
 
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text")
-        end
     end
 
     local auraStackAdvExpanded, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
         title = "Aura Stack Text Advanced",
         build = BuildAuraStackTextAdvanced,
     })
-    CreateCheckboxPromoteButton(auraStackCb, auraStackAdvBtn, "auraStackText", group, style)
+    local auraStackPromoteBtn = CreateCheckboxPromoteButton(auraStackCb, auraStackAdvBtn, "auraStackText", group, style)
+    AddConditionalPreviewBadge(auraStackCb, auraStackPromoteBtn or auraStackAdvBtn, "Preview Aura Stack Text", "aura_stack_text", style.showAuraStackText ~= false)
 
     -- Show Keybind/Custom Text toggle
     local kbCb = AceGUI:Create("CheckBox")

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -123,6 +123,7 @@ local function AddIndicatorsHeading(container, text)
     ColorHeading(heading)
     heading:SetFullWidth(true)
     container:AddChild(heading)
+    return heading
 end
 
 -- Imports from BarModeTabs.lua
@@ -1612,17 +1613,10 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
     end
 
     local advKey = "triggerEffect_" .. effectKey
-    local _, advBtn = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
+    AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
         title = def.label .. " Advanced",
         build = BuildTriggerEffectAdvanced,
     })
-    AddPreviewBadge(enableCb, advBtn, "Preview Effects", function()
-        return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
-    end, function(show)
-        if CS.selectedGroup then
-            CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
-        end
-    end, config.enabled)
 end
 
 local function GetTriggerPanelEffectOrderForDisplayType(group)
@@ -1678,10 +1672,23 @@ local function BuildTriggerEffectsTab(container, group)
     local anyEnabled = false
     local effectOrder = GetTriggerPanelEffectOrderForDisplayType(group)
     for _, effectKey in ipairs(effectOrder) do
-        BuildTriggerPanelEffectSection(container, effects, effectKey)
         if effects[effectKey] and effects[effectKey].enabled then
             anyEnabled = true
+            break
         end
+    end
+
+    local heading = AddIndicatorsHeading(container, "Trigger Panel Effects")
+    AddPreviewBadge(heading, nil, "Preview Effects", function()
+        return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
+    end, function(show)
+        if CS.selectedGroup then
+            CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
+        end
+    end, anyEnabled)
+
+    for _, effectKey in ipairs(effectOrder) do
+        BuildTriggerPanelEffectSection(container, effects, effectKey)
     end
 
     if not anyEnabled and CS.selectedGroup then

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -16,7 +16,6 @@ local CreateCheckboxPromoteButton = ST._CreateCheckboxPromoteButton
 local CreateInfoButton = ST._CreateInfoButton
 local BuildCompactModeControls = ST._BuildCompactModeControls
 local BuildGroupSettingPresetControls = ST._BuildGroupSettingPresetControls
-local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
 local AddAnchorDropdown = ST._AddAnchorDropdown
 local AddFontControls = ST._AddFontControls
@@ -1509,7 +1508,6 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
             CooldownCompanion:RefreshAllAuraTextureVisuals()
         end)
         panel:AddChild(combatCb)
-        ApplyCheckboxIndent(combatCb, 20)
 
         if sectionKey == "aura" then
             local invertCb = AceGUI:Create("CheckBox")
@@ -1521,7 +1519,6 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
                 CooldownCompanion:RefreshAllAuraTextureVisuals()
             end)
             panel:AddChild(invertCb)
-            ApplyCheckboxIndent(invertCb, 20)
         end
 
         local effectList, effectOrder = GetTextureIndicatorEffectList(indicators, sectionKey)
@@ -1735,7 +1732,6 @@ local function BuildProcGlowSection(container, group, style)
             UpdateSelectedGroupStyle()
         end)
         panel:AddChild(procCombatCb)
-        ApplyCheckboxIndent(procCombatCb, 20)
 
         BuildProcGlowControls(panel, style, UpdateSelectedGroupStyle)
 
@@ -1786,7 +1782,6 @@ local function BuildAuraGlowSection(container, group, style)
             UpdateSelectedGroupStyle()
         end)
         panel:AddChild(auraCombatCb)
-        ApplyCheckboxIndent(auraCombatCb, 20)
 
         local auraInvertCb = AceGUI:Create("CheckBox")
         auraInvertCb:SetLabel("Show When Missing")
@@ -1797,7 +1792,6 @@ local function BuildAuraGlowSection(container, group, style)
             UpdateSelectedGroupStyle()
         end)
         panel:AddChild(auraInvertCb)
-        ApplyCheckboxIndent(auraInvertCb, 20)
 
         BuildAuraIndicatorControls(panel, style, UpdateSelectedGroupStyle)
 
@@ -1845,7 +1839,6 @@ local function BuildPandemicGlowSection(container, group, style)
             UpdateSelectedGroupStyle()
         end)
         panel:AddChild(pandemicCombatCb)
-        ApplyCheckboxIndent(pandemicCombatCb, 20)
 
         BuildPandemicGlowControls(panel, style, UpdateSelectedGroupStyle)
 
@@ -1893,7 +1886,6 @@ local function BuildReadyGlowSection(container, group, style)
             UpdateSelectedGroupStyle()
         end)
         panel:AddChild(readyCombatCb)
-        ApplyCheckboxIndent(readyCombatCb, 20)
 
         local readyChargesCb = AceGUI:Create("CheckBox")
         readyChargesCb:SetLabel("Glow When Charges Are Capped")
@@ -1912,7 +1904,6 @@ local function BuildReadyGlowSection(container, group, style)
             CooldownCompanion:UpdateAllCooldowns()
         end)
         panel:AddChild(readyChargesCb)
-        ApplyCheckboxIndent(readyChargesCb, 20)
         CreateInfoButton(readyChargesCb.frame, readyChargesCb.checkbg, "LEFT", "RIGHT", readyChargesCb.text:GetStringWidth() + 6, 0, {
             "Glow When Charges Are Capped",
             {"When this toggle is enabled, the glow will only appear for charge based spells when at max charges.", 1, 1, 1, true},
@@ -1936,7 +1927,6 @@ local function BuildReadyGlowSection(container, group, style)
             CooldownCompanion:RefreshConfigPanel()
         end)
         panel:AddChild(readyDurCb)
-        ApplyCheckboxIndent(readyDurCb, 20)
 
         if (style.readyGlowDuration or 0) > 0 then
             local readyDurSlider = AceGUI:Create("Slider")
@@ -2001,7 +1991,6 @@ local function BuildKeyPressHighlightSection(container, group, style)
             UpdateSelectedGroupStyle()
         end)
         panel:AddChild(kphCombatCb)
-        ApplyCheckboxIndent(kphCombatCb, 20)
 
         BuildKeyPressHighlightControls(panel, style, UpdateSelectedGroupStyle)
 
@@ -2091,7 +2080,6 @@ local function BuildEffectsTab(container)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
         panel:AddChild(assistedCombatCb)
-        ApplyCheckboxIndent(assistedCombatCb, 20)
 
         BuildAssistedHighlightControls(panel, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
@@ -2167,7 +2155,6 @@ local function BuildEffectsTab(container)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
         panel:AddChild(reverseCb)
-        ApplyCheckboxIndent(reverseCb, 20)
 
         -- Show Swipe Fill
         local fillCb = AceGUI:Create("CheckBox")
@@ -2180,7 +2167,6 @@ local function BuildEffectsTab(container)
             CooldownCompanion:RefreshConfigPanel()
         end)
         panel:AddChild(fillCb)
-        ApplyCheckboxIndent(fillCb, 20)
 
         -- Swipe Fill Opacity (only when fill is visible)
         if style.showCooldownSwipeFill ~= false then
@@ -2208,7 +2194,6 @@ local function BuildEffectsTab(container)
             CooldownCompanion:RefreshConfigPanel()
         end)
         panel:AddChild(edgeCb)
-        ApplyCheckboxIndent(edgeCb, 20)
 
         -- Swipe Edge Color (only when edge is visible)
         if style.showCooldownSwipeEdge ~= false then

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1499,74 +1499,76 @@ local function BuildTextureIndicatorSection(container, group, indicators, sectio
     end)
     container:AddChild(enableCb)
 
-    local advKey = "textureIndicator_" .. sectionKey
-    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled)
-
-    if not advExpanded or not config.enabled then
-        if CS.selectedGroup then
-            CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, false)
-        end
-        return
-    end
-
-    local combatCb = AceGUI:Create("CheckBox")
-    combatCb:SetLabel("Show Only In Combat")
-    combatCb:SetValue(config.combatOnly or false)
-    combatCb:SetFullWidth(true)
-    combatCb:SetCallback("OnValueChanged", function(_, _, value)
-        config.combatOnly = value == true
-        CooldownCompanion:RefreshAllAuraTextureVisuals()
-    end)
-    container:AddChild(combatCb)
-    ApplyCheckboxIndent(combatCb, 20)
-
-    if sectionKey == "aura" then
-        local invertCb = AceGUI:Create("CheckBox")
-        invertCb:SetLabel("Show When Missing")
-        invertCb:SetValue(config.invert or false)
-        invertCb:SetFullWidth(true)
-        invertCb:SetCallback("OnValueChanged", function(_, _, value)
-            config.invert = value == true
+    local function BuildTextureIndicatorAdvanced(panel)
+        local combatCb = AceGUI:Create("CheckBox")
+        combatCb:SetLabel("Show Only In Combat")
+        combatCb:SetValue(config.combatOnly or false)
+        combatCb:SetFullWidth(true)
+        combatCb:SetCallback("OnValueChanged", function(_, _, value)
+            config.combatOnly = value == true
             CooldownCompanion:RefreshAllAuraTextureVisuals()
         end)
-        container:AddChild(invertCb)
-        ApplyCheckboxIndent(invertCb, 20)
-    end
+        panel:AddChild(combatCb)
+        ApplyCheckboxIndent(combatCb, 20)
 
-    local effectList, effectOrder = GetTextureIndicatorEffectList(indicators, sectionKey)
-    local effectDrop = AceGUI:Create("Dropdown")
-    effectDrop:SetLabel("Effect Type")
-    effectDrop:SetList(effectList, effectOrder)
-    effectDrop:SetValue(config.effectType)
-    effectDrop:SetFullWidth(true)
-    effectDrop:SetCallback("OnValueChanged", function(_, _, value)
-        config.effectType = value or "none"
-        RefreshTextureIndicatorConfig()
-    end)
-    container:AddChild(effectDrop)
+        if sectionKey == "aura" then
+            local invertCb = AceGUI:Create("CheckBox")
+            invertCb:SetLabel("Show When Missing")
+            invertCb:SetValue(config.invert or false)
+            invertCb:SetFullWidth(true)
+            invertCb:SetCallback("OnValueChanged", function(_, _, value)
+                config.invert = value == true
+                CooldownCompanion:RefreshAllAuraTextureVisuals()
+            end)
+            panel:AddChild(invertCb)
+            ApplyCheckboxIndent(invertCb, 20)
+        end
 
-    if config.effectType == "colorShift" then
-        AddColorPicker(container, config, "color", "Shift Color", { 1, 1, 1, 1 }, true,
-            function() CooldownCompanion:RefreshAllAuraTextureVisuals() end,
-            function() CooldownCompanion:RefreshAllAuraTextureVisuals() end)
-        BuildTextureIndicatorSpeedSlider(container, config, "Shift Duration")
-    elseif config.effectType == "pulse" then
-        BuildTextureIndicatorSpeedSlider(container, config, "Pulse Duration")
-    elseif config.effectType == "shrinkExpand" then
-        BuildTextureIndicatorSpeedSlider(container, config, "Cycle Duration")
-    elseif config.effectType == "bounce" then
-        BuildTextureIndicatorSpeedSlider(container, config, "Bounce Duration")
-    end
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, sectionDef.previewText, function()
-            return CS.selectedGroup
-                and CooldownCompanion:IsGroupTextureIndicatorPreviewActive(CS.selectedGroup, sectionKey)
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, show)
-            end
+        local effectList, effectOrder = GetTextureIndicatorEffectList(indicators, sectionKey)
+        local effectDrop = AceGUI:Create("Dropdown")
+        effectDrop:SetLabel("Effect Type")
+        effectDrop:SetList(effectList, effectOrder)
+        effectDrop:SetValue(config.effectType)
+        effectDrop:SetFullWidth(true)
+        effectDrop:SetCallback("OnValueChanged", function(_, _, value)
+            config.effectType = value or "none"
+            RefreshTextureIndicatorConfig()
         end)
+        panel:AddChild(effectDrop)
+
+        if config.effectType == "colorShift" then
+            AddColorPicker(panel, config, "color", "Shift Color", { 1, 1, 1, 1 }, true,
+                function() CooldownCompanion:RefreshAllAuraTextureVisuals() end,
+                function() CooldownCompanion:RefreshAllAuraTextureVisuals() end)
+            BuildTextureIndicatorSpeedSlider(panel, config, "Shift Duration")
+        elseif config.effectType == "pulse" then
+            BuildTextureIndicatorSpeedSlider(panel, config, "Pulse Duration")
+        elseif config.effectType == "shrinkExpand" then
+            BuildTextureIndicatorSpeedSlider(panel, config, "Cycle Duration")
+        elseif config.effectType == "bounce" then
+            BuildTextureIndicatorSpeedSlider(panel, config, "Bounce Duration")
+        end
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, sectionDef.previewText, function()
+                return CS.selectedGroup
+                    and CooldownCompanion:IsGroupTextureIndicatorPreviewActive(CS.selectedGroup, sectionKey)
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, show)
+                end
+            end)
+        end
+    end
+
+    local advKey = "textureIndicator_" .. sectionKey
+    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
+        title = sectionDef.label .. " Advanced",
+        build = BuildTextureIndicatorAdvanced,
+    })
+
+    if (not advExpanded or not config.enabled) and CS.selectedGroup then
+        CooldownCompanion:SetGroupTextureIndicatorPreview(CS.selectedGroup, sectionKey, false)
     end
 end
 
@@ -1588,27 +1590,39 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
     end)
     container:AddChild(enableCb)
 
+    local function BuildTriggerEffectAdvanced(panel)
+        if effectKey == "colorShift" then
+            AddColorPicker(
+                panel,
+                config,
+                "color",
+                "Shift Color",
+                { 1, 1, 1, 1 },
+                true,
+                function() CooldownCompanion:RefreshAllAuraTextureVisuals() end,
+                function() CooldownCompanion:RefreshAllAuraTextureVisuals() end
+            )
+        end
+
+        BuildTextureIndicatorSpeedSlider(panel, config, def.speedLabel)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Effects", function()
+                return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
     local advKey = "triggerEffect_" .. effectKey
-    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled)
-    if not advExpanded or not config.enabled then
-        return false
-    end
-
-    if effectKey == "colorShift" then
-        AddColorPicker(
-            container,
-            config,
-            "color",
-            "Shift Color",
-            { 1, 1, 1, 1 },
-            true,
-            function() CooldownCompanion:RefreshAllAuraTextureVisuals() end,
-            function() CooldownCompanion:RefreshAllAuraTextureVisuals() end
-        )
-    end
-
-    BuildTextureIndicatorSpeedSlider(container, config, def.speedLabel)
-    return true
+    local advExpanded = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
+        title = def.label .. " Advanced",
+        build = BuildTriggerEffectAdvanced,
+    })
+    return advExpanded and config.enabled
 end
 
 local function GetTriggerPanelEffectOrderForDisplayType(group)
@@ -1674,17 +1688,7 @@ local function BuildTriggerEffectsTab(container, group)
         end
     end
 
-    if anyEnabled and anyAdvancedExpanded then
-        if AddPreviewToggleButton then
-            AddPreviewToggleButton(container, "Preview Effects", function()
-                return CS.selectedGroup and CooldownCompanion:IsTriggerPanelEffectsPreviewActive(CS.selectedGroup)
-            end, function(show)
-                if CS.selectedGroup then
-                    CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
-                end
-            end)
-        end
-    elseif CS.selectedGroup then
+    if not (anyEnabled and anyAdvancedExpanded) and CS.selectedGroup then
         CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, false)
     end
 end
@@ -1721,7 +1725,35 @@ local function BuildProcGlowSection(container, group, style)
     end)
     container:AddChild(procEnableCb)
 
-    local procAdvExpanded, procAdvBtn = AddAdvancedToggle(procEnableCb, "procGlow", tabInfoButtons, style.procGlowStyle ~= "none")
+    local function BuildProcGlowAdvanced(panel)
+        local procCombatCb = AceGUI:Create("CheckBox")
+        procCombatCb:SetLabel("Show Only In Combat")
+        procCombatCb:SetValue(style.procGlowCombatOnly or false)
+        procCombatCb:SetFullWidth(true)
+        procCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.procGlowCombatOnly = val
+            UpdateSelectedGroupStyle()
+        end)
+        panel:AddChild(procCombatCb)
+        ApplyCheckboxIndent(procCombatCb, 20)
+
+        BuildProcGlowControls(panel, style, UpdateSelectedGroupStyle)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Proc Glow", function()
+                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_procGlowPreview")
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
+    local procAdvExpanded, procAdvBtn = AddAdvancedToggle(procEnableCb, "procGlow", tabInfoButtons, style.procGlowStyle ~= "none", {
+        title = "Proc Glow Advanced",
+        build = BuildProcGlowAdvanced,
+    })
     local procBtnData = CS.selectedButton and group.buttons[CS.selectedButton]
     if not (procBtnData and procBtnData.isPassive) then
         CreateCheckboxPromoteButton(procEnableCb, procAdvBtn, "procGlow", group, style)
@@ -1730,29 +1762,6 @@ local function BuildProcGlowSection(container, group, style)
     if not (procAdvExpanded and style.procGlowStyle ~= "none") then
         CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, false)
         return
-    end
-
-    local procCombatCb = AceGUI:Create("CheckBox")
-    procCombatCb:SetLabel("Show Only In Combat")
-    procCombatCb:SetValue(style.procGlowCombatOnly or false)
-    procCombatCb:SetFullWidth(true)
-    procCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.procGlowCombatOnly = val
-        UpdateSelectedGroupStyle()
-    end)
-    container:AddChild(procCombatCb)
-    ApplyCheckboxIndent(procCombatCb, 20)
-
-    BuildProcGlowControls(container, style, UpdateSelectedGroupStyle)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Proc Glow", function()
-            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_procGlowPreview")
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupProcGlowPreview(CS.selectedGroup, show)
-            end
-        end)
     end
 end
 
@@ -1767,46 +1776,51 @@ local function BuildAuraGlowSection(container, group, style)
     end)
     container:AddChild(auraEnableCb)
 
-    local auraAdvExpanded, auraAdvBtn = AddAdvancedToggle(auraEnableCb, "auraGlow", tabInfoButtons, style.auraGlowStyle ~= "none")
+    local function BuildAuraGlowAdvanced(panel)
+        local auraCombatCb = AceGUI:Create("CheckBox")
+        auraCombatCb:SetLabel("Show Only In Combat")
+        auraCombatCb:SetValue(style.auraGlowCombatOnly or false)
+        auraCombatCb:SetFullWidth(true)
+        auraCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.auraGlowCombatOnly = val
+            UpdateSelectedGroupStyle()
+        end)
+        panel:AddChild(auraCombatCb)
+        ApplyCheckboxIndent(auraCombatCb, 20)
+
+        local auraInvertCb = AceGUI:Create("CheckBox")
+        auraInvertCb:SetLabel("Show When Missing")
+        auraInvertCb:SetValue(style.auraGlowInvert or false)
+        auraInvertCb:SetFullWidth(true)
+        auraInvertCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.auraGlowInvert = val
+            UpdateSelectedGroupStyle()
+        end)
+        panel:AddChild(auraInvertCb)
+        ApplyCheckboxIndent(auraInvertCb, 20)
+
+        BuildAuraIndicatorControls(panel, style, UpdateSelectedGroupStyle)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Aura Glow", function()
+                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_auraGlowPreview")
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
+    local auraAdvExpanded, auraAdvBtn = AddAdvancedToggle(auraEnableCb, "auraGlow", tabInfoButtons, style.auraGlowStyle ~= "none", {
+        title = "Aura Glow Advanced",
+        build = BuildAuraGlowAdvanced,
+    })
     CreateCheckboxPromoteButton(auraEnableCb, auraAdvBtn, "auraIndicator", group, style)
 
     if not (auraAdvExpanded and style.auraGlowStyle ~= "none") then
         CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, false)
         return
-    end
-
-    local auraCombatCb = AceGUI:Create("CheckBox")
-    auraCombatCb:SetLabel("Show Only In Combat")
-    auraCombatCb:SetValue(style.auraGlowCombatOnly or false)
-    auraCombatCb:SetFullWidth(true)
-    auraCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.auraGlowCombatOnly = val
-        UpdateSelectedGroupStyle()
-    end)
-    container:AddChild(auraCombatCb)
-    ApplyCheckboxIndent(auraCombatCb, 20)
-
-    local auraInvertCb = AceGUI:Create("CheckBox")
-    auraInvertCb:SetLabel("Show When Missing")
-    auraInvertCb:SetValue(style.auraGlowInvert or false)
-    auraInvertCb:SetFullWidth(true)
-    auraInvertCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.auraGlowInvert = val
-        UpdateSelectedGroupStyle()
-    end)
-    container:AddChild(auraInvertCb)
-    ApplyCheckboxIndent(auraInvertCb, 20)
-
-    BuildAuraIndicatorControls(container, style, UpdateSelectedGroupStyle)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Aura Glow", function()
-            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_auraGlowPreview")
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupAuraGlowPreview(CS.selectedGroup, show)
-            end
-        end)
     end
 end
 
@@ -1821,35 +1835,40 @@ local function BuildPandemicGlowSection(container, group, style)
     end)
     container:AddChild(pandemicGlowCb)
 
-    local pandemicAdvExpanded, pandemicAdvBtn = AddAdvancedToggle(pandemicGlowCb, "pandemicGlow", tabInfoButtons, style.showPandemicGlow ~= false)
+    local function BuildPandemicGlowAdvanced(panel)
+        local pandemicCombatCb = AceGUI:Create("CheckBox")
+        pandemicCombatCb:SetLabel("Show Only In Combat")
+        pandemicCombatCb:SetValue(style.pandemicGlowCombatOnly or false)
+        pandemicCombatCb:SetFullWidth(true)
+        pandemicCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.pandemicGlowCombatOnly = val
+            UpdateSelectedGroupStyle()
+        end)
+        panel:AddChild(pandemicCombatCb)
+        ApplyCheckboxIndent(pandemicCombatCb, 20)
+
+        BuildPandemicGlowControls(panel, style, UpdateSelectedGroupStyle)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Pandemic Glow", function()
+                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
+    local pandemicAdvExpanded, pandemicAdvBtn = AddAdvancedToggle(pandemicGlowCb, "pandemicGlow", tabInfoButtons, style.showPandemicGlow ~= false, {
+        title = "Pandemic Glow Advanced",
+        build = BuildPandemicGlowAdvanced,
+    })
     CreateCheckboxPromoteButton(pandemicGlowCb, pandemicAdvBtn, "pandemicGlow", group, style)
 
     if not (pandemicAdvExpanded and style.showPandemicGlow ~= false) then
         CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, false)
         return
-    end
-
-    local pandemicCombatCb = AceGUI:Create("CheckBox")
-    pandemicCombatCb:SetLabel("Show Only In Combat")
-    pandemicCombatCb:SetValue(style.pandemicGlowCombatOnly or false)
-    pandemicCombatCb:SetFullWidth(true)
-    pandemicCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.pandemicGlowCombatOnly = val
-        UpdateSelectedGroupStyle()
-    end)
-    container:AddChild(pandemicCombatCb)
-    ApplyCheckboxIndent(pandemicCombatCb, 20)
-
-    BuildPandemicGlowControls(container, style, UpdateSelectedGroupStyle)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Pandemic Glow", function()
-            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_pandemicPreview")
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupPandemicPreview(CS.selectedGroup, show)
-            end
-        end)
     end
 end
 
@@ -1864,7 +1883,91 @@ local function BuildReadyGlowSection(container, group, style)
     end)
     container:AddChild(readyEnableCb)
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyEnableCb, "readyGlow", tabInfoButtons, style.readyGlowStyle and style.readyGlowStyle ~= "none")
+    local function BuildReadyGlowAdvanced(panel)
+        local readyCombatCb = AceGUI:Create("CheckBox")
+        readyCombatCb:SetLabel("Show Only In Combat")
+        readyCombatCb:SetValue(style.readyGlowCombatOnly or false)
+        readyCombatCb:SetFullWidth(true)
+        readyCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.readyGlowCombatOnly = val
+            UpdateSelectedGroupStyle()
+        end)
+        panel:AddChild(readyCombatCb)
+        ApplyCheckboxIndent(readyCombatCb, 20)
+
+        local readyChargesCb = AceGUI:Create("CheckBox")
+        readyChargesCb:SetLabel("Glow When Charges Are Capped")
+        readyChargesCb:SetValue(style.readyGlowOnlyAtMaxCharges or false)
+        readyChargesCb:SetFullWidth(true)
+        readyChargesCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.readyGlowOnlyAtMaxCharges = val == true
+            UpdateSelectedGroupStyle()
+            if (style.readyGlowDuration or 0) > 0 then
+                if val then
+                    PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+                else
+                    PrimeReadyGlowNormalTransitions(CS.selectedGroup)
+                end
+            end
+            CooldownCompanion:UpdateAllCooldowns()
+        end)
+        panel:AddChild(readyChargesCb)
+        ApplyCheckboxIndent(readyChargesCb, 20)
+        CreateInfoButton(readyChargesCb.frame, readyChargesCb.checkbg, "LEFT", "RIGHT", readyChargesCb.text:GetStringWidth() + 6, 0, {
+            "Glow When Charges Are Capped",
+            {"When this toggle is enabled, the glow will only appear for charge based spells when at max charges.", 1, 1, 1, true},
+        }, tabInfoButtons)
+
+        local readyDurCb = AceGUI:Create("CheckBox")
+        readyDurCb:SetLabel("Auto-Hide After Duration")
+        readyDurCb:SetValue((style.readyGlowDuration or 0) > 0)
+        readyDurCb:SetFullWidth(true)
+        readyDurCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.readyGlowDuration = val and 3 or 0
+            UpdateSelectedGroupStyle()
+            if val then
+                if style.readyGlowOnlyAtMaxCharges then
+                    PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
+                else
+                    PrimeReadyGlowNormalTransitions(CS.selectedGroup)
+                end
+            end
+            CooldownCompanion:UpdateAllCooldowns()
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        panel:AddChild(readyDurCb)
+        ApplyCheckboxIndent(readyDurCb, 20)
+
+        if (style.readyGlowDuration or 0) > 0 then
+            local readyDurSlider = AceGUI:Create("Slider")
+            readyDurSlider:SetLabel("Duration (seconds)")
+            readyDurSlider:SetSliderValues(0.5, 5, 0.5)
+            readyDurSlider:SetValue(style.readyGlowDuration or 3)
+            readyDurSlider:SetFullWidth(true)
+            readyDurSlider:SetCallback("OnValueChanged", function(widget, event, val)
+                style.readyGlowDuration = val
+                UpdateSelectedGroupStyle()
+            end)
+            panel:AddChild(readyDurSlider)
+        end
+
+        BuildReadyGlowControls(panel, style, UpdateSelectedGroupStyle)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Ready Glow Style", function()
+                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_readyGlowPreview")
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
+    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyEnableCb, "readyGlow", tabInfoButtons, style.readyGlowStyle and style.readyGlowStyle ~= "none", {
+        title = "Ready Glow Advanced",
+        build = BuildReadyGlowAdvanced,
+    })
     local readyPromoteBtn = CreateCheckboxPromoteButton(readyEnableCb, readyAdvBtn, "readyGlow", group, style)
     CreateInfoButton(readyEnableCb.frame, readyPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Ready Glow",
@@ -1874,85 +1977,6 @@ local function BuildReadyGlowSection(container, group, style)
     if not (readyAdvExpanded and style.readyGlowStyle and style.readyGlowStyle ~= "none") then
         CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, false)
         return
-    end
-
-    local readyCombatCb = AceGUI:Create("CheckBox")
-    readyCombatCb:SetLabel("Show Only In Combat")
-    readyCombatCb:SetValue(style.readyGlowCombatOnly or false)
-    readyCombatCb:SetFullWidth(true)
-    readyCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.readyGlowCombatOnly = val
-        UpdateSelectedGroupStyle()
-    end)
-    container:AddChild(readyCombatCb)
-    ApplyCheckboxIndent(readyCombatCb, 20)
-
-    local readyChargesCb = AceGUI:Create("CheckBox")
-    readyChargesCb:SetLabel("Glow When Charges Are Capped")
-    readyChargesCb:SetValue(style.readyGlowOnlyAtMaxCharges or false)
-    readyChargesCb:SetFullWidth(true)
-    readyChargesCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.readyGlowOnlyAtMaxCharges = val == true
-        UpdateSelectedGroupStyle()
-        if (style.readyGlowDuration or 0) > 0 then
-            if val then
-                PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
-            else
-                PrimeReadyGlowNormalTransitions(CS.selectedGroup)
-            end
-        end
-        CooldownCompanion:UpdateAllCooldowns()
-    end)
-    container:AddChild(readyChargesCb)
-    ApplyCheckboxIndent(readyChargesCb, 20)
-    CreateInfoButton(readyChargesCb.frame, readyChargesCb.checkbg, "LEFT", "RIGHT", readyChargesCb.text:GetStringWidth() + 6, 0, {
-        "Glow When Charges Are Capped",
-        {"When this toggle is enabled, the glow will only appear for charge based spells when at max charges.", 1, 1, 1, true},
-    }, tabInfoButtons)
-
-    local readyDurCb = AceGUI:Create("CheckBox")
-    readyDurCb:SetLabel("Auto-Hide After Duration")
-    readyDurCb:SetValue((style.readyGlowDuration or 0) > 0)
-    readyDurCb:SetFullWidth(true)
-    readyDurCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.readyGlowDuration = val and 3 or 0
-        UpdateSelectedGroupStyle()
-        if val then
-            if style.readyGlowOnlyAtMaxCharges then
-                PrimeReadyGlowCappedChargeTransitions(CS.selectedGroup)
-            else
-                PrimeReadyGlowNormalTransitions(CS.selectedGroup)
-            end
-        end
-        CooldownCompanion:UpdateAllCooldowns()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    container:AddChild(readyDurCb)
-    ApplyCheckboxIndent(readyDurCb, 20)
-
-    if (style.readyGlowDuration or 0) > 0 then
-        local readyDurSlider = AceGUI:Create("Slider")
-        readyDurSlider:SetLabel("Duration (seconds)")
-        readyDurSlider:SetSliderValues(0.5, 5, 0.5)
-        readyDurSlider:SetValue(style.readyGlowDuration or 3)
-        readyDurSlider:SetFullWidth(true)
-        readyDurSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            style.readyGlowDuration = val
-            UpdateSelectedGroupStyle()
-        end)
-        container:AddChild(readyDurSlider)
-    end
-
-    BuildReadyGlowControls(container, style, UpdateSelectedGroupStyle)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Ready Glow Style", function()
-            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_readyGlowPreview")
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupReadyGlowPreview(CS.selectedGroup, show)
-            end
-        end)
     end
 end
 
@@ -1967,7 +1991,35 @@ local function BuildKeyPressHighlightSection(container, group, style)
     end)
     container:AddChild(kphEnableCb)
 
-    local kphAdvExpanded, kphAdvBtn = AddAdvancedToggle(kphEnableCb, "keyPressHighlight", tabInfoButtons, style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none")
+    local function BuildKeyPressHighlightAdvanced(panel)
+        local kphCombatCb = AceGUI:Create("CheckBox")
+        kphCombatCb:SetLabel("Show Only In Combat")
+        kphCombatCb:SetValue(style.keyPressHighlightCombatOnly or false)
+        kphCombatCb:SetFullWidth(true)
+        kphCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
+            style.keyPressHighlightCombatOnly = val
+            UpdateSelectedGroupStyle()
+        end)
+        panel:AddChild(kphCombatCb)
+        ApplyCheckboxIndent(kphCombatCb, 20)
+
+        BuildKeyPressHighlightControls(panel, style, UpdateSelectedGroupStyle)
+
+        if AddPreviewToggleButton then
+            AddPreviewToggleButton(panel, "Preview Key Press Highlight", function()
+                return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_keyPressHighlightPreview")
+            end, function(show)
+                if CS.selectedGroup then
+                    CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, show)
+                end
+            end)
+        end
+    end
+
+    local kphAdvExpanded, kphAdvBtn = AddAdvancedToggle(kphEnableCb, "keyPressHighlight", tabInfoButtons, style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none", {
+        title = "Key Press Highlight Advanced",
+        build = BuildKeyPressHighlightAdvanced,
+    })
     local kphPromoteBtn = CreateCheckboxPromoteButton(kphEnableCb, kphAdvBtn, "keyPressHighlight", group, style)
     CreateInfoButton(kphEnableCb.frame, kphPromoteBtn, "LEFT", "RIGHT", 4, 0, {
         "Key Press Highlight",
@@ -1977,29 +2029,6 @@ local function BuildKeyPressHighlightSection(container, group, style)
     if not (kphAdvExpanded and style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none") then
         CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, false)
         return
-    end
-
-    local kphCombatCb = AceGUI:Create("CheckBox")
-    kphCombatCb:SetLabel("Show Only In Combat")
-    kphCombatCb:SetValue(style.keyPressHighlightCombatOnly or false)
-    kphCombatCb:SetFullWidth(true)
-    kphCombatCb:SetCallback("OnValueChanged", function(widget, event, val)
-        style.keyPressHighlightCombatOnly = val
-        UpdateSelectedGroupStyle()
-    end)
-    container:AddChild(kphCombatCb)
-    ApplyCheckboxIndent(kphCombatCb, 20)
-
-    BuildKeyPressHighlightControls(container, style, UpdateSelectedGroupStyle)
-
-    if AddPreviewToggleButton then
-        AddPreviewToggleButton(container, "Preview Key Press Highlight", function()
-            return CS.selectedGroup and CooldownCompanion:IsPreviewFlagActive(CS.selectedGroup, nil, "_keyPressHighlightPreview")
-        end, function(show)
-            if CS.selectedGroup then
-                CooldownCompanion:SetGroupKeyPressHighlightPreview(CS.selectedGroup, show)
-            end
-        end)
     end
 end
 
@@ -2052,9 +2081,7 @@ local function BuildEffectsTab(container)
     end)
     container:AddChild(assistedCb)
 
-    local assistedAdvExpanded = AddAdvancedToggle(assistedCb, "assistedHighlight", tabInfoButtons, style.showAssistedHighlight or false)
-
-    if assistedAdvExpanded and style.showAssistedHighlight then
+    local function BuildAssistedHighlightAdvanced(panel)
         local assistedCombatCb = AceGUI:Create("CheckBox")
         assistedCombatCb:SetLabel("Show Only In Combat")
         assistedCombatCb:SetValue(style.assistedHighlightCombatOnly or false)
@@ -2063,13 +2090,18 @@ local function BuildEffectsTab(container)
             style.assistedHighlightCombatOnly = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(assistedCombatCb)
+        panel:AddChild(assistedCombatCb)
         ApplyCheckboxIndent(assistedCombatCb, 20)
 
-        BuildAssistedHighlightControls(container, style, function()
+        BuildAssistedHighlightControls(panel, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-    end -- assistedAdvExpanded
+    end
+
+    local assistedAdvExpanded = AddAdvancedToggle(assistedCb, "assistedHighlight", tabInfoButtons, style.showAssistedHighlight or false, {
+        title = "Assisted Highlight Advanced",
+        build = BuildAssistedHighlightAdvanced,
+    })
 
     AddIndicatorsHeading(container, "Timers")
     local iconFillTimerActive = style.iconFillEnabled == true and group.masqueEnabled ~= true
@@ -2078,7 +2110,17 @@ local function BuildEffectsTab(container)
     end, {
         masqueEnabled = group.masqueEnabled == true,
     })
-    local iconFillAdvExpanded, iconFillAdvBtn = AddAdvancedToggle(iconFillCb, "iconFillTimerPreview", tabInfoButtons, iconFillTimerActive)
+    local function BuildIconFillAdvanced(panel)
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(panel, "Preview Cooldown Fill", "cooldown")
+            AddConditionalPreviewButton(panel, "Preview Aura Fill", "aura_duration_text")
+        end
+    end
+
+    local iconFillAdvExpanded, iconFillAdvBtn = AddAdvancedToggle(iconFillCb, "iconFillTimerPreview", tabInfoButtons, iconFillTimerActive, {
+        title = "Icon Fill Timer Advanced",
+        build = BuildIconFillAdvanced,
+    })
     local iconFillPromoteBtn
     if not group.masqueEnabled then
         iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, iconFillAdvBtn, "iconFillTimer", group, style)
@@ -2101,11 +2143,6 @@ local function BuildEffectsTab(container)
         {"Show Cooldown/Duration Swipe and Blizzard CDM Aura Swipe Style are unavailable while Icon Fill Timer is active.", 0.7, 0.7, 0.7, true},
     }, tabInfoButtons)
 
-    if iconFillAdvExpanded and iconFillTimerActive and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Cooldown Fill", "cooldown")
-        AddConditionalPreviewButton(container, "Preview Aura Fill", "aura_duration_text")
-    end
-
     local swipeCb = AceGUI:Create("CheckBox")
     swipeCb:SetLabel("Show Cooldown/Duration Swipe")
     swipeCb:SetValue(style.showCooldownSwipe ~= false)
@@ -2119,12 +2156,7 @@ local function BuildEffectsTab(container)
     end)
     container:AddChild(swipeCb)
 
-    local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive)
-    if not iconFillTimerActive then
-        CreateCheckboxPromoteButton(swipeCb, swipeAdvBtn, "cooldownSwipe", group, style)
-    end
-
-    if swipeAdvExpanded and style.showCooldownSwipe ~= false and not iconFillTimerActive then
+    local function BuildCooldownSwipeAdvanced(panel)
         -- Reverse Swipe
         local reverseCb = AceGUI:Create("CheckBox")
         reverseCb:SetLabel("Reverse Swipe")
@@ -2134,7 +2166,7 @@ local function BuildEffectsTab(container)
             style.cooldownSwipeReverse = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(reverseCb)
+        panel:AddChild(reverseCb)
         ApplyCheckboxIndent(reverseCb, 20)
 
         -- Show Swipe Fill
@@ -2147,7 +2179,7 @@ local function BuildEffectsTab(container)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(fillCb)
+        panel:AddChild(fillCb)
         ApplyCheckboxIndent(fillCb, 20)
 
         -- Swipe Fill Opacity (only when fill is visible)
@@ -2162,7 +2194,7 @@ local function BuildEffectsTab(container)
                 style.cooldownSwipeAlpha = val
                 CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             end)
-            container:AddChild(alphaSlider)
+            panel:AddChild(alphaSlider)
         end
 
         -- Show Swipe Edge
@@ -2175,15 +2207,24 @@ local function BuildEffectsTab(container)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(edgeCb)
+        panel:AddChild(edgeCb)
         ApplyCheckboxIndent(edgeCb, 20)
 
         -- Swipe Edge Color (only when edge is visible)
         if style.showCooldownSwipeEdge ~= false then
             local swipeRefresh = function() CooldownCompanion:UpdateGroupStyle(CS.selectedGroup) end
-            AddColorPicker(container, style, "cooldownSwipeEdgeColor", "Swipe Edge Color", {1, 1, 1, 1}, true, swipeRefresh, swipeRefresh)
+            AddColorPicker(panel, style, "cooldownSwipeEdgeColor", "Swipe Edge Color", {1, 1, 1, 1}, true, swipeRefresh, swipeRefresh)
         end
-    end -- swipeAdvExpanded
+    end
+
+    local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive, {
+        title = "Cooldown Swipe Advanced",
+        build = BuildCooldownSwipeAdvanced,
+    })
+    if not iconFillTimerActive then
+        CreateCheckboxPromoteButton(swipeCb, swipeAdvBtn, "cooldownSwipe", group, style)
+    end
+
 
     local auraSwipeCb = BuildAuraDurationSwipeControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
@@ -2233,11 +2274,17 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
-    local oorAdvExpanded, oorAdvBtn = AddAdvancedToggle(oorCb, "showOutOfRange", tabInfoButtons, style.showOutOfRange)
-    CreateCheckboxPromoteButton(oorCb, oorAdvBtn, "showOutOfRange", group, style)
-    if oorAdvExpanded and style.showOutOfRange and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Out of Range State", "out_of_range")
+    local function BuildOutOfRangeAdvanced(panel)
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(panel, "Preview Out of Range State", "out_of_range")
+        end
     end
+
+    local oorAdvExpanded, oorAdvBtn = AddAdvancedToggle(oorCb, "showOutOfRange", tabInfoButtons, style.showOutOfRange, {
+        title = "Out of Range Advanced",
+        build = BuildOutOfRangeAdvanced,
+    })
+    CreateCheckboxPromoteButton(oorCb, oorAdvBtn, "showOutOfRange", group, style)
 
     -- Loss of Control
     local locCb = BuildLossOfControlControls(container, style, function()
@@ -2250,11 +2297,17 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
-    local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "unusableDimming", tabInfoButtons, style.showUnusable)
-    CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
-    if unusableAdvExpanded and style.showUnusable and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
+    local function BuildUnusableAdvanced(panel)
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable")
+        end
     end
+
+    local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "unusableDimming", tabInfoButtons, style.showUnusable, {
+        title = "Unusable Dimming Advanced",
+        build = BuildUnusableAdvanced,
+    })
+    CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
 
     -- Show Tooltips
     local tooltipCb = BuildShowTooltipsControls(container, style, function()
@@ -2693,14 +2746,11 @@ local function BuildAppearanceTab(container)
     end)
     container:AddChild(cdTextCb)
 
-    local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText)
-    CreateCheckboxPromoteButton(cdTextCb, cdTextAdvBtn, "cooldownText", group, style)
+    local function BuildCooldownTextAdvanced(panel)
+        AddFontControls(panel, style, "cooldown", { size = 12 }, refreshStyle)
+        AddColorPicker(panel, style, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshStyle, refreshStyle)
 
-    if cdTextAdvExpanded and style.showCooldownText then
-        AddFontControls(container, style, "cooldown", { size = 12 }, refreshStyle)
-        AddColorPicker(container, style, "cooldownFontColor", "Font Color", {1, 1, 1, 1}, false, refreshStyle, refreshStyle)
-
-        local cdAnchorDrop = AddAnchorDropdown(container, style, "cooldownTextAnchor", "CENTER", refreshStyle)
+        local cdAnchorDrop = AddAnchorDropdown(panel, style, "cooldownTextAnchor", "CENTER", refreshStyle)
 
         -- (?) tooltip for shared positioning
         CreateInfoButton(cdAnchorDrop.frame, cdAnchorDrop.label, "LEFT", "RIGHT", 4, 0, {
@@ -2708,12 +2758,18 @@ local function BuildAppearanceTab(container)
             {"Position is shared with Aura Duration Text by default. Enable 'Separate Text Positions' in the Aura Duration Text section to use independent positions.", 1, 1, 1, true},
         }, cdAnchorDrop)
 
-        AddOffsetSliders(container, style, "cooldownTextXOffset", "cooldownTextYOffset", { x = 0, y = 0 }, refreshStyle)
+        AddOffsetSliders(panel, style, "cooldownTextXOffset", "cooldownTextYOffset", { x = 0, y = 0 }, refreshStyle)
 
         if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Cooldown Text", "cooldown")
+            AddConditionalPreviewButton(panel, "Preview Cooldown Text", "cooldown")
         end
-    end -- cdTextAdvExpanded + showCooldownText
+    end
+
+    local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText, {
+        title = "Cooldown Text Advanced",
+        build = BuildCooldownTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(cdTextCb, cdTextAdvBtn, "cooldownText", group, style)
 
     -- Show Charge Text toggle
     local chargeTextCb = AceGUI:Create("CheckBox")
@@ -2727,17 +2783,20 @@ local function BuildAppearanceTab(container)
     end)
     container:AddChild(chargeTextCb)
 
-    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false)
-    CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
+    local function BuildChargeTextAdvanced(panel)
+        AddFontControls(panel, style, "charge", { size = 12 }, refreshStyle)
+        AddColorPicker(panel, style, "chargeFontColor", "Font Color (Max Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddColorPicker(panel, style, "chargeFontColorMissing", "Font Color (Missing Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddColorPicker(panel, style, "chargeFontColorZero", "Font Color (Zero Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddAnchorDropdown(panel, style, "chargeAnchor", "BOTTOMRIGHT", refreshStyle)
+        AddOffsetSliders(panel, style, "chargeXOffset", "chargeYOffset", { x = -2, y = 2 }, refreshStyle)
+    end
 
-    if chargeAdvExpanded and style.showChargeText ~= false then
-        AddFontControls(container, style, "charge", { size = 12 }, refreshStyle)
-        AddColorPicker(container, style, "chargeFontColor", "Font Color (Max Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddColorPicker(container, style, "chargeFontColorMissing", "Font Color (Missing Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddColorPicker(container, style, "chargeFontColorZero", "Font Color (Zero Charges)", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddAnchorDropdown(container, style, "chargeAnchor", "BOTTOMRIGHT", refreshStyle)
-        AddOffsetSliders(container, style, "chargeXOffset", "chargeYOffset", { x = -2, y = 2 }, refreshStyle)
-    end -- chargeAdvExpanded + showChargeText
+    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false, {
+        title = "Count Text Advanced",
+        build = BuildChargeTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(chargeTextCb, chargeAdvBtn, "chargeText", group, style)
 
     -- Show Aura Duration Text toggle
     local auraTextCb = AceGUI:Create("CheckBox")
@@ -2751,20 +2810,9 @@ local function BuildAppearanceTab(container)
     end)
     container:AddChild(auraTextCb)
 
-    local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false)
-    local auraTextPromoteBtn = CreateCheckboxPromoteButton(auraTextCb, auraTextAdvBtn, "auraText", group, style)
-
-    local auraPosInfo = CreateInfoButton(auraTextCb.frame, auraTextPromoteBtn, "LEFT", "RIGHT", 4, 0, {
-        "Shared Position",
-        {"Position is shared with Cooldown Text by default. Enable 'Separate Text Positions' in advanced settings to use independent positions.", 1, 1, 1, true},
-    }, auraTextCb)
-    if style.showAuraText == false then
-        auraPosInfo:Hide()
-    end
-
-    if style.showAuraText ~= false and auraTextAdvExpanded then
-        AddFontControls(container, style, "auraText", { size = 12 }, refreshStyle)
-        AddColorPicker(container, style, "auraTextFontColor", "Font Color", {0, 0.925, 1, 1}, false, refreshStyle, refreshStyle)
+    local function BuildAuraDurationTextAdvanced(panel)
+        AddFontControls(panel, style, "auraText", { size = 12 }, refreshStyle)
+        AddColorPicker(panel, style, "auraTextFontColor", "Font Color", {0, 0.925, 1, 1}, false, refreshStyle, refreshStyle)
 
         local sepPosCb = AceGUI:Create("CheckBox")
         sepPosCb:SetLabel("Separate Text Positions")
@@ -2775,7 +2823,7 @@ local function BuildAppearanceTab(container)
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
             CooldownCompanion:RefreshConfigPanel()
         end)
-        container:AddChild(sepPosCb)
+        panel:AddChild(sepPosCb)
 
         CreateInfoButton(sepPosCb.frame, sepPosCb.checkbg, "LEFT", "RIGHT", sepPosCb.text:GetStringWidth() + 4, 0, {
             "Separate Text Positions",
@@ -2783,14 +2831,29 @@ local function BuildAppearanceTab(container)
         }, sepPosCb)
 
         if style.separateTextPositions then
-            AddAnchorDropdown(container, style, "auraTextAnchor", "TOPLEFT", refreshStyle)
-            AddOffsetSliders(container, style, "auraTextXOffset", "auraTextYOffset", { x = 2, y = -2 }, refreshStyle)
+            AddAnchorDropdown(panel, style, "auraTextAnchor", "TOPLEFT", refreshStyle)
+            AddOffsetSliders(panel, style, "auraTextXOffset", "auraTextYOffset", { x = 2, y = -2 }, refreshStyle)
         end
 
         if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Aura Duration Text", "aura_duration_text")
+            AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text")
         end
-    end -- auraTextAdvExpanded + showAuraText
+    end
+
+    local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false, {
+        title = "Aura Duration Text Advanced",
+        build = BuildAuraDurationTextAdvanced,
+    })
+    local auraTextPromoteBtn = CreateCheckboxPromoteButton(auraTextCb, auraTextAdvBtn, "auraText", group, style)
+
+    local auraPosInfo = CreateInfoButton(auraTextCb.frame, auraTextPromoteBtn, "LEFT", "RIGHT", 4, 0, {
+        "Shared Position",
+        {"Position is shared with Cooldown Text by default. Enable 'Separate Text Positions' in advanced settings to use independent positions.", 1, 1, 1, true},
+    }, auraTextCb)
+    if style.showAuraText == false then
+        auraPosInfo:Hide()
+    end
+
 
     -- Show Aura Stack Text toggle
     local auraStackCb = AceGUI:Create("CheckBox")
@@ -2804,19 +2867,22 @@ local function BuildAppearanceTab(container)
     end)
     container:AddChild(auraStackCb)
 
-    local auraStackAdvExpanded, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false)
-    CreateCheckboxPromoteButton(auraStackCb, auraStackAdvBtn, "auraStackText", group, style)
-
-    if style.showAuraStackText ~= false and auraStackAdvExpanded then
-        AddFontControls(container, style, "auraStack", { size = 12 }, refreshStyle)
-        AddColorPicker(container, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-        AddAnchorDropdown(container, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
-        AddOffsetSliders(container, style, "auraStackXOffset", "auraStackYOffset", { x = 2, y = 2 }, refreshStyle)
+    local function BuildAuraStackTextAdvanced(panel)
+        AddFontControls(panel, style, "auraStack", { size = 12 }, refreshStyle)
+        AddColorPicker(panel, style, "auraStackFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+        AddAnchorDropdown(panel, style, "auraStackAnchor", "BOTTOMLEFT", refreshStyle)
+        AddOffsetSliders(panel, style, "auraStackXOffset", "auraStackYOffset", { x = 2, y = 2 }, refreshStyle)
 
         if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
+            AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text")
         end
-    end -- auraStackAdvExpanded + showAuraStackText
+    end
+
+    local auraStackAdvExpanded, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
+        title = "Aura Stack Text Advanced",
+        build = BuildAuraStackTextAdvanced,
+    })
+    CreateCheckboxPromoteButton(auraStackCb, auraStackAdvBtn, "auraStackText", group, style)
 
     -- Show Keybind/Custom Text toggle
     local kbCb = AceGUI:Create("CheckBox")
@@ -2830,20 +2896,7 @@ local function BuildAppearanceTab(container)
     end)
     container:AddChild(kbCb)
 
-    local kbAdvExpanded, kbAdvBtn = AddAdvancedToggle(kbCb, "keybindText", tabInfoButtons, style.showKeybindText)
-    local kbPromoteBtn = CreateCheckboxPromoteButton(kbCb, kbAdvBtn, "keybindText", group, style)
-    local kbInfoAnchor = kbCb.checkbg
-    local kbInfoXOff = kbCb.text:GetStringWidth() + 4
-    if kbPromoteBtn and kbPromoteBtn:IsShown() then
-        kbInfoAnchor = kbPromoteBtn
-        kbInfoXOff = 4
-    elseif kbAdvBtn and kbAdvBtn:IsShown() then
-        kbInfoAnchor = kbAdvBtn
-        kbInfoXOff = 4
-    end
-    CreateInfoButton(kbCb.frame, kbInfoAnchor, "LEFT", "RIGHT", kbInfoXOff, 0, KEYBIND_CUSTOM_TOOLTIP, kbCb)
-
-    if style.showKeybindText and kbAdvExpanded then
+    local function BuildKeybindTextAdvanced(panel)
         -- Keybind uses a hardcoded 4-point anchor (not the full 9-point list)
         local kbAnchorDrop = AceGUI:Create("Dropdown")
         kbAnchorDrop:SetLabel("Anchor")
@@ -2859,12 +2912,29 @@ local function BuildAppearanceTab(container)
             style.keybindAnchor = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         end)
-        container:AddChild(kbAnchorDrop)
+        panel:AddChild(kbAnchorDrop)
 
-        AddOffsetSliders(container, style, "keybindXOffset", "keybindYOffset", { x = -2, y = -2 }, refreshStyle)
-        AddFontControls(container, style, "keybind", { size = 10, sizeMin = 6, sizeMax = 24 }, refreshStyle)
-        AddColorPicker(container, style, "keybindFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
-    end -- showKeybindText + kbAdvExpanded
+        AddOffsetSliders(panel, style, "keybindXOffset", "keybindYOffset", { x = -2, y = -2 }, refreshStyle)
+        AddFontControls(panel, style, "keybind", { size = 10, sizeMin = 6, sizeMax = 24 }, refreshStyle)
+        AddColorPicker(panel, style, "keybindFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
+    end
+
+    local kbAdvExpanded, kbAdvBtn = AddAdvancedToggle(kbCb, "keybindText", tabInfoButtons, style.showKeybindText, {
+        title = KEYBIND_CUSTOM_LABEL .. " Advanced",
+        build = BuildKeybindTextAdvanced,
+    })
+    local kbPromoteBtn = CreateCheckboxPromoteButton(kbCb, kbAdvBtn, "keybindText", group, style)
+    local kbInfoAnchor = kbCb.checkbg
+    local kbInfoXOff = kbCb.text:GetStringWidth() + 4
+    if kbPromoteBtn and kbPromoteBtn:IsShown() then
+        kbInfoAnchor = kbPromoteBtn
+        kbInfoXOff = 4
+    elseif kbAdvBtn and kbAdvBtn:IsShown() then
+        kbInfoAnchor = kbAdvBtn
+        kbInfoXOff = 4
+    end
+    CreateInfoButton(kbCb.frame, kbInfoAnchor, "LEFT", "RIGHT", kbInfoXOff, 0, KEYBIND_CUSTOM_TOOLTIP, kbCb)
+
 
     -- Compact Mode toggle + Max Visible Buttons slider
     BuildCompactModeControls(container, group, tabInfoButtons)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -111,6 +111,12 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
 
+local function RefreshActiveAdvancedSettingsPanel()
+    if CS.RefreshAdvancedSettingsPanel then
+        CS.RefreshAdvancedSettingsPanel()
+    end
+end
+
 local function AddIndicatorsHeading(container, text)
     local heading = AceGUI:Create("Heading")
     heading:SetText(text)
@@ -1606,7 +1612,7 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
     end
 
     local advKey = "triggerEffect_" .. effectKey
-    local advExpanded, advBtn = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
+    local _, advBtn = AddAdvancedToggle(enableCb, advKey, tabInfoButtons, config.enabled, {
         title = def.label .. " Advanced",
         build = BuildTriggerEffectAdvanced,
     })
@@ -1617,7 +1623,6 @@ local function BuildTriggerPanelEffectSection(container, effects, effectKey)
             CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, show)
         end
     end, config.enabled)
-    return advExpanded and config.enabled
 end
 
 local function GetTriggerPanelEffectOrderForDisplayType(group)
@@ -1671,19 +1676,15 @@ local function BuildTriggerEffectsTab(container, group)
     end
 
     local anyEnabled = false
-    local anyAdvancedExpanded = false
     local effectOrder = GetTriggerPanelEffectOrderForDisplayType(group)
     for _, effectKey in ipairs(effectOrder) do
-        local sectionAdvancedExpanded = BuildTriggerPanelEffectSection(container, effects, effectKey)
+        BuildTriggerPanelEffectSection(container, effects, effectKey)
         if effects[effectKey] and effects[effectKey].enabled then
             anyEnabled = true
         end
-        if sectionAdvancedExpanded then
-            anyAdvancedExpanded = true
-        end
     end
 
-    if not (anyEnabled and anyAdvancedExpanded) and CS.selectedGroup then
+    if not anyEnabled and CS.selectedGroup then
         CooldownCompanion:SetTriggerPanelEffectsPreview(CS.selectedGroup, false)
     end
 end
@@ -1917,7 +1918,7 @@ local function BuildReadyGlowSection(container, group, style)
                 end
             end
             CooldownCompanion:UpdateAllCooldowns()
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshActiveAdvancedSettingsPanel()
         end)
         panel:AddChild(readyDurCb)
 
@@ -2164,7 +2165,7 @@ local function BuildEffectsTab(container)
         fillCb:SetCallback("OnValueChanged", function(widget, event, val)
             style.showCooldownSwipeFill = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshActiveAdvancedSettingsPanel()
         end)
         panel:AddChild(fillCb)
 
@@ -2191,7 +2192,7 @@ local function BuildEffectsTab(container)
         edgeCb:SetCallback("OnValueChanged", function(widget, event, val)
             style.showCooldownSwipeEdge = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshActiveAdvancedSettingsPanel()
         end)
         panel:AddChild(edgeCb)
 
@@ -2786,7 +2787,7 @@ local function BuildAppearanceTab(container)
         sepPosCb:SetCallback("OnValueChanged", function(widget, event, val)
             style.separateTextPositions = val
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshActiveAdvancedSettingsPanel()
         end)
         panel:AddChild(sepPosCb)
 

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -42,6 +42,7 @@ local BuildShowOutOfRangeControls = ST._BuildShowOutOfRangeControls
 local BuildShowGCDSwipeControls = ST._BuildShowGCDSwipeControls
 local BuildCooldownSwipeControls = ST._BuildCooldownSwipeControls
 local BuildIconFillTimerControls = ST._BuildIconFillTimerControls
+local BuildIconFillTimerAdvancedControls = ST._BuildIconFillTimerAdvancedControls
 local BuildLossOfControlControls = ST._BuildLossOfControlControls
 local BuildUnusableDimmingControls = ST._BuildUnusableDimmingControls
 local BuildIconTintControls = ST._BuildIconTintControls
@@ -51,6 +52,7 @@ local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
 local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
+local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
@@ -108,6 +110,78 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     " ",
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
+
+local function SetPreviewBadgeActive(btn, active)
+    if btn and btn._icon then
+        if active then
+            btn._icon:SetVertexColor(1, 0.82, 0, 1)
+        else
+            btn._icon:SetVertexColor(0.72, 0.72, 0.72, 0.85)
+        end
+    end
+end
+
+local function AddConditionalPreviewBadge(parentWidget, anchorAfterFrame, label, previewKind, enabled)
+    if not enabled
+        or not (parentWidget and parentWidget.frame and parentWidget.checkbg and parentWidget.text)
+        or not (CooldownCompanion.SetConditionalVisualPreviewActive and CooldownCompanion.IsConditionalVisualPreviewActive)
+    then
+        return nil
+    end
+
+    local frame = parentWidget.frame
+    local btn = frame._cdcPreviewBtn
+    if not btn then
+        btn = CreateFrame("Button", nil, frame)
+        btn:SetSize(14, 14)
+        btn._icon = btn:CreateTexture(nil, "ARTWORK")
+        btn._icon:SetSize(13, 13)
+        btn._icon:SetPoint("CENTER")
+        btn._icon:SetAtlas("GM-icon-visible", false)
+        frame._cdcPreviewBtn = btn
+    end
+
+    btn:SetParent(frame)
+    btn:ClearAllPoints()
+    if anchorAfterFrame and anchorAfterFrame:IsShown() then
+        btn:SetPoint("LEFT", anchorAfterFrame, "RIGHT", 4, 0)
+    else
+        btn:SetPoint("LEFT", parentWidget.checkbg, "RIGHT", parentWidget.text:GetStringWidth() + 6, 0)
+    end
+    btn:Show()
+    btn._icon:Show()
+
+    local function IsActive()
+        return CooldownCompanion:IsConditionalVisualPreviewActive(CS.selectedGroup, nil, previewKind)
+    end
+
+    SetPreviewBadgeActive(btn, IsActive())
+    btn:SetScript("OnClick", function()
+        local showPreview = not IsActive()
+        if showPreview and CooldownCompanion.ClearAllConfigPreviews then
+            CooldownCompanion:ClearAllConfigPreviews()
+        end
+        CooldownCompanion:SetConditionalVisualPreviewActive(CS.selectedGroup, nil, previewKind, showPreview)
+        if not (RefreshConfigPanelForPreviewToggle and RefreshConfigPanelForPreviewToggle()) then
+            SetPreviewBadgeActive(btn, IsActive())
+        end
+    end)
+    btn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:AddLine(label)
+        GameTooltip:Show()
+    end)
+    btn:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    parentWidget:SetCallback("OnRelease", function()
+        btn:ClearAllPoints()
+        btn:Hide()
+        btn:SetParent(nil)
+    end)
+
+    return btn
+end
 
 local function AddIndicatorsHeading(container, text)
     local heading = AceGUI:Create("Heading")
@@ -2097,19 +2171,40 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
     end, {
         masqueEnabled = group.masqueEnabled == true,
+        showAdvancedControlsInline = false,
+        onEnabled = function()
+            if CS.QueueAdvancedSettingsPanelOpen then
+                CS.QueueAdvancedSettingsPanelOpen("iconFillTimer")
+            end
+        end,
+    })
+    local function BuildIconFillAdvanced(panel)
+        if BuildIconFillTimerAdvancedControls then
+            BuildIconFillTimerAdvancedControls(panel, style, function()
+                CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            end)
+        end
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(panel, "Preview Cooldown Fill", "cooldown")
+            AddConditionalPreviewButton(panel, "Preview Aura Fill", "aura_duration_text")
+        end
+    end
+
+    local _, iconFillAdvBtn = AddAdvancedToggle(iconFillCb, "iconFillTimer", tabInfoButtons, iconFillTimerActive, {
+        title = "Icon Fill Timer Advanced",
+        build = BuildIconFillAdvanced,
     })
     local iconFillPromoteBtn
     if not group.masqueEnabled then
-        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
-    end
-    if iconFillTimerActive and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Cooldown Fill", "cooldown")
-        AddConditionalPreviewButton(container, "Preview Aura Fill", "aura_duration_text")
+        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, iconFillAdvBtn, "iconFillTimer", group, style)
     end
     local iconFillInfoAnchor = iconFillCb.checkbg
     local iconFillInfoXOff = iconFillCb.text:GetStringWidth() + 4
     if iconFillPromoteBtn and iconFillPromoteBtn:IsShown() then
         iconFillInfoAnchor = iconFillPromoteBtn
+        iconFillInfoXOff = 4
+    elseif iconFillAdvBtn and iconFillAdvBtn:IsShown() then
+        iconFillInfoAnchor = iconFillAdvBtn
         iconFillInfoXOff = 4
     end
     CreateInfoButton(iconFillCb.frame, iconFillInfoAnchor, "LEFT", "RIGHT", iconFillInfoXOff, 0, {
@@ -2249,10 +2344,8 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
-    CreateCheckboxPromoteButton(oorCb, nil, "showOutOfRange", group, style)
-    if style.showOutOfRange and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Out of Range State", "out_of_range")
-    end
+    local oorPromoteBtn = CreateCheckboxPromoteButton(oorCb, nil, "showOutOfRange", group, style)
+    AddConditionalPreviewBadge(oorCb, oorPromoteBtn, "Preview Out of Range State", "out_of_range", style.showOutOfRange)
 
     -- Loss of Control
     local locCb = BuildLossOfControlControls(container, style, function()
@@ -2265,10 +2358,8 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
-    CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
-    if style.showUnusable and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
-    end
+    local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
+    AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn, "Preview Unusable State", "unusable", style.showUnusable)
 
     -- Show Tooltips
     local tooltipCb = BuildShowTooltipsControls(container, style, function()

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2098,28 +2098,18 @@ local function BuildEffectsTab(container)
     end, {
         masqueEnabled = group.masqueEnabled == true,
     })
-    local function BuildIconFillAdvanced(panel)
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Cooldown Fill", "cooldown")
-            AddConditionalPreviewButton(panel, "Preview Aura Fill", "aura_duration_text")
-        end
-    end
-
-    local iconFillAdvExpanded, iconFillAdvBtn = AddAdvancedToggle(iconFillCb, "iconFillTimerPreview", tabInfoButtons, iconFillTimerActive, {
-        title = "Icon Fill Timer Advanced",
-        build = BuildIconFillAdvanced,
-    })
     local iconFillPromoteBtn
     if not group.masqueEnabled then
-        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, iconFillAdvBtn, "iconFillTimer", group, style)
+        iconFillPromoteBtn = CreateCheckboxPromoteButton(iconFillCb, nil, "iconFillTimer", group, style)
+    end
+    if iconFillTimerActive and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Cooldown Fill", "cooldown")
+        AddConditionalPreviewButton(container, "Preview Aura Fill", "aura_duration_text")
     end
     local iconFillInfoAnchor = iconFillCb.checkbg
     local iconFillInfoXOff = iconFillCb.text:GetStringWidth() + 4
     if iconFillPromoteBtn and iconFillPromoteBtn:IsShown() then
         iconFillInfoAnchor = iconFillPromoteBtn
-        iconFillInfoXOff = 4
-    elseif iconFillAdvBtn and iconFillAdvBtn:IsShown() then
-        iconFillInfoAnchor = iconFillAdvBtn
         iconFillInfoXOff = 4
     end
     CreateInfoButton(iconFillCb.frame, iconFillInfoAnchor, "LEFT", "RIGHT", iconFillInfoXOff, 0, {
@@ -2259,17 +2249,10 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
-    local function BuildOutOfRangeAdvanced(panel)
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Out of Range State", "out_of_range")
-        end
+    CreateCheckboxPromoteButton(oorCb, nil, "showOutOfRange", group, style)
+    if style.showOutOfRange and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Out of Range State", "out_of_range")
     end
-
-    local oorAdvExpanded, oorAdvBtn = AddAdvancedToggle(oorCb, "showOutOfRange", tabInfoButtons, style.showOutOfRange, {
-        title = "Out of Range Advanced",
-        build = BuildOutOfRangeAdvanced,
-    })
-    CreateCheckboxPromoteButton(oorCb, oorAdvBtn, "showOutOfRange", group, style)
 
     -- Loss of Control
     local locCb = BuildLossOfControlControls(container, style, function()
@@ -2282,17 +2265,10 @@ local function BuildEffectsTab(container)
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
         CooldownCompanion:RefreshConfigPanel()
     end)
-    local function BuildUnusableAdvanced(panel)
-        if AddConditionalPreviewButton then
-            AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable")
-        end
+    CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
+    if style.showUnusable and AddConditionalPreviewButton then
+        AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
     end
-
-    local unusableAdvExpanded, unusableAdvBtn = AddAdvancedToggle(unusableCb, "unusableDimming", tabInfoButtons, style.showUnusable, {
-        title = "Unusable Dimming Advanced",
-        build = BuildUnusableAdvanced,
-    })
-    CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
 
     -- Show Tooltips
     local tooltipCb = BuildShowTooltipsControls(container, style, function()

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -163,6 +163,15 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
             colBtn:Hide()
             colBtn:SetParent(nil)
         end
+        local previewBtn = frame._cdcPreviewBtn
+        if previewBtn then
+            previewBtn:ClearAllPoints()
+            previewBtn:Hide()
+            previewBtn:SetParent(nil)
+            if CS.activePreviewBadgeButton == previewBtn then
+                CS.activePreviewBadgeButton = nil
+            end
+        end
     end)
 
     -- Hide when parent setting is disabled

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -63,13 +63,70 @@ local function AttachCollapseButton(heading, isCollapsed, onClickFn)
     return btn
 end
 
--- Helper: add an inline advanced-toggle button on a parent widget (CheckBox or Heading).
--- Returns isExpanded (boolean) and the button frame reference.
+-- Helper: add an advanced-settings button on a parent widget (CheckBox or Heading).
+-- The button opens the shared side editor when options.build is provided.
 local ADVANCED_TOGGLE_ATLAS = "QuestLog-icon-setting"
 
-local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnabled)
-    local db = CooldownCompanion.db.profile.showAdvanced
-    local isExpanded = db and db[settingKey] or false
+local function GetAdvancedToggleTitle(parentWidget, options)
+    if options and options.title and options.title ~= "" then
+        return options.title
+    end
+
+    local labelText
+    if parentWidget.text and parentWidget.text.GetText then
+        labelText = parentWidget.text:GetText()
+    elseif parentWidget.label and parentWidget.label.GetText then
+        labelText = parentWidget.label:GetText()
+    end
+
+    if labelText and labelText ~= "" then
+        return labelText .. " Advanced"
+    end
+
+    return "Advanced Settings"
+end
+
+local function BuildAdvancedDescriptor(parentWidget, settingKey, options)
+    return {
+        settingKey = settingKey,
+        title = GetAdvancedToggleTitle(parentWidget, options),
+        build = options and options.build,
+        context = options and options.context,
+    }
+end
+
+local function SetAdvancedToggleActive(btn, active)
+    if btn and btn._icon then
+        if active then
+            btn._icon:SetVertexColor(1, 0.82, 0, 1)
+        else
+            btn._icon:SetVertexColor(0.72, 0.72, 0.72, 0.85)
+        end
+    end
+end
+
+local function SetActiveAdvancedSettingsToggleButton(btn)
+    local current = CS.activeAdvancedSettingsToggleButton
+    if current and current ~= btn then
+        SetAdvancedToggleActive(current, false)
+    end
+
+    CS.activeAdvancedSettingsToggleButton = btn
+    SetAdvancedToggleActive(btn, true)
+end
+
+local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnabled, options)
+    local useSidePanel = options and type(options.build) == "function" and CS.OpenAdvancedSettingsPanel
+    local isActive = false
+    if useSidePanel then
+        if CS.ConsumeQueuedAdvancedSettingsPanelOpen then
+            CS.ConsumeQueuedAdvancedSettingsPanelOpen(BuildAdvancedDescriptor(parentWidget, settingKey, options))
+        end
+        isActive = CS.IsAdvancedSettingsPanelOpen and CS.IsAdvancedSettingsPanelOpen(settingKey, options.context) or false
+        if isActive and CS.RebindAdvancedSettingsPanel then
+            CS.RebindAdvancedSettingsPanel(BuildAdvancedDescriptor(parentWidget, settingKey, options))
+        end
+    end
 
     local frame = parentWidget.frame
     local btn = frame._cdcAdvancedBtn
@@ -87,6 +144,7 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
     btn:SetParent(frame)
     btn:ClearAllPoints()
     btn._isAdvancedToggle = true
+    btn._advancedSettingKey = settingKey
 
     -- Clean up on widget release (prevent leaking into recycled widgets).
     -- Also covers any collapse button on the same frame, since AddAdvancedToggle
@@ -95,6 +153,10 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
         btn:ClearAllPoints()
         btn:Hide()
         btn:SetParent(nil)
+        SetAdvancedToggleActive(btn, false)
+        if CS.activeAdvancedSettingsToggleButton == btn then
+            CS.activeAdvancedSettingsToggleButton = nil
+        end
         local colBtn = frame._cdcCollapseBtn
         if colBtn then
             colBtn:ClearAllPoints()
@@ -105,6 +167,9 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
 
     -- Hide when parent setting is disabled
     if isEnabled == false then
+        if useSidePanel and isActive and CS.CloseAdvancedSettingsPanel then
+            CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+        end
         btn:Hide()
         btn._icon:Hide()
         table.insert(tabInfoBtns, btn)
@@ -120,30 +185,43 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
     end
     -- For headings, caller positions manually (use returned btn reference)
 
-    if isExpanded then
-        btn._icon:SetVertexColor(1, 0.82, 0, 1)
-    else
-        btn._icon:SetVertexColor(0.72, 0.72, 0.72, 0.85)
+    SetAdvancedToggleActive(btn, isActive)
+    if isActive then
+        SetActiveAdvancedSettingsToggleButton(btn)
+    elseif CS.activeAdvancedSettingsToggleButton == btn then
+        CS.activeAdvancedSettingsToggleButton = nil
     end
 
     btn:SetScript("OnClick", function()
-        CooldownCompanion.db.profile.showAdvanced[settingKey] = not isExpanded
-        CooldownCompanion:RefreshConfigPanel()
+        if useSidePanel then
+            if CS.IsAdvancedSettingsPanelOpen and CS.IsAdvancedSettingsPanelOpen(settingKey, options.context) then
+                CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+            else
+                local descriptor = BuildAdvancedDescriptor(parentWidget, settingKey, options)
+                if CS.OpenAdvancedSettingsPanel(descriptor) then
+                    SetActiveAdvancedSettingsToggleButton(btn)
+                end
+            end
+        else
+            CooldownCompanion:RefreshConfigPanel()
+        end
     end)
 
     btn:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-        GameTooltip:AddLine(isExpanded and "Hide advanced settings" or "Show advanced settings")
+        local active = CS.IsAdvancedSettingsPanelOpen and CS.IsAdvancedSettingsPanelOpen(settingKey, options and options.context)
+        GameTooltip:AddLine(active and "Close advanced settings" or "Open advanced settings")
         GameTooltip:Show()
     end)
     btn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
     table.insert(tabInfoBtns, btn)
 
-    return isExpanded, btn
+    return isActive, btn
 end
 
 local tabInfoButtons = CS.tabInfoButtons
+CS.SetActiveAdvancedSettingsToggleButton = SetActiveAdvancedSettingsToggleButton
 
 local function GroupSupportsPerButtonOverrides(group)
     return group and (group.displayMode or "icons") ~= "textures"
@@ -602,25 +680,7 @@ local function BuildCompactModeControls(container, group, tabInfoButtons)
     end)
     container:AddChild(compactCb)
 
-    local compactAdvExpanded, compactAdvBtn = AddAdvancedToggle(compactCb, "compactLayout", tabInfoButtons, group.compactLayout)
-
-    -- (?) tooltip for compact mode — anchor shifts when advanced toggle is visible
-    local compactAnchor, compactRelPoint, compactXOff
-    if group.compactLayout then
-        compactAnchor = compactAdvBtn
-        compactRelPoint = "RIGHT"
-        compactXOff = 4
-    else
-        compactAnchor = compactCb.checkbg
-        compactRelPoint = "RIGHT"
-        compactXOff = compactCb.text:GetStringWidth() + 6
-    end
-    CreateInfoButton(compactCb.frame, compactAnchor, "LEFT", compactRelPoint, compactXOff, 0, {
-        "Compact Mode",
-        {"When per-button visibility rules hide a button, shift remaining buttons to fill the gap and resize the group frame to fit visible buttons only.", 1, 1, 1, true},
-    }, tabInfoButtons)
-
-    if compactAdvExpanded and group.compactLayout then
+    local function BuildCompactAdvanced(panel)
         local growthDirectionDrop = AceGUI:Create("Dropdown")
         growthDirectionDrop:SetLabel("Growth Direction")
         growthDirectionDrop:SetList(GetCompactGrowthDirectionLabels(group), {"start", "center", "end"})
@@ -636,7 +696,7 @@ local function BuildCompactModeControls(container, group, tabInfoButtons)
                 end
             end
         end)
-        container:AddChild(growthDirectionDrop)
+        panel:AddChild(growthDirectionDrop)
 
         CreateInfoButton(growthDirectionDrop.frame, growthDirectionDrop.label, "LEFT", "CENTER", growthDirectionDrop.label:GetStringWidth() / 2 + 4, 0, {
             "Growth Direction",
@@ -659,12 +719,37 @@ local function BuildCompactModeControls(container, group, tabInfoButtons)
             local frame = CooldownCompanion.groupFrames[CS.selectedGroup]
             if frame then frame._layoutDirty = true end
         end)
-        container:AddChild(maxVisSlider)
+        panel:AddChild(maxVisSlider)
 
         CreateInfoButton(maxVisSlider.frame, maxVisSlider.label, "LEFT", "CENTER", maxVisSlider.label:GetStringWidth() / 2 + 4, 0, {
             "Max Visible Buttons",
             {"Limits how many buttons can appear at once. The first buttons (by group order) that pass visibility checks are shown; the rest are hidden.", 1, 1, 1, true},
         }, tabInfoButtons)
+    end
+
+    local compactAdvExpanded, compactAdvBtn = AddAdvancedToggle(compactCb, "compactLayout", tabInfoButtons, group.compactLayout, {
+        title = "Compact Mode Advanced",
+        build = BuildCompactAdvanced,
+    })
+
+    -- (?) tooltip for compact mode — anchor shifts when advanced toggle is visible
+    local compactAnchor, compactRelPoint, compactXOff
+    if group.compactLayout then
+        compactAnchor = compactAdvBtn
+        compactRelPoint = "RIGHT"
+        compactXOff = 4
+    else
+        compactAnchor = compactCb.checkbg
+        compactRelPoint = "RIGHT"
+        compactXOff = compactCb.text:GetStringWidth() + 6
+    end
+    CreateInfoButton(compactCb.frame, compactAnchor, "LEFT", compactRelPoint, compactXOff, 0, {
+        "Compact Mode",
+        {"When per-button visibility rules hide a button, shift remaining buttons to fill the gap and resize the group frame to fit visible buttons only.", 1, 1, 1, true},
+    }, tabInfoButtons)
+
+    if not (compactAdvExpanded and group.compactLayout) then
+        return
     end
 end
 

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -91,7 +91,9 @@ local function BuildAdvancedDescriptor(parentWidget, settingKey, options)
         settingKey = settingKey,
         title = GetAdvancedToggleTitle(parentWidget, options),
         build = options and options.build,
+        isAvailable = options and options.isAvailable,
         context = options and options.context,
+        deferBuild = options and options.deferBuild,
     }
 end
 
@@ -150,6 +152,15 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
     -- Also covers any collapse button on the same frame, since AddAdvancedToggle
     -- is always called after AttachCollapseButton and overwrites its OnRelease.
     parentWidget:SetCallback("OnRelease", function()
+        local activeSidePanelToggleReleased = useSidePanel and CS.activeAdvancedSettingsToggleButton == btn
+        if activeSidePanelToggleReleased
+            and not CS.configRefreshInProgress
+            and not CS.advancedSettingsPanelRefreshing
+            and CS.CloseAdvancedSettingsPanel
+        then
+            CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+        end
+
         btn:ClearAllPoints()
         btn:Hide()
         btn:SetParent(nil)
@@ -207,7 +218,7 @@ local function AddAdvancedToggle(parentWidget, settingKey, tabInfoBtns, isEnable
                 CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
             else
                 local descriptor = BuildAdvancedDescriptor(parentWidget, settingKey, options)
-                if CS.OpenAdvancedSettingsPanel(descriptor) then
+                if CS.OpenAdvancedSettingsPanel(descriptor) and btn:GetParent() == frame then
                     SetActiveAdvancedSettingsToggleButton(btn)
                 end
             end
@@ -538,7 +549,7 @@ local function CreateInfoButton(parentFrame, anchorFrame, anchorPoint, anchorRel
         GameTooltip:Hide()
     end)
 
-    if cleanup.SetCallback then
+    if cleanup and cleanup.SetCallback then
         -- AceGUI widget: chain OnRelease cleanup so existing handlers (e.g.
         -- collapse/advanced button detach) are preserved.
         local prevOnRelease = cleanup.events and cleanup.events["OnRelease"]
@@ -552,6 +563,13 @@ local function CreateInfoButton(parentFrame, anchorFrame, anchorPoint, anchorRel
         end)
     else
         -- Array of buttons: insert and apply hideInfoButtons
+        if CS.advancedSettingsPanelRefreshing then
+            CS.advancedSettingsInfoButtons = CS.advancedSettingsInfoButtons or {}
+            cleanup = CS.advancedSettingsInfoButtons
+        end
+        if type(cleanup) ~= "table" then
+            return btn
+        end
         table.insert(cleanup, btn)
         if CooldownCompanion.db.profile.hideInfoButtons then
             btn:Hide()
@@ -756,10 +774,6 @@ local function BuildCompactModeControls(container, group, tabInfoButtons)
         "Compact Mode",
         {"When per-button visibility rules hide a button, shift remaining buttons to fill the gap and resize the group frame to fit visible buttons only.", 1, 1, 1, true},
     }, tabInfoButtons)
-
-    if not (compactAdvExpanded and group.compactLayout) then
-        return
-    end
 end
 
 local function BuildGroupSettingPresetControls(container, group, mode, tabInfoButtons)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -543,7 +543,6 @@ function HealthResource.BuildColorControls(container, settings, applyBars)
                 health.healthLowHealthAlertMissingHealthOnly = val == true
                 applyBars()
             end)
-            ApplyCheckboxIndent(missingHealthOnlyCb, 20)
             panel:AddChild(missingHealthOnlyCb)
         end,
     }, applyBars)
@@ -3574,7 +3573,6 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 CooldownCompanion:ApplyResourceBars()
             end)
             panel:AddChild(activeAuraCombatCb)
-            ApplyCheckboxIndent(activeAuraCombatCb, 20)
 
             BuildBarActiveAuraControls(panel, customBars[cabIdx], cabApplyBars, {
                 hidePrimaryColorPicker = not isSpellCustomBar,
@@ -3622,7 +3620,6 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                     CooldownCompanion:ApplyResourceBars()
                 end)
                 panel:AddChild(pandemicCombatCb)
-                ApplyCheckboxIndent(pandemicCombatCb, 20)
 
                 BuildPandemicBarControls(panel, customBars[cabIdx], cabApplyBars)
                 BuildPandemicBarPulseControls(panel, customBars[cabIdx], cabApplyBars)

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -297,6 +297,29 @@ function HealthResource.EnsureDisplaySettings(settings, specID)
     return health
 end
 
+local function EnsureResourceSettings(settings, powerType)
+    if type(settings.resources) ~= "table" then
+        settings.resources = {}
+    end
+
+    if powerType == HealthResource.ID then
+        return HealthResource.EnsureSettings(settings)
+    end
+
+    if type(settings.resources[powerType]) ~= "table" then
+        settings.resources[powerType] = {}
+    end
+    return settings.resources[powerType]
+end
+
+local function IsResourceEnabled(settings, powerType)
+    local res = EnsureResourceSettings(settings, powerType)
+    if powerType == HealthResource.ID then
+        return res.enabled == true
+    end
+    return res.enabled ~= false
+end
+
 function HealthResource.AddOpacitySlider(container, health, key, label, defaultValue, applyBars)
     local slider = AceGUI:Create("Slider")
     slider:SetLabel(label)
@@ -772,18 +795,10 @@ local function BuildResourceBarAnchoringPanel(container)
         end
 
         -- Per-resource enable/disable
-        local rbHeightAdvBtns = {}
         local resources = GetConfigActiveResources()
         for _, pt in ipairs(resources) do
             local name = POWER_NAMES[pt] or ("Power " .. pt)
-            if pt == HealthResource.ID then
-                HealthResource.EnsureSettings(settings)
-            elseif not settings.resources[pt] then
-                settings.resources[pt] = {}
-            end
-            local enabled = pt == HealthResource.ID
-                and settings.resources[pt].enabled == true
-                or settings.resources[pt].enabled ~= false
+            local enabled = IsResourceEnabled(settings, pt)
 
             local resCb = AceGUI:Create("CheckBox")
             resCb:SetLabel("Show " .. name)
@@ -802,45 +817,6 @@ local function BuildResourceBarAnchoringPanel(container)
                 CooldownCompanion:RefreshConfigPanel()
             end)
             container:AddChild(resCb)
-
-            if layout.customBarHeights then
-                local capturedPt = pt
-                local function BuildResourceHeightAdvanced(panel)
-                    if type(layout.resources[pt]) ~= "table" then
-                        layout.resources[pt] = {}
-                    end
-                    local resLayout = layout.resources[pt]
-                    local resHeightSlider = AceGUI:Create("Slider")
-                    resHeightSlider:SetLabel(thicknessLabel)
-                    resHeightSlider:SetSliderValues(4, 40, 0.1)
-                    if thicknessField == "barWidth" then
-                        resHeightSlider:SetValue(
-                            resLayout.barWidth or resLayout.barHeight
-                            or layout.barWidth or layout.barHeight or settings.barWidth or settings.barHeight or 12
-                        )
-                    else
-                        resHeightSlider:SetValue(
-                            resLayout.barHeight or resLayout.barWidth
-                            or layout.barHeight or layout.barWidth or settings.barHeight or settings.barWidth or 12
-                        )
-                    end
-                    resHeightSlider:SetFullWidth(true)
-                    resHeightSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                        if not layout.resources[capturedPt] then
-                            layout.resources[capturedPt] = {}
-                        end
-                        layout.resources[capturedPt][thicknessField] = val
-                        CooldownCompanion:ApplyResourceBars()
-                        CooldownCompanion:RepositionCastBar()
-                        CooldownCompanion:UpdateAnchorStacking()
-                    end)
-                    panel:AddChild(resHeightSlider)
-                end
-                AddAdvancedToggle(resCb, "rbHeight_" .. pt, rbHeightAdvBtns, enabled, {
-                    title = name .. " Height Advanced",
-                    build = BuildResourceHeightAdvanced,
-                })
-            end
         end
     end
 
@@ -1103,6 +1079,7 @@ end
 local function BuildBarHeightControls(container, settings, layout)
     layout = layout or settings
     local thicknessField, thicknessLabel, customThicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
+    local customHeightsAdvKey = "customResourceBarHeights"
 
     local hSlider = AceGUI:Create("Slider")
     hSlider:SetLabel(thicknessLabel)
@@ -1140,7 +1117,11 @@ local function BuildBarHeightControls(container, settings, layout)
     customHeightsCb:SetValue(layout.customBarHeights or false)
     customHeightsCb:SetFullWidth(true)
     customHeightsCb:SetCallback("OnValueChanged", function(widget, event, val)
+        local wasEnabled = layout.customBarHeights == true
         layout.customBarHeights = val
+        if val and not wasEnabled and CS.QueueAdvancedSettingsPanelOpen then
+            CS.QueueAdvancedSettingsPanelOpen(customHeightsAdvKey)
+        end
         CooldownCompanion:ApplyResourceBars()
         CooldownCompanion:RepositionCastBar()
         CooldownCompanion:UpdateAnchorStacking()
@@ -1148,9 +1129,67 @@ local function BuildBarHeightControls(container, settings, layout)
     end)
     container:AddChild(customHeightsCb)
 
-    CreateInfoButton(customHeightsCb.frame, customHeightsCb.checkbg, "LEFT", "RIGHT", customHeightsCb.text:GetStringWidth() + 4, 0, {
-        "Custom Resource Bar Heights",
-        {"When enabled, each resource can have its own bar height. Click the advanced settings toggle for a resource in Column 1 to configure its individual height.", 1, 1, 1, true},
+    local function BuildCustomResourceHeightsAdvanced(panel)
+        if type(layout.resources) ~= "table" then
+            layout.resources = {}
+        end
+
+        local resources = GetConfigActiveResources()
+        for _, pt in ipairs(resources) do
+            local capturedPt = pt
+            local name = POWER_NAMES[pt] or ("Power " .. pt)
+            local enabled = IsResourceEnabled(settings, pt)
+            local resLayout = type(layout.resources[capturedPt]) == "table" and layout.resources[capturedPt] or {}
+
+            local resHeightSlider = AceGUI:Create("Slider")
+            resHeightSlider:SetLabel(name .. " " .. thicknessLabel)
+            resHeightSlider:SetSliderValues(4, 40, 0.1)
+            if thicknessField == "barWidth" then
+                resHeightSlider:SetValue(
+                    resLayout.barWidth or resLayout.barHeight
+                    or layout.barWidth or layout.barHeight or settings.barWidth or settings.barHeight or 12
+                )
+            else
+                resHeightSlider:SetValue(
+                    resLayout.barHeight or resLayout.barWidth
+                    or layout.barHeight or layout.barWidth or settings.barHeight or settings.barWidth or 12
+                )
+            end
+            resHeightSlider:SetFullWidth(true)
+            if resHeightSlider.SetDisabled then
+                resHeightSlider:SetDisabled(not enabled)
+            end
+            resHeightSlider:SetCallback("OnValueChanged", function(widget, event, val)
+                if not enabled then
+                    return
+                end
+                if type(layout.resources[capturedPt]) ~= "table" then
+                    layout.resources[capturedPt] = {}
+                end
+                layout.resources[capturedPt][thicknessField] = val
+                CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:RepositionCastBar()
+                CooldownCompanion:UpdateAnchorStacking()
+            end)
+            panel:AddChild(resHeightSlider)
+        end
+    end
+
+    local _, customHeightsAdvBtn = AddAdvancedToggle(customHeightsCb, customHeightsAdvKey, tabInfoButtons, layout.customBarHeights == true, {
+        title = customThicknessLabel .. " Advanced",
+        build = BuildCustomResourceHeightsAdvanced,
+    })
+
+    local customHeightsInfoAnchor = customHeightsCb.checkbg
+    local customHeightsInfoOffset = customHeightsCb.text:GetStringWidth() + 4
+    if customHeightsAdvBtn and customHeightsAdvBtn:IsShown() then
+        customHeightsInfoAnchor = customHeightsAdvBtn
+        customHeightsInfoOffset = 4
+    end
+
+    CreateInfoButton(customHeightsCb.frame, customHeightsInfoAnchor, "LEFT", "RIGHT", customHeightsInfoOffset, 0, {
+        customThicknessLabel,
+        {"When enabled, each resource can have its own bar size. Open advanced settings here to configure all resource sizes together.", 1, 1, 1, true},
     }, customHeightsCb)
 end
 

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -1897,7 +1897,11 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                             end
                             WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickMode", val)
                             CooldownCompanion:ApplyResourceBars()
-                            C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
+                            C_Timer.After(0, function()
+                                if CS.RefreshAdvancedSettingsPanel then
+                                    CS.RefreshAdvancedSettingsPanel()
+                                end
+                            end)
                         end)
                         panel:AddChild(modeDrop)
 
@@ -3754,7 +3758,9 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
             styleDrop:SetCallback("OnValueChanged", function(widget, event, val)
                 customBars[cabIdx].maxStacksGlowStyle = val
                 CooldownCompanion:ApplyResourceBars()
-                CooldownCompanion:RefreshConfigPanel()
+                if CS.RefreshAdvancedSettingsPanel then
+                    CS.RefreshAdvancedSettingsPanel()
+                end
             end)
             panel:AddChild(styleDrop)
 

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -326,13 +326,21 @@ end
 
 function HealthResource.AddEffectStyleControls(container, checkbox, health, options, applyBars)
     local enabled = health[options.enabledKey] == true
-    local expanded, advBtn = AddAdvancedToggle(checkbox, options.advancedKey, tabInfoButtons, enabled)
+    local function BuildEffectStyleAdvanced(panel)
+        AddColorPicker(panel, health, options.colorKey, options.colorLabel, options.defaultColor, true, applyBars, applyBars)
+        HealthResource.AddEffectTextureDropdown(panel, health, options.textureKey, options.textureLabel, applyBars)
+        if type(options.buildExtra) == "function" then
+            options.buildExtra(panel)
+        end
+    end
+
+    local expanded, advBtn = AddAdvancedToggle(checkbox, options.advancedKey, tabInfoButtons, enabled, {
+        build = BuildEffectStyleAdvanced,
+    })
     if not (enabled and expanded) then
         return expanded, advBtn
     end
 
-    AddColorPicker(container, health, options.colorKey, options.colorLabel, options.defaultColor, true, applyBars, applyBars)
-    HealthResource.AddEffectTextureDropdown(container, health, options.textureKey, options.textureLabel, applyBars)
     return expanded, advBtn
 end
 
@@ -526,6 +534,18 @@ function HealthResource.BuildColorControls(container, settings, applyBars)
         colorLabel = "Low Health Alert Color",
         textureLabel = "Low Health Alert Texture",
         defaultColor = DEFAULT_HEALTH_LOW_HEALTH_ALERT_COLOR,
+        buildExtra = function(panel)
+            local missingHealthOnlyCb = AceGUI:Create("CheckBox")
+            missingHealthOnlyCb:SetLabel("Pulse Missing Health Only")
+            missingHealthOnlyCb:SetValue(health.healthLowHealthAlertMissingHealthOnly == true)
+            missingHealthOnlyCb:SetFullWidth(true)
+            missingHealthOnlyCb:SetCallback("OnValueChanged", function(widget, event, val)
+                health.healthLowHealthAlertMissingHealthOnly = val == true
+                applyBars()
+            end)
+            ApplyCheckboxIndent(missingHealthOnlyCb, 20)
+            panel:AddChild(missingHealthOnlyCb)
+        end,
     }, applyBars)
     local lowHealthAlertInfoAnchor = lowHealthAlertAdvancedBtn
     local lowHealthAlertInfoOffset = 4
@@ -537,19 +557,6 @@ function HealthResource.BuildColorControls(container, settings, applyBars)
         "Low Health Alert",
         {"Blizzard sets the low-health threshold to 35%. This cannot be configured.", 1, 1, 1, true},
     }, lowHealthAlertCb)
-    if health.showLowHealthAlert == true and lowHealthAlertAdvancedExpanded then
-        local missingHealthOnlyCb = AceGUI:Create("CheckBox")
-        missingHealthOnlyCb:SetLabel("Pulse Missing Health Only")
-        missingHealthOnlyCb:SetValue(health.healthLowHealthAlertMissingHealthOnly == true)
-        missingHealthOnlyCb:SetFullWidth(true)
-        missingHealthOnlyCb:SetCallback("OnValueChanged", function(widget, event, val)
-            health.healthLowHealthAlertMissingHealthOnly = val == true
-            applyBars()
-        end)
-        ApplyCheckboxIndent(missingHealthOnlyCb, 20)
-        container:AddChild(missingHealthOnlyCb)
-    end
-
     if AddPreviewToggleButton then
         AddPreviewToggleButton(container, "Preview Absorbs", function()
             return CooldownCompanion:IsHealthEffectPreviewActive("absorbs")
@@ -798,8 +805,8 @@ local function BuildResourceBarAnchoringPanel(container)
             container:AddChild(resCb)
 
             if layout.customBarHeights then
-                local advExpanded = AddAdvancedToggle(resCb, "rbHeight_" .. pt, rbHeightAdvBtns, enabled)
-                if advExpanded then
+                local capturedPt = pt
+                local function BuildResourceHeightAdvanced(panel)
                     if type(layout.resources[pt]) ~= "table" then
                         layout.resources[pt] = {}
                     end
@@ -819,7 +826,6 @@ local function BuildResourceBarAnchoringPanel(container)
                         )
                     end
                     resHeightSlider:SetFullWidth(true)
-                    local capturedPt = pt
                     resHeightSlider:SetCallback("OnValueChanged", function(widget, event, val)
                         if not layout.resources[capturedPt] then
                             layout.resources[capturedPt] = {}
@@ -829,8 +835,12 @@ local function BuildResourceBarAnchoringPanel(container)
                         CooldownCompanion:RepositionCastBar()
                         CooldownCompanion:UpdateAnchorStacking()
                     end)
-                    container:AddChild(resHeightSlider)
+                    panel:AddChild(resHeightSlider)
                 end
+                AddAdvancedToggle(resCb, "rbHeight_" .. pt, rbHeightAdvBtns, enabled, {
+                    title = name .. " Height Advanced",
+                    build = BuildResourceHeightAdvanced,
+                })
             end
         end
     end
@@ -1326,8 +1336,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
             end)
             container:AddChild(cb)
 
-            local advExpanded = AddAdvancedToggle(cb, "rbText_" .. capturedPt, rbTextAdvBtns, showTextEnabled)
-            if advExpanded and showTextEnabled then
+            local function BuildResourceTextAdvanced(panel)
                 local textFormatDrop = AceGUI:Create("Dropdown")
                 textFormatDrop:SetLabel("Text Format")
                 local textFormatOptions
@@ -1402,7 +1411,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     end
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(textFormatDrop)
+                panel:AddChild(textFormatDrop)
 
                 local fontDrop = AceGUI:Create("Dropdown")
                 fontDrop:SetLabel("Font")
@@ -1413,7 +1422,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     resSettings.textFont = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(fontDrop)
+                panel:AddChild(fontDrop)
 
                 local sizeDrop = AceGUI:Create("Slider")
                 sizeDrop:SetLabel("Font Size")
@@ -1424,7 +1433,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     resSettings.textFontSize = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(sizeDrop)
+                panel:AddChild(sizeDrop)
 
                 local outlineDrop = AceGUI:Create("Dropdown")
                 outlineDrop:SetLabel("Outline")
@@ -1435,9 +1444,9 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     resSettings.textFontOutline = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(outlineDrop)
+                panel:AddChild(outlineDrop)
 
-                AddColorPicker(container, resSettings, "textFontColor", "Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, applyBars)
+                AddColorPicker(panel, resSettings, "textFontColor", "Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, applyBars)
 
                 local textAnchorDrop = AceGUI:Create("Dropdown")
                 textAnchorDrop:SetLabel("Text Anchor")
@@ -1452,7 +1461,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     resSettings.textAnchor = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(textAnchorDrop)
+                panel:AddChild(textAnchorDrop)
 
                 local textXSlider = AceGUI:Create("Slider")
                 textXSlider:SetLabel("Text X Offset")
@@ -1463,7 +1472,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     resSettings.textXOffset = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(textXSlider)
+                panel:AddChild(textXSlider)
 
                 local textYSlider = AceGUI:Create("Slider")
                 textYSlider:SetLabel("Text Y Offset")
@@ -1474,7 +1483,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     resSettings.textYOffset = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(textYSlider)
+                panel:AddChild(textYSlider)
 
                 if HIDE_AT_ZERO_ELIGIBLE[capturedPt] then
                     local hideAtZeroCb = AceGUI:Create("CheckBox")
@@ -1485,9 +1494,14 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                         resSettings.hideTextAtZero = val == true
                         CooldownCompanion:ApplyResourceBars()
                     end)
-                    container:AddChild(hideAtZeroCb)
+                    panel:AddChild(hideAtZeroCb)
                 end
             end
+
+            AddAdvancedToggle(cb, "rbText_" .. capturedPt, rbTextAdvBtns, showTextEnabled, {
+                title = name .. " Text Advanced",
+                build = BuildResourceTextAdvanced,
+            })
         end
     end
 
@@ -1743,25 +1757,15 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     thresholdEnableCb:SetCallback("OnValueChanged", function(widget, event, val)
                         local wasEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true
                         WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", val == true)
-                        if val and not wasEnabled then
-                            if type(CooldownCompanion.db.profile.showAdvanced) ~= "table" then
-                                CooldownCompanion.db.profile.showAdvanced = {}
-                            end
-                            CooldownCompanion.db.profile.showAdvanced[thresholdAdvKey] = true
+                        if val and not wasEnabled and CS.QueueAdvancedSettingsPanelOpen then
+                            CS.QueueAdvancedSettingsPanelOpen(thresholdAdvKey)
                         end
                         CooldownCompanion:ApplyResourceBars()
                         C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
                     end)
                     container:AddChild(thresholdEnableCb)
 
-                    local _segEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true
-                    local thresholdAdvExpanded = AddAdvancedToggle(
-                        thresholdEnableCb,
-                        thresholdAdvKey,
-                        rbThresholdTickAdvBtns,
-                        _segEnabled
-                    )
-                    if _segEnabled and thresholdAdvExpanded then
+                    local function BuildSegmentedThresholdAdvanced(panel)
                         local thresholdEdit = AceGUI:Create("EditBox")
                         if thresholdEdit.editbox.Instructions then thresholdEdit.editbox.Instructions:Hide() end
                         thresholdEdit:SetLabel(resourceName .. " Threshold Value (>=)")
@@ -1786,13 +1790,25 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                             widget:SetText(tostring(parsed))
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(thresholdEdit)
+                        panel:AddChild(thresholdEdit)
 
                         local _pSeg = { segThresholdColor = GetSafeRGBConfig(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdColor", nil), DEFAULT_SEG_THRESHOLD_COLOR) }
-                        AddColorPicker(container, _pSeg, "segThresholdColor", resourceName .. " Threshold Color", DEFAULT_SEG_THRESHOLD_COLOR, false,
+                        AddColorPicker(panel, _pSeg, "segThresholdColor", resourceName .. " Threshold Color", DEFAULT_SEG_THRESHOLD_COLOR, false,
                             function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdColor", _pSeg.segThresholdColor); applyBars() end,
                             function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdColor", _pSeg.segThresholdColor) end)
                     end
+
+                    local _segEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true
+                    local thresholdAdvExpanded = AddAdvancedToggle(
+                        thresholdEnableCb,
+                        thresholdAdvKey,
+                        rbThresholdTickAdvBtns,
+                        _segEnabled,
+                        {
+                            title = resourceName .. " Threshold Advanced",
+                            build = BuildSegmentedThresholdAdvanced,
+                        }
+                    )
                 elseif capturedPt ~= 101 and capturedPt ~= healthResourceID then
                     -- Stagger (101) and Health have dedicated coloring; tick markers not applicable
                     local tickAdvKey = "rbTickMarker_" .. capturedPt
@@ -1804,11 +1820,8 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     tickEnableCb:SetCallback("OnValueChanged", function(widget, event, val)
                         local wasEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickEnabled", false) == true
                         WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickEnabled", val == true)
-                        if val and not wasEnabled then
-                            if type(CooldownCompanion.db.profile.showAdvanced) ~= "table" then
-                                CooldownCompanion.db.profile.showAdvanced = {}
-                            end
-                            CooldownCompanion.db.profile.showAdvanced[tickAdvKey] = true
+                        if val and not wasEnabled and CS.QueueAdvancedSettingsPanelOpen then
+                            CS.QueueAdvancedSettingsPanelOpen(tickAdvKey)
                         end
                         CooldownCompanion:ApplyResourceBars()
                         C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
@@ -1828,13 +1841,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                         ApplyCheckboxIndent(tickCombatCb, 20)
                     end
 
-                    local tickAdvExpanded = AddAdvancedToggle(
-                        tickEnableCb,
-                        tickAdvKey,
-                        rbThresholdTickAdvBtns,
-                        _tickEnabled
-                    )
-                    if _tickEnabled and tickAdvExpanded then
+                    local function BuildTickMarkerAdvanced(panel)
                         local _tickModeRes = { continuousTickMode = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickMode", nil) }
                         local tickMode = GetContinuousTickModeConfig(_tickModeRes)
                         local modeDrop = AceGUI:Create("Dropdown")
@@ -1853,7 +1860,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                             CooldownCompanion:ApplyResourceBars()
                             C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
                         end)
-                        container:AddChild(modeDrop)
+                        panel:AddChild(modeDrop)
 
                         if tickMode == "percent" then
                             local _tickPercentRes = { continuousTickPercent = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickPercent", nil) }
@@ -1867,7 +1874,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                                 WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickPercent", val)
                                 CooldownCompanion:ApplyResourceBars()
                             end)
-                            container:AddChild(percentSlider)
+                            panel:AddChild(percentSlider)
                         else
                             local _tickAbsRes = { continuousTickAbsolute = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickAbsolute", nil) }
                             local absoluteEdit = AceGUI:Create("EditBox")
@@ -1890,13 +1897,13 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                                 widget:SetText(tostring(parsed))
                                 CooldownCompanion:ApplyResourceBars()
                             end)
-                            container:AddChild(absoluteEdit)
+                            panel:AddChild(absoluteEdit)
                         end
 
                         local _tickColorResolved = GetSafeRGBAConfig(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickColor", nil), DEFAULT_CONTINUOUS_TICK_COLOR)
                         if _tickColorResolved[4] == nil then _tickColorResolved = { _tickColorResolved[1], _tickColorResolved[2], _tickColorResolved[3], 1 } end
                         local _pTick = { continuousTickColor = _tickColorResolved }
-                        AddColorPicker(container, _pTick, "continuousTickColor", resourceName .. " Tick Color", DEFAULT_CONTINUOUS_TICK_COLOR, true,
+                        AddColorPicker(panel, _pTick, "continuousTickColor", resourceName .. " Tick Color", DEFAULT_CONTINUOUS_TICK_COLOR, true,
                             function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickColor", _pTick.continuousTickColor); applyBars() end,
                             function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickColor", _pTick.continuousTickColor) end)
 
@@ -1910,8 +1917,19 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                             WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickWidth", val)
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(tickWidthSlider)
+                        panel:AddChild(tickWidthSlider)
                     end
+
+                    local tickAdvExpanded = AddAdvancedToggle(
+                        tickEnableCb,
+                        tickAdvKey,
+                        rbThresholdTickAdvBtns,
+                        _tickEnabled,
+                        {
+                            title = resourceName .. " Tick Marker Advanced",
+                            build = BuildTickMarkerAdvanced,
+                        }
+                    )
                 end
             end
         end
@@ -3546,8 +3564,7 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
         end)
         container:AddChild(activeAuraCb)
 
-        local activeAuraAdvExpanded = AddAdvancedToggle(activeAuraCb, "rbCabActiveAura_" .. capturedKey, infoButtons, activeAuraEnabled)
-        if activeAuraAdvExpanded and activeAuraEnabled then
+        local function BuildCustomBarActiveAuraAdvanced(panel)
             local activeAuraCombatCb = AceGUI:Create("CheckBox")
             activeAuraCombatCb:SetLabel("Show Only In Combat")
             activeAuraCombatCb:SetValue(cab.auraGlowCombatOnly or false)
@@ -3556,22 +3573,28 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 customBars[cabIdx].auraGlowCombatOnly = val
                 CooldownCompanion:ApplyResourceBars()
             end)
-            container:AddChild(activeAuraCombatCb)
+            panel:AddChild(activeAuraCombatCb)
             ApplyCheckboxIndent(activeAuraCombatCb, 20)
 
-            BuildBarActiveAuraControls(container, customBars[cabIdx], cabApplyBars, {
+            BuildBarActiveAuraControls(panel, customBars[cabIdx], cabApplyBars, {
                 hidePrimaryColorPicker = not isSpellCustomBar,
             })
-            BuildBarAuraPulseControls(container, customBars[cabIdx], cabApplyBars)
+            BuildBarAuraPulseControls(panel, customBars[cabIdx], cabApplyBars)
 
             if AddPreviewToggleButton then
-                AddPreviewToggleButton(container, "Preview Active Aura Effects", function()
+                AddPreviewToggleButton(panel, "Preview Active Aura Effects", function()
                     return CooldownCompanion:IsCustomAuraBarActivePreviewActive(customBars[cabIdx])
                 end, function(show)
                     CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], show)
                 end)
             end
-        else
+        end
+
+        local activeAuraAdvExpanded = AddAdvancedToggle(activeAuraCb, "rbCabActiveAura_" .. capturedKey, infoButtons, activeAuraEnabled, {
+            title = "Active Aura Indicator Advanced",
+            build = BuildCustomBarActiveAuraAdvanced,
+        })
+        if not (activeAuraAdvExpanded and activeAuraEnabled) then
             CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], false)
         end
 
@@ -3589,8 +3612,7 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
             end)
             container:AddChild(pandemicCb)
 
-            local pandemicAdvExpanded = AddAdvancedToggle(pandemicCb, "rbCabPandemic_" .. capturedKey, infoButtons, pandemicEnabled)
-            if pandemicAdvExpanded and pandemicEnabled then
+            local function BuildCustomBarPandemicAdvanced(panel)
                 local pandemicCombatCb = AceGUI:Create("CheckBox")
                 pandemicCombatCb:SetLabel("Show Only In Combat")
                 pandemicCombatCb:SetValue(cab.pandemicGlowCombatOnly or false)
@@ -3599,20 +3621,26 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                     customBars[cabIdx].pandemicGlowCombatOnly = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(pandemicCombatCb)
+                panel:AddChild(pandemicCombatCb)
                 ApplyCheckboxIndent(pandemicCombatCb, 20)
 
-                BuildPandemicBarControls(container, customBars[cabIdx], cabApplyBars)
-                BuildPandemicBarPulseControls(container, customBars[cabIdx], cabApplyBars)
+                BuildPandemicBarControls(panel, customBars[cabIdx], cabApplyBars)
+                BuildPandemicBarPulseControls(panel, customBars[cabIdx], cabApplyBars)
 
                 if AddPreviewToggleButton then
-                    AddPreviewToggleButton(container, "Preview Pandemic Effects", function()
+                    AddPreviewToggleButton(panel, "Preview Pandemic Effects", function()
                         return CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(customBars[cabIdx])
                     end, function(show)
                         CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], show)
                     end)
                 end
-            else
+            end
+
+            local pandemicAdvExpanded = AddAdvancedToggle(pandemicCb, "rbCabPandemic_" .. capturedKey, infoButtons, pandemicEnabled, {
+                title = "Pandemic Indicator Advanced",
+                build = BuildCustomBarPandemicAdvanced,
+            })
+            if not (pandemicAdvExpanded and pandemicEnabled) then
                 CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
             end
         else
@@ -3664,21 +3692,7 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
         end)
         container:AddChild(glowCb)
 
-        local glowAdvExpanded, glowAdvBtn = AddAdvancedToggle(glowCb, "rbCabMaxStacksIndicator_" .. capturedKey, infoButtons, cab.maxStacksGlowEnabled == true)
-        if not glowAdvExpanded and CS.customBarIndicatorPreviewActive and CooldownCompanion:IsResourceBarPreviewActive() then
-            CooldownCompanion:StopResourceBarPreview()
-        end
-
-        CreateInfoButton(glowCb.frame, glowAdvBtn, "LEFT", "RIGHT", 4, 0, {
-            "Max Stack Indicator",
-            {"Due to combat restrictions, individual bar segments cannot be highlighted independently.", 1, 1, 1, true},
-            " ",
-            {"The indicator covers the entire resource bar and appears automatically when your buff reaches its maximum stack count.", 1, 1, 1, true},
-            " ",
-            {"The Pulsing Overlay style is only available for continuous display mode.", 1, 1, 1, true},
-        }, glowCb)
-
-        if glowAdvExpanded and cab.maxStacksGlowEnabled then
+        local function BuildMaxStackIndicatorAdvanced(panel)
             local isContinuousDisplay = (cab.trackingMode == "active") or (cab.displayMode == "continuous")
             local currentStyle = cab.maxStacksGlowStyle or "solidBorder"
             if currentStyle == "pulsingOverlay" and not isContinuousDisplay then
@@ -3711,9 +3725,9 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 CooldownCompanion:ApplyResourceBars()
                 CooldownCompanion:RefreshConfigPanel()
             end)
-            container:AddChild(styleDrop)
+            panel:AddChild(styleDrop)
 
-            AddColorPicker(container, customBars[cabIdx], "maxStacksGlowColor", "Indicator Color", {1, 0.84, 0, 0.9}, true,
+            AddColorPicker(panel, customBars[cabIdx], "maxStacksGlowColor", "Indicator Color", {1, 0.84, 0, 0.9}, true,
                 cabApplyBars, cabApplyBars)
 
             if currentStyle ~= "pulsingOverlay" then
@@ -3726,7 +3740,7 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                     customBars[cabIdx].maxStacksGlowSize = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(sizeSlider)
+                panel:AddChild(sizeSlider)
             end
 
             if currentStyle == "pulsingBorder" or currentStyle == "pulsingOverlay" then
@@ -3739,11 +3753,11 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                     customBars[cabIdx].maxStacksGlowSpeed = val
                     CooldownCompanion:ApplyResourceBars()
                 end)
-                container:AddChild(speedSlider)
+                panel:AddChild(speedSlider)
             end
 
             if AddPreviewToggleButton then
-                AddPreviewToggleButton(container, "Preview Indicator", function()
+                AddPreviewToggleButton(panel, "Preview Indicator", function()
                     return CS.customBarIndicatorPreviewActive == true and CooldownCompanion:IsResourceBarPreviewActive()
                 end, function(show)
                     CS.customBarIndicatorPreviewActive = show and true or nil
@@ -3755,6 +3769,24 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 end)
             end
         end
+
+        local glowAdvExpanded, glowAdvBtn = AddAdvancedToggle(glowCb, "rbCabMaxStacksIndicator_" .. capturedKey, infoButtons, cab.maxStacksGlowEnabled == true, {
+            title = "Max Stack Indicator Advanced",
+            build = BuildMaxStackIndicatorAdvanced,
+        })
+        if not glowAdvExpanded and CS.customBarIndicatorPreviewActive and CooldownCompanion:IsResourceBarPreviewActive() then
+            CooldownCompanion:StopResourceBarPreview()
+        end
+
+        CreateInfoButton(glowCb.frame, glowAdvBtn, "LEFT", "RIGHT", 4, 0, {
+            "Max Stack Indicator",
+            {"Due to combat restrictions, individual bar segments cannot be highlighted independently.", 1, 1, 1, true},
+            " ",
+            {"The indicator covers the entire resource bar and appears automatically when your buff reaches its maximum stack count.", 1, 1, 1, true},
+            " ",
+            {"The Pulsing Overlay style is only available for continuous display mode.", 1, 1, 1, true},
+        }, glowCb)
+
     end
 
     if not renderedControls then
@@ -4010,9 +4042,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
 
                     local showDuration = showDurationControls and cab.showDurationText == true
                     local showStack = (stackVal == true)
-                    local durationAdvExpanded = showDurationControls
-                        and AddAdvancedToggle(durationTextCb, "rbCabDurationText_" .. capturedKey, rbCabTextAdvBtns, showDuration)
-                    if showDurationControls and durationAdvExpanded and showDuration then
+                    local function BuildDurationTextAdvanced(panel)
                         local fontDrop = AceGUI:Create("Dropdown")
                         fontDrop:SetLabel("Duration Font")
                         CS.SetupFontDropdown(fontDrop)
@@ -4022,7 +4052,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             customBars[cabIdx].durationTextFont = val
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(fontDrop)
+                        panel:AddChild(fontDrop)
 
                         local sizeDrop = AceGUI:Create("Slider")
                         sizeDrop:SetLabel("Duration Font Size")
@@ -4033,7 +4063,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             customBars[cabIdx].durationTextFontSize = val
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(sizeDrop)
+                        panel:AddChild(sizeDrop)
 
                         local outlineDrop = AceGUI:Create("Dropdown")
                         outlineDrop:SetLabel("Duration Outline")
@@ -4044,15 +4074,20 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             customBars[cabIdx].durationTextFontOutline = val
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(outlineDrop)
+                        panel:AddChild(outlineDrop)
 
-                        AddColorPicker(container, customBars[cabIdx], "durationTextFontColor", "Duration Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
+                        AddColorPicker(panel, customBars[cabIdx], "durationTextFontColor", "Duration Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
 
-                        AddDurationFormatDropdown(container, customBars[cabIdx], cabApplyBars)
+                        AddDurationFormatDropdown(panel, customBars[cabIdx], cabApplyBars)
                     end
 
-                    local stackAdvExpanded = AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack)
-                    if stackAdvExpanded and showStack then
+                    local durationAdvExpanded = showDurationControls
+                        and AddAdvancedToggle(durationTextCb, "rbCabDurationText_" .. capturedKey, rbCabTextAdvBtns, showDuration, {
+                            title = "Duration Text Advanced",
+                            build = BuildDurationTextAdvanced,
+                        })
+
+                    local function BuildStackTextAdvanced(panel)
                         if not isActive then
                             local stackTextFormatDrop = AceGUI:Create("Dropdown")
                             stackTextFormatDrop:SetLabel("Text Format")
@@ -4076,7 +4111,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                                 end
                                 CooldownCompanion:ApplyResourceBars()
                             end)
-                            container:AddChild(stackTextFormatDrop)
+                            panel:AddChild(stackTextFormatDrop)
                         end
 
                         local fontDrop = AceGUI:Create("Dropdown")
@@ -4089,7 +4124,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             customBars[cabIdx].stackTextFont = val
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(fontDrop)
+                        panel:AddChild(fontDrop)
 
                         local sizeDrop = AceGUI:Create("Slider")
                         local stackSizeLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font Size" or "Charge Font Size") or "Stack Font Size"
@@ -4101,7 +4136,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             customBars[cabIdx].stackTextFontSize = val
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(sizeDrop)
+                        panel:AddChild(sizeDrop)
 
                         local outlineDrop = AceGUI:Create("Dropdown")
                         local stackOutlineLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Outline" or "Charge Outline") or "Stack Outline"
@@ -4113,10 +4148,15 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             customBars[cabIdx].stackTextFontOutline = val
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(outlineDrop)
+                        panel:AddChild(outlineDrop)
 
-                        AddColorPicker(container, customBars[cabIdx], "stackTextFontColor", "Stack Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
+                        AddColorPicker(panel, customBars[cabIdx], "stackTextFontColor", "Stack Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
                     end
+
+                    local stackAdvExpanded = AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack, {
+                        title = stackTextLabel .. " Advanced",
+                        build = BuildStackTextAdvanced,
+                    })
                 end
 
                 if not isSpellCustomBar or cab.auraTracking == true then

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -30,6 +30,7 @@ local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
 local BuildBarAuraPulseControls = ST._BuildBarAuraPulseControls
 local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
+local AddPreviewBadge = ST._AddPreviewBadge
 local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
@@ -3617,21 +3618,18 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 hidePrimaryColorPicker = not isSpellCustomBar,
             })
             BuildBarAuraPulseControls(panel, customBars[cabIdx], cabApplyBars)
-
-            if AddPreviewToggleButton then
-                AddPreviewToggleButton(panel, "Preview Active Aura Effects", function()
-                    return CooldownCompanion:IsCustomAuraBarActivePreviewActive(customBars[cabIdx])
-                end, function(show)
-                    CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], show)
-                end)
-            end
         end
 
-        local activeAuraAdvExpanded = AddAdvancedToggle(activeAuraCb, "rbCabActiveAura_" .. capturedKey, infoButtons, activeAuraEnabled, {
+        local _, activeAuraAdvBtn = AddAdvancedToggle(activeAuraCb, "rbCabActiveAura_" .. capturedKey, infoButtons, activeAuraEnabled, {
             title = "Active Aura Indicator Advanced",
             build = BuildCustomBarActiveAuraAdvanced,
         })
-        if not (activeAuraAdvExpanded and activeAuraEnabled) then
+        AddPreviewBadge(activeAuraCb, activeAuraAdvBtn, "Preview Active Aura Effects", function()
+            return CooldownCompanion:IsCustomAuraBarActivePreviewActive(customBars[cabIdx])
+        end, function(show)
+            CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], show)
+        end, activeAuraEnabled)
+        if not activeAuraEnabled then
             CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], false)
         end
 
@@ -3662,21 +3660,18 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
 
                 BuildPandemicBarControls(panel, customBars[cabIdx], cabApplyBars)
                 BuildPandemicBarPulseControls(panel, customBars[cabIdx], cabApplyBars)
-
-                if AddPreviewToggleButton then
-                    AddPreviewToggleButton(panel, "Preview Pandemic Effects", function()
-                        return CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(customBars[cabIdx])
-                    end, function(show)
-                        CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], show)
-                    end)
-                end
             end
 
-            local pandemicAdvExpanded = AddAdvancedToggle(pandemicCb, "rbCabPandemic_" .. capturedKey, infoButtons, pandemicEnabled, {
+            local _, pandemicAdvBtn = AddAdvancedToggle(pandemicCb, "rbCabPandemic_" .. capturedKey, infoButtons, pandemicEnabled, {
                 title = "Pandemic Indicator Advanced",
                 build = BuildCustomBarPandemicAdvanced,
             })
-            if not (pandemicAdvExpanded and pandemicEnabled) then
+            AddPreviewBadge(pandemicCb, pandemicAdvBtn, "Preview Pandemic Effects", function()
+                return CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(customBars[cabIdx])
+            end, function(show)
+                CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], show)
+            end, pandemicEnabled)
+            if not pandemicEnabled then
                 CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
             end
         else
@@ -3791,30 +3786,27 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 end)
                 panel:AddChild(speedSlider)
             end
-
-            if AddPreviewToggleButton then
-                AddPreviewToggleButton(panel, "Preview Indicator", function()
-                    return CS.customBarIndicatorPreviewActive == true and CooldownCompanion:IsResourceBarPreviewActive()
-                end, function(show)
-                    CS.customBarIndicatorPreviewActive = show and true or nil
-                    if show then
-                        CooldownCompanion:StartResourceBarPreview()
-                    else
-                        CooldownCompanion:StopResourceBarPreview()
-                    end
-                end)
-            end
         end
 
-        local glowAdvExpanded, glowAdvBtn = AddAdvancedToggle(glowCb, "rbCabMaxStacksIndicator_" .. capturedKey, infoButtons, cab.maxStacksGlowEnabled == true, {
+        local _, glowAdvBtn = AddAdvancedToggle(glowCb, "rbCabMaxStacksIndicator_" .. capturedKey, infoButtons, cab.maxStacksGlowEnabled == true, {
             title = "Max Stack Indicator Advanced",
             build = BuildMaxStackIndicatorAdvanced,
         })
-        if not glowAdvExpanded and CS.customBarIndicatorPreviewActive and CooldownCompanion:IsResourceBarPreviewActive() then
+        local glowPreviewBtn = AddPreviewBadge(glowCb, glowAdvBtn, "Preview Indicator", function()
+            return CS.customBarIndicatorPreviewActive == true and CooldownCompanion:IsResourceBarPreviewActive()
+        end, function(show)
+            CS.customBarIndicatorPreviewActive = show and true or nil
+            if show then
+                CooldownCompanion:StartResourceBarPreview()
+            else
+                CooldownCompanion:StopResourceBarPreview()
+            end
+        end, cab.maxStacksGlowEnabled == true)
+        if cab.maxStacksGlowEnabled ~= true and CS.customBarIndicatorPreviewActive and CooldownCompanion:IsResourceBarPreviewActive() then
             CooldownCompanion:StopResourceBarPreview()
         end
 
-        CreateInfoButton(glowCb.frame, glowAdvBtn, "LEFT", "RIGHT", 4, 0, {
+        CreateInfoButton(glowCb.frame, glowPreviewBtn or glowAdvBtn, "LEFT", "RIGHT", 4, 0, {
             "Max Stack Indicator",
             {"Due to combat restrictions, individual bar segments cannot be highlighted independently.", 1, 1, 1, true},
             " ",

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -1867,7 +1867,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                     end)
                     container:AddChild(tickEnableCb)
 
-                    if _tickEnabled then
+                    local function BuildTickMarkerAdvanced(panel)
                         local tickCombatCb = AceGUI:Create("CheckBox")
                         tickCombatCb:SetLabel("Show Only In Combat")
                         tickCombatCb:SetValue(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickCombatOnly", false))
@@ -1876,11 +1876,8 @@ local function BuildResourceBarStylingPanel(container, sectionMode)
                             WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickCombatOnly", val == true)
                             CooldownCompanion:ApplyResourceBars()
                         end)
-                        container:AddChild(tickCombatCb)
-                        ApplyCheckboxIndent(tickCombatCb, 20)
-                    end
+                        panel:AddChild(tickCombatCb)
 
-                    local function BuildTickMarkerAdvanced(panel)
                         local _tickModeRes = { continuousTickMode = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickMode", nil) }
                         local tickMode = GetContinuousTickModeConfig(_tickModeRes)
                         local modeDrop = AceGUI:Create("Dropdown")

--- a/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -834,117 +834,120 @@ local function AddResourceAuraOverrideControls(container, settings, powerType, r
         if not settings.resources[powerType] then settings.resources[powerType] = {} end
         WriteSpecOverrideKey(settings, powerType, currentSpecID, "auraOverlayEnabled", val == true)
 
-        if val then
-            if type(CooldownCompanion.db.profile.showAdvanced) ~= "table" then
-                CooldownCompanion.db.profile.showAdvanced = {}
-            end
-            CooldownCompanion.db.profile.showAdvanced[auraAdvKey] = true
+        if val and CS.QueueAdvancedSettingsPanelOpen then
+            CS.QueueAdvancedSettingsPanelOpen(auraAdvKey)
         end
         CooldownCompanion:ApplyResourceBars()
         C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
     end)
     container:AddChild(enableAuraOverlayCb)
 
+    local function BuildResourceAuraOverlayAdvanced(panel)
+        local entryForSpec = GetResourceAuraEntryConfig(res, currentSpecID)
+
+        AddResourceAuraEntryFields(panel, powerType, resourceName, entryForSpec, {
+            onSpellChanged = function(id)
+                local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+                if not entry then
+                    return
+                end
+                entry.auraColorSpellID = id
+                if RefreshResourceAuraUnitForSpell then
+                    RefreshResourceAuraUnitForSpell(entry, id)
+                end
+                ClearLegacyResourceAuraFieldsConfig(res)
+                CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+            onAuraUnitChanged = function(val)
+                local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+                if not entry then
+                    return
+                end
+                if EnsureResourceAuraUnit then
+                    EnsureResourceAuraUnit(entry, entry.auraColorSpellID, val, true)
+                else
+                    entry.auraUnit = val
+                    entry.auraUnitExplicit = true
+                end
+                ClearLegacyResourceAuraFieldsConfig(res)
+                CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+            onColorChanged = function(r, g, b)
+                local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+                if not entry then
+                    return
+                end
+                entry.auraActiveColor = { r, g, b }
+            end,
+            onColorConfirmed = function(r, g, b)
+                local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+                if not entry then
+                    return
+                end
+                entry.auraActiveColor = { r, g, b }
+                ClearLegacyResourceAuraFieldsConfig(res)
+                CooldownCompanion:ApplyResourceBars()
+            end,
+            onTrackingChanged = function(val)
+                local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+                if not entry then
+                    return
+                end
+                entry.auraColorTrackingMode = val
+                if val == "stacks" then
+                    local current = tonumber(entry.auraColorMaxStacks)
+                    if not current or current < 2 then
+                        entry.auraColorMaxStacks = 2
+                    end
+                end
+                ClearLegacyResourceAuraFieldsConfig(res)
+                CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+            onMaxStacksChanged = function(parsed)
+                local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
+                if not entry then
+                    return
+                end
+                entry.auraColorMaxStacks = parsed
+                ClearLegacyResourceAuraFieldsConfig(res)
+                CooldownCompanion:ApplyResourceBars()
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
+
+        -- Clear Overlay button (only if entry exists)
+        if type(entryForSpec) == "table" then
+            local clearSpacer = AceGUI:Create("Label")
+            clearSpacer:SetText(" ")
+            clearSpacer:SetFullWidth(true)
+            panel:AddChild(clearSpacer)
+
+            local clearBtn = AceGUI:Create("Button")
+            clearBtn:SetText("Clear Overlay")
+            clearBtn:SetFullWidth(true)
+            clearBtn:SetCallback("OnClick", function()
+                ClearResourceAuraEntryConfig(powerType, res, currentSpecID)
+            end)
+            panel:AddChild(clearBtn)
+        end
+    end
+
     local auraAdvExpanded = AddAdvancedToggle(
         enableAuraOverlayCb,
         auraAdvKey,
         auraAdvButtons or tabInfoButtons,
-        auraOverlayEnabled
+        auraOverlayEnabled,
+        {
+            title = resourceName .. " Aura Overlay Advanced",
+            build = BuildResourceAuraOverlayAdvanced,
+        }
     )
 
     if not auraOverlayEnabled or not auraAdvExpanded then
         return
-    end
-
-    local entryForSpec = GetResourceAuraEntryConfig(res, currentSpecID)
-
-    AddResourceAuraEntryFields(container, powerType, resourceName, entryForSpec, {
-        onSpellChanged = function(id)
-            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
-            if not entry then
-                return
-            end
-            entry.auraColorSpellID = id
-            if RefreshResourceAuraUnitForSpell then
-                RefreshResourceAuraUnitForSpell(entry, id)
-            end
-            ClearLegacyResourceAuraFieldsConfig(res)
-            CooldownCompanion:ApplyResourceBars()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
-        onAuraUnitChanged = function(val)
-            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
-            if not entry then
-                return
-            end
-            if EnsureResourceAuraUnit then
-                EnsureResourceAuraUnit(entry, entry.auraColorSpellID, val, true)
-            else
-                entry.auraUnit = val
-                entry.auraUnitExplicit = true
-            end
-            ClearLegacyResourceAuraFieldsConfig(res)
-            CooldownCompanion:ApplyResourceBars()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
-        onColorChanged = function(r, g, b)
-            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
-            if not entry then
-                return
-            end
-            entry.auraActiveColor = { r, g, b }
-        end,
-        onColorConfirmed = function(r, g, b)
-            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
-            if not entry then
-                return
-            end
-            entry.auraActiveColor = { r, g, b }
-            ClearLegacyResourceAuraFieldsConfig(res)
-            CooldownCompanion:ApplyResourceBars()
-        end,
-        onTrackingChanged = function(val)
-            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
-            if not entry then
-                return
-            end
-            entry.auraColorTrackingMode = val
-            if val == "stacks" then
-                local current = tonumber(entry.auraColorMaxStacks)
-                if not current or current < 2 then
-                    entry.auraColorMaxStacks = 2
-                end
-            end
-            ClearLegacyResourceAuraFieldsConfig(res)
-            CooldownCompanion:ApplyResourceBars()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
-        onMaxStacksChanged = function(parsed)
-            local entry = GetOrCreateResourceAuraEntryConfig(res, currentSpecID)
-            if not entry then
-                return
-            end
-            entry.auraColorMaxStacks = parsed
-            ClearLegacyResourceAuraFieldsConfig(res)
-            CooldownCompanion:ApplyResourceBars()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
-    })
-
-    -- Clear Overlay button (only if entry exists)
-    if type(entryForSpec) == "table" then
-        local clearSpacer = AceGUI:Create("Label")
-        clearSpacer:SetText(" ")
-        clearSpacer:SetFullWidth(true)
-        container:AddChild(clearSpacer)
-
-        local clearBtn = AceGUI:Create("Button")
-        clearBtn:SetText("Clear Overlay")
-        clearBtn:SetFullWidth(true)
-        clearBtn:SetCallback("OnClick", function()
-            ClearResourceAuraEntryConfig(powerType, res, currentSpecID)
-        end)
-        container:AddChild(clearBtn)
     end
 end
 

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -418,6 +418,8 @@ local function IsIconFillTimerEnabled(styleTable, opts)
     return opts and opts.fallbackStyle and opts.fallbackStyle.iconFillEnabled == true
 end
 
+local BuildIconFillTimerAdvancedControls
+
 local function BuildCooldownSwipeControls(container, styleTable, refreshCallback, opts)
     opts = opts or {}
     local disabledByIconFill = IsIconFillTimerEnabled(styleTable, opts)
@@ -511,6 +513,9 @@ local function BuildIconFillTimerControls(container, styleTable, refreshCallback
     cb:SetCallback("OnValueChanged", function(widget, event, val)
         if disabledByMasque then return end
         styleTable.iconFillEnabled = val == true
+        if styleTable.iconFillEnabled and type(opts.onEnabled) == "function" then
+            opts.onEnabled()
+        end
         refreshCallback()
         CooldownCompanion:UpdateAllCooldowns()
         CooldownCompanion:RefreshConfigPanel()
@@ -526,67 +531,75 @@ local function BuildIconFillTimerControls(container, styleTable, refreshCallback
         return cb
     end
 
-    if styleTable.iconFillEnabled == true then
-        local iconFillOrientation = styleTable.iconFillOrientation == "horizontal" and "horizontal" or "vertical"
-
-        local orientationDrop = AceGUI:Create("Dropdown")
-        orientationDrop:SetLabel("Orientation")
-        orientationDrop:SetList({
-            vertical = "Vertical",
-            horizontal = "Horizontal",
-        }, { "vertical", "horizontal" })
-        orientationDrop:SetValue(iconFillOrientation)
-        orientationDrop:SetFullWidth(true)
-        orientationDrop:SetCallback("OnValueChanged", function(widget, event, val)
-            styleTable.iconFillOrientation = val == "vertical" and "vertical" or "horizontal"
-            refreshCallback()
-            CooldownCompanion:UpdateAllCooldowns()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        container:AddChild(orientationDrop)
-
-        local anchorEdgeDrop = AceGUI:Create("Dropdown")
-        anchorEdgeDrop:SetLabel("Anchor Edge")
-        if iconFillOrientation == "vertical" then
-            anchorEdgeDrop:SetList({
-                default = "Bottom",
-                reverse = "Top",
-            }, { "default", "reverse" })
-        else
-            anchorEdgeDrop:SetList({
-                default = "Left",
-                reverse = "Right",
-            }, { "default", "reverse" })
-        end
-        anchorEdgeDrop:SetValue(styleTable.iconFillReverse == true and "reverse" or "default")
-        anchorEdgeDrop:SetFullWidth(true)
-        anchorEdgeDrop:SetCallback("OnValueChanged", function(widget, event, val)
-            styleTable.iconFillReverse = val == "reverse"
-            refreshCallback()
-            CooldownCompanion:UpdateAllCooldowns()
-        end)
-        container:AddChild(anchorEdgeDrop)
-
-        local timerMotionDrop = AceGUI:Create("Dropdown")
-        timerMotionDrop:SetLabel("Timer Motion")
-        timerMotionDrop:SetList({
-            drain = "Starts Full (Drain)",
-            fill = "Starts Empty (Fill)",
-        }, { "drain", "fill" })
-        timerMotionDrop:SetValue(styleTable.iconFillTimerBehavior == "fill" and "fill" or "drain")
-        timerMotionDrop:SetFullWidth(true)
-        timerMotionDrop:SetCallback("OnValueChanged", function(widget, event, val)
-            styleTable.iconFillTimerBehavior = val == "drain" and "drain" or "fill"
-            refreshCallback()
-            CooldownCompanion:UpdateAllCooldowns()
-        end)
-        container:AddChild(timerMotionDrop)
-
-        AddColorPicker(container, styleTable, "iconFillCooldownColor", "Cooldown Fill Color", {0.6, 0.13, 0.18, 0.55}, true, refreshCallback, refreshCallback)
-        AddColorPicker(container, styleTable, "iconFillAuraColor", "Aura Fill Color", {0.2, 1.0, 0.2, 0.55}, true, refreshCallback, refreshCallback)
+    if opts.showAdvancedControlsInline ~= false then
+        BuildIconFillTimerAdvancedControls(container, styleTable, refreshCallback)
     end
 
     return cb
+end
+
+BuildIconFillTimerAdvancedControls = function(container, styleTable, refreshCallback)
+    if styleTable.iconFillEnabled ~= true then
+        return
+    end
+
+    local iconFillOrientation = styleTable.iconFillOrientation == "horizontal" and "horizontal" or "vertical"
+
+    local orientationDrop = AceGUI:Create("Dropdown")
+    orientationDrop:SetLabel("Orientation")
+    orientationDrop:SetList({
+        vertical = "Vertical",
+        horizontal = "Horizontal",
+    }, { "vertical", "horizontal" })
+    orientationDrop:SetValue(iconFillOrientation)
+    orientationDrop:SetFullWidth(true)
+    orientationDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        styleTable.iconFillOrientation = val == "vertical" and "vertical" or "horizontal"
+        refreshCallback()
+        CooldownCompanion:UpdateAllCooldowns()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(orientationDrop)
+
+    local anchorEdgeDrop = AceGUI:Create("Dropdown")
+    anchorEdgeDrop:SetLabel("Anchor Edge")
+    if iconFillOrientation == "vertical" then
+        anchorEdgeDrop:SetList({
+            default = "Bottom",
+            reverse = "Top",
+        }, { "default", "reverse" })
+    else
+        anchorEdgeDrop:SetList({
+            default = "Left",
+            reverse = "Right",
+        }, { "default", "reverse" })
+    end
+    anchorEdgeDrop:SetValue(styleTable.iconFillReverse == true and "reverse" or "default")
+    anchorEdgeDrop:SetFullWidth(true)
+    anchorEdgeDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        styleTable.iconFillReverse = val == "reverse"
+        refreshCallback()
+        CooldownCompanion:UpdateAllCooldowns()
+    end)
+    container:AddChild(anchorEdgeDrop)
+
+    local timerMotionDrop = AceGUI:Create("Dropdown")
+    timerMotionDrop:SetLabel("Timer Motion")
+    timerMotionDrop:SetList({
+        drain = "Starts Full (Drain)",
+        fill = "Starts Empty (Fill)",
+    }, { "drain", "fill" })
+    timerMotionDrop:SetValue(styleTable.iconFillTimerBehavior == "fill" and "fill" or "drain")
+    timerMotionDrop:SetFullWidth(true)
+    timerMotionDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        styleTable.iconFillTimerBehavior = val == "drain" and "drain" or "fill"
+        refreshCallback()
+        CooldownCompanion:UpdateAllCooldowns()
+    end)
+    container:AddChild(timerMotionDrop)
+
+    AddColorPicker(container, styleTable, "iconFillCooldownColor", "Cooldown Fill Color", {0.6, 0.13, 0.18, 0.55}, true, refreshCallback, refreshCallback)
+    AddColorPicker(container, styleTable, "iconFillAuraColor", "Aura Fill Color", {0.2, 1.0, 0.2, 0.55}, true, refreshCallback, refreshCallback)
 end
 
 local function BuildAuraDurationSwipeControls(container, styleTable, refreshCallback, opts)
@@ -1332,6 +1345,7 @@ ST._BuildShowOutOfRangeControls = BuildShowOutOfRangeControls
 ST._BuildShowGCDSwipeControls = BuildShowGCDSwipeControls
 ST._BuildCooldownSwipeControls = BuildCooldownSwipeControls
 ST._BuildIconFillTimerControls = BuildIconFillTimerControls
+ST._BuildIconFillTimerAdvancedControls = BuildIconFillTimerAdvancedControls
 ST._BuildAuraDurationSwipeControls = BuildAuraDurationSwipeControls
 ST._BuildLossOfControlControls = BuildLossOfControlControls
 ST._BuildUnusableDimmingControls = BuildUnusableDimmingControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -55,6 +55,12 @@ local function RefreshConfigPanelForPreviewToggle()
     return true
 end
 
+local function ApplyOverrideCheckboxIndent(checkbox, opts)
+    if opts and opts.isOverride then
+        ApplyCheckboxIndent(checkbox, 20)
+    end
+end
+
 local function AddDurationFormatDropdown(container, settings, refreshCallback, opts)
     if not (container and settings and CooldownCompanion.GetDurationFormatOptions) then
         return nil
@@ -439,7 +445,7 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         refreshCallback()
     end)
     container:AddChild(reverseCb)
-    ApplyCheckboxIndent(reverseCb, 20)
+    ApplyOverrideCheckboxIndent(reverseCb, opts)
 
     local fillCb = AceGUI:Create("CheckBox")
     fillCb:SetLabel("Show Swipe Fill")
@@ -453,7 +459,7 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(fillCb)
-    ApplyCheckboxIndent(fillCb, 20)
+    ApplyOverrideCheckboxIndent(fillCb, opts)
 
     -- Swipe Fill Opacity (only when fill is visible)
     if styleTable.showCooldownSwipeFill ~= false then
@@ -484,7 +490,7 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(edgeCb)
-    ApplyCheckboxIndent(edgeCb, 20)
+    ApplyOverrideCheckboxIndent(edgeCb, opts)
 
     -- Swipe Edge Color (only when edge is visible)
     if styleTable.showCooldownSwipeEdge ~= false then
@@ -637,9 +643,7 @@ local function BuildAssistedHighlightControls(container, styleTable, refreshCall
         refreshCallback()
     end)
     container:AddChild(hostileOnlyCb)
-    if not (opts and opts.isOverride) then
-        ApplyCheckboxIndent(hostileOnlyCb, 20)
-    end
+    ApplyOverrideCheckboxIndent(hostileOnlyCb, opts)
 
     local highlightStyles = {
         blizzard = "Blizzard (Marching Ants)",

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -59,6 +59,8 @@ local function IsAdvancedSettingsPanelContainer(container)
     return container and container._isAdvancedSettingsPanel == true
 end
 
+local ClearActivePreviewBadgeButton
+
 local function RefreshStructuralControls(container)
     if IsAdvancedSettingsPanelContainer(container) and CS.RefreshAdvancedSettingsPanel then
         CS.RefreshAdvancedSettingsPanel()
@@ -78,6 +80,10 @@ local function RefreshPreviewToggleButtons(container)
             previewBtn:SetText(previewBtn._isActiveFn() and "Preview: ON" or previewBtn._offLabel)
         end
     end
+end
+
+local function RefreshActiveAdvancedPreviewToggleButtons()
+    RefreshPreviewToggleButtons({ _previewToggleButtons = CS.advancedSettingsPreviewToggleButtons })
 end
 
 local function ApplyOverrideCheckboxIndent(checkbox, opts)
@@ -118,6 +124,7 @@ local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActive
     btn:SetFullWidth(true)
     if IsAdvancedSettingsPanelContainer(container) then
         container._previewToggleButtons = container._previewToggleButtons or {}
+        CS.advancedSettingsPreviewToggleButtons = container._previewToggleButtons
         btn._isActiveFn = isActiveFn
         btn._offLabel = offLabel
         table.insert(container._previewToggleButtons, btn)
@@ -126,6 +133,8 @@ local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActive
         local showPreview = not isActiveFn()
         if showPreview and CooldownCompanion.ClearAllConfigPreviews then
             CooldownCompanion:ClearAllConfigPreviews()
+        elseif not showPreview and ClearActivePreviewBadgeButton then
+            ClearActivePreviewBadgeButton()
         end
         setActiveFn(showPreview)
         if IsAdvancedSettingsPanelContainer(container) then
@@ -165,6 +174,14 @@ local function SetPreviewBadgeActive(btn, active)
     end
 end
 
+function ClearActivePreviewBadgeButton()
+    local btn = CS.activePreviewBadgeButton
+    if btn then
+        SetPreviewBadgeActive(btn, false)
+    end
+    CS.activePreviewBadgeButton = nil
+end
+
 local function SetActivePreviewBadgeButton(btn, active)
     SetPreviewBadgeActive(btn, active)
 
@@ -180,8 +197,10 @@ local function SetActivePreviewBadgeButton(btn, active)
 end
 
 local function AddPreviewBadge(parentWidget, anchorAfterFrame, label, isActiveFn, setActiveFn, enabled)
+    local hasCheckboxAnchor = parentWidget and parentWidget.frame and parentWidget.checkbg and parentWidget.text
+    local hasLabelAnchor = parentWidget and parentWidget.frame and parentWidget.label
     if not enabled
-        or not (parentWidget and parentWidget.frame and parentWidget.checkbg and parentWidget.text)
+        or not (hasCheckboxAnchor or hasLabelAnchor)
         or type(isActiveFn) ~= "function"
         or type(setActiveFn) ~= "function"
     then
@@ -204,8 +223,10 @@ local function AddPreviewBadge(parentWidget, anchorAfterFrame, label, isActiveFn
     btn:ClearAllPoints()
     if anchorAfterFrame and anchorAfterFrame:IsShown() then
         btn:SetPoint("LEFT", anchorAfterFrame, "RIGHT", 4, 0)
-    else
+    elseif hasCheckboxAnchor then
         btn:SetPoint("LEFT", parentWidget.checkbg, "RIGHT", parentWidget.text:GetStringWidth() + 6, 0)
+    else
+        btn:SetPoint("LEFT", parentWidget.label, "RIGHT", 4, 0)
     end
     btn:Show()
     btn._icon:Show()
@@ -218,6 +239,7 @@ local function AddPreviewBadge(parentWidget, anchorAfterFrame, label, isActiveFn
         end
         setActiveFn(showPreview)
         SetActivePreviewBadgeButton(btn, isActiveFn())
+        RefreshActiveAdvancedPreviewToggleButtons()
     end)
     btn:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
@@ -1165,7 +1187,14 @@ local function BuildBarEffectControls(container, styleTable, refreshCallback, cf
     effectDrop:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable[cfg.effectKey] = val
         refreshCallback()
-        RefreshStructuralControls(container)
+        if val == "none" and IsAdvancedSettingsPanelContainer(container) and CS.CloseAdvancedSettingsPanel then
+            CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
+            if CooldownCompanion.RefreshConfigPanel then
+                CooldownCompanion:RefreshConfigPanel()
+            end
+        else
+            RefreshStructuralControls(container)
+        end
     end)
     container:AddChild(effectDrop)
 
@@ -1504,6 +1533,8 @@ ST._AddDurationFormatDropdown = AddDurationFormatDropdown
 ST._AddPreviewToggleButton = AddPreviewToggleButton
 ST._AddPreviewBadge = AddPreviewBadge
 ST._RefreshConfigPanelForPreviewToggle = RefreshConfigPanelForPreviewToggle
+ST._ClearActivePreviewBadgeButton = ClearActivePreviewBadgeButton
+ST._RefreshAdvancedSettingsPreviewButtons = RefreshActiveAdvancedPreviewToggleButtons
 ST._AddConditionalPreviewButton = AddConditionalPreviewButton
 ST._AddConditionalPreviewBadge = AddConditionalPreviewBadge
 ST._BuildAuraTextControls = BuildAuraTextControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -55,6 +55,31 @@ local function RefreshConfigPanelForPreviewToggle()
     return true
 end
 
+local function IsAdvancedSettingsPanelContainer(container)
+    return container and container._isAdvancedSettingsPanel == true
+end
+
+local function RefreshStructuralControls(container)
+    if IsAdvancedSettingsPanelContainer(container) and CS.RefreshAdvancedSettingsPanel then
+        CS.RefreshAdvancedSettingsPanel()
+    elseif CooldownCompanion.RefreshConfigPanel then
+        CooldownCompanion:RefreshConfigPanel()
+    end
+end
+
+local function RefreshPreviewToggleButtons(container)
+    local buttons = container and container._previewToggleButtons
+    if type(buttons) ~= "table" then
+        return
+    end
+
+    for _, previewBtn in ipairs(buttons) do
+        if previewBtn and previewBtn._isActiveFn and previewBtn._offLabel then
+            previewBtn:SetText(previewBtn._isActiveFn() and "Preview: ON" or previewBtn._offLabel)
+        end
+    end
+end
+
 local function ApplyOverrideCheckboxIndent(checkbox, opts)
     if opts and opts.isOverride then
         ApplyCheckboxIndent(checkbox, 20)
@@ -91,13 +116,21 @@ local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActive
     local btn = AceGUI:Create("Button")
     btn:SetText(isActiveFn() and "Preview: ON" or offLabel)
     btn:SetFullWidth(true)
+    if IsAdvancedSettingsPanelContainer(container) then
+        container._previewToggleButtons = container._previewToggleButtons or {}
+        btn._isActiveFn = isActiveFn
+        btn._offLabel = offLabel
+        table.insert(container._previewToggleButtons, btn)
+    end
     btn:SetCallback("OnClick", function()
         local showPreview = not isActiveFn()
         if showPreview and CooldownCompanion.ClearAllConfigPreviews then
             CooldownCompanion:ClearAllConfigPreviews()
         end
         setActiveFn(showPreview)
-        if not RefreshConfigPanelForPreviewToggle() then
+        if IsAdvancedSettingsPanelContainer(container) then
+            RefreshPreviewToggleButtons(container)
+        elseif not RefreshConfigPanelForPreviewToggle() then
             btn:SetText(isActiveFn() and "Preview: ON" or offLabel)
         end
     end)
@@ -295,7 +328,7 @@ local function BuildCooldownTextControls(container, styleTable, refreshCallback,
     cdTextCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showCooldownText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(cdTextCb)
 
@@ -328,7 +361,7 @@ local function BuildAuraTextControls(container, styleTable, refreshCallback)
     auraTextCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showAuraText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(auraTextCb)
 
@@ -349,7 +382,7 @@ local function BuildAuraTextControls(container, styleTable, refreshCallback)
         sepPosCb:SetCallback("OnValueChanged", function(widget, event, val)
             styleTable.separateTextPositions = val
             refreshCallback()
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshStructuralControls(container)
         end)
         container:AddChild(sepPosCb)
 
@@ -373,7 +406,7 @@ local function BuildAuraStackTextControls(container, styleTable, refreshCallback
     auraStackCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showAuraStackText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(auraStackCb)
 
@@ -393,7 +426,7 @@ local function BuildKeybindTextControls(container, styleTable, refreshCallback)
     kbCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showKeybindText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(kbCb)
 
@@ -415,7 +448,7 @@ local function BuildChargeTextControls(container, styleTable, refreshCallback)
     chargeTextCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showChargeText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(chargeTextCb)
 
@@ -432,7 +465,7 @@ end
 local function BuildBorderControls(container, styleTable, refreshCallback)
     local renderMode = AddBorderRenderModeDropdown(container, styleTable, "borderRenderMode", function()
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     local borderThicknessLocked = ST.IsBorderThicknessLocked()
 
@@ -506,7 +539,7 @@ local function BuildIconTintControls(container, styleTable, refreshCallback)
     cdTintCb:SetCallback("OnValueChanged", function(w, e, val)
         styleTable.iconCooldownTintEnabled = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(cdTintCb)
 
@@ -521,7 +554,7 @@ local function BuildIconTintControls(container, styleTable, refreshCallback)
     auraTintCb:SetCallback("OnValueChanged", function(w, e, val)
         styleTable.iconAuraTintEnabled = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(auraTintCb)
 
@@ -596,7 +629,7 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         if disabledByIconFill then return end
         styleTable.showCooldownSwipeFill = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(fillCb)
     ApplyOverrideCheckboxIndent(fillCb, opts)
@@ -627,7 +660,7 @@ local function BuildCooldownSwipeControls(container, styleTable, refreshCallback
         if disabledByIconFill then return end
         styleTable.showCooldownSwipeEdge = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(edgeCb)
     ApplyOverrideCheckboxIndent(edgeCb, opts)
@@ -695,7 +728,7 @@ BuildIconFillTimerAdvancedControls = function(container, styleTable, refreshCall
         styleTable.iconFillOrientation = val == "vertical" and "vertical" or "horizontal"
         refreshCallback()
         CooldownCompanion:UpdateAllCooldowns()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(orientationDrop)
 
@@ -809,7 +842,7 @@ local function BuildAssistedHighlightControls(container, styleTable, refreshCall
     styleDrop:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.assistedHighlightStyle = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(styleDrop)
 
@@ -1023,7 +1056,7 @@ local function BuildGlowStyleControls(container, styleTable, refreshCallback, cf
                 styleTable[cfg.styleKey] = val and cfg.defaultStyle or "none"
             end
             refreshCallback()
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshStructuralControls(container)
         end)
         container:AddChild(enableCb)
 
@@ -1061,7 +1094,7 @@ local function BuildGlowStyleControls(container, styleTable, refreshCallback, cf
         end
         styleTable[cfg.styleKey] = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(styleDrop)
 
@@ -1103,7 +1136,7 @@ local function BuildBarEffectControls(container, styleTable, refreshCallback, cf
         enableCb:SetCallback("OnValueChanged", function(widget, event, val)
             styleTable[cfg.enableKey] = val
             refreshCallback()
-            CooldownCompanion:RefreshConfigPanel()
+            RefreshStructuralControls(container)
         end)
         container:AddChild(enableCb)
 
@@ -1132,7 +1165,7 @@ local function BuildBarEffectControls(container, styleTable, refreshCallback, cf
     effectDrop:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable[cfg.effectKey] = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(effectDrop)
 
@@ -1255,7 +1288,7 @@ local function BuildBarPulseControls(container, styleTable, refreshCallback, cfg
     pulseCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable[cfg.pulseKey] = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(pulseCb)
 
@@ -1280,7 +1313,7 @@ local function BuildBarPulseControls(container, styleTable, refreshCallback, cfg
     shiftCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable[cfg.colorShiftKey] = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(shiftCb)
 
@@ -1331,7 +1364,7 @@ local function BuildBarNameTextControls(container, styleTable, refreshCallback)
     showNameCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showBarNameText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(showNameCb)
 
@@ -1359,7 +1392,7 @@ local function BuildBarReadyTextControls(container, styleTable, refreshCallback)
     showReadyCb:SetCallback("OnValueChanged", function(widget, event, val)
         styleTable.showBarReadyText = val
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(showReadyCb)
 
@@ -1388,7 +1421,7 @@ local function BuildTextBackgroundControls(container, styleTable, refreshCallbac
 
     local renderMode = AddBorderRenderModeDropdown(container, styleTable, "textBorderRenderMode", function()
         refreshCallback()
-        CooldownCompanion:RefreshConfigPanel()
+        RefreshStructuralControls(container)
     end)
     local borderThicknessLocked = ST.IsBorderThicknessLocked()
 

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -105,6 +105,110 @@ local function AddPreviewToggleButton(container, offLabel, isActiveFn, setActive
     return btn
 end
 
+local function SetPreviewBadgeActive(btn, active)
+    if btn then
+        if not btn._activeHighlight then
+            local activeHighlight = btn:CreateTexture(nil, "BACKGROUND")
+            activeHighlight:SetPoint("TOPLEFT", -1, 1)
+            activeHighlight:SetPoint("BOTTOMRIGHT", 1, -1)
+            activeHighlight:SetColorTexture(0.85, 0.65, 0.0, 0.6)
+            activeHighlight:Hide()
+            btn._activeHighlight = activeHighlight
+        end
+
+        if active then
+            btn._activeHighlight:Show()
+        else
+            btn._activeHighlight:Hide()
+        end
+    end
+
+    if btn and btn._icon then
+        if active then
+            btn._icon:SetVertexColor(1, 0.82, 0, 1)
+        else
+            btn._icon:SetVertexColor(0.72, 0.72, 0.72, 0.85)
+        end
+    end
+end
+
+local function SetActivePreviewBadgeButton(btn, active)
+    SetPreviewBadgeActive(btn, active)
+
+    if active then
+        local previousBtn = CS.activePreviewBadgeButton
+        if previousBtn and previousBtn ~= btn then
+            SetPreviewBadgeActive(previousBtn, false)
+        end
+        CS.activePreviewBadgeButton = btn
+    elseif CS.activePreviewBadgeButton == btn then
+        CS.activePreviewBadgeButton = nil
+    end
+end
+
+local function AddPreviewBadge(parentWidget, anchorAfterFrame, label, isActiveFn, setActiveFn, enabled)
+    if not enabled
+        or not (parentWidget and parentWidget.frame and parentWidget.checkbg and parentWidget.text)
+        or type(isActiveFn) ~= "function"
+        or type(setActiveFn) ~= "function"
+    then
+        return nil
+    end
+
+    local frame = parentWidget.frame
+    local btn = frame._cdcPreviewBtn
+    if not btn then
+        btn = CreateFrame("Button", nil, frame)
+        btn:SetSize(14, 14)
+        btn._icon = btn:CreateTexture(nil, "ARTWORK")
+        btn._icon:SetSize(13, 13)
+        btn._icon:SetPoint("CENTER")
+        btn._icon:SetAtlas("CreditsScreen-Assets-Buttons-Play", false)
+        frame._cdcPreviewBtn = btn
+    end
+
+    btn:SetParent(frame)
+    btn:ClearAllPoints()
+    if anchorAfterFrame and anchorAfterFrame:IsShown() then
+        btn:SetPoint("LEFT", anchorAfterFrame, "RIGHT", 4, 0)
+    else
+        btn:SetPoint("LEFT", parentWidget.checkbg, "RIGHT", parentWidget.text:GetStringWidth() + 6, 0)
+    end
+    btn:Show()
+    btn._icon:Show()
+
+    SetActivePreviewBadgeButton(btn, isActiveFn())
+    btn:SetScript("OnClick", function()
+        local showPreview = not isActiveFn()
+        if showPreview and CooldownCompanion.ClearAllConfigPreviews then
+            CooldownCompanion:ClearAllConfigPreviews()
+        end
+        setActiveFn(showPreview)
+        SetActivePreviewBadgeButton(btn, isActiveFn())
+    end)
+    btn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:AddLine(label)
+        GameTooltip:Show()
+    end)
+    btn:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    local advancedBtn = frame._cdcAdvancedBtn
+    if not (advancedBtn and advancedBtn:GetParent() == frame) then
+        parentWidget:SetCallback("OnRelease", function()
+            btn:ClearAllPoints()
+            btn:Hide()
+            btn:SetParent(nil)
+            if CS.activePreviewBadgeButton == btn then
+                CS.activePreviewBadgeButton = nil
+            end
+        end)
+    end
+
+    return btn
+end
+
 local function AddConditionalPreviewButton(container, label, previewKind, opts)
     if not (container and CooldownCompanion.SetConditionalVisualPreviewActive and CooldownCompanion.IsConditionalVisualPreviewActive) then
         return nil
@@ -137,6 +241,40 @@ local function AddConditionalPreviewButton(container, label, previewKind, opts)
             )
         end
     end)
+end
+
+local function AddConditionalPreviewBadge(parentWidget, anchorAfterFrame, label, previewKind, enabled, opts)
+    if not (CooldownCompanion.SetConditionalVisualPreviewActive and CooldownCompanion.IsConditionalVisualPreviewActive) then
+        return nil
+    end
+
+    local function ResolveTarget()
+        local groupId = ResolvePreviewOption(opts and opts.groupId) or CS.selectedGroup
+        local buttonIndex = ResolvePreviewOption(opts and opts.buttonIndex)
+        if opts and opts.requireButton and not buttonIndex then
+            return nil, nil
+        end
+        return groupId, buttonIndex
+    end
+
+    return AddPreviewBadge(parentWidget, anchorAfterFrame, label, function()
+        local groupId, buttonIndex = ResolveTarget()
+        if not groupId then
+            return false
+        end
+        return CooldownCompanion:IsConditionalVisualPreviewActive(groupId, buttonIndex, previewKind)
+    end, function(show)
+        local groupId, buttonIndex = ResolveTarget()
+        if groupId then
+            CooldownCompanion:SetConditionalVisualPreviewActive(
+                groupId,
+                buttonIndex,
+                previewKind,
+                show,
+                opts and opts.sampleState
+            )
+        end
+    end, enabled)
 end
 
 local function BuildCooldownTextControls(container, styleTable, refreshCallback, opts)
@@ -1331,8 +1469,10 @@ end
 ST._BuildCooldownTextControls = BuildCooldownTextControls
 ST._AddDurationFormatDropdown = AddDurationFormatDropdown
 ST._AddPreviewToggleButton = AddPreviewToggleButton
+ST._AddPreviewBadge = AddPreviewBadge
 ST._RefreshConfigPanelForPreviewToggle = RefreshConfigPanelForPreviewToggle
 ST._AddConditionalPreviewButton = AddConditionalPreviewButton
+ST._AddConditionalPreviewBadge = AddConditionalPreviewBadge
 ST._BuildAuraTextControls = BuildAuraTextControls
 ST._BuildAuraStackTextControls = BuildAuraStackTextControls
 ST._BuildKeybindTextControls = BuildKeybindTextControls

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -1286,10 +1286,7 @@ local function BuildTextColorsControls(container, styleTable, refreshCallback)
 
     local readyColorPicker = AddColorPicker(container, styleTable, "textReadyColor", "Ready Color", {0.2, 1.0, 0.2, 1}, true, refreshCallback, refreshCallback)
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyColorPicker, "textReadyText", tabInfoButtons)
-    readyAdvBtn:SetPoint("LEFT", readyColorPicker.colorSwatch, "RIGHT", readyColorPicker.text:GetStringWidth() + 8, 0)
-
-    if readyAdvExpanded then
+    local function BuildReadyTextAdvanced(panel)
         local readyTextBox = AceGUI:Create("EditBox")
         if readyTextBox.editbox.Instructions then readyTextBox.editbox.Instructions:Hide() end
         readyTextBox:SetLabel("Ready Text")
@@ -1299,8 +1296,14 @@ local function BuildTextColorsControls(container, styleTable, refreshCallback)
             styleTable.textReadyText = val
             refreshCallback()
         end)
-        container:AddChild(readyTextBox)
+        panel:AddChild(readyTextBox)
     end
+
+    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyColorPicker, "textReadyText", tabInfoButtons, nil, {
+        title = "Ready Color Advanced",
+        build = BuildReadyTextAdvanced,
+    })
+    readyAdvBtn:SetPoint("LEFT", readyColorPicker.colorSwatch, "RIGHT", readyColorPicker.text:GetStringWidth() + 8, 0)
 
     AddColorPicker(container, styleTable, "textAuraColor", "Aura Color", {0, 0.925, 1, 1}, true, refreshCallback, refreshCallback)
 end

--- a/ConfigSettings/TextModeTabs.lua
+++ b/ConfigSettings/TextModeTabs.lua
@@ -209,7 +209,21 @@ local function BuildTextAppearanceTab(container, group, style)
         CS.collapsedSections["textappearance_format"] = not CS.collapsedSections["textappearance_format"]
         CooldownCompanion:RefreshConfigPanel()
     end)
-    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons)
+    local function BuildFormatPreviewAdvanced(panel)
+        if AddConditionalPreviewButton then
+            AddConditionalPreviewButton(panel, "Preview Cooldown State", "cooldown")
+            AddConditionalPreviewButton(panel, "Preview Aura Duration Text", "aura_duration_text")
+            AddConditionalPreviewButton(panel, "Preview Aura Stack Text", "aura_stack_text")
+            AddConditionalPreviewButton(panel, "Preview Pandemic State", "pandemic")
+            AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable")
+            AddConditionalPreviewButton(panel, "Preview Out of Range State", "out_of_range")
+        end
+    end
+
+    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons, nil, {
+        title = "Format String Advanced",
+        build = BuildFormatPreviewAdvanced,
+    })
     fmtPreviewAdvBtn:SetPoint("LEFT", fmtCollapseBtn, "RIGHT", 4, 0)
 
     -- Token reference info button
@@ -280,14 +294,6 @@ local function BuildTextAppearanceTab(container, group, style)
     end)
     container:AddChild(editBtn)
 
-    if fmtPreviewAdvExpanded and AddConditionalPreviewButton then
-        AddConditionalPreviewButton(container, "Preview Cooldown State", "cooldown")
-        AddConditionalPreviewButton(container, "Preview Aura Duration Text", "aura_duration_text")
-        AddConditionalPreviewButton(container, "Preview Aura Stack Text", "aura_stack_text")
-        AddConditionalPreviewButton(container, "Preview Pandemic State", "pandemic")
-        AddConditionalPreviewButton(container, "Preview Unusable State", "unusable")
-        AddConditionalPreviewButton(container, "Preview Out of Range State", "out_of_range")
-    end
     end -- not fmtCollapsed
 
     -- ================================================================

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -100,6 +100,7 @@ Config\Column4.lua
 Config\PanelChangelogOverlay.lua
 Config\Panel.lua
 ConfigSettings\Helpers.lua
+ConfigSettings\AdvancedSettingsPanel.lua
 ConfigSettings\SectionBuilders.lua
 ConfigSettings\CastBarPanels.lua
 ConfigSettings\ResourceBarPanelsHelpers.lua


### PR DESCRIPTION
## What Players Will Notice
- Clicking gear buttons beside enabled config settings now opens a focused Advanced Settings editor on the right instead of expanding extra controls inline.
- The main config columns stay easier to scan, and many preview actions now appear as compact play badges beside their setting instead of full-width rows.
- Advanced settings still save and preview immediately while editing.

## Why This Changed
- Inline advanced sections made dense config areas taller and harder to scan, especially in Buttons, Bars, Text, Cast Bar, and Resource Bar panels.
- The addon already uses focused right-side editor patterns for texture picking and format editing, so advanced setting details now follow the same model.

## What Changed
- Added a reusable Advanced Settings side-panel window and wired advanced gear buttons to open, rebind, and close it based on current config context.
- Moved existing advanced controls from inline expansions into focused side-panel builders across icon, bar, text, cast bar, resource bar, custom bar, and override settings.
- Replaced single preview-button rows with compact preview badges and kept badge and side-panel preview state synchronized.
- Closed or yielded the advanced editor when the main config context changes or another right-side editor opens, and fixed a reviewed tick-marker combat-only control that was still inline.

## Validation
- `luac -p` passed for 18 changed Lua files.
- `git diff --check` passed.
- `review-fix-loop` completed with no remaining confirmed code findings after the safe close-path fix.
- `review-intake` confirmed and fixed the tick-marker combat-only placement follow-up.
- Not yet verified in-game, including combat or restricted-content behavior.