### PR TITLE
Keep config selections consistent after cleanup actions

### DIFF
--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -38,6 +38,7 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local SelectConfigFinderResult = ST._SelectConfigFinderResult
+local SelectConfigContainer = ST._SelectConfigContainer
 local SelectConfigPanel = ST._SelectConfigPanel
 local ToggleConfigPanelMultiSelect = ST._ToggleConfigPanelMultiSelect
 local SelectConfigButton = ST._SelectConfigButton
@@ -271,12 +272,7 @@ local function FinalizeCreatedPanel(newPanelId, displayMode, opts)
         CooldownCompanion:RefreshGroupFrame(newPanelId)
     end
 
-    CooldownCompanion:ClearAllConfigPreviews()
-    CS.selectedGroup = newPanelId
-    if opts and opts.clearSelection then
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-    end
+    SelectConfigPanel(newPanelId)
     CS.addingToPanelId = newPanelId
     CS.pendingEditBoxFocus = true
     CooldownCompanion:RefreshConfigPanel()
@@ -333,7 +329,6 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
         "Icon Panel",
         function()
             CreatePanelInSelectedContainer("icons", {
-                clearSelection = true,
                 notifyTutorial = true,
             })
         end,
@@ -383,9 +378,7 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
             AddPanelTypeMenuTooltip(info, "textures")
             info.func = function()
                 CloseDropDownMenus()
-                CreatePanelInSelectedContainer("textures", {
-                    clearSelection = true,
-                })
+                CreatePanelInSelectedContainer("textures")
             end
             UIDropDownMenu_AddButton(info, level)
 
@@ -395,9 +388,7 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
             AddPanelTypeMenuTooltip(info, "trigger")
             info.func = function()
                 CloseDropDownMenus()
-                CreatePanelInSelectedContainer("trigger", {
-                    clearSelection = true,
-                })
+                CreatePanelInSelectedContainer("trigger")
             end
             UIDropDownMenu_AddButton(info, level)
         end, "MENU")
@@ -1527,8 +1518,7 @@ local function RefreshColumn2()
                             CS.browseMode = false
                             CS.browseCharKey = nil
                             CS.browseContainerId = nil
-                            CS.selectedContainer = newCid
-                            CS.selectedGroup = newGid
+                            SelectConfigPanel(newGid, { containerId = newCid })
                             CooldownCompanion:RefreshConfigPanel()
                             CooldownCompanion:Print("Panel copied as new group.")
                         end
@@ -1565,8 +1555,7 @@ local function RefreshColumn2()
                                 CS.browseMode = false
                                 CS.browseCharKey = nil
                                 CS.browseContainerId = nil
-                                CS.selectedContainer = targetId
-                                CS.selectedGroup = newGid
+                                SelectConfigPanel(newGid, { containerId = targetId })
                                 CooldownCompanion:RefreshConfigPanel()
                                 CooldownCompanion:Print("Panel copied into " .. target.name .. ".")
                             end
@@ -1599,8 +1588,7 @@ local function RefreshColumn2()
                 CS.browseMode = false
                 CS.browseCharKey = nil
                 CS.browseContainerId = nil
-                CS.selectedContainer = newId
-                CS.selectedGroup = nil
+                SelectConfigContainer(newId)
                 CooldownCompanion:RefreshConfigPanel()
                 CooldownCompanion:Print("Group copied successfully.")
             end
@@ -2216,9 +2204,7 @@ local function RefreshColumn2()
                                         if CooldownCompanion:ChangePanelDisplayMode(ctxPanelId, targetMode) then
                                             if targetMode == "textures" then
                                                 CS.pendingTexturePickerOpen = ctxPanelId
-                                                CS.selectedGroup = ctxPanelId
-                                                CS.selectedButton = nil
-                                                wipe(CS.selectedButtons)
+                                                SelectConfigPanel(ctxPanelId)
                                             end
                                             CooldownCompanion:RefreshConfigPanel()
                                         end
@@ -2234,8 +2220,7 @@ local function RefreshColumn2()
                                 CloseDropDownMenus()
                                 local newPanelId = CooldownCompanion:DuplicatePanel(ctxContainerId, ctxPanelId)
                                 if newPanelId then
-                                    CooldownCompanion:ClearAllConfigPreviews()
-                                    CS.selectedGroup = newPanelId
+                                    SelectConfigPanel(newPanelId)
                                     CooldownCompanion:RefreshConfigPanel()
                                 end
                             end
@@ -2378,15 +2363,10 @@ local function RefreshColumn2()
                                     info.notCheckable = true
                                     info.func = function()
                                         CloseDropDownMenus()
-                                        local _, sourceDeleted = CooldownCompanion:MovePanel(ctxPanelId, c.id)
-                                        CooldownCompanion:ClearAllConfigPreviews()
-                                        if sourceDeleted then
-                                            CS.selectedContainer = c.id
+                                        if CooldownCompanion:MovePanel(ctxPanelId, c.id) then
+                                            SelectConfigPanel(ctxPanelId, { containerId = c.id })
+                                            CooldownCompanion:RefreshConfigPanel()
                                         end
-                                        CS.selectedGroup = ctxPanelId
-                                        CS.selectedButton = nil
-                                        wipe(CS.selectedButtons)
-                                        CooldownCompanion:RefreshConfigPanel()
                                     end
                                     UIDropDownMenu_AddButton(info, level)
                                 end
@@ -2406,15 +2386,10 @@ local function RefreshColumn2()
                                     info.notCheckable = true
                                     info.func = function()
                                         CloseDropDownMenus()
-                                        local _, sourceDeleted = CooldownCompanion:MovePanel(ctxPanelId, c.id)
-                                        CooldownCompanion:ClearAllConfigPreviews()
-                                        if sourceDeleted then
-                                            CS.selectedContainer = c.id
+                                        if CooldownCompanion:MovePanel(ctxPanelId, c.id) then
+                                            SelectConfigPanel(ctxPanelId, { containerId = c.id })
+                                            CooldownCompanion:RefreshConfigPanel()
                                         end
-                                        CS.selectedGroup = ctxPanelId
-                                        CS.selectedButton = nil
-                                        wipe(CS.selectedButtons)
-                                        CooldownCompanion:RefreshConfigPanel()
                                     end
                                     UIDropDownMenu_AddButton(info, level)
                                 end

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -11,6 +11,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
+local ResetConfigSelection = ST._ResetConfigSelection
 local SetConfigCustomBarSettingsTab = ST._SetConfigCustomBarSettingsTab
 local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 
@@ -666,18 +667,8 @@ local function RefreshProfileBar(bar)
     profileDrop:SetValue(currentProfile)
     profileDrop:SetWidth(150)
     profileDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        CooldownCompanion:ClearAllConfigPreviews()
         db:SetProfile(val)
-        CS.selectedFolder = nil
-        CS.selectedContainer = nil
-        CS.selectedGroup = nil
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-        wipe(CS.selectedGroups)
-        -- Exit browse mode on profile switch
-        CS.browseMode = false
-        CS.browseCharKey = nil
-        CS.browseContainerId = nil
+        ResetConfigSelection(true)
         CooldownCompanion:RefreshConfigPanel()
         CooldownCompanion:RefreshAllGroups()
     end)

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -11,6 +11,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local DecodeSharedPayload = ST._DecodeSharedPayload
 local PrepareSharedImportText = ST._PrepareSharedImportText
+local ResetConfigSelection = ST._ResetConfigSelection
 
 -- File-local state
 local decodedDiagnostic = nil
@@ -929,10 +930,7 @@ StaticPopupDialogs["CDC_DIAGNOSTIC_IMPORT_CONFIRM"] = {
             for k, v in pairs(decodedDiagnostic.profile) do
                 db.profile[k] = v
             end
-            CS.selectedGroup = nil
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
-            wipe(CS.selectedGroups)
+            ResetConfigSelection(true)
             -- Remap only the exporter's own entities to the importer's character.
             -- Other characters' entities keep their original createdBy so they
             -- appear in the browse-other-characters module instead of being

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -73,6 +73,36 @@ local function ClearFolderFiltersForUnglobal(folderId)
     end
 end
 
+local function PruneDeletedFolderSelection(folderId)
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not db then return end
+
+    if CS.selectedFolder == folderId then
+        CS.selectedFolder = nil
+    end
+
+    if CS.selectedContainer and not (db.groupContainers and db.groupContainers[CS.selectedContainer]) then
+        ClearConfigContainerSelection()
+    elseif CS.selectedGroup and not (db.groups and db.groups[CS.selectedGroup]) then
+        ClearConfigPanelSelection()
+    end
+
+    if CS.addingToPanelId and not (db.groups and db.groups[CS.addingToPanelId]) then
+        CS.addingToPanelId = nil
+    end
+
+    for containerId in pairs(CS.selectedGroups) do
+        if not (db.groupContainers and db.groupContainers[containerId]) then
+            CS.selectedGroups[containerId] = nil
+        end
+    end
+    for panelId in pairs(CS.selectedPanels) do
+        if not (db.groups and db.groups[panelId]) then
+            CS.selectedPanels[panelId] = nil
+        end
+    end
+end
+
 StaticPopupDialogs["CDC_DELETE_GROUP"] = {
     text = "Are you sure you want to delete group '%s'?",
     button1 = "Delete",
@@ -873,20 +903,7 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
         if data and data.folderId then
             CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:DeleteFolder(data.folderId)
-            if CS.selectedFolder == data.folderId then
-                CS.selectedFolder = nil
-            end
-            if CS.selectedGroup then
-                local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
-                if not group then
-                    ClearConfigPanelSelection()
-                end
-            end
-            for gid in pairs(CS.selectedGroups) do
-                if not CooldownCompanion.db.profile.groups[gid] then
-                    CS.selectedGroups[gid] = nil
-                end
-            end
+            PruneDeletedFolderSelection(data.folderId)
             CooldownCompanion:RefreshConfigPanel()
         end
     end,

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -9,6 +9,7 @@ local CS = ST._configState
 local CreateGlowContainer = ST._CreateGlowContainer
 local ShowGlowStyle = ST._ShowGlowStyle
 local HideGlowStyles = ST._HideGlowStyles
+local ResetConfigSelection = ST._ResetConfigSelection
 local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
 local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigContainerMultiSelection = ST._ClearConfigContainerMultiSelection
@@ -432,25 +433,13 @@ local function NormalizeTutorialContext()
     if CS.talentPickerMode and CooldownCompanion.CloseTalentPicker then
         CooldownCompanion:CloseTalentPicker()
     end
-    if ST._CancelAutoAddFlow then
-        ST._CancelAutoAddFlow()
-    end
 
     CloseDropDownMenus()
     if CS.HideAutocomplete then
         CS.HideAutocomplete()
     end
 
-    CS.browseMode = false
-    CS.browseCharKey = nil
-    CS.browseContainerId = nil
-    CS.selectedContainer = nil
-    CS.selectedGroup = nil
-    CS.selectedButton = nil
-    wipe(CS.selectedButtons)
-    wipe(CS.selectedPanels)
-    wipe(CS.selectedGroups)
-    CS.addingToPanelId = nil
+    ResetConfigSelection(true)
     CS.newInput = ""
     CS.pendingEditBoxFocus = false
 


### PR DESCRIPTION
## What Players Will Notice
- Config selection should stay more predictable after profile switches, diagnostic profile imports, tutorial resets, panel copy/move actions, and folder deletion.
- Moving a panel to another group now keeps that moved panel selected under its new group instead of leaving selection tied to the previous group context.
- Deleting a folder now clears only selection state that became invalid, so unrelated selected groups or panels are not kicked out of their settings view.

## Why This Changed
- The config cleanup work centralized selection transitions across normal navigation, Custom Bars, and lifecycle actions, but the final audit found a few remaining direct mutation paths that could leave stale or overly broad selection state behind.

## What Changed
- Reused the shared config selection helpers for panel creation, copying, duplication, movement, profile switching, diagnostic import, and tutorial reset paths.
- Added targeted folder-delete pruning so removed folder/container/panel IDs are cleared without resetting unrelated active config context.
- Removed redundant inline selection-clearing blocks in favor of the central selection helpers where the helper behavior now matches the caller intent.

## Validation
- `luac -p` passed across all Lua files.
- `git diff --check origin/config-state-cleanup-dev-main...HEAD` passed.
- Static code review passed after fixing the folder-delete reset finding.
- In-game validation still needed before merge: profile switch, diagnostic import, tutorial reset, panel create/copy/duplicate/move, and deleting both selected and unselected folders. Combat/restricted-content validation has not been performed for this config-only cleanup.