### PR TITLE
Clean up text and bar visual-state scaffolding

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -125,7 +125,6 @@ end
 
 local function StoreBarDisplayVisualState(button, details)
     local intent = EnsureBarVisualTable(button, "_barVisualIntent")
-    intent.available = true
     intent.domain = details.domain
     intent.onCooldown = details.onCooldown == true
     intent.chargeState = details.chargeState
@@ -146,7 +145,6 @@ local function StoreBarDisplayVisualState(button, details)
     CopyColor(intent, "colorShiftTarget", details.colorShiftTargetColor)
 
     local applied = EnsureBarVisualTable(button, "_barVisualApplied")
-    applied.available = true
     applied.colorReason = details.colorReason
     applied.auraColorActive = button._barAuraColor ~= nil
     applied.auraEffectActive = button._barAuraEffectActive == true

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -354,7 +354,6 @@ end
 
 local function StoreTextVisualApplied(button, writePath, text, secretValue, secretStackValue, hasSecretNameValue)
     local applied = EnsureTextVisualTable(button, "_textVisualApplied")
-    applied.available = true
     applied.writePath = writePath
     applied.hasText = text ~= nil and text ~= ""
     applied.secretDuration = secretValue ~= nil
@@ -1104,7 +1103,6 @@ end
 ------------------------------------------------------------------------
 ST._UpdateTextDisplay = UpdateTextDisplay
 ST._UpdateTextStyle = UpdateTextStyle
-ST._ClearTextVisualState = ClearTextVisualState
 ST._ParseFormatString = ParseFormatString
 ST._HasAnyEffects = HasAnyEffects
 ST._GetEffectiveTextHeight = GetEffectiveTextHeight

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -28,6 +28,108 @@ local function EnsureSection(parent, key)
     return section
 end
 
+local function CopyFieldList(target, source, fields)
+    for _, fieldName in ipairs(fields) do
+        local value = nil
+        if source then
+            value = source[fieldName]
+        end
+        target[fieldName] = value
+    end
+end
+
+local function CopyFieldMap(target, source, fieldMap)
+    for targetField, sourceField in pairs(fieldMap) do
+        local value = nil
+        if source then
+            value = source[sourceField]
+        end
+        target[targetField] = value
+    end
+end
+
+local TEXT_INTENT_FIELDS = {
+    "domain",
+    "available",
+    "unusable",
+    "outOfRange",
+    "auraActive",
+    "auraHasTimer",
+    "timePresent",
+    "auraTimePresent",
+    "cooldownDeferred",
+    "chargeState",
+    "currentCharges",
+    "maxCharges",
+    "stackSource",
+    "stackPresent",
+    "stackSecret",
+    "secretDuration",
+    "secretDurationToken",
+    "secretStack",
+    "secretName",
+    "hasText",
+    "pulseActive",
+}
+
+local TEXT_APPLIED_FIELDS = {
+    appliedWritePath = "writePath",
+    appliedHasText = "hasText",
+    appliedSecretDuration = "secretDuration",
+    appliedSecretStack = "secretStack",
+    appliedSecretName = "secretName",
+    appliedPulseActive = "pulseActive",
+    appliedAlpha = "alpha",
+}
+
+local BAR_INTENT_FIELDS = {
+    "domain",
+    "onCooldown",
+    "chargeState",
+    "colorReason",
+    "auraColorReason",
+    "auraEffectActive",
+    "auraEffectReason",
+    "pulseActive",
+    "pulseMode",
+    "colorShiftActive",
+    "colorShiftMode",
+    "stackDisplay",
+    "stackMode",
+    "stackSegmentLayerActive",
+    "gcdSuppressed",
+    "colorR",
+    "colorG",
+    "colorB",
+    "colorA",
+    "colorShiftBaseR",
+    "colorShiftBaseG",
+    "colorShiftBaseB",
+    "colorShiftBaseA",
+    "colorShiftTargetR",
+    "colorShiftTargetG",
+    "colorShiftTargetB",
+    "colorShiftTargetA",
+}
+
+local BAR_APPLIED_FIELDS = {
+    appliedColorReason = "colorReason",
+    appliedAuraColorActive = "auraColorActive",
+    appliedAuraEffectActive = "auraEffectActive",
+    appliedPulseActive = "pulseActive",
+    appliedPulseMode = "pulseMode",
+    appliedColorShiftActive = "colorShiftActive",
+    appliedColorShiftMode = "colorShiftMode",
+    appliedStackVisualActive = "stackVisualActive",
+    appliedStackMode = "stackMode",
+    appliedBaseFillHidden = "baseFillHidden",
+    appliedGcdSuppressed = "gcdSuppressed",
+    appliedColorR = "colorR",
+    appliedColorG = "colorG",
+    appliedColorB = "colorB",
+    appliedColorA = "colorA",
+}
+
 local function ResolveVisibilityMode(hidden, alphaOverride)
     if IsTrue(hidden) then
         return "hidden"
@@ -541,72 +643,22 @@ local function CopyTextVisualState(button, text, context)
     local hasIntent = type(intent) == "table"
     text.preservedSecretTextRender = preservedSecretTextRender
     text.intentAvailable = hasIntent
-    if hasIntent then
-        text.domain = intent.domain
-        text.available = intent.available
-        text.unusable = intent.unusable
-        text.outOfRange = intent.outOfRange
-        text.auraActive = intent.auraActive
-        text.auraHasTimer = intent.auraHasTimer
-        text.timePresent = intent.timePresent
-        text.auraTimePresent = intent.auraTimePresent
-        text.cooldownDeferred = intent.cooldownDeferred
-        text.chargeState = intent.chargeState
-        text.currentCharges = intent.currentCharges
-        text.maxCharges = intent.maxCharges
-        text.stackSource = intent.stackSource
-        text.stackPresent = intent.stackPresent
-        text.stackSecret = intent.stackSecret
-        text.secretDuration = intent.secretDuration
-        text.secretDurationToken = intent.secretDurationToken
-        text.secretStack = intent.secretStack
-        text.secretName = intent.secretName
-        text.hasText = intent.hasText
-        text.pulseActive = intent.pulseActive
-    else
-        text.domain = nil
+    CopyFieldList(text, hasIntent and intent or nil, TEXT_INTENT_FIELDS)
+    if not hasIntent then
         text.available = not button._desatCooldownActive
         text.unusable = IsTrue(button._isUnusable)
         text.outOfRange = IsTrue(button._isOutOfRange)
         text.auraActive = IsTrue(button._auraActive)
         text.auraHasTimer = IsTrue(button._auraHasTimer)
-        text.timePresent = nil
-        text.auraTimePresent = nil
         text.cooldownDeferred = IsTrue(button._cooldownDeferred)
         text.chargeState = button._chargeState
         text.currentCharges = button._currentReadableCharges
-        text.maxCharges = nil
-        text.stackSource = nil
-        text.stackPresent = nil
-        text.stackSecret = nil
-        text.secretDuration = nil
-        text.secretDurationToken = nil
-        text.secretStack = nil
-        text.secretName = nil
-        text.hasText = nil
-        text.pulseActive = nil
     end
 
     local applied = textSidecarsAreFresh and button._textVisualApplied or nil
     local hasApplied = type(applied) == "table"
     text.appliedAvailable = hasApplied
-    if hasApplied then
-        text.appliedWritePath = applied.writePath
-        text.appliedHasText = applied.hasText
-        text.appliedSecretDuration = applied.secretDuration
-        text.appliedSecretStack = applied.secretStack
-        text.appliedSecretName = applied.secretName
-        text.appliedPulseActive = applied.pulseActive
-        text.appliedAlpha = applied.alpha
-    else
-        text.appliedWritePath = nil
-        text.appliedHasText = nil
-        text.appliedSecretDuration = nil
-        text.appliedSecretStack = nil
-        text.appliedSecretName = nil
-        text.appliedPulseActive = nil
-        text.appliedAlpha = nil
-    end
+    CopyFieldMap(text, hasApplied and applied or nil, TEXT_APPLIED_FIELDS)
 end
 
 local function CopyBarVisualState(button, bar, context)
@@ -619,99 +671,24 @@ local function CopyBarVisualState(button, bar, context)
     local hasIntent = type(intent) == "table"
 
     bar.intentAvailable = hasIntent
-    if hasIntent then
-        bar.domain = intent.domain
-        bar.onCooldown = intent.onCooldown
-        bar.chargeState = intent.chargeState
-        bar.colorReason = intent.colorReason
-        bar.auraColorReason = intent.auraColorReason
-        bar.auraEffectActive = intent.auraEffectActive
-        bar.auraEffectReason = intent.auraEffectReason
-        bar.pulseActive = intent.pulseActive
-        bar.pulseMode = intent.pulseMode
-        bar.colorShiftActive = intent.colorShiftActive
-        bar.colorShiftMode = intent.colorShiftMode
-        bar.stackDisplay = intent.stackDisplay
-        bar.stackMode = intent.stackMode
-        bar.stackSegmentLayerActive = intent.stackSegmentLayerActive
-        bar.gcdSuppressed = intent.gcdSuppressed
-        bar.colorR = intent.colorR
-        bar.colorG = intent.colorG
-        bar.colorB = intent.colorB
-        bar.colorA = intent.colorA
-        bar.colorShiftBaseR = intent.colorShiftBaseR
-        bar.colorShiftBaseG = intent.colorShiftBaseG
-        bar.colorShiftBaseB = intent.colorShiftBaseB
-        bar.colorShiftBaseA = intent.colorShiftBaseA
-        bar.colorShiftTargetR = intent.colorShiftTargetR
-        bar.colorShiftTargetG = intent.colorShiftTargetG
-        bar.colorShiftTargetB = intent.colorShiftTargetB
-        bar.colorShiftTargetA = intent.colorShiftTargetA
-    else
+    CopyFieldList(bar, hasIntent and intent or nil, BAR_INTENT_FIELDS)
+    if not hasIntent then
         bar.domain = IsTrue(button._barAuraStackDisplay) and "stack" or nil
-        bar.onCooldown = nil
         bar.chargeState = button._chargeState
-        bar.colorReason = nil
-        bar.auraColorReason = nil
-        bar.auraEffectActive = nil
-        bar.auraEffectReason = nil
-        bar.pulseActive = nil
-        bar.pulseMode = nil
-        bar.colorShiftActive = nil
-        bar.colorShiftMode = nil
         bar.stackDisplay = IsTrue(button._barAuraStackDisplay)
         bar.stackMode = button._barAuraStackMode
-        bar.stackSegmentLayerActive = nil
         bar.gcdSuppressed = IsTrue(button._barGCDSuppressed)
-        bar.colorR = nil
-        bar.colorG = nil
-        bar.colorB = nil
-        bar.colorA = nil
-        bar.colorShiftBaseR = nil
-        bar.colorShiftBaseG = nil
-        bar.colorShiftBaseB = nil
-        bar.colorShiftBaseA = nil
-        bar.colorShiftTargetR = nil
-        bar.colorShiftTargetG = nil
-        bar.colorShiftTargetB = nil
-        bar.colorShiftTargetA = nil
     end
 
     local applied = barSidecarsAreFresh and button._barVisualApplied or nil
     local hasApplied = type(applied) == "table"
     bar.appliedAvailable = hasApplied
-    if hasApplied then
-        bar.appliedColorReason = applied.colorReason
-        bar.appliedAuraColorActive = applied.auraColorActive
-        bar.appliedAuraEffectActive = applied.auraEffectActive
-        bar.appliedPulseActive = applied.pulseActive
-        bar.appliedPulseMode = applied.pulseMode
-        bar.appliedColorShiftActive = applied.colorShiftActive
-        bar.appliedColorShiftMode = applied.colorShiftMode
-        bar.appliedStackVisualActive = applied.stackVisualActive
-        bar.appliedStackMode = applied.stackMode
-        bar.appliedBaseFillHidden = applied.baseFillHidden
-        bar.appliedGcdSuppressed = applied.gcdSuppressed
-        bar.appliedColorR = applied.colorR
-        bar.appliedColorG = applied.colorG
-        bar.appliedColorB = applied.colorB
-        bar.appliedColorA = applied.colorA
-    else
-        bar.appliedColorReason = nil
-        bar.appliedAuraColorActive = nil
-        bar.appliedAuraEffectActive = nil
-        bar.appliedPulseActive = nil
-        bar.appliedPulseMode = nil
-        bar.appliedColorShiftActive = nil
-        bar.appliedColorShiftMode = nil
+    CopyFieldMap(bar, hasApplied and applied or nil, BAR_APPLIED_FIELDS)
+    if not hasApplied then
         bar.appliedStackVisualActive = IsTrue(button._barAuraStackVisualActive)
         bar.appliedStackMode = button._barAuraStackVisualMode
         bar.appliedBaseFillHidden = IsTrue(button._barAuraBaseFillHidden)
         bar.appliedGcdSuppressed = IsTrue(button._barGCDSuppressed)
-        bar.appliedColorR = nil
-        bar.appliedColorG = nil
-        bar.appliedColorB = nil
-        bar.appliedColorA = nil
     end
 end
 

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -1193,7 +1193,6 @@ local function RefreshButtonVisualState(button, context)
 
     local text = EnsureSection(state, "text")
     CopyTextVisualState(button, text, context)
-    text.durationObj = button._durationObj
 
     local texture = EnsureSection(state, "texture")
     CopyTextureDisplayVisualState(button, texture)

--- a/ButtonFrame/VisualStateDiagnostics.lua
+++ b/ButtonFrame/VisualStateDiagnostics.lua
@@ -316,7 +316,6 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         appliedSecretName = text.appliedSecretName,
         appliedPulseActive = text.appliedPulseActive,
         appliedAlpha = text.appliedAlpha,
-        durationObj = text.durationObj ~= nil,
     }
     row.texture = {
         intentAvailable = texture.intentAvailable,
@@ -442,9 +441,6 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         end
         CompareValue(row, "glows.ready.intent", glows.readyIntentActive, glows.readyActive)
     end
-    CompareValue(row, "text.unusable", text.unusable, IsTrue(button._isUnusable))
-    CompareValue(row, "text.outOfRange", text.outOfRange, IsTrue(button._isOutOfRange))
-    CompareValue(row, "text.durationObj", text.durationObj ~= nil, button._durationObj ~= nil)
     local compareVisibleTextIntent = row.displayMode == "text"
         and row.phase == "post-dispatch"
         and visibility.hidden ~= true
@@ -457,10 +453,6 @@ local function BuildRow(addon, groupId, frame, button, fallbackIndex, source)
         elseif bar.appliedAvailable ~= true then
             AddMismatch(row, "bar.applied.missing")
         else
-            CompareValue(row, "bar.appliedAuraEffectActive", bar.appliedAuraEffectActive, IsTrue(button._barAuraEffectActive))
-            CompareValue(row, "bar.appliedPulseActive", bar.appliedPulseActive, IsTrue(button._barPulseActive))
-            CompareValue(row, "bar.appliedColorShiftActive", bar.appliedColorShiftActive, IsTrue(button._barColorShiftActive))
-            CompareValue(row, "bar.appliedGcdSuppressed", bar.appliedGcdSuppressed, IsTrue(button._barGCDSuppressed))
             CompareValue(row, "bar.colorReason", bar.appliedColorReason, bar.colorReason)
             CompareValue(row, "bar.auraEffectActive", bar.appliedAuraEffectActive, bar.auraEffectActive)
             CompareValue(row, "bar.pulseActive", bar.appliedPulseActive, bar.pulseActive)


### PR DESCRIPTION
## What Changed
- Consolidated text and bar visual-state snapshot copying into explicit field inventories in `ButtonFrame/VisualState.lua`.
- Removed unused text/bar sidecar `available` writes and the unused text visual-state clear export.
- Removed text/bar migration-only parity checks that compared copied diagnostic state back to the same source caches.
- Preserved hidden, stale, and preserved-secret text fallback behavior.

## Why This Changed
- The visual-state consumer rollout is complete enough to start pruning scaffolding that only existed to prove migration parity.
- Text and bar diagnostics still need to help future support cases, but they should not carry duplicated copy blocks or compare sidecars against themselves.
- This PR keeps the renderer/application paths unchanged while tightening the diagnostic snapshot surface.

## Field Inventory For This Slice
- Runtime truth retained: cooldown state, charge state, duration objects, usability/range state, and bar GCD state remain owned by the existing runtime/update paths.
- Visual intent retained: `_textVisualIntent` and `_barVisualIntent` remain gated snapshot sidecars for text/bar display outcome, secret-safe labels, color/effect reasons, stack state, and GCD suppression.
- Renderer applied caches retained: `_textVisualApplied`, `_barVisualApplied`, and bar applied-effect fields remain as applied summaries because they explain what the renderer wrote without moving widget mutation.
- Useful support diagnostics retained: text domain/write path/secret/pulse labels; bar domain/color/effect/pulse/shift/stack/GCD labels; missing sidecar labels for visible post-dispatch rows.
- Migration scaffolding removed: repeated field-copy assignments, unused sidecar availability flags, unused clear export, duplicate text duration-object row copy, and legacy source-cache parity checks for text/bar sidecars.

## Developer Impact
- Text and bar snapshot fields are now easier to audit from one list per intent/applied sidecar.
- The branch is net negative against `visual-state-dev-main` while keeping support-oriented diagnostics intact.
- No intended player-facing display behavior change.

## Validation
- `luac -p ButtonFrame\VisualState.lua ButtonFrame\TextMode.lua ButtonFrame\BarMode.lua ButtonFrame\VisualStateDiagnostics.lua Config\Diagnostics.lua tests\visual-state-snapshot.lua tests\visual-state-diagnostics.lua tests\otherbars-visual-state.lua`
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- `lua tests\otherbars-visual-state.lua`
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warnings.
- In-game CDC diagnostic capture on Arms Warrior showed `Visual-State Signal: mismatched=0 missing=0 restored=true` and `OtherBars Signal: mismatched=0 missing=0 restored=true`, with sampled rows reporting `match=ok`.
- This PR does not change renderer actuation paths, so no additional combat/restricted-content validation was required for the cleanup itself.
