### PR TITLE
Track icon fill intent in visual-state diagnostics

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -50,6 +50,7 @@ local ApplyIconCountTextStyle = ST._ApplyIconCountTextStyle
 local UpdateIconModeVisuals = ST._UpdateIconModeVisuals
 local UpdateIconModeGlows = ST._UpdateIconModeGlows
 local CacheButtonBindingKeys = ST._CacheButtonBindingKeys
+local ClearIconFillVisualState = ST._ClearIconFillVisualState
 
 -- Imports from BarMode
 local ApplyBarCountTextStyle = ST._ApplyBarCountTextStyle
@@ -134,10 +135,18 @@ local function ClearConditionalVisualPreviewFields(button)
 end
 
 local function HideIconFillForHiddenButton(button)
+    if type(ClearIconFillVisualState) == "function" then
+        ClearIconFillVisualState(button, button and button.style, nil, true)
+        return
+    end
     if not (button and button.iconFill) then return end
     button.iconFill:Hide()
     button.iconFill:SetScript("OnUpdate", nil)
     button._iconFillOnUpdateInstalled = nil
+    button._iconFillActive = nil
+    button._iconFillMode = nil
+    button._iconFillAuraActive = nil
+    button._iconFillIntent = nil
 end
 
 local function ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -31,6 +31,7 @@ local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 -- Imports from VisualState
 local ClearButtonVisualState = ST._ClearButtonVisualState
 local ResolveIconDesaturationIntent = ST._ResolveIconDesaturationIntent
+local ResolveIconFillIntent = ST._ResolveIconFillIntent
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -63,8 +64,6 @@ local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCoo
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
-local DEFAULT_ICON_FILL_COOLDOWN_COLOR = {0.6, 0.13, 0.18, 0.55}
-local DEFAULT_ICON_FILL_AURA_COLOR = {0.2, 1.0, 0.2, 0.55}
 local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1
@@ -173,27 +172,6 @@ local function HideBlizzardAuraSwipe(button, style)
             ApplyDefaultCooldownSwipeStyle(button, style)
         end
     end
-end
-
-local function IsIconFillAvailable(button, style)
-    if not (button and button.iconFill and style and style.iconFillEnabled == true) then
-        return false
-    end
-
-    local group = button._groupId
-        and CooldownCompanion.db and CooldownCompanion.db.profile
-        and CooldownCompanion.db.profile.groups
-        and CooldownCompanion.db.profile.groups[button._groupId]
-    if group then
-        if (group.displayMode or "icons") ~= "icons" then
-            return false
-        end
-        if group.masqueEnabled == true then
-            return false
-        end
-    end
-
-    return true
 end
 
 local function ResolveIconFillPreviewRemaining(button)
@@ -314,77 +292,80 @@ local function IconFillOnUpdate(self)
     SetIconFillValue(self._owner)
 end
 
-local function HideIconFill(button, style)
-    if not (button and button.iconFill) then
+local function ClearIconFillVisualState(button, style, preserveIntent, forceClearScript)
+    if not button then
         return
     end
 
-    button.iconFill:Hide()
-    if button._iconFillOnUpdateInstalled then
-        button.iconFill:SetScript("OnUpdate", nil)
-        button._iconFillOnUpdateInstalled = nil
+    local wasActive = button._iconFillActive == true
+    if button.iconFill then
+        button.iconFill:Hide()
+        if forceClearScript == true or button._iconFillOnUpdateInstalled then
+            button.iconFill:SetScript("OnUpdate", nil)
+        end
     end
-    if button._iconFillActive then
-        button._iconFillActive = nil
-        button._iconFillMode = nil
-        button._iconFillAuraActive = nil
-        button._iconFillColorR = nil
-        button._iconFillColorG = nil
-        button._iconFillColorB = nil
-        button._iconFillColorA = nil
+
+    button._iconFillOnUpdateInstalled = nil
+    button._iconFillActive = nil
+    button._iconFillMode = nil
+    button._iconFillAuraActive = nil
+    button._iconFillColorR = nil
+    button._iconFillColorG = nil
+    button._iconFillColorB = nil
+    button._iconFillColorA = nil
+    if not preserveIntent then
+        button._iconFillIntent = nil
+    end
+
+    if wasActive then
         ApplyDefaultCooldownSwipeStyle(button, style)
     end
 end
 
+local function HideIconFill(button, style, preserveIntent)
+    ClearIconFillVisualState(button, style, preserveIntent)
+end
+
 local function UpdateIconFill(button, buttonData, style)
-    if not IsIconFillAvailable(button, style) then
+    if type(ResolveIconFillIntent) ~= "function" then
         HideIconFill(button, style)
         return
     end
 
-    local auraPreview = button._conditionalAuraPreview == true
-        or button._conditionalAuraDurationTextPreview == true
-    local cooldownPreview = button._conditionalPreviewDomain == "cooldown"
-    local mode
-    local color
-
-    if button._auraPrimarySwipeActive == true or auraPreview then
-        color = style.iconFillAuraColor or DEFAULT_ICON_FILL_AURA_COLOR
-        if button._auraHasTimer == false and not auraPreview then
-            mode = "aura_static"
-        else
-            mode = "aura"
-        end
-    elseif cooldownPreview
-        or button._cooldownState == COOLDOWN_STATE_COOLDOWN
-        or (UsesChargeBehavior(buttonData) and button._chargeRecharging == true and button._hideCooldownChargesActive ~= true) then
-        mode = "cooldown"
-        color = style.iconFillCooldownColor or DEFAULT_ICON_FILL_COOLDOWN_COLOR
+    local intent = button._iconFillIntent
+    if type(intent) ~= "table" then
+        intent = {}
+        button._iconFillIntent = intent
     end
 
-    if not mode then
-        HideIconFill(button, style)
+    ResolveIconFillIntent(button, buttonData, style, intent)
+    if intent.active ~= true or not intent.mode then
+        HideIconFill(button, style, true)
         return
     end
 
+    local mode = intent.mode
     button._iconFillActive = true
     button._iconFillMode = mode
-    button._iconFillAuraActive = (mode == "aura" or mode == "aura_static") or nil
+    button._iconFillAuraActive = intent.auraActive == true or nil
     ApplyIconFillGeometry(button, style)
-    local colorA = color[4]
-    if button._iconFillColorR ~= color[1]
-        or button._iconFillColorG ~= color[2]
-        or button._iconFillColorB ~= color[3]
+    local r = intent.r or 1
+    local g = intent.g or 1
+    local b = intent.b or 1
+    local colorA = intent.a or 1
+    if button._iconFillColorR ~= r
+        or button._iconFillColorG ~= g
+        or button._iconFillColorB ~= b
         or button._iconFillColorA ~= colorA then
-        button._iconFillColorR = color[1]
-        button._iconFillColorG = color[2]
-        button._iconFillColorB = color[3]
+        button._iconFillColorR = r
+        button._iconFillColorG = g
+        button._iconFillColorB = b
         button._iconFillColorA = colorA
-        button.iconFill:SetStatusBarColor(color[1], color[2], color[3], colorA)
+        button.iconFill:SetStatusBarColor(r, g, b, colorA)
     end
     SetIconFillValue(button)
     button.iconFill:Show()
-    if mode == "aura_static" then
+    if intent.usesOnUpdate ~= true then
         if button._iconFillOnUpdateInstalled then
             button.iconFill:SetScript("OnUpdate", nil)
             button._iconFillOnUpdateInstalled = nil
@@ -394,9 +375,11 @@ local function UpdateIconFill(button, buttonData, style)
         button._iconFillOnUpdateInstalled = true
     end
 
-    button.cooldown:SetDrawSwipe(false)
-    button.cooldown:SetDrawEdge(false)
-    if button._iconFillAuraActive then
+    if intent.suppressCooldownSwipe == true and button.cooldown then
+        button.cooldown:SetDrawSwipe(false)
+        button.cooldown:SetDrawEdge(false)
+    end
+    if intent.suppressAuraBlizzardSwipe == true then
         HideBlizzardAuraSwipe(button, style)
     end
 end
@@ -1313,6 +1296,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._desaturated = nil
     button._iconDesaturationIntent = nil
     button._iconTintIntent = nil
+    button._iconFillIntent = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil
@@ -1363,6 +1347,10 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._iconFillActive = nil
     button._iconFillMode = nil
     button._iconFillAuraActive = nil
+    button._iconFillColorR = nil
+    button._iconFillColorG = nil
+    button._iconFillColorB = nil
+    button._iconFillColorA = nil
     if button.auraStackCount then button.auraStackCount:SetText("") end
     button._visibilityHidden = false
     button._prevVisibilityHidden = false
@@ -1671,3 +1659,4 @@ end)
 ST._UpdateIconModeVisuals = UpdateIconModeVisuals
 ST._UpdateIconModeGlows = UpdateIconModeGlows
 ST._ApplyIconCountTextStyle = ApplyCountTextStyle
+ST._ClearIconFillVisualState = ClearIconFillVisualState

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -1,11 +1,15 @@
 local ADDON_NAME, ST = ...
 
+local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic or {}
 local STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local ResolveIconDesaturationIntent = ST._ResolveIconDesaturationIntent
+local DEFAULT_ICON_FILL_COOLDOWN_COLOR = {0.6, 0.13, 0.18, 0.55}
+local DEFAULT_ICON_FILL_AURA_COLOR = {0.2, 1.0, 0.2, 0.55}
+local UsesChargeBehavior = CooldownCompanion and CooldownCompanion.UsesChargeBehavior
 
 local function IsTrue(value)
     return value == true
@@ -18,6 +22,117 @@ local function EnsureSection(parent, key)
         parent[key] = section
     end
     return section
+end
+
+local function UsesIconFillChargeBehavior(buttonData)
+    if type(UsesChargeBehavior) == "function" then
+        return UsesChargeBehavior(buttonData)
+    end
+    return buttonData and buttonData.hasCharges == true
+end
+
+local function GetButtonGroup(button)
+    local groupId = button and button._groupId
+    return groupId
+        and CooldownCompanion and CooldownCompanion.db and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[groupId]
+end
+
+local function SetIconFillIntent(target, available, active, reason, mode, color, auraActive, static)
+    target.available = available == true
+    target.active = active == true
+    target.reason = reason
+    target.mode = mode
+    target.auraActive = auraActive == true
+    target.static = static == true
+    target.usesOnUpdate = target.active and target.static ~= true or false
+    target.suppressCooldownSwipe = target.active
+    target.suppressAuraBlizzardSwipe = target.auraActive
+    target.r = color and color[1] or nil
+    target.g = color and color[2] or nil
+    target.b = color and color[3] or nil
+    target.a = color and color[4] or nil
+    return target
+end
+
+local function ResolveIconFillIntent(button, buttonData, style, target)
+    target = target or {}
+
+    if type(button) ~= "table" or type(buttonData) ~= "table" then
+        return SetIconFillIntent(target, false, false, "invalid")
+    end
+
+    style = style or {}
+
+    if not button.iconFill then
+        return SetIconFillIntent(target, false, false, "missing-widget")
+    end
+
+    if style.iconFillEnabled ~= true then
+        return SetIconFillIntent(target, false, false, "disabled")
+    end
+
+    local group = GetButtonGroup(button)
+    if group then
+        if (group.displayMode or "icons") ~= "icons" then
+            return SetIconFillIntent(target, false, false, "non-icon-mode")
+        end
+        if group.masqueEnabled == true then
+            return SetIconFillIntent(target, false, false, "masque-disabled")
+        end
+    end
+
+    local auraPreview = button._conditionalAuraPreview == true
+        or button._conditionalAuraDurationTextPreview == true
+    local cooldownPreview = button._conditionalPreviewDomain == "cooldown"
+
+    if button._auraPrimarySwipeActive == true or auraPreview then
+        local mode = "aura"
+        local reason = "aura"
+        local static = false
+        if button._auraHasTimer == false and not auraPreview then
+            mode = "aura_static"
+            reason = "aura-static"
+            static = true
+        end
+        return SetIconFillIntent(
+            target,
+            true,
+            true,
+            reason,
+            mode,
+            style.iconFillAuraColor or DEFAULT_ICON_FILL_AURA_COLOR,
+            true,
+            static
+        )
+    end
+
+    local cooldownReason
+    if cooldownPreview then
+        cooldownReason = "cooldown-preview"
+    elseif button._cooldownState == STATE_COOLDOWN then
+        cooldownReason = "cooldown"
+    elseif UsesIconFillChargeBehavior(buttonData)
+        and button._chargeRecharging == true
+        and button._hideCooldownChargesActive ~= true then
+        cooldownReason = "charge-recharge"
+    end
+
+    if cooldownReason then
+        return SetIconFillIntent(
+            target,
+            true,
+            true,
+            cooldownReason,
+            "cooldown",
+            style.iconFillCooldownColor or DEFAULT_ICON_FILL_COOLDOWN_COLOR,
+            false,
+            false
+        )
+    end
+
+    return SetIconFillIntent(target, true, false, "inactive")
 end
 
 ST._buttonVisualStateSnapshotsEnabled = ST._buttonVisualStateSnapshotsEnabled == true
@@ -115,6 +230,8 @@ local function RefreshButtonVisualState(button, context)
     local iconDesaturationIntent = ResolveIconDesaturationIntent(button, buttonData, style)
     local iconTintIntent = button._iconTintIntent
     local hasIconTintIntent = type(iconTintIntent) == "table"
+    local iconFillIntent = button._iconFillIntent
+    local hasIconFillIntent = type(iconFillIntent) == "table"
 
     state.version = 1
     state.phase = context.phase
@@ -221,6 +338,24 @@ local function RefreshButtonVisualState(button, context)
     iconFill.mode = button._iconFillMode
     iconFill.auraActive = IsTrue(button._iconFillAuraActive)
     iconFill.onUpdateInstalled = IsTrue(button._iconFillOnUpdateInstalled)
+    iconFill.r = button._iconFillColorR
+    iconFill.g = button._iconFillColorG
+    iconFill.b = button._iconFillColorB
+    iconFill.a = button._iconFillColorA
+    iconFill.intentAvailable = hasIconFillIntent
+    iconFill.intentFillAvailable = hasIconFillIntent and IsTrue(iconFillIntent.available) or false
+    iconFill.intentActive = hasIconFillIntent and IsTrue(iconFillIntent.active) or false
+    iconFill.intentMode = hasIconFillIntent and iconFillIntent.mode or nil
+    iconFill.intentReason = hasIconFillIntent and iconFillIntent.reason or nil
+    iconFill.intentAuraActive = hasIconFillIntent and IsTrue(iconFillIntent.auraActive) or false
+    iconFill.intentStatic = hasIconFillIntent and IsTrue(iconFillIntent.static) or false
+    iconFill.intentUsesOnUpdate = hasIconFillIntent and IsTrue(iconFillIntent.usesOnUpdate) or false
+    iconFill.intentSuppressCooldownSwipe = hasIconFillIntent and IsTrue(iconFillIntent.suppressCooldownSwipe) or false
+    iconFill.intentSuppressAuraBlizzardSwipe = hasIconFillIntent and IsTrue(iconFillIntent.suppressAuraBlizzardSwipe) or false
+    iconFill.intentR = hasIconFillIntent and iconFillIntent.r or nil
+    iconFill.intentG = hasIconFillIntent and iconFillIntent.g or nil
+    iconFill.intentB = hasIconFillIntent and iconFillIntent.b or nil
+    iconFill.intentA = hasIconFillIntent and iconFillIntent.a or nil
 
     local ready = EnsureSection(state, "ready")
     ready.eligible = readyEligible
@@ -274,3 +409,4 @@ ST._RefreshButtonVisualState = RefreshButtonVisualState
 ST._ClearButtonVisualState = ClearButtonVisualState
 ST._SetButtonVisualStateSnapshotsEnabled = SetButtonVisualStateSnapshotsEnabled
 ST._AreButtonVisualStateSnapshotsEnabled = AreButtonVisualStateSnapshotsEnabled
+ST._ResolveIconFillIntent = ResolveIconFillIntent

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -185,6 +185,26 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         tintA = tint.a,
         iconFillActive = iconFill.active,
         iconFillMode = iconFill.mode,
+        iconFillAuraActive = iconFill.auraActive,
+        iconFillOnUpdateInstalled = iconFill.onUpdateInstalled,
+        iconFillR = iconFill.r,
+        iconFillG = iconFill.g,
+        iconFillB = iconFill.b,
+        iconFillA = iconFill.a,
+        iconFillIntentAvailable = iconFill.intentAvailable,
+        iconFillIntentFillAvailable = iconFill.intentFillAvailable,
+        iconFillIntentActive = iconFill.intentActive,
+        iconFillIntentMode = iconFill.intentMode,
+        iconFillIntentReason = iconFill.intentReason,
+        iconFillIntentAuraActive = iconFill.intentAuraActive,
+        iconFillIntentStatic = iconFill.intentStatic,
+        iconFillIntentUsesOnUpdate = iconFill.intentUsesOnUpdate,
+        iconFillIntentSuppressCooldownSwipe = iconFill.intentSuppressCooldownSwipe,
+        iconFillIntentSuppressAuraBlizzardSwipe = iconFill.intentSuppressAuraBlizzardSwipe,
+        iconFillIntentR = iconFill.intentR,
+        iconFillIntentG = iconFill.intentG,
+        iconFillIntentB = iconFill.intentB,
+        iconFillIntentA = iconFill.intentA,
         readyEligible = ready.eligible,
         readyGlowActive = ready.glowActive,
         procGlowActive = glows.procActive,
@@ -234,6 +254,20 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     end
     CompareValue(row, "iconFill.active", iconFill.active, IsTrue(button._iconFillActive))
     CompareValue(row, "iconFill.mode", iconFill.mode, button._iconFillMode)
+    CompareValue(row, "iconFill.auraActive", iconFill.auraActive, IsTrue(button._iconFillAuraActive))
+    CompareValue(row, "iconFill.onUpdateInstalled", iconFill.onUpdateInstalled, IsTrue(button._iconFillOnUpdateInstalled))
+    if compareVisibleIconIntent and iconFill.intentAvailable == true then
+        CompareValue(row, "iconFill.intent.active", iconFill.intentActive, iconFill.active)
+        CompareValue(row, "iconFill.intent.mode", iconFill.intentMode, iconFill.mode)
+        CompareValue(row, "iconFill.intent.auraActive", iconFill.intentAuraActive, iconFill.auraActive)
+        CompareValue(row, "iconFill.intent.usesOnUpdate", iconFill.intentUsesOnUpdate, iconFill.onUpdateInstalled)
+        if iconFill.intentActive == true then
+            CompareValue(row, "iconFill.intent.r", iconFill.intentR, iconFill.r)
+            CompareValue(row, "iconFill.intent.g", iconFill.intentG, iconFill.g)
+            CompareValue(row, "iconFill.intent.b", iconFill.intentB, iconFill.b)
+            CompareValue(row, "iconFill.intent.a", iconFill.intentA, iconFill.a)
+        end
+    end
     CompareValue(row, "ready.glowActive", ready.glowActive, IsTrue(button._readyGlowActive))
     CompareValue(row, "glows.procActive", glows.procActive, IsTrue(button._procGlowActive))
     CompareValue(row, "glows.auraActive", glows.auraActive, IsTrue(button._auraGlowActive))

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -469,6 +469,12 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                     parts[#parts + 1] = "tintReason=" .. tostring(row.visuals.tintIntentReason)
                 end
                 parts[#parts + 1] = "fill=" .. tostring(row.visuals.iconFillActive)
+                if row.visuals.iconFillIntentMode then
+                    parts[#parts + 1] = "fillMode=" .. tostring(row.visuals.iconFillIntentMode)
+                end
+                if row.visuals.iconFillIntentReason and row.visuals.iconFillIntentReason ~= "inactive" then
+                    parts[#parts + 1] = "fillReason=" .. tostring(row.visuals.iconFillIntentReason)
+                end
             end
             if type(row.mismatches) == "table" and #row.mismatches > 0 then
                 parts[#parts + 1] = "mismatch=" .. table.concat(row.mismatches, ",")


### PR DESCRIPTION
## What Changed
- Moved icon-fill decision intent into the visual-state model while keeping the actual statusbar widget work in icon mode.
- Preserved the existing icon-fill behavior for aura fill, untimed static aura fill, cooldown fill, charge-recharge fill, previews, disabled fill, non-icon panels, and Masque-disabled groups.
- Added icon-fill intent/applied parity fields to visual-state diagnostics and concise `fillMode` / `fillReason` output in Bug Report rows.
- Cleared stale icon-fill intent and applied state in hidden/reset paths so diagnostics do not report old fill state after a button is hidden or restyled.

## Why This Changed
- Icon fill is the next icon-panel visual layer after desaturation and tint in the visual-state rollout.
- Capturing the intent makes future bugs easier to diagnose without changing cooldown truth, aura truth, or the player-facing icon-fill controls.

## Developer Impact
- Bug reports can now explain whether icon fill was disabled, inactive, aura-owned, static, cooldown-owned, preview-owned, or charge-recharge-owned.
- The runtime still has one widget owner: `ButtonFrame/IconMode.lua` handles geometry, statusbar color, timer interpolation, `OnUpdate`, cooldown swipe suppression, and Blizzard aura-swipe interaction.
- This keeps the visual-state migration moving in small reviewable slices before later bar/text/visibility work.

## Validation
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- `luac -p` across tracked Lua files
- `git diff --check`
- In-game smoke: icon-fill validation looked good, and the pasted Bug Report showed `mismatched=0`, `missing=0`, and `restored=true`.
- Combat/restricted-content validation remains part of the final `visual-state-dev-main` gate before merging the full visual-state project to `main`.