### PR TITLE
Capture trigger panel state in visual snapshots

### DIFF
--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -415,6 +415,113 @@ local function CopyBarVisualState(button, bar, context)
     end
 end
 
+local function ClearTable(tbl)
+    if type(tbl) ~= "table" then
+        return
+    end
+    for key in pairs(tbl) do
+        tbl[key] = nil
+    end
+end
+
+local function CopyTriggerConditionList(sourceConditions, target)
+    if type(sourceConditions) ~= "table" or #sourceConditions == 0 then
+        target.conditions = nil
+        return
+    end
+
+    local conditions = {}
+    for index, condition in ipairs(sourceConditions) do
+        conditions[index] = {
+            key = condition.key,
+            expected = condition.expected,
+            actual = condition.actual,
+            matched = condition.matched == true,
+        }
+    end
+    target.conditions = conditions
+end
+
+local function CopyTriggerRowState(source, target)
+    if type(source) ~= "table" then
+        return
+    end
+
+    target.rowIndex = source.rowIndex
+    target.enabled = source.enabled == true
+    target.active = source.active == true
+    target.skipped = source.skipped == true
+    target.hasRuntime = source.hasRuntime == true
+    target.conditionCount = source.conditionCount
+    target.matched = source.matched == true
+    target.reason = source.reason
+    target.failedConditionKey = source.failedConditionKey
+    target.expected = source.expected
+    target.actual = source.actual
+    CopyTriggerConditionList(source.conditions, target)
+end
+
+local function CopyTriggerPanelRows(sourceRows, target)
+    if type(sourceRows) ~= "table" or #sourceRows == 0 then
+        target.rows = nil
+        return
+    end
+
+    local rows = {}
+    for index, sourceRow in ipairs(sourceRows) do
+        local row = {}
+        CopyTriggerRowState(sourceRow, row)
+        rows[index] = row
+    end
+    target.rows = rows
+end
+
+local function CopyTriggerPanelState(source, target)
+    if type(source) ~= "table" then
+        return
+    end
+
+    target.rowCount = source.rowCount
+    target.runtimeRowCount = source.runtimeRowCount
+    target.activeRowCount = source.activeRowCount
+    target.matched = source.matched == true
+    target.matchReason = source.matchReason or source.reason
+    target.displayType = source.displayType
+    target.hasSettings = source.hasSettings == true
+    target.showDisplay = source.showDisplay == true
+    target.triggerMatched = source.triggerMatched == true
+    target.hasTriggerEffectPreview = source.hasTriggerEffectPreview == true
+    target.isEditing = source.isEditing == true
+    target.isUnlocked = source.isUnlocked == true
+    target.isGroupedPreview = source.isGroupedPreview == true
+    target.effectsActive = source.effectsActive == true
+    target.soundVisible = source.soundVisible == true
+    target.rendered = source.rendered == true
+    target.displayReason = source.displayReason
+    target.forceReason = source.forceReason
+    CopyTriggerPanelRows(source.rows, target)
+end
+
+local function CopyTriggerVisualState(button, trigger)
+    ClearTable(trigger)
+
+    local rowSource = button._triggerVisualRow
+    if type(rowSource) == "table" then
+        local row = {}
+        CopyTriggerRowState(rowSource, row)
+        trigger.row = row
+    end
+
+    local panelSource = button._triggerVisualPanel
+    if type(panelSource) == "table" then
+        local panel = {}
+        CopyTriggerPanelState(panelSource, panel)
+        trigger.panel = panel
+    end
+
+    trigger.available = trigger.row ~= nil or trigger.panel ~= nil
+end
+
 local function ClearButtonVisualState(button)
     if button then
         button._visualState = nil
@@ -423,6 +530,8 @@ local function ClearButtonVisualState(button)
         button._textVisualApplied = nil
         button._barVisualIntent = nil
         button._barVisualApplied = nil
+        button._triggerVisualRow = nil
+        button._triggerVisualPanel = nil
     end
 end
 
@@ -614,6 +723,9 @@ local function RefreshButtonVisualState(button, context)
     textureEffects.cooldownActive = state.cooldownVisualActive
     textureEffects.chargeState = button._chargeState
     textureEffects.procActive = IsTrue(button._procOverlayActive)
+
+    local trigger = EnsureSection(state, "trigger")
+    CopyTriggerVisualState(button, trigger)
 
     local applied = EnsureSection(state, "applied")
     applied.desaturated = IsTrue(button._desaturated)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -140,6 +140,7 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     local bar = state.bar or {}
     local text = state.text or {}
     local textureEffects = state.textureEffects or {}
+    local trigger = state.trigger or {}
     local tintActive
     if tint.intentAvailable == true then
         tintActive = IsTrue(tint.intentActive)
@@ -301,6 +302,12 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         chargeState = textureEffects.chargeState,
         procActive = textureEffects.procActive,
     }
+    if trigger.available == true then
+        row.trigger = {
+            row = trigger.row,
+            panel = trigger.panel,
+        }
+    end
 
     CompareValue(row, "cooldown.state", cooldown.state, button._cooldownState)
     CompareValue(row, "cooldown.active", cooldown.active, button._cooldownState == STATE_COOLDOWN)
@@ -409,6 +416,25 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "textureEffects.cooldownActive", textureEffects.cooldownActive, IsTrue(button._desatCooldownActive))
     CompareValue(row, "textureEffects.chargeState", textureEffects.chargeState, button._chargeState)
     CompareValue(row, "textureEffects.procActive", textureEffects.procActive, IsTrue(button._procOverlayActive))
+    if trigger.available == true then
+        local triggerRow = trigger.row
+        local liveTriggerRow = button._triggerVisualRow
+        if type(triggerRow) == "table" then
+            CompareValue(row, "trigger.row.index", triggerRow.rowIndex, liveTriggerRow and liveTriggerRow.rowIndex)
+            CompareValue(row, "trigger.row.reason", triggerRow.reason, liveTriggerRow and liveTriggerRow.reason)
+            CompareValue(row, "trigger.row.matched", triggerRow.matched, liveTriggerRow and liveTriggerRow.matched == true)
+        end
+
+        local triggerPanel = trigger.panel
+        local liveTriggerPanel = button._triggerVisualPanel
+        if type(triggerPanel) == "table" then
+            CompareValue(row, "trigger.panel.matched", triggerPanel.matched, liveTriggerPanel and liveTriggerPanel.matched == true)
+            CompareValue(row, "trigger.panel.showDisplay", triggerPanel.showDisplay, liveTriggerPanel and liveTriggerPanel.showDisplay == true)
+            CompareValue(row, "trigger.panel.displayReason", triggerPanel.displayReason, liveTriggerPanel and liveTriggerPanel.displayReason)
+            CompareValue(row, "trigger.panel.effectsActive", triggerPanel.effectsActive, liveTriggerPanel and liveTriggerPanel.effectsActive == true)
+            CompareValue(row, "trigger.panel.soundVisible", triggerPanel.soundVisible, liveTriggerPanel and liveTriggerPanel.soundVisible == true)
+        end
+    end
 
     return row
 end

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -423,6 +423,33 @@ local function FormatIDList(t)
     return table.concat(parts, ", ")
 end
 
+local function IsTriggerFailureRow(row)
+    return type(row) == "table"
+        and row.enabled ~= false
+        and row.skipped ~= true
+        and row.matched ~= true
+end
+
+local function FindTriggerFailure(trigger)
+    if type(trigger) ~= "table" then
+        return nil
+    end
+
+    if IsTriggerFailureRow(trigger.row) then
+        return trigger.row
+    end
+
+    local panel = trigger.panel
+    if type(panel) == "table" and type(panel.rows) == "table" then
+        for _, row in ipairs(panel.rows) do
+            if IsTriggerFailureRow(row) then
+                return row
+            end
+        end
+    end
+    return nil
+end
+
 local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
     if not visualStateDiagnostics then
         return
@@ -541,6 +568,50 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                 end
                 if row.text.pulseActive then
                     parts[#parts + 1] = "pulse=true"
+                end
+            end
+            if row.trigger then
+                local panel = row.trigger.panel
+                if type(panel) == "table" then
+                    parts[#parts + 1] = "trigger=" .. (panel.showDisplay and "shown" or "hidden")
+                    parts[#parts + 1] = "triggerMatch=" .. tostring(panel.matched)
+                    if panel.displayType then
+                        parts[#parts + 1] = "triggerDisplay=" .. tostring(panel.displayType)
+                    end
+                    if panel.displayReason then
+                        parts[#parts + 1] = "triggerReason=" .. tostring(panel.displayReason)
+                    elseif panel.matchReason then
+                        parts[#parts + 1] = "triggerReason=" .. tostring(panel.matchReason)
+                    end
+                    if panel.forceReason then
+                        parts[#parts + 1] = "triggerForced=" .. tostring(panel.forceReason)
+                    end
+                    if panel.effectsActive then
+                        parts[#parts + 1] = "triggerEffects=true"
+                    end
+                    if panel.soundVisible then
+                        parts[#parts + 1] = "triggerSound=true"
+                    end
+                end
+                local triggerRow = row.trigger.row
+                if type(triggerRow) == "table" then
+                    parts[#parts + 1] = ("triggerRow=%s:%s"):format(
+                        tostring(triggerRow.rowIndex or "?"),
+                        tostring(triggerRow.reason or (triggerRow.matched and "matched" or "unknown"))
+                    )
+                end
+                local failedTriggerRow = FindTriggerFailure(row.trigger)
+                if failedTriggerRow then
+                    local failed = tostring(failedTriggerRow.rowIndex or "?") .. ":" .. tostring(failedTriggerRow.reason or "failed")
+                    if failedTriggerRow.failedConditionKey then
+                        failed = failed .. ":" .. tostring(failedTriggerRow.failedConditionKey)
+                    end
+                    if failedTriggerRow.expected ~= nil or failedTriggerRow.actual ~= nil then
+                        failed = failed
+                            .. "(expected=" .. tostring(failedTriggerRow.expected)
+                            .. ",actual=" .. tostring(failedTriggerRow.actual) .. ")"
+                    end
+                    parts[#parts + 1] = "triggerFail=" .. failed
                 end
             end
             if type(row.mismatches) == "table" and #row.mismatches > 0 then

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -34,6 +34,116 @@ local StopAllTextureIndicatorEffects = AT.StopAllTextureIndicatorEffects
 local ApplyTextureIndicatorEffects = AT.ApplyTextureIndicatorEffects
 local DoesTriggerPanelMatch = AT.DoesTriggerPanelMatch
 
+local function ShouldCaptureButtonVisualState()
+    local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
+    return type(isEnabled) == "function" and isEnabled() == true
+end
+
+local function ClearTriggerPanelVisualState(frame)
+    if not frame then
+        return
+    end
+
+    frame._triggerVisualPanel = nil
+    if type(frame.buttons) ~= "table" then
+        return
+    end
+
+    for _, button in ipairs(frame.buttons) do
+        if type(button) == "table" then
+            button._triggerVisualRow = nil
+            button._triggerVisualPanel = nil
+        end
+    end
+end
+
+local function ResolveTriggerDisplayReason(state, settings, rendered)
+    if not settings then
+        return "missing-settings"
+    end
+    if not state or state.showDisplay ~= true then
+        return state and state.triggerMatched and "matched-hidden" or "unmatched"
+    end
+    if rendered == false then
+        return "render-failed"
+    end
+    if state.triggerMatched then
+        return "matched"
+    end
+    if state.hasTriggerEffectPreview then
+        return "effect-preview"
+    end
+    if state.isEditing then
+        return "editing"
+    end
+    if state.isUnlocked then
+        return state.isGroupedPreview and "container-preview" or "unlocked"
+    end
+    return "shown"
+end
+
+local function CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, rendered)
+    if not (driverButton and group and group.displayMode == "trigger" and ShouldCaptureButtonVisualState()) then
+        return
+    end
+
+    local panelState = driverButton._triggerVisualPanel
+    if type(panelState) ~= "table" then
+        panelState = frame and frame._triggerVisualPanel or {}
+    end
+
+    panelState.displayType = displayType
+    panelState.hasSettings = settings ~= nil
+    panelState.showDisplay = visibilityState and visibilityState.showDisplay == true
+    panelState.triggerMatched = visibilityState and visibilityState.triggerMatched == true
+    panelState.hasTriggerEffectPreview = visibilityState and visibilityState.hasTriggerEffectPreview == true
+    panelState.isEditing = visibilityState and visibilityState.isEditing == true
+    panelState.isUnlocked = visibilityState and visibilityState.isUnlocked == true
+    panelState.isGroupedPreview = visibilityState and visibilityState.isGroupedPreview == true
+    panelState.effectsActive = panelState.triggerMatched or panelState.hasTriggerEffectPreview
+    panelState.soundVisible = visibilityState and visibilityState.triggerSoundVisible == true
+    panelState.rendered = rendered == true
+    panelState.displayReason = ResolveTriggerDisplayReason(visibilityState, settings, rendered)
+    panelState.forceReason = nil
+    if panelState.showDisplay and not panelState.triggerMatched then
+        panelState.forceReason = panelState.hasTriggerEffectPreview and "effect-preview"
+            or panelState.isEditing and "editing"
+            or panelState.isUnlocked and (panelState.isGroupedPreview and "container-preview" or "unlocked")
+            or nil
+    end
+
+    if frame then
+        frame._triggerVisualPanel = panelState
+        if type(frame.buttons) == "table" then
+            for _, button in ipairs(frame.buttons) do
+                if type(button) == "table" then
+                    button._triggerVisualPanel = panelState
+                end
+            end
+        end
+    end
+end
+
+local function RefreshTriggerPanelVisualSnapshots(frame)
+    if not (frame and ShouldCaptureButtonVisualState()) then
+        return
+    end
+
+    local refresh = ST._RefreshButtonVisualState
+    if type(refresh) ~= "function" or type(frame.buttons) ~= "table" then
+        return
+    end
+
+    for _, button in ipairs(frame.buttons) do
+        local context = type(button) == "table" and button._visualStateContext or nil
+        if type(context) == "table" then
+            context.displayMode = "trigger"
+            context.phase = context.phase or "hidden"
+            refresh(button, context)
+        end
+    end
+end
+
 local NUDGE_BTN_SIZE = 12
 local NUDGE_GAP = 2
 local NUDGE_REPEAT_DELAY = 0.5
@@ -969,6 +1079,10 @@ end
 function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
     local groupedPreviewFrame = GetGroupedPreviewContainerFrame(group, driverButton and driverButton._groupId)
     local combatForcedLock = self._combatForcedLock == true
+    local captureTriggerDetails = isTriggerPanel and ShouldCaptureButtonVisualState()
+    if captureTriggerDetails then
+        ClearTriggerPanelVisualState(frame)
+    end
     local state = {
         isEditing = IsStandaloneTextureEditingButton(driverButton),
         isConfigForceVisible = (not isTriggerPanel) and IsTexturePanelConfigForceVisible(driverButton),
@@ -977,7 +1091,7 @@ function CooldownCompanion:GetStandaloneDisplayVisibilityState(group, frame, dri
         isUnlocked = not combatForcedLock and group and (group.locked == false or groupedPreviewFrame ~= nil),
         hasPreviewSelection = displayType == "texture" and type(driverButton._auraTexturePreviewSelection) == "table",
         hasTriggerEffectPreview = isTriggerPanel and driverButton._triggerEffectsPreview == true,
-        triggerMatched = isTriggerPanel and frame and frame:IsShown() and DoesTriggerPanelMatch(frame) or false,
+        triggerMatched = isTriggerPanel and frame and frame:IsShown() and DoesTriggerPanelMatch(frame, captureTriggerDetails) or false,
         showDisplay = false,
     }
 
@@ -1353,6 +1467,10 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
     local displayType, settings = CooldownCompanion.ResolveActiveStandaloneDisplay(driverButton)
     local visibilityState = self:GetStandaloneDisplayVisibilityState(group, frame, driverButton, displayType, settings, isTriggerPanel)
 
+    if isTriggerPanel then
+        CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, false)
+    end
+
     if isTriggerPanel and self.UpdateTriggerPanelSoundAlerts then
         self:UpdateTriggerPanelSoundAlerts(frame, group, visibilityState.triggerSoundVisible)
     end
@@ -1362,6 +1480,9 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
         if driverButton:GetAlpha() ~= 0 then
             driverButton:SetAlpha(0)
             driverButton._lastVisAlpha = 0
+        end
+        if isTriggerPanel then
+            RefreshTriggerPanelVisualSnapshots(frame)
         end
         return
     end
@@ -1383,10 +1504,18 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             driverButton:SetAlpha(0)
             driverButton._lastVisAlpha = 0
         end
+        if isTriggerPanel then
+            CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, false)
+            RefreshTriggerPanelVisualSnapshots(frame)
+        end
         return
     end
 
     self:FinalizeStandaloneDisplay(host, frame, driverButton, group, settings, displayType, isTriggerPanel, visibilityState)
+    if isTriggerPanel then
+        CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, true)
+        RefreshTriggerPanelVisualSnapshots(frame)
+    end
 end
 
 function CooldownCompanion:RefreshAllAuraTextureVisuals()

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -54,6 +54,51 @@ local GetStretchMultiplier = AT.GetStretchMultiplier
 local RotateOffset = AT.RotateOffset
 local ResolveGroup = AT.ResolveGroup
 
+local function ShouldCaptureTriggerPanelVisualState()
+    local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
+    return type(isEnabled) == "function" and isEnabled() == true
+end
+
+local function ClearTriggerVisualRows(runtimeButtons)
+    if type(runtimeButtons) ~= "table" then
+        return
+    end
+
+    for _, button in ipairs(runtimeButtons) do
+        if type(button) == "table" then
+            button._triggerVisualRow = nil
+            button._triggerVisualPanel = nil
+        end
+    end
+end
+
+local function AssignTriggerVisualPanel(frame, panelState)
+    if frame then
+        frame._triggerVisualPanel = panelState
+    end
+
+    local runtimeButtons = frame and frame.buttons
+    if type(runtimeButtons) ~= "table" then
+        return
+    end
+
+    for _, button in ipairs(runtimeButtons) do
+        if type(button) == "table" then
+            button._triggerVisualPanel = panelState
+        end
+    end
+end
+
+local function FinishTriggerPanelMatch(frame, panelState, matched, reason)
+    if panelState then
+        panelState.matched = matched == true
+        panelState.reason = reason
+        panelState.matchReason = reason
+        AssignTriggerVisualPanel(frame, panelState)
+    end
+    return matched == true
+end
+
 local function ApplyTextureSource(texture, settings)
     local resolvedSourceType, resolvedSourceValue = CooldownCompanion:ResolveAuraTextureAsset(
         settings.sourceType,
@@ -709,15 +754,23 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
     return false
 end
 
-local function DoesTriggerPanelMatch(frame)
+local function DoesTriggerPanelMatch(frame, captureDetails)
     if not frame then
         return false
     end
 
     local group = frame.groupId and ResolveGroup(frame.groupId) or nil
     local configuredRows = group and group.buttons
+    captureDetails = captureDetails == true or ShouldCaptureTriggerPanelVisualState()
+    local panelState
+    if captureDetails then
+        panelState = {
+            rowCount = type(configuredRows) == "table" and #configuredRows or 0,
+            rows = {},
+        }
+    end
     if type(configuredRows) ~= "table" or #configuredRows == 0 then
-        return false
+        return FinishTriggerPanelMatch(frame, panelState, false, "missing-config")
     end
 
     local runtimeButtonsByIndex = frame._triggerRuntimeButtonsByIndex
@@ -732,48 +785,129 @@ local function DoesTriggerPanelMatch(frame)
             runtimeButtonsByIndex[button.index] = button
         end
     end
+    if panelState then
+        panelState.runtimeRowCount = type(frame.buttons) == "table" and #frame.buttons or 0
+        ClearTriggerVisualRows(frame.buttons)
+    end
 
     local activeRowCount = 0
+    local function finish(matched, reason)
+        if panelState then
+            panelState.activeRowCount = activeRowCount
+        end
+        return FinishTriggerPanelMatch(frame, panelState, matched, reason)
+    end
+
     for rowIndex, buttonData in ipairs(configuredRows) do
-        if type(buttonData) ~= "table" then
-            return false
+        local rowState
+        if panelState then
+            rowState = {
+                rowIndex = rowIndex,
+                enabled = type(buttonData) == "table" and buttonData.enabled ~= false or false,
+            }
+            panelState.rows[#panelState.rows + 1] = rowState
         end
 
-        if buttonData.enabled ~= false then
+        if type(buttonData) ~= "table" then
+            if rowState then
+                rowState.matched = false
+                rowState.reason = "invalid-row"
+            end
+            return finish(false, "invalid-row")
+        end
+
+        if buttonData.enabled == false then
+            if rowState then
+                rowState.skipped = true
+                rowState.reason = "disabled"
+            end
+        else
             local clauses = CooldownCompanion:GetTriggerConditionClauses(buttonData)
-            if #clauses == 0 then
-                return false
+            activeRowCount = activeRowCount + 1
+            if rowState then
+                rowState.active = true
+                rowState.conditionCount = #clauses
             end
 
-            activeRowCount = activeRowCount + 1
+            if #clauses == 0 then
+                if rowState then
+                    rowState.matched = false
+                    rowState.reason = "no-conditions"
+                end
+                return finish(false, "no-conditions")
+            end
+
             local runtimeButton = runtimeButtonsByIndex[rowIndex]
             if not runtimeButton then
-                return false
+                if rowState then
+                    rowState.matched = false
+                    rowState.reason = "missing-runtime"
+                end
+                return finish(false, "missing-runtime")
+            end
+            if rowState then
+                rowState.hasRuntime = true
+                runtimeButton._triggerVisualRow = rowState
             end
 
             for _, clause in ipairs(clauses) do
                 local conditionKey = NormalizeTriggerConditionKey(buttonData, clause.key)
                 if not conditionKey then
-                    return false
+                    if rowState then
+                        rowState.matched = false
+                        rowState.reason = "invalid-condition"
+                    end
+                    return finish(false, "invalid-condition")
                 end
 
                 local actualState = EvaluateTriggerRowCondition(runtimeButton, conditionKey)
+                local expectedState
+                local conditionMatched
                 if TRIGGER_EXPECTED_LABELS[conditionKey] ~= nil then
-                    local expected = clause.expected ~= false
-                    if actualState ~= expected then
-                        return false
-                    end
+                    expectedState = clause.expected ~= false
+                    conditionMatched = actualState == expectedState
                 else
-                    local expectedState = NormalizeTriggerStateKey(conditionKey, clause.state)
-                    if actualState ~= expectedState then
-                        return false
-                    end
+                    expectedState = NormalizeTriggerStateKey(conditionKey, clause.state)
+                    conditionMatched = actualState == expectedState
                 end
+
+                if rowState then
+                    local conditions = rowState.conditions
+                    if type(conditions) ~= "table" then
+                        conditions = {}
+                        rowState.conditions = conditions
+                    end
+                    conditions[#conditions + 1] = {
+                        key = conditionKey,
+                        expected = expectedState,
+                        actual = actualState,
+                        matched = conditionMatched,
+                    }
+                end
+
+                if not conditionMatched then
+                    if rowState then
+                        rowState.matched = false
+                        rowState.reason = "condition-mismatch"
+                        rowState.failedConditionKey = conditionKey
+                        rowState.expected = expectedState
+                        rowState.actual = actualState
+                    end
+                    return finish(false, "condition-mismatch")
+                end
+            end
+
+            if rowState then
+                rowState.matched = true
+                rowState.reason = "matched"
             end
         end
     end
 
-    return activeRowCount > 0
+    return finish(
+        activeRowCount > 0,
+        activeRowCount > 0 and "matched" or "no-active-rows"
+    )
 end
 
 local function ApplyTextureIndicatorEffects(host, button, group)


### PR DESCRIPTION
## What Changed
- Captures trigger panel row-condition results from the live trigger matching path so visual snapshots can explain why each trigger row matched, failed, was disabled, or was missing runtime state.
- Captures the final standalone trigger display outcome, including display type, matched state, forced preview/edit visibility, effects-active state, and sound-visible state.
- Extends Bug Report visual-state rows with concise trigger tokens so agents can diagnose trigger panels without requiring a full profile dump.

## Why This Changed
- Trigger panels have two display layers: hidden runtime row buttons and one player-facing standalone trigger display.
- The visual-state rollout needed a single diagnostic view that explains both the row-level condition truth and the final trigger display decision without recomputing trigger behavior separately.

## Developer Impact
- Agents can now see whether a trigger panel matched, why it displayed or stayed hidden, which row failed first, and whether trigger effects or sound alerts were considered active.
- This keeps trigger diagnostics tied to the existing live runtime path while the broader visual-state refactor continues.

## Validation
- `git diff --check`
- `luac -p` on touched Lua files
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- User-reported in-game validation cleared for the trigger-panel smoke pass. Supplied Bug Report showed `mismatched=0`, `missing=0`, `trigger=shown`, `triggerMatch=true`, `triggerDisplay=text`, `triggerReason=matched`, `triggerEffects=true`, and `triggerSound=true`.
- Combat/restricted status: user reported the requested validation cleared; no separate restricted-content diagnostic artifact is attached to this PR.