### PR TITLE
Fix hidden cooldown icons during spell overrides (again)

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1782,6 +1782,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._baseNoCooldown = nil
+    button._baseNoCooldownSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -35,7 +35,7 @@ local InCombatLockdown = InCombatLockdown
 local UnitCanAttack = UnitCanAttack
 
 -- Imports from Utils
-local HasTooltipCooldown = ST.HasTooltipCooldown
+local IsNoCooldownSpell = ST.IsNoCooldownSpell
 
 -- Imports from Preview
 local GetConditionalVisualPreview = ST._GetConditionalVisualPreview
@@ -512,22 +512,6 @@ local function GetLiveOverrideSpellID(buttonData)
     end
 
     return nil
-end
-
-local function HasChargeCooldownInfo(spellID)
-    local charges = C_Spell.GetSpellCharges(spellID)
-    local maxCharges = charges and charges.maxCharges
-    if maxCharges and not issecretvalue(maxCharges) then
-        return (tonumber(maxCharges) or 0) > 0
-    end
-    return false
-end
-
-local function IsNoCooldownSpell(spellID)
-    local baseCd = GetSpellBaseCooldown(spellID)
-    return (not baseCd or baseCd == 0)
-        and not HasTooltipCooldown(spellID)
-        and not HasChargeCooldownInfo(spellID)
 end
 
 local function ResolveChargeState(button, buttonData)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -514,9 +514,20 @@ local function GetLiveOverrideSpellID(buttonData)
     return nil
 end
 
+local function HasChargeCooldownInfo(spellID)
+    local charges = C_Spell.GetSpellCharges(spellID)
+    local maxCharges = charges and charges.maxCharges
+    if maxCharges and not issecretvalue(maxCharges) then
+        return (tonumber(maxCharges) or 0) > 0
+    end
+    return false
+end
+
 local function IsNoCooldownSpell(spellID)
     local baseCd = GetSpellBaseCooldown(spellID)
-    return (not baseCd or baseCd == 0) and not HasTooltipCooldown(spellID)
+    return (not baseCd or baseCd == 0)
+        and not HasTooltipCooldown(spellID)
+        and not HasChargeCooldownInfo(spellID)
 end
 
 local function ResolveChargeState(button, buttonData)

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -514,6 +514,11 @@ local function GetLiveOverrideSpellID(buttonData)
     return nil
 end
 
+local function IsNoCooldownSpell(spellID)
+    local baseCd = GetSpellBaseCooldown(spellID)
+    return (not baseCd or baseCd == 0) and not HasTooltipCooldown(spellID)
+end
+
 local function ResolveChargeState(button, buttonData)
     if not UsesChargeBehavior(buttonData) then
         return nil
@@ -729,15 +734,22 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     -- Lazy-cache no-cooldown detection for spells (GCD-only, no real CD).
     -- Tie the cache to the displayed spell so replacements do not inherit the
     -- base spell's cooldown classification.
+    -- Keep the base classification too, so temporary no-CD overrides do not
+    -- bypass cooldown visibility rules for a real cooldown entry.
     if buttonData.type == "spell" and not buttonData.isPassive and not usesChargeBehavior then
+        if button._baseNoCooldown == nil or button._baseNoCooldownSpellId ~= buttonData.id then
+            button._baseNoCooldownSpellId = buttonData.id
+            button._baseNoCooldown = IsNoCooldownSpell(buttonData.id)
+        end
         if button._noCooldown == nil or button._noCooldownSpellId ~= cooldownSpellId then
             button._noCooldownSpellId = cooldownSpellId
-            local baseCd = GetSpellBaseCooldown(cooldownSpellId)
-            button._noCooldown = (not baseCd or baseCd == 0) and not HasTooltipCooldown(cooldownSpellId)
+            button._noCooldown = IsNoCooldownSpell(cooldownSpellId)
         end
     else
         button._noCooldown = false
         button._noCooldownSpellId = nil
+        button._baseNoCooldown = nil
+        button._baseNoCooldownSpellId = nil
     end
 
     -- Proc state: event-driven table lookup (base spell + current displayed override).

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1224,6 +1224,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._readyGlowMaxChargesSpellID = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._baseNoCooldown = nil
+    button._baseNoCooldownSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -90,6 +90,14 @@ local function GetButtonVisibilityReasonNames(reasonBits, target)
     return target
 end
 
+local function IsNoCooldownForVisibility(button)
+    if not (button and button._noCooldown == true) then
+        return false
+    end
+
+    return button._baseNoCooldown ~= false
+end
+
 -- Evaluate per-button visibility rules and set hidden/alpha override state.
 -- Called inside UpdateButtonCooldown after cooldown fetch and aura tracking are complete.
 -- Fast path: if no toggles are enabled, zero overhead.
@@ -121,9 +129,10 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local barAuraStackDisplay = button._barAuraStackDisplay == true
     local itemUsesResolvedCooldownState = buttonData.type == "item"
         and button._resolvedItemQuantityKind == "stacks"
+    local noCooldownForVisibility = IsNoCooldownForVisibility(button)
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
-    if buttonData.hideWhileOnCooldown and not button._noCooldown and not barAuraStackDisplay then
+    if buttonData.hideWhileOnCooldown and not noCooldownForVisibility and not barAuraStackDisplay then
         if itemUsesResolvedCooldownState then
             if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
@@ -145,7 +154,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     end
 
     -- Check hideWhileNotOnCooldown (skip for no-CD spells — would permanently hide)
-    if buttonData.hideWhileNotOnCooldown and not button._noCooldown and not barAuraStackDisplay then
+    if buttonData.hideWhileNotOnCooldown and not noCooldownForVisibility and not barAuraStackDisplay then
         if itemUsesResolvedCooldownState then
             if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -95,7 +95,7 @@ local function IsNoCooldownForVisibility(button)
         return false
     end
 
-    return button._baseNoCooldown ~= false
+    return button._baseNoCooldown == true
 end
 
 -- Evaluate per-button visibility rules and set hidden/alpha override state.

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -15,7 +15,7 @@ local AttachCollapseButton = ST._AttachCollapseButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 
-local HasTooltipCooldown = ST.HasTooltipCooldown
+local IsNoCooldownSpellID = ST.IsNoCooldownSpell
 local HasUsageRequirement = ST.HasUsageRequirement
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
@@ -265,8 +265,7 @@ end
 -- Returns true if a button has no real cooldown (GCD-only spell)
 local function IsNoCooldownSpell(bd)
     if not bd or bd.type ~= "spell" or bd.isPassive or UsesChargeBehavior(bd) then return false end
-    local baseCd = GetSpellBaseCooldown(bd.id)
-    return (not baseCd or baseCd == 0) and not HasTooltipCooldown(bd.id)
+    return IsNoCooldownSpellID(bd.id)
 end
 
 -- Returns true if all selected buttons are no-cooldown spells

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -10,7 +10,7 @@ local CreateRevertButton = ST._CreateRevertButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
-local HasTooltipCooldown = ST.HasTooltipCooldown
+local IsNoCooldownSpellID = ST.IsNoCooldownSpell
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -344,8 +344,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
 
     local isNoCooldownSpell = false
     if buttonData.type == "spell" and not buttonData.isPassive and not UsesChargeBehavior(buttonData) then
-        local baseCd = GetSpellBaseCooldown(buttonData.id)
-        isNoCooldownSpell = (not baseCd or baseCd == 0) and not HasTooltipCooldown(buttonData.id)
+        isNoCooldownSpell = IsNoCooldownSpellID(buttonData.id)
     end
 
     for _, sectionId in ipairs(sectionOrder) do

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -940,10 +940,20 @@ local function ResolveSpellCooldownSecrecy(owner, spellID)
     return C_Secrets.GetSpellCooldownSecrecy(spellID)
 end
 
+local function HasChargeCooldownInfo(spellID)
+    local charges = C_Spell.GetSpellCharges(spellID)
+    local maxCharges = charges and charges.maxCharges
+    if maxCharges and not issecretvalue(maxCharges) then
+        return (tonumber(maxCharges) or 0) > 0
+    end
+    return false
+end
+
 local function IsNoCooldownSpell(spellID)
     local baseCd = GetSpellBaseCooldown(spellID)
     return (not baseCd or baseCd == 0)
         and not (HasTooltipCooldown and HasTooltipCooldown(spellID))
+        and not HasChargeCooldownInfo(spellID)
 end
 
 local function ResolveNoCooldownState(owner, spellID, hasCharges)

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -6,7 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
-local HasTooltipCooldown = ST.HasTooltipCooldown
+local IsNoCooldownSpell = ST.IsNoCooldownSpell
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -938,22 +938,6 @@ local function ResolveSpellCooldownSecrecy(owner, spellID)
     end
 
     return C_Secrets.GetSpellCooldownSecrecy(spellID)
-end
-
-local function HasChargeCooldownInfo(spellID)
-    local charges = C_Spell.GetSpellCharges(spellID)
-    local maxCharges = charges and charges.maxCharges
-    if maxCharges and not issecretvalue(maxCharges) then
-        return (tonumber(maxCharges) or 0) > 0
-    end
-    return false
-end
-
-local function IsNoCooldownSpell(spellID)
-    local baseCd = GetSpellBaseCooldown(spellID)
-    return (not baseCd or baseCd == 0)
-        and not (HasTooltipCooldown and HasTooltipCooldown(spellID))
-        and not HasChargeCooldownInfo(spellID)
 end
 
 local function ResolveNoCooldownState(owner, spellID, hasCharges)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1523,6 +1523,8 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
             if buttonData and buttonData.type == "spell" then
                 button._noCooldown = nil
                 button._noCooldownSpellId = nil
+                button._baseNoCooldown = nil
+                button._baseNoCooldownSpellId = nil
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil

--- a/Core/SpellQueries.lua
+++ b/Core/SpellQueries.lua
@@ -6,6 +6,8 @@
 local ADDON_NAME, ST = ...
 
 local ipairs = ipairs
+local tonumber = tonumber
+local issecretvalue = issecretvalue
 
 --------------------------------------------------------------------------------
 -- Spell Resolution
@@ -109,6 +111,26 @@ function ST.HasTooltipCooldown(spellId)
     end
 
     return lastNoneLine ~= nil and lastNoneLine.rightText ~= nil and lastNoneLine.rightText ~= ""
+end
+
+-- Returns true when the charge API exposes cooldown-bearing data, including
+-- single-charge spells whose base cooldown can report as zero.
+function ST.HasChargeCooldownInfo(spellId)
+    if not spellId then return false end
+    local charges = C_Spell.GetSpellCharges(spellId)
+    local maxCharges = charges and charges.maxCharges
+    if maxCharges and not (issecretvalue and issecretvalue(maxCharges)) then
+        return (tonumber(maxCharges) or 0) > 0
+    end
+    return false
+end
+
+-- Returns true if the spell has no real cooldown surface (GCD-only).
+function ST.IsNoCooldownSpell(spellId)
+    local baseCd = GetSpellBaseCooldown(spellId)
+    return (not baseCd or baseCd == 0)
+        and not ST.HasTooltipCooldown(spellId)
+        and not ST.HasChargeCooldownInfo(spellId)
 end
 
 -- Returns true if the spell tooltip contains a UsageRequirement line


### PR DESCRIPTION
## What Players Will Notice
- Cooldown icons set to hide while not on cooldown should stay hidden when temporary spell override states, such as Downpour-related Shaman behavior, are active.
- Icons should still appear normally when their own saved spell is actually on cooldown.

## Why This Changed
- Temporary spell override and aura states could make Cooldown Companion treat saved cooldown entries as no-cooldown spells. That caused buttons such as Unleash Life and Spirit Link Totem to become visible during Downpour even though their own cooldown state was still ready.
- This replaces PR #303 after that merge was reverted from `main` so the complete fix can be reviewed together.

## What Changed
- Cache the saved/base spell's no-cooldown classification separately from the currently displayed override spell.
- Only let cooldown visibility rules skip when the saved/base spell is positively classified as no-cooldown.
- Treat spells with direct `C_Spell.GetSpellCharges` cooldown metadata as cooldown-capable, even when the base-cooldown or tooltip signal is unstable during temporary override states.
- Clear the new cached base classification anywhere the existing no-cooldown/runtime spell state is reset.

## Validation
- User confirmed the local follow-up patch stopped Unleash Life and Spirit Link Totem from showing during Downpour.
- Ran `git diff --check origin/main...HEAD`.
- Ran `luac -p` on tracked Lua files.
- Ran `lua Tests\visual-state-snapshot.lua`.
- Ran `lua Tests\visual-state-diagnostics.lua`.
- Ran `lua Tests\custom-bar-entry-runtime.lua`.
- Combat and restricted-content behavior were not separately verified for this patch.