### PR TITLE
Route icon tint through visual-state intent

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1686,6 +1686,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
 
     -- Invalidate cached state
     button._desaturated = nil
+    button._iconTintIntent = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1312,6 +1312,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     -- Invalidate cached widget state so next tick reapplies everything
     button._desaturated = nil
     button._iconDesaturationIntent = nil
+    button._iconTintIntent = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -163,33 +163,54 @@ local function UpdateItemChargeTracking(button, buttonData)
     end
 end
 
+local function SetTintIntent(target, active, reason, unusableActive, r, g, b, a)
+    target.active = active == true
+    target.reason = reason
+    target.unusableActive = unusableActive == true
+    target.r = r
+    target.g = g
+    target.b = b
+    target.a = a
+    return target
+end
+
 -- Icon tinting: out-of-range red > unusable dimming > aura tint > cooldown tint > base tint.
--- Shared by icon-mode and bar-mode display paths.
-local function UpdateIconTint(button, buttonData, style)
-    button._unusableTintActive = false
+-- This resolver may read range/usability APIs; call it only from the normal tint update path.
+local function ResolveIconTintIntent(button, buttonData, style, target)
+    target = target or {}
+    if type(button) ~= "table" or type(buttonData) ~= "table" then
+        return SetTintIntent(target, false, nil, false, 1, 1, 1, 1)
+    end
+
+    style = style or {}
+
     if buttonData.isPassive then
         local c
-        if style.iconAuraTintEnabled and buttonData.auraTracking and button._auraActive then
+        local reason = "base"
+        if style.iconAuraTintEnabled and buttonData.auraTracking and button._auraActive and style.iconAuraTintColor then
             c = style.iconAuraTintColor
+            reason = "aura"
         end
         c = c or style.iconTintColor
         local r, g, b, a = c and c[1] or 1, c and c[2] or 1, c and c[3] or 1, c and c[4] or 1
-        if button._vertexR ~= r or button._vertexG ~= g or button._vertexB ~= b or button._vertexA ~= a then
-            button._vertexR, button._vertexG, button._vertexB, button._vertexA = r, g, b, a
-            button.icon:SetVertexColor(r, g, b, a)
-        end
-        return
+        return SetTintIntent(target, reason ~= "base", reason, false, r, g, b, a)
     end
+
     local bc = style.iconTintColor
     local r, g, b, a = 1, 1, 1, bc and bc[4] or 1
+    local reason = "base"
     local stateOverride = false
+    local unusableActive = false
+
     if style.showOutOfRange then
         if button._conditionalOutOfRangePreview then
             r, g, b = 1, 0.2, 0.2
+            reason = "out-of-range-preview"
             stateOverride = true
         elseif buttonData.type == "spell" then
             if button._spellOutOfRange then
                 r, g, b = 1, 0.2, 0.2
+                reason = "out-of-range"
                 stateOverride = true
             end
         elseif buttonData.type == "item" then
@@ -201,26 +222,30 @@ local function UpdateIconTint(button, buttonData, style)
                 -- inRange is nil when no target or item has no range; only tint on explicit false
                 if inRange == false then
                     r, g, b = 1, 0.2, 0.2
+                    reason = "out-of-range"
                     stateOverride = true
                 end
             end
         end
     end
+
     if not stateOverride and style.showUnusable then
         local uc = style.iconUnusableTintColor
         if button._conditionalUnusablePreview then
             r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
             a = uc and uc[4] or a
+            reason = "unusable-preview"
             stateOverride = true
-            button._unusableTintActive = true
+            unusableActive = true
         elseif buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
             local isUsable = C_Spell.IsSpellUsable(spellID)
             if not isUsable then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a
+                reason = "unusable"
                 stateOverride = true
-                button._unusableTintActive = true
+                unusableActive = true
             end
         elseif buttonData.type == "item" then
             local itemID = button._resolvedItemId or buttonData.id
@@ -228,29 +253,47 @@ local function UpdateIconTint(button, buttonData, style)
             if not usable then
                 r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
                 a = uc and uc[4] or a
+                reason = "unusable"
                 stateOverride = true
-                button._unusableTintActive = true
+                unusableActive = true
             end
         end
     end
-    -- Apply user-configured icon tint when no state override is active
+
+    -- Apply user-configured icon tint when no state override is active.
     if not stateOverride then
         if style.iconAuraTintEnabled and buttonData.auraTracking and button._auraActive then
             local c = style.iconAuraTintColor
             if c then
                 r, g, b, a = c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1
             end
+            reason = "aura"
         elseif style.iconCooldownTintEnabled and button._desatCooldownActive then
             local c = style.iconCooldownTintColor
             if c then
                 r, g, b, a = c[1] or 1, c[2] or 1, c[3] or 1, c[4] or 1
             end
-        else
-            if bc then
-                r, g, b, a = bc[1] or 1, bc[2] or 1, bc[3] or 1, bc[4] or 1
-            end
+            reason = "cooldown"
+        elseif bc then
+            r, g, b, a = bc[1] or 1, bc[2] or 1, bc[3] or 1, bc[4] or 1
         end
     end
+
+    return SetTintIntent(target, reason ~= "base", reason, unusableActive, r, g, b, a)
+end
+
+-- Shared by icon-mode and bar-mode display paths.
+local function UpdateIconTint(button, buttonData, style)
+    local intent = button._iconTintIntent
+    if type(intent) ~= "table" then
+        intent = {}
+        button._iconTintIntent = intent
+    end
+
+    ResolveIconTintIntent(button, buttonData, style, intent)
+
+    local r, g, b, a = intent.r, intent.g, intent.b, intent.a
+    button._unusableTintActive = intent.unusableActive == true
     if button._vertexR ~= r or button._vertexG ~= g or button._vertexB ~= b or button._vertexA ~= a then
         button._vertexR, button._vertexG, button._vertexB, button._vertexA = r, g, b, a
         button.icon:SetVertexColor(r, g, b, a)
@@ -349,6 +392,7 @@ ST._UpdateChargeTracking = UpdateChargeTracking
 ST._UpdateDisplayCountTracking = UpdateDisplayCountTracking
 ST._UpdateItemChargeTracking = UpdateItemChargeTracking
 ST._UpdateIconTint = UpdateIconTint
+ST._ResolveIconTintIntent = ResolveIconTintIntent
 ST._ResolveDesaturationIntent = ResolveDesaturationIntent
 ST._ResolveIconDesaturationIntent = ResolveDesaturationIntent
 ST._EvaluateDesaturation = EvaluateDesaturation

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -113,6 +113,8 @@ local function RefreshButtonVisualState(button, context)
     local readyEligible = IsReadyEligible(button, buttonData, cooldownActive)
     local textureReady = IsTextureReady(button, buttonData)
     local iconDesaturationIntent = ResolveIconDesaturationIntent(button, buttonData, style)
+    local iconTintIntent = button._iconTintIntent
+    local hasIconTintIntent = type(iconTintIntent) == "table"
 
     state.version = 1
     state.phase = context.phase
@@ -205,6 +207,14 @@ local function RefreshButtonVisualState(button, context)
     tint.b = button._vertexB
     tint.a = button._vertexA
     tint.hasVertex = button._vertexR ~= nil or button._vertexG ~= nil or button._vertexB ~= nil or button._vertexA ~= nil
+    tint.intentAvailable = hasIconTintIntent
+    tint.intentActive = hasIconTintIntent and IsTrue(iconTintIntent.active) or false
+    tint.intentReason = hasIconTintIntent and iconTintIntent.reason or nil
+    tint.intentUnusableActive = hasIconTintIntent and IsTrue(iconTintIntent.unusableActive) or false
+    tint.intentR = hasIconTintIntent and iconTintIntent.r or nil
+    tint.intentG = hasIconTintIntent and iconTintIntent.g or nil
+    tint.intentB = hasIconTintIntent and iconTintIntent.b or nil
+    tint.intentA = hasIconTintIntent and iconTintIntent.a or nil
 
     local iconFill = EnsureSection(state, "iconFill")
     iconFill.active = IsTrue(button._iconFillActive)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -129,6 +129,12 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     local glows = state.glows or {}
     local text = state.text or {}
     local textureEffects = state.textureEffects or {}
+    local tintActive
+    if tint.intentAvailable == true then
+        tintActive = IsTrue(tint.intentActive)
+    else
+        tintActive = IsTrue(tint.unusableActive)
+    end
 
     row.cooldown = {
         state = cooldown.state,
@@ -163,7 +169,16 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         desaturationIntentReason = iconDesaturation.reason,
         desaturationApplied = desaturation.applied,
         desaturationReason = desaturation.reason,
-        tintActive = tint.unusableActive,
+        tintActive = tintActive,
+        tintUnusableActive = tint.unusableActive,
+        tintIntentAvailable = tint.intentAvailable,
+        tintIntentActive = tint.intentActive,
+        tintIntentReason = tint.intentReason,
+        tintIntentUnusableActive = tint.intentUnusableActive,
+        tintIntentR = tint.intentR,
+        tintIntentG = tint.intentG,
+        tintIntentB = tint.intentB,
+        tintIntentA = tint.intentA,
         tintR = tint.r,
         tintG = tint.g,
         tintB = tint.b,
@@ -198,7 +213,10 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "visibility.hidden", visibility.hidden, IsTrue(button._visibilityHidden))
     CompareValue(row, "visibility.alphaOverride", visibility.alphaOverride, button._visibilityAlphaOverride)
     CompareValue(row, "visibility.lastAlpha", visibility.lastAlpha, button._lastVisAlpha)
-    if row.displayMode == "icons" and row.phase == "post-dispatch" and visibility.hidden ~= true then
+    local compareVisibleIconIntent = row.displayMode == "icons"
+        and row.phase == "post-dispatch"
+        and visibility.hidden ~= true
+    if compareVisibleIconIntent then
         CompareValue(row, "desaturation.intent", iconDesaturation.active, IsTrue(button._desaturated))
     end
     CompareValue(row, "desaturation.applied", desaturation.applied, IsTrue(button._desaturated))
@@ -207,6 +225,13 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "tint.g", tint.g, button._vertexG)
     CompareValue(row, "tint.b", tint.b, button._vertexB)
     CompareValue(row, "tint.a", tint.a, button._vertexA)
+    if compareVisibleIconIntent and tint.intentAvailable == true then
+        CompareValue(row, "tint.intent.unusableActive", tint.intentUnusableActive, tint.unusableActive)
+        CompareValue(row, "tint.intent.r", tint.intentR, tint.r)
+        CompareValue(row, "tint.intent.g", tint.intentG, tint.g)
+        CompareValue(row, "tint.intent.b", tint.intentB, tint.b)
+        CompareValue(row, "tint.intent.a", tint.intentA, tint.a)
+    end
     CompareValue(row, "iconFill.active", iconFill.active, IsTrue(button._iconFillActive))
     CompareValue(row, "iconFill.mode", iconFill.mode, button._iconFillMode)
     CompareValue(row, "ready.glowActive", ready.glowActive, IsTrue(button._readyGlowActive))

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -465,6 +465,9 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
             if row.visuals then
                 parts[#parts + 1] = "desat=" .. tostring(row.visuals.desaturationApplied)
                 parts[#parts + 1] = "tint=" .. tostring(row.visuals.tintActive)
+                if row.visuals.tintIntentReason and row.visuals.tintIntentReason ~= "base" then
+                    parts[#parts + 1] = "tintReason=" .. tostring(row.visuals.tintIntentReason)
+                end
                 parts[#parts + 1] = "fill=" .. tostring(row.visuals.iconFillActive)
             end
             if type(row.mismatches) == "table" and #row.mismatches > 0 then


### PR DESCRIPTION
## What Players Will Notice
- No intended change to how cooldowns, auras, charges, or icon tinting look in normal play.
- Support/debug reports can now explain why an icon is tinted, such as unusable, out-of-range, aura tint, cooldown tint, or base tint.

## Why This Changed
- This is the next icon consumer slice in the visual-state rollout after desaturation.
- Icon tint was still decided and applied as an implicit vertex-color side effect, which made it harder to verify whether the addon intended a tint or merely had a stale applied color.
- Making tint intent explicit helps future visual-state work distinguish true desaturation, vertex tint, icon fill, and visibility alpha without changing cooldown or aura truth.

## What Changed
- Added a shared icon tint intent resolver that preserves the existing priority order: out-of-range, unusable, aura tint, cooldown tint, then base tint.
- Routed runtime icon tint application through that intent while preserving the existing API timing for usability and range checks.
- Captured tint intent in `ButtonFrame/VisualState.lua` without recomputing live usability/range reads from snapshots or diagnostics.
- Compared tint intent to applied vertex color in diagnostics only for visible post-dispatch icon rows.
- Added `tintReason` to bug report visual-state rows when tint intent is active.
- Cleared cached tint intent during icon and bar style refreshes.
- Deferred icon fill to its own later PR because it owns status bar geometry, OnUpdate state, cooldown swipe suppression, and aura-swipe interaction.

## Validation
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- `luac -p` on touched Lua files
- `luac -p` across 87 tracked Lua files
- `git diff --check`
- In-game smoke passed on an Arms Warrior profile: bug report showed `mismatched=0`, `missing=0`, snapshots restored, expected `tint=true tintReason=unusable` rows, and no visual regressions observed.
- Combat/restricted-content validation is still needed before merging the full visual-state dev branch to `main`.