### PR TITLE
Extract shared bar runtime for custom bar parity

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local EntryRuntime = ST.EntryRuntime
 
 -- Localize frequently-used globals
 local GetTime = GetTime
@@ -13,7 +14,6 @@ local tonumber = tonumber
 local tostring = tostring
 local ipairs = ipairs
 local type = type
-local wipe = wipe
 local issecretvalue = issecretvalue
 local math_max = math.max
 
@@ -461,90 +461,6 @@ local function CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverri
     end
 end
 
--- Hidden scratch CooldownFrame for probing DurationObject activity.
--- DurationObject:IsZero() returns a secret boolean in tainted contexts;
--- feeding the object to a Cooldown widget and checking IsShown() yields
--- a plain boolean safe for Lua logic.  Used by action-slot and totem
--- probes, which have no isActive companion field on their return values.
-local scratchParent = CreateFrame("Frame")
-scratchParent:Hide()
-local scratchCooldown = CreateFrame("Cooldown", nil, scratchParent, "CooldownFrameTemplate")
-
-local function DurationObjectShowsCooldown(durationObj)
-    if not durationObj then return false end
-    scratchCooldown:SetCooldownFromDurationObject(durationObj)
-    local shown = scratchCooldown:IsShown()
-    scratchCooldown:SetCooldown(0, 0)
-    return shown
-end
-
-local function GetConfiguredAuraUnit(buttonData)
-    return buttonData.auraUnit or "player"
-end
-
-local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
-    local unit = viewerFrame.auraDataUnit or auraUnit
-    if not (viewerFrame.auraInstanceID and unit == configUnit) then
-        return false
-    end
-
-    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerFrame.auraInstanceID)
-    if not auraData then
-        return false
-    end
-
-    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
-end
-
-local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
-    local viewerCooldown = viewerFrame.Cooldown
-    if not (viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown()) then
-        return false
-    end
-
-    local vUnit = viewerFrame.auraDataUnit or auraUnit
-    if vUnit ~= configUnit then
-        return false
-    end
-
-    local startMs, durMs = viewerCooldown:GetCooldownTimes()
-    if issecretvalue(durMs) then
-        return true
-    end
-
-    return durMs > 0 and (startMs + durMs) > now * 1000
-end
-
-local function ViewerFrameHasActiveTotemDuration(viewerFrame)
-    local totemSlot = viewerFrame.preferredTotemUpdateSlot
-    if not (totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData) then
-        return false
-    end
-
-    return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
-end
-
-local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
-    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
-        or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
-        or ViewerFrameHasActiveTotemDuration(viewerFrame)
-end
-
-local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
-    local firstTrackedFrame
-    for _, spellID in ipairs(candidateIDs or {}) do
-        local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
-        if viewerFrame then
-            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
-                return viewerFrame, firstTrackedFrame
-            end
-            firstTrackedFrame = firstTrackedFrame or viewerFrame
-        end
-    end
-    return nil, firstTrackedFrame
-end
-CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
-
 local function DispatchStandaloneTextureVisual(button)
     if not button then
         return
@@ -593,136 +509,6 @@ function CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
     end
 end
 
--- Deferred spell cooldown detection: distinguish true held cooldowns from
--- start-recovery / empower recovery windows. In 12.0.1, unrelated spells can
--- transiently report isEnabled=false, isActive=false, and a positive
--- timeUntilEndOfStartRecovery while an empowered cast is being held. That
--- state should not drive cooldown desaturation, bar fill, text placeholders,
--- or hide-on-cooldown visibility. Treat it as recovery-only, not deferred CD.
-local function IsSpellCooldownDeferred(info)
-    if not info or info.isEnabled ~= false or info.isActive == true then
-        return false
-    end
-
-    if info.isOnGCD == true then
-        return false
-    end
-
-    local recoveryTime = info.timeUntilEndOfStartRecovery
-    if recoveryTime == nil then
-        return true
-    end
-
-    if issecretvalue(recoveryTime) then
-        -- Secret recovery values are unreadable in restricted states; when they
-        -- coincide with the GCD the earlier guard already classifies them as
-        -- recovery-only. Outside that case, keep the existing deferred-cooldown
-        -- behavior until a concrete counterexample is observed in game.
-        return true
-    end
-
-    return recoveryTime <= 0
-end
-
-local ProbeActionSlotCooldownForSpell
-
-local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
-    local result = {
-        spellID = spellID,
-        fetchOk = false,
-        state = COOLDOWN_STATE_READY,
-        source = "ready",
-        realCooldownShown = false,
-        isOnGCD = false,
-        deferred = false,
-    }
-
-    if not spellID then
-        return result
-    end
-
-    options = options or {}
-
-    local info = C_Spell.GetSpellCooldown(spellID)
-    result.info = info
-    if not info then
-        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
-            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
-            if slotProbe.shown ~= nil then
-                result.fetchOk = true
-                result.normalCooldownShown = slotProbe.shown == true
-                result.realCooldownShown = slotProbe.realShown == true
-                result.durationObj = slotProbe.durationObj
-                result.realDurationObj = slotProbe.realDurationObj
-                result.slotProbe = slotProbe
-                if result.realCooldownShown and slotProbe.realDurationObj then
-                    result.state = COOLDOWN_STATE_COOLDOWN
-                    result.source = "action-slot-real-no-spell-info"
-                    result.renderDurationObj = slotProbe.realDurationObj
-                    result.isOnGCD = CooldownCompanion._gcdActive == true
-                elseif slotProbe.shown and slotProbe.durationObj then
-                    result.source = "action-slot-gcd-no-spell-info"
-                    result.presentationState = COOLDOWN_STATE_GCD
-                    result.renderDurationObj = slotProbe.durationObj
-                    result.isOnGCD = true
-                end
-            end
-        end
-        return result
-    end
-
-    result.fetchOk = true
-    result.isOnGCD = info.isOnGCD or false
-    result.deferred = IsSpellCooldownDeferred(info)
-
-    if info.isActive then
-        result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
-        result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
-        result.normalCooldownShown = DurationObjectShowsCooldown(result.durationObj)
-        result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
-    end
-
-    if result.deferred then
-        result.state = COOLDOWN_STATE_COOLDOWN
-        result.source = "spell-deferred"
-    elseif result.realCooldownShown and result.realDurationObj then
-        result.state = COOLDOWN_STATE_COOLDOWN
-        result.source = "spell-real-ignore-gcd"
-        result.renderDurationObj = result.realDurationObj
-    elseif CooldownLogic.IsSpellGCDOnly(info, {
-        normalCooldownShown = result.normalCooldownShown,
-        realCooldownShown = result.realCooldownShown,
-    }) then
-        result.source = "spell-gcd"
-        result.presentationState = COOLDOWN_STATE_GCD
-        result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
-    end
-
-    local needsRealCooldownFallback = result.state ~= COOLDOWN_STATE_COOLDOWN
-        and (result.isOnGCD == true or result.normalCooldownShown == true)
-
-    -- Some short real cooldowns surface as GCD-only through the spell lane
-    -- until the GCD ends. The action-slot duration object matches Blizzard's
-    -- button display and can expose the real ignoreGCD cooldown immediately.
-    if needsRealCooldownFallback
-        and options.allowActionSlotRealFallback
-        and ProbeActionSlotCooldownForSpell then
-        local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
-        if slotProbe.realShown == true and slotProbe.realDurationObj then
-            result.slotProbe = slotProbe
-            result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
-            result.realCooldownShown = true
-            result.durationObj = slotProbe.durationObj or result.durationObj
-            result.realDurationObj = slotProbe.realDurationObj
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "action-slot-real-fallback"
-            result.renderDurationObj = slotProbe.realDurationObj
-        end
-    end
-
-    return result
-end
-
 local function GetLiveOverrideSpellID(buttonData)
     if not (buttonData and buttonData.type == "spell" and not buttonData.isPassive) then
         return nil
@@ -734,82 +520,6 @@ local function GetLiveOverrideSpellID(buttonData)
     end
 
     return nil
-end
-
-local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
-    local allowActionSlotRealFallback = buttonData.hasCharges ~= true
-        and cooldownSpellId == buttonData.id
-        and noCooldown ~= true
-
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
-        allowActionSlotRealFallback = allowActionSlotRealFallback,
-    })
-end
-
-function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
-    local spellID = tonumber(customBar and customBar.spellID)
-    local result
-    if not spellID then
-        return EvaluateSpellCooldownLane(nil, 0, nil)
-    end
-
-    local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
-    if not cooldownSpellID or cooldownSpellID == 0 then
-        cooldownSpellID = spellID
-    end
-
-    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
-        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
-        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
-        customBar._cooldownSecrecySpellID = cooldownSpellID
-    end
-
-    local charges = C_Spell.GetSpellCharges(cooldownSpellID)
-    local maxCharges = charges and tonumber(charges.maxCharges)
-    if maxCharges and maxCharges > 1 then
-        customBar.hasCharges = true
-        customBar.maxCharges = maxCharges
-    elseif charges then
-        customBar.hasCharges = nil
-        customBar.maxCharges = maxCharges
-    elseif not charges then
-        customBar.hasCharges = nil
-    end
-
-    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
-        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
-    })
-    result.baseSpellID = spellID
-    result.cooldownSpellID = cooldownSpellID
-
-    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
-        result.hasCharges = true
-        result.maxCharges = maxCharges
-        result.charges = charges
-
-        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
-            result.currentCharges = charges.currentCharges
-            if result.currentCharges <= 0 then
-                result.chargeState = CHARGE_STATE_ZERO
-            elseif result.currentCharges >= maxCharges then
-                result.chargeState = CHARGE_STATE_FULL
-            else
-                result.chargeState = CHARGE_STATE_MISSING
-            end
-        end
-
-        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
-        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
-        result.chargeDurationObj = chargeDurationObj
-        result.chargeRecharging = chargeRecharging or false
-        if chargeRecharging then
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "spell-charge-recharge"
-            result.renderDurationObj = chargeDurationObj
-        end
-    end
-
-    return result
 end
 
 local function ResolveChargeState(button, buttonData)
@@ -851,112 +561,6 @@ local function ResolveChargeState(button, buttonData)
     end
 
     return nil
-end
-
--- Probe action-slot cooldown state for a spell ID pair (base + display override).
-local actionSlotSeenScratch = {}
-
-local function MergeActionSlotProbe(result, probe)
-    if probe.sawAnySlot then result.sawAnySlot = true end
-    if probe.sawUnknown then result.sawUnknown = true end
-    if probe.slot and not result.slot then result.slot = probe.slot end
-    if probe.matchedSpellID and not result.matchedSpellID then result.matchedSpellID = probe.matchedSpellID end
-    if probe.shown ~= nil then result.shown = probe.shown end
-    if probe.realShown ~= nil then result.realShown = probe.realShown end
-    if probe.durationObj then result.durationObj = result.durationObj or probe.durationObj end
-    if probe.realDurationObj then result.realDurationObj = result.realDurationObj or probe.realDurationObj end
-    if probe.shown or probe.realShown then
-        result.shown = probe.shown == true
-        result.durationObj = probe.durationObj or result.durationObj
-        result.realShown = probe.realShown == true
-        result.realDurationObj = probe.realDurationObj or result.realDurationObj
-        result.slot = probe.slot or result.slot
-        result.matchedSpellID = probe.matchedSpellID or result.matchedSpellID
-        return true
-    end
-    return false
-end
-
-local function ProbeActionSlotsForSpellID(spellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
-
-    if not spellID then return result end
-
-    local slots = C_ActionBar.FindSpellActionButtons(spellID)
-    if not slots then return result end
-
-    for _, slot in ipairs(slots) do
-        if not actionSlotSeenScratch[slot] then
-            actionSlotSeenScratch[slot] = true
-            result.sawAnySlot = true
-            result.slot = result.slot or slot
-            result.matchedSpellID = result.matchedSpellID or spellID
-
-            local durationObj = C_ActionBar.GetActionCooldownDuration(slot)
-            local realDurationObj = C_ActionBar.GetActionCooldownDuration(slot, true)
-            local shown = false
-            local realShown
-
-            if durationObj then
-                shown = DurationObjectShowsCooldown(durationObj)
-            end
-
-            if realDurationObj then
-                realShown = DurationObjectShowsCooldown(realDurationObj)
-            end
-
-            if shown or realShown then
-                result.shown = shown == true
-                result.durationObj = durationObj
-                result.realShown = realShown == true
-                result.realDurationObj = realDurationObj
-                result.slot = slot
-                result.matchedSpellID = spellID
-                return result
-            end
-        end
-    end
-
-    if result.sawAnySlot then
-        result.shown = false
-    end
-
-    return result
-end
-
-function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
-
-    if not baseSpellID then return result end
-
-    wipe(actionSlotSeenScratch)
-
-    if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(baseSpellID)) then
-        return result
-    end
-
-    if displaySpellID and displaySpellID ~= baseSpellID then
-        if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(displaySpellID)) then
-            return result
-        end
-    end
-
-    if result.sawAnySlot and not result.sawUnknown then
-        result.shown = false
-        result.realShown = false
-    end
-
-    return result
 end
 
 local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
@@ -1219,122 +823,22 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
-        local configUnit = GetConfiguredAuraUnit(buttonData)
+        local configUnit = EntryRuntime.GetConfiguredAuraUnit(buttonData)
         local auraUnit = button._auraUnit or configUnit
-
-        local viewerFrame
-        local cdmEnabled
-        if CooldownCompanion._cooldownUpdatePassActive then
-            cdmEnabled = CooldownCompanion._cdmViewerEnabled == true
-        else
-            cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
-        end
-        local orderedStandaloneAuraIDs
-        local standaloneOriginalAuraIDs
-        local standaloneFallbackAuraIDs
-        if buttonData.addedAs == "aura" then
-            if not button._orderedStandaloneAuraIDs
-                or button._orderedStandaloneAuraIDsRaw ~= buttonData.auraSpellID
-                or button._orderedStandaloneAuraIDsButtonID ~= buttonData.id
-                or button._orderedStandaloneAuraIDsAuraSpellID ~= button._auraSpellID then
-                local originalAuraIDs, fallbackAuraIDs = CooldownCompanion:GetStandaloneAuraCandidateGroups(buttonData)
-                local allAuraIDs = {}
-                for _, spellID in ipairs(originalAuraIDs) do
-                    allAuraIDs[#allAuraIDs + 1] = spellID
-                end
-                for _, spellID in ipairs(fallbackAuraIDs) do
-                    allAuraIDs[#allAuraIDs + 1] = spellID
-                end
-                button._standaloneOriginalAuraIDs = originalAuraIDs
-                button._standaloneFallbackAuraIDs = fallbackAuraIDs
-                button._orderedStandaloneAuraIDs = allAuraIDs
-                button._orderedStandaloneAuraIDsRaw = buttonData.auraSpellID
-                button._orderedStandaloneAuraIDsButtonID = buttonData.id
-                button._orderedStandaloneAuraIDsAuraSpellID = button._auraSpellID
-            end
-            orderedStandaloneAuraIDs = button._orderedStandaloneAuraIDs
-            standaloneOriginalAuraIDs = button._standaloneOriginalAuraIDs
-            standaloneFallbackAuraIDs = button._standaloneFallbackAuraIDs
-        end
 
         -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
         -- untainted code that matches spell IDs to auras during combat and
         -- stores auraInstanceID + auraDataUnit as plain readable properties.
         -- Requires the Blizzard Cooldown Manager to be visible with this spell.
-        -- CDM child slot: use specific child for multi-entry spells (e.g., Diabolic Ritual)
-        if buttonData.cdmChildSlot then
-            local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
-            if allChildren then
-                viewerFrame = allChildren[buttonData.cdmChildSlot]
-            end
-        end
-        -- Try standalone aura identity first; visible fallback IDs are only
-        -- considered after original candidates fail all active proofs.
-        if not viewerFrame and orderedStandaloneAuraIDs then
-            local originalActiveFrame, firstOriginalFrame = CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame(
-                standaloneOriginalAuraIDs,
-                configUnit,
-                auraUnit,
-                now,
-                barAuraStackConfigured
-            )
-            viewerFrame = originalActiveFrame
-            if not viewerFrame then
-                local fallbackActiveFrame, firstFallbackFrame = CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame(
-                    standaloneFallbackAuraIDs,
-                    configUnit,
-                    auraUnit,
-                    now,
-                    barAuraStackConfigured
-                )
-                viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
-            end
-        elseif not viewerFrame and buttonData.auraSpellID then
-            -- Cache parsed IDs on the button to avoid per-tick gmatch allocation.
-            local ids = button._parsedAuraIDs
-            if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
-                ids = {}
-                button._parsedAuraIDsIncludeButtonID = nil
-                for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                    local numId = tonumber(id)
-                    ids[#ids + 1] = numId
-                    if numId == buttonData.id then
-                        button._parsedAuraIDsIncludeButtonID = true
-                    end
-                end
-                button._parsedAuraIDs = ids
-                button._parsedAuraIDsRaw = buttonData.auraSpellID
-                button._parsedAuraIDsButtonID = buttonData.id
-            end
-            for _, numId in ipairs(ids) do
-                local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
-                if f then
-                    if f.auraInstanceID then
-                        viewerFrame = f
-                        break
-                    elseif not viewerFrame then
-                        viewerFrame = f
-                    end
-                end
-            end
-        end
-        -- Fall back to resolved aura ID, then ability ID, then current override form.
-        -- _displaySpellId tracks the current override (e.g. Solar → Lunar Eclipse)
-        -- and is always present in the viewer map after BuildViewerAuraMap.
-        if not viewerFrame then
-            viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(button._auraSpellID)
-            if not viewerFrame then
-                viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(buttonData.id)
-                    or (button._displaySpellId and CooldownCompanion:ResolveBuffViewerFrameForSpell(button._displaySpellId))
-                -- Try base spell for form-variant spells (e.g. Stampeding Roar)
-                if not viewerFrame then
-                    local baseId = C_Spell.GetBaseSpell(buttonData.id)
-                    if baseId and baseId ~= buttonData.id and baseId ~= button._auraSpellID then
-                        viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(baseId)
-                    end
-                end
-            end
-        end
+        local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = EntryRuntime.ResolveTrackedAuraViewerFrame(
+            button,
+            buttonData,
+            button._auraSpellID,
+            configUnit,
+            auraUnit,
+            now,
+            barAuraStackConfigured
+        )
         auraTrackingReady = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
         if auraTrackingReady and not auraOverrideActive and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
             local viewerInstId = viewerFrame.auraInstanceID
@@ -1362,7 +866,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 button._durationObj = durationObj
                                 button.cooldown:SetCooldownFromDurationObject(durationObj)
                             end
-                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
                         else
                             auraHasTimer = false
                         end
@@ -1431,9 +935,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                         local totemDuration = GetTotemDuration(totemSlot)
                         local totemActive = false
                         if totemDuration then
-                            scratchCooldown:SetCooldownFromDurationObject(totemDuration)
-                            totemActive = scratchCooldown:IsShown()
-                            scratchCooldown:SetCooldown(0, 0)
+                            totemActive = EntryRuntime.DurationObjectShowsCooldown(totemDuration)
                         end
                         if totemActive then
                             button._auraDurationObj = totemDuration
@@ -1542,7 +1044,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 button._durationObj = durationObj
                                 button.cooldown:SetCooldownFromDurationObject(durationObj)
                             end
-                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
                         else
                             auraHasTimer = false
                         end
@@ -1581,7 +1083,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 button._durationObj = durationObj
                                 button.cooldown:SetCooldownFromDurationObject(durationObj)
                             end
-                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
                         else
                             auraHasTimer = false
                         end
@@ -1863,65 +1365,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button.cooldown:SetCooldown(0, 0)
         button.cooldown:Hide()
 
-        local stackValue = 0
-        local stackValueAvailable = true
-        local stackValueFromSecretText
-        local previousValueIsSecret = previousBarAuraStackValueSecret
-            or (previousBarAuraStackValueAvailable and issecretvalue(previousBarAuraStackValue))
-        if auraOverrideActive then
-            stackValue = auraApplications
-            local stackValueIsSecret = issecretvalue(stackValue)
-            if not stackValueIsSecret and stackValue == nil and button._auraStackText ~= nil then
-                if issecretvalue(button._auraStackText) then
-                    stackValue = button._auraStackText
-                    stackValueIsSecret = true
-                    stackValueFromSecretText = true
-                else
-                    stackValue = tonumber(button._auraStackText)
-                    stackValueIsSecret = false
-                end
-            end
-            if not stackValueIsSecret and stackValue == nil then
-                if auraGraceHeld and previousBarAuraStackValueAvailable and not previousValueIsSecret then
-                    stackValue = previousBarAuraStackValue
-                    stackValueIsSecret = previousValueIsSecret
-                elseif auraGraceHeld and previousValueIsSecret then
-                    stackValueAvailable = false
-                    preserveBarAuraStackText = true
-                else
-                    stackValue = 1
-                end
-            end
-            if stackValueAvailable and not stackValueIsSecret and stackValue < 1 then
-                stackValue = 1
-            end
-        end
-        local stackValueIsSecret = stackValueAvailable and issecretvalue(stackValue)
-        local stackValueChanged = previousBarAuraStackValueAvailable ~= stackValueAvailable
-        if not stackValueChanged and stackValueAvailable and not stackValueIsSecret and not previousValueIsSecret then
-            stackValueChanged = previousBarAuraStackValue ~= stackValue
-        end
-        if auraGraceHeld and previousValueIsSecret and not stackValueAvailable then
-            button._barAuraStackValue = nil
-            button._barAuraStackValueAvailable = nil
-            button._barAuraStackValueSecret = true
-            button._barAuraStackValueDirty = nil
-        elseif stackValueIsSecret then
-            if not stackValueFromSecretText then
-                barAuraSecretStackValue = stackValue
-            end
-            button._barAuraStackValue = nil
-            button._barAuraStackValueAvailable = nil
-            button._barAuraStackValueSecret = true
-            button._barAuraStackValueDirty = nil
-            if not stackValueFromSecretText and CooldownCompanion.ApplyBarPanelAuraStackVisual then
-                CooldownCompanion.ApplyBarPanelAuraStackVisual(button, stackValue, true)
-            end
-        else
-            button._barAuraStackValue = stackValue
-            button._barAuraStackValueAvailable = stackValueAvailable or nil
-            button._barAuraStackValueDirty = previousValueIsSecret or stackValueChanged
-        end
+        barAuraSecretStackValue, preserveBarAuraStackText = EntryRuntime.ApplyBarAuraStackState(
+            button,
+            auraOverrideActive,
+            auraApplications,
+            auraGraceHeld,
+            previousBarAuraStackValue,
+            previousBarAuraStackValueAvailable,
+            previousBarAuraStackValueSecret
+        )
     end
 
     if buttonData.isPassive and not auraOverrideActive then
@@ -1933,9 +1385,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         auraProbeInfo = C_Spell.GetSpellCooldown(cooldownSpellId)
         if auraProbeInfo and auraProbeInfo.isActive then
             local auraProbeNormalDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId)
-            auraProbeNormalCooldownShown = DurationObjectShowsCooldown(auraProbeNormalDuration)
+            auraProbeNormalCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeNormalDuration)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
-            auraProbeRealCooldownShown = DurationObjectShowsCooldown(auraProbeDuration)
+            auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
         auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, {
             normalCooldownShown = auraProbeNormalCooldownShown,
@@ -1982,7 +1434,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOwnsPrimarySwipe and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
+            spellCooldownResult = EntryRuntime.EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
@@ -2034,7 +1486,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if usesChargeBehavior and buttonData.hasCharges and buttonData.type == "spell" then
         button._displayCountZeroUsabilityFallback = nil
         charges = UpdateChargeTracking(button, buttonData, cooldownSpellId)
-        button._chargeCooldownVisualActive = DurationObjectShowsCooldown(button._chargeDurationObj)
+        button._chargeCooldownVisualActive = EntryRuntime.DurationObjectShowsCooldown(button._chargeDurationObj)
         button._chargeRecharging = button._chargeCooldownVisualActive
     elseif usesChargeBehavior
         and (buttonData._hasDisplayCount or buttonData._displayCountFamily)
@@ -2188,7 +1640,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
             local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
-                or ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+                or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
             if slotProbe.shown ~= nil then
                 button._mainCDShown = slotProbe.realShown == true
             elseif not auraOwnsPrimarySwipe then
@@ -2287,7 +1739,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- Only an active charge DurationObject may replace an existing GCD display.
             local chargeSpellID = cooldownSpellId or buttonData.id
             local fallbackDuration = C_Spell.GetSpellChargeDuration(chargeSpellID)
-            local fallbackActive = DurationObjectShowsCooldown(fallbackDuration)
+            local fallbackActive = EntryRuntime.DurationObjectShowsCooldown(fallbackDuration)
             button._chargeCooldownVisualActive = fallbackActive or nil
             if fallbackActive then
                 button._chargeRecharging = true

--- a/ButtonFrame/EntryRuntime.lua
+++ b/ButtonFrame/EntryRuntime.lua
@@ -1,0 +1,604 @@
+--[[
+    CooldownCompanion - ButtonFrame/EntryRuntime
+    Shared cooldown/aura runtime helpers for bar-panel entries.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+
+local ipairs = ipairs
+local tonumber = tonumber
+local tostring = tostring
+local wipe = wipe
+local issecretvalue = issecretvalue
+
+local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
+local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+
+local EntryRuntime = ST.EntryRuntime or {}
+ST.EntryRuntime = EntryRuntime
+
+-- Hidden scratch CooldownFrame for probing DurationObject activity.
+-- DurationObject:IsZero() returns a secret boolean in tainted contexts;
+-- feeding the object to a Cooldown widget and checking IsShown() yields a
+-- plain boolean safe for Lua logic.
+local scratchParent = CreateFrame("Frame")
+scratchParent:Hide()
+local scratchCooldown = CreateFrame("Cooldown", nil, scratchParent, "CooldownFrameTemplate")
+
+local function DurationObjectShowsCooldown(durationObj)
+    if not durationObj then return false end
+    scratchCooldown:SetCooldownFromDurationObject(durationObj)
+    local shown = scratchCooldown:IsShown()
+    scratchCooldown:SetCooldown(0, 0)
+    return shown
+end
+EntryRuntime.DurationObjectShowsCooldown = DurationObjectShowsCooldown
+
+local function GetConfiguredAuraUnit(buttonData)
+    return buttonData.auraUnit or "player"
+end
+EntryRuntime.GetConfiguredAuraUnit = GetConfiguredAuraUnit
+
+local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+    local unit = viewerFrame.auraDataUnit or auraUnit
+    if not (viewerFrame.auraInstanceID and unit == configUnit) then
+        return false
+    end
+
+    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerFrame.auraInstanceID)
+    if not auraData then
+        return false
+    end
+
+    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
+end
+
+local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+    local viewerCooldown = viewerFrame.Cooldown
+    if not (viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown()) then
+        return false
+    end
+
+    local vUnit = viewerFrame.auraDataUnit or auraUnit
+    if vUnit ~= configUnit then
+        return false
+    end
+
+    local startMs, durMs = viewerCooldown:GetCooldownTimes()
+    if issecretvalue(durMs) then
+        return true
+    end
+
+    return durMs > 0 and (startMs + durMs) > now * 1000
+end
+
+local function ViewerFrameHasActiveTotemDuration(viewerFrame)
+    local totemSlot = viewerFrame.preferredTotemUpdateSlot
+    if not (totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData) then
+        return false
+    end
+
+    return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
+end
+
+local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
+    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+        or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+        or ViewerFrameHasActiveTotemDuration(viewerFrame)
+end
+
+local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
+    local firstTrackedFrame
+    for _, spellID in ipairs(candidateIDs or {}) do
+        local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
+        if viewerFrame then
+            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
+                return viewerFrame, firstTrackedFrame
+            end
+            firstTrackedFrame = firstTrackedFrame or viewerFrame
+        end
+    end
+    return nil, firstTrackedFrame
+end
+EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+
+local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, barAuraStackConfigured)
+    local viewerFrame
+    local cdmEnabled
+    if CooldownCompanion._cooldownUpdatePassActive then
+        cdmEnabled = CooldownCompanion._cdmViewerEnabled == true
+    else
+        cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
+    end
+
+    local orderedStandaloneAuraIDs
+    local standaloneOriginalAuraIDs
+    local standaloneFallbackAuraIDs
+    if buttonData.addedAs == "aura" then
+        if not owner._orderedStandaloneAuraIDs
+            or owner._orderedStandaloneAuraIDsRaw ~= buttonData.auraSpellID
+            or owner._orderedStandaloneAuraIDsButtonID ~= buttonData.id
+            or owner._orderedStandaloneAuraIDsAuraSpellID ~= auraSpellID then
+            local originalAuraIDs, fallbackAuraIDs = CooldownCompanion:GetStandaloneAuraCandidateGroups(buttonData)
+            local allAuraIDs = {}
+            for _, spellID in ipairs(originalAuraIDs) do
+                allAuraIDs[#allAuraIDs + 1] = spellID
+            end
+            for _, spellID in ipairs(fallbackAuraIDs) do
+                allAuraIDs[#allAuraIDs + 1] = spellID
+            end
+            owner._standaloneOriginalAuraIDs = originalAuraIDs
+            owner._standaloneFallbackAuraIDs = fallbackAuraIDs
+            owner._orderedStandaloneAuraIDs = allAuraIDs
+            owner._orderedStandaloneAuraIDsRaw = buttonData.auraSpellID
+            owner._orderedStandaloneAuraIDsButtonID = buttonData.id
+            owner._orderedStandaloneAuraIDsAuraSpellID = auraSpellID
+        end
+        orderedStandaloneAuraIDs = owner._orderedStandaloneAuraIDs
+        standaloneOriginalAuraIDs = owner._standaloneOriginalAuraIDs
+        standaloneFallbackAuraIDs = owner._standaloneFallbackAuraIDs
+    end
+
+    if buttonData.cdmChildSlot then
+        local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
+        if allChildren then
+            viewerFrame = allChildren[buttonData.cdmChildSlot]
+        end
+    end
+
+    if not viewerFrame and orderedStandaloneAuraIDs then
+        local originalActiveFrame, firstOriginalFrame = ResolvePreferredStandaloneAuraViewerFrame(
+            standaloneOriginalAuraIDs,
+            configUnit,
+            auraUnit,
+            now,
+            barAuraStackConfigured
+        )
+        viewerFrame = originalActiveFrame
+        if not viewerFrame then
+            local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredStandaloneAuraViewerFrame(
+                standaloneFallbackAuraIDs,
+                configUnit,
+                auraUnit,
+                now,
+                barAuraStackConfigured
+            )
+            viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
+        end
+    elseif not viewerFrame and buttonData.auraSpellID then
+        local ids = owner._parsedAuraIDs
+        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
+            ids = {}
+            owner._parsedAuraIDsIncludeButtonID = nil
+            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+                local numId = tonumber(id)
+                ids[#ids + 1] = numId
+                if numId == buttonData.id then
+                    owner._parsedAuraIDsIncludeButtonID = true
+                end
+            end
+            owner._parsedAuraIDs = ids
+            owner._parsedAuraIDsRaw = buttonData.auraSpellID
+            owner._parsedAuraIDsButtonID = buttonData.id
+        end
+        for _, numId in ipairs(ids) do
+            local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
+            if f then
+                if f.auraInstanceID then
+                    viewerFrame = f
+                    break
+                elseif not viewerFrame then
+                    viewerFrame = f
+                end
+            end
+        end
+    end
+
+    if not viewerFrame then
+        viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraSpellID)
+        if not viewerFrame then
+            viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(buttonData.id)
+                or (owner._displaySpellId and CooldownCompanion:ResolveBuffViewerFrameForSpell(owner._displaySpellId))
+            if not viewerFrame then
+                local baseId = C_Spell.GetBaseSpell(buttonData.id)
+                if baseId and baseId ~= buttonData.id and baseId ~= auraSpellID then
+                    viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(baseId)
+                end
+            end
+        end
+    end
+
+    return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
+end
+EntryRuntime.ResolveTrackedAuraViewerFrame = ResolveTrackedAuraViewerFrame
+
+local function IsSpellCooldownDeferred(info)
+    if not info or info.isEnabled ~= false or info.isActive == true then
+        return false
+    end
+
+    if info.isOnGCD == true then
+        return false
+    end
+
+    local recoveryTime = info.timeUntilEndOfStartRecovery
+    if recoveryTime == nil then
+        return true
+    end
+
+    if issecretvalue(recoveryTime) then
+        -- Secret recovery values are unreadable in restricted states; when they
+        -- coincide with the GCD the earlier guard already classifies them as
+        -- recovery-only. Outside that case, keep the existing deferred-cooldown
+        -- behavior until a concrete counterexample is observed in game.
+        return true
+    end
+
+    return recoveryTime <= 0
+end
+
+local actionSlotSeenScratch = {}
+
+local function MergeActionSlotProbe(result, probe)
+    if probe.sawAnySlot then result.sawAnySlot = true end
+    if probe.sawUnknown then result.sawUnknown = true end
+    if probe.slot and not result.slot then result.slot = probe.slot end
+    if probe.matchedSpellID and not result.matchedSpellID then result.matchedSpellID = probe.matchedSpellID end
+    if probe.shown ~= nil then result.shown = probe.shown end
+    if probe.realShown ~= nil then result.realShown = probe.realShown end
+    if probe.durationObj then result.durationObj = result.durationObj or probe.durationObj end
+    if probe.realDurationObj then result.realDurationObj = result.realDurationObj or probe.realDurationObj end
+    if probe.shown or probe.realShown then
+        result.shown = probe.shown == true
+        result.durationObj = probe.durationObj or result.durationObj
+        result.realShown = probe.realShown == true
+        result.realDurationObj = probe.realDurationObj or result.realDurationObj
+        result.slot = probe.slot or result.slot
+        result.matchedSpellID = probe.matchedSpellID or result.matchedSpellID
+        return true
+    end
+    return false
+end
+
+local function ProbeActionSlotsForSpellID(spellID)
+    local result = {
+        shown = nil,
+        realShown = nil,
+        sawAnySlot = false,
+        sawUnknown = false,
+    }
+
+    if not spellID then return result end
+
+    local slots = C_ActionBar.FindSpellActionButtons(spellID)
+    if not slots then return result end
+
+    for _, slot in ipairs(slots) do
+        if not actionSlotSeenScratch[slot] then
+            actionSlotSeenScratch[slot] = true
+            result.sawAnySlot = true
+            result.slot = result.slot or slot
+            result.matchedSpellID = result.matchedSpellID or spellID
+
+            local durationObj = C_ActionBar.GetActionCooldownDuration(slot)
+            local realDurationObj = C_ActionBar.GetActionCooldownDuration(slot, true)
+            local shown = false
+            local realShown
+
+            if durationObj then
+                shown = DurationObjectShowsCooldown(durationObj)
+            end
+
+            if realDurationObj then
+                realShown = DurationObjectShowsCooldown(realDurationObj)
+            end
+
+            if shown or realShown then
+                result.shown = shown == true
+                result.durationObj = durationObj
+                result.realShown = realShown == true
+                result.realDurationObj = realDurationObj
+                result.slot = slot
+                result.matchedSpellID = spellID
+                return result
+            end
+        end
+    end
+
+    if result.sawAnySlot then
+        result.shown = false
+    end
+
+    return result
+end
+
+local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
+    local result = {
+        shown = nil,
+        realShown = nil,
+        sawAnySlot = false,
+        sawUnknown = false,
+    }
+
+    if not baseSpellID then return result end
+
+    wipe(actionSlotSeenScratch)
+
+    if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(baseSpellID)) then
+        return result
+    end
+
+    if displaySpellID and displaySpellID ~= baseSpellID then
+        if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(displaySpellID)) then
+            return result
+        end
+    end
+
+    if result.sawAnySlot and not result.sawUnknown then
+        result.shown = false
+        result.realShown = false
+    end
+
+    return result
+end
+EntryRuntime.ProbeActionSlotCooldownForSpell = ProbeActionSlotCooldownForSpell
+
+local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
+    local result = {
+        spellID = spellID,
+        fetchOk = false,
+        state = COOLDOWN_STATE_READY,
+        source = "ready",
+        realCooldownShown = false,
+        isOnGCD = false,
+        deferred = false,
+    }
+
+    if not spellID then
+        return result
+    end
+
+    options = options or {}
+
+    local info = C_Spell.GetSpellCooldown(spellID)
+    result.info = info
+    if not info then
+        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
+            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
+            if slotProbe.shown ~= nil then
+                result.fetchOk = true
+                result.normalCooldownShown = slotProbe.shown == true
+                result.realCooldownShown = slotProbe.realShown == true
+                result.durationObj = slotProbe.durationObj
+                result.realDurationObj = slotProbe.realDurationObj
+                result.slotProbe = slotProbe
+                if result.realCooldownShown and slotProbe.realDurationObj then
+                    result.state = COOLDOWN_STATE_COOLDOWN
+                    result.source = "action-slot-real-no-spell-info"
+                    result.renderDurationObj = slotProbe.realDurationObj
+                    result.isOnGCD = CooldownCompanion._gcdActive == true
+                elseif slotProbe.shown and slotProbe.durationObj then
+                    result.source = "action-slot-gcd-no-spell-info"
+                    result.presentationState = COOLDOWN_STATE_GCD
+                    result.renderDurationObj = slotProbe.durationObj
+                    result.isOnGCD = true
+                end
+            end
+        end
+        return result
+    end
+
+    result.fetchOk = true
+    result.isOnGCD = info.isOnGCD or false
+    result.deferred = IsSpellCooldownDeferred(info)
+
+    if info.isActive then
+        result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+        result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
+        result.normalCooldownShown = DurationObjectShowsCooldown(result.durationObj)
+        result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
+    end
+
+    if result.deferred then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "spell-deferred"
+    elseif result.realCooldownShown and result.realDurationObj then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "spell-real-ignore-gcd"
+        result.renderDurationObj = result.realDurationObj
+    elseif CooldownLogic.IsSpellGCDOnly(info, {
+        normalCooldownShown = result.normalCooldownShown,
+        realCooldownShown = result.realCooldownShown,
+    }) then
+        result.source = "spell-gcd"
+        result.presentationState = COOLDOWN_STATE_GCD
+        result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
+    end
+
+    local needsRealCooldownFallback = result.state ~= COOLDOWN_STATE_COOLDOWN
+        and (result.isOnGCD == true or result.normalCooldownShown == true)
+
+    if needsRealCooldownFallback
+        and options.allowActionSlotRealFallback
+        and ProbeActionSlotCooldownForSpell then
+        local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
+        if slotProbe.realShown == true and slotProbe.realDurationObj then
+            result.slotProbe = slotProbe
+            result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
+            result.realCooldownShown = true
+            result.durationObj = slotProbe.durationObj or result.durationObj
+            result.realDurationObj = slotProbe.realDurationObj
+            result.state = COOLDOWN_STATE_COOLDOWN
+            result.source = "action-slot-real-fallback"
+            result.renderDurationObj = slotProbe.realDurationObj
+        end
+    end
+
+    return result
+end
+EntryRuntime.EvaluateSpellCooldownLane = EvaluateSpellCooldownLane
+
+local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
+    local allowActionSlotRealFallback = buttonData.hasCharges ~= true
+        and cooldownSpellId == buttonData.id
+        and noCooldown ~= true
+
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
+        allowActionSlotRealFallback = allowActionSlotRealFallback,
+    })
+end
+EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
+
+function EntryRuntime.ApplyBarAuraStackState(
+    button,
+    auraOverrideActive,
+    auraApplications,
+    auraGraceHeld,
+    previousBarAuraStackValue,
+    previousBarAuraStackValueAvailable,
+    previousBarAuraStackValueSecret
+)
+    local barAuraSecretStackValue
+    local preserveBarAuraStackText
+    local stackValue = 0
+    local stackValueAvailable = true
+    local stackValueFromSecretText
+    local previousValueIsSecret = previousBarAuraStackValueSecret
+        or (previousBarAuraStackValueAvailable and issecretvalue(previousBarAuraStackValue))
+
+    if auraOverrideActive then
+        stackValue = auraApplications
+        local stackValueIsSecret = issecretvalue(stackValue)
+        if not stackValueIsSecret and stackValue == nil and button._auraStackText ~= nil then
+            if issecretvalue(button._auraStackText) then
+                stackValue = button._auraStackText
+                stackValueIsSecret = true
+                stackValueFromSecretText = true
+            else
+                stackValue = tonumber(button._auraStackText)
+                stackValueIsSecret = false
+            end
+        end
+        if not stackValueIsSecret and stackValue == nil then
+            if auraGraceHeld and previousBarAuraStackValueAvailable and not previousValueIsSecret then
+                stackValue = previousBarAuraStackValue
+                stackValueIsSecret = previousValueIsSecret
+            elseif auraGraceHeld and previousValueIsSecret then
+                stackValueAvailable = false
+                preserveBarAuraStackText = true
+            else
+                stackValue = 1
+            end
+        end
+        if stackValueAvailable and not stackValueIsSecret and stackValue < 1 then
+            stackValue = 1
+        end
+    end
+
+    local stackValueIsSecret = stackValueAvailable and issecretvalue(stackValue)
+    local stackValueChanged = previousBarAuraStackValueAvailable ~= stackValueAvailable
+    if not stackValueChanged and stackValueAvailable and not stackValueIsSecret and not previousValueIsSecret then
+        stackValueChanged = previousBarAuraStackValue ~= stackValue
+    end
+
+    if auraGraceHeld and previousValueIsSecret and not stackValueAvailable then
+        button._barAuraStackValue = nil
+        button._barAuraStackValueAvailable = nil
+        button._barAuraStackValueSecret = true
+        button._barAuraStackValueDirty = nil
+    elseif stackValueIsSecret then
+        if not stackValueFromSecretText then
+            barAuraSecretStackValue = stackValue
+        end
+        button._barAuraStackValue = nil
+        button._barAuraStackValueAvailable = nil
+        button._barAuraStackValueSecret = true
+        button._barAuraStackValueDirty = nil
+        if not stackValueFromSecretText and CooldownCompanion.ApplyBarPanelAuraStackVisual then
+            CooldownCompanion.ApplyBarPanelAuraStackVisual(button, stackValue, true)
+        end
+    else
+        button._barAuraStackValue = stackValue
+        button._barAuraStackValueAvailable = stackValueAvailable or nil
+        button._barAuraStackValueDirty = previousValueIsSecret or stackValueChanged
+    end
+
+    return barAuraSecretStackValue, preserveBarAuraStackText
+end
+
+function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+    local spellID = tonumber(customBar and customBar.spellID)
+    local result
+    if not spellID then
+        return EvaluateSpellCooldownLane(nil, 0, nil)
+    end
+
+    local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
+    if not cooldownSpellID or cooldownSpellID == 0 then
+        cooldownSpellID = spellID
+    end
+
+    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
+        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
+        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
+        customBar._cooldownSecrecySpellID = cooldownSpellID
+    end
+
+    local charges = C_Spell.GetSpellCharges(cooldownSpellID)
+    local maxCharges = charges and tonumber(charges.maxCharges)
+    if maxCharges and maxCharges > 1 then
+        customBar.hasCharges = true
+        customBar.maxCharges = maxCharges
+    elseif charges then
+        customBar.hasCharges = nil
+        customBar.maxCharges = maxCharges
+    elseif not charges then
+        customBar.hasCharges = nil
+    end
+
+    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
+        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
+    })
+    result.baseSpellID = spellID
+    result.cooldownSpellID = cooldownSpellID
+
+    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
+        result.hasCharges = true
+        result.maxCharges = maxCharges
+        result.charges = charges
+
+        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
+            result.currentCharges = charges.currentCharges
+            if result.currentCharges <= 0 then
+                result.chargeState = CHARGE_STATE_ZERO
+            elseif result.currentCharges >= maxCharges then
+                result.chargeState = CHARGE_STATE_FULL
+            else
+                result.chargeState = CHARGE_STATE_MISSING
+            end
+        end
+
+        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+        result.chargeDurationObj = chargeDurationObj
+        result.chargeRecharging = chargeRecharging or false
+        if chargeRecharging then
+            result.state = COOLDOWN_STATE_COOLDOWN
+            result.source = "spell-charge-recharge"
+            result.renderDurationObj = chargeDurationObj
+        end
+    end
+
+    return result
+end
+
+function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
+    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+end

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -78,6 +78,7 @@ ButtonFrame\IconMode.lua
 ButtonFrame\BarMode.lua
 ButtonFrame\TextMode.lua
 ButtonFrame\Preview.lua
+ButtonFrame\EntryRuntime.lua
 ButtonFrame\CooldownUpdate.lua
 Core\GroupFrame.lua
 OtherBars\ResourceBarConstants.lua


### PR DESCRIPTION
## What Changed
- Moved the existing bar-panel cooldown, aura viewer resolution, standalone aura candidate, action-slot cooldown probing, and stack-count state handling into `ButtonFrame/EntryRuntime.lua`.
- Loaded the new helper before `ButtonFrame/CooldownUpdate.lua` and kept `CooldownUpdate.lua` as the current bar-panel adapter.
- Preserved the compatibility `EvaluateSpellCooldownStateForCustomBar` entry point so existing Custom Bar cooldown calls keep working while later PRs move them onto the shared runtime directly.

## Why This Changed
- Custom Bars are being brought to parity with bar panels for cooldown and aura tracking.
- This first PR isolates the proven bar-panel runtime behavior without changing Custom Bar rendering or attachment behavior yet.

## Developer Impact
- Follow-up PRs can reuse one runtime path for Custom Bar cooldowns and auras instead of copying or patching separate resource-bar-only logic.
- Bar panels remain the only direct consumer in this PR, keeping this step behavior-neutral and easier to validate.

## Validation
- `luac -p ButtonFrame\EntryRuntime.lua ButtonFrame\CooldownUpdate.lua ButtonFrame\BarMode.lua ButtonFrame\VisualState.lua Core\Aura.lua OtherBars\ResourceBarCustomBars.lua OtherBars\ResourceBarLifecycle.lua OtherBars\ResourceBar.lua`
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- Inline Lua fixture for extracted stack-state mutation behavior.
- Local code review found no actionable issues.
- Manual validation reported passing after implementation.