### PR TITLE
Route icon glows through visual state

### DIFF
--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -7,14 +7,12 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
-local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
 local pairs = pairs
 local ipairs = ipairs
 local unpack = unpack
-local UnitExists = UnitExists
 local InCombatLockdown = InCombatLockdown
 local GetTime = GetTime
 
@@ -32,6 +30,7 @@ local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
 local ClearButtonVisualState = ST._ClearButtonVisualState
 local ResolveIconDesaturationIntent = ST._ResolveIconDesaturationIntent
 local ResolveIconFillIntent = ST._ResolveIconFillIntent
+local ResolveIconGlowIntent = ST._ResolveIconGlowIntent
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -439,18 +438,6 @@ local function UpdateBlizzardAuraSwipe(button, style)
     else
         HideBlizzardAuraSwipe(button, style)
     end
-end
-
-local function IsReadyGlowAtMaxCharges(button, buttonData)
-    if not (button and buttonData) then
-        return false
-    end
-
-    if buttonData.type ~= "spell" or buttonData.hasCharges ~= true or buttonData._hasDisplayCount then
-        return false
-    end
-
-    return button._chargeState == CHARGE_STATE_FULL
 end
 
 local function ApplyCountTextStyle(button, style)
@@ -1167,103 +1154,35 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         SetAssistedHighlight(button, showHighlight)
     end
 
+    local glowIntent
+    if type(ResolveIconGlowIntent) == "function" then
+        glowIntent = button._iconGlowIntent
+        if type(glowIntent) ~= "table" then
+            glowIntent = {}
+            button._iconGlowIntent = glowIntent
+        end
+        ResolveIconGlowIntent(button, buttonData, style, procOverlayActive, glowIntent, {
+            inCombat = inCombat,
+        })
+    end
+
     -- Proc glow (spell activation overlay)
     if button.procGlow then
-        local showProc = false
-        if button._procGlowPreview then
-            showProc = true
-        elseif style.procGlowStyle ~= "none" and buttonData.type == "spell"
-               and not buttonData.isPassive and not (button._auraTrackingReady == true)
-               and (not style.procGlowCombatOnly or inCombat) then
-            showProc = procOverlayActive and true or false
-        end
+        local showProc = glowIntent and glowIntent.proc and glowIntent.proc.active == true
         SetProcGlow(button, showProc)
     end
 
     -- Aura active glow indicator
     if button.auraGlow then
-        local showAuraGlow = false
-        local pandemicOverride = false
-        local auraIndicatorEnabled = buttonData.auraIndicatorEnabled
-        -- Allow per-button override sections to explicitly disable aura glow,
-        -- even when legacy per-button enable flags are set.
-        if buttonData.overrideSections
-           and buttonData.overrideSections.auraIndicator
-           and style.auraGlowStyle == "none" then
-            auraIndicatorEnabled = false
-        end
-        if button._pandemicPreview then
-            showAuraGlow = true
-            pandemicOverride = true
-        elseif button._auraGlowPreview then
-            showAuraGlow = true
-        elseif style.auraGlowInvert then
-            -- Invert mode: show glow when tracked aura is MISSING
-            if button._auraTrackingReady == true and button._auraSpellID and not button._auraActive then
-                if (auraIndicatorEnabled or style.auraGlowStyle ~= "none")
-                   and (not style.auraGlowCombatOnly or inCombat) then
-                    if button._auraUnit == "target" then
-                        if UnitExists("target") then
-                            showAuraGlow = true
-                        end
-                    else
-                        showAuraGlow = true
-                    end
-                end
-            elseif button._auraActive and button._inPandemic and style.showPandemicGlow ~= false
-                   and (not style.pandemicGlowCombatOnly or inCombat) then
-                showAuraGlow = true
-                pandemicOverride = true
-            end
-        elseif button._auraActive then
-            if button._inPandemic and style.showPandemicGlow ~= false
-               and (not style.pandemicGlowCombatOnly or inCombat) then
-                showAuraGlow = true
-                pandemicOverride = true
-            elseif (auraIndicatorEnabled or style.auraGlowStyle ~= "none")
-                   and (not style.auraGlowCombatOnly or inCombat) then
-                showAuraGlow = true
-            end
-        end
+        local auraIntent = glowIntent and glowIntent.aura
+        local showAuraGlow = auraIntent and auraIntent.active == true
+        local pandemicOverride = auraIntent and auraIntent.pandemic == true or false
         SetAuraGlow(button, showAuraGlow, pandemicOverride)
     end
 
     -- Ready glow (glow while off cooldown)
     if button.readyGlow then
-        local showReady = false
-        if button._readyGlowPreview then
-            showReady = true
-        elseif style.readyGlowStyle and style.readyGlowStyle ~= "none"
-               and not buttonData.isPassive
-               and not button._noCooldown
-               and (not style.readyGlowCombatOnly or inCombat)
-               and button._desatCooldownActive == false
-               and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
-               and not (procOverlayActive and style.procGlowStyle ~= "none") then
-            if style.readyGlowOnlyAtMaxCharges
-               and buttonData.type == "spell"
-               and buttonData.hasCharges == true
-               and not buttonData._hasDisplayCount then
-                local dur = style.readyGlowDuration or 0
-
-                if IsReadyGlowAtMaxCharges(button, buttonData) then
-                    if dur > 0 then
-                        showReady = button._readyGlowMaxChargesStartTime ~= nil
-                            and (GetTime() - button._readyGlowMaxChargesStartTime) <= dur
-                    else
-                        showReady = true
-                    end
-                end
-            else
-                local dur = style.readyGlowDuration or 0
-                if dur > 0 then
-                    showReady = button._readyGlowStartTime ~= nil
-                        and (GetTime() - button._readyGlowStartTime) <= dur
-                else
-                    showReady = true
-                end
-            end
-        end
+        local showReady = glowIntent and glowIntent.ready and glowIntent.ready.active == true
         SetReadyGlow(button, showReady)
     end
 end
@@ -1297,6 +1216,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._iconDesaturationIntent = nil
     button._iconTintIntent = nil
     button._iconFillIntent = nil
+    button._iconGlowIntent = nil
     button._desatCooldownActive = nil
     button._readyGlowStartTime = nil
     button._readyGlowMaxChargesStartTime = nil

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -11,6 +11,9 @@ local GetButtonVisibilityReasonNames = ST._GetButtonVisibilityReasonNames
 local DEFAULT_ICON_FILL_COOLDOWN_COLOR = {0.6, 0.13, 0.18, 0.55}
 local DEFAULT_ICON_FILL_AURA_COLOR = {0.2, 1.0, 0.2, 0.55}
 local UsesChargeBehavior = CooldownCompanion and CooldownCompanion.UsesChargeBehavior
+local InCombatLockdown = InCombatLockdown
+local GetTime = GetTime
+local UnitExists = UnitExists
 
 local function IsTrue(value)
     return value == true
@@ -82,6 +85,303 @@ local function SetIconFillIntent(target, available, active, reason, mode, color,
     target.g = color and color[2] or nil
     target.b = color and color[3] or nil
     target.a = color and color[4] or nil
+    return target
+end
+
+local function SetGlowIntent(section, available, active, reason)
+    section.available = available == true
+    section.active = active == true
+    section.reason = reason
+    section.preview = false
+    section.combatOnly = false
+    section.combatSuppressed = false
+    section.procOverlayActive = false
+    section.suppressedByProc = false
+    section.auraIndicatorEnabled = false
+    section.invert = false
+    section.pandemic = false
+    section.targetRequired = false
+    section.targetExists = nil
+    section.maxCharges = false
+    section.durationWindow = false
+    section.duration = nil
+    section.startTime = nil
+    section.cooldownSuppressed = false
+    section.auraSuppressed = false
+    return section
+end
+
+local function EnsureGlowSection(target, key)
+    local section = target[key]
+    if type(section) ~= "table" then
+        section = {}
+        target[key] = section
+    end
+    return section
+end
+
+local function IsReadyGlowMaxChargeEligible(buttonData)
+    return buttonData
+        and buttonData.type == "spell"
+        and buttonData.hasCharges == true
+        and not buttonData._hasDisplayCount
+end
+
+local function IsReadyGlowAtMaxCharges(button, buttonData)
+    if not (button and IsReadyGlowMaxChargeEligible(buttonData)) then
+        return false
+    end
+
+    return button._chargeState == CHARGE_STATE_FULL
+end
+
+local function GetTargetExists(options)
+    if options and options.targetExists ~= nil then
+        return options.targetExists == true
+    end
+    if type(UnitExists) == "function" then
+        return UnitExists("target") == true
+    end
+    return false
+end
+
+local function GetResolverCombatState(options)
+    if options and options.inCombat ~= nil then
+        return options.inCombat == true
+    end
+    if type(InCombatLockdown) == "function" then
+        return InCombatLockdown() == true
+    end
+    return false
+end
+
+local function GetResolverTime(options)
+    if options and type(options.now) == "number" then
+        return options.now
+    end
+    if type(GetTime) == "function" then
+        return GetTime()
+    end
+    return 0
+end
+
+local function ResolveAuraIndicatorEnabled(buttonData, style)
+    local auraIndicatorEnabled = buttonData and buttonData.auraIndicatorEnabled and true or false
+    if buttonData
+       and buttonData.overrideSections
+       and buttonData.overrideSections.auraIndicator
+       and style.auraGlowStyle == "none" then
+        auraIndicatorEnabled = false
+    end
+    return auraIndicatorEnabled
+end
+
+local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActive, target, options)
+    target = target or {}
+    style = style or {}
+
+    local proc = EnsureGlowSection(target, "proc")
+    local aura = EnsureGlowSection(target, "aura")
+    local ready = EnsureGlowSection(target, "ready")
+    local inCombat = GetResolverCombatState(options)
+    local now
+    local isSpell = buttonData and buttonData.type == "spell"
+    local isPassive = buttonData and buttonData.isPassive == true
+    local procOverlayShown = procOverlayActive == true
+
+    if type(button) ~= "table" or type(buttonData) ~= "table" then
+        SetGlowIntent(proc, false, false, "invalid")
+        SetGlowIntent(aura, false, false, "invalid")
+        SetGlowIntent(ready, false, false, "invalid")
+        return target
+    end
+
+    if not button.procGlow then
+        SetGlowIntent(proc, false, false, "missing-widget")
+        proc.procOverlayActive = procOverlayShown
+    elseif button._procGlowPreview == true then
+        SetGlowIntent(proc, true, true, "preview")
+        proc.preview = true
+        proc.procOverlayActive = procOverlayShown
+    elseif style.procGlowStyle == "none" then
+        SetGlowIntent(proc, true, false, "disabled")
+        proc.procOverlayActive = procOverlayShown
+    elseif not isSpell then
+        SetGlowIntent(proc, true, false, "not-spell")
+        proc.procOverlayActive = procOverlayShown
+    elseif isPassive then
+        SetGlowIntent(proc, true, false, "passive")
+        proc.procOverlayActive = procOverlayShown
+    elseif button._auraTrackingReady == true then
+        SetGlowIntent(proc, true, false, "aura-tracking")
+        proc.procOverlayActive = procOverlayShown
+    elseif style.procGlowCombatOnly and not inCombat then
+        SetGlowIntent(proc, true, false, "combat-only")
+        proc.combatOnly = true
+        proc.combatSuppressed = true
+        proc.procOverlayActive = procOverlayShown
+    elseif procOverlayShown then
+        SetGlowIntent(proc, true, true, "proc")
+        proc.procOverlayActive = true
+    else
+        SetGlowIntent(proc, true, false, "inactive")
+    end
+
+    local auraIndicatorEnabled = ResolveAuraIndicatorEnabled(buttonData, style)
+    local auraCombatOnly = style.auraGlowCombatOnly
+    local pandemicCombatOnly = style.pandemicGlowCombatOnly
+    local targetExists
+
+    if not button.auraGlow then
+        SetGlowIntent(aura, false, false, "missing-widget")
+        aura.auraIndicatorEnabled = auraIndicatorEnabled
+    elseif button._pandemicPreview == true then
+        SetGlowIntent(aura, true, true, "pandemic-preview")
+        aura.preview = true
+        aura.pandemic = true
+        aura.auraIndicatorEnabled = auraIndicatorEnabled
+    elseif button._auraGlowPreview == true then
+        SetGlowIntent(aura, true, true, "preview")
+        aura.preview = true
+        aura.auraIndicatorEnabled = auraIndicatorEnabled
+    elseif style.auraGlowInvert then
+        if button._auraTrackingReady == true and button._auraSpellID and not button._auraActive then
+            if auraIndicatorEnabled or style.auraGlowStyle ~= "none" then
+                if auraCombatOnly and not inCombat then
+                    SetGlowIntent(aura, true, false, "combat-only")
+                    aura.combatOnly = true
+                    aura.combatSuppressed = true
+                    aura.invert = true
+                    aura.auraIndicatorEnabled = auraIndicatorEnabled
+                else
+                    targetExists = button._auraUnit ~= "target" or GetTargetExists(options)
+                    SetGlowIntent(
+                        aura,
+                        true,
+                        targetExists,
+                        targetExists and "aura-missing" or "target-missing"
+                    )
+                    aura.invert = true
+                    aura.targetRequired = button._auraUnit == "target"
+                    aura.targetExists = targetExists
+                    aura.auraIndicatorEnabled = auraIndicatorEnabled
+                end
+            else
+                SetGlowIntent(aura, true, false, "disabled")
+                aura.invert = true
+                aura.auraIndicatorEnabled = auraIndicatorEnabled
+            end
+        elseif button._auraActive and button._inPandemic and style.showPandemicGlow ~= false then
+            SetGlowIntent(
+                aura,
+                true,
+                not (pandemicCombatOnly and not inCombat),
+                pandemicCombatOnly and not inCombat and "pandemic-combat-only" or "pandemic"
+            )
+            aura.pandemic = true
+            aura.combatOnly = pandemicCombatOnly and true or false
+            aura.combatSuppressed = pandemicCombatOnly and not inCombat
+            aura.invert = true
+            aura.auraIndicatorEnabled = auraIndicatorEnabled
+        else
+            SetGlowIntent(aura, true, false, "inactive")
+            aura.invert = true
+            aura.auraIndicatorEnabled = auraIndicatorEnabled
+        end
+    elseif button._auraActive then
+        if button._inPandemic and style.showPandemicGlow ~= false
+            and not (pandemicCombatOnly and not inCombat) then
+            SetGlowIntent(
+                aura,
+                true,
+                true,
+                "pandemic"
+            )
+            aura.pandemic = true
+            aura.combatOnly = pandemicCombatOnly and true or false
+            aura.combatSuppressed = false
+            aura.auraIndicatorEnabled = auraIndicatorEnabled
+        elseif auraIndicatorEnabled or style.auraGlowStyle ~= "none" then
+            SetGlowIntent(
+                aura,
+                true,
+                not (auraCombatOnly and not inCombat),
+                auraCombatOnly and not inCombat and "combat-only" or "aura"
+            )
+            aura.combatOnly = auraCombatOnly and true or false
+            aura.combatSuppressed = auraCombatOnly and not inCombat
+            aura.auraIndicatorEnabled = auraIndicatorEnabled
+        else
+            SetGlowIntent(aura, true, false, "disabled")
+            aura.auraIndicatorEnabled = auraIndicatorEnabled
+        end
+    else
+        SetGlowIntent(aura, true, false, "aura-missing")
+        aura.auraIndicatorEnabled = auraIndicatorEnabled
+    end
+
+    local procSuppressesReady = procOverlayShown and style.procGlowStyle ~= "none"
+    local auraSuppressesReady = button._auraTrackingReady == true and button._auraActive == true
+    if not button.readyGlow then
+        SetGlowIntent(ready, false, false, "missing-widget")
+    elseif button._readyGlowPreview == true then
+        SetGlowIntent(ready, true, true, "preview")
+        ready.preview = true
+    elseif not style.readyGlowStyle or style.readyGlowStyle == "none" then
+        SetGlowIntent(ready, true, false, "disabled")
+    elseif isPassive then
+        SetGlowIntent(ready, true, false, "passive")
+    elseif button._noCooldown then
+        SetGlowIntent(ready, true, false, "no-cooldown")
+    elseif style.readyGlowCombatOnly and not inCombat then
+        SetGlowIntent(ready, true, false, "combat-only")
+        ready.combatOnly = true
+        ready.combatSuppressed = true
+    elseif button._desatCooldownActive ~= false or button._cooldownState == STATE_COOLDOWN then
+        SetGlowIntent(ready, true, false, "cooldown")
+        ready.cooldownSuppressed = true
+    elseif auraSuppressesReady then
+        SetGlowIntent(ready, true, false, "aura-active")
+        ready.auraSuppressed = true
+    elseif procSuppressesReady then
+        SetGlowIntent(ready, true, false, "proc")
+        ready.suppressedByProc = true
+        ready.procOverlayActive = true
+    elseif style.readyGlowOnlyAtMaxCharges and IsReadyGlowMaxChargeEligible(buttonData) then
+        local dur = style.readyGlowDuration or 0
+        if IsReadyGlowAtMaxCharges(button, buttonData) then
+            if dur > 0 then
+                now = now or GetResolverTime(options)
+                local startTime = button._readyGlowMaxChargesStartTime
+                local inWindow = startTime ~= nil and (now - startTime) <= dur
+                SetGlowIntent(ready, true, inWindow, inWindow and "max-charges" or "duration-window")
+                ready.maxCharges = true
+                ready.durationWindow = true
+                ready.duration = dur
+                ready.startTime = startTime
+            else
+                SetGlowIntent(ready, true, true, "max-charges")
+                ready.maxCharges = true
+            end
+        else
+            SetGlowIntent(ready, true, false, "not-max-charges")
+            ready.maxCharges = true
+        end
+    else
+        local dur = style.readyGlowDuration or 0
+        if dur > 0 then
+            now = now or GetResolverTime(options)
+            local startTime = button._readyGlowStartTime
+            local inWindow = startTime ~= nil and (now - startTime) <= dur
+            SetGlowIntent(ready, true, inWindow, inWindow and "ready" or "duration-window")
+            ready.durationWindow = true
+            ready.duration = dur
+            ready.startTime = startTime
+        else
+            SetGlowIntent(ready, true, true, "ready")
+        end
+    end
+
     return target
 end
 
@@ -664,6 +964,7 @@ local function ClearButtonVisualState(button)
         button._visualStateContext = nil
         button._textVisualIntent = nil
         button._textVisualApplied = nil
+        button._iconGlowIntent = nil
         button._barVisualIntent = nil
         button._barVisualApplied = nil
         button._textureDisplayIntent = nil
@@ -699,6 +1000,8 @@ local function RefreshButtonVisualState(button, context)
     local hasIconTintIntent = type(iconTintIntent) == "table"
     local iconFillIntent = button._iconFillIntent
     local hasIconFillIntent = type(iconFillIntent) == "table"
+    local iconGlowIntent = button._iconGlowIntent
+    local hasIconGlowIntent = type(iconGlowIntent) == "table"
 
     state.version = 1
     state.phase = context.phase
@@ -843,6 +1146,63 @@ local function RefreshButtonVisualState(button, context)
     ready.maxChargesActive = IsTrue(button._readyGlowMaxChargesActive)
 
     local glows = EnsureSection(state, "glows")
+    glows.intentAvailable = hasIconGlowIntent
+    if hasIconGlowIntent then
+        local procIntent = iconGlowIntent.proc or {}
+        glows.procIntentAvailable = procIntent.available == true
+        glows.procIntentActive = procIntent.active == true
+        glows.procReason = procIntent.reason
+        glows.procPreview = procIntent.preview == true
+        glows.procCombatSuppressed = procIntent.combatSuppressed == true
+        glows.procOverlayActive = procIntent.procOverlayActive == true
+
+        local auraIntent = iconGlowIntent.aura or {}
+        glows.auraIntentAvailable = auraIntent.available == true
+        glows.auraIntentActive = auraIntent.active == true
+        glows.auraReason = auraIntent.reason
+        glows.auraPreview = auraIntent.preview == true
+        glows.auraCombatSuppressed = auraIntent.combatSuppressed == true
+        glows.auraPandemicIntent = auraIntent.pandemic == true
+        glows.auraInvert = auraIntent.invert == true
+        glows.auraTargetRequired = auraIntent.targetRequired == true
+        glows.auraTargetExists = auraIntent.targetExists
+
+        local readyIntent = iconGlowIntent.ready or {}
+        glows.readyIntentAvailable = readyIntent.available == true
+        glows.readyIntentActive = readyIntent.active == true
+        glows.readyReason = readyIntent.reason
+        glows.readyPreview = readyIntent.preview == true
+        glows.readyCombatSuppressed = readyIntent.combatSuppressed == true
+        glows.readySuppressedByProc = readyIntent.suppressedByProc == true
+        glows.readyAuraSuppressed = readyIntent.auraSuppressed == true
+        glows.readyMaxCharges = readyIntent.maxCharges == true
+        glows.readyDurationWindow = readyIntent.durationWindow == true
+    else
+        glows.procIntentAvailable = nil
+        glows.procIntentActive = nil
+        glows.procReason = nil
+        glows.procPreview = nil
+        glows.procCombatSuppressed = nil
+        glows.procOverlayActive = nil
+        glows.auraIntentAvailable = nil
+        glows.auraIntentActive = nil
+        glows.auraReason = nil
+        glows.auraPreview = nil
+        glows.auraCombatSuppressed = nil
+        glows.auraPandemicIntent = nil
+        glows.auraInvert = nil
+        glows.auraTargetRequired = nil
+        glows.auraTargetExists = nil
+        glows.readyIntentAvailable = nil
+        glows.readyIntentActive = nil
+        glows.readyReason = nil
+        glows.readyPreview = nil
+        glows.readyCombatSuppressed = nil
+        glows.readySuppressedByProc = nil
+        glows.readyAuraSuppressed = nil
+        glows.readyMaxCharges = nil
+        glows.readyDurationWindow = nil
+    end
     glows.procActive = IsTrue(button._procGlowActive)
     glows.auraActive = IsTrue(button._auraGlowActive)
     glows.auraPandemic = IsTrue(button._auraGlowPandemic)
@@ -896,3 +1256,4 @@ ST._ClearButtonVisualState = ClearButtonVisualState
 ST._SetButtonVisualStateSnapshotsEnabled = SetButtonVisualStateSnapshotsEnabled
 ST._AreButtonVisualStateSnapshotsEnabled = AreButtonVisualStateSnapshotsEnabled
 ST._ResolveIconFillIntent = ResolveIconFillIntent
+ST._ResolveIconGlowIntent = ResolveIconGlowIntent

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -236,6 +236,27 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         readyGlowActive = ready.glowActive,
         procGlowActive = glows.procActive,
         auraGlowActive = glows.auraActive,
+        glowIntentAvailable = glows.intentAvailable,
+        procGlowIntentActive = glows.procIntentActive,
+        procGlowReason = glows.procReason,
+        procGlowPreview = glows.procPreview,
+        procGlowCombatSuppressed = glows.procCombatSuppressed,
+        procGlowOverlayActive = glows.procOverlayActive,
+        auraGlowIntentActive = glows.auraIntentActive,
+        auraGlowReason = glows.auraReason,
+        auraGlowPreview = glows.auraPreview,
+        auraGlowCombatSuppressed = glows.auraCombatSuppressed,
+        auraGlowPandemicIntent = glows.auraPandemicIntent,
+        auraGlowPandemicApplied = glows.auraPandemic,
+        auraGlowInvert = glows.auraInvert,
+        readyGlowIntentActive = glows.readyIntentActive,
+        readyGlowReason = glows.readyReason,
+        readyGlowPreview = glows.readyPreview,
+        readyGlowCombatSuppressed = glows.readyCombatSuppressed,
+        readyGlowSuppressedByProc = glows.readySuppressedByProc,
+        readyGlowAuraSuppressed = glows.readyAuraSuppressed,
+        readyGlowMaxCharges = glows.readyMaxCharges,
+        readyGlowDurationWindow = glows.readyDurationWindow,
     }
     row.bar = {
         intentAvailable = bar.intentAvailable,
@@ -413,6 +434,14 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
     CompareValue(row, "ready.glowActive", ready.glowActive, IsTrue(button._readyGlowActive))
     CompareValue(row, "glows.procActive", glows.procActive, IsTrue(button._procGlowActive))
     CompareValue(row, "glows.auraActive", glows.auraActive, IsTrue(button._auraGlowActive))
+    if compareVisibleIconIntent and glows.intentAvailable == true then
+        CompareValue(row, "glows.proc.intent", glows.procIntentActive, glows.procActive)
+        CompareValue(row, "glows.aura.intent", glows.auraIntentActive, glows.auraActive)
+        if glows.auraIntentActive == true or glows.auraActive == true then
+            CompareValue(row, "glows.aura.pandemic", glows.auraPandemicIntent, glows.auraPandemic)
+        end
+        CompareValue(row, "glows.ready.intent", glows.readyIntentActive, glows.readyActive)
+    end
     CompareValue(row, "text.unusable", text.unusable, IsTrue(button._isUnusable))
     CompareValue(row, "text.outOfRange", text.outOfRange, IsTrue(button._isOutOfRange))
     CompareValue(row, "text.durationObj", text.durationObj ~= nil, button._durationObj ~= nil)

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -523,6 +523,55 @@ local function AddVisualStateDiagnosticsLines(add, visualStateDiagnostics)
                 if row.visuals.iconFillIntentReason and row.visuals.iconFillIntentReason ~= "inactive" then
                     parts[#parts + 1] = "fillReason=" .. tostring(row.visuals.iconFillIntentReason)
                 end
+                local showGlowDiagnostics = row.displayMode == "icons" and row.phase == "post-dispatch"
+                if showGlowDiagnostics then
+                    local procGlowReason = row.visuals.procGlowReason
+                    if row.visuals.procGlowActive
+                        or row.visuals.procGlowPreview
+                        or row.visuals.procGlowCombatSuppressed then
+                        parts[#parts + 1] = "procGlow=" .. tostring(row.visuals.procGlowActive)
+                        if procGlowReason then
+                            parts[#parts + 1] = "procGlowReason=" .. tostring(procGlowReason)
+                        end
+                    end
+                    local auraGlowReason = row.visuals.auraGlowReason
+                    if row.visuals.auraGlowActive
+                        or row.visuals.auraGlowPandemicIntent
+                        or row.visuals.auraGlowPreview
+                        or row.visuals.auraGlowCombatSuppressed
+                        or auraGlowReason == "target-missing" then
+                        parts[#parts + 1] = "auraGlow=" .. tostring(row.visuals.auraGlowActive)
+                        if row.visuals.auraGlowPandemicIntent or row.visuals.auraGlowPandemicApplied then
+                            parts[#parts + 1] = "pandemicGlow=true"
+                        end
+                        if auraGlowReason then
+                            parts[#parts + 1] = "auraGlowReason=" .. tostring(auraGlowReason)
+                        end
+                    end
+                    local readyGlowReason = row.visuals.readyGlowReason
+                    if row.visuals.readyGlowActive
+                        or row.visuals.readyGlowPreview
+                        or row.visuals.readyGlowCombatSuppressed
+                        or row.visuals.readyGlowSuppressedByProc
+                        or row.visuals.readyGlowAuraSuppressed
+                        or row.visuals.readyGlowMaxCharges
+                        or readyGlowReason == "duration-window" then
+                        parts[#parts + 1] = "readyGlow=" .. tostring(row.visuals.readyGlowActive)
+                        if readyGlowReason then
+                            parts[#parts + 1] = "readyGlowReason=" .. tostring(readyGlowReason)
+                        end
+                        if row.visuals.readyGlowSuppressedByProc then
+                            parts[#parts + 1] = "readySuppressed=proc"
+                        elseif row.visuals.readyGlowAuraSuppressed then
+                            parts[#parts + 1] = "readySuppressed=aura"
+                        elseif row.visuals.readyGlowCombatSuppressed then
+                            parts[#parts + 1] = "readySuppressed=combat"
+                        end
+                        if row.visuals.readyGlowMaxCharges then
+                            parts[#parts + 1] = "readyMaxCharges=true"
+                        end
+                    end
+                end
             end
             local hasBarSignals = row.bar and (row.bar.intentAvailable == true
                 or row.bar.stackDisplay == true


### PR DESCRIPTION
## What Players Will Notice
- Icon glows for ready, proc, aura, and pandemic states continue to behave as expected while the addon now reports why each glow is active or suppressed.
- Aura-tracked icon entries intentionally suppress ready glow while their tracked aura is active, so aura-owned visuals do not compete with ready-state glow.
- Bug reports now include compact glow reason tokens such as ready, max-charges, combat-only, proc suppression, and pandemic state when those details matter.

## Why This Changed
- Icon glows were the last major ButtonFrame display consumer still deriving behavior directly in `IconMode.lua`, which made visual-state debugging less complete than icons, text, bars, textures, triggers, visibility, and OtherBars.
- Moving the decision into the visual-state layer keeps glow behavior inspectable without moving widget styling or animation ownership out of the existing glow system.

## What Changed
- Added icon glow intent resolution for proc, aura, pandemic, and ready glow state in `ButtonFrame/VisualState.lua`.
- Updated `ButtonFrame/IconMode.lua` to apply resolved glow intent through the existing `SetProcGlow`, `SetAuraGlow`, and `SetReadyGlow` paths.
- Extended visual-state diagnostics and bug-report output with glow intent, applied state, reasons, and suppression labels while avoiding hidden-row and inactive-pandemic false mismatches.
- Preserved glow widget creation, styling, animation, frame layering, and compatibility fields for the follow-up cleanup pass.

## Validation
- `luac -p ButtonFrame\VisualState.lua ButtonFrame\IconMode.lua ButtonFrame\VisualStateDiagnostics.lua Config\Diagnostics.lua` passed.
- `git diff --check` passed with only LF-to-CRLF working-copy warnings.
- Local ignored visual-state fixtures passed: `lua tests\visual-state-snapshot.lua` and `lua tests\visual-state-diagnostics.lua`.
- Code review passed after addressing pandemic fallback and diagnostics parity feedback; active-aura ready-glow suppression was kept as intentional behavior.
- In-game validation passed per user report. The shared bug report showed `Visual-State Signal: mismatched=0 missing=0`, max-charge ready glow on Overpower, normal ready-glow rows, and compact aura/pandemic combat-only diagnostics with `match=ok`.