### PR TITLE
Fix hidden cooldown icons during spell overrides

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1782,6 +1782,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._baseNoCooldown = nil
+    button._baseNoCooldownSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -514,6 +514,11 @@ local function GetLiveOverrideSpellID(buttonData)
     return nil
 end
 
+local function IsNoCooldownSpell(spellID)
+    local baseCd = GetSpellBaseCooldown(spellID)
+    return (not baseCd or baseCd == 0) and not HasTooltipCooldown(spellID)
+end
+
 local function ResolveChargeState(button, buttonData)
     if not UsesChargeBehavior(buttonData) then
         return nil
@@ -729,15 +734,22 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Lazy-cache no-cooldown detection for spells (GCD-only, no real CD).
     -- Tie the cache to the displayed spell so replacements do not inherit the
     -- base spell's cooldown classification.
+    -- Keep the base classification too, so temporary no-CD overrides do not
+    -- bypass cooldown visibility rules for a real cooldown entry.
     if buttonData.type == "spell" and not buttonData.isPassive and not usesChargeBehavior then
+        if button._baseNoCooldown == nil or button._baseNoCooldownSpellId ~= buttonData.id then
+            button._baseNoCooldownSpellId = buttonData.id
+            button._baseNoCooldown = IsNoCooldownSpell(buttonData.id)
+        end
         if button._noCooldown == nil or button._noCooldownSpellId ~= cooldownSpellId then
             button._noCooldownSpellId = cooldownSpellId
-            local baseCd = GetSpellBaseCooldown(cooldownSpellId)
-            button._noCooldown = (not baseCd or baseCd == 0) and not HasTooltipCooldown(cooldownSpellId)
+            button._noCooldown = IsNoCooldownSpell(cooldownSpellId)
         end
     else
         button._noCooldown = false
         button._noCooldownSpellId = nil
+        button._baseNoCooldown = nil
+        button._baseNoCooldownSpellId = nil
     end
 
     -- Proc state: event-driven table lookup (base spell + current displayed override).

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1224,6 +1224,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._baseNoCooldown = nil
+    button._baseNoCooldownSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -90,6 +90,14 @@ local function GetButtonVisibilityReasonNames(reasonBits, target)
     return target
 end
 
+local function IsNoCooldownForVisibility(button)
+    if not (button and button._noCooldown == true) then
+        return false
+    end
+
+    return button._baseNoCooldown ~= false
+end
+
 -- Evaluate per-button visibility rules and set hidden/alpha override state.
 -- Called inside UpdateButtonCooldown after cooldown fetch and aura tracking are complete.
 -- Fast path: if no toggles are enabled, zero overhead.
@@ -121,9 +129,10 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local barAuraStackDisplay = button._barAuraStackDisplay == true
     local itemUsesResolvedCooldownState = buttonData.type == "item"
         and button._resolvedItemQuantityKind == "stacks"
+    local noCooldownForVisibility = IsNoCooldownForVisibility(button)
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
-    if buttonData.hideWhileOnCooldown and not button._noCooldown and not barAuraStackDisplay then
+    if buttonData.hideWhileOnCooldown and not noCooldownForVisibility and not barAuraStackDisplay then
         if itemUsesResolvedCooldownState then
             if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
@@ -145,7 +154,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     end
 
     -- Check hideWhileNotOnCooldown (skip for no-CD spells — would permanently hide)
-    if buttonData.hideWhileNotOnCooldown and not button._noCooldown and not barAuraStackDisplay then
+    if buttonData.hideWhileNotOnCooldown and not noCooldownForVisibility and not barAuraStackDisplay then
         if itemUsesResolvedCooldownState then
             if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1523,6 +1523,8 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
             if buttonData and buttonData.type == "spell" then
                 button._noCooldown = nil
                 button._noCooldownSpellId = nil
+                button._baseNoCooldown = nil
+                button._baseNoCooldownSpellId = nil
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil


### PR DESCRIPTION
## What Players Will Notice
- Cooldown icons set to hide while not on cooldown should stay hidden when temporary spell override states, such as Downpour-related Shaman behavior, are active.
- Icons should still appear normally when their own saved spell is actually on cooldown.

## Why This Changed
- Temporary spell overrides could make Cooldown Companion classify the currently displayed spell as having no real cooldown, then use that result for the saved button's visibility rules. That let some hidden icons appear even though their saved spell should still follow Hide While Not On Cooldown.

## What Changed
- Cache the saved/base spell's no-cooldown classification separately from the currently displayed override spell.
- Use the base spell classification when deciding whether cooldown visibility rules should be skipped.
- Clear the new cached base classification anywhere the existing no-cooldown/runtime spell state is reset.

## Validation
- Confirmed by the affected profile after reload that the original Downpour hidden-icon repro no longer occurred.
- Ran `git diff --check 2fe143aa1e1dec3d65b55be8efb06eca1bd95f62`.
- Ran `luac -p` on tracked Lua files.
- Ran `lua Tests\visual-state-snapshot.lua`.
- Ran `lua Tests\visual-state-diagnostics.lua`.
- Ran `lua Tests\custom-bar-entry-runtime.lua`.
- Ran additional read-only review passes with no actionable findings.
- Combat and restricted-content behavior were not separately verified for this patch.