### PR TITLE
Add spec-aware Custom Bars import and export

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -53,6 +53,7 @@ local function ClearSelection()
     CS.selectedButton = nil
     wipe(CS.selectedButtons)
     wipe(CS.selectedPanels)
+    wipe(CS.selectedCustomBars)
 end
 
 local function TrimGroupName(name)

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -33,8 +33,12 @@ local function FindSelectedCustomBar()
         return nil
     end
 
-    local customBars = CooldownCompanion:GetSpecCustomAuraBars()
-    for _, entry in ipairs(customBars or {}) do
+    local settings = CooldownCompanion:GetResourceBarSettings()
+    if ST._RB and ST._RB.FindCustomBarById then
+        return ST._RB.FindCustomBarById(settings, CS.selectedCustomBarId)
+    end
+
+    for _, entry in ipairs(CooldownCompanion:GetSpecCustomAuraBars() or {}) do
         if type(entry) == "table" and entry.customBarId == CS.selectedCustomBarId then
             return entry
         end
@@ -63,6 +67,99 @@ end
 local function GetCustomBarDetailScrollKey()
     if not CS.selectedCustomBarId then return nil end
     return tostring(CS.selectedCustomBarId) .. ":" .. tostring(CS.customBarSettingsTab or "appearance")
+end
+
+local function ShowCustomBarMultiSelect(container, selectedIds, selectedEntries)
+    if container.placeholderLabel then
+        container.placeholderLabel:Hide()
+    end
+    if container.customBarEntryTabGroup then
+        container.customBarEntryTabGroup.frame:Hide()
+    end
+    if container.customBarsDetailScroll then
+        container.customBarsDetailScroll.frame:Hide()
+    end
+    if container.layoutOrderHost then
+        container.layoutOrderHost:Hide()
+    end
+    if not container.customBarsMultiSelectScroll then
+        local scroll = AceGUI:Create("ScrollFrame")
+        scroll:SetLayout("List")
+        scroll.frame:SetParent(container)
+        container.customBarsMultiSelectScroll = scroll
+    end
+    local scroll = container.customBarsMultiSelectScroll
+    scroll.frame:SetParent(container)
+    scroll.frame:ClearAllPoints()
+    scroll.frame:SetPoint("TOPLEFT", container, "TOPLEFT", 0, 0)
+    scroll.frame:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", 0, 0)
+    scroll:ReleaseChildren()
+    scroll.frame:Show()
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(#selectedEntries .. " Custom Bars Selected")
+    heading:SetFullWidth(true)
+    scroll:AddChild(heading)
+
+    local function AddSpacer()
+        local sp = AceGUI:Create("Label")
+        sp:SetText(" ")
+        sp:SetFullWidth(true)
+        local f, _, fl = sp.label:GetFont()
+        sp:SetFont(f, 3, fl or "")
+        scroll:AddChild(sp)
+    end
+
+    local anyDisabled = false
+    for _, entry in ipairs(selectedEntries) do
+        if entry.enabled ~= true then
+            anyDisabled = true
+            break
+        end
+    end
+
+    local enableBtn = AceGUI:Create("Button")
+    enableBtn:SetText(anyDisabled and "Enable Selected" or "Disable Selected")
+    enableBtn:SetFullWidth(true)
+    enableBtn:SetCallback("OnClick", function()
+        for _, entry in ipairs(selectedEntries) do
+            entry.enabled = anyDisabled and true or false
+            if entry.enabled and not entry.trackingMode then
+                entry.trackingMode = "active"
+            end
+        end
+        CooldownCompanion:ApplyResourceBars()
+        CooldownCompanion:UpdateAnchorStacking()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    scroll:AddChild(enableBtn)
+
+    AddSpacer()
+
+    local exportBtn = AceGUI:Create("Button")
+    exportBtn:SetText("Export Selected")
+    exportBtn:SetFullWidth(true)
+    exportBtn:SetCallback("OnClick", function()
+        local settings = CooldownCompanion:GetResourceBarSettings()
+        local payload = ST._RB.BuildCustomBarsExportPayload and ST._RB.BuildCustomBarsExportPayload(settings, selectedEntries)
+        local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
+        if exportString then
+            CS.ShowPopupAboveConfig("CDC_EXPORT_CUSTOM_BARS", nil, { exportString = exportString })
+        else
+            CooldownCompanion:Print("Export failed: Custom Bar data was unavailable.")
+        end
+    end)
+    scroll:AddChild(exportBtn)
+
+    AddSpacer()
+
+    local deleteBtn = AceGUI:Create("Button")
+    deleteBtn:SetText("Delete Selected")
+    deleteBtn:SetFullWidth(true)
+    deleteBtn:SetCallback("OnClick", function()
+        CS.ShowPopupAboveConfig("CDC_DELETE_SELECTED_CUSTOM_BARS", #selectedIds, { ids = selectedIds })
+    end)
+    scroll:AddChild(deleteBtn)
 end
 
 local function RefreshColumn4(container)
@@ -94,8 +191,28 @@ local function RefreshColumn4(container)
         if container.customBarsDetailScroll then
             container.customBarsDetailScroll.frame:Hide()
         end
+        if container.customBarsMultiSelectScroll then
+            container.customBarsMultiSelectScroll.frame:Hide()
+        end
         if container.customBarEntryTabGroup then
             container.customBarEntryTabGroup.frame:Hide()
+        end
+        local selectedCustomBarIds = {}
+        local selectedCustomBarEntries = {}
+        local settings = CooldownCompanion:GetResourceBarSettings()
+        for customBarId in pairs(CS.selectedCustomBars) do
+            local entry = ST._RB.FindCustomBarById and ST._RB.FindCustomBarById(settings, customBarId)
+            if entry then
+                selectedCustomBarIds[#selectedCustomBarIds + 1] = customBarId
+                selectedCustomBarEntries[#selectedCustomBarEntries + 1] = entry
+            else
+                CS.selectedCustomBars[customBarId] = nil
+            end
+        end
+        table.sort(selectedCustomBarIds)
+        if #selectedCustomBarEntries >= 2 then
+            ShowCustomBarMultiSelect(container, selectedCustomBarIds, selectedCustomBarEntries)
+            return
         end
         if CS.selectedCustomBarId then
             if container.layoutOrderHost then
@@ -147,6 +264,9 @@ local function RefreshColumn4(container)
                 end
 
                 local tabGroup = container.customBarEntryTabGroup
+                if container.customBarsMultiSelectScroll then
+                    container.customBarsMultiSelectScroll.frame:Hide()
+                end
                 tabGroup.frame:ClearAllPoints()
                 tabGroup.frame:SetPoint("TOPLEFT", container, "TOPLEFT", 0, 0)
                 tabGroup.frame:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", 0, 0)
@@ -181,6 +301,9 @@ local function RefreshColumn4(container)
         if container.customBarsDetailScroll then
             container.customBarsDetailScroll.frame:Hide()
         end
+        if container.customBarsMultiSelectScroll then
+            container.customBarsMultiSelectScroll.frame:Hide()
+        end
         if not CS.selectedCustomBarId then
             -- Fall through to Layout & Order when the selected Custom Bar was removed.
         else
@@ -203,6 +326,9 @@ local function RefreshColumn4(container)
     end
     if container.customBarsDetailScroll then
         container.customBarsDetailScroll.frame:Hide()
+    end
+    if container.customBarsMultiSelectScroll then
+        container.customBarsMultiSelectScroll.frame:Hide()
     end
     if container.customBarEntryTabGroup then
         container.customBarEntryTabGroup.frame:Hide()

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -151,7 +151,8 @@ local function BuildDiagnosticSnapshot()
     -- Build spec name cache for all referenced spec IDs
     local specNameCache = {}
     local function cacheSpecName(sid)
-        if sid and not specNameCache[sid] then
+        sid = tonumber(sid)
+        if sid and sid ~= 0 and not specNameCache[sid] then
             specNameCache[sid] = GetSpecializationNameForSpecID(sid)
         end
     end
@@ -175,8 +176,24 @@ local function BuildDiagnosticSnapshot()
             local customBars = type(resourceSettings) == "table"
                 and (type(resourceSettings.customBars) == "table" and resourceSettings.customBars or resourceSettings.customAuraBars)
             if type(customBars) == "table" then
-                for sid in pairs(customBars) do
-                    if sid ~= 0 then cacheSpecName(sid) end
+                if type(customBars.entries) == "table" or type(customBars.order) == "table" then
+                    local entries = type(customBars.entries) == "table" and customBars.entries or {}
+                    for _, entry in pairs(entries) do
+                        if type(entry) == "table" then
+                            cacheSpecsFromTable(entry.specs)
+                            cacheSpecName(entry.specID or entry.spec or entry.sourceSpecID)
+                        end
+                    end
+                    local layoutOrder = type(resourceSettings.layoutOrder) == "table" and resourceSettings.layoutOrder or {}
+                    for sid, layout in pairs(layoutOrder) do
+                        if type(layout) == "table" and type(layout.customBars) == "table" and next(layout.customBars) then
+                            cacheSpecName(sid)
+                        end
+                    end
+                else
+                    for sid in pairs(customBars) do
+                        cacheSpecName(sid)
+                    end
                 end
             end
         end
@@ -748,21 +765,50 @@ local function FormatDiagnosticAsText(diag)
             for _ in pairs(customBars) do hasAny = true; break end
             if hasAny then
                 add("  customBars:")
-                local specIds = {}
-                for sid in pairs(customBars) do specIds[#specIds + 1] = sid end
-                table.sort(specIds, function(a, b) return tostring(a) < tostring(b) end)
-                for _, sid in ipairs(specIds) do
-                    local sName = sid == 0 and "Default" or specNames[sid]
-                    local entryLabel = sName
-                        and ("[%s] (%s)"):format(tostring(sid), sName)
-                        or ("[%s]"):format(tostring(sid))
-                    add(("    %s"):format(entryLabel))
-                    local specBars = customBars[sid]
-                    local slots = {}
-                    for slot in pairs(specBars) do slots[#slots + 1] = slot end
-                    table.sort(slots, function(a, b) return tostring(a) < tostring(b) end)
-                    for _, slot in ipairs(slots) do
-                        add(("      %s: %s"):format(tostring(slot), dumpCustomBarKV(specBars[slot])))
+                if type(customBars.entries) == "table" or type(customBars.order) == "table" then
+                    local entries = type(customBars.entries) == "table" and customBars.entries or {}
+                    local orderedIds = {}
+                    local seenIds = {}
+                    if type(customBars.order) == "table" then
+                        for _, customBarId in ipairs(customBars.order) do
+                            if type(customBarId) == "string" and type(entries[customBarId]) == "table" then
+                                orderedIds[#orderedIds + 1] = customBarId
+                                seenIds[customBarId] = true
+                            end
+                        end
+                    end
+                    local remainingIds = {}
+                    for customBarId, entry in pairs(entries) do
+                        if type(customBarId) == "string" and type(entry) == "table" and not seenIds[customBarId] then
+                            remainingIds[#remainingIds + 1] = customBarId
+                        end
+                    end
+                    table.sort(remainingIds)
+                    for _, customBarId in ipairs(remainingIds) do
+                        orderedIds[#orderedIds + 1] = customBarId
+                    end
+                    for _, customBarId in ipairs(orderedIds) do
+                        add(("    [%s] %s"):format(customBarId, dumpCustomBarKV(entries[customBarId])))
+                    end
+                else
+                    local specIds = {}
+                    for sid in pairs(customBars) do specIds[#specIds + 1] = sid end
+                    table.sort(specIds, function(a, b) return tostring(a) < tostring(b) end)
+                    for _, sid in ipairs(specIds) do
+                        local sName = specNames[sid]
+                        local entryLabel = sName
+                            and ("[%s] (%s)"):format(tostring(sid), sName)
+                            or ("[%s]"):format(tostring(sid))
+                        add(("    %s"):format(entryLabel))
+                        local specBars = customBars[sid]
+                        if type(specBars) == "table" then
+                            local slots = {}
+                            for slot in pairs(specBars) do slots[#slots + 1] = slot end
+                            table.sort(slots, function(a, b) return tostring(a) < tostring(b) end)
+                            for _, slot in ipairs(slots) do
+                                add(("      %s: %s"):format(tostring(slot), dumpCustomBarKV(specBars[slot])))
+                            end
+                        end
                     end
                 end
             end

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -64,7 +64,7 @@ end
 
 local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
-local CONFIG_FINDER_BUTTON_GAP = 6
+local CONFIG_FINDER_BUTTON_GAP = 3
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
 local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
 local CONFIG_NESTED_INLINE_GROUP_INSET = 20
@@ -103,15 +103,7 @@ local function GetLayoutOrderColumnTitle()
 end
 
 local function GetCustomBarsColumnTitle()
-    local specIdx = C_SpecializationInfo.GetSpecialization()
-    if not specIdx then
-        return "Custom Bars"
-    end
-    local _, specName = C_SpecializationInfo.GetSpecializationInfo(specIdx)
-    if not specName or specName == "" then
-        return "Custom Bars"
-    end
-    return "Custom Bars: " .. GetClassColoredText(specName)
+    return "Custom Bars"
 end
 
 local function CountSelections(selectionSet)
@@ -1601,7 +1593,7 @@ local function CreateConfigPanel()
     -- Info button next to Column 3 title
     local bsInfoBtn = CreateFrame("Button", nil, col3.frame)
     bsInfoBtn:SetSize(16, 16)
-    bsInfoBtn:SetPoint("LEFT", col3.titletext, "RIGHT", -2, 0)
+    bsInfoBtn:SetPoint("TOPRIGHT", col3.frame, "TOPRIGHT", -8, -4)
     local bsInfoIcon = bsInfoBtn:CreateTexture(nil, "OVERLAY")
     bsInfoIcon:SetSize(12, 12)
     bsInfoIcon:SetPoint("CENTER")
@@ -1610,9 +1602,11 @@ local function CreateConfigPanel()
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if CS.resourceBarPanelActive then
             GameTooltip:AddLine("Custom Bars")
-            GameTooltip:AddLine("Track buffs or debuffs as resource-style bars.", 1, 1, 1)
+            GameTooltip:AddLine("Create and manage resource-style bars across all specs.", 1, 1, 1, true)
             GameTooltip:AddLine(" ")
-            GameTooltip:AddLine("Entries are configured per-spec.", 1, 1, 1)
+            GameTooltip:AddLine("Loaded shows bars available to the current spec; Inactive Specs shows bars filtered to other specs.", 1, 1, 1, true)
+            GameTooltip:AddLine(" ")
+            GameTooltip:AddLine("No spec filter means the bar applies to every spec.", 1, 1, 1, true)
         elseif CS.autoAddFlowActive then
             GameTooltip:AddLine("Auto Add")
             GameTooltip:AddLine("Guided import flow for Action Bars, Spellbook, and CDM Auras.", 1, 1, 1, true)

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -431,9 +431,13 @@ local function DecodeProfileImport(popup)
         CooldownCompanion:Print("Import failed: invalid data.")
         return nil
     end
-    -- Reject group/folder exports pasted into the profile import dialog
+    -- Reject narrower exports pasted into the profile import dialog
     if data.type then
-        CooldownCompanion:Print("This is a group/folder export. Use the group Import button.")
+        if data.type == "customBars" then
+            CooldownCompanion:Print("This is a Custom Bars export. Use the Custom Bars Import button.")
+        else
+            CooldownCompanion:Print("This is a group/folder export. Use the group Import button.")
+        end
         return nil
     end
     -- Structural validation: a CDC profile must have groups or globalStyle,
@@ -501,19 +505,20 @@ local function ApplyProfileImport(data)
             end
         end
     end
-
     -- Rename foreign characters to class-based placeholders.
     -- A "foreign" character is one whose createdBy doesn't match any
     -- character in the importer's own characterInfo.
     local importerCharInfo = db.global.characterInfo or {}
     local foreignKeys = {}
-    local function markForeign(entity, checkGlobal)
-        local cb = entity.createdBy
+    local function markForeignCharKey(cb)
         if not cb or cb == charKey then return end
-        if checkGlobal and entity.isGlobal then return end
         if not importerCharInfo[cb] and not foreignKeys[cb] then
             foreignKeys[cb] = true
         end
+    end
+    local function markForeign(entity, checkGlobal)
+        if checkGlobal and entity.isGlobal then return end
+        markForeignCharKey(entity.createdBy)
     end
     for _, group in pairs(db.profile.groups or {}) do markForeign(group, true) end
     for _, container in pairs(db.profile.groupContainers or {}) do markForeign(container, true) end
@@ -754,6 +759,32 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_GROUPS"] = {
                 CooldownCompanion:DeleteGroup(gid)
             end
             ResetConfigSelection(true)
+            CooldownCompanion:RefreshConfigPanel()
+        end
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
+    text = "Delete %d selected Custom Bars?",
+    button1 = "Delete",
+    button2 = "Cancel",
+    OnAccept = function(self, data)
+        local rb = ST._RB
+        local settings = CooldownCompanion:GetResourceBarSettings()
+        if data and type(data.ids) == "table" and rb and rb.DeleteCustomBar then
+            for _, customBarId in ipairs(data.ids) do
+                rb.DeleteCustomBar(settings, customBarId)
+            end
+            CS.selectedCustomBarId = nil
+            CS.customBarSpecExpandedId = nil
+            wipe(CS.selectedCustomBars)
+            CooldownCompanion:ClearAllCustomAuraBarPreviews()
+            CooldownCompanion:ApplyResourceBars()
+            CooldownCompanion:UpdateAnchorStacking()
             CooldownCompanion:RefreshConfigPanel()
         end
     end,
@@ -1223,6 +1254,92 @@ StaticPopupDialogs["CDC_IMPORT_GROUP"] = {
         local text = self:GetText()
         if text == "" then return end
         local ok = ImportGroupData(text)
+        if ok then
+            self:GetParent():Hide()
+        end
+    end,
+    EditBoxOnEscapePressed = function(self)
+        self:GetParent():Hide()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+local function ImportCustomBarsData(text)
+    local preparedText, compactText, isLegacyImport = PrepareSharedImportText(text)
+    if not preparedText then
+        return false
+    end
+    if isLegacyImport then
+        CooldownCompanion:NotifyLegacySupportCutoff("custom bars import")
+        return false
+    end
+    if #compactText > 100000 then
+        CooldownCompanion:Print("Import string too large (" .. #compactText .. " characters).")
+        return false
+    end
+
+    local success, data = DecodeSharedPayload(preparedText)
+    if not success then
+        CooldownCompanion:Print("Import failed: invalid data.")
+        return false
+    end
+    if type(data) ~= "table" or data.type ~= "customBars" then
+        CooldownCompanion:Print("Import failed: this is not a Custom Bars export.")
+        return false
+    end
+
+    local rb = ST._RB
+    local settings = CooldownCompanion:GetResourceBarSettings()
+    local ok, message
+    if rb and rb.ImportCustomBarsPayload then
+        ok, message = rb.ImportCustomBarsPayload(settings, data)
+    end
+    if not ok then
+        CooldownCompanion:Print(message or "Import failed.")
+        return false
+    end
+
+    CooldownCompanion:Print(message)
+    CooldownCompanion:ApplyResourceBars()
+    CooldownCompanion:UpdateAnchorStacking()
+    CooldownCompanion:RefreshConfigPanel()
+    return true
+end
+
+StaticPopupDialogs["CDC_EXPORT_CUSTOM_BARS"] = {
+    text = "Export Custom Bars string (Ctrl+C to copy):",
+    button1 = "Close",
+    hasEditBox = true,
+    OnShow = function(self)
+        if self.data and self.data.exportString then
+            self.EditBox:SetText(self.data.exportString)
+            self.EditBox:HighlightText()
+            self.EditBox:SetFocus()
+        end
+    end,
+    EditBoxOnEscapePressed = function(self)
+        self:GetParent():Hide()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+StaticPopupDialogs["CDC_IMPORT_CUSTOM_BARS"] = {
+    text = "Paste Custom Bars import string (Ctrl+V to paste):",
+    button1 = "Close",
+    hasEditBox = true,
+    OnShow = function(self)
+        self.EditBox:SetFocus()
+    end,
+    EditBoxOnTextChanged = function(self)
+        local text = self:GetText()
+        if text == "" then return end
+        local ok = ImportCustomBarsData(text)
         if ok then
             self:GetParent():Hide()
         end

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -126,6 +126,7 @@ ST._configState = {
     selectedButtons = {},
     selectedPanels = {},         -- multi-selected panel IDs (within a container)
     selectedGroups = {},         -- multi-selected container IDs
+    selectedCustomBars = {},     -- multi-selected custom bar IDs
     selectedTab = "appearance",
     selectedContainerTab = "general",
     buttonSettingsTab = "settings",
@@ -232,6 +233,7 @@ ST._configState = {
     resourceAuraOverlayDrafts = {},
     customBarSettingsTab = "appearance",
     selectedCustomBarId = nil,
+    customBarSpecExpandedId = nil,
     customBarIndicatorPreviewActive = nil,
     groupPresetSelection = {
         icons = nil,
@@ -596,6 +598,7 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
     wipe(CS.selectedButtons)
+    wipe(CS.selectedCustomBars)
     CS.selectedFolder = nil
     CS.selectedContainer = containerId
     CS.selectedGroup = panelId
@@ -2129,13 +2132,16 @@ local function ResetConfigSelection(full)
     CS.selectedFolder = nil
     CS.selectedButton = nil
     CS.selectedCustomBarId = nil
+    CS.customBarSpecExpandedId = nil
     CS.customBarSettingsTab = "appearance"
     wipe(CS.selectedButtons)
     wipe(CS.selectedPanels)
+    wipe(CS.selectedCustomBars)
     if full then
         CS.selectedContainer = nil
         CS.selectedGroup = nil
         wipe(CS.selectedGroups)
+        wipe(CS.selectedCustomBars)
         CS.addingToPanelId = nil
         -- Exit browse mode on full reset
         CS.browseMode = false

--- a/ConfigSettings/ResourceBarPanels.lua
+++ b/ConfigSettings/ResourceBarPanels.lua
@@ -2024,6 +2024,8 @@ local function FindCustomBarIndexById(customBars, customBarId)
     return nil
 end
 
+local ClearCustomBarPreviewState
+
 local function EnsureCustomBarRowTextBadge(frame, key)
     local badge = frame[key]
     if not badge then
@@ -2078,6 +2080,123 @@ local function SetCustomBarRowBadgeTooltip(badge, text, r, g, b)
     badge._cdcTooltipR = r or 1
     badge._cdcTooltipG = g or 1
     badge._cdcTooltipB = b or 1
+end
+
+local function GetCustomBarSpecOptions()
+    local specs = {}
+    local _, _, classID = UnitClass("player")
+    local numSpecs = classID
+        and C_SpecializationInfo.GetNumSpecializationsForClassID(classID)
+        or 0
+    for specIndex = 1, numSpecs do
+        local specID, specName, _, specIcon = C_SpecializationInfo.GetSpecializationInfo(
+            specIndex,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
+        if specID then
+            specs[#specs + 1] = {
+                id = specID,
+                name = specName or ("Spec " .. tostring(specID)),
+                icon = specIcon,
+            }
+        end
+    end
+    return specs
+end
+
+local function EnsureCustomBarSpecBadge(frame, index)
+    if not frame._cdcCustomBarSpecBadges then
+        frame._cdcCustomBarSpecBadges = {}
+    end
+    local badge = frame._cdcCustomBarSpecBadges[index]
+    if not badge then
+        badge = CreateFrame("Frame", nil, frame)
+        badge.icon = badge:CreateTexture(nil, "OVERLAY")
+        badge.icon:SetAllPoints()
+        badge:EnableMouse(false)
+        local mask = badge:CreateMaskTexture()
+        mask:SetAllPoints(badge.icon)
+        mask:SetTexture("Interface\\CHARACTERFRAME\\TempPortraitAlphaMask")
+        badge._cdcCircleMask = mask
+        frame._cdcCustomBarSpecBadges[index] = badge
+    end
+    badge:ClearAllPoints()
+    badge:SetSize(16, 16)
+    badge.icon:SetTexture(nil)
+    badge.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+    badge.icon:SetVertexColor(1, 1, 1, 1)
+    if badge._cdcCircleMask then
+        badge.icon:RemoveMaskTexture(badge._cdcCircleMask)
+        badge.icon:AddMaskTexture(badge._cdcCircleMask)
+    end
+    badge:SetFrameLevel(frame:GetFrameLevel() + 6)
+    badge:Show()
+    return badge
+end
+
+local function PlaceCustomBarSpecBadges(rowFrame, settings, entry, currentSpecID, anchor, point, offset)
+    local specs = GetCustomBarSpecOptions()
+    local badgeIndex = 0
+    if RB.CustomBarHasSpecFilters and RB.CustomBarHasSpecFilters(entry) then
+        for _, spec in ipairs(specs) do
+            local active = RB.CustomBarHasExplicitSpec and RB.CustomBarHasExplicitSpec(entry, spec.id)
+            if active and spec.icon then
+                badgeIndex = badgeIndex + 1
+                local badge = EnsureCustomBarSpecBadge(rowFrame, badgeIndex)
+                badge.icon:SetTexture(spec.icon)
+                badge:SetPoint("RIGHT", anchor, point, offset, 0)
+                anchor = badge
+                point = "LEFT"
+                offset = -3
+            end
+        end
+    end
+
+    if rowFrame._cdcCustomBarSpecBadges then
+        for index = badgeIndex + 1, #rowFrame._cdcCustomBarSpecBadges do
+            rowFrame._cdcCustomBarSpecBadges[index]:Hide()
+        end
+    end
+    return anchor, point, offset
+end
+
+local function AddCustomBarSpecFilterControls(container, settings, entry, currentSpecID)
+    local specs = GetCustomBarSpecOptions()
+    for _, spec in ipairs(specs) do
+        local cb = AceGUI:Create("CheckBox")
+        cb:SetLabel(spec.name)
+        if spec.icon then
+            cb:SetImage(spec.icon, 0.08, 0.92, 0.08, 0.92)
+        end
+        cb:SetFullWidth(true)
+        cb:SetValue(RB.CustomBarHasExplicitSpec and RB.CustomBarHasExplicitSpec(entry, spec.id) or false)
+        cb:SetCallback("OnValueChanged", function(widget, event, value)
+            if value then
+                if RB.AddCustomBarToSpec then
+                    RB.AddCustomBarToSpec(settings, entry, spec.id, currentSpecID)
+                end
+            else
+                if RB.RemoveCustomBarFromSpec then
+                    RB.RemoveCustomBarFromSpec(settings, entry, spec.id)
+                end
+                if spec.id == currentSpecID then
+                    ClearCustomBarPreviewState()
+                end
+            end
+            ApplyCustomAuraBarPanelChanges({
+                updateAnchors = true,
+                refreshConfig = true,
+                refreshLayoutPreview = true,
+            })
+        end)
+        ApplyCheckboxIndent(cb, 12)
+        container:AddChild(cb)
+    end
 end
 
 local function StripCustomBarEntryTypeWords(text)
@@ -2165,71 +2284,12 @@ local function ConfigureCustomBarAddInstructions(addBox, placeholderText)
     return Update
 end
 
-local function RemoveCustomBarById(customBars, customBarId)
-    if type(customBars) ~= "table" or type(customBarId) ~= "string" then
-        return false
-    end
-
-    for removeIndex, removeEntry in ipairs(customBars) do
-        if type(removeEntry) == "table" and removeEntry.customBarId == customBarId then
-            table.remove(customBars, removeIndex)
-            return true
-        end
-    end
-    return false
-end
-
-local function ClearCustomBarLayoutById(settings, specID, customBarId)
-    if type(settings) ~= "table" or type(settings.layoutOrder) ~= "table" or type(customBarId) ~= "string" or not specID then
-        return
-    end
-
-    specID = tonumber(specID) or specID
-    local layout = settings.layoutOrder[specID]
-    if type(layout) ~= "table" then
-        local stringSpecID = tostring(specID)
-        if stringSpecID ~= specID then
-            layout = settings.layoutOrder[stringSpecID]
-        end
-    end
-
-    if type(layout) == "table" and type(layout.customBars) == "table" then
-        layout.customBars[customBarId] = nil
-    end
-end
-
-local function ClearLegacyCustomAuraBarSeedForSpec(settings, specID)
-    if type(settings) ~= "table" or type(settings.customAuraBars) ~= "table" or not specID then
-        return
-    end
-
-    specID = tonumber(specID) or specID
-    settings.customAuraBars[specID] = nil
-
-    local stringSpecID = tostring(specID)
-    if stringSpecID ~= specID then
-        settings.customAuraBars[stringSpecID] = nil
-    end
-
-    local layout = type(settings.layoutOrder) == "table" and settings.layoutOrder[specID] or nil
-    if type(layout) ~= "table" and stringSpecID ~= specID and type(settings.layoutOrder) == "table" then
-        layout = settings.layoutOrder[stringSpecID]
-    end
-    if type(layout) == "table" then
-        layout.customAuraBarSlots = nil
-    end
-end
-
 local function DeleteCustomBarById(settings, specID, customBars, customBarId)
-    if not RemoveCustomBarById(customBars, customBarId) then
-        return false
+    if RB.DeleteCustomBar then
+        return RB.DeleteCustomBar(settings, customBarId)
     end
 
-    ClearCustomBarLayoutById(settings, specID, customBarId)
-    if #customBars == 0 then
-        ClearLegacyCustomAuraBarSeedForSpec(settings, specID)
-    end
-    return true
+    return false
 end
 
 local function DuplicateCustomBarById(settings, specID, customBars, customBarId)
@@ -2239,28 +2299,37 @@ local function DuplicateCustomBarById(settings, specID, customBars, customBarId)
         return nil
     end
 
-    local sourceLayout = GetCustomBarLayout(settings, specID, sourceEntry, false)
-    local copy = CopyTable(sourceEntry)
-    copy.customBarId = nil
-
-    local newId = EnsureCustomBarId(settings, copy)
+    local fallbackOrder = 1000 + sourceIndex + 1
+    local newId
+    if RB.DuplicateCustomBar then
+        newId = RB.DuplicateCustomBar(settings, sourceEntry, specID, fallbackOrder)
+    elseif RB.AddCustomBar then
+        local sourceLayout = GetCustomBarLayout(settings, specID, sourceEntry, false)
+        local copy = CopyTable(sourceEntry)
+        copy.customBarId = nil
+        newId = RB.AddCustomBar(settings, copy, specID, fallbackOrder)
+        if newId then
+            local targetLayout = EnsureCustomBarLayout(settings, specID, newId, fallbackOrder)
+            if type(sourceLayout) == "table" and type(targetLayout) == "table" then
+                for key, value in pairs(sourceLayout) do
+                    targetLayout[key] = CopyTableValue(value)
+                end
+                if sourceLayout.order ~= nil then
+                    targetLayout.order = (tonumber(sourceLayout.order) or 1000) + 1
+                end
+                if sourceLayout.verticalOrder ~= nil then
+                    targetLayout.verticalOrder = (tonumber(sourceLayout.verticalOrder) or 1000) + 1
+                end
+            end
+        end
+    else
+        local copy = CopyTable(sourceEntry)
+        copy.customBarId = nil
+        newId = EnsureCustomBarId(settings, copy)
+        table.insert(customBars, sourceIndex + 1, copy)
+    end
     if not newId then
         return nil
-    end
-
-    table.insert(customBars, sourceIndex + 1, copy)
-
-    local targetLayout = EnsureCustomBarLayout(settings, specID, newId, 1000 + sourceIndex + 1)
-    if type(sourceLayout) == "table" and type(targetLayout) == "table" then
-        for key, value in pairs(sourceLayout) do
-            targetLayout[key] = CopyTableValue(value)
-        end
-        if sourceLayout.order ~= nil then
-            targetLayout.order = (tonumber(sourceLayout.order) or 1000) + 1
-        end
-        if sourceLayout.verticalOrder ~= nil then
-            targetLayout.verticalOrder = (tonumber(sourceLayout.verticalOrder) or 1000) + 1
-        end
     end
 
     return newId
@@ -2281,9 +2350,14 @@ local function HideCustomBarRowDecorations(frame)
             badge:Hide()
         end
     end
+    if frame._cdcCustomBarSpecBadges then
+        for _, badge in ipairs(frame._cdcCustomBarSpecBadges) do
+            badge:Hide()
+        end
+    end
 end
 
-local function ClearCustomBarPreviewState()
+ClearCustomBarPreviewState = function()
     CooldownCompanion:ClearAllCustomAuraBarPreviews()
     if CS.customBarIndicatorPreviewActive then
         CooldownCompanion:StopResourceBarPreview()
@@ -2332,6 +2406,22 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
         end
         UIDropDownMenu_AddButton(duplicateInfo, level)
 
+        local exportInfo = UIDropDownMenu_CreateInfo()
+        exportInfo.text = "Export"
+        exportInfo.notCheckable = true
+        exportInfo.func = function()
+            CloseDropDownMenus()
+            local exportSettings = CooldownCompanion:GetResourceBarSettings()
+            local payload = RB.BuildCustomBarsExportPayload and RB.BuildCustomBarsExportPayload(exportSettings, { entry })
+            local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
+            if exportString then
+                ShowPopupAboveConfig("CDC_EXPORT_CUSTOM_BARS", nil, { exportString = exportString })
+            else
+                CooldownCompanion:Print("Export failed: Custom Bar data was unavailable.")
+            end
+        end
+        UIDropDownMenu_AddButton(exportInfo, level)
+
         local removeInfo = UIDropDownMenu_CreateInfo()
         removeInfo.text = "Remove"
         removeInfo.notCheckable = true
@@ -2343,6 +2433,9 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
                     ClearCustomBarPreviewState()
                     CS.selectedCustomBarId = nil
                     CS.customBarSettingsTab = "appearance"
+                end
+                if CS.customBarSpecExpandedId == customBarId then
+                    CS.customBarSpecExpandedId = nil
                 end
             end
             ApplyCustomAuraBarPanelChanges({
@@ -3269,11 +3362,19 @@ end
 local function BuildCustomBarsListPanel(container)
     local settings = CooldownCompanion:GetResourceBarSettings()
     local customBarsSpecID = GetCurrentConfigSpecID()
-    local customBars = CooldownCompanion:GetSpecCustomAuraBars()
+    local customBars = RB.GetAllCustomBars and RB.GetAllCustomBars(settings) or CooldownCompanion:GetSpecCustomAuraBars()
     local selectedId = CS.selectedCustomBarId
     if selectedId and not FindCustomBarIndexById(customBars, selectedId) then
         CS.selectedCustomBarId = nil
         selectedId = nil
+    end
+    if CS.customBarSpecExpandedId and not FindCustomBarIndexById(customBars, CS.customBarSpecExpandedId) then
+        CS.customBarSpecExpandedId = nil
+    end
+    for customBarId in pairs(CS.selectedCustomBars) do
+        if not FindCustomBarIndexById(customBars, customBarId) then
+            CS.selectedCustomBars[customBarId] = nil
+        end
     end
 
     local addBox = AceGUI:Create("EditBox")
@@ -3360,9 +3461,14 @@ local function BuildCustomBarsListPanel(container)
                 entry.maxCharges = maxCharges
             end
         end
-        local id = EnsureCustomBarId(settings, entry)
-        customBars[#customBars + 1] = entry
-        EnsureCustomBarLayout(settings, nil, id, 1000 + #customBars)
+        local id = RB.AddCustomBar
+            and RB.AddCustomBar(settings, entry, customBarsSpecID, 1000 + #CooldownCompanion:GetSpecCustomAuraBars() + 1)
+            or EnsureCustomBarId(settings, entry)
+        if not RB.AddCustomBar then
+            customBars[#customBars + 1] = entry
+            EnsureCustomBarLayout(settings, nil, id, 1000 + #customBars)
+        end
+        wipe(CS.selectedCustomBars)
         CS.selectedCustomBarId = id
         ApplyCustomAuraBarPanelChanges({
             updateAnchors = true,
@@ -3432,13 +3538,62 @@ local function BuildCustomBarsListPanel(container)
     end)
     CS.SetupAutocompleteKeyHandler(addBox)
     addBox.editbox:SetPoint("BOTTOMRIGHT", 1, 0)
-    container:AddChild(addBox)
 
-    local listHeading = AceGUI:Create("Heading")
-    listHeading:SetText("Entries")
-    ColorHeading(listHeading)
-    listHeading:SetFullWidth(true)
-    container:AddChild(listHeading)
+    local actionControls = AceGUI:Create("SimpleGroup")
+    actionControls:SetFullWidth(true)
+    actionControls:SetHeight(59)
+    actionControls.noAutoHeight = true
+    actionControls:SetLayout("CDC_MANUAL")
+    actionControls:AddChild(addBox)
+
+    local importBtn = AceGUI:Create("Button")
+    importBtn:SetText("Import")
+    importBtn:SetCallback("OnClick", function()
+        ShowPopupAboveConfig("CDC_IMPORT_CUSTOM_BARS")
+    end)
+    actionControls:AddChild(importBtn)
+
+    local exportAllBtn = AceGUI:Create("Button")
+    exportAllBtn:SetText("Export All")
+    exportAllBtn:SetCallback("OnClick", function()
+        local payload = RB.BuildCustomBarsExportPayload and RB.BuildCustomBarsExportPayload(settings, customBars)
+        local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
+        if exportString then
+            ShowPopupAboveConfig("CDC_EXPORT_CUSTOM_BARS", nil, { exportString = exportString })
+        else
+            CooldownCompanion:Print("Export failed: Custom Bar data was unavailable.")
+        end
+    end)
+    actionControls:AddChild(exportAllBtn)
+    local function PositionCustomBarActionControls(width)
+        local host = actionControls.content or actionControls.frame
+        width = width or host:GetWidth() or actionControls.frame:GetWidth() or 0
+        if width <= 0 then return end
+        local gap = 3
+        local importWidth = math.floor((width - gap) / 2)
+        local exportWidth = width - gap - importWidth
+        addBox.frame:ClearAllPoints()
+        addBox.frame:SetPoint("TOPLEFT", host, "TOPLEFT", 0, 0)
+        addBox.frame:SetWidth(width)
+        addBox.frame:SetHeight(28)
+        importBtn.frame:ClearAllPoints()
+        importBtn.frame:SetPoint("TOPLEFT", host, "TOPLEFT", 0, -31)
+        importBtn.frame:SetWidth(importWidth)
+        importBtn.frame:SetHeight(28)
+        exportAllBtn.frame:ClearAllPoints()
+        exportAllBtn.frame:SetPoint("LEFT", importBtn.frame, "RIGHT", gap, 0)
+        exportAllBtn.frame:SetWidth(exportWidth)
+        exportAllBtn.frame:SetHeight(28)
+    end
+    local originalActionControlsOnWidthSet = actionControls.OnWidthSet
+    actionControls.OnWidthSet = function(self, width)
+        if originalActionControlsOnWidthSet then
+            originalActionControlsOnWidthSet(self, width)
+        end
+        PositionCustomBarActionControls(width)
+    end
+    container:AddChild(actionControls)
+    PositionCustomBarActionControls()
 
     if #customBars == 0 then
         local empty = AceGUI:Create("Label")
@@ -3449,7 +3604,49 @@ local function BuildCustomBarsListPanel(container)
         return
     end
 
+    local loadedBars = {}
+    local inactiveBars = {}
     for index, entry in ipairs(customBars) do
+        local target = (RB.CustomBarHasSpec and RB.CustomBarHasSpec(entry, customBarsSpecID)) and loadedBars or inactiveBars
+        target[#target + 1] = { entry = entry, index = index }
+    end
+
+    local customBarRows = {
+        { heading = "Loaded" },
+    }
+    if #loadedBars == 0 then
+        customBarRows[#customBarRows + 1] = { empty = "No Custom Bars loaded for this spec." }
+    else
+        for _, row in ipairs(loadedBars) do
+            customBarRows[#customBarRows + 1] = row
+        end
+    end
+    customBarRows[#customBarRows + 1] = { heading = "Inactive Specs" }
+    if #inactiveBars == 0 then
+        customBarRows[#customBarRows + 1] = { empty = "No inactive-spec Custom Bars." }
+    else
+        for _, row in ipairs(inactiveBars) do
+            row.inactive = true
+            customBarRows[#customBarRows + 1] = row
+        end
+    end
+
+    for index, item in ipairs(customBarRows) do
+        if item.heading then
+            local listHeading = AceGUI:Create("Heading")
+            listHeading:SetText(item.heading)
+            ColorHeading(listHeading)
+            listHeading:SetFullWidth(true)
+            container:AddChild(listHeading)
+        elseif item.empty then
+            local empty = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(empty)
+            empty:SetText("|cff888888" .. item.empty .. "|r")
+            empty:SetFullWidth(true)
+            container:AddChild(empty)
+        else
+        local entry = item.entry
+        index = item.index or index
         local customBarId = EnsureCustomBarId(settings, entry)
         local spellName = entry.label
             or (entry.spellID and GetAuraBarAutocompleteDisplayName(entry.spellID))
@@ -3462,6 +3659,24 @@ local function BuildCustomBarsListPanel(container)
         end
         local selected = customBarId == selectedId
         local icon = entry.spellID and (GetAuraBarAutocompleteDisplayIcon(entry.spellID) or C_Spell.GetSpellTexture(entry.spellID)) or 134400
+        local isSpellCustomBar = IsSpellCustomBarConfig(entry)
+        local resolvedRowAuraUnit = GetResolvedCustomAuraBarAuraUnit(entry, entry.spellID)
+        local showAuraStatusBadge = (not item.inactive) and ((not isSpellCustomBar) or entry.auraTracking == true)
+        local auraStatus = showAuraStatusBadge and ResolveCustomBarAuraTrackingStatus(entry, resolvedRowAuraUnit) or nil
+        local rowRightPad = 4
+        if entry.enabled == false then
+            rowRightPad = rowRightPad + 20
+        end
+        if showAuraStatusBadge then
+            rowRightPad = rowRightPad + 20
+        end
+        if RB.CustomBarHasSpecFilters and RB.CustomBarHasSpecFilters(entry) then
+            for _, spec in ipairs(GetCustomBarSpecOptions()) do
+                if spec.icon and RB.CustomBarHasExplicitSpec and RB.CustomBarHasExplicitSpec(entry, spec.id) then
+                    rowRightPad = rowRightPad + 19
+                end
+            end
+        end
 
         local row = AceGUI:Create("InteractiveLabel")
         if CleanRecycledEntry then CleanRecycledEntry(row) end
@@ -3474,22 +3689,22 @@ local function BuildCustomBarsListPanel(container)
             row.frame:RegisterForClicks("AnyUp")
         end
         if ApplyConfigRowIcon then
-            ApplyConfigRowIcon(row, icon, { rightPad = 126 })
+            ApplyConfigRowIcon(row, icon, { rightPad = rowRightPad })
         elseif icon then
             row:SetImage(icon, 0.08, 0.92, 0.08, 0.92)
             row:SetImageSize(18, 18)
         end
-        if selected then
+        if CS.selectedCustomBars[customBarId] then
             row:SetColor(0.4, 0.7, 1.0)
+        elseif selected then
+            row:SetColor(0.4, 0.7, 1.0)
+        elseif item.inactive then
+            row:SetColor(0.62, 0.62, 0.62)
         elseif entry.enabled ~= true then
             row:SetColor(0.55, 0.55, 0.55)
         end
 
         local rowFrame = row.frame
-        local isSpellCustomBar = IsSpellCustomBarConfig(entry)
-        local resolvedRowAuraUnit = GetResolvedCustomAuraBarAuraUnit(entry, entry.spellID)
-        local showAuraStatusBadge = (not isSpellCustomBar) or entry.auraTracking == true
-        local auraStatus = showAuraStatusBadge and ResolveCustomBarAuraTrackingStatus(entry, resolvedRowAuraUnit) or nil
         local rightBadgeAnchor = rowFrame
         local rightBadgePoint = "RIGHT"
         local rightBadgeOffset = -4
@@ -3523,9 +3738,24 @@ local function BuildCustomBarsListPanel(container)
                 end
                 SetCustomBarRowBadgeTooltip(auraStatusBadge, tooltipText, 1, 0.2, 0.2)
             end
+            rightBadgeAnchor = auraStatusBadge
+            rightBadgePoint = "LEFT"
+            rightBadgeOffset = -4
         end
 
-        row:SetCallback("OnClick", function(widget, event, mouseButton)
+        PlaceCustomBarSpecBadges(rowFrame, settings, entry, customBarsSpecID, rightBadgeAnchor, rightBadgePoint, rightBadgeOffset)
+
+        row:SetCallback("OnClick", function() end)
+        row.frame:SetScript("OnMouseUp", function(self, mouseButton)
+            if mouseButton == "LeftButton" and IsShiftKeyDown and IsShiftKeyDown() then
+                if CS.customBarSpecExpandedId == customBarId then
+                    CS.customBarSpecExpandedId = nil
+                else
+                    CS.customBarSpecExpandedId = customBarId
+                end
+                CooldownCompanion:RefreshConfigPanel()
+                return
+            end
             if mouseButton == "RightButton" then
                 local selectionChanged = CS.selectedCustomBarId ~= customBarId
                 if selectionChanged then
@@ -3533,11 +3763,27 @@ local function BuildCustomBarsListPanel(container)
                 end
                 CS.selectedCustomBarId = customBarId
                 wipe(CS.selectedButtons)
+                wipe(CS.selectedCustomBars)
                 if selectionChanged then
                     CooldownCompanion:RefreshConfigPanel()
                 end
                 OpenCustomBarRowMenu(customBars, customBarsSpecID, customBarId, entry)
             elseif mouseButton == "LeftButton" then
+                if IsControlKeyDown and IsControlKeyDown() then
+                    if CS.selectedCustomBars[customBarId] then
+                        CS.selectedCustomBars[customBarId] = nil
+                    else
+                        CS.selectedCustomBars[customBarId] = true
+                    end
+                    if CS.selectedCustomBarId and not CS.selectedCustomBars[CS.selectedCustomBarId] and next(CS.selectedCustomBars) then
+                        CS.selectedCustomBars[CS.selectedCustomBarId] = true
+                    end
+                    ClearCustomBarPreviewState()
+                    CooldownCompanion:RefreshConfigPanel()
+                    return
+                end
+
+                wipe(CS.selectedCustomBars)
                 if CS.selectedCustomBarId == customBarId then
                     ClearCustomBarPreviewState()
                     CS.selectedCustomBarId = nil
@@ -3552,13 +3798,18 @@ local function BuildCustomBarsListPanel(container)
             end
         end)
         container:AddChild(row)
+        if CS.customBarSpecExpandedId == customBarId then
+            AddCustomBarSpecFilterControls(container, settings, entry, customBarsSpecID)
+        end
+        end
     end
 end
 
-local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, cab, isSpellCustomBar, resolvedAuraUnit, capturedKey, infoButtons)
+local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, cab, isSpellCustomBar, resolvedAuraUnit, capturedKey, infoButtons, previewsEnabled)
     local cabIdx = capturedIdx
     local cabApplyBars = function() CooldownCompanion:ApplyResourceBars() end
     local renderedControls = false
+    previewsEnabled = previewsEnabled == true
 
     if not cab.spellID then
         local emptyLabel = AceGUI:Create("Label")
@@ -3625,12 +3876,14 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
             title = "Active Aura Indicator Advanced",
             build = BuildCustomBarActiveAuraAdvanced,
         })
-        AddPreviewBadge(activeAuraCb, activeAuraAdvBtn, "Preview Active Aura Effects", function()
-            return CooldownCompanion:IsCustomAuraBarActivePreviewActive(customBars[cabIdx])
-        end, function(show)
-            CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], show)
-        end, activeAuraEnabled)
-        if not activeAuraEnabled then
+        if previewsEnabled then
+            AddPreviewBadge(activeAuraCb, activeAuraAdvBtn, "Preview Active Aura Effects", function()
+                return CooldownCompanion:IsCustomAuraBarActivePreviewActive(customBars[cabIdx])
+            end, function(show)
+                CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], show)
+            end, activeAuraEnabled)
+        end
+        if not activeAuraEnabled or not previewsEnabled then
             CooldownCompanion:SetCustomAuraBarActivePreview(customBars[cabIdx], false)
         end
 
@@ -3667,12 +3920,14 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
                 title = "Pandemic Indicator Advanced",
                 build = BuildCustomBarPandemicAdvanced,
             })
-            AddPreviewBadge(pandemicCb, pandemicAdvBtn, "Preview Pandemic Effects", function()
-                return CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(customBars[cabIdx])
-            end, function(show)
-                CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], show)
-            end, pandemicEnabled)
-            if not pandemicEnabled then
+            if previewsEnabled then
+                AddPreviewBadge(pandemicCb, pandemicAdvBtn, "Preview Pandemic Effects", function()
+                    return CooldownCompanion:IsCustomAuraBarPandemicPreviewActive(customBars[cabIdx])
+                end, function(show)
+                    CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], show)
+                end, pandemicEnabled)
+            end
+            if not pandemicEnabled or not previewsEnabled then
                 CooldownCompanion:SetCustomAuraBarPandemicPreview(customBars[cabIdx], false)
             end
         else
@@ -3795,18 +4050,25 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
             title = "Max Stack Indicator Advanced",
             build = BuildMaxStackIndicatorAdvanced,
         })
-        local glowPreviewBtn = AddPreviewBadge(glowCb, glowAdvBtn, "Preview Indicator", function()
-            return CS.customBarIndicatorPreviewActive == true and CooldownCompanion:IsResourceBarPreviewActive()
-        end, function(show)
-            CS.customBarIndicatorPreviewActive = show and true or nil
-            if show then
-                CooldownCompanion:StartResourceBarPreview()
-            else
-                CooldownCompanion:StopResourceBarPreview()
-            end
-        end, cab.maxStacksGlowEnabled == true)
-        if cab.maxStacksGlowEnabled ~= true and CS.customBarIndicatorPreviewActive and CooldownCompanion:IsResourceBarPreviewActive() then
+        local glowPreviewBtn
+        if previewsEnabled then
+            glowPreviewBtn = AddPreviewBadge(glowCb, glowAdvBtn, "Preview Indicator", function()
+                return CS.customBarIndicatorPreviewActive == true and CooldownCompanion:IsResourceBarPreviewActive()
+            end, function(show)
+                CS.customBarIndicatorPreviewActive = show and true or nil
+                if show then
+                    CooldownCompanion:StartResourceBarPreview()
+                else
+                    CooldownCompanion:StopResourceBarPreview()
+                end
+            end, cab.maxStacksGlowEnabled == true)
+        end
+        if (not previewsEnabled or cab.maxStacksGlowEnabled ~= true) and CS.customBarIndicatorPreviewActive and CooldownCompanion:IsResourceBarPreviewActive() then
             CooldownCompanion:StopResourceBarPreview()
+            CS.customBarIndicatorPreviewActive = nil
+        end
+        if not previewsEnabled then
+            CS.customBarIndicatorPreviewActive = nil
         end
 
         CreateInfoButton(glowCb.frame, glowPreviewBtn or glowAdvBtn, "LEFT", "RIGHT", 4, 0, {
@@ -3831,9 +4093,7 @@ end
 
 local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     local settings = CooldownCompanion:GetResourceBarSettings()
-    local layout = CooldownCompanion:GetSpecLayoutOrder()
-    local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
-    local customBars = CooldownCompanion:GetSpecCustomAuraBars()
+    local customBars = RB.GetAllCustomBars and RB.GetAllCustomBars(settings) or CooldownCompanion:GetSpecCustomAuraBars()
     local rbCabTextAdvBtns = {}
     local selectedIndex = FindCustomBarIndexById(customBars, customBarId)
     local infoButtons = CS.customBarInfoButtons
@@ -3854,6 +4114,44 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     local capturedIdx = selectedIndex
     local capturedId = EnsureCustomBarId(settings, cab)
     local capturedKey = capturedId or tostring(capturedIdx)
+    local currentConfigSpecID = GetCurrentConfigSpecID()
+    local customBarLoadedForCurrentSpec = not RB.CustomBarHasSpec or RB.CustomBarHasSpec(cab, currentConfigSpecID)
+    local function resolveLayoutSpecID(entry, fallbackSpecID)
+        fallbackSpecID = tonumber(fallbackSpecID) or fallbackSpecID
+        if RB.CustomBarHasSpec and fallbackSpecID and RB.CustomBarHasSpec(entry, fallbackSpecID) then
+            return fallbackSpecID
+        end
+        if RB.CustomBarHasExplicitSpec then
+            for _, spec in ipairs(GetCustomBarSpecOptions()) do
+                if RB.CustomBarHasExplicitSpec(entry, spec.id) then
+                    return spec.id
+                end
+            end
+        end
+
+        local entryCustomBarId = type(entry) == "table" and entry.customBarId or nil
+        local layoutOrder = type(settings) == "table" and settings.layoutOrder or nil
+        if type(entryCustomBarId) == "string" and type(layoutOrder) == "table" then
+            local layoutSpecIDs = {}
+            for specID, specLayout in pairs(layoutOrder) do
+                if type(specLayout) == "table"
+                    and type(specLayout.customBars) == "table"
+                    and type(specLayout.customBars[entryCustomBarId]) == "table" then
+                    layoutSpecIDs[#layoutSpecIDs + 1] = tonumber(specID) or specID
+                end
+            end
+            table.sort(layoutSpecIDs, function(a, b) return tostring(a) < tostring(b) end)
+            if layoutSpecIDs[1] then
+                return layoutSpecIDs[1]
+            end
+        end
+
+        return fallbackSpecID
+    end
+
+    local layoutSpecID = resolveLayoutSpecID(cab, currentConfigSpecID)
+    local layout = RB.GetSpecLayoutOrder and RB.GetSpecLayoutOrder(settings, layoutSpecID) or CooldownCompanion:GetSpecLayoutOrder()
+    local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
     local isSpellCustomBar = IsSpellCustomBarConfig(cab)
     local hasAuraDisplayControls = IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
     local trackingMode = GetCustomBarTrackingModeConfig(cab, isSpellCustomBar)
@@ -3876,7 +4174,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     end
 
     if activeTab == "indicators" then
-        BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, cab, isSpellCustomBar, resolvedAuraUnit, capturedKey, infoButtons)
+        BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, cab, isSpellCustomBar, resolvedAuraUnit, capturedKey, infoButtons, customBarLoadedForCurrentSpec)
         return
     end
 
@@ -3963,7 +4261,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
             if layout and layout.customBarHeights then
                 AddCustomBarSettingsHeading(container, "Size")
 
-                local slotLayout = EnsureCustomBarLayout(settings, nil, capturedId, 1000 + capturedIdx) or {}
+                local slotLayout = EnsureCustomBarLayout(settings, layoutSpecID, capturedId, 1000 + capturedIdx) or {}
                 local cabHeightSlider = AceGUI:Create("Slider")
                 cabHeightSlider:SetLabel(thicknessLabel)
                 cabHeightSlider:SetSliderValues(4, 40, 0.1)
@@ -3976,7 +4274,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 local cabIdx = capturedIdx
                 cabHeightSlider:SetCallback("OnValueChanged", function(widget, event, val)
                     local customBar = customBars[cabIdx]
-                    local customLayout = EnsureCustomBarLayout(settings, nil, customBar and customBar.customBarId, 1000 + cabIdx)
+                    local customLayout = EnsureCustomBarLayout(settings, layoutSpecID, customBar and customBar.customBarId, 1000 + cabIdx)
                     if customLayout then
                         customLayout[thicknessField] = val
                     end
@@ -4250,7 +4548,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 -- Condition list display
                 if condCount > 0 then
                     local cache = CooldownCompanion._talentNodeCache
-                    local currentSpecID = CooldownCompanion._currentSpecId
+                    local currentSpecID = layoutSpecID or CooldownCompanion._currentSpecId
                     local currentHeroSubTreeID = CooldownCompanion._currentHeroSpecId
                     for _, cond in ipairs(conditions) do
                         local condLabel = AceGUI:Create("Label")
@@ -4302,8 +4600,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 pickBtn:SetRelativeWidth(condCount > 0 and 0.5 or 1)
                 pickBtn:SetCallback("OnClick", function()
                     local initialConditions = cab.talentConditions
-                    -- Restrict picker to current spec (aura bars are per-spec)
-                    local specID = CooldownCompanion._currentSpecId
+                    local specID = layoutSpecID or CooldownCompanion._currentSpecId
                     local specHint = specID and { specs = { [specID] = true } } or nil
                     CooldownCompanion:OpenTalentPicker(function(results)
                         if results then

--- a/Core/ChangelogData.lua
+++ b/Core/ChangelogData.lua
@@ -40,6 +40,8 @@ ST._changelogData = {
 ## New Features
 
 - **One-pixel border thickness:** Border settings now include a dedicated One-pixel option for icon, bar, text, cast bar, and resource-style borders, while existing Custom Thickness borders and per-button overrides keep their current behavior.
+- **Spec-aware Custom Bars:** Custom Bars now show Loaded and Inactive Specs sections, include quick spec badges, and can be imported or exported without being tied to a whole profile.
+- **Custom Bar multiselect:** Multiple Custom Bars can now be enabled, disabled, exported, or deleted together from the Bars & Frames config.
 
 ## Polish | QoL
 

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -2428,6 +2428,56 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
             )
     end
 
+    local function NormalizeCustomBarSpecID(specID)
+        local numericSpecID = tonumber(specID)
+        if numericSpecID and numericSpecID > 0 then
+            return numericSpecID
+        end
+        return nil
+    end
+
+    local function IsSharedCustomBarsStore(customBars)
+        return type(customBars) == "table"
+            and (type(customBars.entries) == "table" or type(customBars.order) == "table")
+    end
+
+    local function NormalizeCustomBarSpecMembership(entry)
+        if type(entry) ~= "table" then
+            return {}
+        end
+
+        local normalized = {}
+        if type(entry.specs) == "table" then
+            for key, value in pairs(entry.specs) do
+                if value == true then
+                    local specID = NormalizeCustomBarSpecID(key)
+                    if specID then normalized[specID] = true end
+                elseif type(value) == "number" or type(value) == "string" then
+                    local specID = NormalizeCustomBarSpecID(value)
+                    if specID then normalized[specID] = true end
+                end
+            end
+        end
+
+        local legacySpecID = NormalizeCustomBarSpecID(entry.specID or entry.spec or entry.sourceSpecID)
+        if legacySpecID then
+            normalized[legacySpecID] = true
+        end
+
+        entry.specs = normalized
+        entry.specID = nil
+        entry.spec = nil
+        entry.sourceSpecID = nil
+        return normalized
+    end
+
+    local function SetCustomBarSpecMembership(entry, specID)
+        specID = NormalizeCustomBarSpecID(specID)
+        if type(entry) == "table" and specID then
+            NormalizeCustomBarSpecMembership(entry)[specID] = true
+        end
+    end
+
     local function NormalizeCustomBarAttachedPlacement(entry)
         if type(entry) ~= "table" then
             return
@@ -2449,12 +2499,22 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
             return owners
         end
 
-        for _, specBars in pairs(customBars) do
-            if type(specBars) == "table" then
-                for _, candidate in pairs(specBars) do
-                    local customBarId = type(candidate) == "table" and candidate.customBarId or nil
-                    if type(customBarId) == "string" and customBarId ~= "" and owners[customBarId] == nil then
-                        owners[customBarId] = candidate
+        if IsSharedCustomBarsStore(customBars) then
+            local entries = type(customBars.entries) == "table" and customBars.entries or {}
+            for _, candidate in pairs(entries) do
+                local customBarId = type(candidate) == "table" and candidate.customBarId or nil
+                if type(customBarId) == "string" and customBarId ~= "" and owners[customBarId] == nil then
+                    owners[customBarId] = candidate
+                end
+            end
+        else
+            for _, specBars in pairs(customBars) do
+                if type(specBars) == "table" then
+                    for _, candidate in pairs(specBars) do
+                        local customBarId = type(candidate) == "table" and candidate.customBarId or nil
+                        if type(customBarId) == "string" and customBarId ~= "" and owners[customBarId] == nil then
+                            owners[customBarId] = candidate
+                        end
                     end
                 end
             end
@@ -2481,133 +2541,176 @@ function CooldownCompanion:MigrateCustomAuraBarsToCustomBars()
         return id
     end
 
-    local function HasConfiguredCustomBars(specBars)
-        if type(specBars) ~= "table" then return false end
-        for _, entry in pairs(specBars) do
-            if HasCustomBarContent(entry) then
-                return true
+    local function AddCustomBarOrder(store, customBarId)
+        if type(store) ~= "table" or type(customBarId) ~= "string" or customBarId == "" then
+            return
+        end
+        if type(store.order) ~= "table" then
+            store.order = {}
+        end
+        for _, existingId in ipairs(store.order) do
+            if existingId == customBarId then
+                return
             end
         end
-        return false
+        store.order[#store.order + 1] = customBarId
+    end
+
+    local function CopyLegacyCustomBarLayout(settings, specID, customBarId, slotIdx, fallbackOrder)
+        local layout = type(settings.layoutOrder) == "table"
+            and (settings.layoutOrder[specID] or settings.layoutOrder[tostring(specID)])
+            or nil
+        if type(layout) ~= "table" or type(customBarId) ~= "string" then
+            return
+        end
+        if type(layout.customBars) ~= "table" then
+            layout.customBars = {}
+        end
+        if type(layout.customBars[customBarId]) == "table" then
+            return
+        end
+
+        local legacySlot = type(layout.customAuraBarSlots) == "table"
+            and layout.customAuraBarSlots[slotIdx]
+            or nil
+        layout.customBars[customBarId] = type(legacySlot) == "table"
+            and CopyTable(legacySlot)
+            or { position = "below", order = fallbackOrder or 1000 }
     end
 
     local function MigrateSettings(settings)
         if type(settings) ~= "table" then return end
-        if type(settings.customBars) ~= "table" then
-            settings.customBars = {}
+
+        local sourceCustomBars = type(settings.customBars) == "table" and settings.customBars or {}
+        local sourceCustomAuraBars = type(settings.customAuraBars) == "table" and settings.customAuraBars or nil
+        local store = { entries = {}, order = {} }
+        settings.customBars = store
+        local customBarIdOwners = BuildCustomBarIdOwners(sourceCustomBars)
+
+        local function addEntry(entry, specID, fallbackOrder)
+            specID = NormalizeCustomBarSpecID(specID)
+            if not (specID and IsConfiguredCustomBar(entry)) then
+                return nil
+            end
+            NormalizeCustomBarAttachedPlacement(entry)
+            if not HasCustomBarContent(entry) then
+                return nil
+            end
+            entry.entryType = entry.entryType or "aura"
+            SetCustomBarSpecMembership(entry, specID)
+            local id = EnsureNextId(settings, entry, customBarIdOwners)
+            if not id then
+                return nil
+            end
+            store.entries[id] = entry
+            AddCustomBarOrder(store, id)
+            CopyLegacyCustomBarLayout(settings, specID, id, nil, fallbackOrder)
+            return id
         end
-        local customBarIdOwners = BuildCustomBarIdOwners(settings.customBars)
 
-        if type(settings.customAuraBars) == "table" then
-            for specID, legacyBars in pairs(settings.customAuraBars) do
-                local normalizedSpecID = tonumber(specID) or specID
-                local stringSpecID = tostring(normalizedSpecID)
-                if type(settings.customBars[normalizedSpecID]) ~= "table"
-                    and stringSpecID ~= normalizedSpecID
-                    and type(settings.customBars[stringSpecID]) == "table"
-                then
-                    settings.customBars[normalizedSpecID] = settings.customBars[stringSpecID]
-                    settings.customBars[stringSpecID] = nil
+        local function addSpecBars(specID, specBars)
+            specID = NormalizeCustomBarSpecID(specID)
+            if not (specID and type(specBars) == "table") then
+                return
+            end
+
+            local numericKeys = {}
+            for key in pairs(specBars) do
+                if type(key) == "number" then
+                    numericKeys[#numericKeys + 1] = key
                 end
+            end
+            table.sort(numericKeys)
 
-                if type(legacyBars) == "table" then
-                    local specBars = settings.customBars[normalizedSpecID]
-                    if type(specBars) ~= "table" then
-                        specBars = {}
-                        settings.customBars[normalizedSpecID] = specBars
-                    end
-                    local numericSlots = {}
+            local seen = {}
+            for index, key in ipairs(numericKeys) do
+                addEntry(specBars[key], specID, 1000 + index)
+                seen[key] = true
+            end
+            for key, entry in pairs(specBars) do
+                if not seen[key] then
+                    addEntry(entry, specID, 1000 + #store.order + 1)
+                end
+            end
+        end
+
+        if IsSharedCustomBarsStore(sourceCustomBars) then
+            local entries = type(sourceCustomBars.entries) == "table" and sourceCustomBars.entries or {}
+            local order = type(sourceCustomBars.order) == "table" and sourceCustomBars.order or {}
+            local seen = {}
+            local function addSharedEntry(entry)
+                if not IsConfiguredCustomBar(entry) then
+                    return
+                end
+                NormalizeCustomBarAttachedPlacement(entry)
+                if not HasCustomBarContent(entry) then
+                    return
+                end
+                entry.entryType = entry.entryType or "aura"
+                NormalizeCustomBarSpecMembership(entry)
+                local id = EnsureNextId(settings, entry, customBarIdOwners)
+                if id and not seen[id] then
+                    store.entries[id] = entry
+                    AddCustomBarOrder(store, id)
+                    seen[id] = true
+                end
+            end
+            for _, customBarId in ipairs(order) do
+                addSharedEntry(entries[customBarId])
+            end
+            for _, entry in pairs(entries) do
+                addSharedEntry(entry)
+            end
+        else
+            local specIDs = {}
+            for specID in pairs(sourceCustomBars) do
+                specIDs[#specIDs + 1] = specID
+            end
+            table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+            for _, specID in ipairs(specIDs) do
+                addSpecBars(specID, sourceCustomBars[specID])
+            end
+        end
+
+        if sourceCustomAuraBars then
+            local specIDs = {}
+            for specID in pairs(sourceCustomAuraBars) do
+                specIDs[#specIDs + 1] = specID
+            end
+            table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+
+            for _, specID in ipairs(specIDs) do
+                local normalizedSpecID = NormalizeCustomBarSpecID(specID)
+                local legacyBars = sourceCustomAuraBars[specID]
+                local numericSlots = {}
+                if normalizedSpecID and type(legacyBars) == "table" then
                     for slotIdx in pairs(legacyBars) do
                         if tonumber(slotIdx) then
                             numericSlots[#numericSlots + 1] = tonumber(slotIdx)
                         end
                     end
-                    table.sort(numericSlots)
+                end
+                table.sort(numericSlots)
 
-                    local layout = type(settings.layoutOrder) == "table"
-                        and (settings.layoutOrder[normalizedSpecID] or settings.layoutOrder[tostring(normalizedSpecID)])
-                        or nil
-
-                    if not HasConfiguredCustomBars(specBars) then
-                        for _, slotIdx in ipairs(numericSlots) do
-                            local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
-                            if IsConfiguredCustomBar(cab) then
-                                local entry = CopyTable(cab)
-                                NormalizeCustomBarAttachedPlacement(entry)
-                                if HasCustomBarContent(entry) then
-                                    entry.entryType = entry.entryType or "aura"
-                                    local id = EnsureNextId(settings, entry, customBarIdOwners)
-                                    specBars[#specBars + 1] = entry
-
-                                    if type(layout) == "table" then
-                                        if type(layout.customBars) ~= "table" then
-                                            layout.customBars = {}
-                                        end
-                                        local legacySlot = type(layout.customAuraBarSlots) == "table"
-                                            and layout.customAuraBarSlots[slotIdx]
-                                            or nil
-                                        layout.customBars[id] = type(legacySlot) == "table"
-                                            and CopyTable(legacySlot)
-                                            or { position = "below", order = 1000 + #specBars }
-                                    end
-                                end
-                            end
+                for index, slotIdx in ipairs(numericSlots) do
+                    local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
+                    if IsConfiguredCustomBar(cab) then
+                        local existingID = type(cab.customBarId) == "string" and cab.customBarId or nil
+                        local entry = existingID and store.entries[existingID] or nil
+                        local id
+                        if type(entry) == "table" then
+                            SetCustomBarSpecMembership(entry, normalizedSpecID)
+                            id = existingID
+                        else
+                            entry = CopyTable(cab)
+                            id = addEntry(entry, normalizedSpecID, 1000 + index)
                         end
-                    else
-                        for _, entry in pairs(specBars) do
-                            if type(entry) == "table" then
-                                entry.entryType = entry.entryType or "aura"
-                                EnsureNextId(settings, entry, customBarIdOwners)
-                            end
-                        end
+                        CopyLegacyCustomBarLayout(settings, normalizedSpecID, id, slotIdx, 1000 + index)
                     end
                 end
             end
+            settings.customAuraBars = nil
         end
-
-        local normalizedCustomBars = {}
-        for specID, specBars in pairs(settings.customBars) do
-            local normalizedSpecID = tonumber(specID) or specID
-            if type(specBars) == "table" then
-                if type(normalizedCustomBars[normalizedSpecID]) ~= "table" then
-                    normalizedCustomBars[normalizedSpecID] = {}
-                end
-                local target = normalizedCustomBars[normalizedSpecID]
-                local numericKeys = {}
-                for key in pairs(specBars) do
-                    if type(key) == "number" then
-                        numericKeys[#numericKeys + 1] = key
-                    end
-                end
-                table.sort(numericKeys)
-
-                local seen = {}
-                for _, key in ipairs(numericKeys) do
-                    local entry = specBars[key]
-                    if IsConfiguredCustomBar(entry) then
-                        NormalizeCustomBarAttachedPlacement(entry)
-                        if HasCustomBarContent(entry) then
-                            entry.entryType = entry.entryType or "aura"
-                            EnsureNextId(settings, entry, customBarIdOwners)
-                            target[#target + 1] = entry
-                        end
-                    end
-                    seen[key] = true
-                end
-
-                for key, entry in pairs(specBars) do
-                    if not seen[key] and IsConfiguredCustomBar(entry) then
-                        NormalizeCustomBarAttachedPlacement(entry)
-                        if HasCustomBarContent(entry) then
-                            entry.entryType = entry.entryType or "aura"
-                            EnsureNextId(settings, entry, customBarIdOwners)
-                            target[#target + 1] = entry
-                        end
-                    end
-                end
-            end
-        end
-        settings.customBars = normalizedCustomBars
     end
 
     MigrateSettings(rawget(profile, "resourceBars"))

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -100,6 +100,44 @@ local function ClearSpecKeyedValue(source, specID)
     source[tostring(specID)] = nil
 end
 
+local function IsSharedCustomBarsStore(customBars)
+    return type(customBars) == "table"
+        and (type(customBars.entries) == "table" or type(customBars.order) == "table")
+end
+
+local function NormalizeCustomBarSpecID(specID)
+    local numericSpecID = tonumber(specID)
+    if numericSpecID and numericSpecID > 0 then
+        return numericSpecID
+    end
+    return nil
+end
+
+local function ForEachSharedCustomBarSpec(entry, callback)
+    if type(entry) ~= "table" or type(callback) ~= "function" then
+        return
+    end
+    if type(entry.specs) == "table" then
+        for key, value in pairs(entry.specs) do
+            if value == true then
+                local specID = NormalizeCustomBarSpecID(key)
+                if specID then
+                    callback(specID)
+                end
+            elseif type(value) == "number" or type(value) == "string" then
+                local specID = NormalizeCustomBarSpecID(value)
+                if specID then
+                    callback(specID)
+                end
+            end
+        end
+    end
+    local legacySpecID = NormalizeCustomBarSpecID(entry.specID or entry.spec or entry.sourceSpecID)
+    if legacySpecID then
+        callback(legacySpecID)
+    end
+end
+
 local RESOURCE_SPEC_AURA_KEYS = {
     auraOverlayEnabled = true,
     auraOverlayEntries = true,
@@ -155,27 +193,57 @@ local function PreserveTargetCustomBarLayouts(copied, target)
     end
 
     local targetLayoutOrder = type(target.layoutOrder) == "table" and target.layoutOrder or nil
-    for specID, targetSpecBars in pairs(target.customBars) do
-        if type(targetSpecBars) == "table" then
-            local targetLayout = GetSpecKeyedTable(targetLayoutOrder, specID)
-            local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
-            if not copiedLayout then
-                copiedLayout = type(targetLayout) == "table" and CopyTable(targetLayout) or {}
-                copied.layoutOrder[specID] = copiedLayout
-            end
-
+    local function preserveLayout(specID, customBarId)
+        if type(customBarId) ~= "string" or customBarId == "" then
+            return
+        end
+        local targetLayout = GetSpecKeyedTable(targetLayoutOrder, specID)
+        local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
+        if not copiedLayout then
+            copiedLayout = type(targetLayout) == "table" and CopyTable(targetLayout) or {}
+            copied.layoutOrder[specID] = copiedLayout
+        end
+        if type(copiedLayout.customBars) ~= "table" then
             copiedLayout.customBars = {}
+        end
 
-            local targetCustomBarLayouts = type(targetLayout) == "table" and targetLayout.customBars or nil
-            for _, entry in pairs(targetSpecBars) do
-                local customBarId = type(entry) == "table" and entry.customBarId or nil
-                if type(customBarId) == "string" and customBarId ~= "" then
-                    local targetCustomBarLayout = type(targetCustomBarLayouts) == "table"
-                        and targetCustomBarLayouts[customBarId]
-                        or nil
-                    if type(targetCustomBarLayout) == "table" then
-                        copiedLayout.customBars[customBarId] = CopyTable(targetCustomBarLayout)
+        local targetCustomBarLayouts = type(targetLayout) == "table" and targetLayout.customBars or nil
+        local targetCustomBarLayout = type(targetCustomBarLayouts) == "table"
+            and targetCustomBarLayouts[customBarId]
+            or nil
+        if type(targetCustomBarLayout) == "table" then
+            copiedLayout.customBars[customBarId] = CopyTable(targetCustomBarLayout)
+        end
+    end
+
+    if IsSharedCustomBarsStore(target.customBars) then
+        local entries = type(target.customBars.entries) == "table" and target.customBars.entries or {}
+        for _, entry in pairs(entries) do
+            local customBarId = type(entry) == "table" and entry.customBarId or nil
+            local sawSpec = false
+            ForEachSharedCustomBarSpec(entry, function(specID)
+                sawSpec = true
+                preserveLayout(specID, customBarId)
+            end)
+            if not sawSpec and type(targetLayoutOrder) == "table" then
+                for specID, layout in pairs(targetLayoutOrder) do
+                    if type(layout) == "table"
+                        and type(layout.customBars) == "table"
+                        and type(layout.customBars[customBarId]) == "table" then
+                        preserveLayout(specID, customBarId)
                     end
+                end
+            end
+        end
+    else
+        for specID, targetSpecBars in pairs(target.customBars) do
+            if type(targetSpecBars) == "table" then
+                local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
+                if copiedLayout then
+                    copiedLayout.customBars = {}
+                end
+                for _, entry in pairs(targetSpecBars) do
+                    preserveLayout(specID, type(entry) == "table" and entry.customBarId or nil)
                 end
             end
         end
@@ -579,13 +647,51 @@ local function NormalizeCustomAuraBarsForCurrentClass(settings)
     end
 
     local filtered = {}
-    for key, specBars in pairs(barsBySpec) do
-        local numericSpecID = tonumber(key)
-        if type(specBars) == "table" and (
-            numericSpecID == 0
-            or (numericSpecID and allowedSpecIDs[numericSpecID])
-        ) then
-            filtered[numericSpecID or key] = CopyTable(specBars)
+    if IsSharedCustomBarsStore(barsBySpec) then
+        filtered.entries = {}
+        filtered.order = {}
+        local entries = type(barsBySpec.entries) == "table" and barsBySpec.entries or {}
+        local included = {}
+        for key, entry in pairs(entries) do
+            if type(entry) == "table" then
+                local copiedEntry = CopyTable(entry)
+                local normalizedSpecs = {}
+                local sawSpec = false
+                ForEachSharedCustomBarSpec(copiedEntry, function(specID)
+                    sawSpec = true
+                    if allowedSpecIDs[specID] then
+                        normalizedSpecs[specID] = true
+                    end
+                end)
+                if not sawSpec or next(normalizedSpecs) then
+                    copiedEntry.specs = normalizedSpecs
+                    local customBarId = type(copiedEntry.customBarId) == "string" and copiedEntry.customBarId or key
+                    if type(customBarId) == "string" and customBarId ~= "" then
+                        filtered.entries[customBarId] = copiedEntry
+                        included[customBarId] = true
+                    end
+                end
+            end
+        end
+        if type(barsBySpec.order) == "table" then
+            for _, customBarId in ipairs(barsBySpec.order) do
+                if included[customBarId] then
+                    filtered.order[#filtered.order + 1] = customBarId
+                    included[customBarId] = nil
+                end
+            end
+        end
+        for customBarId in pairs(included) do
+            filtered.order[#filtered.order + 1] = customBarId
+        end
+    else
+        for key, specBars in pairs(barsBySpec) do
+            local numericSpecID = tonumber(key)
+            if type(specBars) == "table" and (
+                numericSpecID and allowedSpecIDs[numericSpecID]
+            ) then
+                filtered[numericSpecID or key] = CopyTable(specBars)
+            end
         end
     end
 
@@ -640,22 +746,33 @@ local function SanitizeResourceBarAnchors(settings)
     end
 
     local ensureCustomAuraBarAuraUnit = GetEnsureCustomAuraBarAuraUnit()
-    for _, specBars in pairs(customBarsBySpec) do
-        if type(specBars) == "table" then
-            for _, customAuraBar in pairs(specBars) do
-                if type(customAuraBar) == "table" then
-                    customAuraBar.independentAnchorEnabled = nil
-                    customAuraBar.independentLocked = nil
-                    customAuraBar.independentAnchorTargetMode = nil
-                    customAuraBar.independentAnchorFrameName = nil
-                    customAuraBar.independentAnchorGroupId = nil
-                    customAuraBar.independentAnchor = nil
-                    customAuraBar.independentSize = nil
-                    customAuraBar.independentOrientation = nil
-                    customAuraBar.independentVerticalFillDirection = nil
-                    if ensureCustomAuraBarAuraUnit then
-                        ensureCustomAuraBarAuraUnit(customAuraBar, customAuraBar.spellID)
-                    end
+    local function sanitizeCustomBar(customAuraBar)
+        if type(customAuraBar) == "table" then
+            customAuraBar.independentAnchorEnabled = nil
+            customAuraBar.independentLocked = nil
+            customAuraBar.independentAnchorTargetMode = nil
+            customAuraBar.independentAnchorFrameName = nil
+            customAuraBar.independentAnchorGroupId = nil
+            customAuraBar.independentAnchor = nil
+            customAuraBar.independentSize = nil
+            customAuraBar.independentOrientation = nil
+            customAuraBar.independentVerticalFillDirection = nil
+            if ensureCustomAuraBarAuraUnit then
+                ensureCustomAuraBarAuraUnit(customAuraBar, customAuraBar.spellID)
+            end
+        end
+    end
+
+    if IsSharedCustomBarsStore(customBarsBySpec) then
+        local entries = type(customBarsBySpec.entries) == "table" and customBarsBySpec.entries or {}
+        for _, customAuraBar in pairs(entries) do
+            sanitizeCustomBar(customAuraBar)
+        end
+    else
+        for _, specBars in pairs(customBarsBySpec) do
+            if type(specBars) == "table" then
+                for _, customAuraBar in pairs(specBars) do
+                    sanitizeCustomBar(customAuraBar)
                 end
             end
         end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -4484,6 +4484,12 @@ end
 
 function CooldownCompanion:SetCustomAuraBarActivePreview(cabConfig, show)
     if not cabConfig then return end
+    if show then
+        local specID = RB.GetCurrentSpecID and RB.GetCurrentSpecID()
+        if not (specID and RB.CustomBarHasSpec and RB.CustomBarHasSpec(cabConfig, specID)) then
+            show = nil
+        end
+    end
     customAuraBarActivePreviewTokens[cabConfig] = (customAuraBarActivePreviewTokens[cabConfig] or 0) + 1
     activeCustomAuraBarActivePreviews[cabConfig] = show or nil
     RefreshCustomAuraBarPreviewState(cabConfig, "_barAuraActivePreview", show)
@@ -4496,6 +4502,12 @@ end
 
 function CooldownCompanion:SetCustomAuraBarPandemicPreview(cabConfig, show)
     if not cabConfig then return end
+    if show then
+        local specID = RB.GetCurrentSpecID and RB.GetCurrentSpecID()
+        if not (specID and RB.CustomBarHasSpec and RB.CustomBarHasSpec(cabConfig, specID)) then
+            show = nil
+        end
+    end
     customAuraBarPandemicPreviewTokens[cabConfig] = (customAuraBarPandemicPreviewTokens[cabConfig] or 0) + 1
     activeCustomAuraBarPandemicPreviews[cabConfig] = show or nil
     RefreshCustomAuraBarPreviewState(cabConfig, "_pandemicPreview", show)

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -290,16 +290,6 @@ local function IsConfiguredCustomBar(cab)
         )
 end
 
-local function HasConfiguredCustomBars(specBars)
-    if type(specBars) ~= "table" then return false end
-    for _, entry in pairs(specBars) do
-        if HasCustomBarContent(entry) then
-            return true
-        end
-    end
-    return false
-end
-
 local function GetCustomBarEntryType(cab)
     if type(cab) == "table" and cab.entryType == "spell" then
         return "spell"
@@ -351,6 +341,111 @@ local function NormalizeCustomBarAttachedPlacement(cab)
     cab.independentVerticalFillDirection = nil
 end
 
+local function NormalizeCustomBarSpecID(specID)
+    local numericSpecID = tonumber(specID)
+    if numericSpecID and numericSpecID > 0 then
+        return numericSpecID
+    end
+    return nil
+end
+
+local function IsCustomBarsSharedStore(customBars)
+    return type(customBars) == "table"
+        and (type(customBars.entries) == "table" or type(customBars.order) == "table")
+end
+
+local function NormalizeCustomBarSpecMembership(entry)
+    if type(entry) ~= "table" then
+        return {}
+    end
+
+    local normalized = {}
+    if type(entry.specs) == "table" then
+        for key, value in pairs(entry.specs) do
+            if value == true then
+                local specID = NormalizeCustomBarSpecID(key)
+                if specID then normalized[specID] = true end
+            elseif type(value) == "number" or type(value) == "string" then
+                local specID = NormalizeCustomBarSpecID(value)
+                if specID then normalized[specID] = true end
+            end
+        end
+    end
+
+    local legacySpecID = NormalizeCustomBarSpecID(entry.specID or entry.spec or entry.sourceSpecID)
+    if legacySpecID then
+        normalized[legacySpecID] = true
+    end
+
+    entry.specs = normalized
+    entry.specID = nil
+    entry.spec = nil
+    entry.sourceSpecID = nil
+    return normalized
+end
+
+local function CustomBarHasSpec(entry, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    if type(entry) ~= "table" or not specID then
+        return false
+    end
+    local specs = NormalizeCustomBarSpecMembership(entry)
+    if not next(specs) then
+        return true
+    end
+    return specs[specID] == true
+end
+
+local function CustomBarHasSpecFilters(entry)
+    return type(entry) == "table" and next(NormalizeCustomBarSpecMembership(entry)) ~= nil
+end
+
+local function CustomBarHasExplicitSpec(entry, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    if type(entry) ~= "table" or not specID then
+        return false
+    end
+    return NormalizeCustomBarSpecMembership(entry)[specID] == true
+end
+
+local function SetCustomBarSpecMembership(entry, specID, enabled)
+    specID = NormalizeCustomBarSpecID(specID)
+    if type(entry) ~= "table" or not specID then
+        return false
+    end
+    NormalizeCustomBarSpecMembership(entry)[specID] = enabled == true or nil
+    return true
+end
+
+local function ForEachCustomBarSpec(entry, callback)
+    if type(entry) ~= "table" or type(callback) ~= "function" then
+        return
+    end
+    local specIDs = {}
+    for specID in pairs(NormalizeCustomBarSpecMembership(entry)) do
+        specIDs[#specIDs + 1] = specID
+    end
+    table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+    for _, specID in ipairs(specIDs) do
+        callback(specID)
+    end
+end
+
+local function AddCustomBarOrder(store, customBarId)
+    if type(store) ~= "table" or type(customBarId) ~= "string" or customBarId == "" then
+        return
+    end
+    if type(store.order) ~= "table" then
+        store.order = {}
+    end
+    for _, existingId in ipairs(store.order) do
+        if existingId == customBarId then
+            return
+        end
+    end
+    store.order[#store.order + 1] = customBarId
+end
+
 local function CustomBarIdOwnedByOther(settings, customBarId, owner)
     if type(settings) ~= "table"
         or type(settings.customBars) ~= "table"
@@ -359,14 +454,15 @@ local function CustomBarIdOwnedByOther(settings, customBarId, owner)
         return false
     end
 
-    for _, specBars in pairs(settings.customBars) do
-        if type(specBars) == "table" then
-            for _, entry in pairs(specBars) do
-                if entry ~= owner
-                    and type(entry) == "table"
-                    and entry.customBarId == customBarId then
-                    return true
-                end
+    local entries = IsCustomBarsSharedStore(settings.customBars)
+        and type(settings.customBars.entries) == "table"
+        and settings.customBars.entries
+        or {}
+    for key, entry in pairs(entries) do
+        if entry ~= owner and type(entry) == "table" then
+            local entryId = type(key) == "string" and key or entry.customBarId
+            if entryId == customBarId or entry.customBarId == customBarId then
+                return true
             end
         end
     end
@@ -431,114 +527,628 @@ local function GetCustomBarLayout(settings, specID, entry, create)
     return layout.customBars[customBarId]
 end
 
-local function MigrateLegacyCustomAuraBars(settings, specID, target)
-    specID = tonumber(specID) or specID
-    local legacyBySpec = type(settings.customAuraBars) == "table" and settings.customAuraBars or nil
-    local legacyBars = legacyBySpec and (legacyBySpec[specID] or legacyBySpec[tostring(specID)])
-    if type(legacyBars) ~= "table" then
-        return
+local function EnsureSharedCustomBarsStore(settings)
+    if type(settings) ~= "table" then
+        return nil
     end
 
-    local numericSlots = {}
-    for slotIdx in pairs(legacyBars) do
-        if tonumber(slotIdx) then
-            numericSlots[#numericSlots + 1] = tonumber(slotIdx)
+    local store = IsCustomBarsSharedStore(settings.customBars)
+        and settings.customBars
+        or { entries = {}, order = {} }
+    local legacyCustomBars = not IsCustomBarsSharedStore(settings.customBars) and settings.customBars or nil
+
+    store.entries = type(store.entries) == "table" and store.entries or {}
+    store.order = type(store.order) == "table" and store.order or {}
+    settings.customBars = store
+
+    local function addEntryForSpec(entry, specID, fallbackOrder)
+        if not (specID and IsConfiguredCustomBar(entry)) then
+            return
+        end
+        NormalizeCustomBarAttachedPlacement(entry)
+        if not HasCustomBarContent(entry) then
+            return
+        end
+        NormalizeCustomBarEntryType(entry)
+        SetCustomBarSpecMembership(entry, specID, true)
+        local id = EnsureCustomBarId(settings, entry)
+        if id then
+            store.entries[id] = entry
+            AddCustomBarOrder(store, id)
+            EnsureCustomBarLayout(settings, specID, id, fallbackOrder)
         end
     end
-    table.sort(numericSlots)
 
-    local layout = GetSpecLayoutOrder and GetSpecLayoutOrder(settings, specID)
-    for _, slotIdx in ipairs(numericSlots) do
-        local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
-        if IsConfiguredCustomBar(cab) then
-            local entry = CopyTable(cab)
-            NormalizeCustomBarAttachedPlacement(entry)
-            if HasCustomBarContent(entry) then
-                entry.entryType = "aura"
-                local id = EnsureCustomBarId(settings, entry)
-                target[#target + 1] = entry
+    local function addLegacyCustomBarsForSpec(specID, specBars)
+        specID = NormalizeCustomBarSpecID(specID)
+        if not (specID and type(specBars) == "table") then
+            return
+        end
 
-                local legacyLayout = layout
-                    and type(layout.customAuraBarSlots) == "table"
-                    and layout.customAuraBarSlots[slotIdx]
-                if type(legacyLayout) == "table" and id then
-                    if type(layout.customBars) ~= "table" then
-                        layout.customBars = {}
+        local numericKeys = {}
+        for key in pairs(specBars) do
+            if type(key) == "number" then
+                numericKeys[#numericKeys + 1] = key
+            end
+        end
+        table.sort(numericKeys)
+
+        local seen = {}
+        for index, key in ipairs(numericKeys) do
+            addEntryForSpec(specBars[key], specID, 1000 + index)
+            seen[key] = true
+        end
+        for key, entry in pairs(specBars) do
+            if not seen[key] then
+                addEntryForSpec(entry, specID, 1000 + #store.order + 1)
+            end
+        end
+    end
+
+    if type(legacyCustomBars) == "table" then
+        local specIDs = {}
+        for specID in pairs(legacyCustomBars) do
+            specIDs[#specIDs + 1] = specID
+        end
+        table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+        for _, specID in ipairs(specIDs) do
+            addLegacyCustomBarsForSpec(specID, legacyCustomBars[specID])
+        end
+    end
+
+    if type(settings.customAuraBars) == "table" then
+        local legacySpecIDs = {}
+        for specID in pairs(settings.customAuraBars) do
+            legacySpecIDs[#legacySpecIDs + 1] = specID
+        end
+        table.sort(legacySpecIDs, function(a, b) return tostring(a) < tostring(b) end)
+
+        for _, legacySpecID in ipairs(legacySpecIDs) do
+            local specID = NormalizeCustomBarSpecID(legacySpecID)
+            local legacyBars = settings.customAuraBars[legacySpecID]
+            local layout = specID and GetSpecLayoutOrder and GetSpecLayoutOrder(settings, specID) or nil
+            local numericSlots = {}
+            if specID and type(legacyBars) == "table" then
+                for slotIdx in pairs(legacyBars) do
+                    if tonumber(slotIdx) then
+                        numericSlots[#numericSlots + 1] = tonumber(slotIdx)
                     end
-                    layout.customBars[id] = CopyTable(legacyLayout)
-                else
-                    EnsureCustomBarLayout(settings, specID, id, 1000 + #target)
+                end
+            end
+            table.sort(numericSlots)
+
+            for _, slotIdx in ipairs(numericSlots) do
+                local cab = legacyBars[slotIdx] or legacyBars[tostring(slotIdx)]
+                if IsConfiguredCustomBar(cab) then
+                    local customBarId = type(cab.customBarId) == "string" and cab.customBarId or nil
+                    local entry = customBarId and store.entries[customBarId] or nil
+                    local isNewEntry = type(entry) ~= "table"
+                    if isNewEntry then
+                        entry = CopyTable(cab)
+                        NormalizeCustomBarAttachedPlacement(entry)
+                        entry.entryType = "aura"
+                    end
+                    if HasCustomBarContent(entry) then
+                        SetCustomBarSpecMembership(entry, specID, true)
+                        local id = EnsureCustomBarId(settings, entry)
+                        if id then
+                            if isNewEntry then
+                                store.entries[id] = entry
+                                AddCustomBarOrder(store, id)
+                            end
+                            local legacyLayout = type(layout) == "table"
+                                and type(layout.customAuraBarSlots) == "table"
+                                and layout.customAuraBarSlots[slotIdx]
+                                or nil
+                            if type(layout) == "table" then
+                                if type(layout.customBars) ~= "table" then
+                                    layout.customBars = {}
+                                end
+                                if type(layout.customBars[id]) ~= "table" then
+                                    layout.customBars[id] = type(legacyLayout) == "table"
+                                        and CopyTable(legacyLayout)
+                                        or { position = "below", order = 1000 + #store.order }
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+
+            settings.customAuraBars[legacySpecID] = nil
+            local numericSpecID = tonumber(legacySpecID)
+            if numericSpecID then
+                settings.customAuraBars[numericSpecID] = nil
+            end
+            local stringSpecID = specID and tostring(specID) or nil
+            if stringSpecID then
+                settings.customAuraBars[stringSpecID] = nil
+            end
+        end
+    end
+
+    return store
+end
+
+local function NormalizeSharedCustomBars(settings)
+    local store = EnsureSharedCustomBarsStore(settings)
+    if type(store) ~= "table" then
+        return { entries = {}, order = {} }
+    end
+
+    local compactOrder = {}
+    local seenIds = {}
+    local function normalizeEntry(entry, fallbackSpecID)
+        if not IsConfiguredCustomBar(entry) then
+            return nil
+        end
+        NormalizeCustomBarAttachedPlacement(entry)
+        if not HasCustomBarContent(entry) then
+            return nil
+        end
+        NormalizeCustomBarEntryType(entry)
+        if fallbackSpecID and not next(NormalizeCustomBarSpecMembership(entry)) then
+            SetCustomBarSpecMembership(entry, fallbackSpecID, true)
+        else
+            NormalizeCustomBarSpecMembership(entry)
+        end
+        local id = EnsureCustomBarId(settings, entry)
+        if not id then
+            return nil
+        end
+        store.entries[id] = entry
+        if not seenIds[id] then
+            compactOrder[#compactOrder + 1] = id
+            seenIds[id] = true
+        end
+        return id
+    end
+
+    for _, id in ipairs(store.order) do
+        local entry = store.entries[id]
+        if type(entry) == "table" then
+            normalizeEntry(entry)
+        end
+    end
+
+    for _, entry in pairs(store.entries) do
+        local id = type(entry) == "table" and entry.customBarId or nil
+        if type(id) == "string" and not seenIds[id] then
+            normalizeEntry(entry)
+        end
+    end
+
+    wipe(store.order)
+    for _, id in ipairs(compactOrder) do
+        store.order[#store.order + 1] = id
+    end
+    return store
+end
+
+local function NormalizeCustomBars(settings, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    local store = NormalizeSharedCustomBars(settings)
+
+    local specBars = {}
+    for _, id in ipairs(store.order) do
+        local entry = store.entries[id]
+        if CustomBarHasSpec(entry, specID) then
+            specBars[#specBars + 1] = entry
+            EnsureCustomBarLayout(settings, specID, id, 1000 + #specBars)
+        end
+    end
+    return specBars
+end
+
+local function GetAllCustomBars(settings)
+    local store = NormalizeSharedCustomBars(settings)
+    local bars = {}
+    for _, id in ipairs(store.order) do
+        local entry = store.entries[id]
+        if type(entry) == "table" then
+            bars[#bars + 1] = entry
+        end
+    end
+    return bars
+end
+
+local function FindCustomBarById(settings, customBarId)
+    if type(customBarId) ~= "string" or customBarId == "" then
+        return nil
+    end
+    return NormalizeSharedCustomBars(settings).entries[customBarId]
+end
+
+local function AddCustomBar(settings, entry, specID, fallbackOrder)
+    if type(settings) ~= "table" or type(entry) ~= "table" then
+        return nil
+    end
+    specID = NormalizeCustomBarSpecID(specID) or GetCurrentSpecID()
+    if not specID then
+        return nil
+    end
+    local store = NormalizeSharedCustomBars(settings)
+    NormalizeCustomBarAttachedPlacement(entry)
+    NormalizeCustomBarEntryType(entry)
+    NormalizeCustomBarSpecMembership(entry)
+    local id = EnsureCustomBarId(settings, entry)
+    if not id then
+        return nil
+    end
+    store.entries[id] = entry
+    AddCustomBarOrder(store, id)
+    EnsureCustomBarLayout(settings, specID, id, fallbackOrder or (1000 + #store.order))
+    return id, entry
+end
+
+local function CopyCustomBarLayoutValues(targetLayout, sourceLayout, incrementOrder)
+    if type(targetLayout) ~= "table" or type(sourceLayout) ~= "table" then
+        return
+    end
+    wipe(targetLayout)
+    for key, value in pairs(sourceLayout) do
+        targetLayout[key] = type(value) == "table" and CopyTable(value) or value
+    end
+    if incrementOrder and sourceLayout.order ~= nil then
+        targetLayout.order = (tonumber(sourceLayout.order) or 1000) + 1
+    end
+    if incrementOrder and sourceLayout.verticalOrder ~= nil then
+        targetLayout.verticalOrder = (tonumber(sourceLayout.verticalOrder) or 1000) + 1
+    end
+end
+
+local function FindCustomBarLayoutToCopy(settings, entry, targetSpecID, preferredSpecID)
+    targetSpecID = NormalizeCustomBarSpecID(targetSpecID)
+    local function copyFromSpec(specID)
+        specID = NormalizeCustomBarSpecID(specID)
+        if not specID or specID == targetSpecID then
+            return nil
+        end
+        local layout = GetCustomBarLayout(settings, specID, entry, false)
+        return type(layout) == "table" and CopyTable(layout) or nil
+    end
+
+    local copiedLayout = copyFromSpec(preferredSpecID)
+    if copiedLayout then
+        return copiedLayout
+    end
+
+    local specIDs = {}
+    ForEachCustomBarSpec(entry, function(specID)
+        specID = NormalizeCustomBarSpecID(specID)
+        if specID and specID ~= targetSpecID then
+            specIDs[#specIDs + 1] = specID
+        end
+    end)
+    table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+    for _, specID in ipairs(specIDs) do
+        copiedLayout = copyFromSpec(specID)
+        if copiedLayout then
+            return copiedLayout
+        end
+    end
+
+    local customBarId = type(entry) == "table" and entry.customBarId or nil
+    local layoutOrder = type(settings) == "table" and settings.layoutOrder or nil
+    if type(customBarId) == "string" and type(layoutOrder) == "table" then
+        wipe(specIDs)
+        for specID, layout in pairs(layoutOrder) do
+            if type(layout) == "table"
+                and type(layout.customBars) == "table"
+                and type(layout.customBars[customBarId]) == "table" then
+                specID = NormalizeCustomBarSpecID(specID)
+                if specID and specID ~= targetSpecID then
+                    specIDs[#specIDs + 1] = specID
+                end
+            end
+        end
+        table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+        for _, specID in ipairs(specIDs) do
+            copiedLayout = copyFromSpec(specID)
+            if copiedLayout then
+                return copiedLayout
+            end
+        end
+    end
+
+    return nil
+end
+
+local function AddCustomBarToSpec(settings, entry, specID, sourceSpecID)
+    if type(settings) ~= "table" or type(entry) ~= "table" then
+        return false
+    end
+    specID = NormalizeCustomBarSpecID(specID)
+    if not specID then
+        return false
+    end
+    local id = EnsureCustomBarId(settings, entry)
+    if not id then
+        return false
+    end
+    local targetLayoutExists = GetCustomBarLayout(settings, specID, entry, false) ~= nil
+    local copiedLayout = not targetLayoutExists and FindCustomBarLayoutToCopy(settings, entry, specID, sourceSpecID) or nil
+    SetCustomBarSpecMembership(entry, specID, true)
+    local targetLayout = EnsureCustomBarLayout(settings, specID, id, 1000)
+    if not targetLayoutExists and type(copiedLayout) == "table" and type(targetLayout) == "table" then
+        CopyCustomBarLayoutValues(targetLayout, copiedLayout)
+    end
+    return true
+end
+
+local function RemoveCustomBarFromSpec(settings, entry, specID)
+    if type(settings) ~= "table" or type(entry) ~= "table" then
+        return false
+    end
+    specID = NormalizeCustomBarSpecID(specID)
+    if not specID then
+        return false
+    end
+    SetCustomBarSpecMembership(entry, specID, false)
+    if not CustomBarHasSpecFilters(entry) then
+        return true
+    end
+
+    local customBarId = entry.customBarId
+    local layout = type(settings.layoutOrder) == "table"
+        and (settings.layoutOrder[specID] or settings.layoutOrder[tostring(specID)])
+        or nil
+    if type(layout) == "table" and type(layout.customBars) == "table" and type(customBarId) == "string" then
+        layout.customBars[customBarId] = nil
+    end
+    return true
+end
+
+local function DeleteCustomBar(settings, customBarId)
+    if type(settings) ~= "table" or type(customBarId) ~= "string" or customBarId == "" then
+        return false
+    end
+    local store = NormalizeSharedCustomBars(settings)
+    local entry = store.entries[customBarId]
+    if type(entry) ~= "table" then
+        return false
+    end
+    store.entries[customBarId] = nil
+    for index = #store.order, 1, -1 do
+        if store.order[index] == customBarId then
+            table.remove(store.order, index)
+        end
+    end
+    if type(settings.layoutOrder) == "table" then
+        for _, layout in pairs(settings.layoutOrder) do
+            if type(layout) == "table" and type(layout.customBars) == "table" then
+                layout.customBars[customBarId] = nil
+            end
+        end
+    end
+    return true
+end
+
+local function CollectCustomBarSpecIDs(entry)
+    local specIDs = {}
+    ForEachCustomBarSpec(entry, function(specID)
+        specIDs[#specIDs + 1] = specID
+    end)
+    return specIDs
+end
+
+local function CollectCustomBarLayoutSpecIDs(settings, customBarId)
+    local specIDs = {}
+    local seen = {}
+    local layoutOrder = type(settings) == "table" and settings.layoutOrder or nil
+    if type(layoutOrder) ~= "table" or type(customBarId) ~= "string" then
+        return specIDs
+    end
+    for specID, layout in pairs(layoutOrder) do
+        if type(layout) == "table"
+            and type(layout.customBars) == "table"
+            and type(layout.customBars[customBarId]) == "table" then
+            local normalizedSpecID = NormalizeCustomBarSpecID(specID)
+            if normalizedSpecID and not seen[normalizedSpecID] then
+                specIDs[#specIDs + 1] = normalizedSpecID
+                seen[normalizedSpecID] = true
+            end
+        end
+    end
+    table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+    return specIDs
+end
+
+local function DuplicateCustomBar(settings, sourceEntry, specID, fallbackOrder)
+    if type(settings) ~= "table" or type(sourceEntry) ~= "table" then
+        return nil
+    end
+
+    local sourceId = type(sourceEntry.customBarId) == "string" and sourceEntry.customBarId or nil
+    local sourceSpecIDs = CollectCustomBarSpecIDs(sourceEntry)
+    local layoutSeedSpecID = sourceSpecIDs[1] or NormalizeCustomBarSpecID(specID) or GetCurrentSpecID()
+    if not layoutSeedSpecID then
+        return nil
+    end
+
+    local copy = CopyTable(sourceEntry)
+    copy.customBarId = nil
+
+    local newId = AddCustomBar(settings, copy, layoutSeedSpecID, fallbackOrder)
+    if not newId then
+        return nil
+    end
+
+    local layoutSpecIDs, seenLayoutSpecs = {}, {}
+    local function addLayoutSpec(layoutSpecID)
+        if layoutSpecID and not seenLayoutSpecs[layoutSpecID] then
+            layoutSpecIDs[#layoutSpecIDs + 1] = layoutSpecID
+            seenLayoutSpecs[layoutSpecID] = true
+        end
+    end
+    for _, layoutSpecID in ipairs(sourceSpecIDs) do
+        addLayoutSpec(layoutSpecID)
+    end
+    if sourceId then
+        for _, layoutSpecID in ipairs(CollectCustomBarLayoutSpecIDs(settings, sourceId)) do
+            addLayoutSpec(layoutSpecID)
+        end
+    end
+
+    for _, layoutSpecID in ipairs(layoutSpecIDs) do
+        local sourceLayout = GetCustomBarLayout(settings, layoutSpecID, sourceEntry, false)
+        if type(sourceLayout) == "table" then
+            local targetLayout = EnsureCustomBarLayout(settings, layoutSpecID, newId, fallbackOrder)
+            CopyCustomBarLayoutValues(targetLayout, sourceLayout, true)
+        end
+    end
+
+    return newId, copy
+end
+
+local function CollectPayloadLayoutSpecIDs(payload, customBarId)
+    local specIDs = {}
+    local seen = {}
+    local layouts = type(payload) == "table" and payload.layouts or nil
+    if type(layouts) ~= "table" or type(customBarId) ~= "string" then
+        return specIDs
+    end
+    for specID, specLayouts in pairs(layouts) do
+        if type(specLayouts) == "table" and type(specLayouts[customBarId]) == "table" then
+            local normalizedSpecID = NormalizeCustomBarSpecID(specID)
+            if normalizedSpecID and not seen[normalizedSpecID] then
+                specIDs[#specIDs + 1] = normalizedSpecID
+                seen[normalizedSpecID] = true
+            end
+        end
+    end
+    table.sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+    return specIDs
+end
+
+local function BuildCustomBarsExportPayload(settings, entries)
+    if type(settings) ~= "table" or type(entries) ~= "table" then
+        return nil
+    end
+
+    local _, classFilename, classID = UnitClass("player")
+    local payload = {
+        type = "customBars",
+        version = 1,
+        classID = classID,
+        classFilename = classFilename,
+        bars = {},
+        layouts = {},
+    }
+
+    for _, entry in ipairs(entries) do
+        if type(entry) == "table" then
+            local id = EnsureCustomBarId(settings, entry)
+            if id then
+                local exportedEntry = CopyTable(entry)
+                exportedEntry.customBarId = id
+                payload.bars[#payload.bars + 1] = exportedEntry
+
+                local layoutSpecIDs = {}
+                local seenLayoutSpecs = {}
+                for _, specID in ipairs(CollectCustomBarSpecIDs(entry)) do
+                    layoutSpecIDs[#layoutSpecIDs + 1] = specID
+                    seenLayoutSpecs[specID] = true
+                end
+                for _, specID in ipairs(CollectCustomBarLayoutSpecIDs(settings, id)) do
+                    if not seenLayoutSpecs[specID] then
+                        layoutSpecIDs[#layoutSpecIDs + 1] = specID
+                        seenLayoutSpecs[specID] = true
+                    end
+                end
+
+                for _, specID in ipairs(layoutSpecIDs) do
+                    local layout = GetCustomBarLayout(settings, specID, entry, false)
+                    if type(layout) == "table" then
+                        if type(payload.layouts[specID]) ~= "table" then
+                            payload.layouts[specID] = {}
+                        end
+                        payload.layouts[specID][id] = CopyTable(layout)
+                    end
                 end
             end
         end
     end
+
+    if #payload.bars == 0 then
+        return nil
+    end
+    return payload
 end
 
-local function NormalizeCustomBars(settings, specID)
-    if type(settings.customBars) ~= "table" then
-        settings.customBars = {}
+local function ImportCustomBarsPayload(settings, payload)
+    if type(settings) ~= "table" or type(payload) ~= "table" or payload.type ~= "customBars" then
+        return false, "Import failed: this is not a Custom Bars export."
     end
 
-    specID = tonumber(specID) or specID
-    local stringSpecID = tostring(specID)
-    local specBars = settings.customBars[specID]
-    if type(specBars) ~= "table" and stringSpecID ~= specID and type(settings.customBars[stringSpecID]) == "table" then
-        specBars = settings.customBars[stringSpecID]
-        settings.customBars[specID] = specBars
-        settings.customBars[stringSpecID] = nil
+    local _, classFilename, classID = UnitClass("player")
+    if payload.classID and payload.classID ~= classID then
+        return false, "Import failed: Custom Bars can only be imported on the same class."
+    end
+    if payload.classFilename and classFilename and payload.classFilename ~= classFilename then
+        return false, "Import failed: Custom Bars can only be imported on the same class."
+    end
+    if type(payload.bars) ~= "table" or #payload.bars == 0 then
+        return false, "Import failed: no Custom Bars were found."
     end
 
-    if type(specBars) ~= "table" then
-        specBars = {}
-        settings.customBars[specID] = specBars
-    end
-
-    if not HasConfiguredCustomBars(specBars) then
-        MigrateLegacyCustomAuraBars(settings, specID, specBars)
-    end
-
-    local compact = {}
-    local numericKeys = {}
-    for key in pairs(specBars) do
-        if type(key) == "number" then
-            numericKeys[#numericKeys + 1] = key
-        end
-    end
-    table.sort(numericKeys)
-
-    local seen = {}
-    for _, key in ipairs(numericKeys) do
-        local entry = specBars[key]
-        if IsConfiguredCustomBar(entry) then
-            NormalizeCustomBarAttachedPlacement(entry)
-            if HasCustomBarContent(entry) then
-                NormalizeCustomBarEntryType(entry)
-                local id = EnsureCustomBarId(settings, entry)
-                EnsureCustomBarLayout(settings, specID, id, 1000 + #compact + 1)
-                compact[#compact + 1] = entry
+    local importedCount = 0
+    local importedSpecs = {}
+    for _, exportedEntry in ipairs(payload.bars) do
+        if IsConfiguredCustomBar(exportedEntry) then
+            local oldId = exportedEntry.customBarId
+            local specIDs = CollectCustomBarSpecIDs(exportedEntry)
+            local firstSpecID = specIDs[1] or GetCurrentSpecID()
+            if firstSpecID then
+                local entry = CopyTable(exportedEntry)
+                entry.customBarId = nil
+                entry.specs = nil
+                local newId = AddCustomBar(settings, entry, firstSpecID)
+                if newId then
+                    importedCount = importedCount + 1
+                    importedSpecs[firstSpecID] = true
+                    local layoutSpecIDs = CollectPayloadLayoutSpecIDs(payload, oldId)
+                    local pendingLayoutSpecs = {}
+                    for _, specID in ipairs(layoutSpecIDs) do
+                        pendingLayoutSpecs[specID] = true
+                    end
+                    for _, specID in ipairs(specIDs) do
+                        importedSpecs[specID] = true
+                        AddCustomBarToSpec(settings, entry, specID, firstSpecID)
+                        local exportedLayout = type(payload.layouts) == "table"
+                            and type(payload.layouts[specID]) == "table"
+                            and payload.layouts[specID][oldId]
+                            or nil
+                        local targetLayout = EnsureCustomBarLayout(settings, specID, newId, 1000)
+                        CopyCustomBarLayoutValues(targetLayout, exportedLayout)
+                        pendingLayoutSpecs[specID] = nil
+                    end
+                    for _, specID in ipairs(layoutSpecIDs) do
+                        if pendingLayoutSpecs[specID] then
+                            importedSpecs[specID] = true
+                            local exportedLayout = type(payload.layouts) == "table"
+                                and type(payload.layouts[specID]) == "table"
+                                and payload.layouts[specID][oldId]
+                                or nil
+                            local targetLayout = EnsureCustomBarLayout(settings, specID, newId, 1000)
+                            CopyCustomBarLayoutValues(targetLayout, exportedLayout)
+                        end
+                    end
+                end
             end
         end
-        seen[key] = true
     end
 
-    for key, entry in pairs(specBars) do
-        if not seen[key] and IsConfiguredCustomBar(entry) then
-            NormalizeCustomBarAttachedPlacement(entry)
-            if HasCustomBarContent(entry) then
-                NormalizeCustomBarEntryType(entry)
-                local id = EnsureCustomBarId(settings, entry)
-                EnsureCustomBarLayout(settings, specID, id, 1000 + #compact + 1)
-                compact[#compact + 1] = entry
-            end
-        end
+    if importedCount == 0 then
+        return false, "Import failed: no valid Custom Bars were found."
     end
 
-    wipe(specBars)
-    for index, entry in ipairs(compact) do
-        specBars[index] = entry
+    local specCount = 0
+    for _ in pairs(importedSpecs) do
+        specCount = specCount + 1
     end
-    settings.customBars[specID] = specBars
-    return specBars
+    return true, "Imported " .. importedCount .. " Custom Bar" .. (importedCount == 1 and "" or "s")
+        .. " across " .. specCount .. " spec" .. (specCount == 1 and "" or "s") .. "."
 end
 
 local function GetSpecCustomAuraBars(settings)
@@ -761,8 +1371,15 @@ local function SeedResourceLayoutFromGlobal(layout, settings, cbSettings, specID
         end
     end
 
-    if specID and type(settings.customBars) == "table" and type(settings.customBars[specID]) == "table" then
-        for _, cab in pairs(settings.customBars[specID]) do
+    if specID and IsCustomBarsSharedStore(settings.customBars) then
+        local specBars = {}
+        local entries = type(settings.customBars.entries) == "table" and settings.customBars.entries or {}
+        for _, cab in pairs(entries) do
+            if CustomBarHasSpec(cab, specID) then
+                specBars[#specBars + 1] = cab
+            end
+        end
+        for _, cab in pairs(specBars or {}) do
             local customBarId = type(cab) == "table" and cab.customBarId
             if type(customBarId) == "string" and (cab.barHeight ~= nil or cab.barWidth ~= nil) then
                 if type(layout.customBars[customBarId]) ~= "table" then layout.customBars[customBarId] = {} end
@@ -1325,6 +1942,21 @@ RB.GetAnchorGroupFrame = GetAnchorGroupFrame
 RB.GetCurrentSpecID = GetCurrentSpecID
 RB.GetPlayerClassID = GetPlayerClassID
 RB.GetSpecCustomAuraBars = GetSpecCustomAuraBars
+RB.NormalizeCustomBars = NormalizeCustomBars
+RB.GetAllCustomBars = GetAllCustomBars
+RB.FindCustomBarById = FindCustomBarById
+RB.AddCustomBar = AddCustomBar
+RB.DuplicateCustomBar = DuplicateCustomBar
+RB.DeleteCustomBar = DeleteCustomBar
+RB.CustomBarHasSpec = CustomBarHasSpec
+RB.CustomBarHasSpecFilters = CustomBarHasSpecFilters
+RB.CustomBarHasExplicitSpec = CustomBarHasExplicitSpec
+RB.SetCustomBarSpecMembership = SetCustomBarSpecMembership
+RB.AddCustomBarToSpec = AddCustomBarToSpec
+RB.RemoveCustomBarFromSpec = RemoveCustomBarFromSpec
+RB.NormalizeCustomBarSpecMembership = NormalizeCustomBarSpecMembership
+RB.BuildCustomBarsExportPayload = BuildCustomBarsExportPayload
+RB.ImportCustomBarsPayload = ImportCustomBarsPayload
 RB.EnsureCustomBarId = EnsureCustomBarId
 RB.GetCustomBarLayout = GetCustomBarLayout
 RB.EnsureCustomBarLayout = EnsureCustomBarLayout


### PR DESCRIPTION
## What Players Will Notice
- Custom Bars can now be imported and exported directly from the Custom Bars settings, including single bars, selected bars, or all Custom Bars.
- Custom Bars now show as Loaded for the active spec or under Inactive Specs for other specs, with spec icon badges for quick identification.
- Players can use spec filters to move Custom Bars between active and inactive specs, and inactive-spec bars can still be configured without being loaded into runtime previews.
- Multi-select actions now work for Custom Bars, including enable/disable, export, and delete.
- Cross-class Custom Bars imports now explain that imports must come from the same class.

## Why This Changed
- Custom Bars were scoped per spec in the addon, but import/export treated them too much like profile-attached data.
- Players needed a way to share Custom Bars while preserving spec ownership and layout without accidentally loading inactive-spec bars.

## What Changed
- Added Custom Bars import/export payloads that include selected entries and their existing per-spec layouts.
- Reworked Custom Bars storage around a shared spec-aware model where explicit spec filters control Loaded vs Inactive behavior, while no filters means all specs.
- Added Custom Bars multiselect support and column 4 batch actions.
- Preserved release-shaped Custom Bars and legacy customAuraBars data through migration into the shared model.
- Kept runtime and preview paths gated to the current spec so inactive-spec bars stay config-only.

## Validation
- Ran `luac -p` across changed Lua files.
- Ran `git diff --check`.
- Ran `lua tests\border-rendering.lua`.
- In-game validation passed for single, selected, and all Custom Bars import/export.
- In-game validation passed for spec filter toggles moving bars between Loaded and Inactive Specs.
- In-game validation confirmed inactive bars can be edited without previewing or entering runtime.
- In-game validation passed for a release-shaped old customAuraBars / per-spec Custom Bars profile.
- Combat and restricted-content validation passed.

## Post-Deploy Monitoring & Validation
- Watch for player reports mentioning Custom Bars import/export, inactive spec bars, spec filters, missing Custom Bars after update, or Custom Bar runtime errors.
- Healthy signal: imported Custom Bars appear in the expected Loaded or Inactive Specs section and existing Custom Bars survive profile migration.
- Failure signal: reports of missing Custom Bars, inactive bars appearing in combat/runtime, import strings rejected without a reason, or Lua errors in `ResourceBarPanels.lua`, `ResourceBarHelpers.lua`, or `ResourceBar.lua`.