### PR TITLE
Align Custom Bar cooldowns with bar panels

### DIFF
--- a/ButtonFrame/EntryRuntime.lua
+++ b/ButtonFrame/EntryRuntime.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local HasTooltipCooldown = ST.HasTooltipCooldown
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -45,7 +46,7 @@ local function GetConfiguredAuraUnit(buttonData)
 end
 EntryRuntime.GetConfiguredAuraUnit = GetConfiguredAuraUnit
 
-local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, allowDurationlessAuraInstance)
     local unit = viewerFrame.auraDataUnit or auraUnit
     if not (viewerFrame.auraInstanceID and unit == configUnit) then
         return false
@@ -56,7 +57,7 @@ local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUni
         return false
     end
 
-    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
+    return allowDurationlessAuraInstance or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
 end
 
 local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
@@ -87,18 +88,18 @@ local function ViewerFrameHasActiveTotemDuration(viewerFrame)
     return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
 end
 
-local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
-    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, allowDurationlessAuraInstance)
+    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, allowDurationlessAuraInstance)
         or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
         or ViewerFrameHasActiveTotemDuration(viewerFrame)
 end
 
-local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
+local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local firstTrackedFrame
     for _, spellID in ipairs(candidateIDs or {}) do
         local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
         if viewerFrame then
-            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
+            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, allowDurationlessAuraInstance) then
                 return viewerFrame, firstTrackedFrame
             end
             firstTrackedFrame = firstTrackedFrame or viewerFrame
@@ -106,10 +107,11 @@ local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUni
     end
     return nil, firstTrackedFrame
 end
-EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
-CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+EntryRuntime.ResolvePreferredAuraViewerFrame = ResolvePreferredAuraViewerFrame
+EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
+CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
 
-local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, barAuraStackConfigured)
+local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local viewerFrame
     local cdmEnabled
     if CooldownCompanion._cooldownUpdatePassActive then
@@ -154,21 +156,21 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
     end
 
     if not viewerFrame and orderedStandaloneAuraIDs then
-        local originalActiveFrame, firstOriginalFrame = ResolvePreferredStandaloneAuraViewerFrame(
+        local originalActiveFrame, firstOriginalFrame = ResolvePreferredAuraViewerFrame(
             standaloneOriginalAuraIDs,
             configUnit,
             auraUnit,
             now,
-            barAuraStackConfigured
+            allowDurationlessAuraInstance
         )
         viewerFrame = originalActiveFrame
         if not viewerFrame then
-            local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredStandaloneAuraViewerFrame(
+            local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredAuraViewerFrame(
                 standaloneFallbackAuraIDs,
                 configUnit,
                 auraUnit,
                 now,
-                barAuraStackConfigured
+                allowDurationlessAuraInstance
             )
             viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
         end
@@ -188,17 +190,14 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
             owner._parsedAuraIDsRaw = buttonData.auraSpellID
             owner._parsedAuraIDsButtonID = buttonData.id
         end
-        for _, numId in ipairs(ids) do
-            local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
-            if f then
-                if f.auraInstanceID then
-                    viewerFrame = f
-                    break
-                elseif not viewerFrame then
-                    viewerFrame = f
-                end
-            end
-        end
+        local activeFrame, firstTrackedFrame = ResolvePreferredAuraViewerFrame(
+            ids,
+            configUnit,
+            auraUnit,
+            now,
+            allowDurationlessAuraInstance
+        )
+        viewerFrame = activeFrame or firstTrackedFrame
     end
 
     if not viewerFrame then
@@ -456,6 +455,175 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
+local function ResolveSpellCooldownSecrecy(owner, spellID)
+    if not (spellID and C_Secrets and C_Secrets.GetSpellCooldownSecrecy) then
+        return owner and owner._cooldownSecrecy or nil
+    end
+
+    if owner then
+        if owner._cooldownSecrecy == nil or owner._cooldownSecrecySpellID ~= spellID then
+            owner._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(spellID)
+            owner._cooldownSecrecySpellID = spellID
+        end
+        return owner._cooldownSecrecy
+    end
+
+    return C_Secrets.GetSpellCooldownSecrecy(spellID)
+end
+
+local function IsNoCooldownSpell(spellID)
+    local baseCd = GetSpellBaseCooldown(spellID)
+    return (not baseCd or baseCd == 0)
+        and not (HasTooltipCooldown and HasTooltipCooldown(spellID))
+end
+
+local function ResolveNoCooldownState(owner, spellID, hasCharges)
+    if hasCharges then
+        if owner then
+            owner._noCooldown = false
+            owner._noCooldownSpellId = nil
+        end
+        return false
+    end
+
+    if not spellID then
+        return false
+    end
+
+    if owner and owner._noCooldown ~= nil and owner._noCooldownSpellId == spellID then
+        return owner._noCooldown == true
+    end
+
+    local noCooldown = IsNoCooldownSpell(spellID)
+    if owner then
+        owner._noCooldownSpellId = spellID
+        owner._noCooldown = noCooldown
+    end
+    return noCooldown
+end
+
+local function ClearOwnerChargeState(owner)
+    if not owner then return end
+    owner._customCooldownHasCharges = nil
+    owner._currentReadableCharges = nil
+    owner._chargeCountReadable = nil
+    owner._zeroChargesConfirmed = nil
+    owner._chargeDurationObj = nil
+    owner._chargeRecharging = nil
+    owner._mainCDShown = nil
+    owner._chargeState = nil
+    owner._chargesSpent = nil
+end
+
+local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
+    if not customBar then return end
+
+    if maxCharges and maxCharges > 1 then
+        if customBar.hasCharges ~= true then
+            customBar.hasCharges = true
+        end
+        if customBar.maxCharges ~= maxCharges then
+            customBar.maxCharges = maxCharges
+        end
+    elseif charges then
+        if customBar.hasCharges ~= nil then
+            customBar.hasCharges = nil
+        end
+        if customBar.maxCharges ~= maxCharges then
+            customBar.maxCharges = maxCharges
+        end
+    else
+        if customBar.hasCharges ~= nil then
+            customBar.hasCharges = nil
+        end
+        if customBar.maxCharges ~= nil then
+            customBar.maxCharges = nil
+        end
+    end
+end
+
+local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpellID, charges, maxCharges)
+    result.hasCharges = true
+    result.maxCharges = maxCharges
+    result.charges = charges
+
+    local currentCharges
+    if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
+        currentCharges = charges.currentCharges
+        result.currentCharges = currentCharges
+    elseif C_Spell.GetSpellDisplayCount then
+        result.chargeDisplayCount = C_Spell.GetSpellDisplayCount(cooldownSpellID)
+    end
+
+    local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+    local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+    result.chargeDurationObj = chargeDurationObj
+    result.chargeRecharging = chargeRecharging or false
+
+    if owner then
+        owner._customCooldownHasCharges = true
+        owner._currentReadableCharges = currentCharges
+        owner._chargeCountReadable = currentCharges ~= nil
+        owner._chargeDurationObj = chargeDurationObj
+        owner._chargeRecharging = result.chargeRecharging
+    end
+
+    local mainCDShown = false
+    if currentCharges ~= nil then
+        mainCDShown = currentCharges <= 0
+    else
+        local slotProbe = result.slotProbe or ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
+        result.chargeSlotProbe = slotProbe
+        if slotProbe.shown ~= nil then
+            mainCDShown = slotProbe.realShown == true
+        elseif result.fetchOk then
+            mainCDShown = result.state == COOLDOWN_STATE_COOLDOWN
+        end
+    end
+
+    if owner then
+        owner._mainCDShown = mainCDShown
+        if result.chargeRecharging and not owner._chargesSpent then
+            owner._chargesSpent = maxCharges or 0
+        end
+    end
+
+    local zeroConfirmed = mainCDShown == true
+    if zeroConfirmed and currentCharges == nil and owner then
+        local spent = owner._chargesSpent
+        if maxCharges and maxCharges > 1 and spent and spent < maxCharges then
+            zeroConfirmed = false
+        end
+    end
+
+    if currentCharges ~= nil then
+        if currentCharges <= 0 then
+            result.chargeState = CHARGE_STATE_ZERO
+        elseif currentCharges >= maxCharges then
+            result.chargeState = CHARGE_STATE_FULL
+        else
+            result.chargeState = CHARGE_STATE_MISSING
+        end
+    elseif zeroConfirmed then
+        result.chargeState = CHARGE_STATE_ZERO
+    elseif result.chargeRecharging then
+        result.chargeState = CHARGE_STATE_MISSING
+    elseif result.chargeRecharging == false then
+        result.chargeState = CHARGE_STATE_FULL
+    end
+
+    if owner then
+        owner._zeroChargesConfirmed = zeroConfirmed
+        owner._chargeState = result.chargeState
+    end
+
+    if result.chargeRecharging then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "spell-charge-recharge"
+        result.renderDurationObj = chargeDurationObj
+    end
+end
+
 function EntryRuntime.ApplyBarAuraStackState(
     button,
     auraOverrideActive,
@@ -533,72 +701,46 @@ function EntryRuntime.ApplyBarAuraStackState(
     return barAuraSecretStackValue, preserveBarAuraStackText
 end
 
-function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local spellID = tonumber(customBar and customBar.spellID)
-    local result
     if not spellID then
         return EvaluateSpellCooldownLane(nil, 0, nil)
     end
+    owner = owner or customBar
 
     local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
     if not cooldownSpellID or cooldownSpellID == 0 then
         cooldownSpellID = spellID
     end
 
-    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
-        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
-        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
-        customBar._cooldownSecrecySpellID = cooldownSpellID
+    if owner then
+        owner._customCooldownBaseSpellID = spellID
+        owner._customCooldownSpellID = cooldownSpellID
     end
 
     local charges = C_Spell.GetSpellCharges(cooldownSpellID)
     local maxCharges = charges and tonumber(charges.maxCharges)
-    if maxCharges and maxCharges > 1 then
-        customBar.hasCharges = true
-        customBar.maxCharges = maxCharges
-    elseif charges then
-        customBar.hasCharges = nil
-        customBar.maxCharges = maxCharges
-    elseif not charges then
-        customBar.hasCharges = nil
-    end
+    SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
+    local hasCharges = (maxCharges or 0) > 1
+    local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
+    local noCooldown = ResolveNoCooldownState(owner, cooldownSpellID, hasCharges)
 
-    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
-        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
+    local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
+        allowActionSlotRealFallback = not hasCharges and cooldownSpellID == spellID and noCooldown ~= true,
     })
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
+    result.noCooldown = noCooldown or nil
 
-    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
-        result.hasCharges = true
-        result.maxCharges = maxCharges
-        result.charges = charges
-
-        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
-            result.currentCharges = charges.currentCharges
-            if result.currentCharges <= 0 then
-                result.chargeState = CHARGE_STATE_ZERO
-            elseif result.currentCharges >= maxCharges then
-                result.chargeState = CHARGE_STATE_FULL
-            else
-                result.chargeState = CHARGE_STATE_MISSING
-            end
-        end
-
-        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
-        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
-        result.chargeDurationObj = chargeDurationObj
-        result.chargeRecharging = chargeRecharging or false
-        if chargeRecharging then
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "spell-charge-recharge"
-            result.renderDurationObj = chargeDurationObj
-        end
+    if hasCharges then
+        ApplyCustomBarChargeState(owner, result, spellID, cooldownSpellID, charges, maxCharges)
+    else
+        ClearOwnerChargeState(owner)
     end
 
     return result
 end
 
-function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
-    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar, owner)
+    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
 end

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -434,6 +434,9 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
                 end
             end
         end)
+        if self.RecordCustomBarSpellCast then
+            self:RecordCustomBarSpellCast(spellID)
+        end
         self:UpdateAllCooldowns()
     end
 end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -428,6 +428,25 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     frame._parsedCustomBarAuraIDsRaw = nil
     frame._parsedCustomBarAuraIDsSpellID = nil
     frame._parsedCustomBarAuraIDsIncludeSpellID = nil
+    frame._parsedAuraIDs = nil
+    frame._parsedAuraIDsRaw = nil
+    frame._parsedAuraIDsButtonID = nil
+    frame._parsedAuraIDsIncludeButtonID = nil
+    frame._customCooldownBaseSpellID = nil
+    frame._customCooldownSpellID = nil
+    frame._customCooldownHasCharges = nil
+    frame._cooldownSecrecy = nil
+    frame._cooldownSecrecySpellID = nil
+    frame._noCooldown = nil
+    frame._noCooldownSpellId = nil
+    frame._currentReadableCharges = nil
+    frame._chargeCountReadable = nil
+    frame._zeroChargesConfirmed = nil
+    frame._chargeDurationObj = nil
+    frame._chargeRecharging = nil
+    frame._mainCDShown = nil
+    frame._chargeState = nil
+    frame._chargesSpent = nil
     frame:SetAlpha(1)
 end
 

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 local math_floor = math.floor
 local GetTime = GetTime
@@ -557,36 +558,21 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return resolvedAuraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(resolvedAuraSpellID) or nil
     end
 
-    local function ViewerFrameHasAuraForUnit(viewerFrame, configUnit)
-        local instId = viewerFrame and viewerFrame.auraInstanceID
-        if not instId then
-            return false
-        end
-
-        local viewerUnit = viewerFrame.auraDataUnit or configUnit
-        return viewerUnit == configUnit
-            and C_UnitAuras.GetAuraDataByAuraInstanceID(viewerUnit, instId) ~= nil
-    end
-
-    local function ResolveSpellCustomBarAuraViewerFrame(bar, cabConfig, spellID, buttonData, configUnit)
-        if cabConfig and cabConfig.auraSpellID then
-            local ids = GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-            local firstTrackedFrame
-            if ids then
-                for _, auraID in ipairs(ids) do
-                    local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraID)
-                    if viewerFrame then
-                        if ViewerFrameHasAuraForUnit(viewerFrame, configUnit) then
-                            return viewerFrame
-                        end
-                        if not firstTrackedFrame then
-                            firstTrackedFrame = viewerFrame
-                        end
-                    end
-                end
-            end
-            if firstTrackedFrame then
-                return firstTrackedFrame
+    local function ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
+        if EntryRuntime and EntryRuntime.ResolveTrackedAuraViewerFrame then
+            local auraUnit = bar and bar._auraUnit or configUnit
+            local allowDurationlessAuraInstance = true
+            local viewerFrame = EntryRuntime.ResolveTrackedAuraViewerFrame(
+                bar,
+                buttonData,
+                resolvedAuraSpellID,
+                configUnit,
+                auraUnit,
+                GetTime(),
+                allowDurationlessAuraInstance
+            )
+            if viewerFrame then
+                return viewerFrame
             end
         end
 
@@ -626,7 +612,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
         local configUnit = buttonData.auraUnit or "player"
-        local viewerFrame = ResolveSpellCustomBarAuraViewerFrame(bar, cabConfig, spellID, buttonData, configUnit)
+        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
+        local viewerFrame = ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
         if not CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame) then
             return {
                 ready = false,
@@ -636,7 +623,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             }
         end
 
-        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
         local auraData
         local durationObj
         local auraUnit = configUnit
@@ -708,8 +694,22 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local currentCharges = cooldownResult and cooldownResult.currentCharges
         local maxCharges = cooldownResult and cooldownResult.maxCharges
-        if currentCharges and maxCharges and maxCharges > 1 then
+        if currentCharges ~= nil and maxCharges and maxCharges > 1 then
             bar.stackText:SetFormattedText("%d / %d", currentCharges, maxCharges)
+        elseif cooldownResult and cooldownResult.chargeDisplayCount ~= nil then
+            local displayCount = cooldownResult.chargeDisplayCount
+            if issecretvalue and issecretvalue(displayCount) then
+                bar.stackText:SetText(displayCount)
+            else
+                local numericCount = tonumber(displayCount)
+                if numericCount and maxCharges and maxCharges > 1 then
+                    bar.stackText:SetFormattedText("%d / %d", numericCount, maxCharges)
+                elseif displayCount and displayCount ~= "" then
+                    bar.stackText:SetText(displayCount)
+                else
+                    bar.stackText:SetText("")
+                end
+            end
         else
             bar.stackText:SetText("")
         end
@@ -739,7 +739,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if not (cabConfig and cabConfig.spellID and bar) then return end
 
         local cooldownResult = CooldownCompanion.EvaluateSpellCooldownStateForCustomBar
-            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig)
+            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
         local cooldownActive = cooldownResult
             and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
@@ -909,6 +909,38 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         UpdateSpellCustomBarSounds(false)
+    end
+
+    function CooldownCompanion:RecordCustomBarSpellCast(spellID)
+        if not spellID then return end
+
+        for _, barInfo in ipairs(resourceBarFrames) do
+            local bar = barInfo and barInfo.frame
+            local cabConfig = barInfo and barInfo.cabConfig
+            if barInfo
+                and barInfo.barType == "custom_cooldown"
+                and bar
+                and cabConfig
+                and cabConfig.entryType == "spell"
+            then
+                local baseSpellID = tonumber(cabConfig.spellID)
+                local runtimeSpellID = baseSpellID and C_Spell.GetOverrideSpell(baseSpellID)
+                if not runtimeSpellID or runtimeSpellID == 0 then
+                    runtimeSpellID = baseSpellID
+                end
+
+                local charges = runtimeSpellID and C_Spell.GetSpellCharges(runtimeSpellID)
+                local maxCharges = charges and tonumber(charges.maxCharges)
+                if (maxCharges or 0) > 1
+                    and (spellID == baseSpellID or spellID == runtimeSpellID) then
+                    if not bar._chargeRecharging then
+                        bar._chargesSpent = 1
+                    else
+                        bar._chargesSpent = (bar._chargesSpent or 0) + 1
+                    end
+                end
+            end
+        end
     end
 
     local function GetHiddenCustomAuraWakeUnit(cabConfig)


### PR DESCRIPTION
## What Players Will Notice
- Spell Custom Bars now behave more like bar-panel bars for cooldowns, including charge spells, replacement spells, and cooldown-only display states.
- Charge-based Custom Bars should keep their fill, text, and ready/cooldown state aligned with matching bar-panel entries.

## Why This Changed
- Custom Bars are being brought into parity with bar panels so the same cooldown logic drives both display surfaces.
- The old Custom Bar cooldown path had separate runtime assumptions for charge state, no-cooldown spells, action-slot fallback, and spell replacements, which could make Custom Bars drift from equivalent bar panels.

## What Changed
- Routed spell Custom Bar cooldown evaluation through shared entry runtime helpers used by bar panels.
- Added Custom Bar owner-frame runtime state for cooldown secrecy, no-cooldown classification, charge/recharge state, and charge cast history.
- Recorded Custom Bar charge casts from the player spell-cast event, resolving the current override at cast time so replacement spell casts update immediately.
- Cleared the new runtime fields when resource bar frames are recycled.
- Kept spell Custom Bar aura-tracking interop intact while preserving this PR's focus on cooldown parity.

## Validation
- User reported the in-game PR checklist passing.
- `lua tests\custom-bar-entry-runtime.lua`
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- `luac -p ButtonFrame\EntryRuntime.lua Core\Lifecycle.lua OtherBars\ResourceBar.lua OtherBars\ResourceBarCustomBars.lua tests\custom-bar-entry-runtime.lua`
- `git diff --check` passed with only existing LF-to-CRLF warnings.