### PR TITLE
Capture visual state for resource and custom bars

### DIFF
--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -322,6 +322,13 @@ local function BuildDiagnosticSnapshot(options)
         })
     end
 
+    local otherBarsVisualStateDiagnostics = nil
+    if CooldownCompanion.CaptureOtherBarsVisualStateDiagnostics then
+        otherBarsVisualStateDiagnostics = CooldownCompanion:CaptureOtherBarsVisualStateDiagnostics({
+            maxRows = 16,
+        })
+    end
+
     local loadedAddons = {}
     for i = 1, C_AddOns.GetNumAddOns() do
         local name, title, _, loadable, reason, security = C_AddOns.GetAddOnInfo(i)
@@ -351,6 +358,7 @@ local function BuildDiagnosticSnapshot(options)
         containerFrameStates = containerFrameStates,
         resourceBarRuntime = resourceBarRuntime,
         visualStateDiagnostics = visualStateDiagnostics,
+        otherBarsVisualStateDiagnostics = otherBarsVisualStateDiagnostics,
         loadedAddons = loadedAddons,
     }
 
@@ -658,6 +666,160 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
     end
 end
 
+local function AddOtherBarsVisualStateDiagnosticsLines(add, diagnostics)
+    if not diagnostics then
+        return
+    end
+
+    add("OtherBars Visual State Diagnostics:")
+    add(("  rows=%s mismatched=%s missing=%s refreshedRows=%s cap=%s restored=%s"):format(
+        tostring(diagnostics.rowCount or 0),
+        tostring(diagnostics.mismatchCount or 0),
+        tostring(diagnostics.missingStates or 0),
+        tostring(diagnostics.refreshedRows or 0),
+        tostring(diagnostics.maxRows or "?"),
+        tostring(diagnostics.captureRestored)
+    ))
+    if diagnostics.truncated then
+        add("  truncated=true")
+    end
+    local stack = diagnostics.stack
+    if type(stack) == "table" then
+        add(("  stack applied=%s preview=%s independent=%s orientation=%s bars=%s"):format(
+            tostring(stack.applied),
+            tostring(stack.previewActive),
+            tostring(stack.independentStack),
+            tostring(stack.orientation or "nil"),
+            tostring(stack.barCount or 0)
+        ))
+    end
+
+    if type(diagnostics.rows) ~= "table" or #diagnostics.rows == 0 then
+        return
+    end
+
+    for _, row in ipairs(diagnostics.rows) do
+        local parts = {
+            ("[%s]"):format(tostring(row.index or "?")),
+            tostring(row.rowKind or "?"),
+            tostring(row.barType or "unknown"),
+            "phase=" .. tostring(row.phase or "nil"),
+            row.shown and "shown" or "hidden",
+        }
+        if row.powerType ~= nil then
+            parts[#parts + 1] = "powerType=" .. tostring(row.powerType)
+        end
+        if row.customBarId ~= nil then
+            parts[#parts + 1] = "customBar=" .. tostring(row.customBarId)
+        end
+        if row.spellID ~= nil then
+            parts[#parts + 1] = "spellID=" .. tostring(row.spellID)
+        end
+        local visibility = row.visibility
+        if type(visibility) == "table" and visibility.reason then
+            parts[#parts + 1] = "visibilityReason=" .. tostring(visibility.reason)
+        end
+        local resource = row.resource
+        if type(resource) == "table" then
+            if resource.domain then
+                parts[#parts + 1] = "resource=" .. tostring(resource.domain)
+            end
+            if resource.valuePath then
+                parts[#parts + 1] = "value=" .. tostring(resource.valuePath)
+            end
+            if resource.colorReason then
+                parts[#parts + 1] = "color=" .. tostring(resource.colorReason)
+            end
+            if resource.thresholdActive then
+                parts[#parts + 1] = "threshold=true"
+            end
+            if resource.auraOverride then
+                parts[#parts + 1] = "auraOverride=true"
+            end
+            if resource.auraStackMode then
+                parts[#parts + 1] = "auraStacks=true"
+            end
+        end
+        local health = row.health
+        if type(health) == "table" then
+            if health.valuePath then
+                parts[#parts + 1] = "health=" .. tostring(health.valuePath)
+            end
+            if health.fillColor then
+                parts[#parts + 1] = "fillColor=" .. tostring(health.fillColor)
+            end
+            if health.backgroundColor then
+                parts[#parts + 1] = "bgColor=" .. tostring(health.backgroundColor)
+            end
+        end
+        local custom = row.custom
+        if type(custom) == "table" then
+            if custom.display then
+                parts[#parts + 1] = "customDisplay=" .. tostring(custom.display)
+            end
+            if custom.auraPresent ~= nil then
+                parts[#parts + 1] = "aura=" .. tostring(custom.auraPresent)
+            end
+            if custom.auraSource then
+                parts[#parts + 1] = "auraSource=" .. tostring(custom.auraSource)
+            end
+            if custom.cooldownState then
+                parts[#parts + 1] = "cooldown=" .. tostring(custom.cooldownState)
+            end
+            if custom.inPandemic then
+                parts[#parts + 1] = "pandemic=true"
+            end
+            if custom.valuePath then
+                parts[#parts + 1] = "value=" .. tostring(custom.valuePath)
+            end
+        end
+        local text = row.text
+        if type(text) == "table" then
+            if text.writePath then
+                parts[#parts + 1] = "text=" .. tostring(text.writePath)
+            elseif text.shown ~= nil then
+                parts[#parts + 1] = "textShown=" .. tostring(text.shown)
+            end
+            if text.format then
+                parts[#parts + 1] = "textFormat=" .. tostring(text.format)
+            end
+            if text.durationSecret then
+                parts[#parts + 1] = "textSecret=duration"
+            end
+            if text.durationShown ~= nil then
+                parts[#parts + 1] = "durationText=" .. tostring(text.durationShown)
+            end
+            if text.stackShown ~= nil then
+                parts[#parts + 1] = "stackText=" .. tostring(text.stackShown)
+            end
+        end
+        local effects = row.effects
+        if type(effects) == "table" then
+            local effectParts = {}
+            if effects.lowHealthAlert then effectParts[#effectParts + 1] = "lowHealth" end
+            if effects.incomingHeals then effectParts[#effectParts + 1] = "incoming" end
+            if effects.absorbs then effectParts[#effectParts + 1] = "absorb" end
+            if effects.absorbOverflow then effectParts[#effectParts + 1] = "overflow" end
+            if effects.healAbsorbs then effectParts[#effectParts + 1] = "healAbsorb" end
+            if effects.auraActive then effectParts[#effectParts + 1] = "aura" end
+            if effects.pandemic then effectParts[#effectParts + 1] = "pandemic" end
+            if effects.pulse then effectParts[#effectParts + 1] = "pulse" end
+            if effects.colorShift then effectParts[#effectParts + 1] = "colorShift" end
+            if #effectParts > 0 then
+                parts[#parts + 1] = "effects=" .. table.concat(effectParts, "+")
+            end
+        end
+        if type(row.mismatches) == "table" and #row.mismatches > 0 then
+            parts[#parts + 1] = "mismatch=" .. table.concat(row.mismatches, ",")
+        elseif row.missingState then
+            parts[#parts + 1] = "state=missing"
+        else
+            parts[#parts + 1] = "match=ok"
+        end
+        add("  " .. table.concat(parts, " "))
+    end
+end
+
 local function FormatCountMap(counts)
     if type(counts) ~= "table" then
         return "none"
@@ -720,6 +882,7 @@ local function AddAgentDebugSignals(add, diag)
     local c = diag.config or {}
     local shape = c.profileShape or {}
     local vsd = r.visualStateDiagnostics
+    local obvsd = r.otherBarsVisualStateDiagnostics
 
     add("--- Agent Debug Signals ---")
     add("Profile Shape: panelModes=" .. FormatCountMap(shape.panelModes)
@@ -744,6 +907,14 @@ local function AddAgentDebugSignals(add, diag)
         ))
     else
         add("Visual-State Signal: unavailable")
+    end
+    if obvsd then
+        add(("OtherBars Signal: mismatched=%s missing=%s restored=%s truncated=%s"):format(
+            tostring(obvsd.mismatchCount or 0),
+            tostring(obvsd.missingStates or 0),
+            tostring(obvsd.captureRestored),
+            tostring(obvsd.truncated == true)
+        ))
     end
 
     add("Relevant Addons: " .. FormatRelevantAddonList(r.loadedAddons))
@@ -879,6 +1050,7 @@ local function FormatDiagnosticBugReportAsText(diag)
     end
 
     AddVisualStateDiagnosticsLines(add, r.visualStateDiagnostics)
+    AddOtherBarsVisualStateDiagnosticsLines(add, r.otherBarsVisualStateDiagnostics)
 
     add("")
     add("--- Loaded Addons (" .. tostring(r.loadedAddons and #r.loadedAddons or 0) .. ") ---")
@@ -1091,6 +1263,7 @@ local function FormatDiagnosticAsText(diag)
     end
 
     AddVisualStateDiagnosticsLines(add, r.visualStateDiagnostics)
+    AddOtherBarsVisualStateDiagnosticsLines(add, r.otherBarsVisualStateDiagnostics)
 
     -- Loaded Addons
     add("")

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -83,6 +83,7 @@ OtherBars\ResourceBarConstants.lua
 OtherBars\ResourceBarHelpers.lua
 OtherBars\CastBar.lua
 OtherBars\ResourceBarVisuals.lua
+OtherBars\ResourceBarVisualState.lua
 OtherBars\ResourceBarHealth.lua
 OtherBars\ResourceBarCustomBars.lua
 OtherBars\ResourceBarPreview.lua

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -156,6 +156,75 @@ local activeCustomAuraBarPandemicPreviews = {}
 local segmentedUpdateScratch = { auraActiveCache = {} }
 local HealthBar = RB.HealthBar
 local HEALTH_EFFECTS = RB.HealthEffects
+local StoreOtherBarsVisualState = RB.StoreOtherBarsVisualState
+local ClearOtherBarsVisualState = RB.ClearOtherBarsVisualState
+local SetOtherBarsVisualStateCaptureEnabled = RB.SetOtherBarsVisualStateCaptureEnabled
+local AreOtherBarsVisualStateCaptureEnabled = RB.AreOtherBarsVisualStateCaptureEnabled
+local CollectOtherBarsVisualStateDiagnostics = RB.CollectOtherBarsVisualStateDiagnostics
+local ClearCapturedOtherBarsVisualStates = RB.ClearCapturedOtherBarsVisualStates
+
+local function ShouldCaptureOtherBarsVisualState()
+    return type(AreOtherBarsVisualStateCaptureEnabled) == "function"
+        and AreOtherBarsVisualStateCaptureEnabled() == true
+end
+
+local function IsFrameShown(frame)
+    return frame and type(frame.IsShown) == "function" and frame:IsShown() == true or false
+end
+
+local function StoreResourceBarVisualState(frame, barType, powerType, details)
+    if type(StoreOtherBarsVisualState) ~= "function" or not frame then
+        return
+    end
+    details = details or {}
+    details.rowKind = barType == "health_continuous" and "health" or "resource"
+    details.identity = {
+        barType = barType,
+        powerType = powerType,
+    }
+    details.visibility = details.visibility or {
+        shown = IsFrameShown(frame),
+        mode = IsFrameShown(frame) and "shown" or "hidden",
+    }
+    StoreOtherBarsVisualState(frame, details)
+end
+
+local function StoreSegmentedResourceVisualState(
+    holder,
+    powerType,
+    useAuraStackMode,
+    auraOverrideColor,
+    domain,
+    currentValue,
+    maxValue,
+    colorReason,
+    thresholdActive,
+    clearText
+)
+    if not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+
+    StoreResourceBarVisualState(holder, "segmented", powerType, {
+        phase = "post-dispatch",
+        resource = {
+            domain = domain or "segmented",
+            valuePath = clearText and "secret-safe" or "plain",
+            current = currentValue,
+            max = maxValue,
+            segments = holder and holder.segments and #holder.segments or nil,
+            colorReason = colorReason or (useAuraStackMode and "aura-stacks" or (auraOverrideColor and "aura" or "resource")),
+            thresholdActive = thresholdActive == true,
+            auraOverride = auraOverrideColor ~= nil,
+            auraStackMode = useAuraStackMode == true,
+        },
+        text = {
+            shown = holder and holder.text and holder.text:IsShown() == true or false,
+            writePath = clearText and "cleared" or "segmented",
+        },
+    })
+end
+
 local function HasCustomAuraBarAuraVisuals(cabConfig)
     return cabConfig and (cabConfig.barAuraEffect or "none") ~= "none"
 end
@@ -426,6 +495,9 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     frame._parsedCustomBarAuraIDsRaw = nil
     frame._parsedCustomBarAuraIDsSpellID = nil
     frame._parsedCustomBarAuraIDsIncludeSpellID = nil
+    if type(ClearOtherBarsVisualState) == "function" then
+        ClearOtherBarsVisualState(frame)
+    end
     frame:SetAlpha(1)
 end
 
@@ -811,6 +883,24 @@ local function UpdateContinuousBar(bar, powerType, settings, auraActiveCache)
         end
     end
 
+    if ShouldCaptureOtherBarsVisualState() then
+        local textFormat = bar.text and bar.text:IsShown() and bar._textFormat or nil
+        StoreResourceBarVisualState(bar, "continuous", powerType, {
+            phase = "post-dispatch",
+            resource = {
+                domain = "power",
+                valuePath = (IsUnitPowerSecret("player", powerType) or maxPowerIsSecret) and "secret-safe" or "plain",
+                colorReason = auraOverrideColor and "aura" or "resource",
+                tickMarker = bar.tickMarker and bar.tickMarker:IsShown() == true or false,
+            },
+            text = {
+                shown = textFormat ~= nil,
+                writePath = textFormat and "formatted" or nil,
+                format = textFormat,
+            },
+        })
+    end
+
 end
 
 ------------------------------------------------------------------------
@@ -868,6 +958,30 @@ local function UpdateStaggerBar(bar, settings)
                 bar.text:SetFormattedText("%d / %d", staggerAmount, maxHealth)
             end
         end
+    end
+    if ShouldCaptureOtherBarsVisualState() then
+        local textFormat = bar.text and bar.text:IsShown() and bar._textFormat or nil
+        local colorReason = "stagger-low"
+        if isSecret then
+            colorReason = "secret-safe"
+        elseif percent and percent >= 60 then
+            colorReason = "stagger-high"
+        elseif percent and percent >= 30 then
+            colorReason = "stagger-medium"
+        end
+        StoreResourceBarVisualState(bar, "stagger_continuous", 101, {
+            phase = "post-dispatch",
+            resource = {
+                domain = "stagger",
+                valuePath = isSecret and "secret-safe" or "plain",
+                colorReason = colorReason,
+            },
+            text = {
+                shown = textFormat ~= nil,
+                writePath = textFormat and (isSecret and "hidden-secret" or "formatted") or nil,
+                format = textFormat,
+            },
+        })
     end
 end
 
@@ -998,6 +1112,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             runeValueTotal = runeValueTotal + segValue
         end
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, runeValueTotal, numSegs, false)
+        StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "runes", readyCount, numSegs, allReady and "max" or (thresholdActive and "threshold" or "ready"), thresholdActive, false)
         return
     end
 
@@ -1005,6 +1120,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         if IsUnitPowerSecret("player", 7) or IsUnitPowerMaxSecret("player", 7) then
             segmentedUpdateScratch.ClearValues(holder)
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "soul-shards", nil, nil, "secret-safe", false, true)
             return
         end
 
@@ -1015,6 +1131,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         if issecretvalue and (issecretvalue(raw) or issecretvalue(rawMax) or issecretvalue(max)) then
             segmentedUpdateScratch.ClearValues(holder)
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "soul-shards", nil, nil, "secret-safe", false, true)
             return
         end
 
@@ -1051,8 +1168,10 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         end
         if type(displayCurrent) == "number" then
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, displayCurrent, max, false)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "soul-shards", displayCurrent, max, nil, false, false)
         else
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "soul-shards", nil, nil, "empty", false, true)
         end
         return
     end
@@ -1061,6 +1180,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         if IsUnitPowerSecret("player", 19) or IsUnitPowerMaxSecret("player", 19) then
             segmentedUpdateScratch.ClearValues(holder)
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "essence", nil, nil, "secret-safe", false, true)
             return
         end
 
@@ -1071,6 +1191,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         if issecretvalue and (issecretvalue(filled) or issecretvalue(max) or issecretvalue(partialRaw)) then
             segmentedUpdateScratch.ClearValues(holder)
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "essence", nil, nil, "secret-safe", false, true)
             return
         end
 
@@ -1095,6 +1216,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             end
         end
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, displayCurrent, max, false)
+        StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "essence", displayCurrent, max, isMax and "max" or (thresholdActive and "threshold" or "ready"), thresholdActive, false)
         return
     end
 
@@ -1103,6 +1225,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         if IsUnitPowerSecret("player", 4) or IsUnitPowerMaxSecret("player", 4) then
             segmentedUpdateScratch.ClearValues(holder)
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "combo-points", nil, nil, "secret-safe", false, true)
             return
         end
 
@@ -1111,6 +1234,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         if issecretvalue and (issecretvalue(current) or issecretvalue(max)) then
             segmentedUpdateScratch.ClearValues(holder)
             segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+            StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "combo-points", nil, nil, "secret-safe", false, true)
             return
         end
 
@@ -1140,6 +1264,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             end
         end
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
+        StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "combo-points", current, max, isMax and "max" or (thresholdActive and "threshold" or "ready"), thresholdActive, false)
         return
     end
 
@@ -1147,6 +1272,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
     if IsUnitPowerSecret("player", powerType) or IsUnitPowerMaxSecret("player", powerType) then
         segmentedUpdateScratch.ClearValues(holder)
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+        StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "segmented", nil, nil, "secret-safe", false, true)
         return
     end
 
@@ -1155,6 +1281,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
     if issecretvalue and (issecretvalue(current) or issecretvalue(max)) then
         segmentedUpdateScratch.ClearValues(holder)
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, nil, nil, true)
+        StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "segmented", nil, nil, "secret-safe", false, true)
         return
     end
     local normalColor, maxColor
@@ -1178,6 +1305,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         end
     end
     segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
+    StoreSegmentedResourceVisualState(holder, powerType, useAuraStackMode, auraOverrideColor, "segmented", current, max, isMax and "max" or (thresholdActive and "threshold" or "ready"), thresholdActive, false)
 end
 
 ------------------------------------------------------------------------
@@ -1211,6 +1339,21 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
         end
         HideResourceAuraStackSegments(holder)
         ClearSegmentedText(holder)
+        if ShouldCaptureOtherBarsVisualState() then
+            StoreResourceBarVisualState(holder, "mw_segmented", RESOURCE_MAELSTROM_WEAPON, {
+                phase = "post-dispatch",
+                resource = {
+                    domain = "maelstrom-weapon",
+                    valuePath = "secret-safe",
+                    colorReason = "secret-safe",
+                    segments = holder.segments and #holder.segments or nil,
+                },
+                text = {
+                    shown = holder.text and holder.text:IsShown() == true or false,
+                    writePath = "cleared",
+                },
+            })
+        end
         return
     end
 
@@ -1267,6 +1410,26 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
     end
 
     SetSegmentedText(holder, stacks, mwMaxStacks)
+    if ShouldCaptureOtherBarsVisualState() then
+        StoreResourceBarVisualState(holder, "mw_segmented", RESOURCE_MAELSTROM_WEAPON, {
+            phase = "post-dispatch",
+            resource = {
+                domain = "maelstrom-weapon",
+                valuePath = "plain",
+                current = stacks,
+                max = mwMaxStacks,
+                segments = holder.segments and #holder.segments or nil,
+                colorReason = isMax and "max" or (thresholdActive and "threshold" or (useAuraStackMode and "aura-stacks" or (auraOverrideColor and "aura" or "resource"))),
+                thresholdActive = thresholdActive == true,
+                auraStackMode = useAuraStackMode == true,
+                overlay = true,
+            },
+            text = {
+                shown = holder.text and holder.text:IsShown() == true or false,
+                writePath = "segmented",
+            },
+        })
+    end
 end
 
 ------------------------------------------------------------------------
@@ -1300,6 +1463,7 @@ local RefreshEventDrivenCustomAuraBarsForUnit = customBarsModule.RefreshEventDri
 local FinalizeAppliedBarVisibility = customBarsModule.FinalizeAppliedBarVisibility
 local HideUnusedResourceBarFrames = customBarsModule.HideUnusedResourceBarFrames
 local PrepareCustomAuraBar = customBarsModule.PrepareCustomAuraBar
+local CaptureCustomBarVisualState = customBarsModule.CaptureCustomBarVisualState
 
 ------------------------------------------------------------------------
 -- Relayout: reposition bars within their containers by visibility/order
@@ -2428,6 +2592,222 @@ function CooldownCompanion:GetResourceBarRuntimeDebugInfo()
         info[#info + 1] = entry
     end
     return info
+end
+
+local function StoreHiddenOtherBarsVisualState(barInfo, reason)
+    if not (barInfo and barInfo.frame) or not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+
+    local rowKind = barInfo.cabConfig and "custom"
+        or (barInfo.barType == "health_continuous" and "health" or "resource")
+    StoreOtherBarsVisualState(barInfo.frame, {
+        phase = "hidden",
+        rowKind = rowKind,
+        identity = {
+            barType = barInfo.barType,
+            powerType = barInfo.powerType,
+            customBarId = barInfo.customBarId,
+        },
+        visibility = {
+            shown = false,
+            mode = "hidden",
+            reason = reason or "frame-hidden",
+        },
+        custom = barInfo.cabConfig and {
+            spellID = tonumber(barInfo.cabConfig.spellID) or barInfo.cabConfig.spellID,
+            trackingMode = barInfo.cabConfig.trackingMode,
+            auraTracking = barInfo.cabConfig.auraTracking == true,
+            hideWhenInactive = barInfo.cabConfig.hideWhenInactive == true,
+            hideWhileAuraActive = barInfo.cabConfig.hideWhileAuraActive == true,
+        } or nil,
+    })
+end
+
+local function StorePreviewOtherBarsVisualState(barInfo)
+    if not (barInfo and barInfo.frame) or not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+
+    local rowKind = barInfo.cabConfig and "custom"
+        or (barInfo.barType == "health_continuous" and "health" or "resource")
+    StoreOtherBarsVisualState(barInfo.frame, {
+        phase = "preview",
+        rowKind = rowKind,
+        identity = {
+            barType = barInfo.barType,
+            powerType = barInfo.powerType,
+            customBarId = barInfo.customBarId,
+        },
+        visibility = {
+            shown = barInfo.frame:IsShown() == true,
+            mode = barInfo.frame:IsShown() and "shown" or "hidden",
+            reason = "preview",
+        },
+        resource = rowKind == "resource" and {
+            domain = "preview",
+            valuePath = "preview",
+            colorReason = "preview",
+        } or nil,
+        health = rowKind == "health" and {
+            valuePath = "preview",
+            fillColor = "preview",
+            backgroundColor = "preview",
+        } or nil,
+        custom = rowKind == "custom" and {
+            display = barInfo.barType,
+            spellID = barInfo.cabConfig and (tonumber(barInfo.cabConfig.spellID) or barInfo.cabConfig.spellID) or nil,
+            valuePath = "preview",
+        } or nil,
+    })
+end
+
+local function StorePassiveCustomOtherBarsVisualState(barInfo)
+    if not (barInfo and barInfo.frame and barInfo.cabConfig) or not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+
+    local frame = barInfo.frame
+    local shown = frame:IsShown() == true
+    StoreOtherBarsVisualState(frame, {
+        phase = shown and "passive" or "hidden",
+        rowKind = "custom",
+        identity = {
+            barType = barInfo.barType,
+            powerType = barInfo.powerType,
+            customBarId = barInfo.customBarId,
+        },
+        visibility = {
+            shown = shown,
+            mode = shown and "shown" or "hidden",
+            reason = shown and "passive-custom-capture" or "frame-hidden",
+        },
+        custom = {
+            display = barInfo.barType,
+            spellID = tonumber(barInfo.cabConfig.spellID) or barInfo.cabConfig.spellID,
+            trackingMode = barInfo.cabConfig.trackingMode,
+            auraTracking = barInfo.cabConfig.auraTracking == true,
+            hideWhenInactive = barInfo.cabConfig.hideWhenInactive == true,
+            hideWhileAuraActive = barInfo.cabConfig.hideWhileAuraActive == true,
+        },
+        text = {
+            durationShown = frame.text and frame.text:IsShown() == true or false,
+            stackShown = frame.stackText and frame.stackText:IsShown() == true or false,
+        },
+        effects = {
+            auraActive = frame._auraActive == true,
+            pandemic = frame._inPandemic == true,
+            pulse = frame._barPulseActive == true,
+            colorShift = frame._barColorShiftActive == true,
+            maxStacksIndicator = barInfo._maxStacksIndicator ~= nil,
+        },
+    })
+end
+
+local function RefreshOtherBarsVisualStateDiagnostics()
+    local settings = GetResourceBarSettings()
+    local auraActiveCache = segmentedUpdateScratch.auraActiveCache
+    wipe(auraActiveCache)
+
+    if isPreviewActive and ApplyPreviewData then
+        ApplyPreviewData()
+    end
+
+    local refreshed = 0
+    for _, barInfo in ipairs(resourceBarFrames) do
+        local frame = barInfo and barInfo.frame
+        if frame then
+            if type(ClearOtherBarsVisualState) == "function" then
+                ClearOtherBarsVisualState(frame)
+            end
+
+            local shown = frame:IsShown() == true
+            if isPreviewActive then
+                StorePreviewOtherBarsVisualState(barInfo)
+            elseif barInfo.barType == "continuous" and shown then
+                UpdateContinuousBar(frame, barInfo.powerType, settings, auraActiveCache)
+            elseif barInfo.barType == "health_continuous" and shown then
+                HealthBar.Update(frame, settings)
+            elseif barInfo.barType == "segmented" and shown then
+                UpdateSegmentedBar(frame, barInfo.powerType, settings, auraActiveCache)
+            elseif barInfo.barType == "mw_segmented" and shown then
+                UpdateMaelstromWeaponBar(frame, settings, auraActiveCache)
+            elseif barInfo.barType == "stagger_continuous" and shown then
+                UpdateStaggerBar(frame, settings)
+            elseif barInfo.barType == "custom_cooldown" then
+                if not (CaptureCustomBarVisualState and CaptureCustomBarVisualState(barInfo)) then
+                    StorePassiveCustomOtherBarsVisualState(barInfo)
+                end
+            elseif barInfo.barType == "custom_continuous"
+                or barInfo.barType == "custom_segmented"
+                or barInfo.barType == "custom_overlay" then
+                if not (CaptureCustomBarVisualState and CaptureCustomBarVisualState(barInfo)) then
+                    StorePassiveCustomOtherBarsVisualState(barInfo)
+                end
+            end
+
+            if not frame._otherBarsVisualState then
+                StoreHiddenOtherBarsVisualState(barInfo, shown and "no-capture-sidecar" or "frame-hidden")
+            end
+            if frame._otherBarsVisualState then
+                refreshed = refreshed + 1
+            end
+        end
+    end
+
+    return refreshed
+end
+
+local function BuildOtherBarsDiagnosticStackState()
+    return {
+        applied = isApplied == true,
+        previewActive = isPreviewActive == true,
+        independentStack = lastAppliedIndependentStack == true,
+        orientation = lastAppliedOrientation,
+        layoutDirty = layoutDirty == true,
+        barCount = #resourceBarFrames,
+    }
+end
+
+function CooldownCompanion:CollectOtherBarsVisualStateDiagnostics(options)
+    if type(CollectOtherBarsVisualStateDiagnostics) ~= "function" then
+        return nil
+    end
+    options = options or {}
+    options.resourceBarFrames = resourceBarFrames
+    options.stack = options.stack or BuildOtherBarsDiagnosticStackState()
+    return CollectOtherBarsVisualStateDiagnostics(self, options)
+end
+
+function CooldownCompanion:CaptureOtherBarsVisualStateDiagnostics(options)
+    if type(SetOtherBarsVisualStateCaptureEnabled) ~= "function"
+        or type(AreOtherBarsVisualStateCaptureEnabled) ~= "function"
+        or type(CollectOtherBarsVisualStateDiagnostics) ~= "function" then
+        return nil
+    end
+
+    options = options or {}
+    local wasEnabled = AreOtherBarsVisualStateCaptureEnabled()
+    SetOtherBarsVisualStateCaptureEnabled(true)
+
+    local refreshed = 0
+    if isApplied or isPreviewActive then
+        refreshed = RefreshOtherBarsVisualStateDiagnostics()
+        options.resourceBarFrames = resourceBarFrames
+    else
+        options.resourceBarFrames = {}
+    end
+    options.refreshedRows = refreshed
+    options.stack = options.stack or BuildOtherBarsDiagnosticStackState()
+    local result = CollectOtherBarsVisualStateDiagnostics(self, options)
+    result.captureWasEnabled = wasEnabled
+    if not wasEnabled and options.preserveSnapshots ~= true and type(ClearCapturedOtherBarsVisualStates) == "function" then
+        result.clearedStates = ClearCapturedOtherBarsVisualStates(resourceBarFrames)
+    end
+
+    SetOtherBarsVisualStateCaptureEnabled(wasEnabled)
+    result.captureRestored = AreOtherBarsVisualStateCaptureEnabled() == wasEnabled
+    return result
 end
 
 ------------------------------------------------------------------------

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -42,9 +42,109 @@ local CreateSegmentedBar = RB.CreateSegmentedBar
 local LayoutSegments = RB.LayoutSegments
 local CreateOverlayBar = RB.CreateOverlayBar
 local LayoutOverlaySegments = RB.LayoutOverlaySegments
+local StoreOtherBarsVisualState = RB.StoreOtherBarsVisualState
+local AreOtherBarsVisualStateCaptureEnabled = RB.AreOtherBarsVisualStateCaptureEnabled
 
 local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
+
+local function ShouldCaptureOtherBarsVisualState()
+    return type(AreOtherBarsVisualStateCaptureEnabled) == "function"
+        and AreOtherBarsVisualStateCaptureEnabled() == true
+end
+
+local function IsFrameShown(frame)
+    return frame and type(frame.IsShown) == "function" and frame:IsShown() == true or false
+end
+
+local function StoreCustomBarVisualState(barInfo, details)
+    if type(StoreOtherBarsVisualState) ~= "function" or not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+    if not (barInfo and barInfo.frame) then
+        return
+    end
+
+    local cabConfig = barInfo.cabConfig
+    details = details or {}
+    details.rowKind = "custom"
+    details.identity = {
+        barType = barInfo.barType,
+        powerType = barInfo.powerType,
+        customBarId = barInfo.customBarId,
+    }
+    details.visibility = details.visibility or {
+        shown = IsFrameShown(barInfo.frame),
+        mode = IsFrameShown(barInfo.frame) and "shown" or "hidden",
+    }
+    if cabConfig then
+        details.custom = details.custom or {}
+        details.custom.spellID = tonumber(cabConfig.spellID) or cabConfig.spellID
+        details.custom.trackingMode = cabConfig.trackingMode
+        details.custom.auraTracking = cabConfig.auraTracking == true
+        details.custom.hideWhenInactive = cabConfig.hideWhenInactive == true
+        details.custom.hideWhileAuraActive = cabConfig.hideWhileAuraActive == true
+    end
+
+    StoreOtherBarsVisualState(barInfo.frame, details)
+end
+
+local function StoreCustomCooldownVisualState(
+    barInfo,
+    bar,
+    cooldownResult,
+    chargeState,
+    cooldownActive,
+    auraState,
+    auraPresent,
+    configUnit,
+    inPandemic,
+    renderAuraState,
+    durationObj,
+    phase,
+    visibilityReason,
+    displayMode,
+    visibilityOverride
+)
+    if not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+
+    local durationSecret = durationObj and durationObj.HasSecretValues and durationObj:HasSecretValues() or false
+    local auraDurationObj = auraState and auraState.durationObj
+    local auraDurationSecret = auraDurationObj and auraDurationObj.HasSecretValues and auraDurationObj:HasSecretValues() or false
+    StoreCustomBarVisualState(barInfo, {
+        phase = phase or "post-dispatch",
+        visibility = visibilityOverride or {
+            shown = IsFrameShown(bar),
+            mode = IsFrameShown(bar) and "shown" or "hidden",
+            reason = visibilityReason,
+        },
+        custom = {
+            display = displayMode or (renderAuraState and "aura" or "cooldown"),
+            auraPresent = auraPresent == true,
+            auraUnit = auraState and auraState.auraUnit or configUnit,
+            auraSource = auraState and auraState.viewerFrame and "viewer" or (auraPresent and "player-fallback" or "none"),
+            inPandemic = inPandemic == true,
+            cooldownActive = cooldownActive == true,
+            cooldownState = cooldownResult and cooldownResult.state,
+            chargeState = chargeState,
+            valuePath = (durationSecret or auraDurationSecret) and "secret-safe" or "plain",
+        },
+        text = {
+            durationShown = bar and bar.text and bar.text:IsShown() == true or false,
+            stackShown = bar and bar.stackText and bar.stackText:IsShown() == true or false,
+            durationSecret = durationSecret or auraDurationSecret,
+        },
+        effects = {
+            auraActive = bar and bar._auraActive == true or false,
+            pandemic = bar and bar._inPandemic == true or false,
+            pulse = bar and bar._barPulseActive == true or false,
+            colorShift = bar and bar._barColorShiftActive == true or false,
+            maxStacksIndicator = barInfo and barInfo._maxStacksIndicator ~= nil or false,
+        },
+    })
+end
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -99,6 +199,28 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return false
     end
 
+    local function PeekCustomBarPandemicState(frame, configUnit, auraPresent, viewerFrame, pandemicPreview)
+        if not frame then
+            return false
+        end
+        if pandemicPreview then
+            return true
+        end
+        if configUnit == "target" and auraPresent and viewerFrame then
+            if frame._pandemicGraceSuppressed then
+                return false
+            end
+            local pi = viewerFrame.PandemicIcon
+            if pi and pi:IsVisible() then
+                return true
+            end
+            if frame._inPandemic then
+                return true
+            end
+        end
+        return false
+    end
+
     local function ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, auraPreview, pandemicPreview)
         if not (cabConfig and (cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive)) then
             return true, false
@@ -114,6 +236,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             or pandemicPreview
 
         return shouldShow, true
+    end
+
+    local function GetCustomAuraVisibilityReason(cabConfig)
+        return cabConfig and cabConfig.hideWhenInactive
+            and "hide-when-inactive"
+            or "hide-while-aura-active"
     end
 
     function RB.RequestCustomBarPresentationRefresh()
@@ -275,6 +403,21 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false)
             end
+            if ShouldCaptureOtherBarsVisualState() then
+                StoreCustomBarVisualState(barInfo, {
+                    phase = "hidden",
+                    visibility = {
+                        shown = IsFrameShown(barInfo.frame),
+                        mode = IsFrameShown(barInfo.frame) and "shown" or "hidden",
+                        reason = "spell-aura-stack-missing",
+                    },
+                    custom = {
+                        auraPresent = false,
+                        auraSource = "spell-stack",
+                        ready = false,
+                    },
+                })
+            end
             RB.RequestCustomBarPresentationRefresh()
             return
         end
@@ -321,6 +464,22 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if not shouldShow then
                 if isActive then
                     UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, false)
+                end
+                if ShouldCaptureOtherBarsVisualState() then
+                    StoreCustomBarVisualState(barInfo, {
+                        phase = "hidden",
+                        visibility = {
+                            shown = false,
+                            mode = "hidden",
+                            reason = cabConfig.hideWhenInactive and "hide-when-inactive" or "hide-while-aura-active",
+                        },
+                        custom = {
+                            auraPresent = auraPresent == true,
+                            auraUnit = auraUnit,
+                            inPandemic = inPandemic == true,
+                            spellAuraStackDisplay = spellAuraStackDisplay == true,
+                        },
+                    })
                 end
                 return
             end
@@ -453,6 +612,38 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         -- Max stacks indicator: SetValue drives visibility via C-level clamping
         if cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
             barInfo._maxStacksIndicator:SetValue(auraPresent and applications or 0)
+        end
+        if ShouldCaptureOtherBarsVisualState() then
+            local stackValuesAreSecret = issecretvalue
+                and (issecretvalue(stacks) or issecretvalue(applications))
+            StoreCustomBarVisualState(barInfo, {
+                phase = "post-dispatch",
+                custom = {
+                    display = barInfo.barType,
+                    auraPresent = auraPresent == true,
+                    auraUnit = auraUnit,
+                    auraSource = viewerFrame and "viewer" or (auraPresent and "player-fallback" or "none"),
+                    inPandemic = inPandemic == true,
+                    spellAuraStackDisplay = spellAuraStackDisplay == true,
+                    valuePath = (stackValuesAreSecret
+                        or (durationObj and durationObj.HasSecretValues and durationObj:HasSecretValues())) and "secret-safe" or "plain",
+                    maxStacks = maxStacks,
+                    thresholdActive = thresholdEnabled == true,
+                    stackValue = stackValuesAreSecret and "secret-safe" or (auraPresent and "present" or "none"),
+                },
+                text = {
+                    durationShown = barInfo.frame.text and barInfo.frame.text:IsShown() == true or false,
+                    stackShown = barInfo.frame.stackText and barInfo.frame.stackText:IsShown() == true or false,
+                    durationSecret = durationObj and durationObj.HasSecretValues and durationObj:HasSecretValues() or false,
+                },
+                effects = {
+                    auraActive = barInfo.frame._auraActive == true,
+                    pandemic = barInfo.frame._inPandemic == true,
+                    pulse = barInfo.frame._barPulseActive == true,
+                    colorShift = barInfo.frame._barColorShiftActive == true,
+                    maxStacksIndicator = barInfo._maxStacksIndicator ~= nil,
+                },
+            })
         end
     end
 
@@ -772,6 +963,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if not shouldShow then
                 ClearSpellCustomBarAuraRuntimeState(barInfo)
                 UpdateSpellCustomBarSounds(auraPresent)
+                StoreCustomCooldownVisualState(barInfo, bar, cooldownResult, chargeState, cooldownActive, auraState, auraPresent, configUnit, inPandemic, renderAuraState, durationObj, "hidden", cabConfig.hideWhenInactive and "hide-when-inactive" or "hide-while-aura-active", "hidden")
                 return
             end
         elseif (cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive)
@@ -782,6 +974,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if spellAuraStackDisplay and auraPresent then
             UpdateSpellCustomBarSounds(true)
+            StoreCustomCooldownVisualState(barInfo, bar, cooldownResult, chargeState, cooldownActive, auraState, auraPresent, configUnit, inPandemic, renderAuraState, durationObj, "post-dispatch", "spell-aura-stack-display", "aura-stack")
             RB.RequestCustomBarPresentationRefresh()
             return
         end
@@ -839,6 +1032,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
 
             UpdateSpellCustomBarSounds(auraPresent)
+            StoreCustomCooldownVisualState(barInfo, bar, cooldownResult, chargeState, cooldownActive, auraState, auraPresent, configUnit, inPandemic, renderAuraState, durationObj, "post-dispatch", nil, "aura")
             return
         end
 
@@ -881,6 +1075,244 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         UpdateSpellCustomBarSounds(false)
+        StoreCustomCooldownVisualState(barInfo, bar, cooldownResult, chargeState, cooldownActive, auraState, auraPresent, configUnit, inPandemic, renderAuraState, durationObj, "post-dispatch", nil, "cooldown")
+    end
+
+    local function CaptureCurrentCustomAuraVisualState(barInfo)
+        local cabConfig = barInfo and barInfo.cabConfig
+        local frame = barInfo and barInfo.frame
+        if not (cabConfig and cabConfig.spellID and frame) then
+            return false
+        end
+
+        local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local auraState = spellAuraStackDisplay and RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
+        local stacks = 0
+        local applications = 0
+        local auraPresent = false
+        local durationObj
+        local isActive = cabConfig.trackingMode == "active"
+        local useDrain = isActive
+        local needsDuration = (useDrain or cabConfig.showDurationText) and not spellAuraStackDisplay
+        local bar = barInfo.barType == "custom_continuous" and frame or nil
+        local auraPreview = bar and bar._barAuraActivePreview
+        local pandemicPreview = bar and bar._pandemicPreview
+        local indicatorPreview = isActive and (auraPreview or pandemicPreview)
+        local configUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
+        local viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
+        local auraUnit = configUnit
+        local instId = viewerFrame and viewerFrame.auraInstanceID
+
+        if spellAuraStackDisplay then
+            configUnit = (auraState and auraState.configUnit) or configUnit
+            viewerFrame = auraState and auraState.viewerFrame or nil
+            if auraState and auraState.ready == true and auraState.auraPresent == true and auraState.auraData then
+                auraPresent = true
+                instId = auraState.auraInstanceID
+                auraUnit = auraState.auraUnit or configUnit
+                applications = auraState.auraData.applications or 0
+                stacks = applications
+            end
+        elseif instId then
+            local viewerUnit = viewerFrame.auraDataUnit or configUnit
+            if viewerUnit == configUnit then
+                local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
+                if auraData then
+                    auraPresent = true
+                    applications = auraData.applications or 0
+                    stacks = isActive and 1 or applications
+                    auraUnit = configUnit
+                    if needsDuration then
+                        durationObj = C_UnitAuras.GetAuraDuration(configUnit, instId)
+                    end
+                end
+            end
+        end
+
+        if not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
+            local auraData = CustomAuraBar.ResolvePlayerAuraData(cabConfig)
+            if auraData then
+                instId = auraData.auraInstanceID
+                auraUnit = "player"
+                auraPresent = true
+                applications = auraData.applications or 0
+                stacks = isActive and 1 or applications
+                if needsDuration and instId then
+                    durationObj = C_UnitAuras.GetAuraDuration("player", instId)
+                end
+            end
+        end
+
+        if spellAuraStackDisplay and not auraPresent and not GetPreviewActive() then
+            local shown = IsFrameShown(frame)
+            StoreCustomBarVisualState(barInfo, {
+                phase = "hidden",
+                visibility = {
+                    shown = shown,
+                    mode = shown and "shown" or "hidden",
+                    reason = "spell-aura-stack-missing",
+                },
+                custom = {
+                    display = barInfo.barType,
+                    auraPresent = false,
+                    auraSource = "spell-stack",
+                    ready = false,
+                },
+            })
+            return true
+        end
+
+        if indicatorPreview and not auraPresent then
+            auraPresent = true
+            applications = CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS
+            stacks = 1
+        end
+
+        local inPandemic = PeekCustomBarPandemicState(frame, configUnit, auraPresent, viewerFrame, pandemicPreview)
+        local shouldShow, hasVisibilityRule = ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, auraPreview, pandemicPreview)
+        if spellAuraStackDisplay and auraState and auraState.ready ~= true then
+            hasVisibilityRule = false
+            shouldShow = true
+        end
+
+        local visibilityReason = nil
+        if hasVisibilityRule and not shouldShow then
+            visibilityReason = GetCustomAuraVisibilityReason(cabConfig)
+        end
+
+        local maxStacks = cabConfig.maxStacks or 1
+        local thresholdEnabled = (not spellAuraStackDisplay) and IsCustomAuraMaxThresholdEnabled(cabConfig)
+        local stackValuesAreSecret = issecretvalue
+            and (issecretvalue(stacks) or issecretvalue(applications))
+        local durationSecret = durationObj and durationObj.HasSecretValues and durationObj:HasSecretValues() or false
+        StoreCustomBarVisualState(barInfo, {
+            phase = shouldShow and "post-dispatch" or "hidden",
+            visibility = {
+                shown = shouldShow == true,
+                mode = shouldShow and "shown" or "hidden",
+                reason = visibilityReason,
+            },
+            custom = {
+                display = barInfo.barType,
+                auraPresent = auraPresent == true,
+                auraUnit = auraUnit,
+                auraSource = viewerFrame and "viewer" or (auraPresent and "player-fallback" or "none"),
+                inPandemic = inPandemic == true,
+                spellAuraStackDisplay = spellAuraStackDisplay == true,
+                valuePath = (stackValuesAreSecret or durationSecret) and "secret-safe" or "plain",
+                maxStacks = maxStacks,
+                thresholdActive = thresholdEnabled == true,
+                stackValue = stackValuesAreSecret and "secret-safe" or (auraPresent and "present" or "none"),
+            },
+            text = {
+                durationShown = frame.text and frame.text:IsShown() == true or false,
+                stackShown = frame.stackText and frame.stackText:IsShown() == true or false,
+                durationSecret = durationSecret,
+            },
+            effects = {
+                auraActive = frame._auraActive == true,
+                pandemic = frame._inPandemic == true,
+                pulse = frame._barPulseActive == true,
+                colorShift = frame._barColorShiftActive == true,
+                maxStacksIndicator = barInfo._maxStacksIndicator ~= nil,
+            },
+        })
+        return true
+    end
+
+    local function CaptureCurrentCustomCooldownVisualState(barInfo)
+        local cabConfig = barInfo and barInfo.cabConfig
+        local bar = barInfo and barInfo.frame
+        if not (cabConfig and cabConfig.spellID and bar) then
+            return false
+        end
+
+        local cooldownResult = CooldownCompanion.EvaluateSpellCooldownStateForCustomBar
+            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig)
+        local durationObj = cooldownResult and cooldownResult.renderDurationObj
+        local cooldownActive = cooldownResult
+            and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
+        local auraState = RB.ResolveSpellCustomBarAuraState(barInfo)
+        local auraPresent = auraState and auraState.ready == true and auraState.auraPresent == true
+        local auraPreview = bar._barAuraActivePreview == true
+        local pandemicPreview = bar._pandemicPreview == true
+        local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local renderAuraState = cabConfig.auraTracking == true
+            and not spellAuraStackDisplay
+            and (auraPresent or auraPreview or pandemicPreview)
+        local chargeState = cooldownResult and cooldownResult.chargeState
+        local configUnit = (auraState and auraState.configUnit)
+            or GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
+        local inPandemic = PeekCustomBarPandemicState(
+            bar,
+            configUnit,
+            auraPresent,
+            auraState and auraState.viewerFrame,
+            pandemicPreview
+        )
+        local shouldShow = IsFrameShown(bar)
+        local visibilityReason = nil
+
+        if auraState
+            and auraState.ready == true
+            and (cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive) then
+            shouldShow = ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, auraPreview, pandemicPreview)
+            if not shouldShow then
+                visibilityReason = GetCustomAuraVisibilityReason(cabConfig)
+            end
+        elseif cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive then
+            shouldShow = true
+        end
+
+        local displayMode = "cooldown"
+        if not shouldShow then
+            displayMode = "hidden"
+        elseif spellAuraStackDisplay and auraPresent then
+            displayMode = "aura-stack"
+            visibilityReason = "spell-aura-stack-display"
+        elseif renderAuraState then
+            displayMode = "aura"
+        end
+
+        StoreCustomCooldownVisualState(
+            barInfo,
+            bar,
+            cooldownResult,
+            chargeState,
+            cooldownActive,
+            auraState,
+            auraPresent,
+            configUnit,
+            inPandemic,
+            renderAuraState,
+            durationObj,
+            shouldShow and "post-dispatch" or "hidden",
+            visibilityReason,
+            displayMode,
+            {
+                shown = shouldShow == true,
+                mode = shouldShow and "shown" or "hidden",
+                reason = visibilityReason,
+            }
+        )
+        return true
+    end
+
+    local function CaptureCustomBarVisualState(barInfo)
+        if not ShouldCaptureOtherBarsVisualState() then
+            return false
+        end
+        if not (barInfo and barInfo.frame and barInfo.cabConfig) then
+            return false
+        end
+        if barInfo.barType == "custom_cooldown" then
+            return CaptureCurrentCustomCooldownVisualState(barInfo)
+        elseif barInfo.barType == "custom_continuous"
+            or barInfo.barType == "custom_segmented"
+            or barInfo.barType == "custom_overlay" then
+            return CaptureCurrentCustomAuraVisualState(barInfo)
+        end
+        return false
     end
 
     local function GetHiddenCustomAuraWakeUnit(cabConfig)
@@ -1451,5 +1883,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         FinalizeAppliedBarVisibility = FinalizeAppliedBarVisibility,
         HideUnusedResourceBarFrames = HideUnusedResourceBarFrames,
         PrepareCustomAuraBar = PrepareCustomAuraBar,
+        CaptureCustomBarVisualState = CaptureCustomBarVisualState,
     }
 end

--- a/OtherBars/ResourceBarHealth.lua
+++ b/OtherBars/ResourceBarHealth.lua
@@ -27,8 +27,68 @@ local IsVerticalResourceLayout = RB.IsVerticalResourceLayout
 local IsVerticalFillReversed = RB.IsVerticalFillReversed
 local ApplyPixelBorders = RB.ApplyPixelBorders
 local HidePixelBorders = RB.HidePixelBorders
+local StoreOtherBarsVisualState = RB.StoreOtherBarsVisualState
+local AreOtherBarsVisualStateCaptureEnabled = RB.AreOtherBarsVisualStateCaptureEnabled
 
 local HEALTH_EFFECT_JOIN_OVERLAP = 1
+local HealthBar
+local HEALTH_EFFECTS
+
+local function ShouldCaptureOtherBarsVisualState()
+    return type(AreOtherBarsVisualStateCaptureEnabled) == "function"
+        and AreOtherBarsVisualStateCaptureEnabled() == true
+end
+
+local function IsFrameShown(frame)
+    return frame and type(frame.IsShown) == "function" and frame:IsShown() == true or false
+end
+
+local function StoreHealthVisualState(bar, config, maxHealth, currentHealthIsSecret, maxHealthIsSecret)
+    if type(StoreOtherBarsVisualState) ~= "function" or not ShouldCaptureOtherBarsVisualState() then
+        return
+    end
+
+    local textFormat = bar.text and bar.text:IsShown() and bar._textFormat or nil
+    local healthValueIsSecret = currentHealthIsSecret == true or maxHealthIsSecret == true
+    local healthState = {
+        valuePath = healthValueIsSecret and "secret-safe" or "plain",
+        fillColor = HealthBar.IsFillGradientEnabled(config) and "gradient" or "static",
+        backgroundColor = HealthBar.IsBackgroundGradientEnabled(config) and "gradient" or "static",
+    }
+    if not maxHealthIsSecret then
+        healthState.maxAvailable = maxHealth ~= nil
+    end
+
+    StoreOtherBarsVisualState(bar, {
+        phase = "post-dispatch",
+        rowKind = "health",
+        identity = {
+            barType = "health_continuous",
+            powerType = RESOURCE_HEALTH,
+        },
+        visibility = {
+            shown = IsFrameShown(bar),
+            mode = IsFrameShown(bar) and "shown" or "hidden",
+        },
+        health = healthState,
+        text = {
+            shown = textFormat ~= nil,
+            writePath = textFormat and "formatted" or nil,
+            format = textFormat,
+        },
+        effects = {
+            lowHealthAlert = bar.lowHealthAlertBar and bar.lowHealthAlertBar:IsShown() == true or false,
+            incomingHeals = bar.incomingHealBar and bar.incomingHealBar:IsShown() == true or false,
+            absorbs = bar.absorbBar and bar.absorbBar:IsShown() == true or false,
+            absorbOverflow = bar.absorbOverflowBar and bar.absorbOverflowBar:IsShown() == true or false,
+            healAbsorbs = bar.healAbsorbBar and bar.healAbsorbBar:IsShown() == true or false,
+            preview = HEALTH_EFFECTS.preview.lowHealthAlert == true
+                or HEALTH_EFFECTS.preview.incomingHeals == true
+                or HEALTH_EFFECTS.preview.absorbs == true
+                or HEALTH_EFFECTS.preview.healAbsorbs == true,
+        },
+    })
+end
 
 local function EnsureNonNilNumber(value)
     if type(value) == "nil" then
@@ -37,8 +97,8 @@ local function EnsureNonNilNumber(value)
     return value
 end
 
-local HealthBar = {}
-local HEALTH_EFFECTS = {
+HealthBar = {}
+HEALTH_EFFECTS = {
     texture = RB.DEFAULT_HEALTH_EFFECT_TEXTURE or "Solid",
     incomingHealColor = RB.DEFAULT_HEALTH_INCOMING_HEAL_COLOR,
     absorbColor = RB.DEFAULT_HEALTH_ABSORB_COLOR,
@@ -688,6 +748,7 @@ function HealthBar.Update(bar, settings)
 
     local currentHealth = UnitHealth("player")
     local maxHealth = UnitHealthMax("player")
+    local currentHealthIsSecret = issecretvalue and issecretvalue(currentHealth)
     local maxHealthIsSecret = issecretvalue and issecretvalue(maxHealth)
     if not maxHealthIsSecret and (not maxHealth or maxHealth < 1) then
         maxHealth = 1
@@ -724,6 +785,8 @@ function HealthBar.Update(bar, settings)
             bar.text:SetFormattedText("%.0f%%", UnitHealthPercent("player", true, PERCENT_SCALE_CURVE))
         end
     end
+
+    StoreHealthVisualState(bar, config, maxHealth, currentHealthIsSecret, maxHealthIsSecret)
 end
 
 function HealthBar.Style(bar, settings)

--- a/OtherBars/ResourceBarVisualState.lua
+++ b/OtherBars/ResourceBarVisualState.lua
@@ -1,0 +1,317 @@
+--[[
+    CooldownCompanion - ResourceBarVisualState
+    Pull-based visual-state capture for OtherBars resource, health, and custom bars.
+
+    This module is intentionally separate from ButtonFrame visual state. Resource
+    bars are stack-owned and OnUpdate-driven, so diagnostics capture renderer-owned
+    facts only when an explicit report asks for them.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local RB = ST._RB
+local DEFAULT_MAX_ROWS = 16
+local SNAPSHOT_VERSION = 1
+
+local function WipeTable(tbl)
+    if wipe then
+        wipe(tbl)
+        return tbl
+    end
+    for key in pairs(tbl) do
+        tbl[key] = nil
+    end
+    return tbl
+end
+
+local function IsTrue(value)
+    return value == true
+end
+
+local function IsFrameShown(frame)
+    if frame and type(frame.IsShown) == "function" then
+        return frame:IsShown() == true
+    end
+    return frame ~= nil
+end
+
+local function CopyPlainTable(source, depth)
+    if type(source) ~= "table" then
+        return source
+    end
+    if depth and depth <= 0 then
+        return nil
+    end
+
+    local nextDepth = depth and (depth - 1) or nil
+    local copy = {}
+    for key, value in pairs(source) do
+        if type(value) == "table" then
+            copy[key] = CopyPlainTable(value, nextDepth)
+        elseif type(value) ~= "function" and type(value) ~= "userdata" and type(value) ~= "thread" then
+            copy[key] = value
+        end
+    end
+    return copy
+end
+
+local function AddMismatch(row, key)
+    local mismatches = row.mismatches
+    if type(mismatches) ~= "table" then
+        mismatches = {}
+        row.mismatches = mismatches
+    end
+    mismatches[#mismatches + 1] = key
+end
+
+local function CompareValue(row, key, actual, expected)
+    if actual ~= expected then
+        AddMismatch(row, key)
+    end
+end
+
+local function ResolveRowKind(barInfo)
+    local barType = barInfo and barInfo.barType
+    if barType == "health_continuous" then
+        return "health"
+    end
+    if barInfo and (barInfo.customBarId ~= nil or barInfo.cabConfig ~= nil) then
+        return "custom"
+    end
+    return "resource"
+end
+
+local function GetCustomBarId(barInfo)
+    if not barInfo then
+        return nil
+    end
+    local customBarId = barInfo.customBarId
+    if customBarId ~= nil then
+        return customBarId
+    end
+    local config = barInfo.cabConfig
+    return config and config.customBarId or nil
+end
+
+local function GetSpellID(barInfo)
+    local config = barInfo and barInfo.cabConfig
+    if not config then
+        return nil
+    end
+    return tonumber(config.spellID) or config.spellID
+end
+
+local function StoreOtherBarsVisualState(frame, details)
+    if not IsTrue(RB._otherBarsVisualStateCaptureEnabled) or not frame then
+        return nil
+    end
+
+    local state = frame._otherBarsVisualState
+    if type(state) ~= "table" then
+        state = {}
+        frame._otherBarsVisualState = state
+    else
+        WipeTable(state)
+    end
+
+    details = details or {}
+    state.version = SNAPSHOT_VERSION
+    state.phase = details.phase
+    state.rowKind = details.rowKind
+    state.identity = CopyPlainTable(details.identity, 2)
+    state.visibility = CopyPlainTable(details.visibility, 2)
+    state.resource = CopyPlainTable(details.resource, 3)
+    state.health = CopyPlainTable(details.health, 3)
+    state.custom = CopyPlainTable(details.custom, 3)
+    state.text = CopyPlainTable(details.text, 3)
+    state.effects = CopyPlainTable(details.effects, 3)
+    state.bar = CopyPlainTable(details.bar, 3)
+    return state
+end
+
+local function ClearOtherBarsVisualState(frame)
+    if frame then
+        frame._otherBarsVisualState = nil
+    end
+end
+
+local function SetOtherBarsVisualStateCaptureEnabled(enabled)
+    RB._otherBarsVisualStateCaptureEnabled = enabled == true
+end
+
+local function AreOtherBarsVisualStateCaptureEnabled()
+    return RB._otherBarsVisualStateCaptureEnabled == true
+end
+
+local function BuildRow(barInfo, index, source)
+    local frame = barInfo and barInfo.frame
+    local rowKind = ResolveRowKind(barInfo)
+    local row = {
+        index = index,
+        source = source,
+        rowKind = rowKind,
+        barType = barInfo and barInfo.barType,
+        powerType = barInfo and barInfo.powerType,
+        customBarId = GetCustomBarId(barInfo),
+        customBarIndex = barInfo and barInfo.customBarIndex,
+        spellID = GetSpellID(barInfo),
+        shown = IsFrameShown(frame),
+    }
+
+    local config = barInfo and barInfo.cabConfig
+    if config then
+        row.hideWhenInactive = config.hideWhenInactive == true
+        row.hideWhileAuraActive = config.hideWhileAuraActive == true
+        row.trackingMode = config.trackingMode
+        row.auraTracking = config.auraTracking == true
+    end
+
+    local state = frame and frame._otherBarsVisualState
+    if type(state) ~= "table" then
+        row.missingState = true
+        AddMismatch(row, "state.missing")
+        return row
+    end
+
+    row.snapshotVersion = state.version
+    row.phase = state.phase
+    row.visibility = CopyPlainTable(state.visibility, 2)
+    row.resource = CopyPlainTable(state.resource, 3)
+    row.health = CopyPlainTable(state.health, 3)
+    row.custom = CopyPlainTable(state.custom, 3)
+    row.text = CopyPlainTable(state.text, 3)
+    row.effects = CopyPlainTable(state.effects, 3)
+    row.bar = CopyPlainTable(state.bar, 3)
+
+    CompareValue(row, "snapshot.version", state.version, SNAPSHOT_VERSION)
+    if state.rowKind then
+        CompareValue(row, "row.kind", state.rowKind, rowKind)
+    end
+    if type(state.identity) == "table" then
+        CompareValue(row, "identity.barType", state.identity.barType, row.barType)
+        CompareValue(row, "identity.powerType", state.identity.powerType, row.powerType)
+        CompareValue(row, "identity.customBarId", state.identity.customBarId, row.customBarId)
+    end
+    if type(state.visibility) == "table" and state.visibility.shown ~= nil then
+        CompareValue(row, "visibility.shown", state.visibility.shown, row.shown)
+    end
+
+    return row
+end
+
+local function RowKey(index)
+    return tostring(index or "?")
+end
+
+local function AddRow(result, seen, barInfo, index, source)
+    if result.rowCount >= result.maxRows then
+        result.truncated = true
+        return false
+    end
+
+    local key = RowKey(index)
+    if seen[key] then
+        return true
+    end
+    seen[key] = true
+
+    local row = BuildRow(barInfo, index, source)
+    result.rows[#result.rows + 1] = row
+    result.rowCount = result.rowCount + 1
+    if row.missingState then
+        result.missingStates = result.missingStates + 1
+    end
+    if type(row.mismatches) == "table" and #row.mismatches > 0 then
+        result.mismatchCount = result.mismatchCount + 1
+    end
+    return true
+end
+
+local function ResolveSelection(options)
+    options = options or {}
+    local selectedIndex = tonumber(options.resourceBarIndex)
+    local selectedCustomBarId = options.customBarId
+    local CS = ST._configState
+    if selectedCustomBarId == nil and CS then
+        selectedCustomBarId = CS.selectedCustomBarId or CS.selectedCustomBar
+    end
+    return selectedIndex, selectedCustomBarId
+end
+
+local function CollectOtherBarsVisualStateDiagnostics(addon, options)
+    options = options or {}
+    local maxRows = tonumber(options.maxRows) or DEFAULT_MAX_ROWS
+    if maxRows < 1 then
+        maxRows = 1
+    end
+
+    local result = {
+        enabled = true,
+        maxRows = maxRows,
+        rowCount = 0,
+        missingStates = 0,
+        mismatchCount = 0,
+        refreshedRows = tonumber(options.refreshedRows) or 0,
+        captureRestored = options.captureRestored,
+        stack = CopyPlainTable(options.stack, 2),
+        rows = {},
+    }
+
+    local frames = options.resourceBarFrames
+    if type(frames) ~= "table" then
+        return result
+    end
+
+    local seen = {}
+    local selectedIndex, selectedCustomBarId = ResolveSelection(options)
+    if selectedIndex then
+        local barInfo = frames[selectedIndex]
+        if barInfo and not AddRow(result, seen, barInfo, selectedIndex, "selected") then
+            return result
+        end
+    elseif selectedCustomBarId ~= nil then
+        for index, barInfo in ipairs(frames) do
+            if GetCustomBarId(barInfo) == selectedCustomBarId then
+                if not AddRow(result, seen, barInfo, index, "selected-custom-bar") then
+                    return result
+                end
+                break
+            end
+        end
+    end
+
+    for index, barInfo in ipairs(frames) do
+        if not AddRow(result, seen, barInfo, index, "stack") then
+            return result
+        end
+    end
+
+    return result
+end
+
+local function ClearCapturedOtherBarsVisualStates(resourceBarFrames)
+    local cleared = 0
+    if type(resourceBarFrames) ~= "table" then
+        return cleared
+    end
+    for _, barInfo in ipairs(resourceBarFrames) do
+        local frame = barInfo and barInfo.frame
+        if frame and frame._otherBarsVisualState then
+            frame._otherBarsVisualState = nil
+            cleared = cleared + 1
+        end
+    end
+    return cleared
+end
+
+RB.StoreOtherBarsVisualState = StoreOtherBarsVisualState
+RB.ClearOtherBarsVisualState = ClearOtherBarsVisualState
+RB.SetOtherBarsVisualStateCaptureEnabled = SetOtherBarsVisualStateCaptureEnabled
+RB.AreOtherBarsVisualStateCaptureEnabled = AreOtherBarsVisualStateCaptureEnabled
+RB.CollectOtherBarsVisualStateDiagnostics = CollectOtherBarsVisualStateDiagnostics
+RB.ClearCapturedOtherBarsVisualStates = ClearCapturedOtherBarsVisualStates
+
+ST._StoreOtherBarsVisualState = StoreOtherBarsVisualState
+ST._ClearOtherBarsVisualState = ClearOtherBarsVisualState
+ST._CollectOtherBarsVisualStateDiagnostics = CollectOtherBarsVisualStateDiagnostics


### PR DESCRIPTION
## What Players Will Notice
- Bug Report output now includes an OtherBars visual-state section for resource bars, health bars, and Custom Bars.
- Reports can show whether these bars are hidden, shown, aura-driven, cooldown-driven, secret-safe, or affected by visual details like aura overrides and health/resource effects.
- Normal bar behavior should remain unchanged; the new capture path is only used when diagnostics are generated.

## Why This Changed
- The visual-state refactor already made button panels easier to debug, but resource bars and Custom Bars still lacked the same agent-readable state.
- Without this, bugs involving Custom Bars, health/resource bars, or hidden OtherBars rows required full profile dumps or manual reproduction details.

## What Changed
- Added a dedicated OtherBars visual-state module and wired it into the addon load order.
- Instrumented resource, health, and Custom Bar render paths to record diagnostic sidecars only during explicit capture.
- Added bug-report formatting for OtherBars rows, including selection-first ordering, mismatch counts, visibility reasons, aura/cooldown/value/text/effect signals, and secret-safe value labels.
- Kept diagnostics capture passive where possible and added diagnostics-only custom-bar capture paths so reports can reflect current state without firing sound/layout side effects.

## Validation
- `luac -p OtherBars\ResourceBarVisualState.lua OtherBars\ResourceBar.lua OtherBars\ResourceBarHealth.lua OtherBars\ResourceBarCustomBars.lua Config\Diagnostics.lua tests\otherbars-visual-state.lua tests\visual-state-diagnostics.lua tests\visual-state-snapshot.lua`
- `lua tests\otherbars-visual-state.lua`
- `lua tests\visual-state-diagnostics.lua`
- `lua tests\visual-state-snapshot.lua`
- `git diff --check` passed with only existing LF-to-CRLF working-copy warnings.
- In-game custom bar, resource, health, and combat smoke checks were reported clear; a pasted Bug Report showed `OtherBars Signal: mismatched=0 missing=0 restored=true`.