### PR TITLE
Route icon desaturation through shared visual-state intent

### DIFF
--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -30,6 +30,7 @@ local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 
 -- Imports from VisualState
 local ClearButtonVisualState = ST._ClearButtonVisualState
+local ResolveIconDesaturationIntent = ST._ResolveIconDesaturationIntent
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -1001,6 +1002,26 @@ function CooldownCompanion:UpdateButtonIcon(button)
     end
 end
 
+local function ApplyIconDesaturationIntent(button, buttonData, style)
+    if type(ResolveIconDesaturationIntent) ~= "function" then
+        EvaluateDesaturation(button, buttonData, style)
+        return
+    end
+
+    local intent = button._iconDesaturationIntent
+    if type(intent) ~= "table" then
+        intent = {}
+        button._iconDesaturationIntent = intent
+    end
+
+    ResolveIconDesaturationIntent(button, buttonData, style, intent)
+
+    if button._desaturated ~= intent.active then
+        button._desaturated = intent.active
+        button.icon:SetDesaturated(intent.active)
+    end
+end
+
 -- Update icon-mode visuals: GCD suppression, cooldown text, desaturation, and vertex color.
 local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
     -- GCD suppression (isOnGCD is NeverSecret, always readable)
@@ -1134,7 +1155,7 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
         end
     end
 
-    EvaluateDesaturation(button, buttonData, style)
+    ApplyIconDesaturationIntent(button, buttonData, style)
 
     UpdateIconTint(button, buttonData, style)
 end
@@ -1290,6 +1311,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     -- Invalidate cached widget state so next tick reapplies everything
     button._desaturated = nil
+    button._iconDesaturationIntent = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -257,6 +257,71 @@ local function UpdateIconTint(button, buttonData, style)
     end
 end
 
+local function ResolveDesaturationIntent(button, buttonData, style, target)
+    target = target or {}
+    target.active = false
+    target.reason = nil
+
+    if type(button) ~= "table" or type(buttonData) ~= "table" then
+        return target
+    end
+
+    style = style or {}
+
+    if button._auraTrackingReady == true then
+        if buttonData.isPassive then
+            if buttonData.neverDesaturate then
+                target.active = false
+            elseif buttonData.invertAuraDesaturationLogic then
+                target.active = button._auraActive == true
+                if target.active then
+                    target.reason = "passive-aura-active-inverted"
+                end
+            else
+                target.active = not button._auraActive
+                if target.active then
+                    target.reason = "passive-aura-missing"
+                end
+            end
+        else
+            target.active = buttonData.desaturateWhileAuraNotActive and not button._auraActive or false
+            if target.active then
+                target.reason = "aura-missing"
+            end
+        end
+        if not target.active and not button._auraActive
+            and style.desaturateOnCooldown and button._desatCooldownActive then
+            target.active = true
+            target.reason = "cooldown"
+        end
+    elseif style.desaturateOnCooldown or buttonData.desaturateWhileZeroCharges
+        or buttonData.desaturateWhileZeroStacks or button._isEquippableNotEquipped then
+        if style.desaturateOnCooldown and button._desatCooldownActive then
+            target.active = true
+            target.reason = "cooldown"
+        end
+        if not target.active and buttonData.desaturateWhileZeroCharges
+                and not CooldownCompanion.HasItemFallbacks(buttonData)
+                and button._chargeState == CHARGE_STATE_ZERO then
+            target.active = true
+            target.reason = "zero-charges"
+        end
+        local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
+            and button._resolvedItemAvailableQuantity
+            or button._itemCount
+        if not target.active and buttonData.desaturateWhileZeroStacks and (itemUseCount or 0) == 0 then
+            target.active = true
+            target.reason = "zero-stacks"
+        end
+    end
+    if not target.active and button._isEquippableNotEquipped then
+        target.active = true
+        target.reason = "not-equipped"
+    end
+
+    return target
+end
+
 -- Icon desaturation: aura-tracked buttons desaturate when aura absent
 -- (passive entries can invert this via invertAuraDesaturationLogic,
 -- disable it entirely via neverDesaturate;
@@ -265,46 +330,17 @@ end
 -- equippable-but-not-equipped items always desaturate.
 -- Shared by icon-mode and bar-mode display paths.
 local function EvaluateDesaturation(button, buttonData, style)
-    local wantDesat = false
-    if button._auraTrackingReady == true then
-        if buttonData.isPassive then
-            if buttonData.neverDesaturate then
-                wantDesat = false
-            elseif buttonData.invertAuraDesaturationLogic then
-                wantDesat = button._auraActive == true
-            else
-                wantDesat = not button._auraActive
-            end
-        else
-            wantDesat = buttonData.desaturateWhileAuraNotActive and not button._auraActive
-        end
-        if not wantDesat and not button._auraActive
-            and style.desaturateOnCooldown and button._desatCooldownActive then
-            wantDesat = true
-        end
-    elseif style.desaturateOnCooldown or buttonData.desaturateWhileZeroCharges
-        or buttonData.desaturateWhileZeroStacks or button._isEquippableNotEquipped then
-        if style.desaturateOnCooldown and button._desatCooldownActive then
-            wantDesat = true
-        end
-        if not wantDesat and buttonData.desaturateWhileZeroCharges
-                and not CooldownCompanion.HasItemFallbacks(buttonData)
-                and button._chargeState == CHARGE_STATE_ZERO then
-            wantDesat = true
-        end
-        local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
-            and button._resolvedItemAvailableQuantity
-            or button._itemCount
-        if not wantDesat and buttonData.desaturateWhileZeroStacks and (itemUseCount or 0) == 0 then
-            wantDesat = true
-        end
+    local intent = button._desaturationIntent
+    if type(intent) ~= "table" then
+        intent = {}
+        button._desaturationIntent = intent
     end
-    if not wantDesat and button._isEquippableNotEquipped then
-        wantDesat = true
-    end
-    if button._desaturated ~= wantDesat then
-        button._desaturated = wantDesat
-        button.icon:SetDesaturated(wantDesat)
+
+    ResolveDesaturationIntent(button, buttonData, style, intent)
+
+    if button._desaturated ~= intent.active then
+        button._desaturated = intent.active
+        button.icon:SetDesaturated(intent.active)
     end
 end
 
@@ -313,4 +349,6 @@ ST._UpdateChargeTracking = UpdateChargeTracking
 ST._UpdateDisplayCountTracking = UpdateDisplayCountTracking
 ST._UpdateItemChargeTracking = UpdateItemChargeTracking
 ST._UpdateIconTint = UpdateIconTint
+ST._ResolveDesaturationIntent = ResolveDesaturationIntent
+ST._ResolveIconDesaturationIntent = ResolveDesaturationIntent
 ST._EvaluateDesaturation = EvaluateDesaturation

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -5,6 +5,7 @@ local STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local ResolveIconDesaturationIntent = ST._ResolveIconDesaturationIntent
 
 local function IsTrue(value)
     return value == true
@@ -111,6 +112,7 @@ local function RefreshButtonVisualState(button, context)
     local chargeZero = button._chargeState == CHARGE_STATE_ZERO
     local readyEligible = IsReadyEligible(button, buttonData, cooldownActive)
     local textureReady = IsTextureReady(button, buttonData)
+    local iconDesaturationIntent = ResolveIconDesaturationIntent(button, buttonData, style)
 
     state.version = 1
     state.phase = context.phase
@@ -187,6 +189,14 @@ local function RefreshButtonVisualState(button, context)
     desaturation.active = state.cooldownVisualActive
     desaturation.applied = IsTrue(button._desaturated)
     desaturation.reason = ResolveDesaturationReason(button, cooldownActive, chargeZero)
+    desaturation.intentActive = IsTrue(iconDesaturationIntent.active)
+    desaturation.intentReason = iconDesaturationIntent.reason
+
+    local icon = EnsureSection(state, "icon")
+    local iconDesaturation = EnsureSection(icon, "desaturation")
+    iconDesaturation.active = IsTrue(iconDesaturationIntent.active)
+    iconDesaturation.reason = iconDesaturationIntent.reason
+    iconDesaturation.applied = IsTrue(button._desaturated)
 
     local tint = EnsureSection(state, "tint")
     tint.unusableActive = IsTrue(button._unusableTintActive)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -121,6 +121,8 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     local charges = state.charges or {}
     local visibility = state.visibility or {}
     local desaturation = state.desaturation or {}
+    local icon = state.icon or {}
+    local iconDesaturation = icon.desaturation or {}
     local tint = state.tint or {}
     local iconFill = state.iconFill or {}
     local ready = state.ready or {}
@@ -157,6 +159,8 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     }
     row.visuals = {
         desaturationActive = desaturation.active,
+        desaturationIntentActive = iconDesaturation.active,
+        desaturationIntentReason = iconDesaturation.reason,
         desaturationApplied = desaturation.applied,
         desaturationReason = desaturation.reason,
         tintActive = tint.unusableActive,
@@ -194,6 +198,9 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "visibility.hidden", visibility.hidden, IsTrue(button._visibilityHidden))
     CompareValue(row, "visibility.alphaOverride", visibility.alphaOverride, button._visibilityAlphaOverride)
     CompareValue(row, "visibility.lastAlpha", visibility.lastAlpha, button._lastVisAlpha)
+    if row.displayMode == "icons" and row.phase == "post-dispatch" and visibility.hidden ~= true then
+        CompareValue(row, "desaturation.intent", iconDesaturation.active, IsTrue(button._desaturated))
+    end
     CompareValue(row, "desaturation.applied", desaturation.applied, IsTrue(button._desaturated))
     CompareValue(row, "tint.unusableActive", tint.unusableActive, IsTrue(button._unusableTintActive))
     CompareValue(row, "tint.r", tint.r, button._vertexR)


### PR DESCRIPTION
## What Changed
- Routed icon-panel desaturation through a shared visual-state intent resolver while preserving the existing applied desaturation behavior.
- Moved the desaturation decision rules into `ButtonFrame/Tracking.lua` so icon mode, bar mode, and visual-state diagnostics use one source of truth.
- Added visual-state diagnostic fields for desaturation intent and limited intent/applied parity checks to visible post-dispatch icon rows, avoiding hidden-button false positives.

## Why This Changed
- This is the first icon visual consumer in the visual-state rollout. Desaturation is visual-only and narrow enough to prove the model without changing cooldown or aura truth.
- Keeping desaturation intent single-sourced reduces drift while later visual consumers are moved into the same model.

## Developer Impact
- Future visual-state work can inspect icon desaturation intent directly instead of re-deriving it from scattered runtime fields.
- Diagnostics can now distinguish the intended desaturation state from the actually applied icon texture state when investigating display bugs.
- Player-facing icon and bar desaturation behavior is expected to remain unchanged.

## Validation
- `git diff --check`
- `luac -p` on touched Lua files
- `luac -p` across all tracked Lua files
- Local ignored fixtures: `lua tests\visual-state-snapshot.lua`, `lua tests\visual-state-diagnostics.lua`
- Static review passes came back clean after the shared-resolver and hidden-row diagnostics fixes.
- In-game smoke/sanity check looked good for the affected display behavior.
- Combat and restricted-content validation still needed before the full visual-state project is considered release-ready.