### PR TITLE
Track text-panel visual state in snapshots

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -2493,6 +2493,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         visualStateContext.forceVisibleByConfig = forceVisibleByConfig
         visualStateContext.forceVisibleByPreview = forceVisibleByPreview
         visualStateContext.forceVisibleByUnlockPreview = forceVisibleByUnlockPreview
+        visualStateContext.preserveSecretTextRender = auraDisplayNameState and auraDisplayNameState.preserveSecretTextRender == true
     end
     -- Track visibility/force-visible state changes for compact layout reflow.
     local visibilityChanged = button._visibilityHidden ~= button._prevVisibilityHidden

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -30,6 +30,7 @@ local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 
 -- Imports from VisualState
 local ClearButtonVisualState = ST._ClearButtonVisualState
+local AreButtonVisualStateSnapshotsEnabled = ST._AreButtonVisualStateSnapshotsEnabled
 
 -- Imports from Glows
 
@@ -270,6 +271,109 @@ local function ResolveTextModeStackDisplay(button)
     return nil, nil
 end
 
+local function ClearTextVisualState(button)
+    if button then
+        button._textVisualIntent = nil
+        button._textVisualApplied = nil
+    end
+end
+
+local function ShouldStoreTextVisualState()
+    return type(AreButtonVisualStateSnapshotsEnabled) == "function"
+        and AreButtonVisualStateSnapshotsEnabled() == true
+end
+
+local function EnsureTextVisualTable(button, fieldName)
+    local target = button[fieldName]
+    if target then
+        wipe(target)
+    else
+        target = {}
+        button[fieldName] = target
+    end
+    return target
+end
+
+local function ResolveTextIntentDomain(button, auraOnlyEntry, auraActive, auraHasTimer, timeRemaining, timeIsSecret, auraRemaining, auraIsSecret)
+    if auraActive then
+        if auraHasTimer and (auraIsSecret or auraRemaining ~= nil) then
+            return "aura-timer"
+        end
+        return "aura-active"
+    end
+
+    if auraOnlyEntry then
+        return "aura-only"
+    end
+
+    if timeIsSecret or (timeRemaining and timeRemaining > 0) then
+        return "cooldown"
+    end
+
+    if button._cooldownDeferred == true then
+        return "deferred"
+    end
+
+    return "ready"
+end
+
+local function StoreTextVisualIntent(button, details)
+    local intent = EnsureTextVisualTable(button, "_textVisualIntent")
+    intent.domain = ResolveTextIntentDomain(
+        button,
+        details.auraOnlyEntry,
+        details.auraActive,
+        details.auraHasTimer,
+        details.timeRemaining,
+        details.timeIsSecret,
+        details.auraRemaining,
+        details.auraIsSecret
+    )
+    intent.available = button._desatCooldownActive ~= true
+    intent.unusable = button._isUnusable == true
+    intent.outOfRange = button._isOutOfRange == true
+    intent.auraActive = details.auraActive == true
+    intent.auraHasTimer = details.auraHasTimer == true
+    intent.timePresent = details.timeIsSecret == true or (details.timeRemaining ~= nil and details.timeRemaining > 0)
+    intent.auraTimePresent = details.auraIsSecret == true or (details.auraRemaining ~= nil and details.auraRemaining > 0)
+    intent.cooldownDeferred = button._cooldownDeferred == true
+    intent.chargeState = button._chargeState
+    intent.currentCharges = details.currentCharges
+    intent.maxCharges = details.maxCharges
+    intent.stackSource = details.stackDisplayKind
+    intent.stackPresent = details.stackDisplayKind ~= nil
+    intent.stackSecret = details.stackDisplayKind ~= nil and issecretvalue(details.stackDisplayText) == true
+    intent.secretDuration = details.secretValue ~= nil
+    intent.secretDurationToken = details.secretColorToken
+    intent.secretStack = details.secretStackValue ~= nil
+    intent.secretName = details.hasSecretNameValue == true
+    intent.hasText = details.text ~= nil and details.text ~= ""
+    intent.pulseActive = details.effectState and details.effectState.pulseActive == true or false
+    return intent
+end
+
+local function StoreTextVisualApplied(button, writePath, text, secretValue, secretStackValue, hasSecretNameValue)
+    local applied = EnsureTextVisualTable(button, "_textVisualApplied")
+    applied.available = true
+    applied.writePath = writePath
+    applied.hasText = text ~= nil and text ~= ""
+    applied.secretDuration = secretValue ~= nil
+    applied.secretStack = secretStackValue ~= nil
+    applied.secretName = hasSecretNameValue == true
+    return applied
+end
+
+local function UpdateTextVisualAppliedPulse(button)
+    local applied = button and button._textVisualApplied
+    if type(applied) ~= "table" then
+        return
+    end
+
+    local es = button._effectState
+    applied.pulseActive = es and es.pulseActive == true or false
+    applied.alpha = applied.pulseActive and es.pulseAlpha or 1.0
+end
+
 ------------------------------------------------------------------------
 -- EVALUATE TOKEN PRESENCE
 -- Returns true if the given token would produce non-empty output.
@@ -328,7 +432,7 @@ end
 -- Builds the final display string from pre-parsed segments.
 -- Returns: displayText, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue
 ------------------------------------------------------------------------
-local function SubstituteTokens(button, segments, style, effectState, secretNameOverride, hasSecretNameOverride)
+local function SubstituteTokens(button, segments, style, effectState, secretNameOverride, hasSecretNameOverride, shouldStoreTextVisualState)
     local buttonData = button.buttonData
     local parts = button._textModeParts
     if parts then
@@ -593,7 +697,30 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
         end
     end
 
-    return table_concat(parts), secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue
+    local text = table_concat(parts)
+    if shouldStoreTextVisualState then
+        StoreTextVisualIntent(button, {
+            auraOnlyEntry = auraOnlyEntry,
+            auraActive = auraActive,
+            auraHasTimer = auraHasTimer,
+            timeRemaining = timeRemaining,
+            timeIsSecret = timeIsSecret,
+            auraRemaining = auraRemaining,
+            auraIsSecret = auraIsSecret,
+            currentCharges = currentCharges,
+            maxCharges = maxCharges,
+            stackDisplayKind = stackDisplayKind,
+            stackDisplayText = stackDisplayText,
+            secretValue = secretValue,
+            secretColorToken = secretColorToken,
+            secretStackValue = secretStackValue,
+            hasSecretNameValue = hasSecretNameValue,
+            text = text,
+            effectState = effectState,
+        })
+    end
+
+    return text, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue
 end
 
 ------------------------------------------------------------------------
@@ -602,7 +729,14 @@ end
 ------------------------------------------------------------------------
 local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverride)
     local style = button.style
-    if not style or not button._textSegments then return end
+    if not style or not button._textSegments then
+        ClearTextVisualState(button)
+        return
+    end
+    local shouldStoreTextVisualState = ShouldStoreTextVisualState()
+    if not shouldStoreTextVisualState then
+        ClearTextVisualState(button)
+    end
 
     -- Reset pulse content flag before substitution
     local es = button._effectState
@@ -610,7 +744,7 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
         es.pulseActive = false
     end
 
-    local text, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue = SubstituteTokens(button, button._textSegments, style, es, secretNameOverride, hasSecretNameOverride)
+    local text, secretValue, secretColorToken, secretStackValue, secretNameValue, hasSecretNameValue = SubstituteTokens(button, button._textSegments, style, es, secretNameOverride, hasSecretNameOverride, shouldStoreTextVisualState)
     button._textSecretNameActive = hasSecretNameValue == true
 
     if secretValue or secretStackValue or hasSecretNameValue then
@@ -676,12 +810,18 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
 
         local finalFmt = table_concat(resultParts)
         button.textString:SetFormattedText(finalFmt, unpack(args))
+        if shouldStoreTextVisualState then
+            StoreTextVisualApplied(button, "formatted", text, secretValue, secretStackValue, hasSecretNameValue)
+        end
         wipe(args)
     else
         -- Normal path: full per-token coloring via escape sequences
         local baseColor = style.textFontColor or DEFAULT_WHITE
         button.textString:SetTextColor(baseColor[1], baseColor[2], baseColor[3], baseColor[4] or 1)
         button.textString:SetText(text)
+        if shouldStoreTextVisualState then
+            StoreTextVisualApplied(button, "text", text, secretValue, secretStackValue, hasSecretNameValue)
+        end
     end
 
     -- Apply pulse alpha effect to the FontString
@@ -691,6 +831,9 @@ local function UpdateTextDisplay(button, secretNameOverride, hasSecretNameOverri
         else
             button.textString:SetAlpha(1.0)
         end
+    end
+    if shouldStoreTextVisualState then
+        UpdateTextVisualAppliedPulse(button)
     end
 
 end
@@ -714,6 +857,11 @@ local function EffectOnUpdate(self, elapsed)
             self.textString:SetAlpha(es.pulseAlpha)
         else
             self.textString:SetAlpha(1.0)
+        end
+        if ShouldStoreTextVisualState() then
+            UpdateTextVisualAppliedPulse(self)
+        else
+            ClearTextVisualState(self)
         end
         return
     end
@@ -748,6 +896,7 @@ local function UpdateTextStyle(button, newStyle)
     if ClearButtonVisualState then
         ClearButtonVisualState(button)
     end
+    ClearTextVisualState(button)
     -- Background
     local bgColor = newStyle.textBgColor or {0, 0, 0, 0}
     button.bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4])
@@ -955,6 +1104,7 @@ end
 ------------------------------------------------------------------------
 ST._UpdateTextDisplay = UpdateTextDisplay
 ST._UpdateTextStyle = UpdateTextStyle
+ST._ClearTextVisualState = ClearTextVisualState
 ST._ParseFormatString = ParseFormatString
 ST._HasAnyEffects = HasAnyEffects
 ST._GetEffectiveTextHeight = GetEffectiveTextHeight

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -201,10 +201,91 @@ local function IsTextureReady(button, buttonData)
     return button._desatCooldownActive == false
 end
 
+local function CopyTextVisualState(button, text, context)
+    local preservedSecretTextRender = IsTrue(context and context.preserveSecretTextRender)
+    local isTextSnapshot = (context and context.displayMode == "text") or button._isText == true
+    local textSidecarsAreFresh = isTextSnapshot
+        and context
+        and context.phase == "post-dispatch"
+        and not preservedSecretTextRender
+    local intent = textSidecarsAreFresh and button._textVisualIntent or nil
+    local hasIntent = type(intent) == "table"
+    text.preservedSecretTextRender = preservedSecretTextRender
+    text.intentAvailable = hasIntent
+    if hasIntent then
+        text.domain = intent.domain
+        text.available = intent.available
+        text.unusable = intent.unusable
+        text.outOfRange = intent.outOfRange
+        text.auraActive = intent.auraActive
+        text.auraHasTimer = intent.auraHasTimer
+        text.timePresent = intent.timePresent
+        text.auraTimePresent = intent.auraTimePresent
+        text.cooldownDeferred = intent.cooldownDeferred
+        text.chargeState = intent.chargeState
+        text.currentCharges = intent.currentCharges
+        text.maxCharges = intent.maxCharges
+        text.stackSource = intent.stackSource
+        text.stackPresent = intent.stackPresent
+        text.stackSecret = intent.stackSecret
+        text.secretDuration = intent.secretDuration
+        text.secretDurationToken = intent.secretDurationToken
+        text.secretStack = intent.secretStack
+        text.secretName = intent.secretName
+        text.hasText = intent.hasText
+        text.pulseActive = intent.pulseActive
+    else
+        text.domain = nil
+        text.available = not button._desatCooldownActive
+        text.unusable = IsTrue(button._isUnusable)
+        text.outOfRange = IsTrue(button._isOutOfRange)
+        text.auraActive = IsTrue(button._auraActive)
+        text.auraHasTimer = IsTrue(button._auraHasTimer)
+        text.timePresent = nil
+        text.auraTimePresent = nil
+        text.cooldownDeferred = IsTrue(button._cooldownDeferred)
+        text.chargeState = button._chargeState
+        text.currentCharges = button._currentReadableCharges
+        text.maxCharges = nil
+        text.stackSource = nil
+        text.stackPresent = nil
+        text.stackSecret = nil
+        text.secretDuration = nil
+        text.secretDurationToken = nil
+        text.secretStack = nil
+        text.secretName = nil
+        text.hasText = nil
+        text.pulseActive = nil
+    end
+
+    local applied = textSidecarsAreFresh and button._textVisualApplied or nil
+    local hasApplied = type(applied) == "table"
+    text.appliedAvailable = hasApplied
+    if hasApplied then
+        text.appliedWritePath = applied.writePath
+        text.appliedHasText = applied.hasText
+        text.appliedSecretDuration = applied.secretDuration
+        text.appliedSecretStack = applied.secretStack
+        text.appliedSecretName = applied.secretName
+        text.appliedPulseActive = applied.pulseActive
+        text.appliedAlpha = applied.alpha
+    else
+        text.appliedWritePath = nil
+        text.appliedHasText = nil
+        text.appliedSecretDuration = nil
+        text.appliedSecretStack = nil
+        text.appliedSecretName = nil
+        text.appliedPulseActive = nil
+        text.appliedAlpha = nil
+    end
+end
+
 local function ClearButtonVisualState(button)
     if button then
         button._visualState = nil
         button._visualStateContext = nil
+        button._textVisualIntent = nil
+        button._textVisualApplied = nil
     end
 end
 
@@ -373,10 +454,7 @@ local function RefreshButtonVisualState(button, context)
     glows.barColorShiftActive = IsTrue(button._barColorShiftActive)
 
     local text = EnsureSection(state, "text")
-    text.available = not state.cooldownVisualActive
-    text.unusable = IsTrue(button._isUnusable)
-    text.outOfRange = IsTrue(button._isOutOfRange)
-    text.chargeState = button._chargeState
+    CopyTextVisualState(button, text, context)
     text.durationObj = button._durationObj
 
     local textureEffects = EnsureSection(state, "textureEffects")

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -211,10 +211,37 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         auraGlowActive = glows.auraActive,
     }
     row.text = {
+        preservedSecretTextRender = text.preservedSecretTextRender,
+        intentAvailable = text.intentAvailable,
+        appliedAvailable = text.appliedAvailable,
+        domain = text.domain,
         available = text.available,
         unusable = text.unusable,
         outOfRange = text.outOfRange,
+        auraActive = text.auraActive,
+        auraHasTimer = text.auraHasTimer,
+        timePresent = text.timePresent,
+        auraTimePresent = text.auraTimePresent,
+        cooldownDeferred = text.cooldownDeferred,
         chargeState = text.chargeState,
+        currentCharges = text.currentCharges,
+        maxCharges = text.maxCharges,
+        stackSource = text.stackSource,
+        stackPresent = text.stackPresent,
+        stackSecret = text.stackSecret,
+        secretDuration = text.secretDuration,
+        secretDurationToken = text.secretDurationToken,
+        secretStack = text.secretStack,
+        secretName = text.secretName,
+        hasText = text.hasText,
+        pulseActive = text.pulseActive,
+        appliedWritePath = text.appliedWritePath,
+        appliedHasText = text.appliedHasText,
+        appliedSecretDuration = text.appliedSecretDuration,
+        appliedSecretStack = text.appliedSecretStack,
+        appliedSecretName = text.appliedSecretName,
+        appliedPulseActive = text.appliedPulseActive,
+        appliedAlpha = text.appliedAlpha,
         durationObj = text.durationObj ~= nil,
     }
     row.textureEffects = {
@@ -274,6 +301,28 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "text.unusable", text.unusable, IsTrue(button._isUnusable))
     CompareValue(row, "text.outOfRange", text.outOfRange, IsTrue(button._isOutOfRange))
     CompareValue(row, "text.durationObj", text.durationObj ~= nil, button._durationObj ~= nil)
+    local compareVisibleTextIntent = row.displayMode == "text"
+        and row.phase == "post-dispatch"
+        and visibility.hidden ~= true
+    local preservedSecretTextWithoutFreshSidecars = text.preservedSecretTextRender == true
+        and (text.intentAvailable ~= true or text.appliedAvailable ~= true)
+    if compareVisibleTextIntent and not preservedSecretTextWithoutFreshSidecars then
+        if text.intentAvailable ~= true then
+            AddMismatch(row, "text.intent.missing")
+        elseif text.appliedAvailable ~= true then
+            AddMismatch(row, "text.applied.missing")
+        else
+            local expectedWritePath = (text.secretDuration == true or text.secretStack == true or text.secretName == true)
+                and "formatted"
+                or "text"
+            CompareValue(row, "text.writePath", text.appliedWritePath, expectedWritePath)
+            CompareValue(row, "text.hasText", text.appliedHasText, text.hasText)
+            CompareValue(row, "text.secretDuration", text.appliedSecretDuration, text.secretDuration)
+            CompareValue(row, "text.secretStack", text.appliedSecretStack, text.secretStack)
+            CompareValue(row, "text.secretName", text.appliedSecretName, text.secretName)
+            CompareValue(row, "text.pulseActive", text.appliedPulseActive, text.pulseActive)
+        end
+    end
     CompareValue(row, "textureEffects.cooldownActive", textureEffects.cooldownActive, IsTrue(button._desatCooldownActive))
     CompareValue(row, "textureEffects.chargeState", textureEffects.chargeState, button._chargeState)
     CompareValue(row, "textureEffects.procActive", textureEffects.procActive, IsTrue(button._procOverlayActive))

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -476,6 +476,35 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                     parts[#parts + 1] = "fillReason=" .. tostring(row.visuals.iconFillIntentReason)
                 end
             end
+            if row.text and (row.displayMode == "text" or row.text.intentAvailable == true) then
+                local textDomain = row.text.domain
+                if not textDomain and row.text.preservedSecretTextRender == true then
+                    textDomain = "preserved-secret"
+                end
+                parts[#parts + 1] = "text=" .. tostring(textDomain or "missing")
+                if row.text.appliedWritePath then
+                    parts[#parts + 1] = "textWrite=" .. tostring(row.text.appliedWritePath)
+                end
+                if row.text.stackSource then
+                    parts[#parts + 1] = "stack=" .. tostring(row.text.stackSource)
+                end
+                if row.text.secretDuration or row.text.secretStack or row.text.secretName then
+                    local secretParts = {}
+                    if row.text.secretDuration then
+                        secretParts[#secretParts + 1] = tostring(row.text.secretDurationToken or "duration")
+                    end
+                    if row.text.secretStack then
+                        secretParts[#secretParts + 1] = "stack"
+                    end
+                    if row.text.secretName then
+                        secretParts[#secretParts + 1] = "name"
+                    end
+                    parts[#parts + 1] = "textSecret=" .. table.concat(secretParts, "+")
+                end
+                if row.text.pulseActive then
+                    parts[#parts + 1] = "pulse=true"
+                end
+            end
             if type(row.mismatches) == "table" and #row.mismatches > 0 then
                 parts[#parts + 1] = "mismatch=" .. table.concat(row.mismatches, ",")
             elseif row.missingSnapshot then


### PR DESCRIPTION
## What Players Will Notice
- Bug Reports now include text-panel visual-state rows when a visible text panel is selected, including whether text rendered through normal text or formatted secret-value text.
- Cooldown, aura, icon, bar, and text displays should look the same; this change is diagnostic-only.

## Why This Changed
- The visual-state refactor needs the same bug-report visibility for text panels that icon desaturation, tint, and fill already have.
- Without text intent/applied details, issues with status text, secret aura names, stacks, pulse text, or formatted text would be harder to diagnose from a Bug Report.

## What Changed
- Captured text visual intent and applied state only while visual-state snapshots are explicitly enabled for diagnostics.
- Added text domain, write path, stack, secret-value, and pulse details to visual-state diagnostic rows.
- Skipped stale text sidecars for hidden buttons and preserved secret text renders so reports do not produce false matches or false mismatches.
- Left text rendering behavior unchanged.

## Validation
- `git diff --check origin/visual-state-dev-main...HEAD`
- `luac -p` on the touched Lua files
- `luac -p` across 87 tracked Lua files
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- Static review found no actionable issues after follow-up fixes.
- In-game Bug Report for a selected visible text panel showed text rows with `text=ready textWrite=text match=ok`, `mismatched=0 missing=0`, and snapshot restore true.
- In-game combat smoke passed with no observed issue.
- Separate restricted instance, arena, or battleground validation was not reported.