### PR TITLE
Unify custom bar runtime with bar panels

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -68,7 +68,6 @@ local ResolveItemFallback = CooldownCompanion.ResolveItemFallback
 local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
-local TARGET_SWITCH_SAFETY_CAP = 0.60
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
@@ -371,13 +370,6 @@ local function RecordAuraDisplayName(state, auraData)
         state.readableName = auraName
         state.nameApplied = true
         return true
-    end
-end
-
-local function GetReadableAuraSpellID(auraData)
-    local spellID = auraData and auraData.spellId
-    if spellID and not issecretvalue(spellID) then
-        return spellID
     end
 end
 
@@ -764,7 +756,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- GetCooldownTimes() which returns secret values after
     -- SetCooldownFromDurationObject() in 12.0.1.
     -- Save previous aura DurationObject for one-tick grace period on target switch.
-    local prevAuraDurationObj = button._auraActive and button._auraDurationObj or nil
+    local wasAuraActive = button._auraActive == true
+    local prevAuraDurationObj = wasAuraActive and button._auraDurationObj or nil
     button._durationObj = nil
     button._auraDurationObj = nil
     button._auraCooldownStart = nil
@@ -794,9 +787,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
     local auraDisplayNameState
-    local activeAuraSpellID
-    local activeAuraSpellIDSourceResolved = false
-    local activeAuraSpellIDFromFallback = false
     local previousActiveAuraSpellID = button._activeAuraSpellID
     local previousActiveAuraSpellIDFromFallback = button._activeAuraSpellIDFromFallback == true
     local auraApplications
@@ -815,397 +805,45 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraPrimarySwipeAllowed = not keepSpellCooldownSwipe
     local auraHasTimer = button._auraHasTimer == true
     local auraTrackingReady = buttonData.isPassive == true
-    -- Capture and clear event-driven removal flag (set by OnUnitAura when
-    -- removedAuraInstanceIDs confirms the aura is gone).  Used to bypass the
-    -- grace hold, which otherwise can't detect expiry in combat (secret values).
-    local auraEventRemoved = button._auraEventRemoved
-    button._auraEventRemoved = nil
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
-        local configUnit = EntryRuntime.GetConfiguredAuraUnit(buttonData)
-        local auraUnit = button._auraUnit or configUnit
-
-        -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
-        -- untainted code that matches spell IDs to auras during combat and
-        -- stores auraInstanceID + auraDataUnit as plain readable properties.
-        -- Requires the Blizzard Cooldown Manager to be visible with this spell.
-        local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = EntryRuntime.ResolveTrackedAuraViewerFrame(
+        local auraState = EntryRuntime.EvaluateTrackedAuraState(
             button,
             buttonData,
             button._auraSpellID,
-            configUnit,
-            auraUnit,
-            now,
-            barAuraStackConfigured
+            {
+                now = now,
+                allowDurationlessAuraInstance = barAuraStackConfigured,
+                previousAuraDurationObj = prevAuraDurationObj,
+                wasAuraActive = wasAuraActive,
+            }
         )
-        auraTrackingReady = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
-        if auraTrackingReady and not auraOverrideActive and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
-            local viewerInstId = viewerFrame.auraInstanceID
-            if viewerInstId then
-                local unit = viewerFrame.auraDataUnit or auraUnit
-                -- Gate on unit compatibility: CDM's GetAuraData() checks player
-                -- auras first, so auraDataUnit can incorrectly be "player" for a
-                -- viewer child that tracks a target debuff.  Reject the mismatch
-                -- so target-debuff buttons don't display random player buff durations.
-                if unit == configUnit then
-                    -- Cross-validate: confirm the aura instance actually exists
-                    -- on the claimed unit.  Stack-count displays may not have a
-                    -- duration object, but still need the validated applications.
-                    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
-                    local durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
-                    if auraData and (durationObj or barAuraStackConfigured) then
-                        auraApplications = auraData.applications
-                        RecordAuraDisplayName(auraDisplayNameState, auraData)
-                        activeAuraSpellID = GetReadableAuraSpellID(auraData)
-                        activeAuraSpellIDSourceResolved = true
-                        button._viewerBar = nil
-                        if durationObj then
-                            button._auraDurationObj = durationObj
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = durationObj
-                                button.cooldown:SetCooldownFromDurationObject(durationObj)
-                            end
-                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
-                        else
-                            auraHasTimer = false
-                        end
-                        button._auraInstanceID = viewerInstId
-                        button._auraUnit = unit
-                        auraOverrideActive = true
-                        fetchOk = true
-                    end
-                end
-            else
-                -- No auraInstanceID — fall back to reading the viewer's cooldown widget.
-                -- Covers spells where the viewer tracks the buff duration internally
-                -- (auraDataUnit set by GetAuraData) but doesn't expose auraInstanceID.
-                local viewerCooldown = viewerFrame.Cooldown
-                if viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown() then
-                    local startMs, durMs = viewerCooldown:GetCooldownTimes()
-                    if not issecretvalue(durMs) then
-                        -- Plain values: safe to do ms->s arithmetic
-                        if durMs > 0 and (startMs + durMs) > now * 1000 then
-                            local vUnit = viewerFrame.auraDataUnit or auraUnit
-                            if vUnit == configUnit then
-                                local auraStart = startMs / 1000
-                                local auraDuration = durMs / 1000
-                                button._auraCooldownStart = auraStart
-                                button._auraCooldownDuration = auraDuration
-                                if auraPrimarySwipeAllowed then
-                                    button.cooldown:SetCooldown(auraStart, auraDuration)
-                                end
-                                button._auraUnit = vUnit
-                                auraOverrideActive = true
-                                auraHasTimer = true
-                                fetchOk = true
-                            end
-                        end
-                    else
-                        -- Secret values: can't convert ms->s. Mark aura active;
-                        -- grace period covers continuity from previous tick's display.
-                        -- (HasSecretValues() on viewer widgets is unreliable when
-                        -- Blizzard secure code set the values — check the returned
-                        -- value directly with issecretvalue() instead.)
-                        local vUnit = viewerFrame.auraDataUnit or auraUnit
-                        if vUnit == configUnit then
-                            button._auraUnit = vUnit
-                            auraOverrideActive = true
-                            fetchOk = true
-                        end
-                    end
-                    if button._auraInstanceID then
-                        button._auraInstanceID = nil
-                    end
-                end
-                -- Fallback 2: GetTotemDuration for totem/summoning spells
-                -- (TrackedBar category). Returns a LuaDurationObject.
-                -- GetTotemDuration is a global (not C_Totem-namespaced).
-                -- Read preferredTotemUpdateSlot directly from the viewer
-                -- frame (plain number set by CDM) rather than caching it,
-                -- since the slot may not be populated at BuildViewerAuraMap time.
-                -- Guard: viewerFrame.totemData is non-nil only when CDM has
-                -- validated that the totem slot still contains this child's
-                -- spell (GetPreferredTotemSlotInfo checks spellID).  Without
-                -- this, a stale preferredTotemUpdateSlot causes CC to read a
-                -- different spell's totem duration after slot reuse.
-                if not auraOverrideActive then
-                    local totemSlot = viewerFrame.preferredTotemUpdateSlot
-                    if totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData then
-                        local totemDuration = GetTotemDuration(totemSlot)
-                        local totemActive = false
-                        if totemDuration then
-                            totemActive = EntryRuntime.DurationObjectShowsCooldown(totemDuration)
-                        end
-                        if totemActive then
-                            button._auraDurationObj = totemDuration
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = totemDuration
-                                button.cooldown:SetCooldownFromDurationObject(totemDuration)
-                            end
-                            auraOverrideActive = true
-                            auraHasTimer = true
-                            fetchOk = true
-                            -- Bar mode: cache viewer's StatusBar for bar fill pass-through
-                            if button._isBar and viewerFrame.Bar then
-                                button._viewerBar = viewerFrame.Bar
-                            end
-                            if button._auraInstanceID then
-                                button._auraInstanceID = nil
-                            end
-                        else
-                            if button._isBar then
-                                button._viewerBar = nil
-                            end
-                        end
-                    end
-                end
-            end
-        end
-        -- Fallback: direct GetPlayerAuraBySpellID for player-tracked auras when
-        -- the viewer path has no auraInstanceID (form-variant spells like
-        -- Stampeding Roar where the CDM can't match the buff across shapeshifts).
-        local canUsePlayerAuraFallback = auraTrackingReady and configUnit == "player"
+        local viewerFrame = auraState.viewerFrame
+        auraTrackingReady = auraState.auraTrackingReady == true
+        auraOverrideActive = auraState.auraPresent == true
+        auraApplications = auraState.auraApplications
+        auraGraceHeld = auraState.auraGraceHeld == true
+        auraHasTimer = auraState.auraHasTimer == true
+        button._viewerBar = auraState.viewerBar
 
-        if canUsePlayerAuraFallback and not auraOverrideActive then
-            local auraData
-            if orderedStandaloneAuraIDs then
-                for _, numId in ipairs(orderedStandaloneAuraIDs) do
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
-                    if auraData then
-                        activeAuraSpellID = numId
-                        activeAuraSpellIDFromFallback = true
-                        break
-                    end
-                end
-            elseif buttonData.auraSpellID then
-                local ids = button._parsedAuraIDs
-                if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
-                    ids = {}
-                    button._parsedAuraIDsIncludeButtonID = nil
-                    for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                        local numId = tonumber(id)
-                        ids[#ids + 1] = numId
-                        if numId == buttonData.id then
-                            button._parsedAuraIDsIncludeButtonID = true
-                        end
-                    end
-                    button._parsedAuraIDs = ids
-                    button._parsedAuraIDsRaw = buttonData.auraSpellID
-                    button._parsedAuraIDsButtonID = buttonData.id
-                end
-                for _, numId in ipairs(ids) do
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
-                    if auraData then
-                        activeAuraSpellID = numId
-                        activeAuraSpellIDFromFallback = true
-                        break
-                    end
-                end
-                if not auraData and not button._parsedAuraIDsIncludeButtonID then
-                    local baseId = C_Spell.GetBaseSpell(buttonData.id)
-                    local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
-                    auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
-                    if auraData then
-                        activeAuraSpellID = fallbackId
-                        activeAuraSpellIDFromFallback = true
-                    end
-                end
-            else
-                local baseId = C_Spell.GetBaseSpell(buttonData.id)
-                -- Try base spell first for implicit form-variant spells where the buff is applied as base.
-                local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
-                auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
-                if auraData then
-                    activeAuraSpellID = fallbackId
-                    activeAuraSpellIDFromFallback = true
-                end
-                if not auraData then
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID)
-                    if auraData then
-                        activeAuraSpellID = button._auraSpellID
-                        activeAuraSpellIDFromFallback = true
-                    end
-                end
-            end
-            if auraData then
-                auraApplications = auraData.applications
-                local instId = auraData.auraInstanceID
-                if instId and not issecretvalue(instId) then
-                    local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                    if durationObj or barAuraStackConfigured then
-                        RecordAuraDisplayName(auraDisplayNameState, auraData)
-                        activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
-                        activeAuraSpellIDSourceResolved = true
-                        button._viewerBar = nil
-                        if durationObj then
-                            button._auraDurationObj = durationObj
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = durationObj
-                                button.cooldown:SetCooldownFromDurationObject(durationObj)
-                            end
-                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
-                        else
-                            auraHasTimer = false
-                        end
-                        button._auraInstanceID = instId
-                        button._auraUnit = "player"
-                        auraOverrideActive = true
-                        fetchOk = true
-                    end
-                end
-            end
+        if auraState.auraData then
+            RecordAuraDisplayName(auraDisplayNameState, auraState.auraData)
+        elseif auraGraceHeld then
+            PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
         end
-        -- Cached instance ID fallback: when the viewer and GetPlayerAuraBySpellID
-        -- both fail (restricted combat + form-variant spells), the previously-cached
-        -- _auraInstanceID may still be valid.  GetAuraDuration works in restricted
-        -- combat and the instance ID persists until OnUnitAura removal clears it.
-        -- Target-debuff tracking intentionally skips this fallback because a stale
-        -- target auraInstanceID can survive brief viewer churn and show ghost time.
-        if canUsePlayerAuraFallback and not auraOverrideActive and button._auraInstanceID then
-            local cachedUnit = button._auraUnit or configUnit
-            if cachedUnit == configUnit then
-                local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, button._auraInstanceID)
-                if auraData then
-                    auraApplications = auraData.applications
-                    local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
-                    if durationObj or barAuraStackConfigured then
-                        RecordAuraDisplayName(auraDisplayNameState, auraData)
-                        activeAuraSpellID = GetReadableAuraSpellID(auraData)
-                        if activeAuraSpellID then
-                            activeAuraSpellIDSourceResolved = true
-                            activeAuraSpellIDFromFallback = true
-                        end
-                        button._viewerBar = nil
-                        if durationObj then
-                            button._auraDurationObj = durationObj
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = durationObj
-                                button.cooldown:SetCooldownFromDurationObject(durationObj)
-                            end
-                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
-                        else
-                            auraHasTimer = false
-                        end
-                        button._auraUnit = cachedUnit
-                        auraOverrideActive = true
-                        fetchOk = true
-                    end
-                end
-            end
-        end
-        -- Grace period: if aura data is momentarily unavailable but we had an
-        -- active aura DurationObject last tick, keep aura state alive.
-        -- Restoring _durationObj preserves bar fill, color, and time text.
-        -- Target-switch path: holds until UNIT_AURA confirms data received
-        -- (debuff absent on new target) or primary path provides fresh data.
-        -- Player path: DurationObject expiry + time-based grace window.
-        if not auraOverrideActive and button._auraActive
-           and prevAuraDurationObj and not buttonData.isPassive then
-            local expired = false
-            if auraEventRemoved then
-                -- Server confirmed aura removal via UNIT_AURA
-                -- removedAuraInstanceIDs — bypass grace hold entirely.
-                -- Without this, combat secret values prevent
-                -- GetRemainingDuration() from detecting expiry, causing
-                -- a ~0.3s ghost hold on every aura-tracked proc consumed.
-                expired = true
-            elseif button._targetSwitchAt then
-                -- CDM processes UNIT_TARGET before PLAYER_TARGET_CHANGED,
-                -- so the viewer frame already reflects the new target.
-                -- If CDM has no auraInstanceID, the debuff is confirmed
-                -- absent on the new target — expire immediately.
-                -- Ghost auras from stale instance IDs are prevented by the
-                -- cross-validation (GetAuraDataByAuraInstanceID) in the
-                -- viewer path, so this nil check is safe.
-                if viewerFrame and not viewerFrame.auraInstanceID then
-                    expired = true
-                elseif button._targetSwitchDataReceived then
-                    expired = true
-                else
-                    expired = (now - button._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
-                end
-            elseif not prevAuraDurationObj:HasSecretValues() then
-                expired = prevAuraDurationObj:GetRemainingDuration() <= 0
-            end
-            if not expired then
-                if not button._auraGraceStart then
-                    button._auraGraceStart = now
-                end
-                if now - button._auraGraceStart <= 0.3 or button._targetSwitchAt then
-                    if prevAuraDurationObj then
-                        button._auraDurationObj = prevAuraDurationObj
-                        if auraPrimarySwipeAllowed then
-                            button._durationObj = prevAuraDurationObj
-                            button.cooldown:SetCooldownFromDurationObject(prevAuraDurationObj)
-                        end
-                    end
-                    auraOverrideActive = true
-                    auraGraceHeld = true
-                    PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
-                else
-                    button._auraGraceStart = nil
-                end
-            else
-                button._auraGraceStart = nil
-                button._targetSwitchAt = nil
-                button._targetSwitchDataReceived = nil
-            end
-        else
-            button._auraGraceStart = nil
-            if button._targetSwitchAt then
-                if auraOverrideActive and (button._auraDurationObj or button._auraCooldownDuration or button._durationObj or barAuraStackConfigured) then
-                    -- Primary path provided fresh aura data: hold complete
-                    button._targetSwitchAt = nil
-                    button._targetSwitchDataReceived = nil
-                elseif not button._auraActive then
-                    -- Safety: _auraActive already false, clear stale hold
-                    button._targetSwitchAt = nil
-                    button._targetSwitchDataReceived = nil
-                end
-            end
-        end
-        -- Target-switch hold catch-all: preserve _auraActive for buttons
-        -- without a previous DurationObject (tracked via fallback path only)
-        if not auraOverrideActive and button._targetSwitchAt and button._auraActive then
-            local catchAllExpired
-            -- Same expiry logic as the grace period hold above.
-            if viewerFrame and not viewerFrame.auraInstanceID then
-                catchAllExpired = true
-            elseif button._targetSwitchDataReceived then
-                catchAllExpired = true
-            else
-                catchAllExpired = (now - button._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
-            end
-            if catchAllExpired then
-                button._targetSwitchAt = nil
-                button._targetSwitchDataReceived = nil
-            else
-                if prevAuraDurationObj then
-                    button._auraDurationObj = prevAuraDurationObj
-                    if auraPrimarySwipeAllowed then
-                        button._durationObj = prevAuraDurationObj
-                        button.cooldown:SetCooldownFromDurationObject(prevAuraDurationObj)
-                    end
-                end
-                auraOverrideActive = true
-                auraGraceHeld = true
-                PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
-            end
-        end
-        button._auraActive = auraOverrideActive
+
         if auraOverrideActive then
-            button._auraHasTimer = auraHasTimer
-            button._activeAuraSpellID = activeAuraSpellID or button._activeAuraSpellID
-            if activeAuraSpellIDSourceResolved then
-                button._activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback or nil
+            if auraState.durationObj then
+                button._auraDurationObj = auraState.durationObj
+                if auraPrimarySwipeAllowed then
+                    button._durationObj = auraState.durationObj
+                    button.cooldown:SetCooldownFromDurationObject(auraState.durationObj)
+                end
+            elseif auraState.auraCooldownStart and auraState.auraCooldownDuration and auraPrimarySwipeAllowed then
+                button.cooldown:SetCooldown(auraState.auraCooldownStart, auraState.auraCooldownDuration)
             end
-        end
-        if not auraOverrideActive then
-            button._auraInstanceID = nil
-            button._auraUnit = configUnit
-            button._activeAuraSpellID = nil
-            button._activeAuraSpellIDFromFallback = nil
+            fetchOk = true
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the
@@ -1281,55 +919,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         end
 
-        -- Pandemic window check: read Blizzard's PandemicIcon from the viewer frame.
-        -- Blizzard calculates the exact per-spell pandemic window internally and
-        -- shows/hides PandemicIcon accordingly.  Use IsVisible() so that a
-        -- PandemicIcon whose parent viewer item was hidden (e.g. aura expired
-        -- before OnUpdate could clean it up) is not treated as active.
-        -- Grace window: PandemicIcon lives on a pool-managed CDM child frame.
-        -- During RefreshLayout, child frames are recycled and re-acquired,
-        -- which briefly invalidates the viewerFrame reference resolved from
-        -- the aura map.  During this window viewerFrame.PandemicIcon may be
-        -- nil or stale, so hold pandemic state for a fixed wall-clock duration
-        -- (0.3s) to absorb brief dropouts.  Time-based rather than tick-based
-        -- so that rapid UNIT_AURA-driven UpdateAllCooldowns() calls during
-        -- heavy combat don't burn through the grace window prematurely.
-        -- Genuine pandemic end sets _inPandemic = false via event handlers
-        -- (Aura.lua aura removal / target switch), causing the grace guard
-        -- to fail on the next evaluation.  Aura reapplication (pandemic
-        -- refresh) sets _pandemicGraceSuppressed, bypassing the grace hold
-        -- entirely so pandemic clears immediately on refresh.
-        local inPandemic = false
-        if button._pandemicPreview then
-            inPandemic = true
-        -- Pandemic detection: style-level (Show Pandemic Glow) OR per-button visibility toggle.
-        elseif auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic) and viewerFrame then
-            local pi = viewerFrame.PandemicIcon
-            if button._pandemicGraceSuppressed then
-                -- Aura was just refreshed (pandemic recast).  Clear pandemic
-                -- immediately regardless of PandemicIcon visibility — CDM may
-                -- not have run its OnUpdate yet, leaving PandemicIcon stale.
-                button._pandemicGraceSuppressed = nil
-                button._pandemicGraceStart = nil
-                -- inPandemic stays false
-            elseif pi and pi:IsVisible() then
-                inPandemic = true
-                button._pandemicGraceStart = nil
-            elseif button._inPandemic then
-                -- Grace hold: absorbs brief CDM RefreshLayout recycling dropouts.
-                -- Time-based rather than tick-based so rapid UNIT_AURA-driven
-                -- UpdateAllCooldowns() calls don't burn through the window.
-                if not button._pandemicGraceStart then
-                    button._pandemicGraceStart = now
-                end
-                if now - button._pandemicGraceStart <= 0.3 then
-                    inPandemic = true
-                else
-                    button._pandemicGraceStart = nil
-                end
-            end
-        end
-        button._inPandemic = inPandemic
+        button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, {
+            now = now,
+            enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic),
+            previewActive = button._pandemicPreview == true,
+        })
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1794,25 +1388,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if button.auraStackCount and button._barAuraStackDisplay then
         if style.showAuraStackText ~= false and button._auraActive then
             if not preserveBarAuraStackText then
-                local function SetBarAuraStackCountText(value)
-                    if CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData) == "current_max" then
-                        button.auraStackCount:SetFormattedText("%d / %d", value, button._barAuraStackMax or 1)
-                    else
-                        button.auraStackCount:SetFormattedText("%d", value)
-                    end
-                end
+                local stackTextFormat = CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData)
 
                 if barAuraSecretStackValue ~= nil then
-                    SetBarAuraStackCountText(barAuraSecretStackValue)
+                    EntryRuntime.SetAuraStackCountText(button.auraStackCount, barAuraSecretStackValue, button._barAuraStackMax, stackTextFormat)
                 elseif button._barAuraStackValueAvailable and not issecretvalue(button._barAuraStackValue) then
-                    SetBarAuraStackCountText(button._barAuraStackValue)
+                    EntryRuntime.SetAuraStackCountText(button.auraStackCount, button._barAuraStackValue, button._barAuraStackMax, stackTextFormat)
                 elseif button._auraStackText ~= nil then
-                    local auraStackTextValue = button._auraStackText
-                    if issecretvalue(auraStackTextValue) or tonumber(auraStackTextValue) then
-                        SetBarAuraStackCountText(auraStackTextValue)
-                    else
-                        button.auraStackCount:SetText(auraStackTextValue)
-                    end
+                    EntryRuntime.SetAuraStackCountText(button.auraStackCount, button._auraStackText, button._barAuraStackMax, stackTextFormat)
                 else
                     button.auraStackCount:SetText("")
                 end

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -46,6 +46,7 @@ Core\SpellQueries.lua
 Core\CooldownLogic.lua
 Core\Utils.lua
 Core\Init.lua
+Core\EntryRuntime.lua
 Core\Defaults.lua
 Core\SpellActivationOverlayData.lua
 Core\AuraTextures.lua
@@ -78,7 +79,6 @@ ButtonFrame\IconMode.lua
 ButtonFrame\BarMode.lua
 ButtonFrame\TextMode.lua
 ButtonFrame\Preview.lua
-ButtonFrame\EntryRuntime.lua
 ButtonFrame\CooldownUpdate.lua
 Core\GroupFrame.lua
 OtherBars\ResourceBarConstants.lua

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -7,6 +7,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 
 local ipairs = ipairs
@@ -528,16 +529,8 @@ function CooldownCompanion:ClearAuraUnit(unitToken)
                 shouldClear = true
             end
             if shouldClear then
-                button._auraInstanceID = nil
-                button._auraActive = false
-                button._auraDurationObj = nil
-                button._auraCooldownStart = nil
-                button._auraCooldownDuration = nil
+                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, { useFalseState = true })
                 button._auraPrimarySwipeActive = nil
-                button._inPandemic = false
-                button._targetSwitchAt = nil
-                button._targetSwitchDataReceived = nil
-                button._auraUnit = configUnit
             end
         end
     end)
@@ -560,11 +553,7 @@ function CooldownCompanion:OnTargetChanged()
             local isTarget = button._auraUnit == "target"
                 or configUnit == "target"
             if isTarget then
-                button._auraInstanceID = nil
-                button._inPandemic = false
-                button._targetSwitchAt = now
-                button._targetSwitchDataReceived = nil
-                button._auraUnit = "target"
+                EntryRuntime.StartTrackedAuraTargetSwitch(button, now, "target")
             end
         end
     end)

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -1,6 +1,6 @@
 --[[
-    CooldownCompanion - ButtonFrame/EntryRuntime
-    Shared cooldown/aura runtime helpers for bar-panel entries.
+    CooldownCompanion - Core/EntryRuntime
+    Shared cooldown/aura runtime helpers for display entries.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -43,10 +43,33 @@ local function DurationObjectShowsCooldown(durationObj)
 end
 EntryRuntime.DurationObjectShowsCooldown = DurationObjectShowsCooldown
 
+local function SetAuraStackCountText(fontString, value, maxStacks, stackTextFormat)
+    if not fontString then return end
+    if value == nil then
+        fontString:SetText("")
+        return
+    end
+
+    local displayValue = value
+    if not issecretvalue(value) then
+        displayValue = tonumber(value)
+        if not displayValue then
+            fontString:SetText(value or "")
+            return
+        end
+    end
+
+    if stackTextFormat == "current_max" then
+        fontString:SetFormattedText("%d / %d", displayValue, maxStacks or 1)
+    else
+        fontString:SetFormattedText("%d", displayValue)
+    end
+end
+EntryRuntime.SetAuraStackCountText = SetAuraStackCountText
+
 local function GetConfiguredAuraUnit(buttonData)
     return buttonData.auraUnit or "player"
 end
-EntryRuntime.GetConfiguredAuraUnit = GetConfiguredAuraUnit
 
 local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, allowDurationlessAuraInstance)
     local unit = viewerFrame.auraDataUnit or auraUnit
@@ -99,6 +122,32 @@ local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, 
         or ViewerFrameHasActiveTotemDuration(viewerFrame)
 end
 
+local function GetParsedAuraIDs(owner, buttonData)
+    if not (owner and buttonData and buttonData.auraSpellID) then
+        return nil, false
+    end
+
+    local rawIDs = buttonData.auraSpellID
+    if not owner._parsedAuraIDs
+        or owner._parsedAuraIDsRaw ~= rawIDs
+        or owner._parsedAuraIDsButtonID ~= buttonData.id then
+        local ids = {}
+        owner._parsedAuraIDsIncludeButtonID = nil
+        for id in tostring(rawIDs):gmatch("%d+") do
+            local spellID = tonumber(id)
+            ids[#ids + 1] = spellID
+            if spellID == buttonData.id then
+                owner._parsedAuraIDsIncludeButtonID = true
+            end
+        end
+        owner._parsedAuraIDs = ids
+        owner._parsedAuraIDsRaw = rawIDs
+        owner._parsedAuraIDsButtonID = buttonData.id
+    end
+
+    return owner._parsedAuraIDs, owner._parsedAuraIDsIncludeButtonID == true
+end
+
 local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local firstTrackedFrame
     for _, spellID in ipairs(candidateIDs or {}) do
@@ -112,11 +161,7 @@ local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUni
     end
     return nil, firstTrackedFrame
 end
-EntryRuntime.ResolvePreferredAuraViewerFrame = ResolvePreferredAuraViewerFrame
-EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
-CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
-
-local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance)
+local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance, useButtonAuraViewerFallback)
     local viewerFrame
     local cdmEnabled
     if CooldownCompanion._cooldownUpdatePassActive then
@@ -180,21 +225,7 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
             viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
         end
     elseif not viewerFrame and buttonData.auraSpellID then
-        local ids = owner._parsedAuraIDs
-        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
-            ids = {}
-            owner._parsedAuraIDsIncludeButtonID = nil
-            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                local numId = tonumber(id)
-                ids[#ids + 1] = numId
-                if numId == buttonData.id then
-                    owner._parsedAuraIDsIncludeButtonID = true
-                end
-            end
-            owner._parsedAuraIDs = ids
-            owner._parsedAuraIDsRaw = buttonData.auraSpellID
-            owner._parsedAuraIDsButtonID = buttonData.id
-        end
+        local ids = GetParsedAuraIDs(owner, buttonData)
         local activeFrame, firstTrackedFrame = ResolvePreferredAuraViewerFrame(
             ids,
             configUnit,
@@ -218,11 +249,12 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
             end
         end
     end
+    if not viewerFrame and useButtonAuraViewerFallback then
+        viewerFrame = CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
+    end
 
     return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
 end
-EntryRuntime.ResolveTrackedAuraViewerFrame = ResolveTrackedAuraViewerFrame
-
 local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStandaloneAuraIDs)
     local auraData
     local activeAuraSpellID
@@ -238,21 +270,7 @@ local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStan
             end
         end
     elseif buttonData.auraSpellID then
-        local ids = owner._parsedAuraIDs
-        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
-            ids = {}
-            owner._parsedAuraIDsIncludeButtonID = nil
-            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                local spellID = tonumber(id)
-                ids[#ids + 1] = spellID
-                if spellID == buttonData.id then
-                    owner._parsedAuraIDsIncludeButtonID = true
-                end
-            end
-            owner._parsedAuraIDs = ids
-            owner._parsedAuraIDsRaw = buttonData.auraSpellID
-            owner._parsedAuraIDsButtonID = buttonData.id
-        end
+        local ids, includesButtonID = GetParsedAuraIDs(owner, buttonData)
         for _, spellID in ipairs(ids) do
             auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
             if auraData then
@@ -261,7 +279,7 @@ local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStan
                 break
             end
         end
-        if not auraData and not owner._parsedAuraIDsIncludeButtonID then
+        if not auraData and not includesButtonID then
             local baseId = C_Spell.GetBaseSpell(buttonData.id)
             local fallbackId = baseId and baseId ~= auraSpellID and baseId or nil
             auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
@@ -298,6 +316,106 @@ local function GetReadableAuraSpellID(auraData)
     return nil
 end
 
+local function AuraDataMatchesTrackedSpell(owner, buttonData, auraSpellID, auraData)
+    local auraDataSpellID = auraData and auraData.spellId
+    if not auraDataSpellID or issecretvalue(auraDataSpellID) then
+        return false
+    end
+
+    if buttonData and buttonData.auraSpellID then
+        local ids = GetParsedAuraIDs(owner, buttonData)
+        for _, spellID in ipairs(ids or {}) do
+            if auraDataSpellID == spellID then
+                return true
+            end
+        end
+    end
+
+    local buttonSpellID = buttonData and buttonData.id
+    local baseID = buttonSpellID and C_Spell.GetBaseSpell(buttonSpellID)
+    return auraDataSpellID == auraSpellID
+        or auraDataSpellID == buttonSpellID
+        or (baseID and auraDataSpellID == baseID)
+end
+EntryRuntime.AuraDataMatchesTrackedSpell = AuraDataMatchesTrackedSpell
+
+function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
+    if not owner then return end
+    options = options or {}
+    local inactiveValue = options.useFalseState and false or nil
+
+    owner._auraActive = inactiveValue
+    owner._auraHasTimer = inactiveValue
+    owner._auraDurationObj = nil
+    owner._auraCooldownStart = nil
+    owner._auraCooldownDuration = nil
+    owner._auraInstanceID = nil
+    owner._auraUnit = configUnit
+    owner._activeAuraSpellID = nil
+    owner._activeAuraSpellIDFromFallback = nil
+    owner._auraEventRemoved = nil
+    owner._auraGraceStart = nil
+    if not options.preserveTargetSwitch then
+        owner._targetSwitchAt = nil
+        owner._targetSwitchDataReceived = nil
+    end
+    owner._inPandemic = inactiveValue
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    if options.clearCustomAuraStacks then
+        owner._customAuraStackValue = nil
+        owner._customAuraApplicationsValue = nil
+    end
+end
+
+function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
+    if not owner then return end
+    owner._auraInstanceID = nil
+    owner._inPandemic = false
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    owner._targetSwitchAt = now
+    owner._targetSwitchDataReceived = nil
+    owner._auraUnit = unit or "target"
+end
+
+function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
+    if not owner then return false end
+    options = options or {}
+
+    if options.previewActive then
+        return true
+    end
+
+    if not (options.enabled and viewerFrame) then
+        if options.clearWhenDisabled then
+            owner._pandemicGraceStart = nil
+            owner._pandemicGraceSuppressed = nil
+        end
+        return false
+    end
+
+    local pandemicIcon = viewerFrame.PandemicIcon
+    if owner._pandemicGraceSuppressed then
+        owner._pandemicGraceSuppressed = nil
+        owner._pandemicGraceStart = nil
+    elseif pandemicIcon and pandemicIcon:IsVisible() then
+        owner._pandemicGraceStart = nil
+        return true
+    elseif owner._inPandemic then
+        local now = options.now or GetTime()
+        if not owner._pandemicGraceStart then
+            owner._pandemicGraceStart = now
+        end
+        if now - owner._pandemicGraceStart <= 0.3 then
+            return true
+        end
+        owner._pandemicGraceStart = nil
+    end
+
+    return false
+end
+
 local function CommitTrackedAuraOwnerState(owner, state)
     if not owner then return end
 
@@ -313,6 +431,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
         elseif not owner._auraUnit then
             owner._auraUnit = state.auraUnit
         end
+        if state.activeAuraSpellIDResolved then
+            owner._activeAuraSpellID = state.activeAuraSpellID or owner._activeAuraSpellID
+            owner._activeAuraSpellIDFromFallback = state.activeAuraSpellIDFromFallback or nil
+        end
         if owner._targetSwitchAt
             and state.auraGraceHeld ~= true
             and (state.durationObj or state.auraCooldownDuration or state.allowDurationlessAuraInstance) then
@@ -320,15 +442,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
             owner._targetSwitchDataReceived = nil
         end
     else
-        owner._auraActive = false
-        owner._auraHasTimer = false
-        owner._auraDurationObj = nil
-        owner._auraCooldownStart = nil
-        owner._auraCooldownDuration = nil
-        owner._auraInstanceID = nil
-        owner._auraUnit = state.configUnit
-        owner._activeAuraSpellID = nil
-        owner._activeAuraSpellIDFromFallback = nil
+        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit, {
+            useFalseState = true,
+            preserveTargetSwitch = state.wasAuraActive == true,
+        })
         if owner._targetSwitchAt and not state.wasAuraActive then
             owner._targetSwitchAt = nil
             owner._targetSwitchDataReceived = nil
@@ -345,8 +462,14 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     local allowDurationlessAuraInstance = options.allowDurationlessAuraInstance == true
     local allowPlayerAuraFallbackWithoutReady = options.allowPlayerAuraFallbackWithoutReady == true
     local mutateOwner = options.mutateOwner ~= false
-    local prevAuraDurationObj = owner._auraActive and owner._auraDurationObj or nil
-    local wasAuraActive = owner._auraActive == true
+    local prevAuraDurationObj = options.previousAuraDurationObj
+    if prevAuraDurationObj == nil and owner._auraActive then
+        prevAuraDurationObj = owner._auraDurationObj
+    end
+    local wasAuraActive = options.wasAuraActive
+    if wasAuraActive == nil then
+        wasAuraActive = owner._auraActive == true
+    end
     local auraEventRemoved = owner._auraEventRemoved
     owner._auraEventRemoved = nil
 
@@ -357,7 +480,8 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         configUnit,
         auraUnit,
         now,
-        allowDurationlessAuraInstance
+        allowDurationlessAuraInstance,
+        options.useButtonAuraViewerFallback == true
     )
     local ready = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
 
@@ -368,9 +492,11 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     local auraApplications
     local auraInstanceID
     local activeAuraSpellID
+    local activeAuraSpellIDResolved = false
     local activeAuraSpellIDFromFallback
     local auraCooldownStart
     local auraCooldownDuration
+    local viewerBar
 
     if ready and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
         local viewerInstId = viewerFrame.auraInstanceID
@@ -382,6 +508,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                 if auraData and (durationObj or allowDurationlessAuraInstance) then
                     auraApplications = auraData.applications
                     activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    activeAuraSpellIDResolved = true
                     auraInstanceID = viewerInstId
                     auraUnit = unit
                     auraPresent = true
@@ -417,6 +544,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                         auraPresent = true
                         auraHasTimer = true
                         auraInstanceID = nil
+                        viewerBar = viewerFrame.Bar
                     end
                 end
             end
@@ -434,6 +562,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
             if durationObj or allowDurationlessAuraInstance then
                 auraApplications = auraData.applications
                 activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
+                activeAuraSpellIDResolved = true
                 auraInstanceID = instId
                 auraUnit = "player"
                 auraPresent = true
@@ -446,11 +575,14 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         local cachedUnit = owner._auraUnit or configUnit
         if cachedUnit == configUnit then
             auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, owner._auraInstanceID)
-            if auraData then
+            if auraData
+                and (not options.validateCachedAuraData
+                    or options.validateCachedAuraData(owner, buttonData, auraSpellID, auraData)) then
                 durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, owner._auraInstanceID)
                 if durationObj or allowDurationlessAuraInstance then
                     auraApplications = auraData.applications
                     activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    activeAuraSpellIDResolved = true
                     activeAuraSpellIDFromFallback = activeAuraSpellID and true or nil
                     auraInstanceID = owner._auraInstanceID
                     auraUnit = cachedUnit
@@ -539,12 +671,14 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         auraUnit = auraPresent and auraUnit or configUnit,
         configUnit = configUnit,
         viewerFrame = viewerFrame,
+        viewerBar = viewerBar,
         durationObj = auraPresent and durationObj or nil,
         auraCooldownStart = auraPresent and auraCooldownStart or nil,
         auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
         auraHasTimer = auraPresent and auraHasTimer == true or false,
         auraGraceHeld = auraGraceHeld == true,
         activeAuraSpellID = activeAuraSpellID,
+        activeAuraSpellIDResolved = activeAuraSpellIDResolved == true,
         activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
         allowDurationlessAuraInstance = allowDurationlessAuraInstance,
         wasAuraActive = wasAuraActive,
@@ -555,10 +689,6 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     end
 
     return state
-end
-
-function CooldownCompanion:EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
-    return EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
 end
 
 local function IsSpellCooldownDeferred(info)
@@ -660,7 +790,6 @@ local function ProbeActionSlotsForSpellID(spellID)
 
     return result
 end
-
 local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
     local result = {
         shown = nil,
@@ -712,7 +841,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     local info = C_Spell.GetSpellCooldown(spellID)
     result.info = info
     if not info then
-        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
+        if secrecy ~= 0 then
             local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
             if slotProbe.shown ~= nil then
                 result.fetchOk = true
@@ -768,8 +897,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         and (result.isOnGCD == true or result.normalCooldownShown == true)
 
     if needsRealCooldownFallback
-        and options.allowActionSlotRealFallback
-        and ProbeActionSlotCooldownForSpell then
+        and options.allowActionSlotRealFallback then
         local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
         if slotProbe.realShown == true and slotProbe.realDurationObj then
             result.slotProbe = slotProbe
@@ -785,8 +913,6 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 
     return result
 end
-EntryRuntime.EvaluateSpellCooldownLane = EvaluateSpellCooldownLane
-
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
     local allowActionSlotRealFallback = buttonData.hasCharges ~= true
         and cooldownSpellId == buttonData.id
@@ -856,6 +982,15 @@ local function ClearOwnerChargeState(owner)
     owner._mainCDShown = nil
     owner._chargeState = nil
     owner._chargesSpent = nil
+end
+
+function EntryRuntime.RecordChargeSpent(owner)
+    if not owner then return end
+    if not owner._chargeRecharging then
+        owner._chargesSpent = 1
+    else
+        owner._chargesSpent = (owner._chargesSpent or 0) + 1
+    end
 end
 
 local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
@@ -1082,8 +1217,4 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     end
 
     return result
-end
-
-function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar, owner)
-    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
 end

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 -- Localize frequently-used globals for faster access
 local InCombatLockdown = InCombatLockdown
@@ -425,11 +426,7 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
                         -- _chargeRecharging at event time reflects the PRE-cast state:
                         --   false = casting from full charges → reset to 1
                         --   true  = already recharging → increment
-                        if not button._chargeRecharging then
-                            button._chargesSpent = 1
-                        else
-                            button._chargesSpent = (button._chargesSpent or 0) + 1
-                        end
+                        EntryRuntime.RecordChargeSpent(button)
                     end
                 end
             end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -16,6 +16,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 local math_floor = math.floor
 local math_min = math.min
@@ -217,22 +218,7 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     local bar = barInfo and barInfo.frame
     if not bar then return end
 
-    bar._auraActive = nil
-    bar._inPandemic = nil
-    bar._auraInstanceID = nil
-    bar._auraDurationObj = nil
-    bar._auraCooldownStart = nil
-    bar._auraCooldownDuration = nil
-    bar._auraHasTimer = nil
-    bar._auraUnit = nil
-    bar._auraEventRemoved = nil
-    bar._auraGraceStart = nil
-    bar._targetSwitchAt = nil
-    bar._targetSwitchDataReceived = nil
-    bar._customAuraStackValue = nil
-    bar._customAuraApplicationsValue = nil
-    bar._pandemicGraceStart = nil
-    bar._pandemicGraceSuppressed = nil
+    EntryRuntime.ClearTrackedAuraOwnerState(bar, nil, { clearCustomAuraStacks = true })
 
     ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
 end
@@ -439,26 +425,7 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     end
     frame._cdcIndependentAlphaTarget = nil
     frame._cdcIndependentLastAlpha = nil
-    frame._auraActive = nil
-    frame._auraInstanceID = nil
-    frame._auraDurationObj = nil
-    frame._auraCooldownStart = nil
-    frame._auraCooldownDuration = nil
-    frame._auraHasTimer = nil
-    frame._auraUnit = nil
-    frame._auraEventRemoved = nil
-    frame._auraGraceStart = nil
-    frame._targetSwitchAt = nil
-    frame._targetSwitchDataReceived = nil
-    frame._customAuraStackValue = nil
-    frame._customAuraApplicationsValue = nil
-    frame._inPandemic = nil
-    frame._pandemicGraceStart = nil
-    frame._pandemicGraceSuppressed = nil
-    frame._parsedCustomBarAuraIDs = nil
-    frame._parsedCustomBarAuraIDsRaw = nil
-    frame._parsedCustomBarAuraIDsSpellID = nil
-    frame._parsedCustomBarAuraIDsIncludeSpellID = nil
+    EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, { clearCustomAuraStacks = true })
     frame._parsedAuraIDs = nil
     frame._parsedAuraIDsRaw = nil
     frame._parsedAuraIDsButtonID = nil
@@ -2039,7 +2006,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
         barInfo._order = orderList[idx]
         barInfo._effectiveThickness = effectiveThickness
 
-        FinalizeAppliedBarVisibility(barInfo, powerType, isPreviewActive)
+        FinalizeAppliedBarVisibility(barInfo, isPreviewActive)
     end
 
     activeResources = filtered

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -7,7 +7,6 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
 
-local math_floor = math.floor
 local math_max = math.max
 local math_min = math.min
 local GetTime = GetTime
@@ -23,34 +22,11 @@ local CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL = 0.65
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS = 3
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION = 12.3
 
-local function IsSecretValue(value)
-    return issecretvalue and issecretvalue(value)
-end
-
 local function GetReadableApplicationCount(value)
-    if value == nil or IsSecretValue(value) then
+    if value == nil or (issecretvalue and issecretvalue(value)) then
         return nil
     end
     return tonumber(value)
-end
-
-local function SetApplicationStackText(fontString, value, maxStacks, stackTextFormat)
-    if IsSecretValue(value) then
-        fontString:SetText(value)
-        return
-    end
-
-    local numericValue = tonumber(value)
-    if not numericValue then
-        fontString:SetText("")
-        return
-    end
-
-    if stackTextFormat == "current" then
-        fontString:SetFormattedText("%d", numericValue)
-    else
-        fontString:SetFormattedText("%d / %d", numericValue, maxStacks)
-    end
 end
 
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
@@ -78,6 +54,7 @@ local LayoutOverlaySegments = RB.LayoutOverlaySegments
 
 local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
+local SetAuraStackCountText = EntryRuntime.SetAuraStackCountText
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -90,71 +67,15 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
-    local customAuraWakeRetryFrame = nil
     local customAuraWakeRetryQueue = {}
     local customAuraWakeRetryPending = {}
+    local customAuraWakeRetryScheduled = false
     local processingCustomAuraWakeRetryQueue = false
+    local customBarPresentationRefreshPending = false
 
     ------------------------------------------------------------------------
     -- Update logic: Custom aura bars (aura-based, secret-safe)
     ------------------------------------------------------------------------
-
-    local function ResolveCustomBarPandemicState(frame, configUnit, auraPresent, viewerFrame, pandemicPreview)
-        if not frame then
-            return false
-        end
-
-        if pandemicPreview then
-            return true
-        end
-
-        if configUnit == "target" and auraPresent and viewerFrame then
-            local pi = viewerFrame.PandemicIcon
-            if frame._pandemicGraceSuppressed then
-                frame._pandemicGraceSuppressed = nil
-                frame._pandemicGraceStart = nil
-            elseif pi and pi:IsVisible() then
-                frame._pandemicGraceStart = nil
-                return true
-            elseif frame._inPandemic then
-                local now = GetTime()
-                if not frame._pandemicGraceStart then
-                    frame._pandemicGraceStart = now
-                end
-                if now - frame._pandemicGraceStart <= 0.3 then
-                    return true
-                end
-                frame._pandemicGraceStart = nil
-            end
-        else
-            frame._pandemicGraceStart = nil
-            frame._pandemicGraceSuppressed = nil
-        end
-
-        return false
-    end
-
-    local function PeekCustomBarPandemicState(frame, configUnit, auraPresent, viewerFrame, pandemicPreview)
-        if not frame then
-            return false
-        end
-        if pandemicPreview then
-            return true
-        end
-        if configUnit == "target" and auraPresent and viewerFrame then
-            if frame._pandemicGraceSuppressed then
-                return false
-            end
-            local pi = viewerFrame.PandemicIcon
-            if pi and pi:IsVisible() then
-                return true
-            end
-            if frame._inPandemic then
-                return true
-            end
-        end
-        return false
-    end
 
     local function ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, auraPreview, pandemicPreview)
         if not (cabConfig and (cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive)) then
@@ -173,95 +94,62 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return shouldShow, true
     end
 
-    local function GetCustomAuraVisibilityReason(cabConfig)
-        return cabConfig and cabConfig.hideWhenInactive
-            and "hide-when-inactive"
-            or "hide-while-aura-active"
-    end
-
-    function RB.RequestCustomBarPresentationRefresh()
-        if RB.customBarPresentationRefreshPending then
+    local function RequestCustomBarPresentationRefresh()
+        if customBarPresentationRefreshPending then
             return
         end
 
-        RB.customBarPresentationRefreshPending = true
+        customBarPresentationRefreshPending = true
         C_Timer.After(0, function()
-            RB.customBarPresentationRefreshPending = nil
+            customBarPresentationRefreshPending = false
             CooldownCompanion:ApplyResourceBars()
             CooldownCompanion:UpdateAnchorStacking()
         end)
     end
 
-    local CustomAuraBar = {}
-
-    function CustomAuraBar.BuildAuraButtonData(cabConfig)
+    local function BuildCustomBarAuraButtonData(cabConfig, addedAsAura)
         local spellID = tonumber(cabConfig and cabConfig.spellID)
-        if not spellID or (RB.IsSpellCustomBarConfig and RB.IsSpellCustomBarConfig(cabConfig)) then
+        if not spellID then
             return nil, spellID
         end
 
-        return {
+        if addedAsAura then
+            if RB.IsSpellCustomBarConfig(cabConfig) then
+                return nil, spellID
+            end
+        elseif not (cabConfig and cabConfig.auraTracking == true) then
+            return nil, nil
+        end
+
+        local buttonData = {
             type = "spell",
             id = spellID,
             auraSpellID = cabConfig.auraSpellID,
             auraTracking = true,
             auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID),
-            addedAs = "aura",
-        }, spellID
+        }
+        if addedAsAura then
+            buttonData.addedAs = "aura"
+        end
+        return buttonData, spellID
     end
 
-    function CustomAuraBar.GetCandidateIDs(cabConfig)
-        local buttonData
-        local spellID
-        buttonData, spellID = CustomAuraBar.BuildAuraButtonData(cabConfig)
-        if buttonData and CooldownCompanion.GetOrderedAuraCandidateIDs then
-            local orderedCandidateIDs = CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
-            if orderedCandidateIDs and #orderedCandidateIDs > 0 then
-                return orderedCandidateIDs
-            end
+    local function ResolveSpellCustomBarAuraState(barInfo)
+        local cabConfig = barInfo and barInfo.cabConfig
+        local bar = barInfo and barInfo.frame
+        local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, false)
+        if not (buttonData and spellID and bar) then
+            return nil
         end
 
-        return spellID and { spellID } or nil
-    end
-
-    function CustomAuraBar.ViewerFrameHasAuraForUnit(viewerFrame, configUnit)
-        local instId = viewerFrame and viewerFrame.auraInstanceID
-        if not instId then
-            return false
-        end
-
-        local viewerUnit = viewerFrame.auraDataUnit or configUnit
-        return viewerUnit == configUnit
-            and C_UnitAuras.GetAuraDataByAuraInstanceID(viewerUnit, instId) ~= nil
-    end
-
-    function CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
-        local firstTrackedFrame
-        local candidateIDs = CustomAuraBar.GetCandidateIDs(cabConfig)
-        for _, auraID in ipairs(candidateIDs or {}) do
-            local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraID)
-            if viewerFrame then
-                if CustomAuraBar.ViewerFrameHasAuraForUnit(viewerFrame, configUnit) then
-                    return viewerFrame
-                end
-                if not firstTrackedFrame then
-                    firstTrackedFrame = viewerFrame
-                end
-            end
-        end
-
-        return firstTrackedFrame
-    end
-
-    function CustomAuraBar.ResolvePlayerAuraData(cabConfig)
-        local candidateIDs = CustomAuraBar.GetCandidateIDs(cabConfig)
-        for _, auraID in ipairs(candidateIDs or {}) do
-            local auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraID)
-            if auraData then
-                return auraData
-            end
-        end
-        return nil
+        local configUnit = buttonData.auraUnit or "player"
+        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
+        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, {
+            configUnit = configUnit,
+            allowDurationlessAuraInstance = true,
+            useButtonAuraViewerFallback = true,
+            validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell,
+        })
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -270,12 +158,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         -- Read aura data from viewer frame (applications may be secret in combat)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
-        local isSpellCustomBar = RB.IsSpellCustomBarConfig and RB.IsSpellCustomBarConfig(cabConfig)
-        local useSharedStandaloneAuraState = not spellAuraStackDisplay
-            and not isSpellCustomBar
-            and EntryRuntime
-            and EntryRuntime.EvaluateTrackedAuraState
-        local auraState = spellAuraStackDisplay and RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
+        local isSpellCustomBar = RB.IsSpellCustomBarConfig(cabConfig)
+        local auraState
         local stacks = 0
         local applications
         local readableApplications
@@ -284,8 +168,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local auraCooldownStart
         local auraCooldownDuration
         local isActive = cabConfig.trackingMode == "active"
-        local useDrain = isActive
-        local needsDuration = (useDrain or cabConfig.showDurationText) and not spellAuraStackDisplay
         local bar = barInfo.barType == "custom_continuous" and barInfo.frame or nil
         local auraPreview = bar and bar._barAuraActivePreview
         local pandemicPreview = bar and bar._pandemicPreview
@@ -295,8 +177,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local auraUnit = configUnit
         local instId
 
-        if useSharedStandaloneAuraState then
-            local buttonData, spellID = CustomAuraBar.BuildAuraButtonData(cabConfig)
+        if spellAuraStackDisplay then
+            auraState = ResolveSpellCustomBarAuraState(barInfo)
+        elseif not isSpellCustomBar then
+            local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, true)
             if buttonData and spellID then
                 configUnit = buttonData.auraUnit or configUnit
                 auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, {
@@ -305,17 +189,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     allowPlayerAuraFallbackWithoutReady = true,
                 })
                 viewerFrame = auraState and auraState.viewerFrame or nil
-                instId = auraState and auraState.auraInstanceID or nil
             end
-        else
-            viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
-            instId = viewerFrame and viewerFrame.auraInstanceID
         end
 
         if auraState then
-            configUnit = (auraState and auraState.configUnit) or configUnit
-            viewerFrame = auraState and auraState.viewerFrame or nil
-            if auraState and auraState.auraPresent == true then
+            configUnit = auraState.configUnit or configUnit
+            viewerFrame = auraState.viewerFrame
+            if auraState.auraPresent == true then
                 auraPresent = true
                 instId = auraState.auraInstanceID
                 if instId == nil and auraState.auraGraceHeld and barInfo.frame then
@@ -345,47 +225,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 auraCooldownStart = auraState.auraCooldownStart
                 auraCooldownDuration = auraState.auraCooldownDuration
             end
-        elseif instId then
-            local viewerUnit = viewerFrame.auraDataUnit or configUnit
-            if viewerUnit == configUnit then
-                local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
-                if auraData then
-                    auraPresent = true
-                    applications = auraData.applications
-                    readableApplications = GetReadableApplicationCount(applications)
-                    if isActive then
-                        stacks = 1
-                    elseif applications ~= nil then
-                        stacks = applications
-                    else
-                        stacks = 0
-                    end
-                    if needsDuration then
-                        durationObj = C_UnitAuras.GetAuraDuration(configUnit, instId)
-                    end
-                end
-            end
-        end
-
-        if not useSharedStandaloneAuraState and not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
-            local auraData = CustomAuraBar.ResolvePlayerAuraData(cabConfig)
-            if auraData then
-                instId = auraData.auraInstanceID
-                auraUnit = "player"
-                auraPresent = true
-                applications = auraData.applications
-                readableApplications = GetReadableApplicationCount(applications)
-                if isActive then
-                    stacks = 1
-                elseif applications ~= nil then
-                    stacks = applications
-                else
-                    stacks = 0
-                end
-                if needsDuration and instId then
-                    durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                end
-            end
         end
 
         if spellAuraStackDisplay and not auraPresent and not GetPreviewActive() then
@@ -396,7 +235,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false)
             end
-            RB.RequestCustomBarPresentationRefresh()
+            RequestCustomBarPresentationRefresh()
             return
         end
 
@@ -413,7 +252,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         local pandemicStateFrame = barInfo.frame
-        local inPandemic = ResolveCustomBarPandemicState(pandemicStateFrame, configUnit, auraPresent, viewerFrame, pandemicPreview)
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, {
+            enabled = configUnit == "target" and auraPresent,
+            previewActive = pandemicPreview == true,
+            clearWhenDisabled = true,
+        })
 
         if isActive and bar then
             if auraPresent then
@@ -459,7 +302,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if barInfo.barType == "custom_continuous" then
             local bar = barInfo.frame
-            if useDrain then
+            if isActive then
                 bar:SetMinMaxValues(0, 1)
                 if durationObj then
                     bar:SetValue(durationObj:GetRemainingPercent())  -- secret-safe, 1->0 drain
@@ -519,10 +362,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if bar.stackText and bar.stackText:IsShown() then
                 if auraPresent then
                     if isActive then
-                        SetApplicationStackText(bar.stackText, applications, maxStacks, "current")
+                        SetAuraStackCountText(bar.stackText, applications, maxStacks, "current")
                     else
                         local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig.stackTextFormat)
-                        SetApplicationStackText(bar.stackText, stacks, maxStacks, stackTextFormat)
+                        SetAuraStackCountText(bar.stackText, stacks, maxStacks, stackTextFormat)
                     end
                 else
                     bar.stackText:SetText("")
@@ -600,208 +443,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
     end
 
-    local function BuildSpellCustomBarAuraButtonData(cabConfig)
-        local spellID = tonumber(cabConfig and cabConfig.spellID)
-        if not spellID or not (cabConfig and cabConfig.auraTracking == true) then
-            return nil, nil
-        end
-
-        return {
-            type = "spell",
-            id = spellID,
-            auraSpellID = cabConfig.auraSpellID,
-            auraTracking = true,
-            auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID),
-        }, spellID
-    end
-
-    local function GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-        if not (bar and cabConfig and cabConfig.auraSpellID) then
-            return nil, false
-        end
-
-        local rawIDs = tostring(cabConfig.auraSpellID)
-        if bar._parsedCustomBarAuraIDsRaw == rawIDs
-            and bar._parsedCustomBarAuraIDsSpellID == spellID then
-            return bar._parsedCustomBarAuraIDs, bar._parsedCustomBarAuraIDsIncludeSpellID == true
-        end
-
-        local ids = {}
-        local includesSpellID = false
-        for id in rawIDs:gmatch("%d+") do
-            local numericID = tonumber(id)
-            ids[#ids + 1] = numericID
-            if numericID == spellID then
-                includesSpellID = true
-            end
-        end
-
-        bar._parsedCustomBarAuraIDs = ids
-        bar._parsedCustomBarAuraIDsRaw = rawIDs
-        bar._parsedCustomBarAuraIDsSpellID = spellID
-        bar._parsedCustomBarAuraIDsIncludeSpellID = includesSpellID or nil
-        return ids, includesSpellID
-    end
-
-    local function ResolveSpellCustomBarPlayerAuraData(bar, cabConfig, spellID, resolvedAuraSpellID)
-        local auraData
-        if cabConfig.auraSpellID then
-            local ids, includesSpellID = GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-            if ids then
-                for _, auraID in ipairs(ids) do
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraID)
-                    if auraData then
-                        return auraData
-                    end
-                end
-            end
-            if not includesSpellID then
-                local baseID = C_Spell.GetBaseSpell(spellID)
-                local fallbackID = baseID and baseID ~= resolvedAuraSpellID and baseID or nil
-                return fallbackID and C_UnitAuras.GetPlayerAuraBySpellID(fallbackID) or nil
-            end
-            return nil
-        end
-
-        local baseID = C_Spell.GetBaseSpell(spellID)
-        local fallbackID = baseID and baseID ~= resolvedAuraSpellID and baseID or nil
-        auraData = fallbackID and C_UnitAuras.GetPlayerAuraBySpellID(fallbackID) or nil
-        if auraData then
-            return auraData
-        end
-
-        return resolvedAuraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(resolvedAuraSpellID) or nil
-    end
-
-    local function ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
-        if EntryRuntime and EntryRuntime.ResolveTrackedAuraViewerFrame then
-            local auraUnit = bar and bar._auraUnit or configUnit
-            local allowDurationlessAuraInstance = true
-            local viewerFrame = EntryRuntime.ResolveTrackedAuraViewerFrame(
-                bar,
-                buttonData,
-                resolvedAuraSpellID,
-                configUnit,
-                auraUnit,
-                GetTime(),
-                allowDurationlessAuraInstance
-            )
-            if viewerFrame then
-                return viewerFrame
-            end
-        end
-
-        return CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
-    end
-
-    local function SpellCustomBarAuraDataMatches(bar, cabConfig, spellID, resolvedAuraSpellID, auraData)
-        local auraSpellID = auraData and auraData.spellId
-        if not auraSpellID or (issecretvalue and issecretvalue(auraSpellID)) then
-            return false
-        end
-
-        if cabConfig and cabConfig.auraSpellID then
-            local ids = GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-            if ids then
-                for _, auraID in ipairs(ids) do
-                    if auraSpellID == auraID then
-                        return true
-                    end
-                end
-            end
-        end
-
-        local baseID = C_Spell.GetBaseSpell(spellID)
-        return auraSpellID == resolvedAuraSpellID
-            or auraSpellID == spellID
-            or (baseID and auraSpellID == baseID)
-    end
-
-    function RB.ResolveSpellCustomBarAuraState(barInfo)
-        local cabConfig = barInfo and barInfo.cabConfig
-        local bar = barInfo and barInfo.frame
-        local buttonData, spellID = BuildSpellCustomBarAuraButtonData(cabConfig)
-        if not (buttonData and spellID and bar) then
-            return nil
-        end
-
-        local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
-        local configUnit = buttonData.auraUnit or "player"
-        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
-        local viewerFrame = ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
-        if not CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame) then
-            return {
-                ready = false,
-                auraPresent = false,
-                configUnit = configUnit,
-                viewerFrame = viewerFrame,
-            }
-        end
-
-        local auraData
-        local durationObj
-        local auraUnit = configUnit
-        local instId = viewerFrame and viewerFrame.auraInstanceID
-
-        if instId and (configUnit == "player" or configUnit == "target") then
-            local viewerUnit = viewerFrame.auraDataUnit or configUnit
-            if viewerUnit == configUnit then
-                auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(viewerUnit, instId)
-                if auraData then
-                    durationObj = C_UnitAuras.GetAuraDuration(viewerUnit, instId)
-                    if durationObj then
-                        auraUnit = viewerUnit
-                    end
-                end
-            end
-        end
-
-        if not (auraData and durationObj) and configUnit == "player" then
-            auraData = ResolveSpellCustomBarPlayerAuraData(bar, cabConfig, spellID, resolvedAuraSpellID)
-            instId = auraData and auraData.auraInstanceID or nil
-            if instId and not issecretvalue(instId) then
-                durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                auraUnit = "player"
-            end
-        end
-
-        if not (auraData and durationObj) and configUnit == "player" and bar._auraInstanceID then
-            local cachedUnit = bar._auraUnit or configUnit
-            if cachedUnit == configUnit then
-                auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, bar._auraInstanceID)
-                if SpellCustomBarAuraDataMatches(bar, cabConfig, spellID, resolvedAuraSpellID, auraData) then
-                    durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, bar._auraInstanceID)
-                    instId = bar._auraInstanceID
-                    auraUnit = cachedUnit
-                end
-            end
-        end
-
-        if not auraData then
-            return {
-                ready = true,
-                auraPresent = false,
-                configUnit = configUnit,
-                viewerFrame = viewerFrame,
-            }
-        end
-
-        return {
-            ready = true,
-            auraPresent = true,
-            auraData = auraData,
-            auraInstanceID = instId,
-            auraUnit = auraUnit,
-            configUnit = configUnit,
-            viewerFrame = viewerFrame,
-            durationObj = durationObj,
-        }
-    end
-
-    local function ClearSpellCustomBarAuraRuntimeState(barInfo)
-        ClearCustomAuraBarIndicatorState(barInfo, false)
-    end
-
     local function UpdateSpellCustomBarChargeText(bar, cooldownResult)
         if not (bar and bar.stackText and bar.stackText:IsShown()) then
             return
@@ -840,12 +481,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return
         end
 
-        local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig and cabConfig.stackTextFormat)
-        if stackTextFormat == "current" then
-            bar.stackText:SetFormattedText("%d", stacks)
-        else
-            bar.stackText:SetFormattedText("%d / %d", stacks, maxStacks)
-        end
+        SetAuraStackCountText(
+            bar.stackText,
+            stacks,
+            maxStacks,
+            NormalizeCustomAuraStackTextFormat(cabConfig and cabConfig.stackTextFormat)
+        )
     end
 
     function RB.UpdateCustomCooldownBar(barInfo)
@@ -853,12 +494,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local bar = barInfo and barInfo.frame
         if not (cabConfig and cabConfig.spellID and bar) then return end
 
-        local cooldownResult = CooldownCompanion.EvaluateSpellCooldownStateForCustomBar
-            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
+        local cooldownResult = EntryRuntime.EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
         local cooldownActive = cooldownResult
             and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
-        local auraState = RB.ResolveSpellCustomBarAuraState(barInfo)
+        local auraState = ResolveSpellCustomBarAuraState(barInfo)
         local auraPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         local auraPreview = bar._barAuraActivePreview == true
         local pandemicPreview = bar._pandemicPreview == true
@@ -895,13 +535,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = (auraState and auraState.configUnit)
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
-        local inPandemic = ResolveCustomBarPandemicState(
-            bar,
-            configUnit,
-            auraPresent,
-            auraState and auraState.viewerFrame,
-            pandemicPreview
-        )
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, {
+            enabled = configUnit == "target" and auraPresent,
+            previewActive = pandemicPreview == true,
+            clearWhenDisabled = true,
+        })
 
         if auraState
             and auraState.ready == true
@@ -913,7 +551,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 MarkLayoutDirty()
             end
             if not shouldShow then
-                ClearSpellCustomBarAuraRuntimeState(barInfo)
+                ClearCustomAuraBarIndicatorState(barInfo, false)
                 UpdateSpellCustomBarSounds(auraPresent)
                 return
             end
@@ -925,7 +563,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if spellAuraStackDisplay and auraPresent then
             UpdateSpellCustomBarSounds(true)
-            RB.RequestCustomBarPresentationRefresh()
+            RequestCustomBarPresentationRefresh()
             return
         end
 
@@ -985,7 +623,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return
         end
 
-        ClearSpellCustomBarAuraRuntimeState(barInfo)
+        ClearCustomAuraBarIndicatorState(barInfo, false)
 
         bar:SetMinMaxValues(0, 1)
         bar:SetStatusBarColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] ~= nil and fillColor[4] or 1)
@@ -1048,11 +686,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 local maxCharges = charges and tonumber(charges.maxCharges)
                 if (maxCharges or 0) > 1
                     and (spellID == baseSpellID or spellID == runtimeSpellID) then
-                    if not bar._chargeRecharging then
-                        bar._chargesSpent = 1
-                    else
-                        bar._chargesSpent = (bar._chargesSpent or 0) + 1
-                    end
+                    EntryRuntime.RecordChargeSpent(bar)
                 end
             end
         end
@@ -1098,17 +732,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target"
     end
 
-    local function StopDeferredCustomAuraWakeRetryFrame()
-        if customAuraWakeRetryFrame then
-            customAuraWakeRetryFrame:SetScript("OnUpdate", nil)
-        end
-    end
-
     local function ClearDeferredCustomAuraWakeRetries()
         wipe(customAuraWakeRetryQueue)
         wipe(customAuraWakeRetryPending)
+        customAuraWakeRetryScheduled = false
         processingCustomAuraWakeRetryQueue = false
-        StopDeferredCustomAuraWakeRetryFrame()
     end
 
     local function ResolveDeferredCustomAuraWakeRetryBarInfo(entry)
@@ -1131,11 +759,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     end
 
     local function ProcessDeferredCustomAuraWakeRetries()
+        customAuraWakeRetryScheduled = false
         if processingCustomAuraWakeRetryQueue then return end
-        if #customAuraWakeRetryQueue == 0 then
-            StopDeferredCustomAuraWakeRetryFrame()
-            return
-        end
+        if #customAuraWakeRetryQueue == 0 then return end
 
         processingCustomAuraWakeRetryQueue = true
         local queue = customAuraWakeRetryQueue
@@ -1168,7 +794,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         processingCustomAuraWakeRetryQueue = false
-        StopDeferredCustomAuraWakeRetryFrame()
 
         if relayoutNeeded then
             RelayoutResourceStack()
@@ -1200,11 +825,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             unit = unit,
         }
 
-        if not customAuraWakeRetryFrame then
-            customAuraWakeRetryFrame = CreateFrame("Frame")
+        if customAuraWakeRetryScheduled then
+            return
         end
-        customAuraWakeRetryFrame:SetScript("OnUpdate", function(self, _elapsed)
-            self:SetScript("OnUpdate", nil)
+
+        customAuraWakeRetryScheduled = true
+        C_Timer.After(0, function()
             ProcessDeferredCustomAuraWakeRetries()
         end)
     end
@@ -1345,7 +971,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
     end
 
-    local function FinalizeAppliedBarVisibility(barInfo, powerType, previewActive)
+    local function FinalizeAppliedBarVisibility(barInfo, previewActive)
         if barInfo and type(barInfo.customBarId) == "string" then
             if previewActive then
                 barInfo.frame:Show()
@@ -1432,7 +1058,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
         local spellAuraStackPresent = spellAuraStackDisplay and GetPreviewActive()
         if spellAuraStackDisplay and not spellAuraStackPresent and barInfo and barInfo.frame then
-            local auraState = RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
+            local auraState = ResolveSpellCustomBarAuraState(barInfo)
             spellAuraStackPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         end
         local spellAuraStackActive = spellAuraStackDisplay and spellAuraStackPresent
@@ -1601,7 +1227,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     end
 
     RB.PrepareCustomAuraBar = PrepareCustomAuraBar
-    RB.StyleCustomAuraBar = StyleCustomAuraBar
 
     ------------------------------------------------------------------------
     -- Live recolor for custom aura bars (called from config color picker)

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 local math_abs = math.abs
 
@@ -33,27 +34,14 @@ function RB.CreateResourceBarLifecycleModule(deps)
             or barInfo.barType == "custom_segmented"
             or barInfo.barType == "custom_overlay"
             or (barInfo.barType == "custom_cooldown"
-                and cabConfig and cabConfig.auraTracking == true)
+                and cabConfig.auraTracking == true)
     end
 
     local function ClearCustomBarAuraRuntime(bar, configUnit)
-        if not bar then return end
-        bar._auraActive = false
-        bar._auraInstanceID = nil
-        bar._auraDurationObj = nil
-        bar._auraCooldownStart = nil
-        bar._auraCooldownDuration = nil
-        bar._auraHasTimer = false
-        bar._auraUnit = configUnit
-        bar._auraGraceStart = nil
-        bar._inPandemic = false
-        bar._pandemicGraceStart = nil
-        bar._pandemicGraceSuppressed = nil
-        bar._targetSwitchAt = nil
-        bar._targetSwitchDataReceived = nil
-        bar._auraEventRemoved = nil
-        bar._customAuraStackValue = nil
-        bar._customAuraApplicationsValue = nil
+        EntryRuntime.ClearTrackedAuraOwnerState(bar, configUnit, {
+            useFalseState = true,
+            clearCustomAuraStacks = true,
+        })
     end
 
     ------------------------------------------------------------------------
@@ -183,13 +171,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
                             and bar
                             and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
                             if hasTarget then
-                                bar._auraInstanceID = nil
-                                bar._inPandemic = false
-                                bar._pandemicGraceStart = nil
-                                bar._pandemicGraceSuppressed = nil
-                                bar._targetSwitchAt = now
-                                bar._targetSwitchDataReceived = nil
-                                bar._auraUnit = "target"
+                                EntryRuntime.StartTrackedAuraTargetSwitch(bar, now, "target")
                             else
                                 ClearCustomBarAuraRuntime(bar, "target")
                             end


### PR DESCRIPTION
## What Changed
- Moved the shared entry runtime into `Core/EntryRuntime.lua` so button entries, bar-panel entries, and resource-attached custom bars use the same cooldown/aura evaluation helpers.
- Replaced custom-bar-specific aura resolution, pandemic handling, stack text formatting, target-switch cleanup, and cooldown/charge evaluation with shared runtime paths.
- Kept custom-bar presentation, anchoring, previews, and resource-stack placement in the resource bar modules while sharing the underlying cooldown/aura truth.

## Why This Changed
- Custom bars had drifted into their own runtime path even though they display the same cooldown and aura states as bar panels.
- Keeping those paths separate made parity bugs easier to introduce and harder to fix consistently across panels and resource-attached custom bars.

## Developer Impact
- Reduces duplicate custom-bar runtime logic and makes future cooldown/aura fixes flow through one shared runtime contract.
- The branch is a cleanup-focused follow-up to the custom-bar parity work, with no intended new player-facing behavior.
- Diff against `custom-bar-parity`: `338 insertions / 1064 deletions`, net `-726`.

## Validation
- `git diff --check origin/custom-bar-parity...HEAD` passed.
- `luac -p` passed for the touched Lua files.
- Full non-`Libs` Lua syntax pass succeeded.
- Focused fixtures passed: `tests/custom-bar-entry-runtime.lua`, `tests/visual-state-snapshot.lua`, and `tests/visual-state-diagnostics.lua`.
- In-game validation checklist was completed with no regressions reported, including cooldown custom bars, aura active/stack modes, target deselect/reselect, hide-when-inactive behavior, aura unit persistence, and combat/restricted checks.
- `cc-devbridge get_errors` reported no captured errors in the latest logout-flush snapshot; the snapshot was stale by about 18 minutes, so this is supporting evidence rather than fresh live proof.