### PR TITLE
Fix Custom Bar aura tracking on target swaps

### DIFF
--- a/ButtonFrame/EntryRuntime.lua
+++ b/ButtonFrame/EntryRuntime.lua
@@ -13,6 +13,7 @@ local tonumber = tonumber
 local tostring = tostring
 local wipe = wipe
 local issecretvalue = issecretvalue
+local GetTime = GetTime
 
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
@@ -20,6 +21,7 @@ local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+local TARGET_SWITCH_SAFETY_CAP = 0.60
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -72,8 +74,11 @@ local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraU
     end
 
     local startMs, durMs = viewerCooldown:GetCooldownTimes()
-    if issecretvalue(durMs) then
+    if issecretvalue(startMs) or issecretvalue(durMs) then
         return true
+    end
+    if not startMs or not durMs then
+        return false
     end
 
     return durMs > 0 and (startMs + durMs) > now * 1000
@@ -217,6 +222,344 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
     return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
 end
 EntryRuntime.ResolveTrackedAuraViewerFrame = ResolveTrackedAuraViewerFrame
+
+local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStandaloneAuraIDs)
+    local auraData
+    local activeAuraSpellID
+    local activeAuraSpellIDFromFallback
+
+    if orderedStandaloneAuraIDs then
+        for _, spellID in ipairs(orderedStandaloneAuraIDs) do
+            auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
+            if auraData then
+                activeAuraSpellID = spellID
+                activeAuraSpellIDFromFallback = true
+                break
+            end
+        end
+    elseif buttonData.auraSpellID then
+        local ids = owner._parsedAuraIDs
+        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
+            ids = {}
+            owner._parsedAuraIDsIncludeButtonID = nil
+            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+                local spellID = tonumber(id)
+                ids[#ids + 1] = spellID
+                if spellID == buttonData.id then
+                    owner._parsedAuraIDsIncludeButtonID = true
+                end
+            end
+            owner._parsedAuraIDs = ids
+            owner._parsedAuraIDsRaw = buttonData.auraSpellID
+            owner._parsedAuraIDsButtonID = buttonData.id
+        end
+        for _, spellID in ipairs(ids) do
+            auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
+            if auraData then
+                activeAuraSpellID = spellID
+                activeAuraSpellIDFromFallback = true
+                break
+            end
+        end
+        if not auraData and not owner._parsedAuraIDsIncludeButtonID then
+            local baseId = C_Spell.GetBaseSpell(buttonData.id)
+            local fallbackId = baseId and baseId ~= auraSpellID and baseId or nil
+            auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+            if auraData then
+                activeAuraSpellID = fallbackId
+                activeAuraSpellIDFromFallback = true
+            end
+        end
+    else
+        local baseId = C_Spell.GetBaseSpell(buttonData.id)
+        local fallbackId = baseId and baseId ~= auraSpellID and baseId or nil
+        auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+        if auraData then
+            activeAuraSpellID = fallbackId
+            activeAuraSpellIDFromFallback = true
+        end
+        if not auraData then
+            auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraSpellID)
+            if auraData then
+                activeAuraSpellID = auraSpellID
+                activeAuraSpellIDFromFallback = true
+            end
+        end
+    end
+
+    return auraData, activeAuraSpellID, activeAuraSpellIDFromFallback
+end
+
+local function GetReadableAuraSpellID(auraData)
+    local spellID = auraData and auraData.spellId
+    if spellID and not issecretvalue(spellID) then
+        return spellID
+    end
+    return nil
+end
+
+local function CommitTrackedAuraOwnerState(owner, state)
+    if not owner then return end
+
+    if state.auraPresent then
+        owner._auraActive = true
+        owner._auraHasTimer = state.auraHasTimer == true
+        owner._auraDurationObj = state.durationObj
+        owner._auraCooldownStart = state.auraCooldownStart
+        owner._auraCooldownDuration = state.auraCooldownDuration
+        if state.auraGraceHeld ~= true then
+            owner._auraInstanceID = state.auraInstanceID
+            owner._auraUnit = state.auraUnit
+        elseif not owner._auraUnit then
+            owner._auraUnit = state.auraUnit
+        end
+        if owner._targetSwitchAt
+            and state.auraGraceHeld ~= true
+            and (state.durationObj or state.auraCooldownDuration or state.allowDurationlessAuraInstance) then
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        end
+    else
+        owner._auraActive = false
+        owner._auraHasTimer = false
+        owner._auraDurationObj = nil
+        owner._auraCooldownStart = nil
+        owner._auraCooldownDuration = nil
+        owner._auraInstanceID = nil
+        owner._auraUnit = state.configUnit
+        owner._activeAuraSpellID = nil
+        owner._activeAuraSpellIDFromFallback = nil
+        if owner._targetSwitchAt and not state.wasAuraActive then
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        end
+    end
+end
+
+function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
+    owner = owner or {}
+    options = options or {}
+    local now = options.now or GetTime()
+    local configUnit = options.configUnit or GetConfiguredAuraUnit(buttonData)
+    local auraUnit = owner._auraUnit or configUnit
+    local allowDurationlessAuraInstance = options.allowDurationlessAuraInstance == true
+    local allowPlayerAuraFallbackWithoutReady = options.allowPlayerAuraFallbackWithoutReady == true
+    local mutateOwner = options.mutateOwner ~= false
+    local prevAuraDurationObj = owner._auraActive and owner._auraDurationObj or nil
+    local wasAuraActive = owner._auraActive == true
+    local auraEventRemoved = owner._auraEventRemoved
+    owner._auraEventRemoved = nil
+
+    local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = ResolveTrackedAuraViewerFrame(
+        owner,
+        buttonData,
+        auraSpellID,
+        configUnit,
+        auraUnit,
+        now,
+        allowDurationlessAuraInstance
+    )
+    local ready = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
+
+    local auraData
+    local durationObj
+    local auraPresent = false
+    local auraHasTimer = owner._auraHasTimer == true
+    local auraApplications
+    local auraInstanceID
+    local activeAuraSpellID
+    local activeAuraSpellIDFromFallback
+    local auraCooldownStart
+    local auraCooldownDuration
+
+    if ready and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
+        local viewerInstId = viewerFrame.auraInstanceID
+        if viewerInstId then
+            local unit = viewerFrame.auraDataUnit or auraUnit
+            if unit == configUnit then
+                auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
+                durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
+                if auraData and (durationObj or allowDurationlessAuraInstance) then
+                    auraApplications = auraData.applications
+                    activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    auraInstanceID = viewerInstId
+                    auraUnit = unit
+                    auraPresent = true
+                    auraHasTimer = durationObj and DurationObjectShowsCooldown(durationObj) or false
+                end
+            end
+        else
+            local viewerCooldown = viewerFrame.Cooldown
+            if viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown() then
+                local vUnit = viewerFrame.auraDataUnit or auraUnit
+                if vUnit == configUnit then
+                    local startMs, durMs = viewerCooldown:GetCooldownTimes()
+                    if issecretvalue(startMs) or issecretvalue(durMs) then
+                        auraUnit = vUnit
+                        auraPresent = true
+                    elseif startMs and durMs and durMs > 0 and (startMs + durMs) > now * 1000 then
+                        auraCooldownStart = startMs / 1000
+                        auraCooldownDuration = durMs / 1000
+                        auraUnit = vUnit
+                        auraPresent = true
+                        auraHasTimer = true
+                    end
+                end
+                auraInstanceID = nil
+            end
+
+            if not auraPresent then
+                local totemSlot = viewerFrame.preferredTotemUpdateSlot
+                if totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData then
+                    local totemDuration = GetTotemDuration(totemSlot)
+                    if totemDuration and DurationObjectShowsCooldown(totemDuration) then
+                        durationObj = totemDuration
+                        auraPresent = true
+                        auraHasTimer = true
+                        auraInstanceID = nil
+                    end
+                end
+            end
+        end
+    end
+
+    local canUsePlayerAuraFallback = configUnit == "player"
+        and (ready or allowPlayerAuraFallbackWithoutReady)
+    if canUsePlayerAuraFallback and not auraPresent then
+        auraData, activeAuraSpellID, activeAuraSpellIDFromFallback =
+            ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStandaloneAuraIDs)
+        local instId = auraData and auraData.auraInstanceID
+        if instId and not issecretvalue(instId) then
+            durationObj = C_UnitAuras.GetAuraDuration("player", instId)
+            if durationObj or allowDurationlessAuraInstance then
+                auraApplications = auraData.applications
+                activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
+                auraInstanceID = instId
+                auraUnit = "player"
+                auraPresent = true
+                auraHasTimer = durationObj and DurationObjectShowsCooldown(durationObj) or false
+            end
+        end
+    end
+
+    if canUsePlayerAuraFallback and not auraPresent and owner._auraInstanceID then
+        local cachedUnit = owner._auraUnit or configUnit
+        if cachedUnit == configUnit then
+            auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, owner._auraInstanceID)
+            if auraData then
+                durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, owner._auraInstanceID)
+                if durationObj or allowDurationlessAuraInstance then
+                    auraApplications = auraData.applications
+                    activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    activeAuraSpellIDFromFallback = activeAuraSpellID and true or nil
+                    auraInstanceID = owner._auraInstanceID
+                    auraUnit = cachedUnit
+                    auraPresent = true
+                    auraHasTimer = durationObj and DurationObjectShowsCooldown(durationObj) or false
+                end
+            end
+        end
+    end
+
+    local auraGraceHeld = false
+    if not auraPresent and wasAuraActive and prevAuraDurationObj and buttonData.isPassive ~= true then
+        local expired = false
+        if auraEventRemoved then
+            expired = true
+        elseif owner._targetSwitchAt then
+            if viewerFrame and not viewerFrame.auraInstanceID then
+                expired = true
+            elseif owner._targetSwitchDataReceived then
+                expired = true
+            else
+                expired = (now - owner._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
+            end
+        elseif prevAuraDurationObj.HasSecretValues and not prevAuraDurationObj:HasSecretValues()
+            and prevAuraDurationObj.GetRemainingDuration then
+            expired = prevAuraDurationObj:GetRemainingDuration() <= 0
+        end
+        if not expired then
+            if not owner._auraGraceStart then
+                owner._auraGraceStart = now
+            end
+            if now - owner._auraGraceStart <= 0.3 or owner._targetSwitchAt then
+                durationObj = prevAuraDurationObj
+                auraPresent = true
+                auraGraceHeld = true
+            else
+                owner._auraGraceStart = nil
+            end
+        else
+            owner._auraGraceStart = nil
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        end
+    else
+        owner._auraGraceStart = nil
+        if owner._targetSwitchAt then
+            if auraPresent and (durationObj or auraCooldownDuration or allowDurationlessAuraInstance) then
+                owner._targetSwitchAt = nil
+                owner._targetSwitchDataReceived = nil
+            elseif not wasAuraActive then
+                owner._targetSwitchAt = nil
+                owner._targetSwitchDataReceived = nil
+            end
+        end
+    end
+
+    if not auraPresent and owner._targetSwitchAt and wasAuraActive then
+        local catchAllExpired
+        if viewerFrame and not viewerFrame.auraInstanceID then
+            catchAllExpired = true
+        elseif owner._targetSwitchDataReceived then
+            catchAllExpired = true
+        else
+            catchAllExpired = (now - owner._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
+        end
+        if catchAllExpired then
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        else
+            if prevAuraDurationObj then
+                durationObj = prevAuraDurationObj
+            end
+            auraPresent = true
+            auraGraceHeld = true
+        end
+    end
+
+    local state = {
+        ready = ready == true,
+        auraPresent = auraPresent == true,
+        auraTrackingReady = ready == true,
+        cdmEnabled = cdmEnabled == true,
+        auraData = auraPresent and auraData or nil,
+        auraApplications = auraPresent and auraApplications or nil,
+        auraInstanceID = auraPresent and auraInstanceID or nil,
+        auraUnit = auraPresent and auraUnit or configUnit,
+        configUnit = configUnit,
+        viewerFrame = viewerFrame,
+        durationObj = auraPresent and durationObj or nil,
+        auraCooldownStart = auraPresent and auraCooldownStart or nil,
+        auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
+        auraHasTimer = auraPresent and auraHasTimer == true or false,
+        auraGraceHeld = auraGraceHeld == true,
+        activeAuraSpellID = activeAuraSpellID,
+        activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
+        allowDurationlessAuraInstance = allowDurationlessAuraInstance,
+        wasAuraActive = wasAuraActive,
+    }
+
+    if mutateOwner then
+        CommitTrackedAuraOwnerState(owner, state)
+    end
+
+    return state
+end
+
+function CooldownCompanion:EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
+    return EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
+end
 
 local function IsSpellCooldownDeferred(info)
     if not info or info.isEnabled ~= false or info.isActive == true then

--- a/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -1319,7 +1319,7 @@ local function BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUni
 
     AddCustomBarAuraTrackingGap(container)
 
-    if isSpellCustomBar then
+    if isSpellCustomBar or spellID then
         if not (cab.auraUnit == "player" or cab.auraUnit == "target") then
             resolvedAuraUnit = EnsureCustomAuraBarAuraUnit(cab, spellID)
         end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -193,6 +193,22 @@ local function IsCustomBarAuraIndicatorFrame(barInfo)
         or barInfo.barType == "custom_cooldown"
 end
 
+local function ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
+    if not IsCustomBarAuraIndicatorFrame(barInfo) then
+        return
+    end
+
+    local bar = barInfo and barInfo.frame
+    if not bar then return end
+
+    if clearPreviewFlags then
+        bar._barAuraActivePreview = nil
+        bar._pandemicPreview = nil
+    end
+
+    ResetCustomAuraBarIndicatorVisuals(bar, barInfo.cabConfig)
+end
+
 local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     if not IsCustomBarAuraIndicatorFrame(barInfo) then
         return
@@ -204,16 +220,21 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     bar._auraActive = nil
     bar._inPandemic = nil
     bar._auraInstanceID = nil
+    bar._auraDurationObj = nil
+    bar._auraCooldownStart = nil
+    bar._auraCooldownDuration = nil
+    bar._auraHasTimer = nil
     bar._auraUnit = nil
+    bar._auraEventRemoved = nil
+    bar._auraGraceStart = nil
+    bar._targetSwitchAt = nil
+    bar._targetSwitchDataReceived = nil
+    bar._customAuraStackValue = nil
+    bar._customAuraApplicationsValue = nil
     bar._pandemicGraceStart = nil
     bar._pandemicGraceSuppressed = nil
 
-    if clearPreviewFlags then
-        bar._barAuraActivePreview = nil
-        bar._pandemicPreview = nil
-    end
-
-    ResetCustomAuraBarIndicatorVisuals(bar, barInfo.cabConfig)
+    ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
 end
 
 local function ApplyCustomAuraBarPreviewState(barInfo)
@@ -266,7 +287,7 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
     if not cabConfig
         or (isSpellCustomCooldown and cabConfig.auraTracking ~= true)
         or (not isSpellCustomCooldown and cabConfig.trackingMode ~= "active") then
-        ClearCustomAuraBarIndicatorState(barInfo, false)
+        ClearCustomAuraBarIndicatorVisualState(barInfo, false)
         return
     end
 
@@ -420,7 +441,17 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     frame._cdcIndependentLastAlpha = nil
     frame._auraActive = nil
     frame._auraInstanceID = nil
+    frame._auraDurationObj = nil
+    frame._auraCooldownStart = nil
+    frame._auraCooldownDuration = nil
+    frame._auraHasTimer = nil
     frame._auraUnit = nil
+    frame._auraEventRemoved = nil
+    frame._auraGraceStart = nil
+    frame._targetSwitchAt = nil
+    frame._targetSwitchDataReceived = nil
+    frame._customAuraStackValue = nil
+    frame._customAuraApplicationsValue = nil
     frame._inPandemic = nil
     frame._pandemicGraceStart = nil
     frame._pandemicGraceSuppressed = nil
@@ -1311,6 +1342,7 @@ local customBarsModule = RB.CreateResourceBarCustomBarsModule({
     end,
     ClearStaleRecycledBarRuntimeState = ClearStaleRecycledBarRuntimeState,
     ClearCustomAuraBarIndicatorState = ClearCustomAuraBarIndicatorState,
+    ClearCustomAuraBarIndicatorVisualState = ClearCustomAuraBarIndicatorVisualState,
     UpdateCustomAuraBarIndicatorVisuals = UpdateCustomAuraBarIndicatorVisuals,
     ApplyCustomAuraBarPreviewState = ApplyCustomAuraBarPreviewState,
 })
@@ -2562,6 +2594,7 @@ local previewModule = RB.CreateResourceBarPreviewModule({
     GetResourceBarSettings = GetResourceBarSettings,
     ApplySegmentedPreviewColors = ApplySegmentedPreviewColors,
     ClearCustomAuraBarIndicatorState = ClearCustomAuraBarIndicatorState,
+    ClearCustomAuraBarIndicatorVisualState = ClearCustomAuraBarIndicatorVisualState,
 })
 ApplyPreviewData = previewModule.ApplyPreviewData
 

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -8,6 +8,8 @@ local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
 
 local math_floor = math.floor
+local math_max = math.max
+local math_min = math.min
 local GetTime = GetTime
 local issecretvalue = issecretvalue
 
@@ -20,6 +22,36 @@ local DEFAULT_RESOURCE_TEXT_COLOR = RB.DEFAULT_RESOURCE_TEXT_COLOR
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL = 0.65
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS = 3
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION = 12.3
+
+local function IsSecretValue(value)
+    return issecretvalue and issecretvalue(value)
+end
+
+local function GetReadableApplicationCount(value)
+    if value == nil or IsSecretValue(value) then
+        return nil
+    end
+    return tonumber(value)
+end
+
+local function SetApplicationStackText(fontString, value, maxStacks, stackTextFormat)
+    if IsSecretValue(value) then
+        fontString:SetText(value)
+        return
+    end
+
+    local numericValue = tonumber(value)
+    if not numericValue then
+        fontString:SetText("")
+        return
+    end
+
+    if stackTextFormat == "current" then
+        fontString:SetFormattedText("%d", numericValue)
+    else
+        fontString:SetFormattedText("%d / %d", numericValue, maxStacks)
+    end
+end
 
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
@@ -54,6 +86,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     local RelayoutResourceStack = deps.RelayoutResourceStack
     local ClearStaleRecycledBarRuntimeState = deps.ClearStaleRecycledBarRuntimeState
     local ClearCustomAuraBarIndicatorState = deps.ClearCustomAuraBarIndicatorState
+    local ClearCustomAuraBarIndicatorVisualState = deps.ClearCustomAuraBarIndicatorVisualState
+        or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
     local customAuraWakeRetryFrame = nil
@@ -236,11 +270,19 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         -- Read aura data from viewer frame (applications may be secret in combat)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local isSpellCustomBar = RB.IsSpellCustomBarConfig and RB.IsSpellCustomBarConfig(cabConfig)
+        local useSharedStandaloneAuraState = not spellAuraStackDisplay
+            and not isSpellCustomBar
+            and EntryRuntime
+            and EntryRuntime.EvaluateTrackedAuraState
         local auraState = spellAuraStackDisplay and RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
         local stacks = 0
-        local applications = 0
+        local applications
+        local readableApplications
         local auraPresent = false
         local durationObj
+        local auraCooldownStart
+        local auraCooldownDuration
         local isActive = cabConfig.trackingMode == "active"
         local useDrain = isActive
         local needsDuration = (useDrain or cabConfig.showDurationText) and not spellAuraStackDisplay
@@ -249,19 +291,59 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local pandemicPreview = bar and bar._pandemicPreview
         local indicatorPreview = isActive and (auraPreview or pandemicPreview)
         local configUnit = EnsureCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
-        local viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
+        local viewerFrame
         local auraUnit = configUnit
-        local instId = viewerFrame and viewerFrame.auraInstanceID
+        local instId
 
-        if spellAuraStackDisplay then
+        if useSharedStandaloneAuraState then
+            local buttonData, spellID = CustomAuraBar.BuildAuraButtonData(cabConfig)
+            if buttonData and spellID then
+                configUnit = buttonData.auraUnit or configUnit
+                auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, {
+                    configUnit = configUnit,
+                    allowDurationlessAuraInstance = true,
+                    allowPlayerAuraFallbackWithoutReady = true,
+                })
+                viewerFrame = auraState and auraState.viewerFrame or nil
+                instId = auraState and auraState.auraInstanceID or nil
+            end
+        else
+            viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
+            instId = viewerFrame and viewerFrame.auraInstanceID
+        end
+
+        if auraState then
             configUnit = (auraState and auraState.configUnit) or configUnit
             viewerFrame = auraState and auraState.viewerFrame or nil
-            if auraState and auraState.ready == true and auraState.auraPresent == true and auraState.auraData then
+            if auraState and auraState.auraPresent == true then
                 auraPresent = true
                 instId = auraState.auraInstanceID
+                if instId == nil and auraState.auraGraceHeld and barInfo.frame then
+                    instId = barInfo.frame._auraInstanceID
+                end
                 auraUnit = auraState.auraUnit or configUnit
-                applications = auraState.auraData.applications or 0
-                stacks = applications
+                local stateApplications = auraState.auraApplications
+                if stateApplications == nil and auraState.auraData then
+                    stateApplications = auraState.auraData.applications
+                end
+                if stateApplications == nil
+                    and auraState.auraGraceHeld
+                    and barInfo.frame then
+                    stateApplications = barInfo.frame._customAuraStackValue
+                        or barInfo.frame._customAuraApplicationsValue
+                end
+                applications = stateApplications
+                readableApplications = GetReadableApplicationCount(applications)
+                if isActive then
+                    stacks = 1
+                elseif applications ~= nil then
+                    stacks = applications
+                else
+                    stacks = 0
+                end
+                durationObj = auraState.durationObj
+                auraCooldownStart = auraState.auraCooldownStart
+                auraCooldownDuration = auraState.auraCooldownDuration
             end
         elseif instId then
             local viewerUnit = viewerFrame.auraDataUnit or configUnit
@@ -269,11 +351,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
                 if auraData then
                     auraPresent = true
-                    applications = auraData.applications or 0
+                    applications = auraData.applications
+                    readableApplications = GetReadableApplicationCount(applications)
                     if isActive then
                         stacks = 1
-                    else
+                    elseif applications ~= nil then
                         stacks = applications
+                    else
+                        stacks = 0
                     end
                     if needsDuration then
                         durationObj = C_UnitAuras.GetAuraDuration(configUnit, instId)
@@ -282,17 +367,20 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
         end
 
-        if not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
+        if not useSharedStandaloneAuraState and not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
             local auraData = CustomAuraBar.ResolvePlayerAuraData(cabConfig)
             if auraData then
                 instId = auraData.auraInstanceID
                 auraUnit = "player"
                 auraPresent = true
-                applications = auraData.applications or 0
+                applications = auraData.applications
+                readableApplications = GetReadableApplicationCount(applications)
                 if isActive then
                     stacks = 1
-                else
+                elseif applications ~= nil then
                     stacks = applications
+                else
+                    stacks = 0
                 end
                 if needsDuration and instId then
                     durationObj = C_UnitAuras.GetAuraDuration("player", instId)
@@ -301,6 +389,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         if spellAuraStackDisplay and not auraPresent and not GetPreviewActive() then
+            if barInfo.frame then
+                barInfo.frame._customAuraStackValue = nil
+                barInfo.frame._customAuraApplicationsValue = nil
+            end
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false)
             end
@@ -312,6 +404,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if indicatorPreview and not auraPresent then
             auraPresent = true
             applications = CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS
+            readableApplications = CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS
             stacks = 1
         end
 
@@ -348,8 +441,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 MarkLayoutDirty()
             end
             if not shouldShow then
+                if barInfo.frame then
+                    if not auraPresent then
+                        barInfo.frame._customAuraStackValue = nil
+                        barInfo.frame._customAuraApplicationsValue = nil
+                    end
+                end
                 if isActive then
-                    UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, false)
+                    ClearCustomAuraBarIndicatorVisualState(barInfo, false)
                 end
                 return
             end
@@ -364,6 +463,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 bar:SetMinMaxValues(0, 1)
                 if durationObj then
                     bar:SetValue(durationObj:GetRemainingPercent())  -- secret-safe, 1->0 drain
+                elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
+                    local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
+                    bar:SetValue(math_max(0, math_min(1, remaining / auraCooldownDuration)))
                 elseif indicatorPreview then
                     bar:SetValue(CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL)
                 else
@@ -399,6 +501,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     else
                         bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
                     end
+                elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
+                    local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
+                    if remaining > 0 then
+                        bar.text:SetText(FormatTime(remaining, cabConfig))
+                    else
+                        bar.text:SetText("")
+                    end
                 elseif indicatorPreview then
                     bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig))
                 else
@@ -410,14 +519,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if bar.stackText and bar.stackText:IsShown() then
                 if auraPresent then
                     if isActive then
-                        bar.stackText:SetFormattedText("%d", applications)
+                        SetApplicationStackText(bar.stackText, applications, maxStacks, "current")
                     else
                         local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig.stackTextFormat)
-                        if stackTextFormat == "current" then
-                            bar.stackText:SetFormattedText("%d", stacks)
-                        else
-                            bar.stackText:SetFormattedText("%d / %d", stacks, maxStacks)
-                        end
+                        SetApplicationStackText(bar.stackText, stacks, maxStacks, stackTextFormat)
                     end
                 else
                     bar.stackText:SetText("")
@@ -427,7 +532,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if isActive then
                 UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPresent)
             else
-                ClearCustomAuraBarIndicatorState(barInfo, true)
+                ClearCustomAuraBarIndicatorVisualState(barInfo, true)
             end
 
         elseif barInfo.barType == "custom_segmented" then
@@ -479,9 +584,19 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
         end
 
+        if barInfo.frame then
+            if auraPresent and applications ~= nil then
+                barInfo.frame._customAuraStackValue = applications
+                barInfo.frame._customAuraApplicationsValue = readableApplications
+            elseif not auraPresent or not (auraState and auraState.auraGraceHeld) then
+                barInfo.frame._customAuraStackValue = nil
+                barInfo.frame._customAuraApplicationsValue = nil
+            end
+        end
+
         -- Max stacks indicator: SetValue drives visibility via C-level clamping
         if cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-            barInfo._maxStacksIndicator:SetValue(auraPresent and applications or 0)
+            barInfo._maxStacksIndicator:SetValue((auraPresent and applications ~= nil) and applications or 0)
         end
     end
 

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -1195,12 +1195,12 @@ local function GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
         resolvedSpellID = cabConfig.spellID
     end
 
-    if type(cabConfig) == "table" and (cabConfig.entryType == nil or cabConfig.entryType == "aura") then
-        return GetDefaultCustomAuraUnit(resolvedSpellID)
-    end
-
     if type(cabConfig) == "table" and HasExplicitCustomAuraBarAuraUnit(cabConfig) then
         return cabConfig.auraUnit
+    end
+
+    if type(cabConfig) == "table" and (cabConfig.entryType == nil or cabConfig.entryType == "aura") then
+        return GetDefaultCustomAuraUnit(resolvedSpellID)
     end
 
     return GetDefaultSpellCustomBarAuraUnit(cabConfig, resolvedSpellID)
@@ -1213,13 +1213,6 @@ local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit, explicit)
     end
 
     if type(cabConfig) == "table" then
-        if cabConfig.entryType == nil or cabConfig.entryType == "aura" then
-            local resolvedUnit = GetDefaultCustomAuraUnit(resolvedSpellID)
-            cabConfig.auraUnit = resolvedUnit
-            cabConfig.auraUnitExplicit = nil
-            return resolvedUnit
-        end
-
         local wasExplicit = HasExplicitCustomAuraBarAuraUnit(cabConfig)
         local resolvedUnit = IsValidCustomAuraUnit(unit) and unit
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, resolvedSpellID)

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -27,6 +27,35 @@ function RB.CreateResourceBarLifecycleModule(deps)
     local lifecycleEventsEnabled = false
     local InstallHooks
 
+    local function IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
+        if not (barInfo and cabConfig) then return false end
+        return barInfo.barType == "custom_continuous"
+            or barInfo.barType == "custom_segmented"
+            or barInfo.barType == "custom_overlay"
+            or (barInfo.barType == "custom_cooldown"
+                and cabConfig and cabConfig.auraTracking == true)
+    end
+
+    local function ClearCustomBarAuraRuntime(bar, configUnit)
+        if not bar then return end
+        bar._auraActive = false
+        bar._auraInstanceID = nil
+        bar._auraDurationObj = nil
+        bar._auraCooldownStart = nil
+        bar._auraCooldownDuration = nil
+        bar._auraHasTimer = false
+        bar._auraUnit = configUnit
+        bar._auraGraceStart = nil
+        bar._inPandemic = false
+        bar._pandemicGraceStart = nil
+        bar._pandemicGraceSuppressed = nil
+        bar._targetSwitchAt = nil
+        bar._targetSwitchDataReceived = nil
+        bar._auraEventRemoved = nil
+        bar._customAuraStackValue = nil
+        bar._customAuraApplicationsValue = nil
+    end
+
     ------------------------------------------------------------------------
     -- Event handling (must be defined before Apply/Revert which call these)
     ------------------------------------------------------------------------
@@ -105,63 +134,73 @@ function RB.CreateResourceBarLifecycleModule(deps)
                     local removedIDs = updateInfo.removedAuraInstanceIDs
                     local updatedIDs = updateInfo.updatedAuraInstanceIDs
                     local hasAuraChange = updateInfo.isFullUpdate or updateInfo.addedAuras or removedIDs or updatedIDs
-                    if hasAuraChange then
-                        RefreshEventDrivenCustomAuraBarsForUnit(unit)
-                    end
-                    if not removedIDs and not updatedIDs then return end
+                    local targetSwitchDataReceived = false
 
-                    for _, barInfo in ipairs(resourceBarFrames) do
-                        local bar = barInfo and barInfo.frame
-                        local cabConfig = barInfo and barInfo.cabConfig
-                        if barInfo
-                            and ((barInfo.barType == "custom_continuous"
-                                    and cabConfig and cabConfig.trackingMode == "active")
-                                or (barInfo.barType == "custom_cooldown"
-                                    and cabConfig and cabConfig.auraTracking == true))
-                            and bar and bar._auraInstanceID and bar._auraUnit == unit then
-                            if removedIDs then
-                                for _, instId in ipairs(removedIDs) do
-                                    if bar._auraInstanceID == instId then
-                                        bar._auraActive = nil
-                                        bar._auraInstanceID = nil
-                                        bar._auraUnit = nil
-                                        bar._inPandemic = nil
-                                        bar._pandemicGraceStart = nil
-                                        break
+                    if removedIDs or updatedIDs or unit == "target" then
+                        for _, barInfo in ipairs(resourceBarFrames) do
+                            local bar = barInfo and barInfo.frame
+                            local cabConfig = barInfo and barInfo.cabConfig
+                            local configUnit = cabConfig and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
+                            if IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
+                                and bar
+                                and (bar._auraUnit == unit or configUnit == unit) then
+                                if removedIDs and bar._auraInstanceID and bar._auraUnit == unit then
+                                    for _, instId in ipairs(removedIDs) do
+                                        if bar._auraInstanceID == instId then
+                                            ClearCustomBarAuraRuntime(bar, configUnit)
+                                            bar._auraEventRemoved = true
+                                            break
+                                        end
                                     end
                                 end
-                            end
-                            if updatedIDs and bar._auraInstanceID then
-                                for _, instId in ipairs(updatedIDs) do
-                                    if bar._auraInstanceID == instId then
-                                        bar._inPandemic = nil
-                                        bar._pandemicGraceStart = nil
-                                        bar._pandemicGraceSuppressed = true
-                                        break
+                                if updatedIDs and bar._auraInstanceID and bar._auraUnit == unit then
+                                    for _, instId in ipairs(updatedIDs) do
+                                        if bar._auraInstanceID == instId then
+                                            bar._inPandemic = false
+                                            bar._pandemicGraceStart = nil
+                                            bar._pandemicGraceSuppressed = true
+                                            break
+                                        end
                                     end
+                                end
+                                if unit == "target" and bar._targetSwitchAt then
+                                    bar._targetSwitchDataReceived = true
+                                    targetSwitchDataReceived = true
                                 end
                             end
                         end
                     end
+                    if hasAuraChange or targetSwitchDataReceived then
+                        RefreshEventDrivenCustomAuraBarsForUnit(unit)
+                    end
                 elseif event == "PLAYER_TARGET_CHANGED" then
+                    local hasTarget = UnitExists("target")
+                    local now = GetTime()
                     for _, barInfo in ipairs(resourceBarFrames) do
                         local bar = barInfo and barInfo.frame
                         local cabConfig = barInfo and barInfo.cabConfig
-                        if barInfo
-                            and ((barInfo.barType == "custom_continuous"
-                                    and cabConfig and cabConfig.trackingMode == "active")
-                                or (barInfo.barType == "custom_cooldown"
-                                    and cabConfig and cabConfig.auraTracking == true))
-                            and bar and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
-                            bar._auraActive = nil
-                            bar._auraInstanceID = nil
-                            bar._auraUnit = nil
-                            bar._inPandemic = nil
-                            bar._pandemicGraceStart = nil
-                            bar._pandemicGraceSuppressed = nil
+                        if IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
+                            and bar
+                            and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
+                            if hasTarget then
+                                bar._auraInstanceID = nil
+                                bar._inPandemic = false
+                                bar._pandemicGraceStart = nil
+                                bar._pandemicGraceSuppressed = nil
+                                bar._targetSwitchAt = now
+                                bar._targetSwitchDataReceived = nil
+                                bar._auraUnit = "target"
+                            else
+                                ClearCustomBarAuraRuntime(bar, "target")
+                            end
                         end
                     end
                     RefreshEventDrivenCustomAuraBarsForUnit("target")
+                elseif event == "UNIT_TARGET" then
+                    local unitToken = ...
+                    if unitToken == "player" then
+                        RefreshEventDrivenCustomAuraBarsForUnit("target")
+                    end
                 end
             end)
         end
@@ -170,6 +209,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
         -- but RegisterUnitEvent with "player" filter has negligible overhead for others
         eventFrame:RegisterUnitEvent("UNIT_MAXHEALTH", "player")
         eventFrame:RegisterUnitEvent("UNIT_AURA", "player", "target")
+        eventFrame:RegisterUnitEvent("UNIT_TARGET", "player")
         eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
         eventFrameEnabled = true
     end


### PR DESCRIPTION
## What Players Will Notice
- Standalone aura Custom Bars can now choose the Aura Unit, matching standalone aura entries in normal panels.
- Target-based aura Custom Bars, especially stack bars, should update more reliably when targets are deselected and reselected instead of waiting for a later stack or aura event.
- Player-based standalone aura Custom Bars keep working even when Blizzard CDM does not have a ready viewer frame.

## Why This Changed
- Custom Bars were using a separate aura runtime path from bar-panel bars, so target swaps, stack-mode auras, and manual aura-unit selection could fall out of sync with the equivalent panel behavior.
- Automatic aura-unit detection can be wrong for some auras, so Custom Bars need the same explicit Player/Target override available elsewhere.

## What Changed
- Added shared aura-state evaluation for standalone aura Custom Bars through `EntryRuntime` so they follow the same unit-aware candidate selection and target-switch grace behavior as bar panels.
- Preserved explicit `auraUnit` / `auraUnitExplicit` choices for standalone aura Custom Bars and exposed the Aura Unit dropdown in the Custom Bar Aura Tracking section.
- Refreshed event-driven Custom Bars on target-change, player `UNIT_TARGET`, and target aura data arrival, including payload-empty target aura updates that resolve target-switch grace.
- Preserved cached aura instance and raw stack/application values during target-switch grace so secret stack values are not coerced or dropped.
- Split visual-only aura indicator clearing from full runtime clearing so non-active stack bars do not wipe aura tracking state while clearing active-mode effects.

## Validation
- `luac -p ButtonFrame\EntryRuntime.lua ConfigSettings\ResourceBarPanelsCustomBars.lua OtherBars\ResourceBar.lua OtherBars\ResourceBarCustomBars.lua OtherBars\ResourceBarHelpers.lua OtherBars\ResourceBarLifecycle.lua`
- `git diff --check origin/custom-bar-parity...HEAD`
- `lua tests\custom-bar-entry-runtime.lua`
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- In-game combat/restricted-content validation still needs to be completed for final merge confidence.
