### PR TITLE
Centralize config selection navigation

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -38,23 +38,13 @@ local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
-local ClearConfigFinderText = ST._ClearConfigFinderText
+local ClearConfigPrimarySelection = ST._ClearConfigPrimarySelection
+local SelectConfigFolder = ST._SelectConfigFolder
+local SelectConfigContainer = ST._SelectConfigContainer
+local ToggleConfigContainerMultiSelect = ST._ToggleConfigContainerMultiSelect
+local SelectConfigPanel = ST._SelectConfigPanel
 
 local GenerateGroupName
-
-------------------------------------------------------------------------
--- Clear all selection state (container, panel, button, multi-select)
-------------------------------------------------------------------------
-local function ClearSelection()
-    CooldownCompanion:ClearAllConfigPreviews()
-    CS.selectedFolder = nil
-    CS.selectedContainer = nil
-    CS.selectedGroup = nil
-    CS.selectedButton = nil
-    wipe(CS.selectedButtons)
-    wipe(CS.selectedPanels)
-    wipe(CS.selectedCustomBars)
-end
 
 local function TrimGroupName(name)
     if name == nil then return "" end
@@ -159,7 +149,7 @@ local function RenderBrowseMode()
             CS.browseMode = false
             CS.browseCharKey = nil
             CS.browseContainerId = nil
-            ClearSelection()
+            ClearConfigPrimarySelection()
             CooldownCompanion:RefreshConfigPanel()
         end)
         CS.col1Scroll:AddChild(backBtn)
@@ -197,7 +187,7 @@ local function RenderBrowseMode()
             entry:SetCallback("OnClick", function()
                 CS.browseCharKey = charInfo.charKey
                 CS.browseContainerId = nil
-                ClearSelection()
+                ClearConfigPrimarySelection()
                 CooldownCompanion:RefreshConfigPanel()
             end)
             CS.col1Scroll:AddChild(entry)
@@ -214,7 +204,7 @@ local function RenderBrowseMode()
         backBtn:SetCallback("OnClick", function()
             CS.browseCharKey = nil
             CS.browseContainerId = nil
-            ClearSelection()
+            ClearConfigPrimarySelection()
             CooldownCompanion:RefreshConfigPanel()
         end)
         CS.col1Scroll:AddChild(backBtn)
@@ -274,18 +264,13 @@ local function RenderBrowseMode()
             -- Left-click: select for preview; Right-click: copy context menu
             entry.frame:SetScript("OnMouseUp", function(self, button)
                 if button == "LeftButton" then
-                    CooldownCompanion:ClearAllConfigPreviews()
                     if CS.browseContainerId == containerId then
                         CS.browseContainerId = nil
-                        CS.selectedContainer = nil
+                        SelectConfigContainer(nil, { keepContainerMulti = true })
                     else
                         CS.browseContainerId = containerId
-                        CS.selectedContainer = containerId
+                        SelectConfigContainer(containerId, { keepContainerMulti = true })
                     end
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
-                    wipe(CS.selectedPanels)
                     CooldownCompanion:RefreshConfigPanel()
                 elseif button == "RightButton" then
                     -- Verify source still exists
@@ -302,12 +287,10 @@ local function RenderBrowseMode()
                             if not db.groupContainers[containerId] then return end
                             local newId = CooldownCompanion:CopyContainerFromBrowse(containerId)
                             if newId then
-                                CooldownCompanion:ClearAllConfigPreviews()
                                 CS.browseMode = false
                                 CS.browseCharKey = nil
                                 CS.browseContainerId = nil
-                                CS.selectedContainer = newId
-                                CS.selectedGroup = nil
+                                SelectConfigContainer(newId)
                                 CooldownCompanion:RefreshConfigPanel()
                                 CooldownCompanion:Print("Group copied successfully.")
                             end
@@ -462,9 +445,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                 CloseDropDownMenus()
                 local newContainerId = CooldownCompanion:DuplicateGroup(containerId)
                 if newContainerId then
-                    CooldownCompanion:ClearAllConfigPreviews()
-                    CS.selectedContainer = newContainerId
-                    CS.selectedGroup = nil
+                    SelectConfigContainer(newContainerId)
                     CooldownCompanion:RefreshConfigPanel()
                 end
             end
@@ -616,9 +597,10 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                     CloseDropDownMenus()
                     local newPanelId = CooldownCompanion:CreatePanel(containerId, targetMode)
                     if newPanelId then
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        CS.selectedContainer = containerId
-                        CS.selectedGroup = newPanelId
+                        SelectConfigPanel(newPanelId, {
+                            containerId = containerId,
+                            keepPanelMulti = true,
+                        })
                         CS.addingToPanelId = newPanelId
                         CS.pendingEditBoxFocus = true
                         CooldownCompanion:RefreshConfigPanel()
@@ -655,11 +637,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
             CloseDropDownMenus()
             local containerId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
             CooldownCompanion:MoveGroupToFolder(containerId, folderId)
-            CooldownCompanion:ClearAllConfigPreviews()
-            CS.selectedContainer = containerId
-            CS.selectedGroup = nil
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
+            SelectConfigContainer(containerId)
             CooldownCompanion:RefreshConfigPanel()
         end
         UIDropDownMenu_AddButton(info, level)
@@ -823,11 +801,7 @@ local function PopulateColumn1ButtonBar()
     newGroupBtn:SetText("New Group")
     newGroupBtn:SetCallback("OnClick", function()
         local containerId, groupId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
-        CooldownCompanion:ClearAllConfigPreviews()
-        CS.selectedContainer = containerId
-        CS.selectedGroup = nil
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        SelectConfigContainer(containerId)
         CooldownCompanion:RefreshConfigPanel()
         if NotifyTutorialAction then
             NotifyTutorialAction("group_created", {
@@ -1282,17 +1256,7 @@ local function RefreshColumn1(preserveDrag)
             if CS.dragState and CS.dragState.phase == "active" then return end
             if button == "LeftButton" then
                 if searchResults then
-                    CooldownCompanion:ClearAllConfigPreviews()
-                    wipe(CS.selectedGroups)
-                    wipe(CS.selectedPanels)
-                    wipe(CS.selectedButtons)
-                    CS.selectedFolder = nil
-                    CS.selectedContainer = containerId
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    if ClearConfigFinderText then
-                        ClearConfigFinderText()
-                    end
+                    SelectConfigContainer(containerId, { clearFinder = true })
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
@@ -1307,38 +1271,12 @@ local function RefreshColumn1(preserveDrag)
                     return
                 elseif IsControlKeyDown() then
                     -- Ctrl+click: toggle multi-select (container IDs)
-                    if CS.selectedGroups[containerId] then
-                        CS.selectedGroups[containerId] = nil
-                    else
-                        CS.selectedGroups[containerId] = true
-                    end
-                    if CS.selectedContainer and not CS.selectedGroups[CS.selectedContainer] and next(CS.selectedGroups) then
-                        CS.selectedGroups[CS.selectedContainer] = true
-                    end
-                    CS.selectedFolder = nil
-                    ClearSelection()
+                    ToggleConfigContainerMultiSelect(containerId)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
                 -- Normal click: toggle-through selection, clear multi-select
-                CooldownCompanion:ClearAllConfigPreviews()
-                wipe(CS.selectedGroups)
-                CS.selectedFolder = nil
-                if CS.selectedContainer == containerId then
-                    if CS.selectedGroup then
-                        -- First re-click: clear panel selection (return to container settings)
-                        CS.selectedGroup = nil
-                    else
-                        -- Second re-click: deselect container entirely
-                        CS.selectedContainer = nil
-                    end
-                else
-                    CS.selectedContainer = containerId
-                    CS.selectedGroup = nil
-                end
-                CS.selectedButton = nil
-                wipe(CS.selectedButtons)
-                wipe(CS.selectedPanels)
+                SelectConfigContainer(containerId, { toggle = true })
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "RightButton" then
                 ShowContainerContextMenu(db, charKey, containerId, container)
@@ -1683,14 +1621,7 @@ local function RefreshColumn1(preserveDrag)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
-                CooldownCompanion:ClearAllConfigPreviews()
-                CS.selectedFolder = folderId
-                CS.selectedContainer = nil
-                CS.selectedGroup = nil
-                CS.selectedButton = nil
-                wipe(CS.selectedGroups)
-                wipe(CS.selectedPanels)
-                wipe(CS.selectedButtons)
+                SelectConfigFolder(folderId)
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "MiddleButton" then
                 -- Lock/unlock all containers in this folder

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -38,6 +38,10 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local SelectConfigFinderResult = ST._SelectConfigFinderResult
+local SelectConfigPanel = ST._SelectConfigPanel
+local ToggleConfigPanelMultiSelect = ST._ToggleConfigPanelMultiSelect
+local SelectConfigButton = ST._SelectConfigButton
+local SelectConfigButtonPanel = ST._SelectConfigButtonPanel
 
 local IsTriggerPanelGroup
 
@@ -1434,11 +1438,7 @@ local function RefreshColumn2()
             end
             header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
             header:SetCallback("OnClick", function()
-                CooldownCompanion:ClearAllConfigPreviews()
-                CS.selectedContainer = CS.browseContainerId
-                CS.selectedGroup = panelGroupId
-                CS.selectedButton = nil
-                wipe(CS.selectedButtons)
+                SelectConfigPanel(panelGroupId, { containerId = CS.browseContainerId })
                 CooldownCompanion:RefreshConfigPanel()
             end)
             panelContainer:AddChild(header)
@@ -1472,11 +1472,10 @@ local function RefreshColumn2()
                     end
                     local capturedIndex = buttonIndex
                     entry:SetCallback("OnClick", function()
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        CS.selectedContainer = CS.browseContainerId
-                        CS.selectedGroup = panelGroupId
-                        CS.selectedButton = capturedIndex
-                        wipe(CS.selectedButtons)
+                        SelectConfigButton(panelGroupId, capturedIndex, {
+                            containerId = CS.browseContainerId,
+                            force = true,
+                        })
                         CooldownCompanion:RefreshConfigPanel()
                     end)
                     panelContainer:AddChild(entry)
@@ -2131,32 +2130,12 @@ local function RefreshColumn2()
                         end
 
                         if IsControlKeyDown() then
-                            CooldownCompanion:ClearAllConfigPreviews()
-                            if CS.selectedPanels[panelId] then
-                                CS.selectedPanels[panelId] = nil
-                            else
-                                CS.selectedPanels[panelId] = true
-                            end
-                            if CS.selectedGroup and not CS.selectedPanels[CS.selectedGroup] and next(CS.selectedPanels) then
-                                CS.selectedPanels[CS.selectedGroup] = true
-                            end
-                            CS.selectedGroup = nil
-                            CS.selectedButton = nil
-                            wipe(CS.selectedButtons)
-                            CS.addingToPanelId = nil
+                            ToggleConfigPanelMultiSelect(panelId)
                             CooldownCompanion:RefreshConfigPanel()
                             return
                         end
 
-                        wipe(CS.selectedPanels)
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        if CS.selectedGroup == panelId and not CS.selectedButton then
-                            CS.selectedGroup = nil
-                        else
-                            CS.selectedGroup = panelId
-                        end
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        SelectConfigPanel(panelId, { toggle = true })
                         CooldownCompanion:RefreshConfigPanel()
                         return
                     elseif mouseButton == "MiddleButton" then
@@ -2472,10 +2451,7 @@ local function RefreshColumn2()
                         CS.addingToPanelId = nil
                     else
                         CS.addingToPanelId = addBtnPanelId
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        CS.selectedGroup = addBtnPanelId
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        SelectConfigPanel(addBtnPanelId, { keepPanelMulti = true })
                         CS.collapsedPanels[addBtnPanelId] = nil
                         CS.pendingEditBoxFocus = true
                     end
@@ -2665,43 +2641,11 @@ local function RefreshColumn2()
                         end
                         if mouseButton == "LeftButton" then
                             -- Auto-select this button's panel
-                            local panelChanged = CS.selectedGroup ~= btnPanelId
-                            if panelChanged then
-                                CS.selectedGroup = btnPanelId
-                                CS.selectedButton = nil
-                                wipe(CS.selectedButtons)
-                            end
-                            wipe(CS.selectedPanels)
-
-                            if IsControlKeyDown() then
-                                if CS.selectedButtons[btnIndex] then
-                                    CS.selectedButtons[btnIndex] = nil
-                                else
-                                    CS.selectedButtons[btnIndex] = true
-                                end
-                                if CS.selectedButton and not CS.selectedButtons[CS.selectedButton] and next(CS.selectedButtons) then
-                                    CS.selectedButtons[CS.selectedButton] = true
-                                end
-                                CS.selectedButton = nil
-                            else
-                                wipe(CS.selectedButtons)
-                                if not panelChanged and CS.selectedButton == btnIndex then
-                                    CS.selectedButton = nil
-                                else
-                                    CS.selectedButton = btnIndex
-                                end
-                            end
-                            CooldownCompanion:ClearAllConfigPreviews()
+                            SelectConfigButton(btnPanelId, btnIndex, { multi = IsControlKeyDown() })
                             CooldownCompanion:RefreshConfigPanel()
                         elseif mouseButton == "RightButton" then
                             -- Auto-select panel on right-click too
-                            if CS.selectedGroup ~= btnPanelId then
-                                CooldownCompanion:ClearAllConfigPreviews()
-                                CS.selectedGroup = btnPanelId
-                                CS.selectedButton = nil
-                                wipe(CS.selectedButtons)
-                            end
-                            wipe(CS.selectedPanels)
+                            SelectConfigButtonPanel(btnPanelId, { clearPanelMulti = true })
                             if not CS.buttonContextMenu then
                                 CS.buttonContextMenu = CreateFrame("Frame", "CDCButtonContextMenu", UIParent, "UIDropDownMenuTemplate")
                             end
@@ -2794,12 +2738,7 @@ local function RefreshColumn2()
                             CS.buttonContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
                             ToggleDropDownMenu(1, nil, CS.buttonContextMenu, "cursor", 0, 0)
                         elseif mouseButton == "MiddleButton" then
-                            if CS.selectedGroup ~= btnPanelId then
-                                CooldownCompanion:ClearAllConfigPreviews()
-                                CS.selectedGroup = btnPanelId
-                                CS.selectedButton = nil
-                                wipe(CS.selectedButtons)
-                            end
+                            SelectConfigButtonPanel(btnPanelId)
                             if not CS.moveMenuFrame then
                                 CS.moveMenuFrame = CreateFrame("Frame", "CDCMoveMenu", UIParent, "UIDropDownMenuTemplate")
                             end

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2342,6 +2342,157 @@ end
 -- Shared selection / spec helpers (consumed by Popups, Panel, Column*, DragReorder)
 ------------------------------------------------------------------------
 
+local function ClearSelectedButton()
+    CS.selectedButton = nil
+    wipe(CS.selectedButtons)
+end
+
+local function ClearConfigPrimarySelection()
+    CooldownCompanion:ClearAllConfigPreviews()
+    CS.selectedFolder = nil
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    wipe(CS.selectedPanels)
+    wipe(CS.selectedCustomBars)
+end
+
+local function SelectConfigFolder(folderId)
+    CooldownCompanion:ClearAllConfigPreviews()
+    CS.selectedFolder = folderId
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    wipe(CS.selectedGroups)
+    wipe(CS.selectedPanels)
+end
+
+local function SelectConfigContainer(containerId, opts)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if not (opts and opts.keepContainerMulti) then
+        wipe(CS.selectedGroups)
+    end
+    CS.selectedFolder = nil
+
+    if opts and opts.toggle and CS.selectedContainer == containerId then
+        if CS.selectedGroup then
+            CS.selectedGroup = nil
+        else
+            CS.selectedContainer = nil
+        end
+    else
+        CS.selectedContainer = containerId
+        CS.selectedGroup = nil
+    end
+
+    ClearSelectedButton()
+    wipe(CS.selectedPanels)
+    if opts and opts.clearFinder then
+        ClearConfigFinderText()
+    end
+end
+
+local function ToggleConfigContainerMultiSelect(containerId)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if CS.selectedGroups[containerId] then
+        CS.selectedGroups[containerId] = nil
+    else
+        CS.selectedGroups[containerId] = true
+    end
+    if CS.selectedContainer and not CS.selectedGroups[CS.selectedContainer] and next(CS.selectedGroups) then
+        CS.selectedGroups[CS.selectedContainer] = true
+    end
+
+    CS.selectedFolder = nil
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    wipe(CS.selectedPanels)
+    wipe(CS.selectedCustomBars)
+end
+
+local function SelectConfigPanel(panelId, opts)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if opts and opts.containerId ~= nil then
+        CS.selectedContainer = opts.containerId
+    end
+    if not (opts and opts.keepPanelMulti) then
+        wipe(CS.selectedPanels)
+    end
+
+    if opts and opts.toggle and CS.selectedGroup == panelId and not CS.selectedButton then
+        CS.selectedGroup = nil
+    else
+        CS.selectedGroup = panelId
+    end
+
+    ClearSelectedButton()
+end
+
+local function ToggleConfigPanelMultiSelect(panelId)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if CS.selectedPanels[panelId] then
+        CS.selectedPanels[panelId] = nil
+    else
+        CS.selectedPanels[panelId] = true
+    end
+    if CS.selectedGroup and not CS.selectedPanels[CS.selectedGroup] and next(CS.selectedPanels) then
+        CS.selectedPanels[CS.selectedGroup] = true
+    end
+
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    CS.addingToPanelId = nil
+end
+
+local function SelectConfigButton(panelId, buttonIndex, opts)
+    local panelChanged = CS.selectedGroup ~= panelId
+    if opts and opts.containerId ~= nil then
+        CS.selectedContainer = opts.containerId
+    end
+    if panelChanged then
+        CS.selectedGroup = panelId
+        ClearSelectedButton()
+    end
+    if not (opts and opts.keepPanelMulti) then
+        wipe(CS.selectedPanels)
+    end
+
+    if opts and opts.multi then
+        if CS.selectedButtons[buttonIndex] then
+            CS.selectedButtons[buttonIndex] = nil
+        else
+            CS.selectedButtons[buttonIndex] = true
+        end
+        if CS.selectedButton and not CS.selectedButtons[CS.selectedButton] and next(CS.selectedButtons) then
+            CS.selectedButtons[CS.selectedButton] = true
+        end
+        CS.selectedButton = nil
+    else
+        wipe(CS.selectedButtons)
+        if opts and opts.force then
+            CS.selectedButton = buttonIndex
+        elseif not panelChanged and CS.selectedButton == buttonIndex then
+            CS.selectedButton = nil
+        else
+            CS.selectedButton = buttonIndex
+        end
+    end
+
+    CooldownCompanion:ClearAllConfigPreviews()
+end
+
+local function SelectConfigButtonPanel(panelId, opts)
+    if CS.selectedGroup ~= panelId then
+        CooldownCompanion:ClearAllConfigPreviews()
+        CS.selectedGroup = panelId
+        ClearSelectedButton()
+    end
+    if opts and opts.clearPanelMulti then
+        wipe(CS.selectedPanels)
+    end
+end
+
 local function ResetConfigSelection(full)
     if full and ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
@@ -2573,6 +2724,14 @@ ST._BUTTON_SPACING = BUTTON_SPACING
 ST._PROFILE_BAR_HEIGHT = PROFILE_BAR_HEIGHT
 ST._BuildHeroTalentSubTreeCheckboxes = BuildHeroTalentSubTreeCheckboxes
 ST._ApplyCheckboxIndent = ApplyCheckboxIndent
+ST._ClearConfigPrimarySelection = ClearConfigPrimarySelection
+ST._SelectConfigFolder = SelectConfigFolder
+ST._SelectConfigContainer = SelectConfigContainer
+ST._ToggleConfigContainerMultiSelect = ToggleConfigContainerMultiSelect
+ST._SelectConfigPanel = SelectConfigPanel
+ST._ToggleConfigPanelMultiSelect = ToggleConfigPanelMultiSelect
+ST._SelectConfigButton = SelectConfigButton
+ST._SelectConfigButtonPanel = SelectConfigButtonPanel
 ST._ResetConfigSelection = ResetConfigSelection
 ST._SetConfigPrimaryMode = SetConfigPrimaryMode
 ST._GroupsHaveForeignSpecs = GroupsHaveForeignSpecs


### PR DESCRIPTION
## What Changed
- Added shared config state helpers for normal folder, group, panel, and button selection transitions.
- Replaced repeated selection mutation blocks in Column 1 and Column 2 normal navigation flows with named helper calls.
- Left specialized lifecycle, drag, import, and Custom Bars paths for the later planned PRs.

## Why This Changed
- Config selection is effectively a small state machine, but the transition rules were duplicated across config columns.
- Centralizing the common transitions reduces stale-selection risk and makes the remaining direct mutations easier to audit in follow-up PRs.

## Developer Impact
- Column code now expresses the intended selection action instead of manually clearing each related `CS.selected*` field.
- The change removes most duplicated normal-navigation cleanup from the columns while keeping the broader cleanup effort incremental.

## Validation
- `luac -p Config\State.lua Config\Column1.lua Config\Column2.lua`
- Full repo Lua parse for all `.lua` files.
- `git diff --check -- Config/State.lua Config/Column1.lua Config/Column2.lua`
- Manual in-game validation checklist cleared on May 25, 2026: select/deselect, ctrl-click multiselect, right-click context selection, search navigation, add-new paths, browse/copy flows, and Lua-error watch.