### PR TITLE
Prune legacy compact export rehydration

### DIFF
--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -12,8 +12,10 @@ local LibDeflate = LibStub("LibDeflate")
 local COMPRESSION_CONFIG = { level = 9 }
 local COMPACT_FORMAT_KEY = "_cdcExportFormat"
 local CURRENT_COMPACT_FORMAT_VALUE = "compact3"
-local PREVIOUS_COMPACT_FORMAT_VALUE = "compact2"
-local LEGACY_COMPACT_FORMAT_VALUE = "compact1"
+local UNSUPPORTED_COMPACT_FORMATS = {
+    compact1 = true,
+    compact2 = true,
+}
 
 local function CopyValue(value)
     if type(value) == "table" then
@@ -199,16 +201,6 @@ local COMPACT_ENTITY_DEFAULTS = {
         },
     },
 }
-
-COMPACT_PROFILE_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_PROFILE_DEFAULTS[CURRENT_COMPACT_FORMAT_VALUE])
-COMPACT_PROFILE_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE].auraTextureLibrary.recentProcOverlays = {}
-COMPACT_ENTITY_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_ENTITY_DEFAULTS[CURRENT_COMPACT_FORMAT_VALUE])
-
--- compact1 shipped before defaults were version-pinned. Freeze it against the
--- original baseline so older compact strings do not drift as live defaults
--- evolve in later releases.
-COMPACT_PROFILE_DEFAULTS[LEGACY_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_PROFILE_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE])
-COMPACT_ENTITY_DEFAULTS[LEGACY_COMPACT_FORMAT_VALUE] = CopyTable(COMPACT_ENTITY_DEFAULTS[PREVIOUS_COMPACT_FORMAT_VALUE])
 
 local function PrepareSharedImportText(text)
     if type(text) ~= "string" then
@@ -1068,11 +1060,12 @@ local function DecodeSharedPayload(text)
     end
 
     local formatVersion = data[COMPACT_FORMAT_KEY]
-    if formatVersion == LEGACY_COMPACT_FORMAT_VALUE
-        or formatVersion == PREVIOUS_COMPACT_FORMAT_VALUE
-        or formatVersion == CURRENT_COMPACT_FORMAT_VALUE then
+    if formatVersion == CURRENT_COMPACT_FORMAT_VALUE then
         data[COMPACT_FORMAT_KEY] = nil
         data = RehydrateCompactPayload(data, formatVersion)
+    elseif UNSUPPORTED_COMPACT_FORMATS[formatVersion] then
+        data[COMPACT_FORMAT_KEY] = nil
+        data._cdcUnsupportedCompactFormat = formatVersion
     else
         data = NormalizeTextureLibraryPayload(data)
     end

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -151,6 +151,9 @@ function CooldownCompanion:IsUnsupportedImportPayload(payload)
     if type(payload) ~= "table" then
         return false
     end
+    if payload._cdcUnsupportedCompactFormat then
+        return true
+    end
     return self:IsUnsupportedLegacyProfile(payload) or not self:HasSupportedImportCheckpoint(payload)
 end
 


### PR DESCRIPTION
## What Changed
- Removed the old `compact1` and `compact2` rehydration baselines from the shared export codec.
- Kept `compact3` as the only compact format that expands back into importable data.
- Routes decoded `compact1` and `compact2` payloads through the existing unsupported-import cutoff path so players get the recovery guidance instead of a generic invalid-data failure.

## Why This Changed
- Cooldown Companion now treats 1.15 as the compatibility checkpoint for supported imports.
- These older compact formats predate that supported import model, so keeping their frozen defaults around made the codec harder to review without adding meaningful post-1.15 support.

## Developer Impact
- The import/export codec now has one current compact format to reason about, plus an explicit unsupported-format list.
- Future migration and import reviews have less legacy rehydration baggage to audit.

## Validation
- Reviewed against `origin/main` with no actionable findings.
- `git diff --check origin/main...HEAD`
- `luac -p` across 85 tracked Lua files
- No in-game validation run; this change is limited to import/export string handling and does not touch cooldown or aura display runtime.