### PR TITLE
Add gated button visual-state snapshots

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -36,6 +36,9 @@ local DEFAULT_BAR_AURA_COLOR = ST._DEFAULT_BAR_AURA_COLOR
 local DEFAULT_BAR_PANDEMIC_COLOR = ST._DEFAULT_BAR_PANDEMIC_COLOR
 local DEFAULT_BAR_CHARGE_COLOR = ST._DEFAULT_BAR_CHARGE_COLOR
 
+-- Imports from VisualState
+local ClearButtonVisualState = ST._ClearButtonVisualState
+
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
@@ -1671,6 +1674,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     local barAreaTop = showIcon and (iconSize + iconOffset) or 0
 
     button.style = newStyle
+    if ClearButtonVisualState then
+        ClearButtonVisualState(button)
+    end
     button._isVertical = isVertical
 
     -- Update bar fill OnUpdate interval

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -75,6 +75,24 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
+function CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot()
+    local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
+    return isEnabled and isEnabled() == true
+end
+
+function CooldownCompanion:RefreshButtonVisualStateSnapshot(button, context, phase)
+    if not CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot() then
+        return nil
+    end
+
+    local refresh = ST._RefreshButtonVisualState
+    if refresh and context then
+        context.phase = phase
+        return refresh(button, context)
+    end
+    return nil
+end
+
 local function ClearConditionalVisualPreviewFields(button)
     if button._conditionalAuraPreview then
         local buttonData = button.buttonData
@@ -2447,6 +2465,26 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
     button._forceVisibleByConfig = ((forceVisibleByConfig or forceVisibleByUnlockPreview or forceVisibleByPreview) and not isTriggerPanel) or nil
 
+    local visualStateContext
+    local shouldCaptureVisualState = CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot()
+    if shouldCaptureVisualState then
+        visualStateContext = button._visualStateContext
+        if type(visualStateContext) ~= "table" then
+            visualStateContext = {}
+            button._visualStateContext = visualStateContext
+        end
+        visualStateContext.displayMode = buttonDisplayMode
+        visualStateContext.isOnGCD = isOnGCD
+        visualStateContext.isGCDOnly = isGCDOnly
+        visualStateContext.cooldownSource = spellCooldownResult and spellCooldownResult.source
+        visualStateContext.presentationState = spellCooldownResult and (spellCooldownResult.presentationState or spellCooldownResult.state) or button._cooldownState
+        visualStateContext.cooldownSpellId = cooldownSpellId
+        visualStateContext.auraOwnsPrimarySwipe = auraOwnsPrimarySwipe
+        visualStateContext.auraOverrideActive = auraOverrideActive
+        visualStateContext.forceVisibleByConfig = forceVisibleByConfig
+        visualStateContext.forceVisibleByPreview = forceVisibleByPreview
+        visualStateContext.forceVisibleByUnlockPreview = forceVisibleByUnlockPreview
+    end
     -- Track visibility/force-visible state changes for compact layout reflow.
     local visibilityChanged = button._visibilityHidden ~= button._prevVisibilityHidden
     if visibilityChanged then
@@ -2472,6 +2510,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button._lastVisAlpha = 0
             end
             DispatchStandaloneTextureVisual(button)
+            if shouldCaptureVisualState then
+                CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
+            end
             return  -- Skip all visual updates
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -2489,6 +2530,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button.cooldown:Hide()
             HideIconFillForHiddenButton(button)
             DispatchStandaloneTextureVisual(button)
+            if shouldCaptureVisualState then
+                CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
+            end
             return  -- Skip visual updates for hidden buttons
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -2553,5 +2597,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
+    end
+    if shouldCaptureVisualState then
+        CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end
 end

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -28,6 +28,9 @@ local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
 local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 
+-- Imports from VisualState
+local ClearButtonVisualState = ST._ClearButtonVisualState
+
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
 local CreateAssistedHighlight = ST._CreateAssistedHighlight
@@ -1281,6 +1284,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Store updated style reference
     button.style = style
+    if ClearButtonVisualState then
+        ClearButtonVisualState(button)
+    end
 
     -- Invalidate cached widget state so next tick reapplies everything
     button._desaturated = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -28,6 +28,9 @@ local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 -- Imports from Helpers
 local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 
+-- Imports from VisualState
+local ClearButtonVisualState = ST._ClearButtonVisualState
+
 -- Imports from Glows
 
 -- Shared click-through helpers from Utils.lua
@@ -742,6 +745,9 @@ end
 ------------------------------------------------------------------------
 local function UpdateTextStyle(button, newStyle)
     button.style = newStyle
+    if ClearButtonVisualState then
+        ClearButtonVisualState(button)
+    end
     -- Background
     local bgColor = newStyle.textBgColor or {0, 0, 0, 0}
     button.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -1,0 +1,256 @@
+local ADDON_NAME, ST = ...
+
+local CooldownLogic = ST.CooldownLogic or {}
+local STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+
+local function IsTrue(value)
+    return value == true
+end
+
+local function EnsureSection(parent, key)
+    local section = parent[key]
+    if type(section) ~= "table" then
+        section = {}
+        parent[key] = section
+    end
+    return section
+end
+
+ST._buttonVisualStateSnapshotsEnabled = ST._buttonVisualStateSnapshotsEnabled == true
+
+local function SetButtonVisualStateSnapshotsEnabled(enabled)
+    ST._buttonVisualStateSnapshotsEnabled = enabled == true
+end
+
+local function AreButtonVisualStateSnapshotsEnabled()
+    return ST._buttonVisualStateSnapshotsEnabled == true
+end
+
+local function ResolveDesaturationReason(button, cooldownActive, chargeZero)
+    if not IsTrue(button._desatCooldownActive) then
+        return nil
+    end
+
+    if chargeZero then
+        return "zero-charges"
+    end
+
+    if cooldownActive then
+        return "cooldown"
+    end
+
+    if IsTrue(button._auraPrimarySwipeActive) then
+        return "aura"
+    end
+
+    return "cooldown-active"
+end
+
+local function IsReadyEligible(button, buttonData, cooldownActive)
+    if cooldownActive then
+        return false
+    end
+
+    if IsTrue(button._desatCooldownActive) then
+        return false
+    end
+
+    if IsTrue(button._noCooldown) then
+        return false
+    end
+
+    if buttonData and buttonData.isPassive then
+        return false
+    end
+
+    return true
+end
+
+local function IsTextureReady(button, buttonData)
+    if not buttonData then
+        return false
+    end
+
+    if buttonData.isPassive then
+        return false
+    end
+
+    if IsTrue(button._noCooldown) then
+        return false
+    end
+
+    return button._desatCooldownActive == false
+end
+
+local function ClearButtonVisualState(button)
+    if button then
+        button._visualState = nil
+        button._visualStateContext = nil
+    end
+end
+
+local function RefreshButtonVisualState(button, context)
+    if type(button) ~= "table" then
+        return nil
+    end
+
+    context = context or {}
+
+    local state = button._visualState
+    if type(state) ~= "table" then
+        state = {}
+        button._visualState = state
+    end
+
+    local buttonData = button.buttonData
+    local style = button.style
+    local cooldownActive = button._cooldownState == STATE_COOLDOWN
+    local chargeZero = button._chargeState == CHARGE_STATE_ZERO
+    local readyEligible = IsReadyEligible(button, buttonData, cooldownActive)
+    local textureReady = IsTextureReady(button, buttonData)
+
+    state.version = 1
+    state.phase = context.phase
+    state.displayMode = context.displayMode
+    state.buttonType = buttonData and buttonData.type
+    state.isText = IsTrue(button._isText)
+    state.isBar = IsTrue(button._isBar)
+    state.cooldownVisualActive = IsTrue(button._desatCooldownActive)
+    state.readyEligible = readyEligible
+
+    local cooldown = EnsureSection(state, "cooldown")
+    cooldown.state = button._cooldownState
+    cooldown.active = cooldownActive
+    cooldown.deferred = IsTrue(button._cooldownDeferred)
+    cooldown.noCooldown = IsTrue(button._noCooldown)
+    cooldown.durationObj = button._durationObj
+    cooldown.source = context.cooldownSource
+    cooldown.presentationState = context.presentationState
+    cooldown.spellID = context.cooldownSpellId
+
+    local presentation = EnsureSection(state, "presentation")
+    presentation.isOnGCD = IsTrue(context.isOnGCD) or IsTrue(button._isOnGCD)
+    presentation.gcdOnly = IsTrue(context.isGCDOnly)
+    presentation.showGCDSwipe = style and IsTrue(style.showGCDSwipe) or false
+    presentation.barGCDSuppressed = IsTrue(button._barGCDSuppressed)
+    presentation.durationObj = button._durationObj
+
+    local aura = EnsureSection(state, "aura")
+    aura.trackingReady = IsTrue(button._auraTrackingReady)
+    aura.active = IsTrue(button._auraActive)
+    aura.ownsPrimarySwipe = IsTrue(context.auraOwnsPrimarySwipe)
+    aura.overrideActive = IsTrue(context.auraOverrideActive)
+    aura.primarySwipeActive = IsTrue(button._auraPrimarySwipeActive)
+    aura.inPandemic = IsTrue(button._inPandemic)
+    aura.spellID = button._auraSpellID
+    aura.unit = button._auraUnit
+    aura.durationObj = button._auraDurationObj
+
+    local charges = EnsureSection(state, "charges")
+    charges.state = button._chargeState
+    charges.zero = chargeZero
+    charges.full = button._chargeState == CHARGE_STATE_FULL
+    charges.missing = button._chargeState == CHARGE_STATE_MISSING
+    charges.recharging = IsTrue(button._chargeRecharging)
+    charges.cooldownVisualActive = IsTrue(button._chargeCooldownVisualActive)
+    charges.durationObj = button._chargeDurationObj
+    charges.currentReadable = button._currentReadableCharges
+    charges.countReadable = button._chargeCountReadable
+    charges.zeroConfirmed = IsTrue(button._zeroChargesConfirmed)
+    charges.mainCooldownShown = IsTrue(button._mainCDShown)
+
+    local visibility = EnsureSection(state, "visibility")
+    visibility.hidden = IsTrue(button._visibilityHidden)
+    visibility.alphaOverride = button._visibilityAlphaOverride
+    visibility.rawHidden = IsTrue(button._rawVisibilityHidden)
+    visibility.rawAlphaOverride = button._rawVisibilityAlphaOverride
+    visibility.reasonBits = button._visibilityReasonBits
+    visibility.reasonMode = button._visibilityReasonMode
+    visibility.forceVisible = IsTrue(button._forceVisibleByConfig)
+    visibility.forceVisibleByConfig = IsTrue(context.forceVisibleByConfig)
+    visibility.forceVisibleByPreview = IsTrue(context.forceVisibleByPreview)
+    visibility.forceVisibleByUnlockPreview = IsTrue(context.forceVisibleByUnlockPreview)
+    visibility.lastAlpha = button._lastVisAlpha
+
+    local usability = EnsureSection(state, "usability")
+    usability.spellOutOfRange = IsTrue(button._spellOutOfRange)
+    usability.conditionalPreview = button._conditionalPreviewKind ~= nil
+    usability.conditionalPreviewKind = button._conditionalPreviewKind
+    usability.conditionalPreviewDomain = button._conditionalPreviewDomain
+    usability.conditionalPreviewRemaining = button._conditionalPreviewRemaining
+
+    local desaturation = EnsureSection(state, "desaturation")
+    desaturation.cooldownActive = state.cooldownVisualActive
+    desaturation.active = state.cooldownVisualActive
+    desaturation.applied = IsTrue(button._desaturated)
+    desaturation.reason = ResolveDesaturationReason(button, cooldownActive, chargeZero)
+
+    local tint = EnsureSection(state, "tint")
+    tint.unusableActive = IsTrue(button._unusableTintActive)
+    tint.r = button._vertexR
+    tint.g = button._vertexG
+    tint.b = button._vertexB
+    tint.a = button._vertexA
+    tint.hasVertex = button._vertexR ~= nil or button._vertexG ~= nil or button._vertexB ~= nil or button._vertexA ~= nil
+
+    local iconFill = EnsureSection(state, "iconFill")
+    iconFill.active = IsTrue(button._iconFillActive)
+    iconFill.mode = button._iconFillMode
+    iconFill.auraActive = IsTrue(button._iconFillAuraActive)
+    iconFill.onUpdateInstalled = IsTrue(button._iconFillOnUpdateInstalled)
+
+    local ready = EnsureSection(state, "ready")
+    ready.eligible = readyEligible
+    ready.glowActive = IsTrue(button._readyGlowActive)
+    ready.glowStartTime = button._readyGlowStartTime
+    ready.maxChargesActive = IsTrue(button._readyGlowMaxChargesActive)
+
+    local glows = EnsureSection(state, "glows")
+    glows.procActive = IsTrue(button._procGlowActive)
+    glows.auraActive = IsTrue(button._auraGlowActive)
+    glows.auraPandemic = IsTrue(button._auraGlowPandemic)
+    glows.readyActive = IsTrue(button._readyGlowActive)
+    glows.barAuraEffectActive = IsTrue(button._barAuraEffectActive)
+    glows.barPulseActive = IsTrue(button._barPulseActive)
+    glows.barColorShiftActive = IsTrue(button._barColorShiftActive)
+
+    local text = EnsureSection(state, "text")
+    text.available = not state.cooldownVisualActive
+    text.unusable = IsTrue(button._isUnusable)
+    text.outOfRange = IsTrue(button._isOutOfRange)
+    text.chargeState = button._chargeState
+    text.durationObj = button._durationObj
+
+    local textureEffects = EnsureSection(state, "textureEffects")
+    textureEffects.ready = textureReady
+    textureEffects.cooldownActive = state.cooldownVisualActive
+    textureEffects.chargeState = button._chargeState
+    textureEffects.procActive = IsTrue(button._procOverlayActive)
+
+    local applied = EnsureSection(state, "applied")
+    applied.desaturated = IsTrue(button._desaturated)
+    applied.unusableTintActive = IsTrue(button._unusableTintActive)
+    applied.vertexR = button._vertexR
+    applied.vertexG = button._vertexG
+    applied.vertexB = button._vertexB
+    applied.vertexA = button._vertexA
+    applied.iconFillActive = IsTrue(button._iconFillActive)
+    applied.readyGlowActive = glows.readyActive
+    applied.procGlowActive = glows.procActive
+    applied.auraGlowActive = glows.auraActive
+    applied.barAuraEffectActive = glows.barAuraEffectActive
+    applied.barPulseActive = glows.barPulseActive
+    applied.barColorShiftActive = glows.barColorShiftActive
+    applied.visibilityHidden = IsTrue(button._visibilityHidden)
+    applied.alpha = button._lastVisAlpha
+
+    return state
+end
+
+ST._RefreshButtonVisualState = RefreshButtonVisualState
+ST._ClearButtonVisualState = ClearButtonVisualState
+ST._SetButtonVisualStateSnapshotsEnabled = SetButtonVisualStateSnapshotsEnabled
+ST._AreButtonVisualStateSnapshotsEnabled = AreButtonVisualStateSnapshotsEnabled

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -71,6 +71,7 @@ ButtonFrame\Helpers.lua
 ButtonFrame\Glows.lua
 ButtonFrame\Visibility.lua
 ButtonFrame\Tracking.lua
+ButtonFrame\VisualState.lua
 ButtonFrame\IconMode.lua
 ButtonFrame\BarMode.lua
 ButtonFrame\TextMode.lua

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -18,6 +18,13 @@ local UnitCanAttack = UnitCanAttack
 local InCombatLockdown = InCombatLockdown
 local C_CVar_GetCVarBool = C_CVar.GetCVarBool
 
+local function ClearButtonVisualState(button)
+    local clear = ST._ClearButtonVisualState
+    if clear then
+        clear(button)
+    end
+end
+
 local LOAD_CONDITION_DEFAULTS = {
     raid = false,
     dungeon = false,
@@ -1537,6 +1544,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._chargeCountReadable = nil
                 button._zeroChargesConfirmed = nil
                 button._displayCountZeroUsabilityFallback = nil
+                ClearButtonVisualState(button)
             end
         end
     end


### PR DESCRIPTION
## What Changed
- Added a gated `ButtonFrame/VisualState.lua` snapshot builder for per-button cooldown truth, GCD presentation, aura state, charges, visibility, desaturation/tint, icon fill, glows, text, texture effects, and applied visual state.
- Loaded the snapshot module before the icon/bar/text renderers and clear stale snapshots during style/runtime resets.
- Kept snapshot capture default-off so normal cooldown refreshes do not add production hot-path work until diagnostics or future consumers opt in.

## Why This Changed
- The visual-state project needs one clear per-button state shape before migrating display consumers.
- Keeping the foundation gated lets later PRs adopt the snapshot incrementally without changing cooldown or aura display behavior in this first step.

## Developer Impact
- Future visual-state PRs can move consumers toward `button._visualState` with a known snapshot contract.
- The local fixture documents the expected snapshot shape while the addon runtime stays inert by default.

## Validation
- `git diff --check origin/visual-state-dev-main...HEAD`
- `luac -p` across tracked Lua files
- `lua tests\visual-state-snapshot.lua` local ignored fixture
- In-game smoke checklist passed: reload/config open, normal cooldown, charge spell, aura-tracked button, icon/bar/text modes, style refresh, and combat tracked abilities.
- Restricted-content smoke was not separately reported and should still be checked before the final dev-branch merge to main.