### PR TITLE
Make Custom Bars match bar-panel cooldown and aura tracking

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -68,7 +68,6 @@ local ResolveItemFallback = CooldownCompanion.ResolveItemFallback
 local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
-local TARGET_SWITCH_SAFETY_CAP = 0.60
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
@@ -371,13 +370,6 @@ local function RecordAuraDisplayName(state, auraData)
         state.readableName = auraName
         state.nameApplied = true
         return true
-    end
-end
-
-local function GetReadableAuraSpellID(auraData)
-    local spellID = auraData and auraData.spellId
-    if spellID and not issecretvalue(spellID) then
-        return spellID
     end
 end
 
@@ -764,7 +756,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- GetCooldownTimes() which returns secret values after
     -- SetCooldownFromDurationObject() in 12.0.1.
     -- Save previous aura DurationObject for one-tick grace period on target switch.
-    local prevAuraDurationObj = button._auraActive and button._auraDurationObj or nil
+    local wasAuraActive = button._auraActive == true
+    local prevAuraDurationObj = wasAuraActive and button._auraDurationObj or nil
     button._durationObj = nil
     button._auraDurationObj = nil
     button._auraCooldownStart = nil
@@ -794,9 +787,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraProbeNormalCooldownShown = false
     local auraProbeRealCooldownShown = false
     local auraDisplayNameState
-    local activeAuraSpellID
-    local activeAuraSpellIDSourceResolved = false
-    local activeAuraSpellIDFromFallback = false
     local previousActiveAuraSpellID = button._activeAuraSpellID
     local previousActiveAuraSpellIDFromFallback = button._activeAuraSpellIDFromFallback == true
     local auraApplications
@@ -815,397 +805,45 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraPrimarySwipeAllowed = not keepSpellCooldownSwipe
     local auraHasTimer = button._auraHasTimer == true
     local auraTrackingReady = buttonData.isPassive == true
-    -- Capture and clear event-driven removal flag (set by OnUnitAura when
-    -- removedAuraInstanceIDs confirms the aura is gone).  Used to bypass the
-    -- grace hold, which otherwise can't detect expiry in combat (secret values).
-    local auraEventRemoved = button._auraEventRemoved
-    button._auraEventRemoved = nil
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
-        local configUnit = EntryRuntime.GetConfiguredAuraUnit(buttonData)
-        local auraUnit = button._auraUnit or configUnit
-
-        -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
-        -- untainted code that matches spell IDs to auras during combat and
-        -- stores auraInstanceID + auraDataUnit as plain readable properties.
-        -- Requires the Blizzard Cooldown Manager to be visible with this spell.
-        local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = EntryRuntime.ResolveTrackedAuraViewerFrame(
+        local auraState = EntryRuntime.EvaluateTrackedAuraState(
             button,
             buttonData,
             button._auraSpellID,
-            configUnit,
-            auraUnit,
-            now,
-            barAuraStackConfigured
+            {
+                now = now,
+                allowDurationlessAuraInstance = barAuraStackConfigured,
+                previousAuraDurationObj = prevAuraDurationObj,
+                wasAuraActive = wasAuraActive,
+            }
         )
-        auraTrackingReady = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
-        if auraTrackingReady and not auraOverrideActive and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
-            local viewerInstId = viewerFrame.auraInstanceID
-            if viewerInstId then
-                local unit = viewerFrame.auraDataUnit or auraUnit
-                -- Gate on unit compatibility: CDM's GetAuraData() checks player
-                -- auras first, so auraDataUnit can incorrectly be "player" for a
-                -- viewer child that tracks a target debuff.  Reject the mismatch
-                -- so target-debuff buttons don't display random player buff durations.
-                if unit == configUnit then
-                    -- Cross-validate: confirm the aura instance actually exists
-                    -- on the claimed unit.  Stack-count displays may not have a
-                    -- duration object, but still need the validated applications.
-                    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
-                    local durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
-                    if auraData and (durationObj or barAuraStackConfigured) then
-                        auraApplications = auraData.applications
-                        RecordAuraDisplayName(auraDisplayNameState, auraData)
-                        activeAuraSpellID = GetReadableAuraSpellID(auraData)
-                        activeAuraSpellIDSourceResolved = true
-                        button._viewerBar = nil
-                        if durationObj then
-                            button._auraDurationObj = durationObj
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = durationObj
-                                button.cooldown:SetCooldownFromDurationObject(durationObj)
-                            end
-                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
-                        else
-                            auraHasTimer = false
-                        end
-                        button._auraInstanceID = viewerInstId
-                        button._auraUnit = unit
-                        auraOverrideActive = true
-                        fetchOk = true
-                    end
-                end
-            else
-                -- No auraInstanceID — fall back to reading the viewer's cooldown widget.
-                -- Covers spells where the viewer tracks the buff duration internally
-                -- (auraDataUnit set by GetAuraData) but doesn't expose auraInstanceID.
-                local viewerCooldown = viewerFrame.Cooldown
-                if viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown() then
-                    local startMs, durMs = viewerCooldown:GetCooldownTimes()
-                    if not issecretvalue(durMs) then
-                        -- Plain values: safe to do ms->s arithmetic
-                        if durMs > 0 and (startMs + durMs) > now * 1000 then
-                            local vUnit = viewerFrame.auraDataUnit or auraUnit
-                            if vUnit == configUnit then
-                                local auraStart = startMs / 1000
-                                local auraDuration = durMs / 1000
-                                button._auraCooldownStart = auraStart
-                                button._auraCooldownDuration = auraDuration
-                                if auraPrimarySwipeAllowed then
-                                    button.cooldown:SetCooldown(auraStart, auraDuration)
-                                end
-                                button._auraUnit = vUnit
-                                auraOverrideActive = true
-                                auraHasTimer = true
-                                fetchOk = true
-                            end
-                        end
-                    else
-                        -- Secret values: can't convert ms->s. Mark aura active;
-                        -- grace period covers continuity from previous tick's display.
-                        -- (HasSecretValues() on viewer widgets is unreliable when
-                        -- Blizzard secure code set the values — check the returned
-                        -- value directly with issecretvalue() instead.)
-                        local vUnit = viewerFrame.auraDataUnit or auraUnit
-                        if vUnit == configUnit then
-                            button._auraUnit = vUnit
-                            auraOverrideActive = true
-                            fetchOk = true
-                        end
-                    end
-                    if button._auraInstanceID then
-                        button._auraInstanceID = nil
-                    end
-                end
-                -- Fallback 2: GetTotemDuration for totem/summoning spells
-                -- (TrackedBar category). Returns a LuaDurationObject.
-                -- GetTotemDuration is a global (not C_Totem-namespaced).
-                -- Read preferredTotemUpdateSlot directly from the viewer
-                -- frame (plain number set by CDM) rather than caching it,
-                -- since the slot may not be populated at BuildViewerAuraMap time.
-                -- Guard: viewerFrame.totemData is non-nil only when CDM has
-                -- validated that the totem slot still contains this child's
-                -- spell (GetPreferredTotemSlotInfo checks spellID).  Without
-                -- this, a stale preferredTotemUpdateSlot causes CC to read a
-                -- different spell's totem duration after slot reuse.
-                if not auraOverrideActive then
-                    local totemSlot = viewerFrame.preferredTotemUpdateSlot
-                    if totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData then
-                        local totemDuration = GetTotemDuration(totemSlot)
-                        local totemActive = false
-                        if totemDuration then
-                            totemActive = EntryRuntime.DurationObjectShowsCooldown(totemDuration)
-                        end
-                        if totemActive then
-                            button._auraDurationObj = totemDuration
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = totemDuration
-                                button.cooldown:SetCooldownFromDurationObject(totemDuration)
-                            end
-                            auraOverrideActive = true
-                            auraHasTimer = true
-                            fetchOk = true
-                            -- Bar mode: cache viewer's StatusBar for bar fill pass-through
-                            if button._isBar and viewerFrame.Bar then
-                                button._viewerBar = viewerFrame.Bar
-                            end
-                            if button._auraInstanceID then
-                                button._auraInstanceID = nil
-                            end
-                        else
-                            if button._isBar then
-                                button._viewerBar = nil
-                            end
-                        end
-                    end
-                end
-            end
-        end
-        -- Fallback: direct GetPlayerAuraBySpellID for player-tracked auras when
-        -- the viewer path has no auraInstanceID (form-variant spells like
-        -- Stampeding Roar where the CDM can't match the buff across shapeshifts).
-        local canUsePlayerAuraFallback = auraTrackingReady and configUnit == "player"
+        local viewerFrame = auraState.viewerFrame
+        auraTrackingReady = auraState.auraTrackingReady == true
+        auraOverrideActive = auraState.auraPresent == true
+        auraApplications = auraState.auraApplications
+        auraGraceHeld = auraState.auraGraceHeld == true
+        auraHasTimer = auraState.auraHasTimer == true
+        button._viewerBar = auraState.viewerBar
 
-        if canUsePlayerAuraFallback and not auraOverrideActive then
-            local auraData
-            if orderedStandaloneAuraIDs then
-                for _, numId in ipairs(orderedStandaloneAuraIDs) do
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
-                    if auraData then
-                        activeAuraSpellID = numId
-                        activeAuraSpellIDFromFallback = true
-                        break
-                    end
-                end
-            elseif buttonData.auraSpellID then
-                local ids = button._parsedAuraIDs
-                if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
-                    ids = {}
-                    button._parsedAuraIDsIncludeButtonID = nil
-                    for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                        local numId = tonumber(id)
-                        ids[#ids + 1] = numId
-                        if numId == buttonData.id then
-                            button._parsedAuraIDsIncludeButtonID = true
-                        end
-                    end
-                    button._parsedAuraIDs = ids
-                    button._parsedAuraIDsRaw = buttonData.auraSpellID
-                    button._parsedAuraIDsButtonID = buttonData.id
-                end
-                for _, numId in ipairs(ids) do
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(numId)
-                    if auraData then
-                        activeAuraSpellID = numId
-                        activeAuraSpellIDFromFallback = true
-                        break
-                    end
-                end
-                if not auraData and not button._parsedAuraIDsIncludeButtonID then
-                    local baseId = C_Spell.GetBaseSpell(buttonData.id)
-                    local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
-                    auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
-                    if auraData then
-                        activeAuraSpellID = fallbackId
-                        activeAuraSpellIDFromFallback = true
-                    end
-                end
-            else
-                local baseId = C_Spell.GetBaseSpell(buttonData.id)
-                -- Try base spell first for implicit form-variant spells where the buff is applied as base.
-                local fallbackId = baseId and baseId ~= button._auraSpellID and baseId or nil
-                auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
-                if auraData then
-                    activeAuraSpellID = fallbackId
-                    activeAuraSpellIDFromFallback = true
-                end
-                if not auraData then
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(button._auraSpellID)
-                    if auraData then
-                        activeAuraSpellID = button._auraSpellID
-                        activeAuraSpellIDFromFallback = true
-                    end
-                end
-            end
-            if auraData then
-                auraApplications = auraData.applications
-                local instId = auraData.auraInstanceID
-                if instId and not issecretvalue(instId) then
-                    local durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                    if durationObj or barAuraStackConfigured then
-                        RecordAuraDisplayName(auraDisplayNameState, auraData)
-                        activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
-                        activeAuraSpellIDSourceResolved = true
-                        button._viewerBar = nil
-                        if durationObj then
-                            button._auraDurationObj = durationObj
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = durationObj
-                                button.cooldown:SetCooldownFromDurationObject(durationObj)
-                            end
-                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
-                        else
-                            auraHasTimer = false
-                        end
-                        button._auraInstanceID = instId
-                        button._auraUnit = "player"
-                        auraOverrideActive = true
-                        fetchOk = true
-                    end
-                end
-            end
+        if auraState.auraData then
+            RecordAuraDisplayName(auraDisplayNameState, auraState.auraData)
+        elseif auraGraceHeld then
+            PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
         end
-        -- Cached instance ID fallback: when the viewer and GetPlayerAuraBySpellID
-        -- both fail (restricted combat + form-variant spells), the previously-cached
-        -- _auraInstanceID may still be valid.  GetAuraDuration works in restricted
-        -- combat and the instance ID persists until OnUnitAura removal clears it.
-        -- Target-debuff tracking intentionally skips this fallback because a stale
-        -- target auraInstanceID can survive brief viewer churn and show ghost time.
-        if canUsePlayerAuraFallback and not auraOverrideActive and button._auraInstanceID then
-            local cachedUnit = button._auraUnit or configUnit
-            if cachedUnit == configUnit then
-                local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, button._auraInstanceID)
-                if auraData then
-                    auraApplications = auraData.applications
-                    local durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, button._auraInstanceID)
-                    if durationObj or barAuraStackConfigured then
-                        RecordAuraDisplayName(auraDisplayNameState, auraData)
-                        activeAuraSpellID = GetReadableAuraSpellID(auraData)
-                        if activeAuraSpellID then
-                            activeAuraSpellIDSourceResolved = true
-                            activeAuraSpellIDFromFallback = true
-                        end
-                        button._viewerBar = nil
-                        if durationObj then
-                            button._auraDurationObj = durationObj
-                            if auraPrimarySwipeAllowed then
-                                button._durationObj = durationObj
-                                button.cooldown:SetCooldownFromDurationObject(durationObj)
-                            end
-                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
-                        else
-                            auraHasTimer = false
-                        end
-                        button._auraUnit = cachedUnit
-                        auraOverrideActive = true
-                        fetchOk = true
-                    end
-                end
-            end
-        end
-        -- Grace period: if aura data is momentarily unavailable but we had an
-        -- active aura DurationObject last tick, keep aura state alive.
-        -- Restoring _durationObj preserves bar fill, color, and time text.
-        -- Target-switch path: holds until UNIT_AURA confirms data received
-        -- (debuff absent on new target) or primary path provides fresh data.
-        -- Player path: DurationObject expiry + time-based grace window.
-        if not auraOverrideActive and button._auraActive
-           and prevAuraDurationObj and not buttonData.isPassive then
-            local expired = false
-            if auraEventRemoved then
-                -- Server confirmed aura removal via UNIT_AURA
-                -- removedAuraInstanceIDs — bypass grace hold entirely.
-                -- Without this, combat secret values prevent
-                -- GetRemainingDuration() from detecting expiry, causing
-                -- a ~0.3s ghost hold on every aura-tracked proc consumed.
-                expired = true
-            elseif button._targetSwitchAt then
-                -- CDM processes UNIT_TARGET before PLAYER_TARGET_CHANGED,
-                -- so the viewer frame already reflects the new target.
-                -- If CDM has no auraInstanceID, the debuff is confirmed
-                -- absent on the new target — expire immediately.
-                -- Ghost auras from stale instance IDs are prevented by the
-                -- cross-validation (GetAuraDataByAuraInstanceID) in the
-                -- viewer path, so this nil check is safe.
-                if viewerFrame and not viewerFrame.auraInstanceID then
-                    expired = true
-                elseif button._targetSwitchDataReceived then
-                    expired = true
-                else
-                    expired = (now - button._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
-                end
-            elseif not prevAuraDurationObj:HasSecretValues() then
-                expired = prevAuraDurationObj:GetRemainingDuration() <= 0
-            end
-            if not expired then
-                if not button._auraGraceStart then
-                    button._auraGraceStart = now
-                end
-                if now - button._auraGraceStart <= 0.3 or button._targetSwitchAt then
-                    if prevAuraDurationObj then
-                        button._auraDurationObj = prevAuraDurationObj
-                        if auraPrimarySwipeAllowed then
-                            button._durationObj = prevAuraDurationObj
-                            button.cooldown:SetCooldownFromDurationObject(prevAuraDurationObj)
-                        end
-                    end
-                    auraOverrideActive = true
-                    auraGraceHeld = true
-                    PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
-                else
-                    button._auraGraceStart = nil
-                end
-            else
-                button._auraGraceStart = nil
-                button._targetSwitchAt = nil
-                button._targetSwitchDataReceived = nil
-            end
-        else
-            button._auraGraceStart = nil
-            if button._targetSwitchAt then
-                if auraOverrideActive and (button._auraDurationObj or button._auraCooldownDuration or button._durationObj or barAuraStackConfigured) then
-                    -- Primary path provided fresh aura data: hold complete
-                    button._targetSwitchAt = nil
-                    button._targetSwitchDataReceived = nil
-                elseif not button._auraActive then
-                    -- Safety: _auraActive already false, clear stale hold
-                    button._targetSwitchAt = nil
-                    button._targetSwitchDataReceived = nil
-                end
-            end
-        end
-        -- Target-switch hold catch-all: preserve _auraActive for buttons
-        -- without a previous DurationObject (tracked via fallback path only)
-        if not auraOverrideActive and button._targetSwitchAt and button._auraActive then
-            local catchAllExpired
-            -- Same expiry logic as the grace period hold above.
-            if viewerFrame and not viewerFrame.auraInstanceID then
-                catchAllExpired = true
-            elseif button._targetSwitchDataReceived then
-                catchAllExpired = true
-            else
-                catchAllExpired = (now - button._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
-            end
-            if catchAllExpired then
-                button._targetSwitchAt = nil
-                button._targetSwitchDataReceived = nil
-            else
-                if prevAuraDurationObj then
-                    button._auraDurationObj = prevAuraDurationObj
-                    if auraPrimarySwipeAllowed then
-                        button._durationObj = prevAuraDurationObj
-                        button.cooldown:SetCooldownFromDurationObject(prevAuraDurationObj)
-                    end
-                end
-                auraOverrideActive = true
-                auraGraceHeld = true
-                PreserveAuraDisplayNameDuringGrace(auraDisplayNameState)
-            end
-        end
-        button._auraActive = auraOverrideActive
+
         if auraOverrideActive then
-            button._auraHasTimer = auraHasTimer
-            button._activeAuraSpellID = activeAuraSpellID or button._activeAuraSpellID
-            if activeAuraSpellIDSourceResolved then
-                button._activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback or nil
+            if auraState.durationObj then
+                button._auraDurationObj = auraState.durationObj
+                if auraPrimarySwipeAllowed then
+                    button._durationObj = auraState.durationObj
+                    button.cooldown:SetCooldownFromDurationObject(auraState.durationObj)
+                end
+            elseif auraState.auraCooldownStart and auraState.auraCooldownDuration and auraPrimarySwipeAllowed then
+                button.cooldown:SetCooldown(auraState.auraCooldownStart, auraState.auraCooldownDuration)
             end
-        end
-        if not auraOverrideActive then
-            button._auraInstanceID = nil
-            button._auraUnit = configUnit
-            button._activeAuraSpellID = nil
-            button._activeAuraSpellIDFromFallback = nil
+            fetchOk = true
         end
 
         -- Viewer icon change detection: for passive aura-tracked buttons, the
@@ -1281,55 +919,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         end
 
-        -- Pandemic window check: read Blizzard's PandemicIcon from the viewer frame.
-        -- Blizzard calculates the exact per-spell pandemic window internally and
-        -- shows/hides PandemicIcon accordingly.  Use IsVisible() so that a
-        -- PandemicIcon whose parent viewer item was hidden (e.g. aura expired
-        -- before OnUpdate could clean it up) is not treated as active.
-        -- Grace window: PandemicIcon lives on a pool-managed CDM child frame.
-        -- During RefreshLayout, child frames are recycled and re-acquired,
-        -- which briefly invalidates the viewerFrame reference resolved from
-        -- the aura map.  During this window viewerFrame.PandemicIcon may be
-        -- nil or stale, so hold pandemic state for a fixed wall-clock duration
-        -- (0.3s) to absorb brief dropouts.  Time-based rather than tick-based
-        -- so that rapid UNIT_AURA-driven UpdateAllCooldowns() calls during
-        -- heavy combat don't burn through the grace window prematurely.
-        -- Genuine pandemic end sets _inPandemic = false via event handlers
-        -- (Aura.lua aura removal / target switch), causing the grace guard
-        -- to fail on the next evaluation.  Aura reapplication (pandemic
-        -- refresh) sets _pandemicGraceSuppressed, bypassing the grace hold
-        -- entirely so pandemic clears immediately on refresh.
-        local inPandemic = false
-        if button._pandemicPreview then
-            inPandemic = true
-        -- Pandemic detection: style-level (Show Pandemic Glow) OR per-button visibility toggle.
-        elseif auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic) and viewerFrame then
-            local pi = viewerFrame.PandemicIcon
-            if button._pandemicGraceSuppressed then
-                -- Aura was just refreshed (pandemic recast).  Clear pandemic
-                -- immediately regardless of PandemicIcon visibility — CDM may
-                -- not have run its OnUpdate yet, leaving PandemicIcon stale.
-                button._pandemicGraceSuppressed = nil
-                button._pandemicGraceStart = nil
-                -- inPandemic stays false
-            elseif pi and pi:IsVisible() then
-                inPandemic = true
-                button._pandemicGraceStart = nil
-            elseif button._inPandemic then
-                -- Grace hold: absorbs brief CDM RefreshLayout recycling dropouts.
-                -- Time-based rather than tick-based so rapid UNIT_AURA-driven
-                -- UpdateAllCooldowns() calls don't burn through the window.
-                if not button._pandemicGraceStart then
-                    button._pandemicGraceStart = now
-                end
-                if now - button._pandemicGraceStart <= 0.3 then
-                    inPandemic = true
-                else
-                    button._pandemicGraceStart = nil
-                end
-            end
-        end
-        button._inPandemic = inPandemic
+        button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, {
+            now = now,
+            enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic),
+            previewActive = button._pandemicPreview == true,
+        })
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1794,25 +1388,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if button.auraStackCount and button._barAuraStackDisplay then
         if style.showAuraStackText ~= false and button._auraActive then
             if not preserveBarAuraStackText then
-                local function SetBarAuraStackCountText(value)
-                    if CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData) == "current_max" then
-                        button.auraStackCount:SetFormattedText("%d / %d", value, button._barAuraStackMax or 1)
-                    else
-                        button.auraStackCount:SetFormattedText("%d", value)
-                    end
-                end
+                local stackTextFormat = CooldownCompanion:GetBarPanelAuraStackTextFormat(buttonData)
 
                 if barAuraSecretStackValue ~= nil then
-                    SetBarAuraStackCountText(barAuraSecretStackValue)
+                    EntryRuntime.SetAuraStackCountText(button.auraStackCount, barAuraSecretStackValue, button._barAuraStackMax, stackTextFormat)
                 elseif button._barAuraStackValueAvailable and not issecretvalue(button._barAuraStackValue) then
-                    SetBarAuraStackCountText(button._barAuraStackValue)
+                    EntryRuntime.SetAuraStackCountText(button.auraStackCount, button._barAuraStackValue, button._barAuraStackMax, stackTextFormat)
                 elseif button._auraStackText ~= nil then
-                    local auraStackTextValue = button._auraStackText
-                    if issecretvalue(auraStackTextValue) or tonumber(auraStackTextValue) then
-                        SetBarAuraStackCountText(auraStackTextValue)
-                    else
-                        button.auraStackCount:SetText(auraStackTextValue)
-                    end
+                    EntryRuntime.SetAuraStackCountText(button.auraStackCount, button._auraStackText, button._barAuraStackMax, stackTextFormat)
                 else
                     button.auraStackCount:SetText("")
                 end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local EntryRuntime = ST.EntryRuntime
 
 -- Localize frequently-used globals
 local GetTime = GetTime
@@ -13,7 +14,6 @@ local tonumber = tonumber
 local tostring = tostring
 local ipairs = ipairs
 local type = type
-local wipe = wipe
 local issecretvalue = issecretvalue
 local math_max = math.max
 
@@ -461,90 +461,6 @@ local function CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverri
     end
 end
 
--- Hidden scratch CooldownFrame for probing DurationObject activity.
--- DurationObject:IsZero() returns a secret boolean in tainted contexts;
--- feeding the object to a Cooldown widget and checking IsShown() yields
--- a plain boolean safe for Lua logic.  Used by action-slot and totem
--- probes, which have no isActive companion field on their return values.
-local scratchParent = CreateFrame("Frame")
-scratchParent:Hide()
-local scratchCooldown = CreateFrame("Cooldown", nil, scratchParent, "CooldownFrameTemplate")
-
-local function DurationObjectShowsCooldown(durationObj)
-    if not durationObj then return false end
-    scratchCooldown:SetCooldownFromDurationObject(durationObj)
-    local shown = scratchCooldown:IsShown()
-    scratchCooldown:SetCooldown(0, 0)
-    return shown
-end
-
-local function GetConfiguredAuraUnit(buttonData)
-    return buttonData.auraUnit or "player"
-end
-
-local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
-    local unit = viewerFrame.auraDataUnit or auraUnit
-    if not (viewerFrame.auraInstanceID and unit == configUnit) then
-        return false
-    end
-
-    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerFrame.auraInstanceID)
-    if not auraData then
-        return false
-    end
-
-    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
-end
-
-local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
-    local viewerCooldown = viewerFrame.Cooldown
-    if not (viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown()) then
-        return false
-    end
-
-    local vUnit = viewerFrame.auraDataUnit or auraUnit
-    if vUnit ~= configUnit then
-        return false
-    end
-
-    local startMs, durMs = viewerCooldown:GetCooldownTimes()
-    if issecretvalue(durMs) then
-        return true
-    end
-
-    return durMs > 0 and (startMs + durMs) > now * 1000
-end
-
-local function ViewerFrameHasActiveTotemDuration(viewerFrame)
-    local totemSlot = viewerFrame.preferredTotemUpdateSlot
-    if not (totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData) then
-        return false
-    end
-
-    return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
-end
-
-local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
-    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
-        or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
-        or ViewerFrameHasActiveTotemDuration(viewerFrame)
-end
-
-local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
-    local firstTrackedFrame
-    for _, spellID in ipairs(candidateIDs or {}) do
-        local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
-        if viewerFrame then
-            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
-                return viewerFrame, firstTrackedFrame
-            end
-            firstTrackedFrame = firstTrackedFrame or viewerFrame
-        end
-    end
-    return nil, firstTrackedFrame
-end
-CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
-
 local function DispatchStandaloneTextureVisual(button)
     if not button then
         return
@@ -593,136 +509,6 @@ function CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
     end
 end
 
--- Deferred spell cooldown detection: distinguish true held cooldowns from
--- start-recovery / empower recovery windows. In 12.0.1, unrelated spells can
--- transiently report isEnabled=false, isActive=false, and a positive
--- timeUntilEndOfStartRecovery while an empowered cast is being held. That
--- state should not drive cooldown desaturation, bar fill, text placeholders,
--- or hide-on-cooldown visibility. Treat it as recovery-only, not deferred CD.
-local function IsSpellCooldownDeferred(info)
-    if not info or info.isEnabled ~= false or info.isActive == true then
-        return false
-    end
-
-    if info.isOnGCD == true then
-        return false
-    end
-
-    local recoveryTime = info.timeUntilEndOfStartRecovery
-    if recoveryTime == nil then
-        return true
-    end
-
-    if issecretvalue(recoveryTime) then
-        -- Secret recovery values are unreadable in restricted states; when they
-        -- coincide with the GCD the earlier guard already classifies them as
-        -- recovery-only. Outside that case, keep the existing deferred-cooldown
-        -- behavior until a concrete counterexample is observed in game.
-        return true
-    end
-
-    return recoveryTime <= 0
-end
-
-local ProbeActionSlotCooldownForSpell
-
-local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
-    local result = {
-        spellID = spellID,
-        fetchOk = false,
-        state = COOLDOWN_STATE_READY,
-        source = "ready",
-        realCooldownShown = false,
-        isOnGCD = false,
-        deferred = false,
-    }
-
-    if not spellID then
-        return result
-    end
-
-    options = options or {}
-
-    local info = C_Spell.GetSpellCooldown(spellID)
-    result.info = info
-    if not info then
-        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
-            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
-            if slotProbe.shown ~= nil then
-                result.fetchOk = true
-                result.normalCooldownShown = slotProbe.shown == true
-                result.realCooldownShown = slotProbe.realShown == true
-                result.durationObj = slotProbe.durationObj
-                result.realDurationObj = slotProbe.realDurationObj
-                result.slotProbe = slotProbe
-                if result.realCooldownShown and slotProbe.realDurationObj then
-                    result.state = COOLDOWN_STATE_COOLDOWN
-                    result.source = "action-slot-real-no-spell-info"
-                    result.renderDurationObj = slotProbe.realDurationObj
-                    result.isOnGCD = CooldownCompanion._gcdActive == true
-                elseif slotProbe.shown and slotProbe.durationObj then
-                    result.source = "action-slot-gcd-no-spell-info"
-                    result.presentationState = COOLDOWN_STATE_GCD
-                    result.renderDurationObj = slotProbe.durationObj
-                    result.isOnGCD = true
-                end
-            end
-        end
-        return result
-    end
-
-    result.fetchOk = true
-    result.isOnGCD = info.isOnGCD or false
-    result.deferred = IsSpellCooldownDeferred(info)
-
-    if info.isActive then
-        result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
-        result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
-        result.normalCooldownShown = DurationObjectShowsCooldown(result.durationObj)
-        result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
-    end
-
-    if result.deferred then
-        result.state = COOLDOWN_STATE_COOLDOWN
-        result.source = "spell-deferred"
-    elseif result.realCooldownShown and result.realDurationObj then
-        result.state = COOLDOWN_STATE_COOLDOWN
-        result.source = "spell-real-ignore-gcd"
-        result.renderDurationObj = result.realDurationObj
-    elseif CooldownLogic.IsSpellGCDOnly(info, {
-        normalCooldownShown = result.normalCooldownShown,
-        realCooldownShown = result.realCooldownShown,
-    }) then
-        result.source = "spell-gcd"
-        result.presentationState = COOLDOWN_STATE_GCD
-        result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
-    end
-
-    local needsRealCooldownFallback = result.state ~= COOLDOWN_STATE_COOLDOWN
-        and (result.isOnGCD == true or result.normalCooldownShown == true)
-
-    -- Some short real cooldowns surface as GCD-only through the spell lane
-    -- until the GCD ends. The action-slot duration object matches Blizzard's
-    -- button display and can expose the real ignoreGCD cooldown immediately.
-    if needsRealCooldownFallback
-        and options.allowActionSlotRealFallback
-        and ProbeActionSlotCooldownForSpell then
-        local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
-        if slotProbe.realShown == true and slotProbe.realDurationObj then
-            result.slotProbe = slotProbe
-            result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
-            result.realCooldownShown = true
-            result.durationObj = slotProbe.durationObj or result.durationObj
-            result.realDurationObj = slotProbe.realDurationObj
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "action-slot-real-fallback"
-            result.renderDurationObj = slotProbe.realDurationObj
-        end
-    end
-
-    return result
-end
-
 local function GetLiveOverrideSpellID(buttonData)
     if not (buttonData and buttonData.type == "spell" and not buttonData.isPassive) then
         return nil
@@ -734,82 +520,6 @@ local function GetLiveOverrideSpellID(buttonData)
     end
 
     return nil
-end
-
-local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
-    local allowActionSlotRealFallback = buttonData.hasCharges ~= true
-        and cooldownSpellId == buttonData.id
-        and noCooldown ~= true
-
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
-        allowActionSlotRealFallback = allowActionSlotRealFallback,
-    })
-end
-
-function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
-    local spellID = tonumber(customBar and customBar.spellID)
-    local result
-    if not spellID then
-        return EvaluateSpellCooldownLane(nil, 0, nil)
-    end
-
-    local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
-    if not cooldownSpellID or cooldownSpellID == 0 then
-        cooldownSpellID = spellID
-    end
-
-    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
-        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
-        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
-        customBar._cooldownSecrecySpellID = cooldownSpellID
-    end
-
-    local charges = C_Spell.GetSpellCharges(cooldownSpellID)
-    local maxCharges = charges and tonumber(charges.maxCharges)
-    if maxCharges and maxCharges > 1 then
-        customBar.hasCharges = true
-        customBar.maxCharges = maxCharges
-    elseif charges then
-        customBar.hasCharges = nil
-        customBar.maxCharges = maxCharges
-    elseif not charges then
-        customBar.hasCharges = nil
-    end
-
-    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
-        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
-    })
-    result.baseSpellID = spellID
-    result.cooldownSpellID = cooldownSpellID
-
-    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
-        result.hasCharges = true
-        result.maxCharges = maxCharges
-        result.charges = charges
-
-        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
-            result.currentCharges = charges.currentCharges
-            if result.currentCharges <= 0 then
-                result.chargeState = CHARGE_STATE_ZERO
-            elseif result.currentCharges >= maxCharges then
-                result.chargeState = CHARGE_STATE_FULL
-            else
-                result.chargeState = CHARGE_STATE_MISSING
-            end
-        end
-
-        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
-        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
-        result.chargeDurationObj = chargeDurationObj
-        result.chargeRecharging = chargeRecharging or false
-        if chargeRecharging then
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "spell-charge-recharge"
-            result.renderDurationObj = chargeDurationObj
-        end
-    end
-
-    return result
 end
 
 local function ResolveChargeState(button, buttonData)
@@ -851,112 +561,6 @@ local function ResolveChargeState(button, buttonData)
     end
 
     return nil
-end
-
--- Probe action-slot cooldown state for a spell ID pair (base + display override).
-local actionSlotSeenScratch = {}
-
-local function MergeActionSlotProbe(result, probe)
-    if probe.sawAnySlot then result.sawAnySlot = true end
-    if probe.sawUnknown then result.sawUnknown = true end
-    if probe.slot and not result.slot then result.slot = probe.slot end
-    if probe.matchedSpellID and not result.matchedSpellID then result.matchedSpellID = probe.matchedSpellID end
-    if probe.shown ~= nil then result.shown = probe.shown end
-    if probe.realShown ~= nil then result.realShown = probe.realShown end
-    if probe.durationObj then result.durationObj = result.durationObj or probe.durationObj end
-    if probe.realDurationObj then result.realDurationObj = result.realDurationObj or probe.realDurationObj end
-    if probe.shown or probe.realShown then
-        result.shown = probe.shown == true
-        result.durationObj = probe.durationObj or result.durationObj
-        result.realShown = probe.realShown == true
-        result.realDurationObj = probe.realDurationObj or result.realDurationObj
-        result.slot = probe.slot or result.slot
-        result.matchedSpellID = probe.matchedSpellID or result.matchedSpellID
-        return true
-    end
-    return false
-end
-
-local function ProbeActionSlotsForSpellID(spellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
-
-    if not spellID then return result end
-
-    local slots = C_ActionBar.FindSpellActionButtons(spellID)
-    if not slots then return result end
-
-    for _, slot in ipairs(slots) do
-        if not actionSlotSeenScratch[slot] then
-            actionSlotSeenScratch[slot] = true
-            result.sawAnySlot = true
-            result.slot = result.slot or slot
-            result.matchedSpellID = result.matchedSpellID or spellID
-
-            local durationObj = C_ActionBar.GetActionCooldownDuration(slot)
-            local realDurationObj = C_ActionBar.GetActionCooldownDuration(slot, true)
-            local shown = false
-            local realShown
-
-            if durationObj then
-                shown = DurationObjectShowsCooldown(durationObj)
-            end
-
-            if realDurationObj then
-                realShown = DurationObjectShowsCooldown(realDurationObj)
-            end
-
-            if shown or realShown then
-                result.shown = shown == true
-                result.durationObj = durationObj
-                result.realShown = realShown == true
-                result.realDurationObj = realDurationObj
-                result.slot = slot
-                result.matchedSpellID = spellID
-                return result
-            end
-        end
-    end
-
-    if result.sawAnySlot then
-        result.shown = false
-    end
-
-    return result
-end
-
-function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
-
-    if not baseSpellID then return result end
-
-    wipe(actionSlotSeenScratch)
-
-    if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(baseSpellID)) then
-        return result
-    end
-
-    if displaySpellID and displaySpellID ~= baseSpellID then
-        if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(displaySpellID)) then
-            return result
-        end
-    end
-
-    if result.sawAnySlot and not result.sawUnknown then
-        result.shown = false
-        result.realShown = false
-    end
-
-    return result
 end
 
 local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
@@ -1219,122 +823,22 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
-        local configUnit = GetConfiguredAuraUnit(buttonData)
+        local configUnit = EntryRuntime.GetConfiguredAuraUnit(buttonData)
         local auraUnit = button._auraUnit or configUnit
-
-        local viewerFrame
-        local cdmEnabled
-        if CooldownCompanion._cooldownUpdatePassActive then
-            cdmEnabled = CooldownCompanion._cdmViewerEnabled == true
-        else
-            cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
-        end
-        local orderedStandaloneAuraIDs
-        local standaloneOriginalAuraIDs
-        local standaloneFallbackAuraIDs
-        if buttonData.addedAs == "aura" then
-            if not button._orderedStandaloneAuraIDs
-                or button._orderedStandaloneAuraIDsRaw ~= buttonData.auraSpellID
-                or button._orderedStandaloneAuraIDsButtonID ~= buttonData.id
-                or button._orderedStandaloneAuraIDsAuraSpellID ~= button._auraSpellID then
-                local originalAuraIDs, fallbackAuraIDs = CooldownCompanion:GetStandaloneAuraCandidateGroups(buttonData)
-                local allAuraIDs = {}
-                for _, spellID in ipairs(originalAuraIDs) do
-                    allAuraIDs[#allAuraIDs + 1] = spellID
-                end
-                for _, spellID in ipairs(fallbackAuraIDs) do
-                    allAuraIDs[#allAuraIDs + 1] = spellID
-                end
-                button._standaloneOriginalAuraIDs = originalAuraIDs
-                button._standaloneFallbackAuraIDs = fallbackAuraIDs
-                button._orderedStandaloneAuraIDs = allAuraIDs
-                button._orderedStandaloneAuraIDsRaw = buttonData.auraSpellID
-                button._orderedStandaloneAuraIDsButtonID = buttonData.id
-                button._orderedStandaloneAuraIDsAuraSpellID = button._auraSpellID
-            end
-            orderedStandaloneAuraIDs = button._orderedStandaloneAuraIDs
-            standaloneOriginalAuraIDs = button._standaloneOriginalAuraIDs
-            standaloneFallbackAuraIDs = button._standaloneFallbackAuraIDs
-        end
 
         -- Viewer-based aura tracking: Blizzard's cooldown viewer frames run
         -- untainted code that matches spell IDs to auras during combat and
         -- stores auraInstanceID + auraDataUnit as plain readable properties.
         -- Requires the Blizzard Cooldown Manager to be visible with this spell.
-        -- CDM child slot: use specific child for multi-entry spells (e.g., Diabolic Ritual)
-        if buttonData.cdmChildSlot then
-            local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
-            if allChildren then
-                viewerFrame = allChildren[buttonData.cdmChildSlot]
-            end
-        end
-        -- Try standalone aura identity first; visible fallback IDs are only
-        -- considered after original candidates fail all active proofs.
-        if not viewerFrame and orderedStandaloneAuraIDs then
-            local originalActiveFrame, firstOriginalFrame = CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame(
-                standaloneOriginalAuraIDs,
-                configUnit,
-                auraUnit,
-                now,
-                barAuraStackConfigured
-            )
-            viewerFrame = originalActiveFrame
-            if not viewerFrame then
-                local fallbackActiveFrame, firstFallbackFrame = CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame(
-                    standaloneFallbackAuraIDs,
-                    configUnit,
-                    auraUnit,
-                    now,
-                    barAuraStackConfigured
-                )
-                viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
-            end
-        elseif not viewerFrame and buttonData.auraSpellID then
-            -- Cache parsed IDs on the button to avoid per-tick gmatch allocation.
-            local ids = button._parsedAuraIDs
-            if not ids or button._parsedAuraIDsRaw ~= buttonData.auraSpellID or button._parsedAuraIDsButtonID ~= buttonData.id then
-                ids = {}
-                button._parsedAuraIDsIncludeButtonID = nil
-                for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                    local numId = tonumber(id)
-                    ids[#ids + 1] = numId
-                    if numId == buttonData.id then
-                        button._parsedAuraIDsIncludeButtonID = true
-                    end
-                end
-                button._parsedAuraIDs = ids
-                button._parsedAuraIDsRaw = buttonData.auraSpellID
-                button._parsedAuraIDsButtonID = buttonData.id
-            end
-            for _, numId in ipairs(ids) do
-                local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
-                if f then
-                    if f.auraInstanceID then
-                        viewerFrame = f
-                        break
-                    elseif not viewerFrame then
-                        viewerFrame = f
-                    end
-                end
-            end
-        end
-        -- Fall back to resolved aura ID, then ability ID, then current override form.
-        -- _displaySpellId tracks the current override (e.g. Solar → Lunar Eclipse)
-        -- and is always present in the viewer map after BuildViewerAuraMap.
-        if not viewerFrame then
-            viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(button._auraSpellID)
-            if not viewerFrame then
-                viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(buttonData.id)
-                    or (button._displaySpellId and CooldownCompanion:ResolveBuffViewerFrameForSpell(button._displaySpellId))
-                -- Try base spell for form-variant spells (e.g. Stampeding Roar)
-                if not viewerFrame then
-                    local baseId = C_Spell.GetBaseSpell(buttonData.id)
-                    if baseId and baseId ~= buttonData.id and baseId ~= button._auraSpellID then
-                        viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(baseId)
-                    end
-                end
-            end
-        end
+        local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = EntryRuntime.ResolveTrackedAuraViewerFrame(
+            button,
+            buttonData,
+            button._auraSpellID,
+            configUnit,
+            auraUnit,
+            now,
+            barAuraStackConfigured
+        )
         auraTrackingReady = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
         if auraTrackingReady and not auraOverrideActive and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
             local viewerInstId = viewerFrame.auraInstanceID
@@ -1362,7 +866,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 button._durationObj = durationObj
                                 button.cooldown:SetCooldownFromDurationObject(durationObj)
                             end
-                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
                         else
                             auraHasTimer = false
                         end
@@ -1431,9 +935,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                         local totemDuration = GetTotemDuration(totemSlot)
                         local totemActive = false
                         if totemDuration then
-                            scratchCooldown:SetCooldownFromDurationObject(totemDuration)
-                            totemActive = scratchCooldown:IsShown()
-                            scratchCooldown:SetCooldown(0, 0)
+                            totemActive = EntryRuntime.DurationObjectShowsCooldown(totemDuration)
                         end
                         if totemActive then
                             button._auraDurationObj = totemDuration
@@ -1542,7 +1044,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 button._durationObj = durationObj
                                 button.cooldown:SetCooldownFromDurationObject(durationObj)
                             end
-                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
                         else
                             auraHasTimer = false
                         end
@@ -1581,7 +1083,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                                 button._durationObj = durationObj
                                 button.cooldown:SetCooldownFromDurationObject(durationObj)
                             end
-                            auraHasTimer = DurationObjectShowsCooldown(durationObj)
+                            auraHasTimer = EntryRuntime.DurationObjectShowsCooldown(durationObj)
                         else
                             auraHasTimer = false
                         end
@@ -1863,65 +1365,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button.cooldown:SetCooldown(0, 0)
         button.cooldown:Hide()
 
-        local stackValue = 0
-        local stackValueAvailable = true
-        local stackValueFromSecretText
-        local previousValueIsSecret = previousBarAuraStackValueSecret
-            or (previousBarAuraStackValueAvailable and issecretvalue(previousBarAuraStackValue))
-        if auraOverrideActive then
-            stackValue = auraApplications
-            local stackValueIsSecret = issecretvalue(stackValue)
-            if not stackValueIsSecret and stackValue == nil and button._auraStackText ~= nil then
-                if issecretvalue(button._auraStackText) then
-                    stackValue = button._auraStackText
-                    stackValueIsSecret = true
-                    stackValueFromSecretText = true
-                else
-                    stackValue = tonumber(button._auraStackText)
-                    stackValueIsSecret = false
-                end
-            end
-            if not stackValueIsSecret and stackValue == nil then
-                if auraGraceHeld and previousBarAuraStackValueAvailable and not previousValueIsSecret then
-                    stackValue = previousBarAuraStackValue
-                    stackValueIsSecret = previousValueIsSecret
-                elseif auraGraceHeld and previousValueIsSecret then
-                    stackValueAvailable = false
-                    preserveBarAuraStackText = true
-                else
-                    stackValue = 1
-                end
-            end
-            if stackValueAvailable and not stackValueIsSecret and stackValue < 1 then
-                stackValue = 1
-            end
-        end
-        local stackValueIsSecret = stackValueAvailable and issecretvalue(stackValue)
-        local stackValueChanged = previousBarAuraStackValueAvailable ~= stackValueAvailable
-        if not stackValueChanged and stackValueAvailable and not stackValueIsSecret and not previousValueIsSecret then
-            stackValueChanged = previousBarAuraStackValue ~= stackValue
-        end
-        if auraGraceHeld and previousValueIsSecret and not stackValueAvailable then
-            button._barAuraStackValue = nil
-            button._barAuraStackValueAvailable = nil
-            button._barAuraStackValueSecret = true
-            button._barAuraStackValueDirty = nil
-        elseif stackValueIsSecret then
-            if not stackValueFromSecretText then
-                barAuraSecretStackValue = stackValue
-            end
-            button._barAuraStackValue = nil
-            button._barAuraStackValueAvailable = nil
-            button._barAuraStackValueSecret = true
-            button._barAuraStackValueDirty = nil
-            if not stackValueFromSecretText and CooldownCompanion.ApplyBarPanelAuraStackVisual then
-                CooldownCompanion.ApplyBarPanelAuraStackVisual(button, stackValue, true)
-            end
-        else
-            button._barAuraStackValue = stackValue
-            button._barAuraStackValueAvailable = stackValueAvailable or nil
-            button._barAuraStackValueDirty = previousValueIsSecret or stackValueChanged
-        end
+        barAuraSecretStackValue, preserveBarAuraStackText = EntryRuntime.ApplyBarAuraStackState(
+            button,
+            auraOverrideActive,
+            auraApplications,
+            auraGraceHeld,
+            previousBarAuraStackValue,
+            previousBarAuraStackValueAvailable,
+            previousBarAuraStackValueSecret
+        )
     end
 
     if buttonData.isPassive and not auraOverrideActive then
@@ -1933,9 +1385,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         auraProbeInfo = C_Spell.GetSpellCooldown(cooldownSpellId)
         if auraProbeInfo and auraProbeInfo.isActive then
             local auraProbeNormalDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId)
-            auraProbeNormalCooldownShown = DurationObjectShowsCooldown(auraProbeNormalDuration)
+            auraProbeNormalCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeNormalDuration)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
-            auraProbeRealCooldownShown = DurationObjectShowsCooldown(auraProbeDuration)
+            auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
         auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, {
             normalCooldownShown = auraProbeNormalCooldownShown,
@@ -1982,7 +1434,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOwnsPrimarySwipe and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            spellCooldownResult = EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
+            spellCooldownResult = EntryRuntime.EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj
@@ -2034,7 +1486,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if usesChargeBehavior and buttonData.hasCharges and buttonData.type == "spell" then
         button._displayCountZeroUsabilityFallback = nil
         charges = UpdateChargeTracking(button, buttonData, cooldownSpellId)
-        button._chargeCooldownVisualActive = DurationObjectShowsCooldown(button._chargeDurationObj)
+        button._chargeCooldownVisualActive = EntryRuntime.DurationObjectShowsCooldown(button._chargeDurationObj)
         button._chargeRecharging = button._chargeCooldownVisualActive
     elseif usesChargeBehavior
         and (buttonData._hasDisplayCount or buttonData._displayCountFamily)
@@ -2188,7 +1640,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
             local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
-                or ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+                or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
             if slotProbe.shown ~= nil then
                 button._mainCDShown = slotProbe.realShown == true
             elseif not auraOwnsPrimarySwipe then
@@ -2287,7 +1739,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- Only an active charge DurationObject may replace an existing GCD display.
             local chargeSpellID = cooldownSpellId or buttonData.id
             local fallbackDuration = C_Spell.GetSpellChargeDuration(chargeSpellID)
-            local fallbackActive = DurationObjectShowsCooldown(fallbackDuration)
+            local fallbackActive = EntryRuntime.DurationObjectShowsCooldown(fallbackDuration)
             button._chargeCooldownVisualActive = fallbackActive or nil
             if fallbackActive then
                 button._chargeRecharging = true

--- a/ButtonFrame/EntryRuntime.lua
+++ b/ButtonFrame/EntryRuntime.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local HasTooltipCooldown = ST.HasTooltipCooldown
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -45,7 +46,7 @@ local function GetConfiguredAuraUnit(buttonData)
 end
 EntryRuntime.GetConfiguredAuraUnit = GetConfiguredAuraUnit
 
-local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, allowDurationlessAuraInstance)
     local unit = viewerFrame.auraDataUnit or auraUnit
     if not (viewerFrame.auraInstanceID and unit == configUnit) then
         return false
@@ -56,7 +57,7 @@ local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUni
         return false
     end
 
-    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
+    return allowDurationlessAuraInstance or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
 end
 
 local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
@@ -87,18 +88,18 @@ local function ViewerFrameHasActiveTotemDuration(viewerFrame)
     return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
 end
 
-local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
-    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, allowDurationlessAuraInstance)
+    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, allowDurationlessAuraInstance)
         or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
         or ViewerFrameHasActiveTotemDuration(viewerFrame)
 end
 
-local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
+local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local firstTrackedFrame
     for _, spellID in ipairs(candidateIDs or {}) do
         local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
         if viewerFrame then
-            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
+            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, allowDurationlessAuraInstance) then
                 return viewerFrame, firstTrackedFrame
             end
             firstTrackedFrame = firstTrackedFrame or viewerFrame
@@ -106,10 +107,11 @@ local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUni
     end
     return nil, firstTrackedFrame
 end
-EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
-CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+EntryRuntime.ResolvePreferredAuraViewerFrame = ResolvePreferredAuraViewerFrame
+EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
+CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
 
-local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, barAuraStackConfigured)
+local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local viewerFrame
     local cdmEnabled
     if CooldownCompanion._cooldownUpdatePassActive then
@@ -154,21 +156,21 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
     end
 
     if not viewerFrame and orderedStandaloneAuraIDs then
-        local originalActiveFrame, firstOriginalFrame = ResolvePreferredStandaloneAuraViewerFrame(
+        local originalActiveFrame, firstOriginalFrame = ResolvePreferredAuraViewerFrame(
             standaloneOriginalAuraIDs,
             configUnit,
             auraUnit,
             now,
-            barAuraStackConfigured
+            allowDurationlessAuraInstance
         )
         viewerFrame = originalActiveFrame
         if not viewerFrame then
-            local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredStandaloneAuraViewerFrame(
+            local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredAuraViewerFrame(
                 standaloneFallbackAuraIDs,
                 configUnit,
                 auraUnit,
                 now,
-                barAuraStackConfigured
+                allowDurationlessAuraInstance
             )
             viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
         end
@@ -188,17 +190,14 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
             owner._parsedAuraIDsRaw = buttonData.auraSpellID
             owner._parsedAuraIDsButtonID = buttonData.id
         end
-        for _, numId in ipairs(ids) do
-            local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
-            if f then
-                if f.auraInstanceID then
-                    viewerFrame = f
-                    break
-                elseif not viewerFrame then
-                    viewerFrame = f
-                end
-            end
-        end
+        local activeFrame, firstTrackedFrame = ResolvePreferredAuraViewerFrame(
+            ids,
+            configUnit,
+            auraUnit,
+            now,
+            allowDurationlessAuraInstance
+        )
+        viewerFrame = activeFrame or firstTrackedFrame
     end
 
     if not viewerFrame then
@@ -456,6 +455,175 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
+local function ResolveSpellCooldownSecrecy(owner, spellID)
+    if not (spellID and C_Secrets and C_Secrets.GetSpellCooldownSecrecy) then
+        return owner and owner._cooldownSecrecy or nil
+    end
+
+    if owner then
+        if owner._cooldownSecrecy == nil or owner._cooldownSecrecySpellID ~= spellID then
+            owner._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(spellID)
+            owner._cooldownSecrecySpellID = spellID
+        end
+        return owner._cooldownSecrecy
+    end
+
+    return C_Secrets.GetSpellCooldownSecrecy(spellID)
+end
+
+local function IsNoCooldownSpell(spellID)
+    local baseCd = GetSpellBaseCooldown(spellID)
+    return (not baseCd or baseCd == 0)
+        and not (HasTooltipCooldown and HasTooltipCooldown(spellID))
+end
+
+local function ResolveNoCooldownState(owner, spellID, hasCharges)
+    if hasCharges then
+        if owner then
+            owner._noCooldown = false
+            owner._noCooldownSpellId = nil
+        end
+        return false
+    end
+
+    if not spellID then
+        return false
+    end
+
+    if owner and owner._noCooldown ~= nil and owner._noCooldownSpellId == spellID then
+        return owner._noCooldown == true
+    end
+
+    local noCooldown = IsNoCooldownSpell(spellID)
+    if owner then
+        owner._noCooldownSpellId = spellID
+        owner._noCooldown = noCooldown
+    end
+    return noCooldown
+end
+
+local function ClearOwnerChargeState(owner)
+    if not owner then return end
+    owner._customCooldownHasCharges = nil
+    owner._currentReadableCharges = nil
+    owner._chargeCountReadable = nil
+    owner._zeroChargesConfirmed = nil
+    owner._chargeDurationObj = nil
+    owner._chargeRecharging = nil
+    owner._mainCDShown = nil
+    owner._chargeState = nil
+    owner._chargesSpent = nil
+end
+
+local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
+    if not customBar then return end
+
+    if maxCharges and maxCharges > 1 then
+        if customBar.hasCharges ~= true then
+            customBar.hasCharges = true
+        end
+        if customBar.maxCharges ~= maxCharges then
+            customBar.maxCharges = maxCharges
+        end
+    elseif charges then
+        if customBar.hasCharges ~= nil then
+            customBar.hasCharges = nil
+        end
+        if customBar.maxCharges ~= maxCharges then
+            customBar.maxCharges = maxCharges
+        end
+    else
+        if customBar.hasCharges ~= nil then
+            customBar.hasCharges = nil
+        end
+        if customBar.maxCharges ~= nil then
+            customBar.maxCharges = nil
+        end
+    end
+end
+
+local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpellID, charges, maxCharges)
+    result.hasCharges = true
+    result.maxCharges = maxCharges
+    result.charges = charges
+
+    local currentCharges
+    if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
+        currentCharges = charges.currentCharges
+        result.currentCharges = currentCharges
+    elseif C_Spell.GetSpellDisplayCount then
+        result.chargeDisplayCount = C_Spell.GetSpellDisplayCount(cooldownSpellID)
+    end
+
+    local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+    local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+    result.chargeDurationObj = chargeDurationObj
+    result.chargeRecharging = chargeRecharging or false
+
+    if owner then
+        owner._customCooldownHasCharges = true
+        owner._currentReadableCharges = currentCharges
+        owner._chargeCountReadable = currentCharges ~= nil
+        owner._chargeDurationObj = chargeDurationObj
+        owner._chargeRecharging = result.chargeRecharging
+    end
+
+    local mainCDShown = false
+    if currentCharges ~= nil then
+        mainCDShown = currentCharges <= 0
+    else
+        local slotProbe = result.slotProbe or ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
+        result.chargeSlotProbe = slotProbe
+        if slotProbe.shown ~= nil then
+            mainCDShown = slotProbe.realShown == true
+        elseif result.fetchOk then
+            mainCDShown = result.state == COOLDOWN_STATE_COOLDOWN
+        end
+    end
+
+    if owner then
+        owner._mainCDShown = mainCDShown
+        if result.chargeRecharging and not owner._chargesSpent then
+            owner._chargesSpent = maxCharges or 0
+        end
+    end
+
+    local zeroConfirmed = mainCDShown == true
+    if zeroConfirmed and currentCharges == nil and owner then
+        local spent = owner._chargesSpent
+        if maxCharges and maxCharges > 1 and spent and spent < maxCharges then
+            zeroConfirmed = false
+        end
+    end
+
+    if currentCharges ~= nil then
+        if currentCharges <= 0 then
+            result.chargeState = CHARGE_STATE_ZERO
+        elseif currentCharges >= maxCharges then
+            result.chargeState = CHARGE_STATE_FULL
+        else
+            result.chargeState = CHARGE_STATE_MISSING
+        end
+    elseif zeroConfirmed then
+        result.chargeState = CHARGE_STATE_ZERO
+    elseif result.chargeRecharging then
+        result.chargeState = CHARGE_STATE_MISSING
+    elseif result.chargeRecharging == false then
+        result.chargeState = CHARGE_STATE_FULL
+    end
+
+    if owner then
+        owner._zeroChargesConfirmed = zeroConfirmed
+        owner._chargeState = result.chargeState
+    end
+
+    if result.chargeRecharging then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "spell-charge-recharge"
+        result.renderDurationObj = chargeDurationObj
+    end
+end
+
 function EntryRuntime.ApplyBarAuraStackState(
     button,
     auraOverrideActive,
@@ -533,72 +701,46 @@ function EntryRuntime.ApplyBarAuraStackState(
     return barAuraSecretStackValue, preserveBarAuraStackText
 end
 
-function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local spellID = tonumber(customBar and customBar.spellID)
-    local result
     if not spellID then
         return EvaluateSpellCooldownLane(nil, 0, nil)
     end
+    owner = owner or customBar
 
     local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
     if not cooldownSpellID or cooldownSpellID == 0 then
         cooldownSpellID = spellID
     end
 
-    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
-        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
-        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
-        customBar._cooldownSecrecySpellID = cooldownSpellID
+    if owner then
+        owner._customCooldownBaseSpellID = spellID
+        owner._customCooldownSpellID = cooldownSpellID
     end
 
     local charges = C_Spell.GetSpellCharges(cooldownSpellID)
     local maxCharges = charges and tonumber(charges.maxCharges)
-    if maxCharges and maxCharges > 1 then
-        customBar.hasCharges = true
-        customBar.maxCharges = maxCharges
-    elseif charges then
-        customBar.hasCharges = nil
-        customBar.maxCharges = maxCharges
-    elseif not charges then
-        customBar.hasCharges = nil
-    end
+    SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
+    local hasCharges = (maxCharges or 0) > 1
+    local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
+    local noCooldown = ResolveNoCooldownState(owner, cooldownSpellID, hasCharges)
 
-    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
-        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
+    local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
+        allowActionSlotRealFallback = not hasCharges and cooldownSpellID == spellID and noCooldown ~= true,
     })
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
+    result.noCooldown = noCooldown or nil
 
-    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
-        result.hasCharges = true
-        result.maxCharges = maxCharges
-        result.charges = charges
-
-        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
-            result.currentCharges = charges.currentCharges
-            if result.currentCharges <= 0 then
-                result.chargeState = CHARGE_STATE_ZERO
-            elseif result.currentCharges >= maxCharges then
-                result.chargeState = CHARGE_STATE_FULL
-            else
-                result.chargeState = CHARGE_STATE_MISSING
-            end
-        end
-
-        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
-        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
-        result.chargeDurationObj = chargeDurationObj
-        result.chargeRecharging = chargeRecharging or false
-        if chargeRecharging then
-            result.state = COOLDOWN_STATE_COOLDOWN
-            result.source = "spell-charge-recharge"
-            result.renderDurationObj = chargeDurationObj
-        end
+    if hasCharges then
+        ApplyCustomBarChargeState(owner, result, spellID, cooldownSpellID, charges, maxCharges)
+    else
+        ClearOwnerChargeState(owner)
     end
 
     return result
 end
 
-function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
-    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar, owner)
+    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
 end

--- a/ButtonFrame/EntryRuntime.lua
+++ b/ButtonFrame/EntryRuntime.lua
@@ -1,0 +1,604 @@
+--[[
+    CooldownCompanion - ButtonFrame/EntryRuntime
+    Shared cooldown/aura runtime helpers for bar-panel entries.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic
+
+local ipairs = ipairs
+local tonumber = tonumber
+local tostring = tostring
+local wipe = wipe
+local issecretvalue = issecretvalue
+
+local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
+local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+
+local EntryRuntime = ST.EntryRuntime or {}
+ST.EntryRuntime = EntryRuntime
+
+-- Hidden scratch CooldownFrame for probing DurationObject activity.
+-- DurationObject:IsZero() returns a secret boolean in tainted contexts;
+-- feeding the object to a Cooldown widget and checking IsShown() yields a
+-- plain boolean safe for Lua logic.
+local scratchParent = CreateFrame("Frame")
+scratchParent:Hide()
+local scratchCooldown = CreateFrame("Cooldown", nil, scratchParent, "CooldownFrameTemplate")
+
+local function DurationObjectShowsCooldown(durationObj)
+    if not durationObj then return false end
+    scratchCooldown:SetCooldownFromDurationObject(durationObj)
+    local shown = scratchCooldown:IsShown()
+    scratchCooldown:SetCooldown(0, 0)
+    return shown
+end
+EntryRuntime.DurationObjectShowsCooldown = DurationObjectShowsCooldown
+
+local function GetConfiguredAuraUnit(buttonData)
+    return buttonData.auraUnit or "player"
+end
+EntryRuntime.GetConfiguredAuraUnit = GetConfiguredAuraUnit
+
+local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+    local unit = viewerFrame.auraDataUnit or auraUnit
+    if not (viewerFrame.auraInstanceID and unit == configUnit) then
+        return false
+    end
+
+    local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerFrame.auraInstanceID)
+    if not auraData then
+        return false
+    end
+
+    return barAuraStackConfigured or C_UnitAuras.GetAuraDuration(unit, viewerFrame.auraInstanceID) ~= nil
+end
+
+local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+    local viewerCooldown = viewerFrame.Cooldown
+    if not (viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown()) then
+        return false
+    end
+
+    local vUnit = viewerFrame.auraDataUnit or auraUnit
+    if vUnit ~= configUnit then
+        return false
+    end
+
+    local startMs, durMs = viewerCooldown:GetCooldownTimes()
+    if issecretvalue(durMs) then
+        return true
+    end
+
+    return durMs > 0 and (startMs + durMs) > now * 1000
+end
+
+local function ViewerFrameHasActiveTotemDuration(viewerFrame)
+    local totemSlot = viewerFrame.preferredTotemUpdateSlot
+    if not (totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData) then
+        return false
+    end
+
+    return DurationObjectShowsCooldown(GetTotemDuration(totemSlot))
+end
+
+local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured)
+    return ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, barAuraStackConfigured)
+        or ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraUnit, now)
+        or ViewerFrameHasActiveTotemDuration(viewerFrame)
+end
+
+local function ResolvePreferredStandaloneAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, barAuraStackConfigured)
+    local firstTrackedFrame
+    for _, spellID in ipairs(candidateIDs or {}) do
+        local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
+        if viewerFrame then
+            if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, barAuraStackConfigured) then
+                return viewerFrame, firstTrackedFrame
+            end
+            firstTrackedFrame = firstTrackedFrame or viewerFrame
+        end
+    end
+    return nil, firstTrackedFrame
+end
+EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredStandaloneAuraViewerFrame
+
+local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, barAuraStackConfigured)
+    local viewerFrame
+    local cdmEnabled
+    if CooldownCompanion._cooldownUpdatePassActive then
+        cdmEnabled = CooldownCompanion._cdmViewerEnabled == true
+    else
+        cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
+    end
+
+    local orderedStandaloneAuraIDs
+    local standaloneOriginalAuraIDs
+    local standaloneFallbackAuraIDs
+    if buttonData.addedAs == "aura" then
+        if not owner._orderedStandaloneAuraIDs
+            or owner._orderedStandaloneAuraIDsRaw ~= buttonData.auraSpellID
+            or owner._orderedStandaloneAuraIDsButtonID ~= buttonData.id
+            or owner._orderedStandaloneAuraIDsAuraSpellID ~= auraSpellID then
+            local originalAuraIDs, fallbackAuraIDs = CooldownCompanion:GetStandaloneAuraCandidateGroups(buttonData)
+            local allAuraIDs = {}
+            for _, spellID in ipairs(originalAuraIDs) do
+                allAuraIDs[#allAuraIDs + 1] = spellID
+            end
+            for _, spellID in ipairs(fallbackAuraIDs) do
+                allAuraIDs[#allAuraIDs + 1] = spellID
+            end
+            owner._standaloneOriginalAuraIDs = originalAuraIDs
+            owner._standaloneFallbackAuraIDs = fallbackAuraIDs
+            owner._orderedStandaloneAuraIDs = allAuraIDs
+            owner._orderedStandaloneAuraIDsRaw = buttonData.auraSpellID
+            owner._orderedStandaloneAuraIDsButtonID = buttonData.id
+            owner._orderedStandaloneAuraIDsAuraSpellID = auraSpellID
+        end
+        orderedStandaloneAuraIDs = owner._orderedStandaloneAuraIDs
+        standaloneOriginalAuraIDs = owner._standaloneOriginalAuraIDs
+        standaloneFallbackAuraIDs = owner._standaloneFallbackAuraIDs
+    end
+
+    if buttonData.cdmChildSlot then
+        local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
+        if allChildren then
+            viewerFrame = allChildren[buttonData.cdmChildSlot]
+        end
+    end
+
+    if not viewerFrame and orderedStandaloneAuraIDs then
+        local originalActiveFrame, firstOriginalFrame = ResolvePreferredStandaloneAuraViewerFrame(
+            standaloneOriginalAuraIDs,
+            configUnit,
+            auraUnit,
+            now,
+            barAuraStackConfigured
+        )
+        viewerFrame = originalActiveFrame
+        if not viewerFrame then
+            local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredStandaloneAuraViewerFrame(
+                standaloneFallbackAuraIDs,
+                configUnit,
+                auraUnit,
+                now,
+                barAuraStackConfigured
+            )
+            viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
+        end
+    elseif not viewerFrame and buttonData.auraSpellID then
+        local ids = owner._parsedAuraIDs
+        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
+            ids = {}
+            owner._parsedAuraIDsIncludeButtonID = nil
+            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+                local numId = tonumber(id)
+                ids[#ids + 1] = numId
+                if numId == buttonData.id then
+                    owner._parsedAuraIDsIncludeButtonID = true
+                end
+            end
+            owner._parsedAuraIDs = ids
+            owner._parsedAuraIDsRaw = buttonData.auraSpellID
+            owner._parsedAuraIDsButtonID = buttonData.id
+        end
+        for _, numId in ipairs(ids) do
+            local f = CooldownCompanion:ResolveBuffViewerFrameForSpell(numId)
+            if f then
+                if f.auraInstanceID then
+                    viewerFrame = f
+                    break
+                elseif not viewerFrame then
+                    viewerFrame = f
+                end
+            end
+        end
+    end
+
+    if not viewerFrame then
+        viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraSpellID)
+        if not viewerFrame then
+            viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(buttonData.id)
+                or (owner._displaySpellId and CooldownCompanion:ResolveBuffViewerFrameForSpell(owner._displaySpellId))
+            if not viewerFrame then
+                local baseId = C_Spell.GetBaseSpell(buttonData.id)
+                if baseId and baseId ~= buttonData.id and baseId ~= auraSpellID then
+                    viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(baseId)
+                end
+            end
+        end
+    end
+
+    return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
+end
+EntryRuntime.ResolveTrackedAuraViewerFrame = ResolveTrackedAuraViewerFrame
+
+local function IsSpellCooldownDeferred(info)
+    if not info or info.isEnabled ~= false or info.isActive == true then
+        return false
+    end
+
+    if info.isOnGCD == true then
+        return false
+    end
+
+    local recoveryTime = info.timeUntilEndOfStartRecovery
+    if recoveryTime == nil then
+        return true
+    end
+
+    if issecretvalue(recoveryTime) then
+        -- Secret recovery values are unreadable in restricted states; when they
+        -- coincide with the GCD the earlier guard already classifies them as
+        -- recovery-only. Outside that case, keep the existing deferred-cooldown
+        -- behavior until a concrete counterexample is observed in game.
+        return true
+    end
+
+    return recoveryTime <= 0
+end
+
+local actionSlotSeenScratch = {}
+
+local function MergeActionSlotProbe(result, probe)
+    if probe.sawAnySlot then result.sawAnySlot = true end
+    if probe.sawUnknown then result.sawUnknown = true end
+    if probe.slot and not result.slot then result.slot = probe.slot end
+    if probe.matchedSpellID and not result.matchedSpellID then result.matchedSpellID = probe.matchedSpellID end
+    if probe.shown ~= nil then result.shown = probe.shown end
+    if probe.realShown ~= nil then result.realShown = probe.realShown end
+    if probe.durationObj then result.durationObj = result.durationObj or probe.durationObj end
+    if probe.realDurationObj then result.realDurationObj = result.realDurationObj or probe.realDurationObj end
+    if probe.shown or probe.realShown then
+        result.shown = probe.shown == true
+        result.durationObj = probe.durationObj or result.durationObj
+        result.realShown = probe.realShown == true
+        result.realDurationObj = probe.realDurationObj or result.realDurationObj
+        result.slot = probe.slot or result.slot
+        result.matchedSpellID = probe.matchedSpellID or result.matchedSpellID
+        return true
+    end
+    return false
+end
+
+local function ProbeActionSlotsForSpellID(spellID)
+    local result = {
+        shown = nil,
+        realShown = nil,
+        sawAnySlot = false,
+        sawUnknown = false,
+    }
+
+    if not spellID then return result end
+
+    local slots = C_ActionBar.FindSpellActionButtons(spellID)
+    if not slots then return result end
+
+    for _, slot in ipairs(slots) do
+        if not actionSlotSeenScratch[slot] then
+            actionSlotSeenScratch[slot] = true
+            result.sawAnySlot = true
+            result.slot = result.slot or slot
+            result.matchedSpellID = result.matchedSpellID or spellID
+
+            local durationObj = C_ActionBar.GetActionCooldownDuration(slot)
+            local realDurationObj = C_ActionBar.GetActionCooldownDuration(slot, true)
+            local shown = false
+            local realShown
+
+            if durationObj then
+                shown = DurationObjectShowsCooldown(durationObj)
+            end
+
+            if realDurationObj then
+                realShown = DurationObjectShowsCooldown(realDurationObj)
+            end
+
+            if shown or realShown then
+                result.shown = shown == true
+                result.durationObj = durationObj
+                result.realShown = realShown == true
+                result.realDurationObj = realDurationObj
+                result.slot = slot
+                result.matchedSpellID = spellID
+                return result
+            end
+        end
+    end
+
+    if result.sawAnySlot then
+        result.shown = false
+    end
+
+    return result
+end
+
+local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
+    local result = {
+        shown = nil,
+        realShown = nil,
+        sawAnySlot = false,
+        sawUnknown = false,
+    }
+
+    if not baseSpellID then return result end
+
+    wipe(actionSlotSeenScratch)
+
+    if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(baseSpellID)) then
+        return result
+    end
+
+    if displaySpellID and displaySpellID ~= baseSpellID then
+        if MergeActionSlotProbe(result, ProbeActionSlotsForSpellID(displaySpellID)) then
+            return result
+        end
+    end
+
+    if result.sawAnySlot and not result.sawUnknown then
+        result.shown = false
+        result.realShown = false
+    end
+
+    return result
+end
+EntryRuntime.ProbeActionSlotCooldownForSpell = ProbeActionSlotCooldownForSpell
+
+local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
+    local result = {
+        spellID = spellID,
+        fetchOk = false,
+        state = COOLDOWN_STATE_READY,
+        source = "ready",
+        realCooldownShown = false,
+        isOnGCD = false,
+        deferred = false,
+    }
+
+    if not spellID then
+        return result
+    end
+
+    options = options or {}
+
+    local info = C_Spell.GetSpellCooldown(spellID)
+    result.info = info
+    if not info then
+        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
+            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
+            if slotProbe.shown ~= nil then
+                result.fetchOk = true
+                result.normalCooldownShown = slotProbe.shown == true
+                result.realCooldownShown = slotProbe.realShown == true
+                result.durationObj = slotProbe.durationObj
+                result.realDurationObj = slotProbe.realDurationObj
+                result.slotProbe = slotProbe
+                if result.realCooldownShown and slotProbe.realDurationObj then
+                    result.state = COOLDOWN_STATE_COOLDOWN
+                    result.source = "action-slot-real-no-spell-info"
+                    result.renderDurationObj = slotProbe.realDurationObj
+                    result.isOnGCD = CooldownCompanion._gcdActive == true
+                elseif slotProbe.shown and slotProbe.durationObj then
+                    result.source = "action-slot-gcd-no-spell-info"
+                    result.presentationState = COOLDOWN_STATE_GCD
+                    result.renderDurationObj = slotProbe.durationObj
+                    result.isOnGCD = true
+                end
+            end
+        end
+        return result
+    end
+
+    result.fetchOk = true
+    result.isOnGCD = info.isOnGCD or false
+    result.deferred = IsSpellCooldownDeferred(info)
+
+    if info.isActive then
+        result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+        result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
+        result.normalCooldownShown = DurationObjectShowsCooldown(result.durationObj)
+        result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
+    end
+
+    if result.deferred then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "spell-deferred"
+    elseif result.realCooldownShown and result.realDurationObj then
+        result.state = COOLDOWN_STATE_COOLDOWN
+        result.source = "spell-real-ignore-gcd"
+        result.renderDurationObj = result.realDurationObj
+    elseif CooldownLogic.IsSpellGCDOnly(info, {
+        normalCooldownShown = result.normalCooldownShown,
+        realCooldownShown = result.realCooldownShown,
+    }) then
+        result.source = "spell-gcd"
+        result.presentationState = COOLDOWN_STATE_GCD
+        result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
+    end
+
+    local needsRealCooldownFallback = result.state ~= COOLDOWN_STATE_COOLDOWN
+        and (result.isOnGCD == true or result.normalCooldownShown == true)
+
+    if needsRealCooldownFallback
+        and options.allowActionSlotRealFallback
+        and ProbeActionSlotCooldownForSpell then
+        local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
+        if slotProbe.realShown == true and slotProbe.realDurationObj then
+            result.slotProbe = slotProbe
+            result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
+            result.realCooldownShown = true
+            result.durationObj = slotProbe.durationObj or result.durationObj
+            result.realDurationObj = slotProbe.realDurationObj
+            result.state = COOLDOWN_STATE_COOLDOWN
+            result.source = "action-slot-real-fallback"
+            result.renderDurationObj = slotProbe.realDurationObj
+        end
+    end
+
+    return result
+end
+EntryRuntime.EvaluateSpellCooldownLane = EvaluateSpellCooldownLane
+
+local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
+    local allowActionSlotRealFallback = buttonData.hasCharges ~= true
+        and cooldownSpellId == buttonData.id
+        and noCooldown ~= true
+
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
+        allowActionSlotRealFallback = allowActionSlotRealFallback,
+    })
+end
+EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
+
+function EntryRuntime.ApplyBarAuraStackState(
+    button,
+    auraOverrideActive,
+    auraApplications,
+    auraGraceHeld,
+    previousBarAuraStackValue,
+    previousBarAuraStackValueAvailable,
+    previousBarAuraStackValueSecret
+)
+    local barAuraSecretStackValue
+    local preserveBarAuraStackText
+    local stackValue = 0
+    local stackValueAvailable = true
+    local stackValueFromSecretText
+    local previousValueIsSecret = previousBarAuraStackValueSecret
+        or (previousBarAuraStackValueAvailable and issecretvalue(previousBarAuraStackValue))
+
+    if auraOverrideActive then
+        stackValue = auraApplications
+        local stackValueIsSecret = issecretvalue(stackValue)
+        if not stackValueIsSecret and stackValue == nil and button._auraStackText ~= nil then
+            if issecretvalue(button._auraStackText) then
+                stackValue = button._auraStackText
+                stackValueIsSecret = true
+                stackValueFromSecretText = true
+            else
+                stackValue = tonumber(button._auraStackText)
+                stackValueIsSecret = false
+            end
+        end
+        if not stackValueIsSecret and stackValue == nil then
+            if auraGraceHeld and previousBarAuraStackValueAvailable and not previousValueIsSecret then
+                stackValue = previousBarAuraStackValue
+                stackValueIsSecret = previousValueIsSecret
+            elseif auraGraceHeld and previousValueIsSecret then
+                stackValueAvailable = false
+                preserveBarAuraStackText = true
+            else
+                stackValue = 1
+            end
+        end
+        if stackValueAvailable and not stackValueIsSecret and stackValue < 1 then
+            stackValue = 1
+        end
+    end
+
+    local stackValueIsSecret = stackValueAvailable and issecretvalue(stackValue)
+    local stackValueChanged = previousBarAuraStackValueAvailable ~= stackValueAvailable
+    if not stackValueChanged and stackValueAvailable and not stackValueIsSecret and not previousValueIsSecret then
+        stackValueChanged = previousBarAuraStackValue ~= stackValue
+    end
+
+    if auraGraceHeld and previousValueIsSecret and not stackValueAvailable then
+        button._barAuraStackValue = nil
+        button._barAuraStackValueAvailable = nil
+        button._barAuraStackValueSecret = true
+        button._barAuraStackValueDirty = nil
+    elseif stackValueIsSecret then
+        if not stackValueFromSecretText then
+            barAuraSecretStackValue = stackValue
+        end
+        button._barAuraStackValue = nil
+        button._barAuraStackValueAvailable = nil
+        button._barAuraStackValueSecret = true
+        button._barAuraStackValueDirty = nil
+        if not stackValueFromSecretText and CooldownCompanion.ApplyBarPanelAuraStackVisual then
+            CooldownCompanion.ApplyBarPanelAuraStackVisual(button, stackValue, true)
+        end
+    else
+        button._barAuraStackValue = stackValue
+        button._barAuraStackValueAvailable = stackValueAvailable or nil
+        button._barAuraStackValueDirty = previousValueIsSecret or stackValueChanged
+    end
+
+    return barAuraSecretStackValue, preserveBarAuraStackText
+end
+
+function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+    local spellID = tonumber(customBar and customBar.spellID)
+    local result
+    if not spellID then
+        return EvaluateSpellCooldownLane(nil, 0, nil)
+    end
+
+    local cooldownSpellID = C_Spell.GetOverrideSpell(spellID)
+    if not cooldownSpellID or cooldownSpellID == 0 then
+        cooldownSpellID = spellID
+    end
+
+    if C_Secrets and C_Secrets.GetSpellCooldownSecrecy
+        and (customBar._cooldownSecrecy == nil or customBar._cooldownSecrecySpellID ~= cooldownSpellID) then
+        customBar._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(cooldownSpellID)
+        customBar._cooldownSecrecySpellID = cooldownSpellID
+    end
+
+    local charges = C_Spell.GetSpellCharges(cooldownSpellID)
+    local maxCharges = charges and tonumber(charges.maxCharges)
+    if maxCharges and maxCharges > 1 then
+        customBar.hasCharges = true
+        customBar.maxCharges = maxCharges
+    elseif charges then
+        customBar.hasCharges = nil
+        customBar.maxCharges = maxCharges
+    elseif not charges then
+        customBar.hasCharges = nil
+    end
+
+    result = EvaluateSpellCooldownLane(cooldownSpellID, customBar._cooldownSecrecy, spellID, {
+        allowActionSlotRealFallback = customBar.hasCharges ~= true and cooldownSpellID == spellID,
+    })
+    result.baseSpellID = spellID
+    result.cooldownSpellID = cooldownSpellID
+
+    if customBar.hasCharges == true and maxCharges and maxCharges > 1 then
+        result.hasCharges = true
+        result.maxCharges = maxCharges
+        result.charges = charges
+
+        if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
+            result.currentCharges = charges.currentCharges
+            if result.currentCharges <= 0 then
+                result.chargeState = CHARGE_STATE_ZERO
+            elseif result.currentCharges >= maxCharges then
+                result.chargeState = CHARGE_STATE_FULL
+            else
+                result.chargeState = CHARGE_STATE_MISSING
+            end
+        end
+
+        local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+        local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+        result.chargeDurationObj = chargeDurationObj
+        result.chargeRecharging = chargeRecharging or false
+        if chargeRecharging then
+            result.state = COOLDOWN_STATE_COOLDOWN
+            result.source = "spell-charge-recharge"
+            result.renderDurationObj = chargeDurationObj
+        end
+    end
+
+    return result
+end
+
+function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar)
+    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar)
+end

--- a/ButtonFrame/EntryRuntime.lua
+++ b/ButtonFrame/EntryRuntime.lua
@@ -13,6 +13,7 @@ local tonumber = tonumber
 local tostring = tostring
 local wipe = wipe
 local issecretvalue = issecretvalue
+local GetTime = GetTime
 
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
@@ -20,6 +21,7 @@ local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
+local TARGET_SWITCH_SAFETY_CAP = 0.60
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -72,8 +74,11 @@ local function ViewerFrameHasActiveCooldownWidget(viewerFrame, configUnit, auraU
     end
 
     local startMs, durMs = viewerCooldown:GetCooldownTimes()
-    if issecretvalue(durMs) then
+    if issecretvalue(startMs) or issecretvalue(durMs) then
         return true
+    end
+    if not startMs or not durMs then
+        return false
     end
 
     return durMs > 0 and (startMs + durMs) > now * 1000
@@ -217,6 +222,344 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
     return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
 end
 EntryRuntime.ResolveTrackedAuraViewerFrame = ResolveTrackedAuraViewerFrame
+
+local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStandaloneAuraIDs)
+    local auraData
+    local activeAuraSpellID
+    local activeAuraSpellIDFromFallback
+
+    if orderedStandaloneAuraIDs then
+        for _, spellID in ipairs(orderedStandaloneAuraIDs) do
+            auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
+            if auraData then
+                activeAuraSpellID = spellID
+                activeAuraSpellIDFromFallback = true
+                break
+            end
+        end
+    elseif buttonData.auraSpellID then
+        local ids = owner._parsedAuraIDs
+        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
+            ids = {}
+            owner._parsedAuraIDsIncludeButtonID = nil
+            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+                local spellID = tonumber(id)
+                ids[#ids + 1] = spellID
+                if spellID == buttonData.id then
+                    owner._parsedAuraIDsIncludeButtonID = true
+                end
+            end
+            owner._parsedAuraIDs = ids
+            owner._parsedAuraIDsRaw = buttonData.auraSpellID
+            owner._parsedAuraIDsButtonID = buttonData.id
+        end
+        for _, spellID in ipairs(ids) do
+            auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
+            if auraData then
+                activeAuraSpellID = spellID
+                activeAuraSpellIDFromFallback = true
+                break
+            end
+        end
+        if not auraData and not owner._parsedAuraIDsIncludeButtonID then
+            local baseId = C_Spell.GetBaseSpell(buttonData.id)
+            local fallbackId = baseId and baseId ~= auraSpellID and baseId or nil
+            auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+            if auraData then
+                activeAuraSpellID = fallbackId
+                activeAuraSpellIDFromFallback = true
+            end
+        end
+    else
+        local baseId = C_Spell.GetBaseSpell(buttonData.id)
+        local fallbackId = baseId and baseId ~= auraSpellID and baseId or nil
+        auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
+        if auraData then
+            activeAuraSpellID = fallbackId
+            activeAuraSpellIDFromFallback = true
+        end
+        if not auraData then
+            auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraSpellID)
+            if auraData then
+                activeAuraSpellID = auraSpellID
+                activeAuraSpellIDFromFallback = true
+            end
+        end
+    end
+
+    return auraData, activeAuraSpellID, activeAuraSpellIDFromFallback
+end
+
+local function GetReadableAuraSpellID(auraData)
+    local spellID = auraData and auraData.spellId
+    if spellID and not issecretvalue(spellID) then
+        return spellID
+    end
+    return nil
+end
+
+local function CommitTrackedAuraOwnerState(owner, state)
+    if not owner then return end
+
+    if state.auraPresent then
+        owner._auraActive = true
+        owner._auraHasTimer = state.auraHasTimer == true
+        owner._auraDurationObj = state.durationObj
+        owner._auraCooldownStart = state.auraCooldownStart
+        owner._auraCooldownDuration = state.auraCooldownDuration
+        if state.auraGraceHeld ~= true then
+            owner._auraInstanceID = state.auraInstanceID
+            owner._auraUnit = state.auraUnit
+        elseif not owner._auraUnit then
+            owner._auraUnit = state.auraUnit
+        end
+        if owner._targetSwitchAt
+            and state.auraGraceHeld ~= true
+            and (state.durationObj or state.auraCooldownDuration or state.allowDurationlessAuraInstance) then
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        end
+    else
+        owner._auraActive = false
+        owner._auraHasTimer = false
+        owner._auraDurationObj = nil
+        owner._auraCooldownStart = nil
+        owner._auraCooldownDuration = nil
+        owner._auraInstanceID = nil
+        owner._auraUnit = state.configUnit
+        owner._activeAuraSpellID = nil
+        owner._activeAuraSpellIDFromFallback = nil
+        if owner._targetSwitchAt and not state.wasAuraActive then
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        end
+    end
+end
+
+function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
+    owner = owner or {}
+    options = options or {}
+    local now = options.now or GetTime()
+    local configUnit = options.configUnit or GetConfiguredAuraUnit(buttonData)
+    local auraUnit = owner._auraUnit or configUnit
+    local allowDurationlessAuraInstance = options.allowDurationlessAuraInstance == true
+    local allowPlayerAuraFallbackWithoutReady = options.allowPlayerAuraFallbackWithoutReady == true
+    local mutateOwner = options.mutateOwner ~= false
+    local prevAuraDurationObj = owner._auraActive and owner._auraDurationObj or nil
+    local wasAuraActive = owner._auraActive == true
+    local auraEventRemoved = owner._auraEventRemoved
+    owner._auraEventRemoved = nil
+
+    local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = ResolveTrackedAuraViewerFrame(
+        owner,
+        buttonData,
+        auraSpellID,
+        configUnit,
+        auraUnit,
+        now,
+        allowDurationlessAuraInstance
+    )
+    local ready = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
+
+    local auraData
+    local durationObj
+    local auraPresent = false
+    local auraHasTimer = owner._auraHasTimer == true
+    local auraApplications
+    local auraInstanceID
+    local activeAuraSpellID
+    local activeAuraSpellIDFromFallback
+    local auraCooldownStart
+    local auraCooldownDuration
+
+    if ready and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
+        local viewerInstId = viewerFrame.auraInstanceID
+        if viewerInstId then
+            local unit = viewerFrame.auraDataUnit or auraUnit
+            if unit == configUnit then
+                auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, viewerInstId)
+                durationObj = C_UnitAuras.GetAuraDuration(unit, viewerInstId)
+                if auraData and (durationObj or allowDurationlessAuraInstance) then
+                    auraApplications = auraData.applications
+                    activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    auraInstanceID = viewerInstId
+                    auraUnit = unit
+                    auraPresent = true
+                    auraHasTimer = durationObj and DurationObjectShowsCooldown(durationObj) or false
+                end
+            end
+        else
+            local viewerCooldown = viewerFrame.Cooldown
+            if viewerFrame.auraDataUnit and viewerCooldown and viewerCooldown:IsShown() then
+                local vUnit = viewerFrame.auraDataUnit or auraUnit
+                if vUnit == configUnit then
+                    local startMs, durMs = viewerCooldown:GetCooldownTimes()
+                    if issecretvalue(startMs) or issecretvalue(durMs) then
+                        auraUnit = vUnit
+                        auraPresent = true
+                    elseif startMs and durMs and durMs > 0 and (startMs + durMs) > now * 1000 then
+                        auraCooldownStart = startMs / 1000
+                        auraCooldownDuration = durMs / 1000
+                        auraUnit = vUnit
+                        auraPresent = true
+                        auraHasTimer = true
+                    end
+                end
+                auraInstanceID = nil
+            end
+
+            if not auraPresent then
+                local totemSlot = viewerFrame.preferredTotemUpdateSlot
+                if totemSlot and viewerFrame:IsVisible() and viewerFrame.totemData then
+                    local totemDuration = GetTotemDuration(totemSlot)
+                    if totemDuration and DurationObjectShowsCooldown(totemDuration) then
+                        durationObj = totemDuration
+                        auraPresent = true
+                        auraHasTimer = true
+                        auraInstanceID = nil
+                    end
+                end
+            end
+        end
+    end
+
+    local canUsePlayerAuraFallback = configUnit == "player"
+        and (ready or allowPlayerAuraFallbackWithoutReady)
+    if canUsePlayerAuraFallback and not auraPresent then
+        auraData, activeAuraSpellID, activeAuraSpellIDFromFallback =
+            ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStandaloneAuraIDs)
+        local instId = auraData and auraData.auraInstanceID
+        if instId and not issecretvalue(instId) then
+            durationObj = C_UnitAuras.GetAuraDuration("player", instId)
+            if durationObj or allowDurationlessAuraInstance then
+                auraApplications = auraData.applications
+                activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
+                auraInstanceID = instId
+                auraUnit = "player"
+                auraPresent = true
+                auraHasTimer = durationObj and DurationObjectShowsCooldown(durationObj) or false
+            end
+        end
+    end
+
+    if canUsePlayerAuraFallback and not auraPresent and owner._auraInstanceID then
+        local cachedUnit = owner._auraUnit or configUnit
+        if cachedUnit == configUnit then
+            auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, owner._auraInstanceID)
+            if auraData then
+                durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, owner._auraInstanceID)
+                if durationObj or allowDurationlessAuraInstance then
+                    auraApplications = auraData.applications
+                    activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    activeAuraSpellIDFromFallback = activeAuraSpellID and true or nil
+                    auraInstanceID = owner._auraInstanceID
+                    auraUnit = cachedUnit
+                    auraPresent = true
+                    auraHasTimer = durationObj and DurationObjectShowsCooldown(durationObj) or false
+                end
+            end
+        end
+    end
+
+    local auraGraceHeld = false
+    if not auraPresent and wasAuraActive and prevAuraDurationObj and buttonData.isPassive ~= true then
+        local expired = false
+        if auraEventRemoved then
+            expired = true
+        elseif owner._targetSwitchAt then
+            if viewerFrame and not viewerFrame.auraInstanceID then
+                expired = true
+            elseif owner._targetSwitchDataReceived then
+                expired = true
+            else
+                expired = (now - owner._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
+            end
+        elseif prevAuraDurationObj.HasSecretValues and not prevAuraDurationObj:HasSecretValues()
+            and prevAuraDurationObj.GetRemainingDuration then
+            expired = prevAuraDurationObj:GetRemainingDuration() <= 0
+        end
+        if not expired then
+            if not owner._auraGraceStart then
+                owner._auraGraceStart = now
+            end
+            if now - owner._auraGraceStart <= 0.3 or owner._targetSwitchAt then
+                durationObj = prevAuraDurationObj
+                auraPresent = true
+                auraGraceHeld = true
+            else
+                owner._auraGraceStart = nil
+            end
+        else
+            owner._auraGraceStart = nil
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        end
+    else
+        owner._auraGraceStart = nil
+        if owner._targetSwitchAt then
+            if auraPresent and (durationObj or auraCooldownDuration or allowDurationlessAuraInstance) then
+                owner._targetSwitchAt = nil
+                owner._targetSwitchDataReceived = nil
+            elseif not wasAuraActive then
+                owner._targetSwitchAt = nil
+                owner._targetSwitchDataReceived = nil
+            end
+        end
+    end
+
+    if not auraPresent and owner._targetSwitchAt and wasAuraActive then
+        local catchAllExpired
+        if viewerFrame and not viewerFrame.auraInstanceID then
+            catchAllExpired = true
+        elseif owner._targetSwitchDataReceived then
+            catchAllExpired = true
+        else
+            catchAllExpired = (now - owner._targetSwitchAt) > TARGET_SWITCH_SAFETY_CAP
+        end
+        if catchAllExpired then
+            owner._targetSwitchAt = nil
+            owner._targetSwitchDataReceived = nil
+        else
+            if prevAuraDurationObj then
+                durationObj = prevAuraDurationObj
+            end
+            auraPresent = true
+            auraGraceHeld = true
+        end
+    end
+
+    local state = {
+        ready = ready == true,
+        auraPresent = auraPresent == true,
+        auraTrackingReady = ready == true,
+        cdmEnabled = cdmEnabled == true,
+        auraData = auraPresent and auraData or nil,
+        auraApplications = auraPresent and auraApplications or nil,
+        auraInstanceID = auraPresent and auraInstanceID or nil,
+        auraUnit = auraPresent and auraUnit or configUnit,
+        configUnit = configUnit,
+        viewerFrame = viewerFrame,
+        durationObj = auraPresent and durationObj or nil,
+        auraCooldownStart = auraPresent and auraCooldownStart or nil,
+        auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
+        auraHasTimer = auraPresent and auraHasTimer == true or false,
+        auraGraceHeld = auraGraceHeld == true,
+        activeAuraSpellID = activeAuraSpellID,
+        activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
+        allowDurationlessAuraInstance = allowDurationlessAuraInstance,
+        wasAuraActive = wasAuraActive,
+    }
+
+    if mutateOwner then
+        CommitTrackedAuraOwnerState(owner, state)
+    end
+
+    return state
+end
+
+function CooldownCompanion:EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
+    return EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
+end
 
 local function IsSpellCooldownDeferred(info)
     if not info or info.isEnabled ~= false or info.isActive == true then

--- a/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -1319,7 +1319,7 @@ local function BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUni
 
     AddCustomBarAuraTrackingGap(container)
 
-    if isSpellCustomBar then
+    if isSpellCustomBar or spellID then
         if not (cab.auraUnit == "player" or cab.auraUnit == "target") then
             resolvedAuraUnit = EnsureCustomAuraBarAuraUnit(cab, spellID)
         end

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -78,6 +78,7 @@ ButtonFrame\IconMode.lua
 ButtonFrame\BarMode.lua
 ButtonFrame\TextMode.lua
 ButtonFrame\Preview.lua
+ButtonFrame\EntryRuntime.lua
 ButtonFrame\CooldownUpdate.lua
 Core\GroupFrame.lua
 OtherBars\ResourceBarConstants.lua

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -46,6 +46,7 @@ Core\SpellQueries.lua
 Core\CooldownLogic.lua
 Core\Utils.lua
 Core\Init.lua
+Core\EntryRuntime.lua
 Core\Defaults.lua
 Core\SpellActivationOverlayData.lua
 Core\AuraTextures.lua
@@ -78,7 +79,6 @@ ButtonFrame\IconMode.lua
 ButtonFrame\BarMode.lua
 ButtonFrame\TextMode.lua
 ButtonFrame\Preview.lua
-ButtonFrame\EntryRuntime.lua
 ButtonFrame\CooldownUpdate.lua
 Core\GroupFrame.lua
 OtherBars\ResourceBarConstants.lua

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -7,6 +7,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 
 local ipairs = ipairs
@@ -528,16 +529,8 @@ function CooldownCompanion:ClearAuraUnit(unitToken)
                 shouldClear = true
             end
             if shouldClear then
-                button._auraInstanceID = nil
-                button._auraActive = false
-                button._auraDurationObj = nil
-                button._auraCooldownStart = nil
-                button._auraCooldownDuration = nil
+                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, { useFalseState = true })
                 button._auraPrimarySwipeActive = nil
-                button._inPandemic = false
-                button._targetSwitchAt = nil
-                button._targetSwitchDataReceived = nil
-                button._auraUnit = configUnit
             end
         end
     end)
@@ -560,11 +553,7 @@ function CooldownCompanion:OnTargetChanged()
             local isTarget = button._auraUnit == "target"
                 or configUnit == "target"
             if isTarget then
-                button._auraInstanceID = nil
-                button._inPandemic = false
-                button._targetSwitchAt = now
-                button._targetSwitchDataReceived = nil
-                button._auraUnit = "target"
+                EntryRuntime.StartTrackedAuraTargetSwitch(button, now, "target")
             end
         end
     end)

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -1,6 +1,6 @@
 --[[
-    CooldownCompanion - ButtonFrame/EntryRuntime
-    Shared cooldown/aura runtime helpers for bar-panel entries.
+    CooldownCompanion - Core/EntryRuntime
+    Shared cooldown/aura runtime helpers for display entries.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -43,10 +43,33 @@ local function DurationObjectShowsCooldown(durationObj)
 end
 EntryRuntime.DurationObjectShowsCooldown = DurationObjectShowsCooldown
 
+local function SetAuraStackCountText(fontString, value, maxStacks, stackTextFormat)
+    if not fontString then return end
+    if value == nil then
+        fontString:SetText("")
+        return
+    end
+
+    local displayValue = value
+    if not issecretvalue(value) then
+        displayValue = tonumber(value)
+        if not displayValue then
+            fontString:SetText(value or "")
+            return
+        end
+    end
+
+    if stackTextFormat == "current_max" then
+        fontString:SetFormattedText("%d / %d", displayValue, maxStacks or 1)
+    else
+        fontString:SetFormattedText("%d", displayValue)
+    end
+end
+EntryRuntime.SetAuraStackCountText = SetAuraStackCountText
+
 local function GetConfiguredAuraUnit(buttonData)
     return buttonData.auraUnit or "player"
 end
-EntryRuntime.GetConfiguredAuraUnit = GetConfiguredAuraUnit
 
 local function ViewerFrameHasActiveAuraInstance(viewerFrame, configUnit, auraUnit, allowDurationlessAuraInstance)
     local unit = viewerFrame.auraDataUnit or auraUnit
@@ -99,6 +122,32 @@ local function ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, 
         or ViewerFrameHasActiveTotemDuration(viewerFrame)
 end
 
+local function GetParsedAuraIDs(owner, buttonData)
+    if not (owner and buttonData and buttonData.auraSpellID) then
+        return nil, false
+    end
+
+    local rawIDs = buttonData.auraSpellID
+    if not owner._parsedAuraIDs
+        or owner._parsedAuraIDsRaw ~= rawIDs
+        or owner._parsedAuraIDsButtonID ~= buttonData.id then
+        local ids = {}
+        owner._parsedAuraIDsIncludeButtonID = nil
+        for id in tostring(rawIDs):gmatch("%d+") do
+            local spellID = tonumber(id)
+            ids[#ids + 1] = spellID
+            if spellID == buttonData.id then
+                owner._parsedAuraIDsIncludeButtonID = true
+            end
+        end
+        owner._parsedAuraIDs = ids
+        owner._parsedAuraIDsRaw = rawIDs
+        owner._parsedAuraIDsButtonID = buttonData.id
+    end
+
+    return owner._parsedAuraIDs, owner._parsedAuraIDsIncludeButtonID == true
+end
+
 local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local firstTrackedFrame
     for _, spellID in ipairs(candidateIDs or {}) do
@@ -112,11 +161,7 @@ local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUni
     end
     return nil, firstTrackedFrame
 end
-EntryRuntime.ResolvePreferredAuraViewerFrame = ResolvePreferredAuraViewerFrame
-EntryRuntime.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
-CooldownCompanion.ResolvePreferredStandaloneAuraViewerFrame = ResolvePreferredAuraViewerFrame
-
-local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance)
+local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance, useButtonAuraViewerFallback)
     local viewerFrame
     local cdmEnabled
     if CooldownCompanion._cooldownUpdatePassActive then
@@ -180,21 +225,7 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
             viewerFrame = fallbackActiveFrame or firstOriginalFrame or firstFallbackFrame
         end
     elseif not viewerFrame and buttonData.auraSpellID then
-        local ids = owner._parsedAuraIDs
-        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
-            ids = {}
-            owner._parsedAuraIDsIncludeButtonID = nil
-            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                local numId = tonumber(id)
-                ids[#ids + 1] = numId
-                if numId == buttonData.id then
-                    owner._parsedAuraIDsIncludeButtonID = true
-                end
-            end
-            owner._parsedAuraIDs = ids
-            owner._parsedAuraIDsRaw = buttonData.auraSpellID
-            owner._parsedAuraIDsButtonID = buttonData.id
-        end
+        local ids = GetParsedAuraIDs(owner, buttonData)
         local activeFrame, firstTrackedFrame = ResolvePreferredAuraViewerFrame(
             ids,
             configUnit,
@@ -218,11 +249,12 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
             end
         end
     end
+    if not viewerFrame and useButtonAuraViewerFallback then
+        viewerFrame = CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
+    end
 
     return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
 end
-EntryRuntime.ResolveTrackedAuraViewerFrame = ResolveTrackedAuraViewerFrame
-
 local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStandaloneAuraIDs)
     local auraData
     local activeAuraSpellID
@@ -238,21 +270,7 @@ local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStan
             end
         end
     elseif buttonData.auraSpellID then
-        local ids = owner._parsedAuraIDs
-        if not ids or owner._parsedAuraIDsRaw ~= buttonData.auraSpellID or owner._parsedAuraIDsButtonID ~= buttonData.id then
-            ids = {}
-            owner._parsedAuraIDsIncludeButtonID = nil
-            for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
-                local spellID = tonumber(id)
-                ids[#ids + 1] = spellID
-                if spellID == buttonData.id then
-                    owner._parsedAuraIDsIncludeButtonID = true
-                end
-            end
-            owner._parsedAuraIDs = ids
-            owner._parsedAuraIDsRaw = buttonData.auraSpellID
-            owner._parsedAuraIDsButtonID = buttonData.id
-        end
+        local ids, includesButtonID = GetParsedAuraIDs(owner, buttonData)
         for _, spellID in ipairs(ids) do
             auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
             if auraData then
@@ -261,7 +279,7 @@ local function ResolvePlayerAuraData(owner, buttonData, auraSpellID, orderedStan
                 break
             end
         end
-        if not auraData and not owner._parsedAuraIDsIncludeButtonID then
+        if not auraData and not includesButtonID then
             local baseId = C_Spell.GetBaseSpell(buttonData.id)
             local fallbackId = baseId and baseId ~= auraSpellID and baseId or nil
             auraData = fallbackId and C_UnitAuras.GetPlayerAuraBySpellID(fallbackId)
@@ -298,6 +316,106 @@ local function GetReadableAuraSpellID(auraData)
     return nil
 end
 
+local function AuraDataMatchesTrackedSpell(owner, buttonData, auraSpellID, auraData)
+    local auraDataSpellID = auraData and auraData.spellId
+    if not auraDataSpellID or issecretvalue(auraDataSpellID) then
+        return false
+    end
+
+    if buttonData and buttonData.auraSpellID then
+        local ids = GetParsedAuraIDs(owner, buttonData)
+        for _, spellID in ipairs(ids or {}) do
+            if auraDataSpellID == spellID then
+                return true
+            end
+        end
+    end
+
+    local buttonSpellID = buttonData and buttonData.id
+    local baseID = buttonSpellID and C_Spell.GetBaseSpell(buttonSpellID)
+    return auraDataSpellID == auraSpellID
+        or auraDataSpellID == buttonSpellID
+        or (baseID and auraDataSpellID == baseID)
+end
+EntryRuntime.AuraDataMatchesTrackedSpell = AuraDataMatchesTrackedSpell
+
+function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
+    if not owner then return end
+    options = options or {}
+    local inactiveValue = options.useFalseState and false or nil
+
+    owner._auraActive = inactiveValue
+    owner._auraHasTimer = inactiveValue
+    owner._auraDurationObj = nil
+    owner._auraCooldownStart = nil
+    owner._auraCooldownDuration = nil
+    owner._auraInstanceID = nil
+    owner._auraUnit = configUnit
+    owner._activeAuraSpellID = nil
+    owner._activeAuraSpellIDFromFallback = nil
+    owner._auraEventRemoved = nil
+    owner._auraGraceStart = nil
+    if not options.preserveTargetSwitch then
+        owner._targetSwitchAt = nil
+        owner._targetSwitchDataReceived = nil
+    end
+    owner._inPandemic = inactiveValue
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    if options.clearCustomAuraStacks then
+        owner._customAuraStackValue = nil
+        owner._customAuraApplicationsValue = nil
+    end
+end
+
+function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
+    if not owner then return end
+    owner._auraInstanceID = nil
+    owner._inPandemic = false
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    owner._targetSwitchAt = now
+    owner._targetSwitchDataReceived = nil
+    owner._auraUnit = unit or "target"
+end
+
+function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
+    if not owner then return false end
+    options = options or {}
+
+    if options.previewActive then
+        return true
+    end
+
+    if not (options.enabled and viewerFrame) then
+        if options.clearWhenDisabled then
+            owner._pandemicGraceStart = nil
+            owner._pandemicGraceSuppressed = nil
+        end
+        return false
+    end
+
+    local pandemicIcon = viewerFrame.PandemicIcon
+    if owner._pandemicGraceSuppressed then
+        owner._pandemicGraceSuppressed = nil
+        owner._pandemicGraceStart = nil
+    elseif pandemicIcon and pandemicIcon:IsVisible() then
+        owner._pandemicGraceStart = nil
+        return true
+    elseif owner._inPandemic then
+        local now = options.now or GetTime()
+        if not owner._pandemicGraceStart then
+            owner._pandemicGraceStart = now
+        end
+        if now - owner._pandemicGraceStart <= 0.3 then
+            return true
+        end
+        owner._pandemicGraceStart = nil
+    end
+
+    return false
+end
+
 local function CommitTrackedAuraOwnerState(owner, state)
     if not owner then return end
 
@@ -313,6 +431,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
         elseif not owner._auraUnit then
             owner._auraUnit = state.auraUnit
         end
+        if state.activeAuraSpellIDResolved then
+            owner._activeAuraSpellID = state.activeAuraSpellID or owner._activeAuraSpellID
+            owner._activeAuraSpellIDFromFallback = state.activeAuraSpellIDFromFallback or nil
+        end
         if owner._targetSwitchAt
             and state.auraGraceHeld ~= true
             and (state.durationObj or state.auraCooldownDuration or state.allowDurationlessAuraInstance) then
@@ -320,15 +442,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
             owner._targetSwitchDataReceived = nil
         end
     else
-        owner._auraActive = false
-        owner._auraHasTimer = false
-        owner._auraDurationObj = nil
-        owner._auraCooldownStart = nil
-        owner._auraCooldownDuration = nil
-        owner._auraInstanceID = nil
-        owner._auraUnit = state.configUnit
-        owner._activeAuraSpellID = nil
-        owner._activeAuraSpellIDFromFallback = nil
+        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit, {
+            useFalseState = true,
+            preserveTargetSwitch = state.wasAuraActive == true,
+        })
         if owner._targetSwitchAt and not state.wasAuraActive then
             owner._targetSwitchAt = nil
             owner._targetSwitchDataReceived = nil
@@ -345,8 +462,14 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     local allowDurationlessAuraInstance = options.allowDurationlessAuraInstance == true
     local allowPlayerAuraFallbackWithoutReady = options.allowPlayerAuraFallbackWithoutReady == true
     local mutateOwner = options.mutateOwner ~= false
-    local prevAuraDurationObj = owner._auraActive and owner._auraDurationObj or nil
-    local wasAuraActive = owner._auraActive == true
+    local prevAuraDurationObj = options.previousAuraDurationObj
+    if prevAuraDurationObj == nil and owner._auraActive then
+        prevAuraDurationObj = owner._auraDurationObj
+    end
+    local wasAuraActive = options.wasAuraActive
+    if wasAuraActive == nil then
+        wasAuraActive = owner._auraActive == true
+    end
     local auraEventRemoved = owner._auraEventRemoved
     owner._auraEventRemoved = nil
 
@@ -357,7 +480,8 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         configUnit,
         auraUnit,
         now,
-        allowDurationlessAuraInstance
+        allowDurationlessAuraInstance,
+        options.useButtonAuraViewerFallback == true
     )
     local ready = CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
 
@@ -368,9 +492,11 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     local auraApplications
     local auraInstanceID
     local activeAuraSpellID
+    local activeAuraSpellIDResolved = false
     local activeAuraSpellIDFromFallback
     local auraCooldownStart
     local auraCooldownDuration
+    local viewerBar
 
     if ready and viewerFrame and (auraUnit == "player" or auraUnit == "target") then
         local viewerInstId = viewerFrame.auraInstanceID
@@ -382,6 +508,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                 if auraData and (durationObj or allowDurationlessAuraInstance) then
                     auraApplications = auraData.applications
                     activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    activeAuraSpellIDResolved = true
                     auraInstanceID = viewerInstId
                     auraUnit = unit
                     auraPresent = true
@@ -417,6 +544,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                         auraPresent = true
                         auraHasTimer = true
                         auraInstanceID = nil
+                        viewerBar = viewerFrame.Bar
                     end
                 end
             end
@@ -434,6 +562,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
             if durationObj or allowDurationlessAuraInstance then
                 auraApplications = auraData.applications
                 activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
+                activeAuraSpellIDResolved = true
                 auraInstanceID = instId
                 auraUnit = "player"
                 auraPresent = true
@@ -446,11 +575,14 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         local cachedUnit = owner._auraUnit or configUnit
         if cachedUnit == configUnit then
             auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, owner._auraInstanceID)
-            if auraData then
+            if auraData
+                and (not options.validateCachedAuraData
+                    or options.validateCachedAuraData(owner, buttonData, auraSpellID, auraData)) then
                 durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, owner._auraInstanceID)
                 if durationObj or allowDurationlessAuraInstance then
                     auraApplications = auraData.applications
                     activeAuraSpellID = GetReadableAuraSpellID(auraData)
+                    activeAuraSpellIDResolved = true
                     activeAuraSpellIDFromFallback = activeAuraSpellID and true or nil
                     auraInstanceID = owner._auraInstanceID
                     auraUnit = cachedUnit
@@ -539,12 +671,14 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         auraUnit = auraPresent and auraUnit or configUnit,
         configUnit = configUnit,
         viewerFrame = viewerFrame,
+        viewerBar = viewerBar,
         durationObj = auraPresent and durationObj or nil,
         auraCooldownStart = auraPresent and auraCooldownStart or nil,
         auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
         auraHasTimer = auraPresent and auraHasTimer == true or false,
         auraGraceHeld = auraGraceHeld == true,
         activeAuraSpellID = activeAuraSpellID,
+        activeAuraSpellIDResolved = activeAuraSpellIDResolved == true,
         activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
         allowDurationlessAuraInstance = allowDurationlessAuraInstance,
         wasAuraActive = wasAuraActive,
@@ -555,10 +689,6 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     end
 
     return state
-end
-
-function CooldownCompanion:EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
-    return EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
 end
 
 local function IsSpellCooldownDeferred(info)
@@ -660,7 +790,6 @@ local function ProbeActionSlotsForSpellID(spellID)
 
     return result
 end
-
 local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
     local result = {
         shown = nil,
@@ -712,7 +841,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     local info = C_Spell.GetSpellCooldown(spellID)
     result.info = info
     if not info then
-        if secrecy ~= 0 and ProbeActionSlotCooldownForSpell then
+        if secrecy ~= 0 then
             local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
             if slotProbe.shown ~= nil then
                 result.fetchOk = true
@@ -768,8 +897,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         and (result.isOnGCD == true or result.normalCooldownShown == true)
 
     if needsRealCooldownFallback
-        and options.allowActionSlotRealFallback
-        and ProbeActionSlotCooldownForSpell then
+        and options.allowActionSlotRealFallback then
         local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
         if slotProbe.realShown == true and slotProbe.realDurationObj then
             result.slotProbe = slotProbe
@@ -785,8 +913,6 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 
     return result
 end
-EntryRuntime.EvaluateSpellCooldownLane = EvaluateSpellCooldownLane
-
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
     local allowActionSlotRealFallback = buttonData.hasCharges ~= true
         and cooldownSpellId == buttonData.id
@@ -856,6 +982,15 @@ local function ClearOwnerChargeState(owner)
     owner._mainCDShown = nil
     owner._chargeState = nil
     owner._chargesSpent = nil
+end
+
+function EntryRuntime.RecordChargeSpent(owner)
+    if not owner then return end
+    if not owner._chargeRecharging then
+        owner._chargesSpent = 1
+    else
+        owner._chargesSpent = (owner._chargesSpent or 0) + 1
+    end
 end
 
 local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
@@ -1082,8 +1217,4 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     end
 
     return result
-end
-
-function CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(customBar, owner)
-    return EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
 end

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 -- Localize frequently-used globals for faster access
 local InCombatLockdown = InCombatLockdown
@@ -425,11 +426,7 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
                         -- _chargeRecharging at event time reflects the PRE-cast state:
                         --   false = casting from full charges → reset to 1
                         --   true  = already recharging → increment
-                        if not button._chargeRecharging then
-                            button._chargesSpent = 1
-                        else
-                            button._chargesSpent = (button._chargesSpent or 0) + 1
-                        end
+                        EntryRuntime.RecordChargeSpent(button)
                     end
                 end
             end

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -434,6 +434,9 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
                 end
             end
         end)
+        if self.RecordCustomBarSpellCast then
+            self:RecordCustomBarSpellCast(spellID)
+        end
         self:UpdateAllCooldowns()
     end
 end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -428,6 +428,25 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     frame._parsedCustomBarAuraIDsRaw = nil
     frame._parsedCustomBarAuraIDsSpellID = nil
     frame._parsedCustomBarAuraIDsIncludeSpellID = nil
+    frame._parsedAuraIDs = nil
+    frame._parsedAuraIDsRaw = nil
+    frame._parsedAuraIDsButtonID = nil
+    frame._parsedAuraIDsIncludeButtonID = nil
+    frame._customCooldownBaseSpellID = nil
+    frame._customCooldownSpellID = nil
+    frame._customCooldownHasCharges = nil
+    frame._cooldownSecrecy = nil
+    frame._cooldownSecrecySpellID = nil
+    frame._noCooldown = nil
+    frame._noCooldownSpellId = nil
+    frame._currentReadableCharges = nil
+    frame._chargeCountReadable = nil
+    frame._zeroChargesConfirmed = nil
+    frame._chargeDurationObj = nil
+    frame._chargeRecharging = nil
+    frame._mainCDShown = nil
+    frame._chargeState = nil
+    frame._chargesSpent = nil
     frame:SetAlpha(1)
 end
 

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -193,6 +193,22 @@ local function IsCustomBarAuraIndicatorFrame(barInfo)
         or barInfo.barType == "custom_cooldown"
 end
 
+local function ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
+    if not IsCustomBarAuraIndicatorFrame(barInfo) then
+        return
+    end
+
+    local bar = barInfo and barInfo.frame
+    if not bar then return end
+
+    if clearPreviewFlags then
+        bar._barAuraActivePreview = nil
+        bar._pandemicPreview = nil
+    end
+
+    ResetCustomAuraBarIndicatorVisuals(bar, barInfo.cabConfig)
+end
+
 local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     if not IsCustomBarAuraIndicatorFrame(barInfo) then
         return
@@ -204,16 +220,21 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     bar._auraActive = nil
     bar._inPandemic = nil
     bar._auraInstanceID = nil
+    bar._auraDurationObj = nil
+    bar._auraCooldownStart = nil
+    bar._auraCooldownDuration = nil
+    bar._auraHasTimer = nil
     bar._auraUnit = nil
+    bar._auraEventRemoved = nil
+    bar._auraGraceStart = nil
+    bar._targetSwitchAt = nil
+    bar._targetSwitchDataReceived = nil
+    bar._customAuraStackValue = nil
+    bar._customAuraApplicationsValue = nil
     bar._pandemicGraceStart = nil
     bar._pandemicGraceSuppressed = nil
 
-    if clearPreviewFlags then
-        bar._barAuraActivePreview = nil
-        bar._pandemicPreview = nil
-    end
-
-    ResetCustomAuraBarIndicatorVisuals(bar, barInfo.cabConfig)
+    ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
 end
 
 local function ApplyCustomAuraBarPreviewState(barInfo)
@@ -266,7 +287,7 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
     if not cabConfig
         or (isSpellCustomCooldown and cabConfig.auraTracking ~= true)
         or (not isSpellCustomCooldown and cabConfig.trackingMode ~= "active") then
-        ClearCustomAuraBarIndicatorState(barInfo, false)
+        ClearCustomAuraBarIndicatorVisualState(barInfo, false)
         return
     end
 
@@ -420,7 +441,17 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     frame._cdcIndependentLastAlpha = nil
     frame._auraActive = nil
     frame._auraInstanceID = nil
+    frame._auraDurationObj = nil
+    frame._auraCooldownStart = nil
+    frame._auraCooldownDuration = nil
+    frame._auraHasTimer = nil
     frame._auraUnit = nil
+    frame._auraEventRemoved = nil
+    frame._auraGraceStart = nil
+    frame._targetSwitchAt = nil
+    frame._targetSwitchDataReceived = nil
+    frame._customAuraStackValue = nil
+    frame._customAuraApplicationsValue = nil
     frame._inPandemic = nil
     frame._pandemicGraceStart = nil
     frame._pandemicGraceSuppressed = nil
@@ -1311,6 +1342,7 @@ local customBarsModule = RB.CreateResourceBarCustomBarsModule({
     end,
     ClearStaleRecycledBarRuntimeState = ClearStaleRecycledBarRuntimeState,
     ClearCustomAuraBarIndicatorState = ClearCustomAuraBarIndicatorState,
+    ClearCustomAuraBarIndicatorVisualState = ClearCustomAuraBarIndicatorVisualState,
     UpdateCustomAuraBarIndicatorVisuals = UpdateCustomAuraBarIndicatorVisuals,
     ApplyCustomAuraBarPreviewState = ApplyCustomAuraBarPreviewState,
 })
@@ -2562,6 +2594,7 @@ local previewModule = RB.CreateResourceBarPreviewModule({
     GetResourceBarSettings = GetResourceBarSettings,
     ApplySegmentedPreviewColors = ApplySegmentedPreviewColors,
     ClearCustomAuraBarIndicatorState = ClearCustomAuraBarIndicatorState,
+    ClearCustomAuraBarIndicatorVisualState = ClearCustomAuraBarIndicatorVisualState,
 })
 ApplyPreviewData = previewModule.ApplyPreviewData
 

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -16,6 +16,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 local math_floor = math.floor
 local math_min = math.min
@@ -217,22 +218,7 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     local bar = barInfo and barInfo.frame
     if not bar then return end
 
-    bar._auraActive = nil
-    bar._inPandemic = nil
-    bar._auraInstanceID = nil
-    bar._auraDurationObj = nil
-    bar._auraCooldownStart = nil
-    bar._auraCooldownDuration = nil
-    bar._auraHasTimer = nil
-    bar._auraUnit = nil
-    bar._auraEventRemoved = nil
-    bar._auraGraceStart = nil
-    bar._targetSwitchAt = nil
-    bar._targetSwitchDataReceived = nil
-    bar._customAuraStackValue = nil
-    bar._customAuraApplicationsValue = nil
-    bar._pandemicGraceStart = nil
-    bar._pandemicGraceSuppressed = nil
+    EntryRuntime.ClearTrackedAuraOwnerState(bar, nil, { clearCustomAuraStacks = true })
 
     ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
 end
@@ -439,26 +425,7 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     end
     frame._cdcIndependentAlphaTarget = nil
     frame._cdcIndependentLastAlpha = nil
-    frame._auraActive = nil
-    frame._auraInstanceID = nil
-    frame._auraDurationObj = nil
-    frame._auraCooldownStart = nil
-    frame._auraCooldownDuration = nil
-    frame._auraHasTimer = nil
-    frame._auraUnit = nil
-    frame._auraEventRemoved = nil
-    frame._auraGraceStart = nil
-    frame._targetSwitchAt = nil
-    frame._targetSwitchDataReceived = nil
-    frame._customAuraStackValue = nil
-    frame._customAuraApplicationsValue = nil
-    frame._inPandemic = nil
-    frame._pandemicGraceStart = nil
-    frame._pandemicGraceSuppressed = nil
-    frame._parsedCustomBarAuraIDs = nil
-    frame._parsedCustomBarAuraIDsRaw = nil
-    frame._parsedCustomBarAuraIDsSpellID = nil
-    frame._parsedCustomBarAuraIDsIncludeSpellID = nil
+    EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, { clearCustomAuraStacks = true })
     frame._parsedAuraIDs = nil
     frame._parsedAuraIDsRaw = nil
     frame._parsedAuraIDsButtonID = nil
@@ -2039,7 +2006,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
         barInfo._order = orderList[idx]
         barInfo._effectiveThickness = effectiveThickness
 
-        FinalizeAppliedBarVisibility(barInfo, powerType, isPreviewActive)
+        FinalizeAppliedBarVisibility(barInfo, isPreviewActive)
     end
 
     activeResources = filtered

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 local math_floor = math.floor
 local GetTime = GetTime
@@ -557,36 +558,21 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return resolvedAuraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(resolvedAuraSpellID) or nil
     end
 
-    local function ViewerFrameHasAuraForUnit(viewerFrame, configUnit)
-        local instId = viewerFrame and viewerFrame.auraInstanceID
-        if not instId then
-            return false
-        end
-
-        local viewerUnit = viewerFrame.auraDataUnit or configUnit
-        return viewerUnit == configUnit
-            and C_UnitAuras.GetAuraDataByAuraInstanceID(viewerUnit, instId) ~= nil
-    end
-
-    local function ResolveSpellCustomBarAuraViewerFrame(bar, cabConfig, spellID, buttonData, configUnit)
-        if cabConfig and cabConfig.auraSpellID then
-            local ids = GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-            local firstTrackedFrame
-            if ids then
-                for _, auraID in ipairs(ids) do
-                    local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraID)
-                    if viewerFrame then
-                        if ViewerFrameHasAuraForUnit(viewerFrame, configUnit) then
-                            return viewerFrame
-                        end
-                        if not firstTrackedFrame then
-                            firstTrackedFrame = viewerFrame
-                        end
-                    end
-                end
-            end
-            if firstTrackedFrame then
-                return firstTrackedFrame
+    local function ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
+        if EntryRuntime and EntryRuntime.ResolveTrackedAuraViewerFrame then
+            local auraUnit = bar and bar._auraUnit or configUnit
+            local allowDurationlessAuraInstance = true
+            local viewerFrame = EntryRuntime.ResolveTrackedAuraViewerFrame(
+                bar,
+                buttonData,
+                resolvedAuraSpellID,
+                configUnit,
+                auraUnit,
+                GetTime(),
+                allowDurationlessAuraInstance
+            )
+            if viewerFrame then
+                return viewerFrame
             end
         end
 
@@ -626,7 +612,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
         local configUnit = buttonData.auraUnit or "player"
-        local viewerFrame = ResolveSpellCustomBarAuraViewerFrame(bar, cabConfig, spellID, buttonData, configUnit)
+        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
+        local viewerFrame = ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
         if not CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame) then
             return {
                 ready = false,
@@ -636,7 +623,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             }
         end
 
-        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
         local auraData
         local durationObj
         local auraUnit = configUnit
@@ -708,8 +694,22 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local currentCharges = cooldownResult and cooldownResult.currentCharges
         local maxCharges = cooldownResult and cooldownResult.maxCharges
-        if currentCharges and maxCharges and maxCharges > 1 then
+        if currentCharges ~= nil and maxCharges and maxCharges > 1 then
             bar.stackText:SetFormattedText("%d / %d", currentCharges, maxCharges)
+        elseif cooldownResult and cooldownResult.chargeDisplayCount ~= nil then
+            local displayCount = cooldownResult.chargeDisplayCount
+            if issecretvalue and issecretvalue(displayCount) then
+                bar.stackText:SetText(displayCount)
+            else
+                local numericCount = tonumber(displayCount)
+                if numericCount and maxCharges and maxCharges > 1 then
+                    bar.stackText:SetFormattedText("%d / %d", numericCount, maxCharges)
+                elseif displayCount and displayCount ~= "" then
+                    bar.stackText:SetText(displayCount)
+                else
+                    bar.stackText:SetText("")
+                end
+            end
         else
             bar.stackText:SetText("")
         end
@@ -739,7 +739,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if not (cabConfig and cabConfig.spellID and bar) then return end
 
         local cooldownResult = CooldownCompanion.EvaluateSpellCooldownStateForCustomBar
-            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig)
+            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
         local cooldownActive = cooldownResult
             and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
@@ -909,6 +909,38 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         UpdateSpellCustomBarSounds(false)
+    end
+
+    function CooldownCompanion:RecordCustomBarSpellCast(spellID)
+        if not spellID then return end
+
+        for _, barInfo in ipairs(resourceBarFrames) do
+            local bar = barInfo and barInfo.frame
+            local cabConfig = barInfo and barInfo.cabConfig
+            if barInfo
+                and barInfo.barType == "custom_cooldown"
+                and bar
+                and cabConfig
+                and cabConfig.entryType == "spell"
+            then
+                local baseSpellID = tonumber(cabConfig.spellID)
+                local runtimeSpellID = baseSpellID and C_Spell.GetOverrideSpell(baseSpellID)
+                if not runtimeSpellID or runtimeSpellID == 0 then
+                    runtimeSpellID = baseSpellID
+                end
+
+                local charges = runtimeSpellID and C_Spell.GetSpellCharges(runtimeSpellID)
+                local maxCharges = charges and tonumber(charges.maxCharges)
+                if (maxCharges or 0) > 1
+                    and (spellID == baseSpellID or spellID == runtimeSpellID) then
+                    if not bar._chargeRecharging then
+                        bar._chargesSpent = 1
+                    else
+                        bar._chargesSpent = (bar._chargesSpent or 0) + 1
+                    end
+                end
+            end
+        end
     end
 
     local function GetHiddenCustomAuraWakeUnit(cabConfig)

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -7,7 +7,6 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
 
-local math_floor = math.floor
 local math_max = math.max
 local math_min = math.min
 local GetTime = GetTime
@@ -23,34 +22,11 @@ local CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL = 0.65
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS = 3
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION = 12.3
 
-local function IsSecretValue(value)
-    return issecretvalue and issecretvalue(value)
-end
-
 local function GetReadableApplicationCount(value)
-    if value == nil or IsSecretValue(value) then
+    if value == nil or (issecretvalue and issecretvalue(value)) then
         return nil
     end
     return tonumber(value)
-end
-
-local function SetApplicationStackText(fontString, value, maxStacks, stackTextFormat)
-    if IsSecretValue(value) then
-        fontString:SetText(value)
-        return
-    end
-
-    local numericValue = tonumber(value)
-    if not numericValue then
-        fontString:SetText("")
-        return
-    end
-
-    if stackTextFormat == "current" then
-        fontString:SetFormattedText("%d", numericValue)
-    else
-        fontString:SetFormattedText("%d / %d", numericValue, maxStacks)
-    end
 end
 
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
@@ -78,6 +54,7 @@ local LayoutOverlaySegments = RB.LayoutOverlaySegments
 
 local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
+local SetAuraStackCountText = EntryRuntime.SetAuraStackCountText
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -90,71 +67,15 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
-    local customAuraWakeRetryFrame = nil
     local customAuraWakeRetryQueue = {}
     local customAuraWakeRetryPending = {}
+    local customAuraWakeRetryScheduled = false
     local processingCustomAuraWakeRetryQueue = false
+    local customBarPresentationRefreshPending = false
 
     ------------------------------------------------------------------------
     -- Update logic: Custom aura bars (aura-based, secret-safe)
     ------------------------------------------------------------------------
-
-    local function ResolveCustomBarPandemicState(frame, configUnit, auraPresent, viewerFrame, pandemicPreview)
-        if not frame then
-            return false
-        end
-
-        if pandemicPreview then
-            return true
-        end
-
-        if configUnit == "target" and auraPresent and viewerFrame then
-            local pi = viewerFrame.PandemicIcon
-            if frame._pandemicGraceSuppressed then
-                frame._pandemicGraceSuppressed = nil
-                frame._pandemicGraceStart = nil
-            elseif pi and pi:IsVisible() then
-                frame._pandemicGraceStart = nil
-                return true
-            elseif frame._inPandemic then
-                local now = GetTime()
-                if not frame._pandemicGraceStart then
-                    frame._pandemicGraceStart = now
-                end
-                if now - frame._pandemicGraceStart <= 0.3 then
-                    return true
-                end
-                frame._pandemicGraceStart = nil
-            end
-        else
-            frame._pandemicGraceStart = nil
-            frame._pandemicGraceSuppressed = nil
-        end
-
-        return false
-    end
-
-    local function PeekCustomBarPandemicState(frame, configUnit, auraPresent, viewerFrame, pandemicPreview)
-        if not frame then
-            return false
-        end
-        if pandemicPreview then
-            return true
-        end
-        if configUnit == "target" and auraPresent and viewerFrame then
-            if frame._pandemicGraceSuppressed then
-                return false
-            end
-            local pi = viewerFrame.PandemicIcon
-            if pi and pi:IsVisible() then
-                return true
-            end
-            if frame._inPandemic then
-                return true
-            end
-        end
-        return false
-    end
 
     local function ResolveCustomAuraVisibility(cabConfig, auraPresent, inPandemic, auraPreview, pandemicPreview)
         if not (cabConfig and (cabConfig.hideWhenInactive or cabConfig.hideWhileAuraActive)) then
@@ -173,95 +94,62 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return shouldShow, true
     end
 
-    local function GetCustomAuraVisibilityReason(cabConfig)
-        return cabConfig and cabConfig.hideWhenInactive
-            and "hide-when-inactive"
-            or "hide-while-aura-active"
-    end
-
-    function RB.RequestCustomBarPresentationRefresh()
-        if RB.customBarPresentationRefreshPending then
+    local function RequestCustomBarPresentationRefresh()
+        if customBarPresentationRefreshPending then
             return
         end
 
-        RB.customBarPresentationRefreshPending = true
+        customBarPresentationRefreshPending = true
         C_Timer.After(0, function()
-            RB.customBarPresentationRefreshPending = nil
+            customBarPresentationRefreshPending = false
             CooldownCompanion:ApplyResourceBars()
             CooldownCompanion:UpdateAnchorStacking()
         end)
     end
 
-    local CustomAuraBar = {}
-
-    function CustomAuraBar.BuildAuraButtonData(cabConfig)
+    local function BuildCustomBarAuraButtonData(cabConfig, addedAsAura)
         local spellID = tonumber(cabConfig and cabConfig.spellID)
-        if not spellID or (RB.IsSpellCustomBarConfig and RB.IsSpellCustomBarConfig(cabConfig)) then
+        if not spellID then
             return nil, spellID
         end
 
-        return {
+        if addedAsAura then
+            if RB.IsSpellCustomBarConfig(cabConfig) then
+                return nil, spellID
+            end
+        elseif not (cabConfig and cabConfig.auraTracking == true) then
+            return nil, nil
+        end
+
+        local buttonData = {
             type = "spell",
             id = spellID,
             auraSpellID = cabConfig.auraSpellID,
             auraTracking = true,
             auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID),
-            addedAs = "aura",
-        }, spellID
+        }
+        if addedAsAura then
+            buttonData.addedAs = "aura"
+        end
+        return buttonData, spellID
     end
 
-    function CustomAuraBar.GetCandidateIDs(cabConfig)
-        local buttonData
-        local spellID
-        buttonData, spellID = CustomAuraBar.BuildAuraButtonData(cabConfig)
-        if buttonData and CooldownCompanion.GetOrderedAuraCandidateIDs then
-            local orderedCandidateIDs = CooldownCompanion:GetOrderedAuraCandidateIDs(buttonData)
-            if orderedCandidateIDs and #orderedCandidateIDs > 0 then
-                return orderedCandidateIDs
-            end
+    local function ResolveSpellCustomBarAuraState(barInfo)
+        local cabConfig = barInfo and barInfo.cabConfig
+        local bar = barInfo and barInfo.frame
+        local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, false)
+        if not (buttonData and spellID and bar) then
+            return nil
         end
 
-        return spellID and { spellID } or nil
-    end
-
-    function CustomAuraBar.ViewerFrameHasAuraForUnit(viewerFrame, configUnit)
-        local instId = viewerFrame and viewerFrame.auraInstanceID
-        if not instId then
-            return false
-        end
-
-        local viewerUnit = viewerFrame.auraDataUnit or configUnit
-        return viewerUnit == configUnit
-            and C_UnitAuras.GetAuraDataByAuraInstanceID(viewerUnit, instId) ~= nil
-    end
-
-    function CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
-        local firstTrackedFrame
-        local candidateIDs = CustomAuraBar.GetCandidateIDs(cabConfig)
-        for _, auraID in ipairs(candidateIDs or {}) do
-            local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraID)
-            if viewerFrame then
-                if CustomAuraBar.ViewerFrameHasAuraForUnit(viewerFrame, configUnit) then
-                    return viewerFrame
-                end
-                if not firstTrackedFrame then
-                    firstTrackedFrame = viewerFrame
-                end
-            end
-        end
-
-        return firstTrackedFrame
-    end
-
-    function CustomAuraBar.ResolvePlayerAuraData(cabConfig)
-        local candidateIDs = CustomAuraBar.GetCandidateIDs(cabConfig)
-        for _, auraID in ipairs(candidateIDs or {}) do
-            local auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraID)
-            if auraData then
-                return auraData
-            end
-        end
-        return nil
+        local configUnit = buttonData.auraUnit or "player"
+        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
+        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, {
+            configUnit = configUnit,
+            allowDurationlessAuraInstance = true,
+            useButtonAuraViewerFallback = true,
+            validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell,
+        })
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -270,12 +158,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         -- Read aura data from viewer frame (applications may be secret in combat)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
-        local isSpellCustomBar = RB.IsSpellCustomBarConfig and RB.IsSpellCustomBarConfig(cabConfig)
-        local useSharedStandaloneAuraState = not spellAuraStackDisplay
-            and not isSpellCustomBar
-            and EntryRuntime
-            and EntryRuntime.EvaluateTrackedAuraState
-        local auraState = spellAuraStackDisplay and RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
+        local isSpellCustomBar = RB.IsSpellCustomBarConfig(cabConfig)
+        local auraState
         local stacks = 0
         local applications
         local readableApplications
@@ -284,8 +168,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local auraCooldownStart
         local auraCooldownDuration
         local isActive = cabConfig.trackingMode == "active"
-        local useDrain = isActive
-        local needsDuration = (useDrain or cabConfig.showDurationText) and not spellAuraStackDisplay
         local bar = barInfo.barType == "custom_continuous" and barInfo.frame or nil
         local auraPreview = bar and bar._barAuraActivePreview
         local pandemicPreview = bar and bar._pandemicPreview
@@ -295,8 +177,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local auraUnit = configUnit
         local instId
 
-        if useSharedStandaloneAuraState then
-            local buttonData, spellID = CustomAuraBar.BuildAuraButtonData(cabConfig)
+        if spellAuraStackDisplay then
+            auraState = ResolveSpellCustomBarAuraState(barInfo)
+        elseif not isSpellCustomBar then
+            local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, true)
             if buttonData and spellID then
                 configUnit = buttonData.auraUnit or configUnit
                 auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, {
@@ -305,17 +189,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     allowPlayerAuraFallbackWithoutReady = true,
                 })
                 viewerFrame = auraState and auraState.viewerFrame or nil
-                instId = auraState and auraState.auraInstanceID or nil
             end
-        else
-            viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
-            instId = viewerFrame and viewerFrame.auraInstanceID
         end
 
         if auraState then
-            configUnit = (auraState and auraState.configUnit) or configUnit
-            viewerFrame = auraState and auraState.viewerFrame or nil
-            if auraState and auraState.auraPresent == true then
+            configUnit = auraState.configUnit or configUnit
+            viewerFrame = auraState.viewerFrame
+            if auraState.auraPresent == true then
                 auraPresent = true
                 instId = auraState.auraInstanceID
                 if instId == nil and auraState.auraGraceHeld and barInfo.frame then
@@ -345,47 +225,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 auraCooldownStart = auraState.auraCooldownStart
                 auraCooldownDuration = auraState.auraCooldownDuration
             end
-        elseif instId then
-            local viewerUnit = viewerFrame.auraDataUnit or configUnit
-            if viewerUnit == configUnit then
-                local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
-                if auraData then
-                    auraPresent = true
-                    applications = auraData.applications
-                    readableApplications = GetReadableApplicationCount(applications)
-                    if isActive then
-                        stacks = 1
-                    elseif applications ~= nil then
-                        stacks = applications
-                    else
-                        stacks = 0
-                    end
-                    if needsDuration then
-                        durationObj = C_UnitAuras.GetAuraDuration(configUnit, instId)
-                    end
-                end
-            end
-        end
-
-        if not useSharedStandaloneAuraState and not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
-            local auraData = CustomAuraBar.ResolvePlayerAuraData(cabConfig)
-            if auraData then
-                instId = auraData.auraInstanceID
-                auraUnit = "player"
-                auraPresent = true
-                applications = auraData.applications
-                readableApplications = GetReadableApplicationCount(applications)
-                if isActive then
-                    stacks = 1
-                elseif applications ~= nil then
-                    stacks = applications
-                else
-                    stacks = 0
-                end
-                if needsDuration and instId then
-                    durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                end
-            end
         end
 
         if spellAuraStackDisplay and not auraPresent and not GetPreviewActive() then
@@ -396,7 +235,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false)
             end
-            RB.RequestCustomBarPresentationRefresh()
+            RequestCustomBarPresentationRefresh()
             return
         end
 
@@ -413,7 +252,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         local pandemicStateFrame = barInfo.frame
-        local inPandemic = ResolveCustomBarPandemicState(pandemicStateFrame, configUnit, auraPresent, viewerFrame, pandemicPreview)
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, {
+            enabled = configUnit == "target" and auraPresent,
+            previewActive = pandemicPreview == true,
+            clearWhenDisabled = true,
+        })
 
         if isActive and bar then
             if auraPresent then
@@ -459,7 +302,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if barInfo.barType == "custom_continuous" then
             local bar = barInfo.frame
-            if useDrain then
+            if isActive then
                 bar:SetMinMaxValues(0, 1)
                 if durationObj then
                     bar:SetValue(durationObj:GetRemainingPercent())  -- secret-safe, 1->0 drain
@@ -519,10 +362,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if bar.stackText and bar.stackText:IsShown() then
                 if auraPresent then
                     if isActive then
-                        SetApplicationStackText(bar.stackText, applications, maxStacks, "current")
+                        SetAuraStackCountText(bar.stackText, applications, maxStacks, "current")
                     else
                         local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig.stackTextFormat)
-                        SetApplicationStackText(bar.stackText, stacks, maxStacks, stackTextFormat)
+                        SetAuraStackCountText(bar.stackText, stacks, maxStacks, stackTextFormat)
                     end
                 else
                     bar.stackText:SetText("")
@@ -600,208 +443,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
     end
 
-    local function BuildSpellCustomBarAuraButtonData(cabConfig)
-        local spellID = tonumber(cabConfig and cabConfig.spellID)
-        if not spellID or not (cabConfig and cabConfig.auraTracking == true) then
-            return nil, nil
-        end
-
-        return {
-            type = "spell",
-            id = spellID,
-            auraSpellID = cabConfig.auraSpellID,
-            auraTracking = true,
-            auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID),
-        }, spellID
-    end
-
-    local function GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-        if not (bar and cabConfig and cabConfig.auraSpellID) then
-            return nil, false
-        end
-
-        local rawIDs = tostring(cabConfig.auraSpellID)
-        if bar._parsedCustomBarAuraIDsRaw == rawIDs
-            and bar._parsedCustomBarAuraIDsSpellID == spellID then
-            return bar._parsedCustomBarAuraIDs, bar._parsedCustomBarAuraIDsIncludeSpellID == true
-        end
-
-        local ids = {}
-        local includesSpellID = false
-        for id in rawIDs:gmatch("%d+") do
-            local numericID = tonumber(id)
-            ids[#ids + 1] = numericID
-            if numericID == spellID then
-                includesSpellID = true
-            end
-        end
-
-        bar._parsedCustomBarAuraIDs = ids
-        bar._parsedCustomBarAuraIDsRaw = rawIDs
-        bar._parsedCustomBarAuraIDsSpellID = spellID
-        bar._parsedCustomBarAuraIDsIncludeSpellID = includesSpellID or nil
-        return ids, includesSpellID
-    end
-
-    local function ResolveSpellCustomBarPlayerAuraData(bar, cabConfig, spellID, resolvedAuraSpellID)
-        local auraData
-        if cabConfig.auraSpellID then
-            local ids, includesSpellID = GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-            if ids then
-                for _, auraID in ipairs(ids) do
-                    auraData = C_UnitAuras.GetPlayerAuraBySpellID(auraID)
-                    if auraData then
-                        return auraData
-                    end
-                end
-            end
-            if not includesSpellID then
-                local baseID = C_Spell.GetBaseSpell(spellID)
-                local fallbackID = baseID and baseID ~= resolvedAuraSpellID and baseID or nil
-                return fallbackID and C_UnitAuras.GetPlayerAuraBySpellID(fallbackID) or nil
-            end
-            return nil
-        end
-
-        local baseID = C_Spell.GetBaseSpell(spellID)
-        local fallbackID = baseID and baseID ~= resolvedAuraSpellID and baseID or nil
-        auraData = fallbackID and C_UnitAuras.GetPlayerAuraBySpellID(fallbackID) or nil
-        if auraData then
-            return auraData
-        end
-
-        return resolvedAuraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(resolvedAuraSpellID) or nil
-    end
-
-    local function ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
-        if EntryRuntime and EntryRuntime.ResolveTrackedAuraViewerFrame then
-            local auraUnit = bar and bar._auraUnit or configUnit
-            local allowDurationlessAuraInstance = true
-            local viewerFrame = EntryRuntime.ResolveTrackedAuraViewerFrame(
-                bar,
-                buttonData,
-                resolvedAuraSpellID,
-                configUnit,
-                auraUnit,
-                GetTime(),
-                allowDurationlessAuraInstance
-            )
-            if viewerFrame then
-                return viewerFrame
-            end
-        end
-
-        return CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
-    end
-
-    local function SpellCustomBarAuraDataMatches(bar, cabConfig, spellID, resolvedAuraSpellID, auraData)
-        local auraSpellID = auraData and auraData.spellId
-        if not auraSpellID or (issecretvalue and issecretvalue(auraSpellID)) then
-            return false
-        end
-
-        if cabConfig and cabConfig.auraSpellID then
-            local ids = GetSpellCustomBarParsedAuraIDs(bar, cabConfig, spellID)
-            if ids then
-                for _, auraID in ipairs(ids) do
-                    if auraSpellID == auraID then
-                        return true
-                    end
-                end
-            end
-        end
-
-        local baseID = C_Spell.GetBaseSpell(spellID)
-        return auraSpellID == resolvedAuraSpellID
-            or auraSpellID == spellID
-            or (baseID and auraSpellID == baseID)
-    end
-
-    function RB.ResolveSpellCustomBarAuraState(barInfo)
-        local cabConfig = barInfo and barInfo.cabConfig
-        local bar = barInfo and barInfo.frame
-        local buttonData, spellID = BuildSpellCustomBarAuraButtonData(cabConfig)
-        if not (buttonData and spellID and bar) then
-            return nil
-        end
-
-        local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
-        local configUnit = buttonData.auraUnit or "player"
-        local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
-        local viewerFrame = ResolveSpellCustomBarAuraViewerFrame(bar, buttonData, configUnit, resolvedAuraSpellID)
-        if not CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame) then
-            return {
-                ready = false,
-                auraPresent = false,
-                configUnit = configUnit,
-                viewerFrame = viewerFrame,
-            }
-        end
-
-        local auraData
-        local durationObj
-        local auraUnit = configUnit
-        local instId = viewerFrame and viewerFrame.auraInstanceID
-
-        if instId and (configUnit == "player" or configUnit == "target") then
-            local viewerUnit = viewerFrame.auraDataUnit or configUnit
-            if viewerUnit == configUnit then
-                auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(viewerUnit, instId)
-                if auraData then
-                    durationObj = C_UnitAuras.GetAuraDuration(viewerUnit, instId)
-                    if durationObj then
-                        auraUnit = viewerUnit
-                    end
-                end
-            end
-        end
-
-        if not (auraData and durationObj) and configUnit == "player" then
-            auraData = ResolveSpellCustomBarPlayerAuraData(bar, cabConfig, spellID, resolvedAuraSpellID)
-            instId = auraData and auraData.auraInstanceID or nil
-            if instId and not issecretvalue(instId) then
-                durationObj = C_UnitAuras.GetAuraDuration("player", instId)
-                auraUnit = "player"
-            end
-        end
-
-        if not (auraData and durationObj) and configUnit == "player" and bar._auraInstanceID then
-            local cachedUnit = bar._auraUnit or configUnit
-            if cachedUnit == configUnit then
-                auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(cachedUnit, bar._auraInstanceID)
-                if SpellCustomBarAuraDataMatches(bar, cabConfig, spellID, resolvedAuraSpellID, auraData) then
-                    durationObj = C_UnitAuras.GetAuraDuration(cachedUnit, bar._auraInstanceID)
-                    instId = bar._auraInstanceID
-                    auraUnit = cachedUnit
-                end
-            end
-        end
-
-        if not auraData then
-            return {
-                ready = true,
-                auraPresent = false,
-                configUnit = configUnit,
-                viewerFrame = viewerFrame,
-            }
-        end
-
-        return {
-            ready = true,
-            auraPresent = true,
-            auraData = auraData,
-            auraInstanceID = instId,
-            auraUnit = auraUnit,
-            configUnit = configUnit,
-            viewerFrame = viewerFrame,
-            durationObj = durationObj,
-        }
-    end
-
-    local function ClearSpellCustomBarAuraRuntimeState(barInfo)
-        ClearCustomAuraBarIndicatorState(barInfo, false)
-    end
-
     local function UpdateSpellCustomBarChargeText(bar, cooldownResult)
         if not (bar and bar.stackText and bar.stackText:IsShown()) then
             return
@@ -840,12 +481,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return
         end
 
-        local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig and cabConfig.stackTextFormat)
-        if stackTextFormat == "current" then
-            bar.stackText:SetFormattedText("%d", stacks)
-        else
-            bar.stackText:SetFormattedText("%d / %d", stacks, maxStacks)
-        end
+        SetAuraStackCountText(
+            bar.stackText,
+            stacks,
+            maxStacks,
+            NormalizeCustomAuraStackTextFormat(cabConfig and cabConfig.stackTextFormat)
+        )
     end
 
     function RB.UpdateCustomCooldownBar(barInfo)
@@ -853,12 +494,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local bar = barInfo and barInfo.frame
         if not (cabConfig and cabConfig.spellID and bar) then return end
 
-        local cooldownResult = CooldownCompanion.EvaluateSpellCooldownStateForCustomBar
-            and CooldownCompanion:EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
+        local cooldownResult = EntryRuntime.EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
         local cooldownActive = cooldownResult
             and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
-        local auraState = RB.ResolveSpellCustomBarAuraState(barInfo)
+        local auraState = ResolveSpellCustomBarAuraState(barInfo)
         local auraPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         local auraPreview = bar._barAuraActivePreview == true
         local pandemicPreview = bar._pandemicPreview == true
@@ -895,13 +535,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = (auraState and auraState.configUnit)
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
-        local inPandemic = ResolveCustomBarPandemicState(
-            bar,
-            configUnit,
-            auraPresent,
-            auraState and auraState.viewerFrame,
-            pandemicPreview
-        )
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, {
+            enabled = configUnit == "target" and auraPresent,
+            previewActive = pandemicPreview == true,
+            clearWhenDisabled = true,
+        })
 
         if auraState
             and auraState.ready == true
@@ -913,7 +551,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 MarkLayoutDirty()
             end
             if not shouldShow then
-                ClearSpellCustomBarAuraRuntimeState(barInfo)
+                ClearCustomAuraBarIndicatorState(barInfo, false)
                 UpdateSpellCustomBarSounds(auraPresent)
                 return
             end
@@ -925,7 +563,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if spellAuraStackDisplay and auraPresent then
             UpdateSpellCustomBarSounds(true)
-            RB.RequestCustomBarPresentationRefresh()
+            RequestCustomBarPresentationRefresh()
             return
         end
 
@@ -985,7 +623,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return
         end
 
-        ClearSpellCustomBarAuraRuntimeState(barInfo)
+        ClearCustomAuraBarIndicatorState(barInfo, false)
 
         bar:SetMinMaxValues(0, 1)
         bar:SetStatusBarColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] ~= nil and fillColor[4] or 1)
@@ -1048,11 +686,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 local maxCharges = charges and tonumber(charges.maxCharges)
                 if (maxCharges or 0) > 1
                     and (spellID == baseSpellID or spellID == runtimeSpellID) then
-                    if not bar._chargeRecharging then
-                        bar._chargesSpent = 1
-                    else
-                        bar._chargesSpent = (bar._chargesSpent or 0) + 1
-                    end
+                    EntryRuntime.RecordChargeSpent(bar)
                 end
             end
         end
@@ -1098,17 +732,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target"
     end
 
-    local function StopDeferredCustomAuraWakeRetryFrame()
-        if customAuraWakeRetryFrame then
-            customAuraWakeRetryFrame:SetScript("OnUpdate", nil)
-        end
-    end
-
     local function ClearDeferredCustomAuraWakeRetries()
         wipe(customAuraWakeRetryQueue)
         wipe(customAuraWakeRetryPending)
+        customAuraWakeRetryScheduled = false
         processingCustomAuraWakeRetryQueue = false
-        StopDeferredCustomAuraWakeRetryFrame()
     end
 
     local function ResolveDeferredCustomAuraWakeRetryBarInfo(entry)
@@ -1131,11 +759,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     end
 
     local function ProcessDeferredCustomAuraWakeRetries()
+        customAuraWakeRetryScheduled = false
         if processingCustomAuraWakeRetryQueue then return end
-        if #customAuraWakeRetryQueue == 0 then
-            StopDeferredCustomAuraWakeRetryFrame()
-            return
-        end
+        if #customAuraWakeRetryQueue == 0 then return end
 
         processingCustomAuraWakeRetryQueue = true
         local queue = customAuraWakeRetryQueue
@@ -1168,7 +794,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         processingCustomAuraWakeRetryQueue = false
-        StopDeferredCustomAuraWakeRetryFrame()
 
         if relayoutNeeded then
             RelayoutResourceStack()
@@ -1200,11 +825,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             unit = unit,
         }
 
-        if not customAuraWakeRetryFrame then
-            customAuraWakeRetryFrame = CreateFrame("Frame")
+        if customAuraWakeRetryScheduled then
+            return
         end
-        customAuraWakeRetryFrame:SetScript("OnUpdate", function(self, _elapsed)
-            self:SetScript("OnUpdate", nil)
+
+        customAuraWakeRetryScheduled = true
+        C_Timer.After(0, function()
             ProcessDeferredCustomAuraWakeRetries()
         end)
     end
@@ -1345,7 +971,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
     end
 
-    local function FinalizeAppliedBarVisibility(barInfo, powerType, previewActive)
+    local function FinalizeAppliedBarVisibility(barInfo, previewActive)
         if barInfo and type(barInfo.customBarId) == "string" then
             if previewActive then
                 barInfo.frame:Show()
@@ -1432,7 +1058,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
         local spellAuraStackPresent = spellAuraStackDisplay and GetPreviewActive()
         if spellAuraStackDisplay and not spellAuraStackPresent and barInfo and barInfo.frame then
-            local auraState = RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
+            local auraState = ResolveSpellCustomBarAuraState(barInfo)
             spellAuraStackPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         end
         local spellAuraStackActive = spellAuraStackDisplay and spellAuraStackPresent
@@ -1601,7 +1227,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     end
 
     RB.PrepareCustomAuraBar = PrepareCustomAuraBar
-    RB.StyleCustomAuraBar = StyleCustomAuraBar
 
     ------------------------------------------------------------------------
     -- Live recolor for custom aura bars (called from config color picker)

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -8,6 +8,8 @@ local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
 
 local math_floor = math.floor
+local math_max = math.max
+local math_min = math.min
 local GetTime = GetTime
 local issecretvalue = issecretvalue
 
@@ -20,6 +22,36 @@ local DEFAULT_RESOURCE_TEXT_COLOR = RB.DEFAULT_RESOURCE_TEXT_COLOR
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL = 0.65
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS = 3
 local CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION = 12.3
+
+local function IsSecretValue(value)
+    return issecretvalue and issecretvalue(value)
+end
+
+local function GetReadableApplicationCount(value)
+    if value == nil or IsSecretValue(value) then
+        return nil
+    end
+    return tonumber(value)
+end
+
+local function SetApplicationStackText(fontString, value, maxStacks, stackTextFormat)
+    if IsSecretValue(value) then
+        fontString:SetText(value)
+        return
+    end
+
+    local numericValue = tonumber(value)
+    if not numericValue then
+        fontString:SetText("")
+        return
+    end
+
+    if stackTextFormat == "current" then
+        fontString:SetFormattedText("%d", numericValue)
+    else
+        fontString:SetFormattedText("%d / %d", numericValue, maxStacks)
+    end
+end
 
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
@@ -54,6 +86,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     local RelayoutResourceStack = deps.RelayoutResourceStack
     local ClearStaleRecycledBarRuntimeState = deps.ClearStaleRecycledBarRuntimeState
     local ClearCustomAuraBarIndicatorState = deps.ClearCustomAuraBarIndicatorState
+    local ClearCustomAuraBarIndicatorVisualState = deps.ClearCustomAuraBarIndicatorVisualState
+        or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
     local customAuraWakeRetryFrame = nil
@@ -236,11 +270,19 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         -- Read aura data from viewer frame (applications may be secret in combat)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local isSpellCustomBar = RB.IsSpellCustomBarConfig and RB.IsSpellCustomBarConfig(cabConfig)
+        local useSharedStandaloneAuraState = not spellAuraStackDisplay
+            and not isSpellCustomBar
+            and EntryRuntime
+            and EntryRuntime.EvaluateTrackedAuraState
         local auraState = spellAuraStackDisplay and RB.ResolveSpellCustomBarAuraState and RB.ResolveSpellCustomBarAuraState(barInfo) or nil
         local stacks = 0
-        local applications = 0
+        local applications
+        local readableApplications
         local auraPresent = false
         local durationObj
+        local auraCooldownStart
+        local auraCooldownDuration
         local isActive = cabConfig.trackingMode == "active"
         local useDrain = isActive
         local needsDuration = (useDrain or cabConfig.showDurationText) and not spellAuraStackDisplay
@@ -249,19 +291,59 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local pandemicPreview = bar and bar._pandemicPreview
         local indicatorPreview = isActive and (auraPreview or pandemicPreview)
         local configUnit = EnsureCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
-        local viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
+        local viewerFrame
         local auraUnit = configUnit
-        local instId = viewerFrame and viewerFrame.auraInstanceID
+        local instId
 
-        if spellAuraStackDisplay then
+        if useSharedStandaloneAuraState then
+            local buttonData, spellID = CustomAuraBar.BuildAuraButtonData(cabConfig)
+            if buttonData and spellID then
+                configUnit = buttonData.auraUnit or configUnit
+                auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, {
+                    configUnit = configUnit,
+                    allowDurationlessAuraInstance = true,
+                    allowPlayerAuraFallbackWithoutReady = true,
+                })
+                viewerFrame = auraState and auraState.viewerFrame or nil
+                instId = auraState and auraState.auraInstanceID or nil
+            end
+        else
+            viewerFrame = CustomAuraBar.ResolveViewerFrame(cabConfig, configUnit)
+            instId = viewerFrame and viewerFrame.auraInstanceID
+        end
+
+        if auraState then
             configUnit = (auraState and auraState.configUnit) or configUnit
             viewerFrame = auraState and auraState.viewerFrame or nil
-            if auraState and auraState.ready == true and auraState.auraPresent == true and auraState.auraData then
+            if auraState and auraState.auraPresent == true then
                 auraPresent = true
                 instId = auraState.auraInstanceID
+                if instId == nil and auraState.auraGraceHeld and barInfo.frame then
+                    instId = barInfo.frame._auraInstanceID
+                end
                 auraUnit = auraState.auraUnit or configUnit
-                applications = auraState.auraData.applications or 0
-                stacks = applications
+                local stateApplications = auraState.auraApplications
+                if stateApplications == nil and auraState.auraData then
+                    stateApplications = auraState.auraData.applications
+                end
+                if stateApplications == nil
+                    and auraState.auraGraceHeld
+                    and barInfo.frame then
+                    stateApplications = barInfo.frame._customAuraStackValue
+                        or barInfo.frame._customAuraApplicationsValue
+                end
+                applications = stateApplications
+                readableApplications = GetReadableApplicationCount(applications)
+                if isActive then
+                    stacks = 1
+                elseif applications ~= nil then
+                    stacks = applications
+                else
+                    stacks = 0
+                end
+                durationObj = auraState.durationObj
+                auraCooldownStart = auraState.auraCooldownStart
+                auraCooldownDuration = auraState.auraCooldownDuration
             end
         elseif instId then
             local viewerUnit = viewerFrame.auraDataUnit or configUnit
@@ -269,11 +351,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(configUnit, instId)
                 if auraData then
                     auraPresent = true
-                    applications = auraData.applications or 0
+                    applications = auraData.applications
+                    readableApplications = GetReadableApplicationCount(applications)
                     if isActive then
                         stacks = 1
-                    else
+                    elseif applications ~= nil then
                         stacks = applications
+                    else
+                        stacks = 0
                     end
                     if needsDuration then
                         durationObj = C_UnitAuras.GetAuraDuration(configUnit, instId)
@@ -282,17 +367,20 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
         end
 
-        if not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
+        if not useSharedStandaloneAuraState and not spellAuraStackDisplay and not auraPresent and configUnit == "player" then
             local auraData = CustomAuraBar.ResolvePlayerAuraData(cabConfig)
             if auraData then
                 instId = auraData.auraInstanceID
                 auraUnit = "player"
                 auraPresent = true
-                applications = auraData.applications or 0
+                applications = auraData.applications
+                readableApplications = GetReadableApplicationCount(applications)
                 if isActive then
                     stacks = 1
-                else
+                elseif applications ~= nil then
                     stacks = applications
+                else
+                    stacks = 0
                 end
                 if needsDuration and instId then
                     durationObj = C_UnitAuras.GetAuraDuration("player", instId)
@@ -301,6 +389,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         if spellAuraStackDisplay and not auraPresent and not GetPreviewActive() then
+            if barInfo.frame then
+                barInfo.frame._customAuraStackValue = nil
+                barInfo.frame._customAuraApplicationsValue = nil
+            end
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, false)
             end
@@ -312,6 +404,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if indicatorPreview and not auraPresent then
             auraPresent = true
             applications = CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS
+            readableApplications = CUSTOM_AURA_BAR_EFFECT_PREVIEW_STACKS
             stacks = 1
         end
 
@@ -348,8 +441,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 MarkLayoutDirty()
             end
             if not shouldShow then
+                if barInfo.frame then
+                    if not auraPresent then
+                        barInfo.frame._customAuraStackValue = nil
+                        barInfo.frame._customAuraApplicationsValue = nil
+                    end
+                end
                 if isActive then
-                    UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, false)
+                    ClearCustomAuraBarIndicatorVisualState(barInfo, false)
                 end
                 return
             end
@@ -364,6 +463,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 bar:SetMinMaxValues(0, 1)
                 if durationObj then
                     bar:SetValue(durationObj:GetRemainingPercent())  -- secret-safe, 1->0 drain
+                elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
+                    local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
+                    bar:SetValue(math_max(0, math_min(1, remaining / auraCooldownDuration)))
                 elseif indicatorPreview then
                     bar:SetValue(CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL)
                 else
@@ -399,6 +501,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     else
                         bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
                     end
+                elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
+                    local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
+                    if remaining > 0 then
+                        bar.text:SetText(FormatTime(remaining, cabConfig))
+                    else
+                        bar.text:SetText("")
+                    end
                 elseif indicatorPreview then
                     bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig))
                 else
@@ -410,14 +519,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if bar.stackText and bar.stackText:IsShown() then
                 if auraPresent then
                     if isActive then
-                        bar.stackText:SetFormattedText("%d", applications)
+                        SetApplicationStackText(bar.stackText, applications, maxStacks, "current")
                     else
                         local stackTextFormat = NormalizeCustomAuraStackTextFormat(cabConfig.stackTextFormat)
-                        if stackTextFormat == "current" then
-                            bar.stackText:SetFormattedText("%d", stacks)
-                        else
-                            bar.stackText:SetFormattedText("%d / %d", stacks, maxStacks)
-                        end
+                        SetApplicationStackText(bar.stackText, stacks, maxStacks, stackTextFormat)
                     end
                 else
                     bar.stackText:SetText("")
@@ -427,7 +532,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             if isActive then
                 UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPresent)
             else
-                ClearCustomAuraBarIndicatorState(barInfo, true)
+                ClearCustomAuraBarIndicatorVisualState(barInfo, true)
             end
 
         elseif barInfo.barType == "custom_segmented" then
@@ -479,9 +584,19 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
         end
 
+        if barInfo.frame then
+            if auraPresent and applications ~= nil then
+                barInfo.frame._customAuraStackValue = applications
+                barInfo.frame._customAuraApplicationsValue = readableApplications
+            elseif not auraPresent or not (auraState and auraState.auraGraceHeld) then
+                barInfo.frame._customAuraStackValue = nil
+                barInfo.frame._customAuraApplicationsValue = nil
+            end
+        end
+
         -- Max stacks indicator: SetValue drives visibility via C-level clamping
         if cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-            barInfo._maxStacksIndicator:SetValue(auraPresent and applications or 0)
+            barInfo._maxStacksIndicator:SetValue((auraPresent and applications ~= nil) and applications or 0)
         end
     end
 

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -1195,12 +1195,12 @@ local function GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
         resolvedSpellID = cabConfig.spellID
     end
 
-    if type(cabConfig) == "table" and (cabConfig.entryType == nil or cabConfig.entryType == "aura") then
-        return GetDefaultCustomAuraUnit(resolvedSpellID)
-    end
-
     if type(cabConfig) == "table" and HasExplicitCustomAuraBarAuraUnit(cabConfig) then
         return cabConfig.auraUnit
+    end
+
+    if type(cabConfig) == "table" and (cabConfig.entryType == nil or cabConfig.entryType == "aura") then
+        return GetDefaultCustomAuraUnit(resolvedSpellID)
     end
 
     return GetDefaultSpellCustomBarAuraUnit(cabConfig, resolvedSpellID)
@@ -1213,13 +1213,6 @@ local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit, explicit)
     end
 
     if type(cabConfig) == "table" then
-        if cabConfig.entryType == nil or cabConfig.entryType == "aura" then
-            local resolvedUnit = GetDefaultCustomAuraUnit(resolvedSpellID)
-            cabConfig.auraUnit = resolvedUnit
-            cabConfig.auraUnitExplicit = nil
-            return resolvedUnit
-        end
-
         local wasExplicit = HasExplicitCustomAuraBarAuraUnit(cabConfig)
         local resolvedUnit = IsValidCustomAuraUnit(unit) and unit
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, resolvedSpellID)

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 local math_abs = math.abs
 
@@ -33,27 +34,14 @@ function RB.CreateResourceBarLifecycleModule(deps)
             or barInfo.barType == "custom_segmented"
             or barInfo.barType == "custom_overlay"
             or (barInfo.barType == "custom_cooldown"
-                and cabConfig and cabConfig.auraTracking == true)
+                and cabConfig.auraTracking == true)
     end
 
     local function ClearCustomBarAuraRuntime(bar, configUnit)
-        if not bar then return end
-        bar._auraActive = false
-        bar._auraInstanceID = nil
-        bar._auraDurationObj = nil
-        bar._auraCooldownStart = nil
-        bar._auraCooldownDuration = nil
-        bar._auraHasTimer = false
-        bar._auraUnit = configUnit
-        bar._auraGraceStart = nil
-        bar._inPandemic = false
-        bar._pandemicGraceStart = nil
-        bar._pandemicGraceSuppressed = nil
-        bar._targetSwitchAt = nil
-        bar._targetSwitchDataReceived = nil
-        bar._auraEventRemoved = nil
-        bar._customAuraStackValue = nil
-        bar._customAuraApplicationsValue = nil
+        EntryRuntime.ClearTrackedAuraOwnerState(bar, configUnit, {
+            useFalseState = true,
+            clearCustomAuraStacks = true,
+        })
     end
 
     ------------------------------------------------------------------------
@@ -183,13 +171,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
                             and bar
                             and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
                             if hasTarget then
-                                bar._auraInstanceID = nil
-                                bar._inPandemic = false
-                                bar._pandemicGraceStart = nil
-                                bar._pandemicGraceSuppressed = nil
-                                bar._targetSwitchAt = now
-                                bar._targetSwitchDataReceived = nil
-                                bar._auraUnit = "target"
+                                EntryRuntime.StartTrackedAuraTargetSwitch(bar, now, "target")
                             else
                                 ClearCustomBarAuraRuntime(bar, "target")
                             end

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -27,6 +27,35 @@ function RB.CreateResourceBarLifecycleModule(deps)
     local lifecycleEventsEnabled = false
     local InstallHooks
 
+    local function IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
+        if not (barInfo and cabConfig) then return false end
+        return barInfo.barType == "custom_continuous"
+            or barInfo.barType == "custom_segmented"
+            or barInfo.barType == "custom_overlay"
+            or (barInfo.barType == "custom_cooldown"
+                and cabConfig and cabConfig.auraTracking == true)
+    end
+
+    local function ClearCustomBarAuraRuntime(bar, configUnit)
+        if not bar then return end
+        bar._auraActive = false
+        bar._auraInstanceID = nil
+        bar._auraDurationObj = nil
+        bar._auraCooldownStart = nil
+        bar._auraCooldownDuration = nil
+        bar._auraHasTimer = false
+        bar._auraUnit = configUnit
+        bar._auraGraceStart = nil
+        bar._inPandemic = false
+        bar._pandemicGraceStart = nil
+        bar._pandemicGraceSuppressed = nil
+        bar._targetSwitchAt = nil
+        bar._targetSwitchDataReceived = nil
+        bar._auraEventRemoved = nil
+        bar._customAuraStackValue = nil
+        bar._customAuraApplicationsValue = nil
+    end
+
     ------------------------------------------------------------------------
     -- Event handling (must be defined before Apply/Revert which call these)
     ------------------------------------------------------------------------
@@ -105,63 +134,73 @@ function RB.CreateResourceBarLifecycleModule(deps)
                     local removedIDs = updateInfo.removedAuraInstanceIDs
                     local updatedIDs = updateInfo.updatedAuraInstanceIDs
                     local hasAuraChange = updateInfo.isFullUpdate or updateInfo.addedAuras or removedIDs or updatedIDs
-                    if hasAuraChange then
-                        RefreshEventDrivenCustomAuraBarsForUnit(unit)
-                    end
-                    if not removedIDs and not updatedIDs then return end
+                    local targetSwitchDataReceived = false
 
-                    for _, barInfo in ipairs(resourceBarFrames) do
-                        local bar = barInfo and barInfo.frame
-                        local cabConfig = barInfo and barInfo.cabConfig
-                        if barInfo
-                            and ((barInfo.barType == "custom_continuous"
-                                    and cabConfig and cabConfig.trackingMode == "active")
-                                or (barInfo.barType == "custom_cooldown"
-                                    and cabConfig and cabConfig.auraTracking == true))
-                            and bar and bar._auraInstanceID and bar._auraUnit == unit then
-                            if removedIDs then
-                                for _, instId in ipairs(removedIDs) do
-                                    if bar._auraInstanceID == instId then
-                                        bar._auraActive = nil
-                                        bar._auraInstanceID = nil
-                                        bar._auraUnit = nil
-                                        bar._inPandemic = nil
-                                        bar._pandemicGraceStart = nil
-                                        break
+                    if removedIDs or updatedIDs or unit == "target" then
+                        for _, barInfo in ipairs(resourceBarFrames) do
+                            local bar = barInfo and barInfo.frame
+                            local cabConfig = barInfo and barInfo.cabConfig
+                            local configUnit = cabConfig and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
+                            if IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
+                                and bar
+                                and (bar._auraUnit == unit or configUnit == unit) then
+                                if removedIDs and bar._auraInstanceID and bar._auraUnit == unit then
+                                    for _, instId in ipairs(removedIDs) do
+                                        if bar._auraInstanceID == instId then
+                                            ClearCustomBarAuraRuntime(bar, configUnit)
+                                            bar._auraEventRemoved = true
+                                            break
+                                        end
                                     end
                                 end
-                            end
-                            if updatedIDs and bar._auraInstanceID then
-                                for _, instId in ipairs(updatedIDs) do
-                                    if bar._auraInstanceID == instId then
-                                        bar._inPandemic = nil
-                                        bar._pandemicGraceStart = nil
-                                        bar._pandemicGraceSuppressed = true
-                                        break
+                                if updatedIDs and bar._auraInstanceID and bar._auraUnit == unit then
+                                    for _, instId in ipairs(updatedIDs) do
+                                        if bar._auraInstanceID == instId then
+                                            bar._inPandemic = false
+                                            bar._pandemicGraceStart = nil
+                                            bar._pandemicGraceSuppressed = true
+                                            break
+                                        end
                                     end
+                                end
+                                if unit == "target" and bar._targetSwitchAt then
+                                    bar._targetSwitchDataReceived = true
+                                    targetSwitchDataReceived = true
                                 end
                             end
                         end
                     end
+                    if hasAuraChange or targetSwitchDataReceived then
+                        RefreshEventDrivenCustomAuraBarsForUnit(unit)
+                    end
                 elseif event == "PLAYER_TARGET_CHANGED" then
+                    local hasTarget = UnitExists("target")
+                    local now = GetTime()
                     for _, barInfo in ipairs(resourceBarFrames) do
                         local bar = barInfo and barInfo.frame
                         local cabConfig = barInfo and barInfo.cabConfig
-                        if barInfo
-                            and ((barInfo.barType == "custom_continuous"
-                                    and cabConfig and cabConfig.trackingMode == "active")
-                                or (barInfo.barType == "custom_cooldown"
-                                    and cabConfig and cabConfig.auraTracking == true))
-                            and bar and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
-                            bar._auraActive = nil
-                            bar._auraInstanceID = nil
-                            bar._auraUnit = nil
-                            bar._inPandemic = nil
-                            bar._pandemicGraceStart = nil
-                            bar._pandemicGraceSuppressed = nil
+                        if IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
+                            and bar
+                            and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID) == "target" then
+                            if hasTarget then
+                                bar._auraInstanceID = nil
+                                bar._inPandemic = false
+                                bar._pandemicGraceStart = nil
+                                bar._pandemicGraceSuppressed = nil
+                                bar._targetSwitchAt = now
+                                bar._targetSwitchDataReceived = nil
+                                bar._auraUnit = "target"
+                            else
+                                ClearCustomBarAuraRuntime(bar, "target")
+                            end
                         end
                     end
                     RefreshEventDrivenCustomAuraBarsForUnit("target")
+                elseif event == "UNIT_TARGET" then
+                    local unitToken = ...
+                    if unitToken == "player" then
+                        RefreshEventDrivenCustomAuraBarsForUnit("target")
+                    end
                 end
             end)
         end
@@ -170,6 +209,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
         -- but RegisterUnitEvent with "player" filter has negligible overhead for others
         eventFrame:RegisterUnitEvent("UNIT_MAXHEALTH", "player")
         eventFrame:RegisterUnitEvent("UNIT_AURA", "player", "target")
+        eventFrame:RegisterUnitEvent("UNIT_TARGET", "player")
         eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
         eventFrameEnabled = true
     end


### PR DESCRIPTION
## What Players Will Notice
- Custom Bars now follow the same cooldown and aura tracking behavior as bar-panel bars.
- Cooldown Custom Bars should stay aligned with bar panels for normal cooldowns, charges, override spells, and GCD presentation.
- Aura Custom Bars should stay aligned with icon panels and bar panels for player/target aura tracking, target deselect/reselect, aura expiry, stack changes, pandemic display, Hide When Inactive, and explicit Aura Unit selection.

## Why This Changed
- Custom Bars had grown their own cooldown and aura runtime logic even though they represent the same display states as bar-panel bars.
- That separate path caused parity bugs, especially around target-based aura stack tracking and target switching.

## What Changed
- Added `Core/EntryRuntime.lua` as the shared runtime contract for cooldown, charge, GCD, aura, stack, pandemic, target-switch, and custom-bar entry state.
- Moved bar panels and resource-attached Custom Bars onto the shared runtime while keeping their separate presentation, anchoring, layout, resource-stack placement, and config surfaces.
- Removed duplicate custom-bar resolver, retry, wakeup, stack formatting, and cooldown evaluation paths that are now covered by the shared runtime.
- Added the standalone Aura Unit control for aura Custom Bars so manual Player/Target tracking matches standalone aura entries elsewhere in the addon.

## Validation
- `git diff --check origin/main...HEAD` passed.
- `luac -p` passed for the changed Lua files.
- Full non-`Libs` Lua syntax pass succeeded.
- Focused fixtures passed: `tests/custom-bar-entry-runtime.lua`, `tests/visual-state-snapshot.lua`, and `tests/visual-state-diagnostics.lua`.
- Maintainer in-game validation passed across the task stack with no regressions reported, including cooldown parity, aura parity, target switching, Hide When Inactive, Aura Unit persistence, combat, restricted content, and no Lua errors.
- `cc-devbridge get_errors` reported no captured errors in the latest logout-flush snapshot; the snapshot was 27 minutes old, so this is supporting evidence rather than fresh live proof.