### PR TITLE
Keep config selection cleanup consistent after lifecycle actions

### DIFF
--- a/Config/DragReorderLifecycle.lua
+++ b/Config/DragReorderLifecycle.lua
@@ -12,6 +12,8 @@ ST._DragReorder = DR
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
 local GroupsHaveForeignSpecs = ST._GroupsHaveForeignSpecs
 local FolderHasForeignSpecs = ST._FolderHasForeignSpecs
+local SelectConfigPanel = ST._SelectConfigPanel
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
 
 local DRAG_THRESHOLD = 8
 local PREVIEW_MODE_PANEL_COMPACT = DR.PREVIEW_MODE_PANEL_COMPACT
@@ -570,11 +572,7 @@ local function FinishPanelDrag(state)
     local dropTarget = state.dropTarget
     local changed = dropTarget and not IsPanelReorderNoOp(state.sourcePanelId, dropTarget.targetIndex, state.panelDropTargets)
     if changed then
-        CooldownCompanion:ClearAllConfigPreviews()
-        wipe(CS.selectedPanels)
-        CS.selectedGroup = state.sourcePanelId
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        SelectConfigPanel(state.sourcePanelId)
         PerformPanelReorder(state.sourcePanelId, dropTarget.targetIndex, state.panelDropTargets)
         for _, entry in ipairs(state.panelDropTargets) do
             CooldownCompanion:RefreshGroupFrame(entry.panelId)
@@ -615,8 +613,7 @@ local function FinishButtonDrag(state)
         CooldownCompanion:RefreshGroupFrame(state.groupId)
     end
     CooldownCompanion:ClearAllConfigPreviews()
-    CS.selectedButton = nil
-    wipe(CS.selectedButtons)
+    ClearConfigButtonSelection()
     CooldownCompanion:RefreshConfigPanel()
 end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -13,6 +13,7 @@ local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 
 -- Imports from earlier Config/ files
 local ResetConfigSelection = ST._ResetConfigSelection
+local ClearConfigPrimarySelection = ST._ClearConfigPrimarySelection
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
 local COLUMN_PADDING = ST._COLUMN_PADDING
 local BuildAutocompleteCache = ST._BuildAutocompleteCache
@@ -489,7 +490,6 @@ local function ResetConfigForProfileChange()
     ResetConfigSelection(true)
     wipe(CS.collapsedFolders)
     wipe(CS.collapsedPanels)
-    CS.selectedCustomBarId = nil
     wipe(CS.resourceAuraOverlayDrafts)
     if ClearConfigFinderText then
         ClearConfigFinderText()
@@ -1012,17 +1012,10 @@ local function CreateConfigPanel()
         if CS.resourceBarPanelActive then
             SetPrimaryMode("buttons", { skipRefresh = true })
         end
-        CooldownCompanion:ClearAllConfigPreviews()
         CS.browseMode = true
         CS.browseCharKey = nil
         CS.browseContainerId = nil
-        CS.selectedFolder = nil
-        CS.selectedContainer = nil
-        CS.selectedGroup = nil
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-        wipe(CS.selectedPanels)
-        wipe(CS.selectedGroups)
+        ClearConfigPrimarySelection()
         CooldownCompanion:RefreshConfigPanel()
     end)
     browseBtn:SetScript("OnEnter", function(self)

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -9,6 +9,11 @@ local CooldownCompanion = ST.Addon
 local CS = ST._configState
 
 local ResetConfigSelection = ST._ResetConfigSelection
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelSelection = ST._ClearConfigPanelSelection
+local ClearConfigContainerSelection = ST._ClearConfigContainerSelection
+local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
+local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local DecodeSharedPayload = ST._DecodeSharedPayload
 local PrepareSharedImportText = ST._PrepareSharedImportText
@@ -80,16 +85,11 @@ StaticPopupDialogs["CDC_DELETE_GROUP"] = {
             CooldownCompanion:DeleteGroup(id)
             if data.containerId then
                 if CS.selectedContainer == id then
-                    CS.selectedContainer = nil
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
+                    ClearConfigContainerSelection()
                 end
             else
                 if CS.selectedGroup == id then
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
+                    ClearConfigPanelSelection()
                 end
             end
             CS.selectedGroups[id] = nil
@@ -111,7 +111,7 @@ StaticPopupDialogs["CDC_DELETE_PANEL"] = {
         CooldownCompanion:ClearAllConfigPreviews()
         CooldownCompanion:DeletePanel(data.containerId, data.panelId)
         if CS.selectedGroup == data.panelId then
-            CS.selectedGroup = nil
+            ClearConfigPanelSelection()
         end
         if CS.addingToPanelId == data.panelId then
             CS.addingToPanelId = nil
@@ -220,8 +220,8 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_PANELS"] = {
             for _, pid in ipairs(data.panelIds) do
                 CooldownCompanion:DeletePanel(data.containerId, pid)
             end
-            wipe(CS.selectedPanels)
-            CS.selectedGroup = nil
+            ClearConfigPanelMultiSelection()
+            ClearConfigPanelSelection()
             CooldownCompanion:RefreshConfigPanel()
         end
     end,
@@ -714,8 +714,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
             ST._StripButtonOverrides(buttonData)
             CooldownCompanion:RefreshGroupFrame(data.sourcePanelId)
             CooldownCompanion:RefreshGroupFrame(data.targetPanelId)
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
+            ClearConfigButtonSelection()
             CooldownCompanion:RefreshConfigPanel()
         end
     end,
@@ -791,10 +790,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
             for _, customBarId in ipairs(data.ids) do
                 rb.DeleteCustomBar(settings, customBarId)
             end
-            CS.selectedCustomBarId = nil
-            CS.customBarSpecExpandedId = nil
-            wipe(CS.selectedCustomBars)
-            CooldownCompanion:ClearAllCustomAuraBarPreviews()
+            ClearConfigCustomBarSelection(true, { clearExpanded = true })
             CooldownCompanion:ApplyResourceBars()
             CooldownCompanion:UpdateAnchorStacking()
             CooldownCompanion:RefreshConfigPanel()
@@ -883,9 +879,7 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
             if CS.selectedGroup then
                 local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
                 if not group then
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
+                    ClearConfigPanelSelection()
                 end
             end
             for gid in pairs(CS.selectedGroups) do

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2347,6 +2347,31 @@ local function ClearSelectedButton()
     wipe(CS.selectedButtons)
 end
 
+local function ClearConfigButtonSelection()
+    ClearSelectedButton()
+end
+
+local function ClearConfigPanelSelection()
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+end
+
+local function ClearConfigContainerSelection()
+    CS.selectedContainer = nil
+    ClearConfigPanelSelection()
+end
+
+local function ClearConfigPanelMultiSelection(opts)
+    wipe(CS.selectedPanels)
+    if opts and opts.selectContainerId ~= nil then
+        CS.selectedContainer = opts.selectContainerId
+    end
+end
+
+local function ClearConfigContainerMultiSelection()
+    wipe(CS.selectedGroups)
+end
+
 local function ClearConfigPrimarySelection()
     CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedFolder = nil
@@ -2354,6 +2379,7 @@ local function ClearConfigPrimarySelection()
     CS.selectedGroup = nil
     ClearSelectedButton()
     wipe(CS.selectedPanels)
+    wipe(CS.selectedGroups)
     wipe(CS.selectedCustomBars)
 end
 
@@ -2509,11 +2535,14 @@ local function SetConfigCustomBarSettingsTab(tab, clearPreviewOnNonIndicator)
     end
 end
 
-local function ClearConfigCustomBarSelection(clearPreview)
+local function ClearConfigCustomBarSelection(clearPreview, opts)
     if clearPreview then
         ClearConfigCustomBarPreviewState()
     end
     CS.selectedCustomBarId = nil
+    if opts and opts.clearExpanded then
+        CS.customBarSpecExpandedId = nil
+    end
     wipe(CS.selectedCustomBars)
     SetConfigCustomBarSettingsTab("appearance")
 end
@@ -2803,6 +2832,11 @@ ST._BUTTON_SPACING = BUTTON_SPACING
 ST._PROFILE_BAR_HEIGHT = PROFILE_BAR_HEIGHT
 ST._BuildHeroTalentSubTreeCheckboxes = BuildHeroTalentSubTreeCheckboxes
 ST._ApplyCheckboxIndent = ApplyCheckboxIndent
+ST._ClearConfigButtonSelection = ClearConfigButtonSelection
+ST._ClearConfigPanelSelection = ClearConfigPanelSelection
+ST._ClearConfigContainerSelection = ClearConfigContainerSelection
+ST._ClearConfigPanelMultiSelection = ClearConfigPanelMultiSelection
+ST._ClearConfigContainerMultiSelection = ClearConfigContainerMultiSelection
 ST._ClearConfigPrimarySelection = ClearConfigPrimarySelection
 ST._SelectConfigFolder = SelectConfigFolder
 ST._SelectConfigContainer = SelectConfigContainer

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -9,6 +9,9 @@ local CS = ST._configState
 local CreateGlowContainer = ST._CreateGlowContainer
 local ShowGlowStyle = ST._ShowGlowStyle
 local HideGlowStyles = ST._HideGlowStyles
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
+local ClearConfigContainerMultiSelection = ST._ClearConfigContainerMultiSelection
 
 local pairs = pairs
 local next = next
@@ -787,18 +790,16 @@ local function NotifyTutorialAction(action, payload)
 
     if action == "group_created" and (runtime.step == "welcome" or runtime.step == "groups_column_intro" or runtime.step == "create_group") then
         runtime.createdGroup = true
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-        wipe(CS.selectedPanels)
-        wipe(CS.selectedGroups)
+        ClearConfigButtonSelection()
+        ClearConfigPanelMultiSelection()
+        ClearConfigContainerMultiSelection()
         AdvanceStep("panels_column_intro")
     elseif action == "panel_created" and (runtime.step == "panels_column_intro" or runtime.step == "create_panel") then
         if payload and payload.displayMode == "icons" then
             runtime.createdPanel = true
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
-            wipe(CS.selectedPanels)
-            wipe(CS.selectedGroups)
+            ClearConfigButtonSelection()
+            ClearConfigPanelMultiSelection()
+            ClearConfigContainerMultiSelection()
             AdvanceStep("panel_area_intro")
         end
     elseif action == "inline_add_succeeded" and (runtime.step == "panel_area_intro" or runtime.step == "add_one_spell") then

--- a/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -7,6 +7,8 @@ local ColorHeading = ST._ColorHeading
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
@@ -46,8 +48,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
             table.insert(sourceGroup.buttons, idx + 1, copy)
         end
         CooldownCompanion:RefreshGroupFrame(sourceGroupId)
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        ClearConfigButtonSelection()
         CooldownCompanion:RefreshConfigPanel()
     end)
     scroll:AddChild(dupBtn)
@@ -119,8 +120,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                         end
                         CooldownCompanion:RefreshGroupFrame(groupEntry.id)
                         CooldownCompanion:RefreshGroupFrame(sourceGroupId)
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        ClearConfigButtonSelection()
                         CooldownCompanion:RefreshConfigPanel()
                         CloseDropDownMenus()
                     end
@@ -149,8 +149,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                         end
                         CooldownCompanion:RefreshGroupFrame(groupEntry.id)
                         CooldownCompanion:RefreshGroupFrame(sourceGroupId)
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        ClearConfigButtonSelection()
                         CooldownCompanion:RefreshConfigPanel()
                         CloseDropDownMenus()
                     end
@@ -280,7 +279,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
         for _, pid in ipairs(multiPanelIds) do
             CooldownCompanion:DuplicatePanel(containerId, pid)
         end
-        wipe(CS.selectedPanels)
+        ClearConfigPanelMultiSelection()
         CooldownCompanion:RefreshConfigPanel()
     end)
     scroll:AddChild(dupBtn)
@@ -354,8 +353,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                             for _, pid in ipairs(multiPanelIds) do
                                 CooldownCompanion:MovePanel(pid, container.id)
                             end
-                            wipe(CS.selectedPanels)
-                            CS.selectedContainer = container.id
+                            ClearConfigPanelMultiSelection({ selectContainerId = container.id })
                             CooldownCompanion:RefreshConfigPanel()
                         end
                         UIDropDownMenu_AddButton(info, level)
@@ -379,8 +377,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                             for _, pid in ipairs(multiPanelIds) do
                                 CooldownCompanion:MovePanel(pid, container.id)
                             end
-                            wipe(CS.selectedPanels)
-                            CS.selectedContainer = container.id
+                            ClearConfigPanelMultiSelection({ selectContainerId = container.id })
                             CooldownCompanion:RefreshConfigPanel()
                         end
                         UIDropDownMenu_AddButton(info, level)


### PR DESCRIPTION
## What Changed
- Centralized repeated config selection cleanup after delete, browse-mode, tutorial, drag/reorder, and batch multiselect actions into shared `Config/State.lua` helpers.
- Replaced duplicated `CS.selected*` clear blocks in popup, panel lifecycle, tutorial, drag lifecycle, and multiselect settings paths.
- Left direct selection mutation in place where it is still intentional local behavior, such as drag index repair, tutorial entry focus, and stale folder pruning.

## Why This Changed
- Config selection behaves like a small state machine across columns, and duplicated cleanup blocks made stale selections easier to reintroduce after lifecycle actions.
- Keeping those transitions named and shared should make future config changes easier to reason about.

## Developer Impact
- Future config cleanup paths can use focused helper calls instead of re-listing every selected container, panel, button, multiselect, and custom-bar field by hand.
- The scope stays behavior-preserving: no config UI redesign, storage change, import/export format change, or runtime display behavior change.

## Validation
- Lua parse passed for all touched files.
- Full repo Lua parse passed.
- `git diff --check` passed, with only expected LF/CRLF checkout warnings.
- `compound-engineering:ce-code-review` reported no actionable issues.
- User-reported in-game validation passed for the destructive and lifecycle config smoke flows.
- No runtime display, combat, or restricted-content behavior was changed by this config-only refactor.