### PR TITLE
Add 1.15 import checkpoint

### DIFF
--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -16,6 +16,14 @@ local PrepareSharedImportText = ST._PrepareSharedImportText
 local decodedDiagnostic = nil
 local diagnosticDecodeFrame = nil
 
+local function RejectUnsupportedImportPayload(data, dataLabel)
+    if CooldownCompanion.IsUnsupportedImportPayload and CooldownCompanion:IsUnsupportedImportPayload(data) then
+        CooldownCompanion:NotifyLegacySupportCutoff(dataLabel)
+        return true
+    end
+    return false
+end
+
 local RESOURCE_NAMES = {
     [0] = "Mana", [1] = "Rage", [2] = "Focus", [3] = "Energy",
     [4] = "Combo Points", [5] = "Runes", [6] = "Runic Power",
@@ -1025,8 +1033,7 @@ StaticPopupDialogs["CDC_DIAGNOSTIC_IMPORT_CONFIRM"] = {
     button2 = "Cancel",
     OnAccept = function()
         if decodedDiagnostic and decodedDiagnostic.profile then
-            if CooldownCompanion:IsUnsupportedLegacyProfile(decodedDiagnostic.profile) then
-                CooldownCompanion:NotifyLegacySupportCutoff("diagnostic profile")
+            if RejectUnsupportedImportPayload(decodedDiagnostic.profile, "diagnostic profile") then
                 return
             end
             local db = CooldownCompanion.db
@@ -1131,6 +1138,11 @@ local function OpenDiagnosticDecodePanel()
         local success, data = DecodeSharedPayload(preparedText)
         if not success or type(data) ~= "table" then
             outputBox:SetText("Error: Failed to deserialize.")
+            return
+        end
+        if RejectUnsupportedImportPayload(data, "diagnostic string") then
+            decodedDiagnostic = nil
+            outputBox:SetText("")
             return
         end
         decodedDiagnostic = data

--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -1023,6 +1023,10 @@ local function EncodeSharedPayload(payload, exportKind)
     local exportData = CopyTable(payload)
     local formatVersion = CURRENT_COMPACT_FORMAT_VALUE
 
+    if CooldownCompanion.StampExportPayloadCheckpoint then
+        CooldownCompanion:StampExportPayloadCheckpoint(exportData, exportKind)
+    end
+
     if exportKind == "profile" then
         exportData = CompactProfile(exportData, formatVersion)
     elseif exportKind == "diagnostic" then

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -27,6 +27,14 @@ local function TrimPopupText(text)
     return (text:gsub("^%s+", ""):gsub("%s+$", ""))
 end
 
+local function RejectUnsupportedImportPayload(data, dataLabel)
+    if CooldownCompanion.IsUnsupportedImportPayload and CooldownCompanion:IsUnsupportedImportPayload(data) then
+        CooldownCompanion:NotifyLegacySupportCutoff(dataLabel)
+        return true
+    end
+    return false
+end
+
 local function ShowPopupOverConfig(which, textArg1, data)
     local showFn = (CS and CS.ShowPopupAboveConfig) or ST._ShowPopupAboveConfig
     if showFn then
@@ -431,6 +439,9 @@ local function DecodeProfileImport(popup)
         CooldownCompanion:Print("Import failed: invalid data.")
         return nil
     end
+    if RejectUnsupportedImportPayload(data, "profile import") then
+        return nil
+    end
     -- Reject narrower exports pasted into the profile import dialog
     if data.type then
         if data.type == "customBars" then
@@ -451,8 +462,7 @@ local function DecodeProfileImport(popup)
         CooldownCompanion:Print("Import failed: profile data is malformed.")
         return nil
     end
-    if CooldownCompanion:IsUnsupportedLegacyProfile(data) then
-        CooldownCompanion:NotifyLegacySupportCutoff("profile import")
+    if RejectUnsupportedImportPayload(data, "profile import") then
         return nil
     end
     return data
@@ -463,8 +473,7 @@ end
 -- their original createdBy so they appear in the browse-other-characters
 -- module instead of being flattened into the current character.
 local function ApplyProfileImport(data)
-    if CooldownCompanion:IsUnsupportedLegacyProfile(data) then
-        CooldownCompanion:NotifyLegacySupportCutoff("profile import")
+    if RejectUnsupportedImportPayload(data, "profile import") then
         return false
     end
 
@@ -1100,6 +1109,9 @@ local function ImportGroupData(text)
     if not success or type(data) ~= "table" then
         return false
     end
+    if RejectUnsupportedImportPayload(data, "group import") then
+        return false
+    end
 
     -- Reject profile exports (no type field)
     if not data.type then
@@ -1287,7 +1299,13 @@ local function ImportCustomBarsData(text)
         return false
     end
     if type(data) ~= "table" or data.type ~= "customBars" then
+        if RejectUnsupportedImportPayload(data, "custom bars import") then
+            return false
+        end
         CooldownCompanion:Print("Import failed: this is not a Custom Bars export.")
+        return false
+    end
+    if RejectUnsupportedImportPayload(data, "custom bars import") then
         return false
     end
 

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -13,8 +13,40 @@ local type = type
 local next = next
 local rawget = rawget
 
-local LEGACY_SUPPORT_FLOOR_VERSION = "1.10"
-local LEGACY_UNSUPPORTED_MAX_VERSION = "1.9"
+local IMPORT_CHECKPOINT_KEY = "_cdcImportCheckpoint"
+local IMPORT_CHECKPOINT_VERSION = "1.15"
+local LEGACY_SUPPORT_FLOOR_VERSION = IMPORT_CHECKPOINT_VERSION
+local LEGACY_UNSUPPORTED_MAX_VERSION = "1.14"
+
+local function CompareVersion(left, right)
+    left = tostring(left or "")
+    right = tostring(right or "")
+
+    local leftParts = {}
+    for part in left:gmatch("%d+") do
+        leftParts[#leftParts + 1] = tonumber(part) or 0
+    end
+
+    local rightParts = {}
+    for part in right:gmatch("%d+") do
+        rightParts[#rightParts + 1] = tonumber(part) or 0
+    end
+
+    if #leftParts == 0 or #rightParts == 0 then
+        return nil
+    end
+
+    local maxParts = math.max(#leftParts, #rightParts)
+    for index = 1, maxParts do
+        local leftPart = leftParts[index] or 0
+        local rightPart = rightParts[index] or 0
+        if leftPart ~= rightPart then
+            return leftPart < rightPart and -1 or 1
+        end
+    end
+
+    return 0
+end
 
 local function LooksLikeProfilePayload(profile)
     return rawget(profile, "groups") ~= nil
@@ -47,12 +79,44 @@ function CooldownCompanion:IsUnsupportedLegacyProfile(profile)
         and not next(containers)
 end
 
+function CooldownCompanion:StampImportCheckpoint(payload)
+    if type(payload) == "table" then
+        payload[IMPORT_CHECKPOINT_KEY] = IMPORT_CHECKPOINT_VERSION
+    end
+    return payload
+end
+
+function CooldownCompanion:StampExportPayloadCheckpoint(payload, exportKind)
+    self:StampImportCheckpoint(payload)
+    if exportKind == "diagnostic" and type(payload) == "table" and type(payload.profile) == "table" then
+        self:StampImportCheckpoint(payload.profile)
+    end
+    return payload
+end
+
+function CooldownCompanion:HasSupportedImportCheckpoint(payload)
+    if type(payload) ~= "table" then
+        return false
+    end
+
+    local comparison = CompareVersion(payload[IMPORT_CHECKPOINT_KEY], IMPORT_CHECKPOINT_VERSION)
+    return comparison ~= nil and comparison >= 0
+end
+
+function CooldownCompanion:IsUnsupportedImportPayload(payload)
+    if type(payload) ~= "table" then
+        return false
+    end
+    return self:IsUnsupportedLegacyProfile(payload) or not self:HasSupportedImportCheckpoint(payload)
+end
+
 function CooldownCompanion:GetLegacySupportCutoffMessage(dataLabel)
     dataLabel = dataLabel or "data"
-    return ("This build supports Cooldown Companion %s and newer. This %s appears to come from %s or older. Use an older addon version first if you need to recover it."):format(
+    return ("This build supports Cooldown Companion %s and newer data. This %s appears to come from %s or older. To recover it, load or import it with an older addon version, then export it again after it has been opened by %s."):format(
         LEGACY_SUPPORT_FLOOR_VERSION,
         dataLabel,
-        LEGACY_UNSUPPORTED_MAX_VERSION
+        LEGACY_UNSUPPORTED_MAX_VERSION,
+        LEGACY_SUPPORT_FLOOR_VERSION
     )
 end
 
@@ -123,6 +187,7 @@ function CooldownCompanion:RunAllMigrations()
     self:MigrateResourceBarDisplayProfiles()
     self:MigrateCustomAuraBarsToCustomBars()
     self:MigrateDurationFormatSettings()
+    self:StampImportCheckpoint(self.db and self.db.profile)
     return true
 end
 

--- a/tests/migration-checkpoint.lua
+++ b/tests/migration-checkpoint.lua
@@ -1,0 +1,197 @@
+local ST = {
+    Addon = {},
+    _defaults = {
+        profile = {
+            minimap = {},
+            hideInfoButtons = false,
+            escClosesConfig = true,
+            showAdvanced = false,
+            autoAddPrefs = {},
+            groupSettingPresets = {},
+            auraTextureLibrary = {},
+            globalStyle = {},
+            locked = false,
+            cdmHidden = false,
+            resourceBars = {},
+            castBar = {},
+            frameAnchoring = {},
+        },
+    },
+}
+
+local function deepCopy(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, child in pairs(value) do
+        copy[deepCopy(key)] = deepCopy(child)
+    end
+    return copy
+end
+
+CopyTable = deepCopy
+
+local function assertEquals(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s: expected %s, got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function assertFalse(value, label)
+    if value then
+        error(label, 2)
+    end
+end
+
+local migrationChunk = assert(loadfile("Core/Migrations.lua"))
+migrationChunk("CooldownCompanion", ST)
+
+local addon = ST.Addon
+addon.db = {
+    profile = {
+        groups = {},
+        groupContainers = {},
+    },
+}
+addon.printed = {}
+
+function addon:Print(message)
+    self.printed[#self.printed + 1] = message
+end
+
+local migrationCalls = {}
+local migrationNames = {
+    "MigrateGroupOwnership",
+    "MigrateFolderOwnership",
+    "MigrateOrphanedGroups",
+    "MigrateAlphaSystem",
+    "MigrateDisplayMode",
+    "MigrateMasqueField",
+    "MigrateRemoveBarChargeOldFields",
+    "MigrateVisibility",
+    "MigrateStandaloneAuraMetadata",
+    "MigrateAddedAsClassification",
+    "MigrateInvertAuraDesaturationLogic",
+    "MigrateFolders",
+    "MigrateFolderSpecFilters",
+    "MigrateContainerHeroTalentStamps",
+    "ReverseMigrateMW",
+    "MigrateCustomAuraBarsToSpecKeyed",
+    "MigrateLSMNames",
+    "MigrateChargeTextToGroupStyle",
+    "MigrateProcGlowToStyleOverrides",
+    "MigrateGlowSettingsToGroupStyle",
+    "MigrateAuraIndicatorToGroupStyle",
+    "MigrateAssistedHighlightHostileTargetOnly",
+    "MigrateBarOrdering",
+    "MigrateRemoveAuraDurationCache",
+    "MigrateResourceBarYOffset",
+    "MigrateLegacyCastBarYOffsetField",
+    "MigrateResourceAuraOverlayEntries",
+    "MigrateMaxStacksGlowStyles",
+    "MigrateTalentConditions",
+    "MigrateChoiceTalentConditions",
+    "MigrateNewDefaults",
+    "MigrateBorderRenderModeOverrides",
+    "MigrateIconFillTimerDefaults",
+    "MigrateCharacterScopedBarSettings",
+    "MigratePanelAnchorCenter",
+    "MigrateContainerAnchorsToScreenOffsets",
+    "MigrateContainerAlphaToPanel",
+    "MigrateStrataOrderExpansion",
+    "MigrateCustomAuraBarSlots5",
+    "MigrateLayoutOrderToSpecKeyed",
+    "MigrateResourceBarExpandedSpecLayouts",
+    "MigrateBaseSpellResolution",
+    "MigrateSpecColorsToSpecOverrides",
+    "MigrateResourceBarDisplayProfiles",
+    "MigrateCustomAuraBarsToCustomBars",
+    "MigrateDurationFormatSettings",
+}
+
+for _, name in ipairs(migrationNames) do
+    addon[name] = function()
+        migrationCalls[#migrationCalls + 1] = name
+    end
+end
+
+assertTrue(addon:IsUnsupportedImportPayload({ globalStyle = {} }), "missing checkpoint is unsupported for imports")
+assertFalse(addon:HasSupportedImportCheckpoint({ _cdcImportCheckpoint = "1.14.99" }), "older checkpoint is unsupported")
+assertTrue(addon:HasSupportedImportCheckpoint({ _cdcImportCheckpoint = "1.15" }), "1.15 checkpoint is supported")
+assertTrue(addon:HasSupportedImportCheckpoint({ _cdcImportCheckpoint = "1.15.2" }), "1.15 patch checkpoint is supported")
+assertTrue(addon:HasSupportedImportCheckpoint({ _cdcImportCheckpoint = "1.16" }), "newer checkpoint is supported")
+
+local stamped = addon:StampImportCheckpoint({ type = "customBars" })
+assertEquals(stamped._cdcImportCheckpoint, "1.15", "manual stamp records checkpoint")
+assertFalse(addon:IsUnsupportedImportPayload(stamped), "stamped payload is supported for imports")
+
+assertTrue(addon:RunAllMigrations(), "local profile migrations still run")
+assertEquals(#migrationCalls, #migrationNames, "all stubbed migrations ran before checkpoint stamp")
+assertEquals(addon.db.profile._cdcImportCheckpoint, "1.15", "local profile is stamped after migrations")
+
+local serializedStore = {}
+local nextSerializedId = 0
+local aceSerializer = {}
+function aceSerializer:Serialize(data)
+    nextSerializedId = nextSerializedId + 1
+    local key = "serialized:" .. nextSerializedId
+    serializedStore[key] = deepCopy(data)
+    return key
+end
+function aceSerializer:Deserialize(key)
+    return serializedStore[key] ~= nil, deepCopy(serializedStore[key])
+end
+
+local libDeflate = {}
+function libDeflate:CompressDeflate(value)
+    return value
+end
+function libDeflate:EncodeForPrint(value)
+    return value
+end
+function libDeflate:DecodeForPrint(value)
+    return value
+end
+function libDeflate:DecompressDeflate(value)
+    return value
+end
+
+function LibStub(name)
+    if name == "AceSerializer-3.0" then
+        return aceSerializer
+    end
+    if name == "LibDeflate" then
+        return libDeflate
+    end
+    error("unexpected library: " .. tostring(name), 2)
+end
+
+local codecChunk = assert(loadfile("Config/ExportCodec.lua"))
+codecChunk("CooldownCompanion", ST)
+
+local encodedProfile = ST._EncodeSharedPayload({ globalStyle = {} }, "profile")
+local profileOk, decodedProfile = ST._DecodeSharedPayload(encodedProfile)
+assertTrue(profileOk, "encoded profile decodes")
+assertTrue(addon:HasSupportedImportCheckpoint(decodedProfile), "profile export keeps checkpoint after decode")
+
+local encodedEntity = ST._EncodeSharedPayload({ type = "customBars", version = 1, bars = { { customBarId = 1 } } }, "entity")
+local entityOk, decodedEntity = ST._DecodeSharedPayload(encodedEntity)
+assertTrue(entityOk, "encoded entity decodes")
+assertEquals(decodedEntity.type, "customBars", "entity type survives decode")
+assertTrue(addon:HasSupportedImportCheckpoint(decodedEntity), "entity export keeps checkpoint after decode")
+
+local encodedDiagnostic = ST._EncodeSharedPayload({ meta = {}, runtime = {}, profile = { globalStyle = {} } }, "diagnostic")
+local diagnosticOk, decodedDiagnostic = ST._DecodeSharedPayload(encodedDiagnostic)
+assertTrue(diagnosticOk, "encoded diagnostic decodes")
+assertTrue(addon:HasSupportedImportCheckpoint(decodedDiagnostic), "diagnostic export keeps top-level checkpoint")
+assertTrue(addon:HasSupportedImportCheckpoint(decodedDiagnostic.profile), "diagnostic profile keeps nested checkpoint")
+
+print("migration checkpoint tests passed")


### PR DESCRIPTION
## What Players Will Notice
- Existing local profiles still open and migrate normally when the addon loads.
- Newly exported profiles, groups, folders, Custom Bars, and diagnostic strings now carry a 1.15 import checkpoint.
- Import strings created before the 1.15 checkpoint are rejected with a recovery message instead of trying to run old import paths indefinitely.

## Why This Changed
1.15 is the bridge release for migration cleanup. This PR lets real local profiles cross that bridge while drawing a clear support boundary for imported data. The old migrations intentionally remain in place so users can update existing profiles before the later pruning pass.

## What Changed
- Added a shared `_cdcImportCheckpoint = "1.15"` marker and support helpers in the migration orchestrator.
- Stamped the active local profile after successful migrations.
- Stamped profile, entity, Custom Bars, and diagnostic exports through the shared export codec.
- Rejected profile, group/folder, Custom Bars, and diagnostic imports when the decoded payload lacks the 1.15 checkpoint or still matches the already-unsupported legacy profile shape.
- Added a Lua fixture for checkpoint stamping, import rejection, local-profile stamping, and profile/entity/diagnostic export round trips.

## Intentionally Not Changed
- No old migration code was pruned in this PR.
- No compact export format bump was made; the checkpoint is import-policy metadata, not a codec shape change.
- Cooldown, aura, resource-bar, cast-bar, and display runtime behavior was not changed.

## Validation
- `lua tests\border-rendering.lua`
- `lua tests\migration-checkpoint.lua`
- `luac -p` across addon Lua files excluding `Libs/` and `.local-tools/`
- `git diff --check`
- `git diff --cached --check`

## Post-Deploy Monitoring & Validation
- In-game smoke: export a profile/group/folder/Custom Bars setup from this branch and confirm it imports on this branch.
- In-game smoke: try a saved pre-checkpoint export string and confirm it shows the 1.15 recovery message.
- After the 1.15 release has served as the bridge, use this checkpoint to guide the separate 1.16 migration-pruning pass.
