### PR TITLE
Keep config selections consistent across the settings UI

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -38,23 +38,13 @@ local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
-local ClearConfigFinderText = ST._ClearConfigFinderText
+local ClearConfigPrimarySelection = ST._ClearConfigPrimarySelection
+local SelectConfigFolder = ST._SelectConfigFolder
+local SelectConfigContainer = ST._SelectConfigContainer
+local ToggleConfigContainerMultiSelect = ST._ToggleConfigContainerMultiSelect
+local SelectConfigPanel = ST._SelectConfigPanel
 
 local GenerateGroupName
-
-------------------------------------------------------------------------
--- Clear all selection state (container, panel, button, multi-select)
-------------------------------------------------------------------------
-local function ClearSelection()
-    CooldownCompanion:ClearAllConfigPreviews()
-    CS.selectedFolder = nil
-    CS.selectedContainer = nil
-    CS.selectedGroup = nil
-    CS.selectedButton = nil
-    wipe(CS.selectedButtons)
-    wipe(CS.selectedPanels)
-    wipe(CS.selectedCustomBars)
-end
 
 local function TrimGroupName(name)
     if name == nil then return "" end
@@ -159,7 +149,7 @@ local function RenderBrowseMode()
             CS.browseMode = false
             CS.browseCharKey = nil
             CS.browseContainerId = nil
-            ClearSelection()
+            ClearConfigPrimarySelection()
             CooldownCompanion:RefreshConfigPanel()
         end)
         CS.col1Scroll:AddChild(backBtn)
@@ -197,7 +187,7 @@ local function RenderBrowseMode()
             entry:SetCallback("OnClick", function()
                 CS.browseCharKey = charInfo.charKey
                 CS.browseContainerId = nil
-                ClearSelection()
+                ClearConfigPrimarySelection()
                 CooldownCompanion:RefreshConfigPanel()
             end)
             CS.col1Scroll:AddChild(entry)
@@ -214,7 +204,7 @@ local function RenderBrowseMode()
         backBtn:SetCallback("OnClick", function()
             CS.browseCharKey = nil
             CS.browseContainerId = nil
-            ClearSelection()
+            ClearConfigPrimarySelection()
             CooldownCompanion:RefreshConfigPanel()
         end)
         CS.col1Scroll:AddChild(backBtn)
@@ -274,18 +264,13 @@ local function RenderBrowseMode()
             -- Left-click: select for preview; Right-click: copy context menu
             entry.frame:SetScript("OnMouseUp", function(self, button)
                 if button == "LeftButton" then
-                    CooldownCompanion:ClearAllConfigPreviews()
                     if CS.browseContainerId == containerId then
                         CS.browseContainerId = nil
-                        CS.selectedContainer = nil
+                        SelectConfigContainer(nil, { keepContainerMulti = true })
                     else
                         CS.browseContainerId = containerId
-                        CS.selectedContainer = containerId
+                        SelectConfigContainer(containerId, { keepContainerMulti = true })
                     end
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
-                    wipe(CS.selectedPanels)
                     CooldownCompanion:RefreshConfigPanel()
                 elseif button == "RightButton" then
                     -- Verify source still exists
@@ -302,12 +287,10 @@ local function RenderBrowseMode()
                             if not db.groupContainers[containerId] then return end
                             local newId = CooldownCompanion:CopyContainerFromBrowse(containerId)
                             if newId then
-                                CooldownCompanion:ClearAllConfigPreviews()
                                 CS.browseMode = false
                                 CS.browseCharKey = nil
                                 CS.browseContainerId = nil
-                                CS.selectedContainer = newId
-                                CS.selectedGroup = nil
+                                SelectConfigContainer(newId)
                                 CooldownCompanion:RefreshConfigPanel()
                                 CooldownCompanion:Print("Group copied successfully.")
                             end
@@ -462,9 +445,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                 CloseDropDownMenus()
                 local newContainerId = CooldownCompanion:DuplicateGroup(containerId)
                 if newContainerId then
-                    CooldownCompanion:ClearAllConfigPreviews()
-                    CS.selectedContainer = newContainerId
-                    CS.selectedGroup = nil
+                    SelectConfigContainer(newContainerId)
                     CooldownCompanion:RefreshConfigPanel()
                 end
             end
@@ -616,9 +597,10 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                     CloseDropDownMenus()
                     local newPanelId = CooldownCompanion:CreatePanel(containerId, targetMode)
                     if newPanelId then
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        CS.selectedContainer = containerId
-                        CS.selectedGroup = newPanelId
+                        SelectConfigPanel(newPanelId, {
+                            containerId = containerId,
+                            keepPanelMulti = true,
+                        })
                         CS.addingToPanelId = newPanelId
                         CS.pendingEditBoxFocus = true
                         CooldownCompanion:RefreshConfigPanel()
@@ -655,11 +637,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
             CloseDropDownMenus()
             local containerId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
             CooldownCompanion:MoveGroupToFolder(containerId, folderId)
-            CooldownCompanion:ClearAllConfigPreviews()
-            CS.selectedContainer = containerId
-            CS.selectedGroup = nil
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
+            SelectConfigContainer(containerId)
             CooldownCompanion:RefreshConfigPanel()
         end
         UIDropDownMenu_AddButton(info, level)
@@ -823,11 +801,7 @@ local function PopulateColumn1ButtonBar()
     newGroupBtn:SetText("New Group")
     newGroupBtn:SetCallback("OnClick", function()
         local containerId, groupId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
-        CooldownCompanion:ClearAllConfigPreviews()
-        CS.selectedContainer = containerId
-        CS.selectedGroup = nil
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        SelectConfigContainer(containerId)
         CooldownCompanion:RefreshConfigPanel()
         if NotifyTutorialAction then
             NotifyTutorialAction("group_created", {
@@ -1282,17 +1256,7 @@ local function RefreshColumn1(preserveDrag)
             if CS.dragState and CS.dragState.phase == "active" then return end
             if button == "LeftButton" then
                 if searchResults then
-                    CooldownCompanion:ClearAllConfigPreviews()
-                    wipe(CS.selectedGroups)
-                    wipe(CS.selectedPanels)
-                    wipe(CS.selectedButtons)
-                    CS.selectedFolder = nil
-                    CS.selectedContainer = containerId
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    if ClearConfigFinderText then
-                        ClearConfigFinderText()
-                    end
+                    SelectConfigContainer(containerId, { clearFinder = true })
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
@@ -1307,38 +1271,12 @@ local function RefreshColumn1(preserveDrag)
                     return
                 elseif IsControlKeyDown() then
                     -- Ctrl+click: toggle multi-select (container IDs)
-                    if CS.selectedGroups[containerId] then
-                        CS.selectedGroups[containerId] = nil
-                    else
-                        CS.selectedGroups[containerId] = true
-                    end
-                    if CS.selectedContainer and not CS.selectedGroups[CS.selectedContainer] and next(CS.selectedGroups) then
-                        CS.selectedGroups[CS.selectedContainer] = true
-                    end
-                    CS.selectedFolder = nil
-                    ClearSelection()
+                    ToggleConfigContainerMultiSelect(containerId)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
                 -- Normal click: toggle-through selection, clear multi-select
-                CooldownCompanion:ClearAllConfigPreviews()
-                wipe(CS.selectedGroups)
-                CS.selectedFolder = nil
-                if CS.selectedContainer == containerId then
-                    if CS.selectedGroup then
-                        -- First re-click: clear panel selection (return to container settings)
-                        CS.selectedGroup = nil
-                    else
-                        -- Second re-click: deselect container entirely
-                        CS.selectedContainer = nil
-                    end
-                else
-                    CS.selectedContainer = containerId
-                    CS.selectedGroup = nil
-                end
-                CS.selectedButton = nil
-                wipe(CS.selectedButtons)
-                wipe(CS.selectedPanels)
+                SelectConfigContainer(containerId, { toggle = true })
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "RightButton" then
                 ShowContainerContextMenu(db, charKey, containerId, container)
@@ -1683,14 +1621,7 @@ local function RefreshColumn1(preserveDrag)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
-                CooldownCompanion:ClearAllConfigPreviews()
-                CS.selectedFolder = folderId
-                CS.selectedContainer = nil
-                CS.selectedGroup = nil
-                CS.selectedButton = nil
-                wipe(CS.selectedGroups)
-                wipe(CS.selectedPanels)
-                wipe(CS.selectedButtons)
+                SelectConfigFolder(folderId)
                 CooldownCompanion:RefreshConfigPanel()
             elseif button == "MiddleButton" then
                 -- Lock/unlock all containers in this folder

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -38,6 +38,7 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local SelectConfigFinderResult = ST._SelectConfigFinderResult
+local SelectConfigContainer = ST._SelectConfigContainer
 local SelectConfigPanel = ST._SelectConfigPanel
 local ToggleConfigPanelMultiSelect = ST._ToggleConfigPanelMultiSelect
 local SelectConfigButton = ST._SelectConfigButton
@@ -271,12 +272,7 @@ local function FinalizeCreatedPanel(newPanelId, displayMode, opts)
         CooldownCompanion:RefreshGroupFrame(newPanelId)
     end
 
-    CooldownCompanion:ClearAllConfigPreviews()
-    CS.selectedGroup = newPanelId
-    if opts and opts.clearSelection then
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-    end
+    SelectConfigPanel(newPanelId)
     CS.addingToPanelId = newPanelId
     CS.pendingEditBoxFocus = true
     CooldownCompanion:RefreshConfigPanel()
@@ -333,7 +329,6 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
         "Icon Panel",
         function()
             CreatePanelInSelectedContainer("icons", {
-                clearSelection = true,
                 notifyTutorial = true,
             })
         end,
@@ -383,9 +378,7 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
             AddPanelTypeMenuTooltip(info, "textures")
             info.func = function()
                 CloseDropDownMenus()
-                CreatePanelInSelectedContainer("textures", {
-                    clearSelection = true,
-                })
+                CreatePanelInSelectedContainer("textures")
             end
             UIDropDownMenu_AddButton(info, level)
 
@@ -395,9 +388,7 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
             AddPanelTypeMenuTooltip(info, "trigger")
             info.func = function()
                 CloseDropDownMenus()
-                CreatePanelInSelectedContainer("trigger", {
-                    clearSelection = true,
-                })
+                CreatePanelInSelectedContainer("trigger")
             end
             UIDropDownMenu_AddButton(info, level)
         end, "MENU")
@@ -1527,8 +1518,7 @@ local function RefreshColumn2()
                             CS.browseMode = false
                             CS.browseCharKey = nil
                             CS.browseContainerId = nil
-                            CS.selectedContainer = newCid
-                            CS.selectedGroup = newGid
+                            SelectConfigPanel(newGid, { containerId = newCid })
                             CooldownCompanion:RefreshConfigPanel()
                             CooldownCompanion:Print("Panel copied as new group.")
                         end
@@ -1565,8 +1555,7 @@ local function RefreshColumn2()
                                 CS.browseMode = false
                                 CS.browseCharKey = nil
                                 CS.browseContainerId = nil
-                                CS.selectedContainer = targetId
-                                CS.selectedGroup = newGid
+                                SelectConfigPanel(newGid, { containerId = targetId })
                                 CooldownCompanion:RefreshConfigPanel()
                                 CooldownCompanion:Print("Panel copied into " .. target.name .. ".")
                             end
@@ -1599,8 +1588,7 @@ local function RefreshColumn2()
                 CS.browseMode = false
                 CS.browseCharKey = nil
                 CS.browseContainerId = nil
-                CS.selectedContainer = newId
-                CS.selectedGroup = nil
+                SelectConfigContainer(newId)
                 CooldownCompanion:RefreshConfigPanel()
                 CooldownCompanion:Print("Group copied successfully.")
             end
@@ -2216,9 +2204,7 @@ local function RefreshColumn2()
                                         if CooldownCompanion:ChangePanelDisplayMode(ctxPanelId, targetMode) then
                                             if targetMode == "textures" then
                                                 CS.pendingTexturePickerOpen = ctxPanelId
-                                                CS.selectedGroup = ctxPanelId
-                                                CS.selectedButton = nil
-                                                wipe(CS.selectedButtons)
+                                                SelectConfigPanel(ctxPanelId)
                                             end
                                             CooldownCompanion:RefreshConfigPanel()
                                         end
@@ -2234,8 +2220,7 @@ local function RefreshColumn2()
                                 CloseDropDownMenus()
                                 local newPanelId = CooldownCompanion:DuplicatePanel(ctxContainerId, ctxPanelId)
                                 if newPanelId then
-                                    CooldownCompanion:ClearAllConfigPreviews()
-                                    CS.selectedGroup = newPanelId
+                                    SelectConfigPanel(newPanelId)
                                     CooldownCompanion:RefreshConfigPanel()
                                 end
                             end
@@ -2378,15 +2363,10 @@ local function RefreshColumn2()
                                     info.notCheckable = true
                                     info.func = function()
                                         CloseDropDownMenus()
-                                        local _, sourceDeleted = CooldownCompanion:MovePanel(ctxPanelId, c.id)
-                                        CooldownCompanion:ClearAllConfigPreviews()
-                                        if sourceDeleted then
-                                            CS.selectedContainer = c.id
+                                        if CooldownCompanion:MovePanel(ctxPanelId, c.id) then
+                                            SelectConfigPanel(ctxPanelId, { containerId = c.id })
+                                            CooldownCompanion:RefreshConfigPanel()
                                         end
-                                        CS.selectedGroup = ctxPanelId
-                                        CS.selectedButton = nil
-                                        wipe(CS.selectedButtons)
-                                        CooldownCompanion:RefreshConfigPanel()
                                     end
                                     UIDropDownMenu_AddButton(info, level)
                                 end
@@ -2406,15 +2386,10 @@ local function RefreshColumn2()
                                     info.notCheckable = true
                                     info.func = function()
                                         CloseDropDownMenus()
-                                        local _, sourceDeleted = CooldownCompanion:MovePanel(ctxPanelId, c.id)
-                                        CooldownCompanion:ClearAllConfigPreviews()
-                                        if sourceDeleted then
-                                            CS.selectedContainer = c.id
+                                        if CooldownCompanion:MovePanel(ctxPanelId, c.id) then
+                                            SelectConfigPanel(ctxPanelId, { containerId = c.id })
+                                            CooldownCompanion:RefreshConfigPanel()
                                         end
-                                        CS.selectedGroup = ctxPanelId
-                                        CS.selectedButton = nil
-                                        wipe(CS.selectedButtons)
-                                        CooldownCompanion:RefreshConfigPanel()
                                     end
                                     UIDropDownMenu_AddButton(info, level)
                                 end

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -38,6 +38,10 @@ local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local SelectConfigFinderResult = ST._SelectConfigFinderResult
+local SelectConfigPanel = ST._SelectConfigPanel
+local ToggleConfigPanelMultiSelect = ST._ToggleConfigPanelMultiSelect
+local SelectConfigButton = ST._SelectConfigButton
+local SelectConfigButtonPanel = ST._SelectConfigButtonPanel
 
 local IsTriggerPanelGroup
 
@@ -1434,11 +1438,7 @@ local function RefreshColumn2()
             end
             header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
             header:SetCallback("OnClick", function()
-                CooldownCompanion:ClearAllConfigPreviews()
-                CS.selectedContainer = CS.browseContainerId
-                CS.selectedGroup = panelGroupId
-                CS.selectedButton = nil
-                wipe(CS.selectedButtons)
+                SelectConfigPanel(panelGroupId, { containerId = CS.browseContainerId })
                 CooldownCompanion:RefreshConfigPanel()
             end)
             panelContainer:AddChild(header)
@@ -1472,11 +1472,10 @@ local function RefreshColumn2()
                     end
                     local capturedIndex = buttonIndex
                     entry:SetCallback("OnClick", function()
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        CS.selectedContainer = CS.browseContainerId
-                        CS.selectedGroup = panelGroupId
-                        CS.selectedButton = capturedIndex
-                        wipe(CS.selectedButtons)
+                        SelectConfigButton(panelGroupId, capturedIndex, {
+                            containerId = CS.browseContainerId,
+                            force = true,
+                        })
                         CooldownCompanion:RefreshConfigPanel()
                     end)
                     panelContainer:AddChild(entry)
@@ -2131,32 +2130,12 @@ local function RefreshColumn2()
                         end
 
                         if IsControlKeyDown() then
-                            CooldownCompanion:ClearAllConfigPreviews()
-                            if CS.selectedPanels[panelId] then
-                                CS.selectedPanels[panelId] = nil
-                            else
-                                CS.selectedPanels[panelId] = true
-                            end
-                            if CS.selectedGroup and not CS.selectedPanels[CS.selectedGroup] and next(CS.selectedPanels) then
-                                CS.selectedPanels[CS.selectedGroup] = true
-                            end
-                            CS.selectedGroup = nil
-                            CS.selectedButton = nil
-                            wipe(CS.selectedButtons)
-                            CS.addingToPanelId = nil
+                            ToggleConfigPanelMultiSelect(panelId)
                             CooldownCompanion:RefreshConfigPanel()
                             return
                         end
 
-                        wipe(CS.selectedPanels)
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        if CS.selectedGroup == panelId and not CS.selectedButton then
-                            CS.selectedGroup = nil
-                        else
-                            CS.selectedGroup = panelId
-                        end
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        SelectConfigPanel(panelId, { toggle = true })
                         CooldownCompanion:RefreshConfigPanel()
                         return
                     elseif mouseButton == "MiddleButton" then
@@ -2472,10 +2451,7 @@ local function RefreshColumn2()
                         CS.addingToPanelId = nil
                     else
                         CS.addingToPanelId = addBtnPanelId
-                        CooldownCompanion:ClearAllConfigPreviews()
-                        CS.selectedGroup = addBtnPanelId
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        SelectConfigPanel(addBtnPanelId, { keepPanelMulti = true })
                         CS.collapsedPanels[addBtnPanelId] = nil
                         CS.pendingEditBoxFocus = true
                     end
@@ -2665,43 +2641,11 @@ local function RefreshColumn2()
                         end
                         if mouseButton == "LeftButton" then
                             -- Auto-select this button's panel
-                            local panelChanged = CS.selectedGroup ~= btnPanelId
-                            if panelChanged then
-                                CS.selectedGroup = btnPanelId
-                                CS.selectedButton = nil
-                                wipe(CS.selectedButtons)
-                            end
-                            wipe(CS.selectedPanels)
-
-                            if IsControlKeyDown() then
-                                if CS.selectedButtons[btnIndex] then
-                                    CS.selectedButtons[btnIndex] = nil
-                                else
-                                    CS.selectedButtons[btnIndex] = true
-                                end
-                                if CS.selectedButton and not CS.selectedButtons[CS.selectedButton] and next(CS.selectedButtons) then
-                                    CS.selectedButtons[CS.selectedButton] = true
-                                end
-                                CS.selectedButton = nil
-                            else
-                                wipe(CS.selectedButtons)
-                                if not panelChanged and CS.selectedButton == btnIndex then
-                                    CS.selectedButton = nil
-                                else
-                                    CS.selectedButton = btnIndex
-                                end
-                            end
-                            CooldownCompanion:ClearAllConfigPreviews()
+                            SelectConfigButton(btnPanelId, btnIndex, { multi = IsControlKeyDown() })
                             CooldownCompanion:RefreshConfigPanel()
                         elseif mouseButton == "RightButton" then
                             -- Auto-select panel on right-click too
-                            if CS.selectedGroup ~= btnPanelId then
-                                CooldownCompanion:ClearAllConfigPreviews()
-                                CS.selectedGroup = btnPanelId
-                                CS.selectedButton = nil
-                                wipe(CS.selectedButtons)
-                            end
-                            wipe(CS.selectedPanels)
+                            SelectConfigButtonPanel(btnPanelId, { clearPanelMulti = true })
                             if not CS.buttonContextMenu then
                                 CS.buttonContextMenu = CreateFrame("Frame", "CDCButtonContextMenu", UIParent, "UIDropDownMenuTemplate")
                             end
@@ -2794,12 +2738,7 @@ local function RefreshColumn2()
                             CS.buttonContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
                             ToggleDropDownMenu(1, nil, CS.buttonContextMenu, "cursor", 0, 0)
                         elseif mouseButton == "MiddleButton" then
-                            if CS.selectedGroup ~= btnPanelId then
-                                CooldownCompanion:ClearAllConfigPreviews()
-                                CS.selectedGroup = btnPanelId
-                                CS.selectedButton = nil
-                                wipe(CS.selectedButtons)
-                            end
+                            SelectConfigButtonPanel(btnPanelId)
                             if not CS.moveMenuFrame then
                                 CS.moveMenuFrame = CreateFrame("Frame", "CDCMoveMenu", UIParent, "UIDropDownMenuTemplate")
                             end

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -11,6 +11,8 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
+local SetConfigCustomBarSettingsTab = ST._SetConfigCustomBarSettingsTab
+local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 
 ------------------------------------------------------------------------
 -- COLUMN 4: Group / Panel Settings Column
@@ -28,22 +30,29 @@ local function ClearInfoButtons(buttons)
     wipe(buttons)
 end
 
-local function FindSelectedCustomBar()
-    if not CS.selectedCustomBarId or not CooldownCompanion.GetSpecCustomAuraBars then
+local function FindCustomBarById(settings, customBarId)
+    if not customBarId then
         return nil
     end
 
-    local settings = CooldownCompanion:GetResourceBarSettings()
     if ST._RB and ST._RB.FindCustomBarById then
-        return ST._RB.FindCustomBarById(settings, CS.selectedCustomBarId)
+        return ST._RB.FindCustomBarById(settings, customBarId)
+    end
+
+    if not CooldownCompanion.GetSpecCustomAuraBars then
+        return nil
     end
 
     for _, entry in ipairs(CooldownCompanion:GetSpecCustomAuraBars() or {}) do
-        if type(entry) == "table" and entry.customBarId == CS.selectedCustomBarId then
+        if type(entry) == "table" and entry.customBarId == customBarId then
             return entry
         end
     end
     return nil
+end
+
+local function FindSelectedCustomBar()
+    return FindCustomBarById(CooldownCompanion:GetResourceBarSettings(), CS.selectedCustomBarId)
 end
 
 local function GetCustomBarEntryTabs(entry)
@@ -239,14 +248,14 @@ local function RefreshColumn4(container)
             local selectedCustomBarIds = {}
             local selectedCustomBarEntries = {}
             local settings = CooldownCompanion:GetResourceBarSettings()
+            local function CustomBarExists(customBarId)
+                return FindCustomBarById(settings, customBarId) ~= nil
+            end
+            PruneConfigCustomBarSelection(CustomBarExists, true)
             for customBarId in pairs(CS.selectedCustomBars) do
-                local entry = ST._RB.FindCustomBarById and ST._RB.FindCustomBarById(settings, customBarId)
-                if entry then
-                    selectedCustomBarIds[#selectedCustomBarIds + 1] = customBarId
-                    selectedCustomBarEntries[#selectedCustomBarEntries + 1] = entry
-                else
-                    CS.selectedCustomBars[customBarId] = nil
-                end
+                local entry = FindCustomBarById(settings, customBarId)
+                selectedCustomBarIds[#selectedCustomBarIds + 1] = customBarId
+                selectedCustomBarEntries[#selectedCustomBarEntries + 1] = entry
             end
             table.sort(selectedCustomBarIds)
             if #selectedCustomBarEntries >= 2 then
@@ -260,18 +269,17 @@ local function RefreshColumn4(container)
 
                 local selectedEntry = FindSelectedCustomBar()
                 if not selectedEntry then
-                    CS.selectedCustomBarId = nil
-                    CS.customBarSettingsTab = "appearance"
+                    PruneConfigCustomBarSelection(CustomBarExists, true)
                 else
                     if CS.customBarSettingsTab == "settings"
                         or CS.customBarSettingsTab == "layout"
                         or CS.customBarSettingsTab == "anchor"
                         or CS.customBarSettingsTab == "alpha"
                     then
-                        CS.customBarSettingsTab = "appearance"
+                        SetConfigCustomBarSettingsTab("appearance")
                     end
                     if not IsCustomBarEntryTabAllowed(selectedEntry, CS.customBarSettingsTab) then
-                        CS.customBarSettingsTab = "appearance"
+                        SetConfigCustomBarSettingsTab("appearance")
                     end
 
                     if not container.customBarEntryTabGroup then
@@ -279,15 +287,7 @@ local function RefreshColumn4(container)
                         tabGroup:SetLayout("Fill")
                         tabGroup.frame:SetParent(container)
                         tabGroup:SetCallback("OnGroupSelected", function(widget, event, tab)
-                            CS.customBarSettingsTab = tab or "appearance"
-                            if CS.customBarSettingsTab ~= "indicators" then
-                                if CooldownCompanion.ClearAllCustomAuraBarPreviews then
-                                    CooldownCompanion:ClearAllCustomAuraBarPreviews()
-                                end
-                                if CS.customBarIndicatorPreviewActive and CooldownCompanion.StopResourceBarPreview then
-                                    CooldownCompanion:StopResourceBarPreview()
-                                end
-                            end
+                            SetConfigCustomBarSettingsTab(tab, true)
                             ClearInfoButtons(CS.customBarInfoButtons)
                             widget:ReleaseChildren()
 

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -11,6 +11,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
+local ResetConfigSelection = ST._ResetConfigSelection
 local SetConfigCustomBarSettingsTab = ST._SetConfigCustomBarSettingsTab
 local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 
@@ -666,18 +667,8 @@ local function RefreshProfileBar(bar)
     profileDrop:SetValue(currentProfile)
     profileDrop:SetWidth(150)
     profileDrop:SetCallback("OnValueChanged", function(widget, event, val)
-        CooldownCompanion:ClearAllConfigPreviews()
         db:SetProfile(val)
-        CS.selectedFolder = nil
-        CS.selectedContainer = nil
-        CS.selectedGroup = nil
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-        wipe(CS.selectedGroups)
-        -- Exit browse mode on profile switch
-        CS.browseMode = false
-        CS.browseCharKey = nil
-        CS.browseContainerId = nil
+        ResetConfigSelection(true)
         CooldownCompanion:RefreshConfigPanel()
         CooldownCompanion:RefreshAllGroups()
     end)

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -11,6 +11,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local DecodeSharedPayload = ST._DecodeSharedPayload
 local PrepareSharedImportText = ST._PrepareSharedImportText
+local ResetConfigSelection = ST._ResetConfigSelection
 
 -- File-local state
 local decodedDiagnostic = nil
@@ -929,10 +930,7 @@ StaticPopupDialogs["CDC_DIAGNOSTIC_IMPORT_CONFIRM"] = {
             for k, v in pairs(decodedDiagnostic.profile) do
                 db.profile[k] = v
             end
-            CS.selectedGroup = nil
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
-            wipe(CS.selectedGroups)
+            ResetConfigSelection(true)
             -- Remap only the exporter's own entities to the importer's character.
             -- Other characters' entities keep their original createdBy so they
             -- appear in the browse-other-characters module instead of being

--- a/Config/DragReorderLifecycle.lua
+++ b/Config/DragReorderLifecycle.lua
@@ -12,6 +12,8 @@ ST._DragReorder = DR
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
 local GroupsHaveForeignSpecs = ST._GroupsHaveForeignSpecs
 local FolderHasForeignSpecs = ST._FolderHasForeignSpecs
+local SelectConfigPanel = ST._SelectConfigPanel
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
 
 local DRAG_THRESHOLD = 8
 local PREVIEW_MODE_PANEL_COMPACT = DR.PREVIEW_MODE_PANEL_COMPACT
@@ -570,11 +572,7 @@ local function FinishPanelDrag(state)
     local dropTarget = state.dropTarget
     local changed = dropTarget and not IsPanelReorderNoOp(state.sourcePanelId, dropTarget.targetIndex, state.panelDropTargets)
     if changed then
-        CooldownCompanion:ClearAllConfigPreviews()
-        wipe(CS.selectedPanels)
-        CS.selectedGroup = state.sourcePanelId
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        SelectConfigPanel(state.sourcePanelId)
         PerformPanelReorder(state.sourcePanelId, dropTarget.targetIndex, state.panelDropTargets)
         for _, entry in ipairs(state.panelDropTargets) do
             CooldownCompanion:RefreshGroupFrame(entry.panelId)
@@ -615,8 +613,7 @@ local function FinishButtonDrag(state)
         CooldownCompanion:RefreshGroupFrame(state.groupId)
     end
     CooldownCompanion:ClearAllConfigPreviews()
-    CS.selectedButton = nil
-    wipe(CS.selectedButtons)
+    ClearConfigButtonSelection()
     CooldownCompanion:RefreshConfigPanel()
 end
 

--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -13,6 +13,7 @@ local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 
 -- Imports from earlier Config/ files
 local ResetConfigSelection = ST._ResetConfigSelection
+local ClearConfigPrimarySelection = ST._ClearConfigPrimarySelection
 local ShowPopupAboveConfig = ST._ShowPopupAboveConfig
 local COLUMN_PADDING = ST._COLUMN_PADDING
 local BuildAutocompleteCache = ST._BuildAutocompleteCache
@@ -489,7 +490,6 @@ local function ResetConfigForProfileChange()
     ResetConfigSelection(true)
     wipe(CS.collapsedFolders)
     wipe(CS.collapsedPanels)
-    CS.selectedCustomBarId = nil
     wipe(CS.resourceAuraOverlayDrafts)
     if ClearConfigFinderText then
         ClearConfigFinderText()
@@ -1012,17 +1012,10 @@ local function CreateConfigPanel()
         if CS.resourceBarPanelActive then
             SetPrimaryMode("buttons", { skipRefresh = true })
         end
-        CooldownCompanion:ClearAllConfigPreviews()
         CS.browseMode = true
         CS.browseCharKey = nil
         CS.browseContainerId = nil
-        CS.selectedFolder = nil
-        CS.selectedContainer = nil
-        CS.selectedGroup = nil
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-        wipe(CS.selectedPanels)
-        wipe(CS.selectedGroups)
+        ClearConfigPrimarySelection()
         CooldownCompanion:RefreshConfigPanel()
     end)
     browseBtn:SetScript("OnEnter", function(self)

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -73,6 +73,36 @@ local function ClearFolderFiltersForUnglobal(folderId)
     end
 end
 
+local function PruneDeletedFolderSelection(folderId)
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not db then return end
+
+    if CS.selectedFolder == folderId then
+        CS.selectedFolder = nil
+    end
+
+    if CS.selectedContainer and not (db.groupContainers and db.groupContainers[CS.selectedContainer]) then
+        ClearConfigContainerSelection()
+    elseif CS.selectedGroup and not (db.groups and db.groups[CS.selectedGroup]) then
+        ClearConfigPanelSelection()
+    end
+
+    if CS.addingToPanelId and not (db.groups and db.groups[CS.addingToPanelId]) then
+        CS.addingToPanelId = nil
+    end
+
+    for containerId in pairs(CS.selectedGroups) do
+        if not (db.groupContainers and db.groupContainers[containerId]) then
+            CS.selectedGroups[containerId] = nil
+        end
+    end
+    for panelId in pairs(CS.selectedPanels) do
+        if not (db.groups and db.groups[panelId]) then
+            CS.selectedPanels[panelId] = nil
+        end
+    end
+end
+
 StaticPopupDialogs["CDC_DELETE_GROUP"] = {
     text = "Are you sure you want to delete group '%s'?",
     button1 = "Delete",
@@ -873,20 +903,7 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
         if data and data.folderId then
             CooldownCompanion:ClearAllConfigPreviews()
             CooldownCompanion:DeleteFolder(data.folderId)
-            if CS.selectedFolder == data.folderId then
-                CS.selectedFolder = nil
-            end
-            if CS.selectedGroup then
-                local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
-                if not group then
-                    ClearConfigPanelSelection()
-                end
-            end
-            for gid in pairs(CS.selectedGroups) do
-                if not CooldownCompanion.db.profile.groups[gid] then
-                    CS.selectedGroups[gid] = nil
-                end
-            end
+            PruneDeletedFolderSelection(data.folderId)
             CooldownCompanion:RefreshConfigPanel()
         end
     end,

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -9,6 +9,11 @@ local CooldownCompanion = ST.Addon
 local CS = ST._configState
 
 local ResetConfigSelection = ST._ResetConfigSelection
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelSelection = ST._ClearConfigPanelSelection
+local ClearConfigContainerSelection = ST._ClearConfigContainerSelection
+local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
+local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local DecodeSharedPayload = ST._DecodeSharedPayload
 local PrepareSharedImportText = ST._PrepareSharedImportText
@@ -80,16 +85,11 @@ StaticPopupDialogs["CDC_DELETE_GROUP"] = {
             CooldownCompanion:DeleteGroup(id)
             if data.containerId then
                 if CS.selectedContainer == id then
-                    CS.selectedContainer = nil
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
+                    ClearConfigContainerSelection()
                 end
             else
                 if CS.selectedGroup == id then
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
+                    ClearConfigPanelSelection()
                 end
             end
             CS.selectedGroups[id] = nil
@@ -111,7 +111,7 @@ StaticPopupDialogs["CDC_DELETE_PANEL"] = {
         CooldownCompanion:ClearAllConfigPreviews()
         CooldownCompanion:DeletePanel(data.containerId, data.panelId)
         if CS.selectedGroup == data.panelId then
-            CS.selectedGroup = nil
+            ClearConfigPanelSelection()
         end
         if CS.addingToPanelId == data.panelId then
             CS.addingToPanelId = nil
@@ -220,8 +220,8 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_PANELS"] = {
             for _, pid in ipairs(data.panelIds) do
                 CooldownCompanion:DeletePanel(data.containerId, pid)
             end
-            wipe(CS.selectedPanels)
-            CS.selectedGroup = nil
+            ClearConfigPanelMultiSelection()
+            ClearConfigPanelSelection()
             CooldownCompanion:RefreshConfigPanel()
         end
     end,
@@ -714,8 +714,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
             ST._StripButtonOverrides(buttonData)
             CooldownCompanion:RefreshGroupFrame(data.sourcePanelId)
             CooldownCompanion:RefreshGroupFrame(data.targetPanelId)
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
+            ClearConfigButtonSelection()
             CooldownCompanion:RefreshConfigPanel()
         end
     end,
@@ -791,10 +790,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
             for _, customBarId in ipairs(data.ids) do
                 rb.DeleteCustomBar(settings, customBarId)
             end
-            CS.selectedCustomBarId = nil
-            CS.customBarSpecExpandedId = nil
-            wipe(CS.selectedCustomBars)
-            CooldownCompanion:ClearAllCustomAuraBarPreviews()
+            ClearConfigCustomBarSelection(true, { clearExpanded = true })
             CooldownCompanion:ApplyResourceBars()
             CooldownCompanion:UpdateAnchorStacking()
             CooldownCompanion:RefreshConfigPanel()
@@ -883,9 +879,7 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
             if CS.selectedGroup then
                 local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
                 if not group then
-                    CS.selectedGroup = nil
-                    CS.selectedButton = nil
-                    wipe(CS.selectedButtons)
+                    ClearConfigPanelSelection()
                 end
             end
             for gid in pairs(CS.selectedGroups) do

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -16,30 +16,29 @@ local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local GetButtonIcon = ST._GetButtonIcon
 local CDM_VIEWER_NAMES = ST._CDM_VIEWER_NAMES
 local NotifyTutorialAction = ST._NotifyTutorialAction
+local SelectConfigPanel = ST._SelectConfigPanel
+local SelectConfigButton = ST._SelectConfigButton
 
 -- After a successful add, set selection state to the new button so the
 -- next RefreshConfigPanel shows its settings in Column 3.
 -- Precondition: CS.selectedContainer is already set by the caller's
 -- panel/container selection flow.
 local function SelectNewButton(panelId, buttonIndex)
-    CooldownCompanion:ClearAllConfigPreviews()
-
     local group = panelId and CooldownCompanion.db
         and CooldownCompanion.db.profile
         and CooldownCompanion.db.profile.groups
         and CooldownCompanion.db.profile.groups[panelId]
     if group and group.displayMode == "textures" then
-        CS.selectedGroup = panelId
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        SelectConfigPanel(panelId)
         CS.addingToPanelId = nil
         CS.pendingTexturePickerOpen = panelId
         return
     end
-    if not buttonIndex then return end
-    CS.selectedGroup = panelId
-    CS.selectedButton = buttonIndex
-    wipe(CS.selectedButtons)
+    if not buttonIndex then
+        CooldownCompanion:ClearAllConfigPreviews()
+        return
+    end
+    SelectConfigButton(panelId, buttonIndex, { force = true })
 end
 
 local function IsTexturePanelTarget(groupId)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2342,6 +2342,157 @@ end
 -- Shared selection / spec helpers (consumed by Popups, Panel, Column*, DragReorder)
 ------------------------------------------------------------------------
 
+local function ClearSelectedButton()
+    CS.selectedButton = nil
+    wipe(CS.selectedButtons)
+end
+
+local function ClearConfigPrimarySelection()
+    CooldownCompanion:ClearAllConfigPreviews()
+    CS.selectedFolder = nil
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    wipe(CS.selectedPanels)
+    wipe(CS.selectedCustomBars)
+end
+
+local function SelectConfigFolder(folderId)
+    CooldownCompanion:ClearAllConfigPreviews()
+    CS.selectedFolder = folderId
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    wipe(CS.selectedGroups)
+    wipe(CS.selectedPanels)
+end
+
+local function SelectConfigContainer(containerId, opts)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if not (opts and opts.keepContainerMulti) then
+        wipe(CS.selectedGroups)
+    end
+    CS.selectedFolder = nil
+
+    if opts and opts.toggle and CS.selectedContainer == containerId then
+        if CS.selectedGroup then
+            CS.selectedGroup = nil
+        else
+            CS.selectedContainer = nil
+        end
+    else
+        CS.selectedContainer = containerId
+        CS.selectedGroup = nil
+    end
+
+    ClearSelectedButton()
+    wipe(CS.selectedPanels)
+    if opts and opts.clearFinder then
+        ClearConfigFinderText()
+    end
+end
+
+local function ToggleConfigContainerMultiSelect(containerId)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if CS.selectedGroups[containerId] then
+        CS.selectedGroups[containerId] = nil
+    else
+        CS.selectedGroups[containerId] = true
+    end
+    if CS.selectedContainer and not CS.selectedGroups[CS.selectedContainer] and next(CS.selectedGroups) then
+        CS.selectedGroups[CS.selectedContainer] = true
+    end
+
+    CS.selectedFolder = nil
+    CS.selectedContainer = nil
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    wipe(CS.selectedPanels)
+    wipe(CS.selectedCustomBars)
+end
+
+local function SelectConfigPanel(panelId, opts)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if opts and opts.containerId ~= nil then
+        CS.selectedContainer = opts.containerId
+    end
+    if not (opts and opts.keepPanelMulti) then
+        wipe(CS.selectedPanels)
+    end
+
+    if opts and opts.toggle and CS.selectedGroup == panelId and not CS.selectedButton then
+        CS.selectedGroup = nil
+    else
+        CS.selectedGroup = panelId
+    end
+
+    ClearSelectedButton()
+end
+
+local function ToggleConfigPanelMultiSelect(panelId)
+    CooldownCompanion:ClearAllConfigPreviews()
+    if CS.selectedPanels[panelId] then
+        CS.selectedPanels[panelId] = nil
+    else
+        CS.selectedPanels[panelId] = true
+    end
+    if CS.selectedGroup and not CS.selectedPanels[CS.selectedGroup] and next(CS.selectedPanels) then
+        CS.selectedPanels[CS.selectedGroup] = true
+    end
+
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+    CS.addingToPanelId = nil
+end
+
+local function SelectConfigButton(panelId, buttonIndex, opts)
+    local panelChanged = CS.selectedGroup ~= panelId
+    if opts and opts.containerId ~= nil then
+        CS.selectedContainer = opts.containerId
+    end
+    if panelChanged then
+        CS.selectedGroup = panelId
+        ClearSelectedButton()
+    end
+    if not (opts and opts.keepPanelMulti) then
+        wipe(CS.selectedPanels)
+    end
+
+    if opts and opts.multi then
+        if CS.selectedButtons[buttonIndex] then
+            CS.selectedButtons[buttonIndex] = nil
+        else
+            CS.selectedButtons[buttonIndex] = true
+        end
+        if CS.selectedButton and not CS.selectedButtons[CS.selectedButton] and next(CS.selectedButtons) then
+            CS.selectedButtons[CS.selectedButton] = true
+        end
+        CS.selectedButton = nil
+    else
+        wipe(CS.selectedButtons)
+        if opts and opts.force then
+            CS.selectedButton = buttonIndex
+        elseif not panelChanged and CS.selectedButton == buttonIndex then
+            CS.selectedButton = nil
+        else
+            CS.selectedButton = buttonIndex
+        end
+    end
+
+    CooldownCompanion:ClearAllConfigPreviews()
+end
+
+local function SelectConfigButtonPanel(panelId, opts)
+    if CS.selectedGroup ~= panelId then
+        CooldownCompanion:ClearAllConfigPreviews()
+        CS.selectedGroup = panelId
+        ClearSelectedButton()
+    end
+    if opts and opts.clearPanelMulti then
+        wipe(CS.selectedPanels)
+    end
+end
+
 local function ResetConfigSelection(full)
     if full and ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
@@ -2573,6 +2724,14 @@ ST._BUTTON_SPACING = BUTTON_SPACING
 ST._PROFILE_BAR_HEIGHT = PROFILE_BAR_HEIGHT
 ST._BuildHeroTalentSubTreeCheckboxes = BuildHeroTalentSubTreeCheckboxes
 ST._ApplyCheckboxIndent = ApplyCheckboxIndent
+ST._ClearConfigPrimarySelection = ClearConfigPrimarySelection
+ST._SelectConfigFolder = SelectConfigFolder
+ST._SelectConfigContainer = SelectConfigContainer
+ST._ToggleConfigContainerMultiSelect = ToggleConfigContainerMultiSelect
+ST._SelectConfigPanel = SelectConfigPanel
+ST._ToggleConfigPanelMultiSelect = ToggleConfigPanelMultiSelect
+ST._SelectConfigButton = SelectConfigButton
+ST._SelectConfigButtonPanel = SelectConfigButtonPanel
 ST._ResetConfigSelection = ResetConfigSelection
 ST._SetConfigPrimaryMode = SetConfigPrimaryMode
 ST._GroupsHaveForeignSpecs = GroupsHaveForeignSpecs

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2347,6 +2347,31 @@ local function ClearSelectedButton()
     wipe(CS.selectedButtons)
 end
 
+local function ClearConfigButtonSelection()
+    ClearSelectedButton()
+end
+
+local function ClearConfigPanelSelection()
+    CS.selectedGroup = nil
+    ClearSelectedButton()
+end
+
+local function ClearConfigContainerSelection()
+    CS.selectedContainer = nil
+    ClearConfigPanelSelection()
+end
+
+local function ClearConfigPanelMultiSelection(opts)
+    wipe(CS.selectedPanels)
+    if opts and opts.selectContainerId ~= nil then
+        CS.selectedContainer = opts.selectContainerId
+    end
+end
+
+local function ClearConfigContainerMultiSelection()
+    wipe(CS.selectedGroups)
+end
+
 local function ClearConfigPrimarySelection()
     CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedFolder = nil
@@ -2354,6 +2379,7 @@ local function ClearConfigPrimarySelection()
     CS.selectedGroup = nil
     ClearSelectedButton()
     wipe(CS.selectedPanels)
+    wipe(CS.selectedGroups)
     wipe(CS.selectedCustomBars)
 end
 
@@ -2509,11 +2535,14 @@ local function SetConfigCustomBarSettingsTab(tab, clearPreviewOnNonIndicator)
     end
 end
 
-local function ClearConfigCustomBarSelection(clearPreview)
+local function ClearConfigCustomBarSelection(clearPreview, opts)
     if clearPreview then
         ClearConfigCustomBarPreviewState()
     end
     CS.selectedCustomBarId = nil
+    if opts and opts.clearExpanded then
+        CS.customBarSpecExpandedId = nil
+    end
     wipe(CS.selectedCustomBars)
     SetConfigCustomBarSettingsTab("appearance")
 end
@@ -2803,6 +2832,11 @@ ST._BUTTON_SPACING = BUTTON_SPACING
 ST._PROFILE_BAR_HEIGHT = PROFILE_BAR_HEIGHT
 ST._BuildHeroTalentSubTreeCheckboxes = BuildHeroTalentSubTreeCheckboxes
 ST._ApplyCheckboxIndent = ApplyCheckboxIndent
+ST._ClearConfigButtonSelection = ClearConfigButtonSelection
+ST._ClearConfigPanelSelection = ClearConfigPanelSelection
+ST._ClearConfigContainerSelection = ClearConfigContainerSelection
+ST._ClearConfigPanelMultiSelection = ClearConfigPanelMultiSelection
+ST._ClearConfigContainerMultiSelection = ClearConfigContainerMultiSelection
 ST._ClearConfigPrimarySelection = ClearConfigPrimarySelection
 ST._SelectConfigFolder = SelectConfigFolder
 ST._SelectConfigContainer = SelectConfigContainer

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -2493,6 +2493,85 @@ local function SelectConfigButtonPanel(panelId, opts)
     end
 end
 
+local function ClearConfigCustomBarPreviewState()
+    if CooldownCompanion.ClearAllCustomAuraBarPreviews then
+        CooldownCompanion:ClearAllCustomAuraBarPreviews()
+    end
+    if CS.customBarIndicatorPreviewActive and CooldownCompanion.StopResourceBarPreview then
+        CooldownCompanion:StopResourceBarPreview()
+    end
+end
+
+local function SetConfigCustomBarSettingsTab(tab, clearPreviewOnNonIndicator)
+    CS.customBarSettingsTab = tab or "appearance"
+    if clearPreviewOnNonIndicator and CS.customBarSettingsTab ~= "indicators" then
+        ClearConfigCustomBarPreviewState()
+    end
+end
+
+local function ClearConfigCustomBarSelection(clearPreview)
+    if clearPreview then
+        ClearConfigCustomBarPreviewState()
+    end
+    CS.selectedCustomBarId = nil
+    wipe(CS.selectedCustomBars)
+    SetConfigCustomBarSettingsTab("appearance")
+end
+
+local function SelectConfigCustomBar(customBarId, opts)
+    local selectionChanged = CS.selectedCustomBarId ~= customBarId
+    if opts and opts.toggle and not selectionChanged then
+        ClearConfigCustomBarSelection(opts.clearPreview)
+        return true
+    end
+
+    if selectionChanged and opts and opts.clearPreview then
+        ClearConfigCustomBarPreviewState()
+    end
+    CS.selectedCustomBarId = customBarId
+    if opts and opts.resetTab then
+        SetConfigCustomBarSettingsTab("appearance")
+    end
+    wipe(CS.selectedCustomBars)
+    if opts and opts.clearButtonMulti then
+        wipe(CS.selectedButtons)
+    end
+    return selectionChanged
+end
+
+local function ToggleConfigCustomBarMultiSelect(customBarId)
+    if CS.selectedCustomBars[customBarId] then
+        CS.selectedCustomBars[customBarId] = nil
+    else
+        CS.selectedCustomBars[customBarId] = true
+    end
+    if CS.selectedCustomBarId and not CS.selectedCustomBars[CS.selectedCustomBarId] and next(CS.selectedCustomBars) then
+        CS.selectedCustomBars[CS.selectedCustomBarId] = true
+    end
+    ClearConfigCustomBarPreviewState()
+end
+
+local function PruneConfigCustomBarSelection(customBarExists, resetTab)
+    if type(customBarExists) ~= "function" then
+        return
+    end
+
+    if CS.selectedCustomBarId and not customBarExists(CS.selectedCustomBarId) then
+        CS.selectedCustomBarId = nil
+        if resetTab then
+            SetConfigCustomBarSettingsTab("appearance")
+        end
+    end
+    if CS.customBarSpecExpandedId and not customBarExists(CS.customBarSpecExpandedId) then
+        CS.customBarSpecExpandedId = nil
+    end
+    for customBarId in pairs(CS.selectedCustomBars) do
+        if not customBarExists(customBarId) then
+            CS.selectedCustomBars[customBarId] = nil
+        end
+    end
+end
+
 local function ResetConfigSelection(full)
     if full and ST._CancelAutoAddFlow then
         ST._CancelAutoAddFlow()
@@ -2732,6 +2811,12 @@ ST._SelectConfigPanel = SelectConfigPanel
 ST._ToggleConfigPanelMultiSelect = ToggleConfigPanelMultiSelect
 ST._SelectConfigButton = SelectConfigButton
 ST._SelectConfigButtonPanel = SelectConfigButtonPanel
+ST._ClearConfigCustomBarPreviewState = ClearConfigCustomBarPreviewState
+ST._SetConfigCustomBarSettingsTab = SetConfigCustomBarSettingsTab
+ST._ClearConfigCustomBarSelection = ClearConfigCustomBarSelection
+ST._SelectConfigCustomBar = SelectConfigCustomBar
+ST._ToggleConfigCustomBarMultiSelect = ToggleConfigCustomBarMultiSelect
+ST._PruneConfigCustomBarSelection = PruneConfigCustomBarSelection
 ST._ResetConfigSelection = ResetConfigSelection
 ST._SetConfigPrimaryMode = SetConfigPrimaryMode
 ST._GroupsHaveForeignSpecs = GroupsHaveForeignSpecs

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -9,6 +9,9 @@ local CS = ST._configState
 local CreateGlowContainer = ST._CreateGlowContainer
 local ShowGlowStyle = ST._ShowGlowStyle
 local HideGlowStyles = ST._HideGlowStyles
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
+local ClearConfigContainerMultiSelection = ST._ClearConfigContainerMultiSelection
 
 local pairs = pairs
 local next = next
@@ -787,18 +790,16 @@ local function NotifyTutorialAction(action, payload)
 
     if action == "group_created" and (runtime.step == "welcome" or runtime.step == "groups_column_intro" or runtime.step == "create_group") then
         runtime.createdGroup = true
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
-        wipe(CS.selectedPanels)
-        wipe(CS.selectedGroups)
+        ClearConfigButtonSelection()
+        ClearConfigPanelMultiSelection()
+        ClearConfigContainerMultiSelection()
         AdvanceStep("panels_column_intro")
     elseif action == "panel_created" and (runtime.step == "panels_column_intro" or runtime.step == "create_panel") then
         if payload and payload.displayMode == "icons" then
             runtime.createdPanel = true
-            CS.selectedButton = nil
-            wipe(CS.selectedButtons)
-            wipe(CS.selectedPanels)
-            wipe(CS.selectedGroups)
+            ClearConfigButtonSelection()
+            ClearConfigPanelMultiSelection()
+            ClearConfigContainerMultiSelection()
             AdvanceStep("panel_area_intro")
         end
     elseif action == "inline_add_succeeded" and (runtime.step == "panel_area_intro" or runtime.step == "add_one_spell") then

--- a/Config/Tutorial.lua
+++ b/Config/Tutorial.lua
@@ -9,6 +9,7 @@ local CS = ST._configState
 local CreateGlowContainer = ST._CreateGlowContainer
 local ShowGlowStyle = ST._ShowGlowStyle
 local HideGlowStyles = ST._HideGlowStyles
+local ResetConfigSelection = ST._ResetConfigSelection
 local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
 local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigContainerMultiSelection = ST._ClearConfigContainerMultiSelection
@@ -432,25 +433,13 @@ local function NormalizeTutorialContext()
     if CS.talentPickerMode and CooldownCompanion.CloseTalentPicker then
         CooldownCompanion:CloseTalentPicker()
     end
-    if ST._CancelAutoAddFlow then
-        ST._CancelAutoAddFlow()
-    end
 
     CloseDropDownMenus()
     if CS.HideAutocomplete then
         CS.HideAutocomplete()
     end
 
-    CS.browseMode = false
-    CS.browseCharKey = nil
-    CS.browseContainerId = nil
-    CS.selectedContainer = nil
-    CS.selectedGroup = nil
-    CS.selectedButton = nil
-    wipe(CS.selectedButtons)
-    wipe(CS.selectedPanels)
-    wipe(CS.selectedGroups)
-    CS.addingToPanelId = nil
+    ResetConfigSelection(true)
     CS.newInput = ""
     CS.pendingEditBoxFocus = false
 

--- a/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -7,6 +7,8 @@ local ColorHeading = ST._ColorHeading
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
@@ -46,8 +48,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
             table.insert(sourceGroup.buttons, idx + 1, copy)
         end
         CooldownCompanion:RefreshGroupFrame(sourceGroupId)
-        CS.selectedButton = nil
-        wipe(CS.selectedButtons)
+        ClearConfigButtonSelection()
         CooldownCompanion:RefreshConfigPanel()
     end)
     scroll:AddChild(dupBtn)
@@ -119,8 +120,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                         end
                         CooldownCompanion:RefreshGroupFrame(groupEntry.id)
                         CooldownCompanion:RefreshGroupFrame(sourceGroupId)
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        ClearConfigButtonSelection()
                         CooldownCompanion:RefreshConfigPanel()
                         CloseDropDownMenus()
                     end
@@ -149,8 +149,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                         end
                         CooldownCompanion:RefreshGroupFrame(groupEntry.id)
                         CooldownCompanion:RefreshGroupFrame(sourceGroupId)
-                        CS.selectedButton = nil
-                        wipe(CS.selectedButtons)
+                        ClearConfigButtonSelection()
                         CooldownCompanion:RefreshConfigPanel()
                         CloseDropDownMenus()
                     end
@@ -280,7 +279,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
         for _, pid in ipairs(multiPanelIds) do
             CooldownCompanion:DuplicatePanel(containerId, pid)
         end
-        wipe(CS.selectedPanels)
+        ClearConfigPanelMultiSelection()
         CooldownCompanion:RefreshConfigPanel()
     end)
     scroll:AddChild(dupBtn)
@@ -354,8 +353,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                             for _, pid in ipairs(multiPanelIds) do
                                 CooldownCompanion:MovePanel(pid, container.id)
                             end
-                            wipe(CS.selectedPanels)
-                            CS.selectedContainer = container.id
+                            ClearConfigPanelMultiSelection({ selectContainerId = container.id })
                             CooldownCompanion:RefreshConfigPanel()
                         end
                         UIDropDownMenu_AddButton(info, level)
@@ -379,8 +377,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                             for _, pid in ipairs(multiPanelIds) do
                                 CooldownCompanion:MovePanel(pid, container.id)
                             end
-                            wipe(CS.selectedPanels)
-                            CS.selectedContainer = container.id
+                            ClearConfigPanelMultiSelection({ selectContainerId = container.id })
                             CooldownCompanion:RefreshConfigPanel()
                         end
                         UIDropDownMenu_AddButton(info, level)

--- a/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -12,6 +12,11 @@ local LSM = LibStub("LibSharedMedia-3.0")
 local CS = ST._configState
 local IsPassiveOrProc = ST._IsPassiveOrProc
 local ShowPopupAboveConfig = CS.ShowPopupAboveConfig
+local ClearCustomBarPreviewState = ST._ClearConfigCustomBarPreviewState
+local SelectConfigCustomBar = ST._SelectConfigCustomBar
+local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
+local ToggleConfigCustomBarMultiSelect = ST._ToggleConfigCustomBarMultiSelect
+local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
@@ -209,8 +214,6 @@ local function FindCustomBarIndexById(customBars, customBarId)
     end
     return nil
 end
-
-local ClearCustomBarPreviewState
 
 local function EnsureCustomBarRowTextBadge(frame, key)
     local badge = frame[key]
@@ -543,13 +546,6 @@ local function HideCustomBarRowDecorations(frame)
     end
 end
 
-ClearCustomBarPreviewState = function()
-    CooldownCompanion:ClearAllCustomAuraBarPreviews()
-    if CS.customBarIndicatorPreviewActive then
-        CooldownCompanion:StopResourceBarPreview()
-    end
-end
-
 local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
     if not CS.customBarContextMenu then
         CS.customBarContextMenu = CreateFrame("Frame", "CDCCustomBarContextMenu", UIParent, "UIDropDownMenuTemplate")
@@ -581,9 +577,10 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
             CloseDropDownMenus()
             local newId = DuplicateCustomBarById(CooldownCompanion:GetResourceBarSettings(), specID, customBars, customBarId)
             if newId then
-                ClearCustomBarPreviewState()
-                CS.selectedCustomBarId = newId
-                CS.customBarSettingsTab = "appearance"
+                SelectConfigCustomBar(newId, {
+                    clearPreview = true,
+                    resetTab = true,
+                })
             end
             ApplyCustomAuraBarPanelChanges({
                 updateAnchors = true,
@@ -616,9 +613,7 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
             local settings = CooldownCompanion:GetResourceBarSettings()
             if DeleteCustomBarById(settings, specID, customBars, customBarId) then
                 if CS.selectedCustomBarId == customBarId then
-                    ClearCustomBarPreviewState()
-                    CS.selectedCustomBarId = nil
-                    CS.customBarSettingsTab = "appearance"
+                    ClearConfigCustomBarSelection(true)
                 end
                 if CS.customBarSpecExpandedId == customBarId then
                     CS.customBarSpecExpandedId = nil
@@ -1562,19 +1557,10 @@ local function BuildCustomBarsListPanel(container)
 
     local customBarsSpecID = GetCurrentConfigSpecID()
     local customBars = RB.GetAllCustomBars and RB.GetAllCustomBars(settings) or CooldownCompanion:GetSpecCustomAuraBars()
+    PruneConfigCustomBarSelection(function(customBarId)
+        return FindCustomBarIndexById(customBars, customBarId) ~= nil
+    end)
     local selectedId = CS.selectedCustomBarId
-    if selectedId and not FindCustomBarIndexById(customBars, selectedId) then
-        CS.selectedCustomBarId = nil
-        selectedId = nil
-    end
-    if CS.customBarSpecExpandedId and not FindCustomBarIndexById(customBars, CS.customBarSpecExpandedId) then
-        CS.customBarSpecExpandedId = nil
-    end
-    for customBarId in pairs(CS.selectedCustomBars) do
-        if not FindCustomBarIndexById(customBars, customBarId) then
-            CS.selectedCustomBars[customBarId] = nil
-        end
-    end
 
     local addBox = AceGUI:Create("EditBox")
     if addBox.editbox.Instructions then addBox.editbox.Instructions:Hide() end
@@ -1667,8 +1653,7 @@ local function BuildCustomBarsListPanel(container)
             customBars[#customBars + 1] = entry
             EnsureCustomBarLayout(settings, nil, id, 1000 + #customBars)
         end
-        wipe(CS.selectedCustomBars)
-        CS.selectedCustomBarId = id
+        SelectConfigCustomBar(id)
         ApplyCustomAuraBarPanelChanges({
             updateAnchors = true,
             refreshConfig = true,
@@ -1956,43 +1941,25 @@ local function BuildCustomBarsListPanel(container)
                 return
             end
             if mouseButton == "RightButton" then
-                local selectionChanged = CS.selectedCustomBarId ~= customBarId
-                if selectionChanged then
-                    ClearCustomBarPreviewState()
-                end
-                CS.selectedCustomBarId = customBarId
-                wipe(CS.selectedButtons)
-                wipe(CS.selectedCustomBars)
+                local selectionChanged = SelectConfigCustomBar(customBarId, {
+                    clearPreview = true,
+                    clearButtonMulti = true,
+                })
                 if selectionChanged then
                     CooldownCompanion:RefreshConfigPanel()
                 end
                 OpenCustomBarRowMenu(customBars, customBarsSpecID, customBarId, entry)
             elseif mouseButton == "LeftButton" then
                 if IsControlKeyDown and IsControlKeyDown() then
-                    if CS.selectedCustomBars[customBarId] then
-                        CS.selectedCustomBars[customBarId] = nil
-                    else
-                        CS.selectedCustomBars[customBarId] = true
-                    end
-                    if CS.selectedCustomBarId and not CS.selectedCustomBars[CS.selectedCustomBarId] and next(CS.selectedCustomBars) then
-                        CS.selectedCustomBars[CS.selectedCustomBarId] = true
-                    end
-                    ClearCustomBarPreviewState()
+                    ToggleConfigCustomBarMultiSelect(customBarId)
                     CooldownCompanion:RefreshConfigPanel()
                     return
                 end
 
-                wipe(CS.selectedCustomBars)
-                if CS.selectedCustomBarId == customBarId then
-                    ClearCustomBarPreviewState()
-                    CS.selectedCustomBarId = nil
-                    CS.customBarSettingsTab = "appearance"
-                else
-                    if CS.selectedCustomBarId ~= customBarId then
-                        ClearCustomBarPreviewState()
-                    end
-                    CS.selectedCustomBarId = customBarId
-                end
+                SelectConfigCustomBar(customBarId, {
+                    clearPreview = true,
+                    toggle = true,
+                })
                 CooldownCompanion:RefreshConfigPanel()
             end
         end)


### PR DESCRIPTION
## What Players Will Notice
- The settings UI should keep the right folder, group, panel, entry, and Custom Bar selected as players navigate, add entries, delete config objects, or switch between config views.
- Custom Bar rows now participate in the same selected-row feedback as other config lists, so the active Custom Bar is easier to track while editing.

## Why This Changed
- Config selection had grown into an implicit state machine spread across multiple columns and popup handlers.
- Directly mutating selection fields in many places made stale selections easier to introduce when folders, panels, entries, or Custom Bars changed underneath the UI.

## What Changed
- Added shared config-selection helpers in `Config/State.lua` for folder, container, panel, button, multiselect, Custom Bar, preview, and reset transitions.
- Routed the main config columns, lifecycle handlers, popups, Custom Bar settings, and Spell/Item add flows through those helpers.
- Pruned deleted or missing selected IDs instead of broadly clearing unrelated selection state.
- Reduced direct selected-state mutations outside `Config/State.lua` from 210 to 34 in the changed config surfaces.

## Validation
- `luac -p` passed across all Lua files.
- `git diff --check origin/main...HEAD` passed.
- Incremental in-game config validation was performed while merging the dev-branch PRs into `config-state-cleanup-dev-main`.
- No combat or restricted-content validation was performed for this config-screen cleanup; a final in-game smoke pass before merging to `main` is still recommended.