### PR TITLE
Add visual-state tracking for texture panels

### DIFF
--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -522,6 +522,142 @@ local function CopyTriggerVisualState(button, trigger)
     trigger.available = trigger.row ~= nil or trigger.panel ~= nil
 end
 
+local function CopyTextureDisplayVisualState(button, texture)
+    ClearTable(texture)
+
+    local intent = button._textureDisplayIntent
+    local hasIntent = type(intent) == "table"
+    texture.intentAvailable = hasIntent
+    if hasIntent then
+        texture.displayType = intent.displayType
+        texture.hasSettings = intent.hasSettings == true
+        texture.showDisplay = intent.showDisplay == true
+        texture.reason = intent.reason
+        texture.isEditing = intent.isEditing == true
+        texture.isConfigForceVisible = intent.isConfigForceVisible == true
+        texture.isUnlocked = intent.isUnlocked == true
+        texture.isGroupedPreview = intent.isGroupedPreview == true
+        texture.hasPreviewSelection = intent.hasPreviewSelection == true
+        texture.bypassModuleAlpha = intent.bypassModuleAlpha == true
+    else
+        texture.displayType = nil
+        texture.hasSettings = false
+        texture.showDisplay = false
+        texture.reason = nil
+        texture.isEditing = false
+        texture.isConfigForceVisible = false
+        texture.isUnlocked = false
+        texture.isGroupedPreview = false
+        texture.hasPreviewSelection = false
+        texture.bypassModuleAlpha = false
+    end
+
+    local applied = button._textureDisplayApplied
+    local hasApplied = type(applied) == "table"
+    texture.appliedAvailable = hasApplied
+    if hasApplied then
+        texture.appliedRendered = applied.rendered == true
+        texture.appliedShown = applied.shown == true
+        texture.appliedDisplayType = applied.displayType
+        texture.appliedAlpha = applied.alpha
+        texture.appliedDriverAlpha = applied.driverAlpha
+        texture.appliedHasSavedDisplay = applied.hasSavedDisplay == true
+        texture.appliedDragEnabled = applied.dragEnabled == true
+        texture.appliedWrapperManaged = applied.wrapperManaged == true
+    else
+        texture.appliedRendered = false
+        texture.appliedShown = false
+        texture.appliedDisplayType = nil
+        texture.appliedAlpha = nil
+        texture.appliedDriverAlpha = nil
+        texture.appliedHasSavedDisplay = false
+        texture.appliedDragEnabled = false
+        texture.appliedWrapperManaged = false
+    end
+end
+
+local function CopyTextureEffectSections(sourceSections)
+    if type(sourceSections) ~= "table" then
+        return nil
+    end
+
+    local sections = {}
+    local hasSections = false
+    for key, source in pairs(sourceSections) do
+        if type(source) == "table" then
+            sections[key] = {
+                enabled = source.enabled == true,
+                active = source.active == true,
+                reason = source.reason,
+                preview = source.preview == true,
+                effectType = source.effectType,
+                normalizedEffectType = source.normalizedEffectType,
+                combatOnly = source.combatOnly == true,
+                invert = source.invert == true,
+            }
+            hasSections = true
+        end
+    end
+
+    return hasSections and sections or nil
+end
+
+local function CopyTextureEffectsVisualState(button, textureEffects)
+    local intent = button._textureEffectIntent
+    local hasIntent = type(intent) == "table"
+    textureEffects.intentAvailable = hasIntent
+    if hasIntent then
+        textureEffects.hasIndicators = intent.hasIndicators == true
+        textureEffects.freezeGeometryWhileUnlocked = intent.freezeGeometryWhileUnlocked == true
+        textureEffects.pulseActive = intent.pulseActive == true
+        textureEffects.pulseSection = intent.pulseSection
+        textureEffects.colorShiftActive = intent.colorShiftActive == true
+        textureEffects.colorShiftSection = intent.colorShiftSection
+        textureEffects.shrinkExpandActive = intent.shrinkExpandActive == true
+        textureEffects.shrinkExpandSection = intent.shrinkExpandSection
+        textureEffects.bounceActive = intent.bounceActive == true
+        textureEffects.bounceSection = intent.bounceSection
+        textureEffects.sections = CopyTextureEffectSections(intent.sections)
+    else
+        textureEffects.hasIndicators = false
+        textureEffects.freezeGeometryWhileUnlocked = false
+        textureEffects.pulseActive = false
+        textureEffects.pulseSection = nil
+        textureEffects.colorShiftActive = false
+        textureEffects.colorShiftSection = nil
+        textureEffects.shrinkExpandActive = false
+        textureEffects.shrinkExpandSection = nil
+        textureEffects.bounceActive = false
+        textureEffects.bounceSection = nil
+        textureEffects.sections = nil
+    end
+
+    local applied = button._textureEffectApplied
+    local hasApplied = type(applied) == "table"
+    textureEffects.appliedAvailable = hasApplied
+    if hasApplied then
+        textureEffects.appliedPulseActive = applied.pulseActive == true
+        textureEffects.appliedPulseSection = applied.pulseSection
+        textureEffects.appliedColorShiftActive = applied.colorShiftActive == true
+        textureEffects.appliedColorShiftSection = applied.colorShiftSection
+        textureEffects.appliedShrinkExpandActive = applied.shrinkExpandActive == true
+        textureEffects.appliedShrinkExpandSection = applied.shrinkExpandSection
+        textureEffects.appliedBounceActive = applied.bounceActive == true
+        textureEffects.appliedBounceSection = applied.bounceSection
+        textureEffects.appliedFreezeGeometryWhileUnlocked = applied.freezeGeometryWhileUnlocked == true
+    else
+        textureEffects.appliedPulseActive = false
+        textureEffects.appliedPulseSection = nil
+        textureEffects.appliedColorShiftActive = false
+        textureEffects.appliedColorShiftSection = nil
+        textureEffects.appliedShrinkExpandActive = false
+        textureEffects.appliedShrinkExpandSection = nil
+        textureEffects.appliedBounceActive = false
+        textureEffects.appliedBounceSection = nil
+        textureEffects.appliedFreezeGeometryWhileUnlocked = false
+    end
+end
+
 local function ClearButtonVisualState(button)
     if button then
         button._visualState = nil
@@ -530,6 +666,10 @@ local function ClearButtonVisualState(button)
         button._textVisualApplied = nil
         button._barVisualIntent = nil
         button._barVisualApplied = nil
+        button._textureDisplayIntent = nil
+        button._textureDisplayApplied = nil
+        button._textureEffectIntent = nil
+        button._textureEffectApplied = nil
         button._triggerVisualRow = nil
         button._triggerVisualPanel = nil
     end
@@ -718,11 +858,15 @@ local function RefreshButtonVisualState(button, context)
     CopyTextVisualState(button, text, context)
     text.durationObj = button._durationObj
 
+    local texture = EnsureSection(state, "texture")
+    CopyTextureDisplayVisualState(button, texture)
+
     local textureEffects = EnsureSection(state, "textureEffects")
     textureEffects.ready = textureReady
     textureEffects.cooldownActive = state.cooldownVisualActive
     textureEffects.chargeState = button._chargeState
     textureEffects.procActive = IsTrue(button._procOverlayActive)
+    CopyTextureEffectsVisualState(button, textureEffects)
 
     local trigger = EnsureSection(state, "trigger")
     CopyTriggerVisualState(button, trigger)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -139,6 +139,7 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     local glows = state.glows or {}
     local bar = state.bar or {}
     local text = state.text or {}
+    local texture = state.texture or {}
     local textureEffects = state.textureEffects or {}
     local trigger = state.trigger or {}
     local tintActive
@@ -296,11 +297,55 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         appliedAlpha = text.appliedAlpha,
         durationObj = text.durationObj ~= nil,
     }
+    row.texture = {
+        intentAvailable = texture.intentAvailable,
+        appliedAvailable = texture.appliedAvailable,
+        displayType = texture.displayType,
+        hasSettings = texture.hasSettings,
+        showDisplay = texture.showDisplay,
+        reason = texture.reason,
+        isEditing = texture.isEditing,
+        isConfigForceVisible = texture.isConfigForceVisible,
+        isUnlocked = texture.isUnlocked,
+        isGroupedPreview = texture.isGroupedPreview,
+        hasPreviewSelection = texture.hasPreviewSelection,
+        bypassModuleAlpha = texture.bypassModuleAlpha,
+        appliedRendered = texture.appliedRendered,
+        appliedShown = texture.appliedShown,
+        appliedDisplayType = texture.appliedDisplayType,
+        appliedAlpha = texture.appliedAlpha,
+        appliedDriverAlpha = texture.appliedDriverAlpha,
+        appliedHasSavedDisplay = texture.appliedHasSavedDisplay,
+        appliedDragEnabled = texture.appliedDragEnabled,
+        appliedWrapperManaged = texture.appliedWrapperManaged,
+    }
     row.textureEffects = {
         ready = textureEffects.ready,
         cooldownActive = textureEffects.cooldownActive,
         chargeState = textureEffects.chargeState,
         procActive = textureEffects.procActive,
+        intentAvailable = textureEffects.intentAvailable,
+        appliedAvailable = textureEffects.appliedAvailable,
+        hasIndicators = textureEffects.hasIndicators,
+        freezeGeometryWhileUnlocked = textureEffects.freezeGeometryWhileUnlocked,
+        pulseActive = textureEffects.pulseActive,
+        pulseSection = textureEffects.pulseSection,
+        colorShiftActive = textureEffects.colorShiftActive,
+        colorShiftSection = textureEffects.colorShiftSection,
+        shrinkExpandActive = textureEffects.shrinkExpandActive,
+        shrinkExpandSection = textureEffects.shrinkExpandSection,
+        bounceActive = textureEffects.bounceActive,
+        bounceSection = textureEffects.bounceSection,
+        appliedPulseActive = textureEffects.appliedPulseActive,
+        appliedPulseSection = textureEffects.appliedPulseSection,
+        appliedColorShiftActive = textureEffects.appliedColorShiftActive,
+        appliedColorShiftSection = textureEffects.appliedColorShiftSection,
+        appliedShrinkExpandActive = textureEffects.appliedShrinkExpandActive,
+        appliedShrinkExpandSection = textureEffects.appliedShrinkExpandSection,
+        appliedBounceActive = textureEffects.appliedBounceActive,
+        appliedBounceSection = textureEffects.appliedBounceSection,
+        appliedFreezeGeometryWhileUnlocked = textureEffects.appliedFreezeGeometryWhileUnlocked,
+        sections = textureEffects.sections,
     }
     if trigger.available == true then
         row.trigger = {
@@ -413,9 +458,42 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
             CompareValue(row, "text.pulseActive", text.appliedPulseActive, text.pulseActive)
         end
     end
+    local compareTextureIntent = row.displayMode == "textures"
+        and (row.phase == "post-dispatch" or row.phase == "hidden")
+    if compareTextureIntent then
+        if texture.intentAvailable ~= true then
+            AddMismatch(row, "texture.intent.missing")
+        elseif texture.appliedAvailable ~= true then
+            AddMismatch(row, "texture.applied.missing")
+        else
+            local liveIntent = button._textureDisplayIntent
+            local liveApplied = button._textureDisplayApplied
+            CompareValue(row, "texture.reason", texture.reason, liveIntent and liveIntent.reason)
+            CompareValue(row, "texture.showDisplay", texture.showDisplay, liveIntent and liveIntent.showDisplay == true)
+            CompareValue(row, "texture.appliedRendered", texture.appliedRendered, liveApplied and liveApplied.rendered == true)
+            CompareValue(row, "texture.appliedShown", texture.appliedShown, liveApplied and liveApplied.shown == true)
+            if texture.appliedRendered == true then
+                CompareValue(row, "texture.displayType", texture.appliedDisplayType, texture.displayType)
+            end
+        end
+    end
     CompareValue(row, "textureEffects.cooldownActive", textureEffects.cooldownActive, IsTrue(button._desatCooldownActive))
     CompareValue(row, "textureEffects.chargeState", textureEffects.chargeState, button._chargeState)
     CompareValue(row, "textureEffects.procActive", textureEffects.procActive, IsTrue(button._procOverlayActive))
+    local compareTextureEffects = row.displayMode == "textures"
+        and texture.appliedRendered == true
+    if compareTextureEffects then
+        if textureEffects.intentAvailable ~= true then
+            AddMismatch(row, "textureEffects.intent.missing")
+        elseif textureEffects.appliedAvailable ~= true then
+            AddMismatch(row, "textureEffects.applied.missing")
+        else
+            CompareValue(row, "textureEffects.pulseActive", textureEffects.appliedPulseActive, textureEffects.pulseActive)
+            CompareValue(row, "textureEffects.colorShiftActive", textureEffects.appliedColorShiftActive, textureEffects.colorShiftActive)
+            CompareValue(row, "textureEffects.shrinkExpandActive", textureEffects.appliedShrinkExpandActive, textureEffects.shrinkExpandActive)
+            CompareValue(row, "textureEffects.bounceActive", textureEffects.appliedBounceActive, textureEffects.bounceActive)
+        end
+    end
     if trigger.available == true then
         local triggerRow = trigger.row
         local liveTriggerRow = button._triggerVisualRow

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -570,6 +570,38 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                     parts[#parts + 1] = "pulse=true"
                 end
             end
+            if row.texture and (row.displayMode == "textures" or row.texture.intentAvailable == true) then
+                local textureStatus = row.texture.appliedRendered and "shown" or "hidden"
+                if row.texture.reason == "render-failed" then
+                    textureStatus = "render-failed"
+                end
+                parts[#parts + 1] = "texture=" .. textureStatus
+                if row.texture.reason then
+                    parts[#parts + 1] = "textureReason=" .. tostring(row.texture.reason)
+                end
+                if row.texture.appliedDisplayType then
+                    parts[#parts + 1] = "textureDisplay=" .. tostring(row.texture.appliedDisplayType)
+                end
+                if row.texture.appliedAlpha ~= nil then
+                    parts[#parts + 1] = "textureAlpha=" .. tostring(row.texture.appliedAlpha)
+                end
+            end
+            if row.textureEffects and (row.displayMode == "textures" or row.textureEffects.intentAvailable == true) then
+                local effects = {}
+                if row.textureEffects.pulseActive then
+                    effects[#effects + 1] = "pulse"
+                end
+                if row.textureEffects.colorShiftActive then
+                    effects[#effects + 1] = "colorShift"
+                end
+                if row.textureEffects.shrinkExpandActive then
+                    effects[#effects + 1] = "shrinkExpand"
+                end
+                if row.textureEffects.bounceActive then
+                    effects[#effects + 1] = "bounce"
+                end
+                parts[#parts + 1] = "textureEffects=" .. (#effects > 0 and table.concat(effects, "+") or "none")
+            end
             if row.trigger then
                 local panel = row.trigger.panel
                 if type(panel) == "table" then

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -57,6 +57,21 @@ local function ClearTriggerPanelVisualState(frame)
     end
 end
 
+local function ClearTexturePanelVisualState(button)
+    if not button then
+        return
+    end
+
+    button._textureDisplayIntent = nil
+    button._textureDisplayApplied = nil
+    button._textureEffectIntent = nil
+    button._textureEffectApplied = nil
+end
+
+local function IsShown(frame)
+    return frame and type(frame.IsShown) == "function" and frame:IsShown() == true or false
+end
+
 local function ResolveTriggerDisplayReason(state, settings, rendered)
     if not settings then
         return "missing-settings"
@@ -80,6 +95,31 @@ local function ResolveTriggerDisplayReason(state, settings, rendered)
         return state.isGroupedPreview and "container-preview" or "unlocked"
     end
     return "shown"
+end
+
+local function ResolveTextureDisplayReason(state, settings, rendered)
+    if not settings then
+        return "missing-settings"
+    end
+    if not state or state.showDisplay ~= true then
+        return "hidden"
+    end
+    if rendered == false then
+        return "render-failed"
+    end
+    if state.hasPreviewSelection then
+        return "preview"
+    end
+    if state.isEditing then
+        return "editing"
+    end
+    if state.isConfigForceVisible then
+        return "config-force"
+    end
+    if state.isUnlocked then
+        return state.isGroupedPreview and "container-preview" or "unlocked"
+    end
+    return "runtime"
 end
 
 local function CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, rendered)
@@ -122,6 +162,36 @@ local function CaptureTriggerDisplayVisualState(frame, driverButton, group, disp
             end
         end
     end
+end
+
+local function CaptureTextureDisplayVisualState(driverButton, group, displayType, settings, visibilityState, rendered, host)
+    if not (driverButton and group and group.displayMode == "textures" and ShouldCaptureButtonVisualState()) then
+        return
+    end
+
+    driverButton._textureDisplayIntent = {
+        displayType = displayType,
+        hasSettings = settings ~= nil,
+        showDisplay = visibilityState and visibilityState.showDisplay == true,
+        reason = ResolveTextureDisplayReason(visibilityState, settings, rendered),
+        isEditing = visibilityState and visibilityState.isEditing == true,
+        isConfigForceVisible = visibilityState and visibilityState.isConfigForceVisible == true,
+        isUnlocked = visibilityState and visibilityState.isUnlocked == true,
+        isGroupedPreview = visibilityState and visibilityState.isGroupedPreview == true,
+        hasPreviewSelection = visibilityState and visibilityState.hasPreviewSelection == true,
+        bypassModuleAlpha = visibilityState and visibilityState.bypassModuleAlpha == true,
+    }
+
+    driverButton._textureDisplayApplied = {
+        rendered = rendered == true,
+        shown = IsShown(host),
+        displayType = host and host._activeDisplayType or nil,
+        alpha = host and type(host.GetAlpha) == "function" and host:GetAlpha() or nil,
+        driverAlpha = driverButton._lastVisAlpha,
+        hasSavedDisplay = host and host._hasSavedDisplay == true,
+        dragEnabled = host and host._dragEnabled == true,
+        wrapperManaged = host and host._wrapperManaged == true,
+    }
 end
 
 local function RefreshTriggerPanelVisualSnapshots(frame)
@@ -806,6 +876,8 @@ local function GetTexturePanelLayoutPreviewAlpha(button)
 end
 
 function CooldownCompanion:HideAuraTextureVisual(button)
+    ClearTexturePanelVisualState(button)
+
     local alphaModuleId = button and GetTexturePanelAlphaModuleId(button._groupId) or nil
     if alphaModuleId then
         self:UnregisterModuleAlpha(alphaModuleId, true)
@@ -1481,6 +1553,9 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             driverButton:SetAlpha(0)
             driverButton._lastVisAlpha = 0
         end
+        if not isTriggerPanel then
+            CaptureTextureDisplayVisualState(driverButton, group, displayType, settings, visibilityState, false, driverButton.auraTextureHost)
+        end
         if isTriggerPanel then
             RefreshTriggerPanelVisualSnapshots(frame)
         end
@@ -1504,6 +1579,9 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
             driverButton:SetAlpha(0)
             driverButton._lastVisAlpha = 0
         end
+        if not isTriggerPanel then
+            CaptureTextureDisplayVisualState(driverButton, group, displayType, settings, visibilityState, false, driverButton.auraTextureHost)
+        end
         if isTriggerPanel then
             CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, false)
             RefreshTriggerPanelVisualSnapshots(frame)
@@ -1515,6 +1593,8 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
     if isTriggerPanel then
         CaptureTriggerDisplayVisualState(frame, driverButton, group, displayType, settings, visibilityState, true)
         RefreshTriggerPanelVisualSnapshots(frame)
+    else
+        CaptureTextureDisplayVisualState(driverButton, group, displayType, settings, visibilityState, true, host)
     end
 end
 

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -54,7 +54,7 @@ local GetStretchMultiplier = AT.GetStretchMultiplier
 local RotateOffset = AT.RotateOffset
 local ResolveGroup = AT.ResolveGroup
 
-local function ShouldCaptureTriggerPanelVisualState()
+local function ShouldCaptureButtonVisualState()
     local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
     return type(isEnabled) == "function" and isEnabled() == true
 end
@@ -566,76 +566,130 @@ local function StopAllTextureIndicatorEffects(host)
     SetTextureIndicatorBaseVisuals(host)
 end
 
-local function IsTextureIndicatorSectionActive(button, sectionKey, config)
-    if not button or type(config) ~= "table" or not config.enabled then
-        return false
+local function SetTextureEffectFlag(target, effectType, sectionKey, active)
+    if not target or not effectType then
+        return
     end
 
-    if sectionKey == "proc" and button._textureProcPreview then
-        return true
+    if effectType == TEXTURE_INDICATOR_EFFECT_PULSE then
+        target.pulseActive = active == true
+        target.pulseSection = active and sectionKey or nil
+    elseif effectType == TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT then
+        target.colorShiftActive = active == true
+        target.colorShiftSection = active and sectionKey or nil
+    elseif effectType == TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND then
+        target.shrinkExpandActive = active == true
+        target.shrinkExpandSection = active and sectionKey or nil
+    elseif effectType == TEXTURE_INDICATOR_EFFECT_BOUNCE then
+        target.bounceActive = active == true
+        target.bounceSection = active and sectionKey or nil
     end
-    if sectionKey == "aura" and button._textureAuraPreview then
-        return true
+end
+
+local function FinishTextureIndicatorSectionState(target, active, reason, preview, effectType)
+    if target then
+        target.active = active == true
+        target.reason = reason
+        if preview ~= nil then
+            target.preview = preview == true
+        end
     end
-    if sectionKey == "pandemic" and button._texturePandemicPreview then
-        return true
+    return active == true, effectType, target
+end
+
+local function ResolveTextureIndicatorSectionState(button, sectionKey, config, target)
+    local hasTarget = type(target) == "table"
+    local hasConfig = type(config) == "table"
+    local effectType = hasConfig and NormalizeTextureIndicatorEffect(config.effectType) or nil
+    if hasTarget then
+        target.enabled = hasConfig and config.enabled == true
+        target.effectType = hasConfig and config.effectType or nil
+        target.normalizedEffectType = effectType
+        target.combatOnly = hasConfig and config.combatOnly == true
+        target.invert = hasConfig and config.invert == true
+        target.preview = false
+        target.active = false
+        target.reason = nil
     end
-    if sectionKey == "ready" and button._textureReadyPreview then
-        return true
+
+    if not button then
+        return FinishTextureIndicatorSectionState(target, false, "missing-button", nil, effectType)
     end
-    if sectionKey == "unusable" and button._textureUnusablePreview then
-        return true
+    if not hasConfig then
+        return FinishTextureIndicatorSectionState(target, false, "missing-config", nil, effectType)
+    end
+    if config.enabled ~= true then
+        return FinishTextureIndicatorSectionState(target, false, "disabled", nil, effectType)
+    end
+
+    local previewActive = (sectionKey == "proc" and button._textureProcPreview)
+        or (sectionKey == "aura" and button._textureAuraPreview)
+        or (sectionKey == "pandemic" and button._texturePandemicPreview)
+        or (sectionKey == "ready" and button._textureReadyPreview)
+        or (sectionKey == "unusable" and button._textureUnusablePreview)
+    if previewActive then
+        return FinishTextureIndicatorSectionState(target, true, "preview", true, effectType)
     end
 
     if config.combatOnly and not InCombatLockdown() then
-        return false
+        return FinishTextureIndicatorSectionState(target, false, "out-of-combat", nil, effectType)
     end
 
     if sectionKey == "proc" then
-        return button._procOverlayActive == true
+        local active = button._procOverlayActive == true
+        return FinishTextureIndicatorSectionState(target, active, active and "proc-active" or "proc-inactive", nil, effectType)
     end
 
     if sectionKey == "aura" then
         if button._auraTrackingReady ~= true or not button._auraSpellID then
-            return false
+            return FinishTextureIndicatorSectionState(target, false, "aura-missing", nil, effectType)
         end
         if config.invert then
             if button._auraUnit == "target" and not UnitExists("target") then
-                return false
+                return FinishTextureIndicatorSectionState(target, false, "missing-target", nil, effectType)
             end
-            return button._auraActive ~= true
+            local active = button._auraActive ~= true
+            return FinishTextureIndicatorSectionState(target, active, active and "aura-inactive" or "aura-active", nil, effectType)
         end
-        return button._auraActive == true
+        local active = button._auraActive == true
+        return FinishTextureIndicatorSectionState(target, active, active and "aura-active" or "aura-inactive", nil, effectType)
     end
 
     if sectionKey == "pandemic" then
-        return button._auraActive == true and button._inPandemic == true
+        local active = button._auraActive == true and button._inPandemic == true
+        return FinishTextureIndicatorSectionState(target, active, active and "pandemic" or "inactive", nil, effectType)
     end
 
     if sectionKey == "ready" then
         local buttonData = button.buttonData
         if not buttonData or buttonData.isPassive or button._noCooldown then
-            return false
+            local reason = not buttonData and "missing-button-data"
+                or buttonData.isPassive and "passive"
+                or "no-cooldown"
+            return FinishTextureIndicatorSectionState(target, false, reason, nil, effectType)
         end
-        return button._desatCooldownActive == false
+        local active = button._desatCooldownActive == false
+        return FinishTextureIndicatorSectionState(target, active, active and "ready" or "not-ready", nil, effectType)
     end
 
     if sectionKey == "unusable" then
         local buttonData = button.buttonData
         if not buttonData or buttonData.isPassive then
-            return false
+            return FinishTextureIndicatorSectionState(target, false, not buttonData and "missing-button-data" or "passive", nil, effectType)
         end
         if buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
-            return not C_Spell_IsSpellUsable(spellID)
+            local active = not C_Spell_IsSpellUsable(spellID)
+            return FinishTextureIndicatorSectionState(target, active, active and "unusable" or "usable", nil, effectType)
         end
         if buttonData.type == "item" or buttonData.type == "equipitem" then
-            return not C_Item_IsUsableItem(button._resolvedItemId or buttonData.id)
+            local active = not C_Item_IsUsableItem(button._resolvedItemId or buttonData.id)
+            return FinishTextureIndicatorSectionState(target, active, active and "unusable" or "usable", nil, effectType)
         end
-        return false
+        return FinishTextureIndicatorSectionState(target, false, "unsupported-type", nil, effectType)
     end
 
-    return false
+    return FinishTextureIndicatorSectionState(target, false, "unknown-section", nil, effectType)
 end
 
 local function EvaluateTriggerRowCondition(button, conditionKey)
@@ -761,7 +815,7 @@ local function DoesTriggerPanelMatch(frame, captureDetails)
 
     local group = frame.groupId and ResolveGroup(frame.groupId) or nil
     local configuredRows = group and group.buttons
-    captureDetails = captureDetails == true or ShouldCaptureTriggerPanelVisualState()
+    captureDetails = captureDetails == true or ShouldCaptureButtonVisualState()
     local panelState
     if captureDetails then
         panelState = {
@@ -915,10 +969,34 @@ local function ApplyTextureIndicatorEffects(host, button, group)
         return
     end
 
+    local captureVisualState = ShouldCaptureButtonVisualState()
+    local freezeGeometryWhileUnlocked = group.locked == false
+    local intentState
+    local appliedState
+    local effectSources
+    if captureVisualState then
+        intentState = {
+            hasIndicators = false,
+            freezeGeometryWhileUnlocked = freezeGeometryWhileUnlocked,
+            sections = {},
+        }
+        appliedState = {
+            freezeGeometryWhileUnlocked = freezeGeometryWhileUnlocked,
+        }
+        effectSources = {}
+    end
+
     local indicators = CooldownCompanion:GetTexturePanelIndicatorSettings(group)
     if not indicators then
         StopAllTextureIndicatorEffects(host)
+        if captureVisualState then
+            button._textureEffectIntent = intentState
+            button._textureEffectApplied = appliedState
+        end
         return
+    end
+    if intentState then
+        intentState.hasIndicators = true
     end
 
     local effectStates = host._textureIndicatorEffectStates
@@ -930,15 +1008,30 @@ local function ApplyTextureIndicatorEffects(host, button, group)
     end
     for _, sectionKey in ipairs(TEXTURE_INDICATOR_SECTION_ORDER) do
         local config = indicators[sectionKey]
-        if IsTextureIndicatorSectionActive(button, sectionKey, config) then
-            local effectType = NormalizeTextureIndicatorEffect(config.effectType)
-            if effectType ~= TEXTURE_INDICATOR_EFFECT_NONE and not effectStates[effectType] then
+        local sectionTarget = intentState and {} or nil
+        local active, effectType, sectionState = ResolveTextureIndicatorSectionState(button, sectionKey, config, sectionTarget)
+        if intentState and sectionState then
+            intentState.sections[sectionKey] = sectionState
+        end
+        if active then
+            if effectType and effectType ~= TEXTURE_INDICATOR_EFFECT_NONE and not effectStates[effectType] then
                 effectStates[effectType] = config
+                if effectSources then
+                    effectSources[effectType] = sectionKey
+                end
             end
         end
     end
 
-    local freezeGeometryWhileUnlocked = group.locked == false
+    if intentState then
+        SetTextureEffectFlag(intentState, TEXTURE_INDICATOR_EFFECT_PULSE, effectSources[TEXTURE_INDICATOR_EFFECT_PULSE], effectStates[TEXTURE_INDICATOR_EFFECT_PULSE] ~= nil)
+        SetTextureEffectFlag(intentState, TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT, effectSources[TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT], effectStates[TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT] ~= nil)
+        SetTextureEffectFlag(intentState, TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND, effectSources[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND], (not freezeGeometryWhileUnlocked) and effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND] ~= nil)
+        SetTextureEffectFlag(intentState, TEXTURE_INDICATOR_EFFECT_BOUNCE, effectSources[TEXTURE_INDICATOR_EFFECT_BOUNCE], (not freezeGeometryWhileUnlocked) and effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE] ~= nil)
+        intentState.shrinkExpandSuppressedByUnlock = freezeGeometryWhileUnlocked and effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND] ~= nil or false
+        intentState.bounceSuppressedByUnlock = freezeGeometryWhileUnlocked and effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE] ~= nil or false
+    end
+
     local bounceAmplitude = math_max(
         6,
         math_min(
@@ -972,6 +1065,15 @@ local function ApplyTextureIndicatorEffects(host, button, group)
         StartTextureColorShift(host, colorShift.color, colorShift.speed)
     else
         StopTextureColorShift(host)
+    end
+
+    if appliedState then
+        SetTextureEffectFlag(appliedState, TEXTURE_INDICATOR_EFFECT_PULSE, effectSources[TEXTURE_INDICATOR_EFFECT_PULSE], effectStates[TEXTURE_INDICATOR_EFFECT_PULSE] ~= nil)
+        SetTextureEffectFlag(appliedState, TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT, effectSources[TEXTURE_INDICATOR_EFFECT_COLOR_SHIFT], colorShift ~= nil)
+        SetTextureEffectFlag(appliedState, TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND, effectSources[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND], (not freezeGeometryWhileUnlocked) and effectStates[TEXTURE_INDICATOR_EFFECT_SHRINK_EXPAND] ~= nil)
+        SetTextureEffectFlag(appliedState, TEXTURE_INDICATOR_EFFECT_BOUNCE, effectSources[TEXTURE_INDICATOR_EFFECT_BOUNCE], (not freezeGeometryWhileUnlocked) and effectStates[TEXTURE_INDICATOR_EFFECT_BOUNCE] ~= nil)
+        button._textureEffectIntent = intentState
+        button._textureEffectApplied = appliedState
     end
 end
 


### PR DESCRIPTION
## What Players Will Notice
- Texture panel diagnostics now show whether a standalone texture is shown or hidden, why it is in that state, which texture display is active, and which texture effects are active.
- Texture panel visuals and effects should behave the same as before; this PR is meant to make their runtime state easier to inspect, not change how they look.

## Why This Changed
- The visual-state project is moving each display consumer toward one inspectable per-button state.
- Texture panels previously rendered and animated through their own runtime side paths, which made bugs harder to diagnose from Bug Report output.

## What Changed
- Added texture display intent/applied sidecars for standalone texture panels.
- Centralized texture indicator effect decisions for proc, aura, pandemic, ready, and unusable effects while keeping detailed diagnostic state gated behind snapshot capture.
- Copied texture display and texture effect state into `ButtonFrame/VisualState.lua` snapshots.
- Extended visual-state diagnostics and Bug Report rows with compact `texture=` and `textureEffects=` signals.

## Validation
- `luac -p` on the five changed Lua files.
- `luac -p` across all tracked Lua files.
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- `git diff --check` passed with only LF-to-CRLF working-copy warnings.
- In-game smoke: selected texture panel Bug Report showed `mismatched=0`, `missing=0`, `texture=shown`, and `textureEffects=bounce`.
- Combat/restricted validation still needed before final release unless verified separately.