### PR TITLE
Keep add selection aligned with config navigation

### DIFF
--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -16,30 +16,29 @@ local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local GetButtonIcon = ST._GetButtonIcon
 local CDM_VIEWER_NAMES = ST._CDM_VIEWER_NAMES
 local NotifyTutorialAction = ST._NotifyTutorialAction
+local SelectConfigPanel = ST._SelectConfigPanel
+local SelectConfigButton = ST._SelectConfigButton
 
 -- After a successful add, set selection state to the new button so the
 -- next RefreshConfigPanel shows its settings in Column 3.
 -- Precondition: CS.selectedContainer is already set by the caller's
 -- panel/container selection flow.
 local function SelectNewButton(panelId, buttonIndex)
-    CooldownCompanion:ClearAllConfigPreviews()
-
     local group = panelId and CooldownCompanion.db
         and CooldownCompanion.db.profile
         and CooldownCompanion.db.profile.groups
         and CooldownCompanion.db.profile.groups[panelId]
     if group and group.displayMode == "textures" then
-        CS.selectedGroup = panelId
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        SelectConfigPanel(panelId)
         CS.addingToPanelId = nil
         CS.pendingTexturePickerOpen = panelId
         return
     end
-    if not buttonIndex then return end
-    CS.selectedGroup = panelId
-    CS.selectedButton = buttonIndex
-    wipe(CS.selectedButtons)
+    if not buttonIndex then
+        CooldownCompanion:ClearAllConfigPreviews()
+        return
+    end
+    SelectConfigButton(panelId, buttonIndex, { force = true })
 end
 
 local function IsTexturePanelTarget(groupId)


### PR DESCRIPTION
## What Changed
- New spell, item, and CDM aura additions now use the shared config selection helpers when selecting the newly added entry.
- Texture-panel adds still select the panel and stage the texture picker instead of forcing an entry settings row.

## Why This Changed
- The config-selection cleanup centralized almost all selection transitions, but successful add behavior in `Config/SpellItemAdd.lua` still directly mutated selected panel/button state.
- Routing this last meaningful add path through the shared helpers keeps future config selection work easier to reason about.

## Developer Impact
- Successful add selection now follows the same stale-selection cleanup behavior as normal button selection.
- `SpellItemAdd` keeps its local post-add adapter, so add call sites stay readable while the shared helper owns the actual selection transition.

## Validation
- `luac -p Config\SpellItemAdd.lua` passed.
- `git diff --check origin/config-state-cleanup-dev-main...HEAD` passed.
- Static code review found no actionable issues.
- In-game validation still needed before merge: add a normal spell, add an item, pick an autocomplete result, drag/drop an entry, and add to a texture panel to confirm the texture picker still opens. Combat/restricted-content validation has not been performed for this config-only cleanup.