### PR TITLE
Fix character group auto-anchoring exclusions

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -512,7 +512,11 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                     if fresh.isGlobal then
                         fresh.anchorEligible = not fresh.anchorEligible or nil
                     else
-                        fresh.anchorEligible = fresh.anchorEligible ~= false and false or nil
+                        if fresh.anchorEligible ~= false then
+                            fresh.anchorEligible = false
+                        else
+                            fresh.anchorEligible = nil
+                        end
                     end
                     CooldownCompanion:EvaluateResourceBars()
                     CooldownCompanion:UpdateAnchorStacking()


### PR DESCRIPTION
## What Players Will Notice
- Character-only groups excluded from auto-anchoring should no longer stay eligible anyway.
- Auto-anchored resource bars, cast bars, and unit frames can move past an excluded character group to the next eligible icon panel.

## Why This Changed
- The character-group toggle tried to store `false` through Lua's `condition and false or nil` pattern, which always collapsed to `nil` because `false` is falsy.
- Global groups were unaffected because their opt-in path stores `true` or clears back to `nil`.

## What Changed
- Replaced the character-group auto-anchoring toggle assignment with an explicit `if/else` so excluding stores `anchorEligible = false` and including clears it back to `nil`.
- Left the existing global-group opt-in behavior and anchor-selection logic unchanged.

## Validation
- `luac -p Config\Column1.lua`
- `git diff --check origin/main...HEAD`
- In-game menu, saved-variable, anchor-selection, combat, and restricted-content validation are still pending.