### PR TITLE
Keep Custom Bar config selection in sync

### DIFF
--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -11,6 +11,8 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
+local SetConfigCustomBarSettingsTab = ST._SetConfigCustomBarSettingsTab
+local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 
 ------------------------------------------------------------------------
 -- COLUMN 4: Group / Panel Settings Column
@@ -28,22 +30,29 @@ local function ClearInfoButtons(buttons)
     wipe(buttons)
 end
 
-local function FindSelectedCustomBar()
-    if not CS.selectedCustomBarId or not CooldownCompanion.GetSpecCustomAuraBars then
+local function FindCustomBarById(settings, customBarId)
+    if not customBarId then
         return nil
     end
 
-    local settings = CooldownCompanion:GetResourceBarSettings()
     if ST._RB and ST._RB.FindCustomBarById then
-        return ST._RB.FindCustomBarById(settings, CS.selectedCustomBarId)
+        return ST._RB.FindCustomBarById(settings, customBarId)
+    end
+
+    if not CooldownCompanion.GetSpecCustomAuraBars then
+        return nil
     end
 
     for _, entry in ipairs(CooldownCompanion:GetSpecCustomAuraBars() or {}) do
-        if type(entry) == "table" and entry.customBarId == CS.selectedCustomBarId then
+        if type(entry) == "table" and entry.customBarId == customBarId then
             return entry
         end
     end
     return nil
+end
+
+local function FindSelectedCustomBar()
+    return FindCustomBarById(CooldownCompanion:GetResourceBarSettings(), CS.selectedCustomBarId)
 end
 
 local function GetCustomBarEntryTabs(entry)
@@ -239,14 +248,14 @@ local function RefreshColumn4(container)
             local selectedCustomBarIds = {}
             local selectedCustomBarEntries = {}
             local settings = CooldownCompanion:GetResourceBarSettings()
+            local function CustomBarExists(customBarId)
+                return FindCustomBarById(settings, customBarId) ~= nil
+            end
+            PruneConfigCustomBarSelection(CustomBarExists, true)
             for customBarId in pairs(CS.selectedCustomBars) do
-                local entry = ST._RB.FindCustomBarById and ST._RB.FindCustomBarById(settings, customBarId)
-                if entry then
-                    selectedCustomBarIds[#selectedCustomBarIds + 1] = customBarId
-                    selectedCustomBarEntries[#selectedCustomBarEntries + 1] = entry
-                else
-                    CS.selectedCustomBars[customBarId] = nil
-                end
+                local entry = FindCustomBarById(settings, customBarId)
+                selectedCustomBarIds[#selectedCustomBarIds + 1] = customBarId
+                selectedCustomBarEntries[#selectedCustomBarEntries + 1] = entry
             end
             table.sort(selectedCustomBarIds)
             if #selectedCustomBarEntries >= 2 then
@@ -260,18 +269,17 @@ local function RefreshColumn4(container)
 
                 local selectedEntry = FindSelectedCustomBar()
                 if not selectedEntry then
-                    CS.selectedCustomBarId = nil
-                    CS.customBarSettingsTab = "appearance"
+                    PruneConfigCustomBarSelection(CustomBarExists, true)
                 else
                     if CS.customBarSettingsTab == "settings"
                         or CS.customBarSettingsTab == "layout"
                         or CS.customBarSettingsTab == "anchor"
                         or CS.customBarSettingsTab == "alpha"
                     then
-                        CS.customBarSettingsTab = "appearance"
+                        SetConfigCustomBarSettingsTab("appearance")
                     end
                     if not IsCustomBarEntryTabAllowed(selectedEntry, CS.customBarSettingsTab) then
-                        CS.customBarSettingsTab = "appearance"
+                        SetConfigCustomBarSettingsTab("appearance")
                     end
 
                     if not container.customBarEntryTabGroup then
@@ -279,15 +287,7 @@ local function RefreshColumn4(container)
                         tabGroup:SetLayout("Fill")
                         tabGroup.frame:SetParent(container)
                         tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
-                            CS.customBarSettingsTab = tab or "appearance"
-                            if CS.customBarSettingsTab ~= "indicators" then
-                                if CooldownCompanion.ClearAllCustomAuraBarPreviews then
-                                    CooldownCompanion:ClearAllCustomAuraBarPreviews()
-                                end
-                                if CS.customBarIndicatorPreviewActive and CooldownCompanion.StopResourceBarPreview then
-                                    CooldownCompanion:StopResourceBarPreview()
-                                end
-                            end
+                            SetConfigCustomBarSettingsTab(tab, true)
                             ClearInfoButtons(CS.customBarInfoButtons)
                             widget:ReleaseChildren()
 

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2493,6 +2493,85 @@ local function SelectConfigButtonPanel(panelId, opts)
     end
 end
 
+local function ClearConfigCustomBarPreviewState()
+    if CooldownCompanion.ClearAllCustomAuraBarPreviews then
+        CooldownCompanion:ClearAllCustomAuraBarPreviews()
+    end
+    if CS.customBarIndicatorPreviewActive and CooldownCompanion.StopResourceBarPreview then
+        CooldownCompanion:StopResourceBarPreview()
+    end
+end
+
+local function SetConfigCustomBarSettingsTab(tab, clearPreviewOnNonIndicator)
+    CS.customBarSettingsTab = tab or "appearance"
+    if clearPreviewOnNonIndicator and CS.customBarSettingsTab ~= "indicators" then
+        ClearConfigCustomBarPreviewState()
+    end
+end
+
+local function ClearConfigCustomBarSelection(clearPreview)
+    if clearPreview then
+        ClearConfigCustomBarPreviewState()
+    end
+    CS.selectedCustomBarId = nil
+    wipe(CS.selectedCustomBars)
+    SetConfigCustomBarSettingsTab("appearance")
+end
+
+local function SelectConfigCustomBar(customBarId, opts)
+    local selectionChanged = CS.selectedCustomBarId ~= customBarId
+    if opts and opts.toggle and not selectionChanged then
+        ClearConfigCustomBarSelection(opts.clearPreview)
+        return true
+    end
+
+    if selectionChanged and opts and opts.clearPreview then
+        ClearConfigCustomBarPreviewState()
+    end
+    CS.selectedCustomBarId = customBarId
+    if opts and opts.resetTab then
+        SetConfigCustomBarSettingsTab("appearance")
+    end
+    wipe(CS.selectedCustomBars)
+    if opts and opts.clearButtonMulti then
+        wipe(CS.selectedButtons)
+    end
+    return selectionChanged
+end
+
+local function ToggleConfigCustomBarMultiSelect(customBarId)
+    if CS.selectedCustomBars[customBarId] then
+        CS.selectedCustomBars[customBarId] = nil
+    else
+        CS.selectedCustomBars[customBarId] = true
+    end
+    if CS.selectedCustomBarId and not CS.selectedCustomBars[CS.selectedCustomBarId] and next(CS.selectedCustomBars) then
+        CS.selectedCustomBars[CS.selectedCustomBarId] = true
+    end
+    ClearConfigCustomBarPreviewState()
+end
+
+local function PruneConfigCustomBarSelection(customBarExists, resetTab)
+    if type(customBarExists) ~= "function" then
+        return
+    end
+
+    if CS.selectedCustomBarId and not customBarExists(CS.selectedCustomBarId) then
+        CS.selectedCustomBarId = nil
+        if resetTab then
+            SetConfigCustomBarSettingsTab("appearance")
+        end
+    end
+    if CS.customBarSpecExpandedId and not customBarExists(CS.customBarSpecExpandedId) then
+        CS.customBarSpecExpandedId = nil
+    end
+    for customBarId in pairs(CS.selectedCustomBars) do
+        if not customBarExists(customBarId) then
+            CS.selectedCustomBars[customBarId] = nil
+        end
+    end
+end
+
 local function ResetConfigSelection(full)
     if full and ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
@@ -2732,6 +2811,12 @@ ST._SelectConfigPanel = SelectConfigPanel
 ST._ToggleConfigPanelMultiSelect = ToggleConfigPanelMultiSelect
 ST._SelectConfigButton = SelectConfigButton
 ST._SelectConfigButtonPanel = SelectConfigButtonPanel
+ST._ClearConfigCustomBarPreviewState = ClearConfigCustomBarPreviewState
+ST._SetConfigCustomBarSettingsTab = SetConfigCustomBarSettingsTab
+ST._ClearConfigCustomBarSelection = ClearConfigCustomBarSelection
+ST._SelectConfigCustomBar = SelectConfigCustomBar
+ST._ToggleConfigCustomBarMultiSelect = ToggleConfigCustomBarMultiSelect
+ST._PruneConfigCustomBarSelection = PruneConfigCustomBarSelection
 ST._ResetConfigSelection = ResetConfigSelection
 ST._SetConfigPrimaryMode = SetConfigPrimaryMode
 ST._GroupsHaveForeignSpecs = GroupsHaveForeignSpecs

--- a/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -12,6 +12,11 @@ local LSM = LibStub("LibSharedMedia-3.0")
 local CS = ST._configState
 local IsPassiveOrProc = ST._IsPassiveOrProc
 local ShowPopupAboveConfig = CS.ShowPopupAboveConfig
+local ClearCustomBarPreviewState = ST._ClearConfigCustomBarPreviewState
+local SelectConfigCustomBar = ST._SelectConfigCustomBar
+local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
+local ToggleConfigCustomBarMultiSelect = ST._ToggleConfigCustomBarMultiSelect
+local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
@@ -209,8 +214,6 @@ local function FindCustomBarIndexById(customBars, customBarId)
     end
     return nil
 end
-
-local ClearCustomBarPreviewState
 
 local function EnsureCustomBarRowTextBadge(frame, key)
     local badge = frame[key]
@@ -543,13 +546,6 @@ local function HideCustomBarRowDecorations(frame)
     end
 end
 
-ClearCustomBarPreviewState = function()
-    CooldownCompanion:ClearAllCustomAuraBarPreviews()
-    if CS.customBarIndicatorPreviewActive then
-        CooldownCompanion:StopResourceBarPreview()
-    end
-end
-
 local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
     if not CS.customBarContextMenu then
         CS.customBarContextMenu = CreateFrame("Frame", "CDCCustomBarContextMenu", UIParent, "UIDropDownMenuTemplate")
@@ -581,9 +577,10 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
             CloseDropDownMenus()
             local newId = DuplicateCustomBarById(CooldownCompanion:GetResourceBarSettings(), specID, customBars, customBarId)
             if newId then
-                ClearCustomBarPreviewState()
-                CS.selectedCustomBarId = newId
-                CS.customBarSettingsTab = "appearance"
+                SelectConfigCustomBar(newId, {
+                    clearPreview = true,
+                    resetTab = true,
+                })
             end
             ApplyCustomAuraBarPanelChanges({
                 updateAnchors = true,
@@ -616,9 +613,7 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
             local settings = CooldownCompanion:GetResourceBarSettings()
             if DeleteCustomBarById(settings, specID, customBars, customBarId) then
                 if CS.selectedCustomBarId == customBarId then
-                    ClearCustomBarPreviewState()
-                    CS.selectedCustomBarId = nil
-                    CS.customBarSettingsTab = "appearance"
+                    ClearConfigCustomBarSelection(true)
                 end
                 if CS.customBarSpecExpandedId == customBarId then
                     CS.customBarSpecExpandedId = nil
@@ -1562,19 +1557,10 @@ local function BuildCustomBarsListPanel(container)
 
     local customBarsSpecID = GetCurrentConfigSpecID()
     local customBars = RB.GetAllCustomBars and RB.GetAllCustomBars(settings) or CooldownCompanion:GetSpecCustomAuraBars()
+    PruneConfigCustomBarSelection(function(customBarId)
+        return FindCustomBarIndexById(customBars, customBarId) ~= nil
+    end)
     local selectedId = CS.selectedCustomBarId
-    if selectedId and not FindCustomBarIndexById(customBars, selectedId) then
-        CS.selectedCustomBarId = nil
-        selectedId = nil
-    end
-    if CS.customBarSpecExpandedId and not FindCustomBarIndexById(customBars, CS.customBarSpecExpandedId) then
-        CS.customBarSpecExpandedId = nil
-    end
-    for customBarId in pairs(CS.selectedCustomBars) do
-        if not FindCustomBarIndexById(customBars, customBarId) then
-            CS.selectedCustomBars[customBarId] = nil
-        end
-    end
 
     local addBox = AceGUI:Create("EditBox")
     if addBox.editbox.Instructions then addBox.editbox.Instructions:Hide() end
@@ -1667,8 +1653,7 @@ local function BuildCustomBarsListPanel(container)
             customBars[#customBars + 1] = entry
             EnsureCustomBarLayout(settings, nil, id, 1000 + #customBars)
         end
-        wipe(CS.selectedCustomBars)
-        CS.selectedCustomBarId = id
+        SelectConfigCustomBar(id)
         ApplyCustomAuraBarPanelChanges({
             updateAnchors = true,
             refreshConfig = true,
@@ -1956,43 +1941,25 @@ local function BuildCustomBarsListPanel(container)
                 return
             end
             if mouseButton == "RightButton" then
-                local selectionChanged = CS.selectedCustomBarId ~= customBarId
-                if selectionChanged then
-                    ClearCustomBarPreviewState()
-                end
-                CS.selectedCustomBarId = customBarId
-                wipe(CS.selectedButtons)
-                wipe(CS.selectedCustomBars)
+                local selectionChanged = SelectConfigCustomBar(customBarId, {
+                    clearPreview = true,
+                    clearButtonMulti = true,
+                })
                 if selectionChanged then
                     CooldownCompanion:RefreshConfigPanel()
                 end
                 OpenCustomBarRowMenu(customBars, customBarsSpecID, customBarId, entry)
             elseif mouseButton == "LeftButton" then
                 if IsControlKeyDown and IsControlKeyDown() then
-                    if CS.selectedCustomBars[customBarId] then
-                        CS.selectedCustomBars[customBarId] = nil
-                    else
-                        CS.selectedCustomBars[customBarId] = true
-                    end
-                    if CS.selectedCustomBarId and not CS.selectedCustomBars[CS.selectedCustomBarId] and next(CS.selectedCustomBars) then
-                        CS.selectedCustomBars[CS.selectedCustomBarId] = true
-                    end
-                    ClearCustomBarPreviewState()
+                    ToggleConfigCustomBarMultiSelect(customBarId)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
 
-                wipe(CS.selectedCustomBars)
-                if CS.selectedCustomBarId == customBarId then
-                    ClearCustomBarPreviewState()
-                    CS.selectedCustomBarId = nil
-                    CS.customBarSettingsTab = "appearance"
-                else
-                    if CS.selectedCustomBarId ~= customBarId then
-                        ClearCustomBarPreviewState()
-                    end
-                    CS.selectedCustomBarId = customBarId
-                end
+                SelectConfigCustomBar(customBarId, {
+                    clearPreview = true,
+                    toggle = true,
+                })
                 CooldownCompanion:RefreshConfigPanel()
             end
         end)


### PR DESCRIPTION
## What Players Will Notice
- Custom Bar rows in Bars & Frames config keep behaving like the other selectable config rows, including showing the selected-row highlight after the list refreshes.
- Single-select, multi-select, duplicate, delete, and settings-tab navigation should feel unchanged from the player side.

## Why This Changed
- Custom Bar selection was being changed directly in multiple config surfaces, which made stale or drifting selection state easier to introduce.
- During validation, that risk showed up as the selected Custom Bar row losing its visible highlight after stale-selection cleanup moved.

## What Changed
- Added shared Config state helpers for Custom Bar selection, multi-select toggling, stale-selection pruning, tab selection, and preview clearing.
- Routed Custom Bar list interactions and Column 4 detail refresh through those helpers.
- Preserved the selected-row state used by the Custom Bar list renderer after pruning stale selections.

## Validation
- Targeted Lua parse passed for `Config/State.lua`, `Config/Column4.lua`, and `ConfigSettings/ResourceBarPanelsCustomBars.lua`.
- Full repo Lua parse passed: `All Lua files parsed`.
- `git diff --check` passed, with only Git LF-to-CRLF warnings.
- Code review found no actionable issues.
- In-game validation: the broader PR2 checklist was confirmed before the selected-row highlight follow-up. The final highlight fix still needs one focused in-game confirmation, and combat or restricted-content behavior was not separately verified for this config-only cleanup.