### PR TITLE
Add bar panel visual-state diagnostics

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -38,6 +38,7 @@ local DEFAULT_BAR_CHARGE_COLOR = ST._DEFAULT_BAR_CHARGE_COLOR
 
 -- Imports from VisualState
 local ClearButtonVisualState = ST._ClearButtonVisualState
+local AreButtonVisualStateSnapshotsEnabled = ST._AreButtonVisualStateSnapshotsEnabled
 
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
@@ -90,6 +91,74 @@ local function SetBarIconTooltipScripts(button, enable)
         iconBounds:SetScript("OnEnter", nil)
         iconBounds:SetScript("OnLeave", nil)
     end
+end
+
+local function ShouldStoreBarVisualState()
+    return type(AreButtonVisualStateSnapshotsEnabled) == "function"
+        and AreButtonVisualStateSnapshotsEnabled() == true
+end
+
+local function EnsureBarVisualTable(button, fieldName)
+    local target = button[fieldName]
+    if target then
+        wipe(target)
+    else
+        target = {}
+        button[fieldName] = target
+    end
+    return target
+end
+
+local function ClearBarVisualState(button)
+    if button then
+        button._barVisualIntent = nil
+        button._barVisualApplied = nil
+    end
+end
+
+local function CopyColor(target, prefix, color)
+    target[prefix .. "R"] = color and color[1] or nil
+    target[prefix .. "G"] = color and color[2] or nil
+    target[prefix .. "B"] = color and color[3] or nil
+    target[prefix .. "A"] = color and color[4] or nil
+end
+
+local function StoreBarDisplayVisualState(button, details)
+    local intent = EnsureBarVisualTable(button, "_barVisualIntent")
+    intent.available = true
+    intent.domain = details.domain
+    intent.onCooldown = details.onCooldown == true
+    intent.chargeState = details.chargeState
+    intent.colorReason = details.colorReason
+    intent.auraColorReason = details.auraColorReason
+    intent.auraEffectActive = details.auraEffectActive == true
+    intent.auraEffectReason = details.auraEffectReason
+    intent.pulseActive = details.pulseMode ~= nil
+    intent.pulseMode = details.pulseMode
+    intent.colorShiftActive = details.colorShiftMode ~= nil
+    intent.colorShiftMode = details.colorShiftMode
+    intent.stackDisplay = details.stackDisplay == true
+    intent.stackMode = details.stackMode
+    intent.stackSegmentLayerActive = details.stackSegmentLayerActive == true
+    intent.gcdSuppressed = button._barGCDSuppressed == true
+    CopyColor(intent, "color", details.color)
+    CopyColor(intent, "colorShiftBase", details.colorShiftBaseColor)
+    CopyColor(intent, "colorShiftTarget", details.colorShiftTargetColor)
+
+    local applied = EnsureBarVisualTable(button, "_barVisualApplied")
+    applied.available = true
+    applied.colorReason = details.colorReason
+    applied.auraColorActive = button._barAuraColor ~= nil
+    applied.auraEffectActive = button._barAuraEffectActive == true
+    applied.pulseActive = button._barPulseActive == true
+    applied.pulseMode = details.pulseMode
+    applied.colorShiftActive = button._barColorShiftActive == true
+    applied.colorShiftMode = details.colorShiftMode
+    applied.stackVisualActive = button._barAuraStackVisualActive == true
+    applied.stackMode = button._barAuraStackVisualMode or details.stackMode
+    applied.baseFillHidden = button._barAuraBaseFillHidden == true
+    applied.gcdSuppressed = button._barGCDSuppressed == true
+    CopyColor(applied, "color", details.color)
 end
 
 local function ResolveConditionalPreviewRemaining(button)
@@ -1067,6 +1136,10 @@ end
 -- Bar fill + time text are handled by the per-button OnUpdate for smooth interpolation.
 local function UpdateBarDisplay(button)
     local style = button.style
+    local shouldStoreBarVisualState = ShouldStoreBarVisualState()
+    if not shouldStoreBarVisualState and (button._barVisualIntent or button._barVisualApplied) then
+        ClearBarVisualState(button)
+    end
 
     -- "On cooldown" for bar color/ready text follows canonical state.
     -- _durationObj may also hold aura/totem timing and must not imply cooldown.
@@ -1104,11 +1177,14 @@ local function UpdateBarDisplay(button)
     -- Bar color: switch between ready, cooldown, and partial charge colors.
     -- Aura-tracked buttons always use the base bar color (aura color override handles active state).
     local wantCdColor
+    local cdColorReason
     if onCooldown and not button.buttonData.isPassive then
         if isChargeButton and chargeState == CHARGE_STATE_MISSING then
             wantCdColor = style.barChargeColor or DEFAULT_BAR_CHARGE_COLOR
+            cdColorReason = "charge"
         else
             wantCdColor = style.barCooldownColor
+            cdColorReason = "cooldown"
         end
     end
     if button._barCdColor ~= wantCdColor then
@@ -1131,19 +1207,24 @@ local function UpdateBarDisplay(button)
 
     -- Bar aura color: override bar fill when aura is active (pandemic overrides aura color)
     local wantAuraColor
+    local auraColorReason
     if barAuraStackDisplay then
         wantAuraColor = nil
     elseif button._pandemicPreview or button._conditionalPreviewKind == "pandemic" then
         wantAuraColor = (button.style and button.style.barPandemicColor) or DEFAULT_BAR_PANDEMIC_COLOR
+        auraColorReason = "pandemic"
     elseif button._barAuraActivePreview or button._conditionalBarAuraActivePreview then
         wantAuraColor = (button.style and button.style.barAuraColor) or DEFAULT_BAR_AURA_COLOR
+        auraColorReason = "aura"
     elseif button._auraActive then
         if button._inPandemic and style.showPandemicGlow ~= false
            and (not style.pandemicGlowCombatOnly or inCombat) then
             wantAuraColor = (button.style and button.style.barPandemicColor) or DEFAULT_BAR_PANDEMIC_COLOR
+            auraColorReason = "pandemic"
         elseif barAuraVisualsEnabled
                and (not style.auraGlowCombatOnly or inCombat) then
             wantAuraColor = (button.style and button.style.barAuraColor) or DEFAULT_BAR_AURA_COLOR
+            auraColorReason = "aura"
         end
     end
     if button._barAuraColor ~= wantAuraColor then
@@ -1179,6 +1260,10 @@ local function UpdateBarDisplay(button)
         or button._pandemicPreview
         or (button._auraActive and (barAuraEffectPandemic
             or (barAuraVisualsEnabled and (not style.auraGlowCombatOnly or inCombat))))
+    local auraEffectReason
+    if barAuraEffectShow then
+        auraEffectReason = barAuraEffectPandemic and "pandemic" or "aura"
+    end
     SetBarAuraEffect(button, barAuraEffectShow, barAuraEffectPandemic or false)
 
     -- Bar indicator effects: alpha pulse, color shift
@@ -1236,6 +1321,31 @@ local function UpdateBarDisplay(button)
     end
     if stackSegmentLayerActive then
         HideBarAuraBaseFill(button)
+    end
+
+    if shouldStoreBarVisualState then
+        local colorReason = barAuraStackDisplay and "stack"
+            or auraColorReason
+            or cdColorReason
+            or "ready"
+        local color = wantAuraColor or wantCdColor or style.barColor or DEFAULT_BAR_COLOR
+        StoreBarDisplayVisualState(button, {
+            domain = colorReason,
+            onCooldown = onCooldown,
+            chargeState = chargeState,
+            colorReason = colorReason,
+            auraColorReason = auraColorReason,
+            color = color,
+            auraEffectActive = button._barAuraEffectActive == true,
+            auraEffectReason = button._barAuraEffectActive == true and auraEffectReason or nil,
+            pulseMode = wantPulse,
+            colorShiftMode = wantColorShift,
+            colorShiftBaseColor = button._barCSBaseColor,
+            colorShiftTargetColor = button._barCSShiftColor,
+            stackDisplay = barAuraStackDisplay,
+            stackMode = button._barAuraStackMode,
+            stackSegmentLayerActive = stackSegmentLayerActive,
+        })
     end
 
     -- Keep the cooldown widget hidden — SetCooldown auto-shows it

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -280,12 +280,120 @@ local function CopyTextVisualState(button, text, context)
     end
 end
 
+local function CopyBarVisualState(button, bar, context)
+    local isBarSnapshot = (context and context.displayMode == "bars") or button._isBar == true
+    local barSidecarsAreFresh = isBarSnapshot
+        and context
+        and context.phase == "post-dispatch"
+        and not IsTrue(button._visibilityHidden)
+    local intent = barSidecarsAreFresh and button._barVisualIntent or nil
+    local hasIntent = type(intent) == "table"
+
+    bar.intentAvailable = hasIntent
+    if hasIntent then
+        bar.domain = intent.domain
+        bar.onCooldown = intent.onCooldown
+        bar.chargeState = intent.chargeState
+        bar.colorReason = intent.colorReason
+        bar.auraColorReason = intent.auraColorReason
+        bar.auraEffectActive = intent.auraEffectActive
+        bar.auraEffectReason = intent.auraEffectReason
+        bar.pulseActive = intent.pulseActive
+        bar.pulseMode = intent.pulseMode
+        bar.colorShiftActive = intent.colorShiftActive
+        bar.colorShiftMode = intent.colorShiftMode
+        bar.stackDisplay = intent.stackDisplay
+        bar.stackMode = intent.stackMode
+        bar.stackSegmentLayerActive = intent.stackSegmentLayerActive
+        bar.gcdSuppressed = intent.gcdSuppressed
+        bar.colorR = intent.colorR
+        bar.colorG = intent.colorG
+        bar.colorB = intent.colorB
+        bar.colorA = intent.colorA
+        bar.colorShiftBaseR = intent.colorShiftBaseR
+        bar.colorShiftBaseG = intent.colorShiftBaseG
+        bar.colorShiftBaseB = intent.colorShiftBaseB
+        bar.colorShiftBaseA = intent.colorShiftBaseA
+        bar.colorShiftTargetR = intent.colorShiftTargetR
+        bar.colorShiftTargetG = intent.colorShiftTargetG
+        bar.colorShiftTargetB = intent.colorShiftTargetB
+        bar.colorShiftTargetA = intent.colorShiftTargetA
+    else
+        bar.domain = IsTrue(button._barAuraStackDisplay) and "stack" or nil
+        bar.onCooldown = nil
+        bar.chargeState = button._chargeState
+        bar.colorReason = nil
+        bar.auraColorReason = nil
+        bar.auraEffectActive = nil
+        bar.auraEffectReason = nil
+        bar.pulseActive = nil
+        bar.pulseMode = nil
+        bar.colorShiftActive = nil
+        bar.colorShiftMode = nil
+        bar.stackDisplay = IsTrue(button._barAuraStackDisplay)
+        bar.stackMode = button._barAuraStackMode
+        bar.stackSegmentLayerActive = nil
+        bar.gcdSuppressed = IsTrue(button._barGCDSuppressed)
+        bar.colorR = nil
+        bar.colorG = nil
+        bar.colorB = nil
+        bar.colorA = nil
+        bar.colorShiftBaseR = nil
+        bar.colorShiftBaseG = nil
+        bar.colorShiftBaseB = nil
+        bar.colorShiftBaseA = nil
+        bar.colorShiftTargetR = nil
+        bar.colorShiftTargetG = nil
+        bar.colorShiftTargetB = nil
+        bar.colorShiftTargetA = nil
+    end
+
+    local applied = barSidecarsAreFresh and button._barVisualApplied or nil
+    local hasApplied = type(applied) == "table"
+    bar.appliedAvailable = hasApplied
+    if hasApplied then
+        bar.appliedColorReason = applied.colorReason
+        bar.appliedAuraColorActive = applied.auraColorActive
+        bar.appliedAuraEffectActive = applied.auraEffectActive
+        bar.appliedPulseActive = applied.pulseActive
+        bar.appliedPulseMode = applied.pulseMode
+        bar.appliedColorShiftActive = applied.colorShiftActive
+        bar.appliedColorShiftMode = applied.colorShiftMode
+        bar.appliedStackVisualActive = applied.stackVisualActive
+        bar.appliedStackMode = applied.stackMode
+        bar.appliedBaseFillHidden = applied.baseFillHidden
+        bar.appliedGcdSuppressed = applied.gcdSuppressed
+        bar.appliedColorR = applied.colorR
+        bar.appliedColorG = applied.colorG
+        bar.appliedColorB = applied.colorB
+        bar.appliedColorA = applied.colorA
+    else
+        bar.appliedColorReason = nil
+        bar.appliedAuraColorActive = nil
+        bar.appliedAuraEffectActive = nil
+        bar.appliedPulseActive = nil
+        bar.appliedPulseMode = nil
+        bar.appliedColorShiftActive = nil
+        bar.appliedColorShiftMode = nil
+        bar.appliedStackVisualActive = IsTrue(button._barAuraStackVisualActive)
+        bar.appliedStackMode = button._barAuraStackVisualMode
+        bar.appliedBaseFillHidden = IsTrue(button._barAuraBaseFillHidden)
+        bar.appliedGcdSuppressed = IsTrue(button._barGCDSuppressed)
+        bar.appliedColorR = nil
+        bar.appliedColorG = nil
+        bar.appliedColorB = nil
+        bar.appliedColorA = nil
+    end
+end
+
 local function ClearButtonVisualState(button)
     if button then
         button._visualState = nil
         button._visualStateContext = nil
         button._textVisualIntent = nil
         button._textVisualApplied = nil
+        button._barVisualIntent = nil
+        button._barVisualApplied = nil
     end
 end
 
@@ -452,6 +560,9 @@ local function RefreshButtonVisualState(button, context)
     glows.barAuraEffectActive = IsTrue(button._barAuraEffectActive)
     glows.barPulseActive = IsTrue(button._barPulseActive)
     glows.barColorShiftActive = IsTrue(button._barColorShiftActive)
+
+    local bar = EnsureSection(state, "bar")
+    CopyBarVisualState(button, bar, context)
 
     local text = EnsureSection(state, "text")
     CopyTextVisualState(button, text, context)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -127,6 +127,7 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     local iconFill = state.iconFill or {}
     local ready = state.ready or {}
     local glows = state.glows or {}
+    local bar = state.bar or {}
     local text = state.text or {}
     local textureEffects = state.textureEffects or {}
     local tintActive
@@ -209,6 +210,32 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         readyGlowActive = ready.glowActive,
         procGlowActive = glows.procActive,
         auraGlowActive = glows.auraActive,
+    }
+    row.bar = {
+        intentAvailable = bar.intentAvailable,
+        appliedAvailable = bar.appliedAvailable,
+        domain = bar.domain,
+        onCooldown = bar.onCooldown,
+        chargeState = bar.chargeState,
+        colorReason = bar.colorReason,
+        appliedColorReason = bar.appliedColorReason,
+        auraColorReason = bar.auraColorReason,
+        auraEffectActive = bar.auraEffectActive,
+        appliedAuraEffectActive = bar.appliedAuraEffectActive,
+        auraEffectReason = bar.auraEffectReason,
+        pulseActive = bar.pulseActive,
+        appliedPulseActive = bar.appliedPulseActive,
+        pulseMode = bar.pulseMode,
+        colorShiftActive = bar.colorShiftActive,
+        appliedColorShiftActive = bar.appliedColorShiftActive,
+        colorShiftMode = bar.colorShiftMode,
+        stackDisplay = bar.stackDisplay,
+        stackMode = bar.stackMode,
+        appliedStackVisualActive = bar.appliedStackVisualActive,
+        appliedStackMode = bar.appliedStackMode,
+        appliedBaseFillHidden = bar.appliedBaseFillHidden,
+        gcdSuppressed = bar.gcdSuppressed,
+        appliedGcdSuppressed = bar.appliedGcdSuppressed,
     }
     row.text = {
         preservedSecretTextRender = text.preservedSecretTextRender,
@@ -304,6 +331,26 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     local compareVisibleTextIntent = row.displayMode == "text"
         and row.phase == "post-dispatch"
         and visibility.hidden ~= true
+    local compareVisibleBarIntent = row.displayMode == "bars"
+        and row.phase == "post-dispatch"
+        and visibility.hidden ~= true
+    if compareVisibleBarIntent then
+        if bar.intentAvailable ~= true then
+            AddMismatch(row, "bar.intent.missing")
+        elseif bar.appliedAvailable ~= true then
+            AddMismatch(row, "bar.applied.missing")
+        else
+            CompareValue(row, "bar.appliedAuraEffectActive", bar.appliedAuraEffectActive, IsTrue(button._barAuraEffectActive))
+            CompareValue(row, "bar.appliedPulseActive", bar.appliedPulseActive, IsTrue(button._barPulseActive))
+            CompareValue(row, "bar.appliedColorShiftActive", bar.appliedColorShiftActive, IsTrue(button._barColorShiftActive))
+            CompareValue(row, "bar.appliedGcdSuppressed", bar.appliedGcdSuppressed, IsTrue(button._barGCDSuppressed))
+            CompareValue(row, "bar.colorReason", bar.appliedColorReason, bar.colorReason)
+            CompareValue(row, "bar.auraEffectActive", bar.appliedAuraEffectActive, bar.auraEffectActive)
+            CompareValue(row, "bar.pulseActive", bar.appliedPulseActive, bar.pulseActive)
+            CompareValue(row, "bar.colorShiftActive", bar.appliedColorShiftActive, bar.colorShiftActive)
+            CompareValue(row, "bar.gcdSuppressed", bar.appliedGcdSuppressed, bar.gcdSuppressed)
+        end
+    end
     local preservedSecretTextWithoutFreshSidecars = text.preservedSecretTextRender == true
         and (text.intentAvailable ~= true or text.appliedAvailable ~= true)
     if compareVisibleTextIntent and not preservedSecretTextWithoutFreshSidecars then

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -476,6 +476,31 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                     parts[#parts + 1] = "fillReason=" .. tostring(row.visuals.iconFillIntentReason)
                 end
             end
+            local hasBarSignals = row.bar and (row.bar.intentAvailable == true
+                or row.bar.stackDisplay == true
+                or row.bar.gcdSuppressed == true
+                or (row.displayMode == "bars" and row.phase == "post-dispatch"))
+            if hasBarSignals then
+                parts[#parts + 1] = "bar=" .. tostring(row.bar.domain or "missing")
+                if row.bar.colorReason then
+                    parts[#parts + 1] = "barColor=" .. tostring(row.bar.colorReason)
+                end
+                if row.bar.auraEffectActive then
+                    parts[#parts + 1] = "barEffect=" .. tostring(row.bar.auraEffectReason or "aura")
+                end
+                if row.bar.pulseActive then
+                    parts[#parts + 1] = "barPulse=" .. tostring(row.bar.pulseMode or true)
+                end
+                if row.bar.colorShiftActive then
+                    parts[#parts + 1] = "barShift=" .. tostring(row.bar.colorShiftMode or true)
+                end
+                if row.bar.stackDisplay then
+                    parts[#parts + 1] = "barStack=" .. tostring(row.bar.stackMode or "default")
+                end
+                if row.bar.gcdSuppressed then
+                    parts[#parts + 1] = "barGCDSuppressed=true"
+                end
+            end
             if row.text and (row.displayMode == "text" or row.text.intentAvailable == true) then
                 local textDomain = row.text.domain
                 if not textDomain and row.text.preservedSecretTextRender == true then


### PR DESCRIPTION
## What Changed
- Added bar-mode visual-state snapshots for post-dispatch bar display decisions.
- Added Bug Report bar diagnostics for bar domain, color reason, aura effects, pulse, color shift, stack display, and GCD suppression.
- Kept bar fill/time diagnostics out of this pass because those are driven from the bar OnUpdate path and would be stale or noisy in one-shot captures.
- Guarded bar snapshot storage behind the existing visual-state diagnostic capture flag so normal bar updates do not populate diagnostic sidecars.

## Why This Changed
- The visual-state refactor is moving each display consumer toward one clearer per-button snapshot.
- Bar panels needed the same agent-facing visibility that icon and text panels now have, without changing the player-facing bar display path.

## Developer Impact
- Bug Reports can now show why a bar panel appears ready, cooldown-colored, stack-driven, pulsing, color-shifted, or GCD-suppressed.
- Future visual-state reviews get cleaner evidence for bar panels while avoiding OnUpdate-only false positives.

## Validation
- `git diff --check origin/visual-state-dev-main...HEAD`
- `luac -p` on touched Lua files
- `luac -p` across tracked Lua files
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- In-game bar panel smoke passed.
- Combat smoke passed.
- Bug Report after combat showed `mismatched=0 missing=0` for a selected bar panel/entry, including `bar=stack barColor=stack barStack=segmented match=ok`.
- Restricted-instance smoke was not separately reported.