### PR TITLE
Capture visibility state in button visual snapshots

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -2449,6 +2449,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     EvaluateButtonVisibility(button, buttonData, auraOverrideActive, procOverlayActive, auraOwnsPrimarySwipe)
     button._rawVisibilityHidden = button._visibilityHidden
     button._rawVisibilityAlphaOverride = button._visibilityAlphaOverride
+    button._rawVisibilityReasonBits = button._visibilityReasonBits
+    button._rawVisibilityReasonMode = button._visibilityReasonMode
 
     local group = button._groupId and CooldownCompanion.db.profile.groups[button._groupId]
     local isTriggerPanel = group and group.displayMode == "trigger"
@@ -2457,9 +2459,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         and CooldownCompanion.IsContainerUnlockPreviewActive
         and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
         and not isTriggerPanel
+    local visibilityOverrideSource
     if isTriggerPanel then
         button._visibilityHidden = true
         button._visibilityAlphaOverride = 0
+        visibilityOverrideSource = "trigger"
     end
 
     -- Config panel QOL: selected buttons in column 2 are always fully visible.
@@ -2468,11 +2472,23 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if forceVisibleByUnlockPreview or forceVisibleByPreview then
         button._visibilityHidden = false
         button._visibilityAlphaOverride = 1
+        visibilityOverrideSource = forceVisibleByUnlockPreview and "unlock-preview" or "conditional-preview"
     elseif forceVisibleByConfig and not isTriggerPanel then
         button._visibilityHidden = false
         button._visibilityAlphaOverride = 1
+        visibilityOverrideSource = "config"
     end
     button._forceVisibleByConfig = ((forceVisibleByConfig or forceVisibleByUnlockPreview or forceVisibleByPreview) and not isTriggerPanel) or nil
+    if button._visibilityHidden == true then
+        button._visibilityFinalMode = "hidden"
+    elseif button._visibilityAlphaOverride ~= nil and button._visibilityAlphaOverride ~= 1 then
+        button._visibilityFinalMode = "dimmed"
+    else
+        button._visibilityFinalMode = "visible"
+    end
+    button._visibilityOverrideSource = visibilityOverrideSource
+    button._visibilityTriggerSuppressed = visibilityOverrideSource == "trigger" or nil
+    button._visibilityCompactLayout = group and group.compactLayout == true or nil
 
     local visualStateContext
     local shouldCaptureVisualState = CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot()

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -18,6 +18,9 @@ local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
 local bit_band = bit.band
 local bit_bor  = bit.bor
+local ipairs = ipairs
+local tonumber = tonumber
+local type = type
 
 -- Bitmask constants for hide reasons
 local HIDE_ON_COOLDOWN      = 0x001
@@ -29,6 +32,18 @@ local HIDE_ZERO_CHARGES     = 0x020
 local HIDE_ZERO_STACKS      = 0x040
 local HIDE_NOT_EQUIPPED     = 0x080
 local HIDE_UNUSABLE         = 0x100
+
+local HIDE_REASON_NAMES = {
+    { bit = HIDE_ON_COOLDOWN,      name = "on-cooldown" },
+    { bit = HIDE_NOT_ON_COOLDOWN,  name = "not-on-cooldown" },
+    { bit = HIDE_AURA_NOT_ACTIVE,  name = "aura-missing" },
+    { bit = HIDE_AURA_ACTIVE,      name = "aura-active" },
+    { bit = HIDE_NO_PROC,          name = "no-proc" },
+    { bit = HIDE_ZERO_CHARGES,     name = "zero-charges" },
+    { bit = HIDE_ZERO_STACKS,      name = "zero-stacks" },
+    { bit = HIDE_NOT_EQUIPPED,     name = "not-equipped" },
+    { bit = HIDE_UNUSABLE,         name = "unusable" },
+}
 
 -- Baseline alpha fallback descriptors: each entry maps a hide reason bit
 -- to the buttonData config key that enables "dim instead of hide" when
@@ -48,6 +63,32 @@ local BASELINE_FALLBACKS = {
     { bit = HIDE_NO_PROC,         key = "useBaselineAlphaFallbackNoProc" },
     { bit = HIDE_UNUSABLE,        key = "useBaselineAlphaFallbackUnusable" },
 }
+
+local function ClearArray(tbl)
+    if type(tbl) == "table" then
+        for i = #tbl, 1, -1 do
+            tbl[i] = nil
+        end
+    end
+end
+
+local function GetButtonVisibilityReasonNames(reasonBits, target)
+    target = target or {}
+    ClearArray(target)
+
+    reasonBits = tonumber(reasonBits) or 0
+    if reasonBits == 0 then
+        return target
+    end
+
+    for _, entry in ipairs(HIDE_REASON_NAMES) do
+        if bit_band(reasonBits, entry.bit) ~= 0 then
+            target[#target + 1] = entry.name
+        end
+    end
+
+    return target
+end
 
 -- Evaluate per-button visibility rules and set hidden/alpha override state.
 -- Called inside UpdateButtonCooldown after cooldown fetch and aura tracking are complete.
@@ -230,4 +271,5 @@ end
 
 -- Exports
 ST._EvaluateButtonVisibility = EvaluateButtonVisibility
+ST._GetButtonVisibilityReasonNames = GetButtonVisibilityReasonNames
 ST._UpdateLossOfControl = UpdateLossOfControl

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -7,6 +7,7 @@ local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local ResolveIconDesaturationIntent = ST._ResolveIconDesaturationIntent
+local GetButtonVisibilityReasonNames = ST._GetButtonVisibilityReasonNames
 local DEFAULT_ICON_FILL_COOLDOWN_COLOR = {0.6, 0.13, 0.18, 0.55}
 local DEFAULT_ICON_FILL_AURA_COLOR = {0.2, 1.0, 0.2, 0.55}
 local UsesChargeBehavior = CooldownCompanion and CooldownCompanion.UsesChargeBehavior
@@ -22,6 +23,34 @@ local function EnsureSection(parent, key)
         parent[key] = section
     end
     return section
+end
+
+local function ResolveVisibilityMode(hidden, alphaOverride)
+    if IsTrue(hidden) then
+        return "hidden"
+    end
+    if alphaOverride ~= nil and alphaOverride ~= 1 then
+        return "dimmed"
+    end
+    return "visible"
+end
+
+local function CopyVisibilityReasonNames(visibility, reasonBits)
+    if type(GetButtonVisibilityReasonNames) ~= "function" then
+        visibility.reasonNames = nil
+        return
+    end
+
+    local names = visibility.reasonNames
+    if type(names) ~= "table" then
+        names = {}
+        visibility.reasonNames = names
+    end
+
+    GetButtonVisibilityReasonNames(reasonBits, names)
+    if #names == 0 then
+        visibility.reasonNames = nil
+    end
 end
 
 local function UsesIconFillChargeBehavior(buttonData)
@@ -477,13 +506,25 @@ local function RefreshButtonVisualState(button, context)
     visibility.alphaOverride = button._visibilityAlphaOverride
     visibility.rawHidden = IsTrue(button._rawVisibilityHidden)
     visibility.rawAlphaOverride = button._rawVisibilityAlphaOverride
+    visibility.rawReasonBits = button._rawVisibilityReasonBits
+    visibility.rawReasonMode = button._rawVisibilityReasonMode
     visibility.reasonBits = button._visibilityReasonBits
     visibility.reasonMode = button._visibilityReasonMode
+    visibility.mode = button._visibilityFinalMode
+        or ResolveVisibilityMode(button._visibilityHidden, button._visibilityAlphaOverride)
+    visibility.rawMode = button._rawVisibilityReasonMode
+        or ResolveVisibilityMode(button._rawVisibilityHidden, button._rawVisibilityAlphaOverride)
+    visibility.overrideSource = button._visibilityOverrideSource
+    visibility.triggerSuppressed = IsTrue(button._visibilityTriggerSuppressed)
+    visibility.compactLayout = IsTrue(button._visibilityCompactLayout)
     visibility.forceVisible = IsTrue(button._forceVisibleByConfig)
     visibility.forceVisibleByConfig = IsTrue(context.forceVisibleByConfig)
     visibility.forceVisibleByPreview = IsTrue(context.forceVisibleByPreview)
     visibility.forceVisibleByUnlockPreview = IsTrue(context.forceVisibleByUnlockPreview)
     visibility.lastAlpha = button._lastVisAlpha
+    visibility.appliedAlpha = button._lastVisAlpha
+    visibility.hiddenPhase = context.phase == "hidden"
+    CopyVisibilityReasonNames(visibility, button._rawVisibilityReasonBits or button._visibilityReasonBits)
 
     local usability = EnsureSection(state, "usability")
     usability.spellOutOfRange = IsTrue(button._spellOutOfRange)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -17,6 +17,16 @@ local function IsFrameShown(frame)
     return frame ~= nil
 end
 
+local function ResolveVisibilityMode(hidden, alphaOverride)
+    if IsTrue(hidden) then
+        return "hidden"
+    end
+    if alphaOverride ~= nil and alphaOverride ~= 1 then
+        return "dimmed"
+    end
+    return "visible"
+end
+
 local function AddMismatch(row, key)
     local mismatches = row.mismatches
     if type(mismatches) ~= "table" then
@@ -160,9 +170,23 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         alphaOverride = visibility.alphaOverride,
         rawHidden = visibility.rawHidden,
         rawAlphaOverride = visibility.rawAlphaOverride,
+        rawReasonBits = visibility.rawReasonBits,
+        rawReasonMode = visibility.rawReasonMode,
         reasonBits = visibility.reasonBits,
         reasonMode = visibility.reasonMode,
+        reasonNames = visibility.reasonNames,
+        mode = visibility.mode,
+        rawMode = visibility.rawMode,
+        overrideSource = visibility.overrideSource,
+        triggerSuppressed = visibility.triggerSuppressed,
+        compactLayout = visibility.compactLayout,
+        forceVisible = visibility.forceVisible,
+        forceVisibleByConfig = visibility.forceVisibleByConfig,
+        forceVisibleByPreview = visibility.forceVisibleByPreview,
+        forceVisibleByUnlockPreview = visibility.forceVisibleByUnlockPreview,
+        hiddenPhase = visibility.hiddenPhase,
         lastAlpha = visibility.lastAlpha,
+        appliedAlpha = visibility.appliedAlpha,
     }
     row.visuals = {
         desaturationActive = desaturation.active,
@@ -286,7 +310,19 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "charges.state", charges.state, button._chargeState)
     CompareValue(row, "visibility.hidden", visibility.hidden, IsTrue(button._visibilityHidden))
     CompareValue(row, "visibility.alphaOverride", visibility.alphaOverride, button._visibilityAlphaOverride)
+    CompareValue(row, "visibility.rawHidden", visibility.rawHidden, IsTrue(button._rawVisibilityHidden))
+    CompareValue(row, "visibility.rawAlphaOverride", visibility.rawAlphaOverride, button._rawVisibilityAlphaOverride)
+    CompareValue(row, "visibility.rawReasonBits", visibility.rawReasonBits, button._rawVisibilityReasonBits)
+    CompareValue(row, "visibility.rawReasonMode", visibility.rawReasonMode, button._rawVisibilityReasonMode)
+    CompareValue(row, "visibility.reasonBits", visibility.reasonBits, button._visibilityReasonBits)
+    CompareValue(row, "visibility.reasonMode", visibility.reasonMode, button._visibilityReasonMode)
+    CompareValue(row, "visibility.mode", visibility.mode, button._visibilityFinalMode or ResolveVisibilityMode(button._visibilityHidden, button._visibilityAlphaOverride))
+    CompareValue(row, "visibility.rawMode", visibility.rawMode, button._rawVisibilityReasonMode or ResolveVisibilityMode(button._rawVisibilityHidden, button._rawVisibilityAlphaOverride))
+    CompareValue(row, "visibility.overrideSource", visibility.overrideSource, button._visibilityOverrideSource)
+    CompareValue(row, "visibility.triggerSuppressed", visibility.triggerSuppressed, IsTrue(button._visibilityTriggerSuppressed))
+    CompareValue(row, "visibility.compactLayout", visibility.compactLayout, IsTrue(button._visibilityCompactLayout))
     CompareValue(row, "visibility.lastAlpha", visibility.lastAlpha, button._lastVisAlpha)
+    CompareValue(row, "visibility.appliedAlpha", visibility.appliedAlpha, button._lastVisAlpha)
     local compareVisibleIconIntent = row.displayMode == "icons"
         and row.phase == "post-dispatch"
         and visibility.hidden ~= true

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -457,9 +457,22 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                 parts[#parts + 1] = "visual=" .. tostring(row.cooldown.visualActive)
             end
             if row.visibility then
+                parts[#parts + 1] = "visibility=" .. tostring(row.visibility.mode or (row.visibility.hidden and "hidden" or "visible"))
                 parts[#parts + 1] = "hidden=" .. tostring(row.visibility.hidden)
                 if row.visibility.alphaOverride ~= nil then
                     parts[#parts + 1] = "alpha=" .. tostring(row.visibility.alphaOverride)
+                end
+                if row.visibility.rawMode and row.visibility.rawMode ~= row.visibility.mode then
+                    parts[#parts + 1] = "rawVisibility=" .. tostring(row.visibility.rawMode)
+                end
+                if row.visibility.overrideSource then
+                    parts[#parts + 1] = "override=" .. tostring(row.visibility.overrideSource)
+                end
+                if type(row.visibility.reasonNames) == "table" and #row.visibility.reasonNames > 0 then
+                    parts[#parts + 1] = "visibilityReason=" .. table.concat(row.visibility.reasonNames, "+")
+                end
+                if row.visibility.triggerSuppressed then
+                    parts[#parts + 1] = "triggerSuppressed=true"
                 end
             end
             if row.visuals then


### PR DESCRIPTION
## What Players Will Notice
- No intended display behavior changes.
- Bug Report output now includes clearer visibility details for sampled cooldown entries, including whether they are visible, dimmed, hidden, or force-shown by config/preview state.

## Why This Changed
- The visual-state refactor needs button visibility represented as part of the same per-button snapshot as cooldown, desaturation, tint, fill, text, and bar state.
- Without this, visibility bugs are harder to reason about because the raw runtime rule and the final displayed state can differ.

## What Changed
- Added stable visibility reason labels for the existing hide-reason bitmask.
- Captured raw visibility state before overrides and final visibility mode after overrides in the per-button visual-state snapshot.
- Extended visual-state diagnostics with visibility mode, raw visibility, override source, trigger suppression, compact-layout state, and reason labels.
- Surfaced the new visibility snapshot fields in Bug Report rows so the diagnostic output reflects the new visual-state model.

## Validation
- `git diff --check origin/visual-state-dev-main...HEAD`
- `luac -p ButtonFrame\Visibility.lua ButtonFrame\CooldownUpdate.lua ButtonFrame\VisualState.lua ButtonFrame\VisualStateDiagnostics.lua Config\Diagnostics.lua`
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- Static review found no actionable issues.
- In-game bug-report validation passed with `mismatched=0` and `missing=0`.
- Combat/restricted-content validation was not separately captured for this diagnostic-focused branch.