### PR TITLE
Keep profile and bug-report restores on the same apply path

### DIFF
--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -11,7 +11,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local DecodeSharedPayload = ST._DecodeSharedPayload
 local PrepareSharedImportText = ST._PrepareSharedImportText
-local ResetConfigSelection = ST._ResetConfigSelection
+local ApplyFullProfileImport = ST._ApplyFullProfileImport
 
 -- File-local state
 local decodedDiagnostic = nil
@@ -922,52 +922,15 @@ StaticPopupDialogs["CDC_DIAGNOSTIC_IMPORT_CONFIRM"] = {
     button2 = "Cancel",
     OnAccept = function()
         if decodedDiagnostic and decodedDiagnostic.profile then
-            if RejectUnsupportedImportPayload(decodedDiagnostic.profile, "diagnostic profile") then
-                return
+            local imported = ApplyFullProfileImport and ApplyFullProfileImport(decodedDiagnostic.profile, {
+                dataLabel = "diagnostic profile",
+                exporterCharKey = decodedDiagnostic.meta and decodedDiagnostic.meta.charKey,
+                runtimeReason = "diagnostic-profile-import",
+                renameForeignCharacters = false,
+            })
+            if imported then
+                CooldownCompanion:Print("Diagnostic profile imported.")
             end
-            local db = CooldownCompanion.db
-            wipe(db.profile)
-            for k, v in pairs(decodedDiagnostic.profile) do
-                db.profile[k] = v
-            end
-            ResetConfigSelection(true)
-            -- Remap only the exporter's own entities to the importer's character.
-            -- Other characters' entities keep their original createdBy so they
-            -- appear in the browse-other-characters module instead of being
-            -- flattened into the current character.
-            local charKey = db.keys.char
-            local exporterCharKey = decodedDiagnostic.meta and decodedDiagnostic.meta.charKey
-            if db.profile.groups then
-                for _, group in pairs(db.profile.groups) do
-                    if not group.isGlobal and (exporterCharKey == nil or group.createdBy == exporterCharKey) then
-                        group.createdBy = charKey
-                    end
-                end
-            end
-            if db.profile.groupContainers then
-                for _, container in pairs(db.profile.groupContainers) do
-                    if not container.isGlobal and (exporterCharKey == nil or container.createdBy == exporterCharKey) then
-                        container.createdBy = charKey
-                    end
-                end
-            end
-            if db.profile.folders then
-                for _, folder in pairs(db.profile.folders) do
-                    if folder.section == "char" and (exporterCharKey == nil or folder.createdBy == exporterCharKey) then
-                        folder.createdBy = charKey
-                    end
-                end
-            end
-            CooldownCompanion:ClearMigrationSentinels()
-            if not CooldownCompanion:RunAllMigrations() then
-                return
-            end
-            CooldownCompanion:RefreshConfigPanel()
-            CooldownCompanion:RefreshAllGroups()
-            if CooldownCompanion.EvaluateBarsAndFramesRuntime then
-                CooldownCompanion:EvaluateBarsAndFramesRuntime("diagnostic-profile-import")
-            end
-            CooldownCompanion:Print("Diagnostic profile imported.")
         end
     end,
     timeout = 0,

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -17,6 +17,7 @@ local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local DecodeSharedPayload = ST._DecodeSharedPayload
 local PrepareSharedImportText = ST._PrepareSharedImportText
+local ApplyFullProfileImport = ST._ApplyFullProfileImport
 
 -- Check whether a profile name already exists (case-exact match).
 local function ProfileNameExists(name)
@@ -498,133 +499,16 @@ local function DecodeProfileImport(popup)
     return data
 end
 
--- Applies a decoded profile import, remapping only the exporter's own
--- entities to the current character. Other characters' entities keep
--- their original createdBy so they appear in the browse-other-characters
--- module instead of being flattened into the current character.
 local function ApplyProfileImport(data)
-    if RejectUnsupportedImportPayload(data, "profile import") then
+    if not ApplyFullProfileImport then
         return false
     end
 
-    local db = CooldownCompanion.db
-    local exporterCharKey = data._exporterCharKey
-    local exportedCharInfo = data._characterInfo
-    data._exporterCharKey = nil
-    data._characterInfo = nil
-
-    -- True replace: wipe existing profile before applying import.
-    -- AceDB metatable survives wipe, supplying defaults for missing keys.
-    wipe(db.profile)
-    for k, v in pairs(data) do
-        db.profile[k] = v
-    end
-    ResetConfigSelection(true)
-
-    -- Remap only the exporter's own entities to the importer's character.
-    local charKey = db.keys.char
-    if db.profile.groups then
-        for _, group in pairs(db.profile.groups) do
-            if not group.isGlobal and (exporterCharKey == nil or group.createdBy == exporterCharKey) then
-                group.createdBy = charKey
-            end
-        end
-    end
-    if db.profile.groupContainers then
-        for _, container in pairs(db.profile.groupContainers) do
-            if not container.isGlobal and (exporterCharKey == nil or container.createdBy == exporterCharKey) then
-                container.createdBy = charKey
-            end
-        end
-    end
-    if db.profile.folders then
-        for _, folder in pairs(db.profile.folders) do
-            if folder.section == "char" and (exporterCharKey == nil or folder.createdBy == exporterCharKey) then
-                folder.createdBy = charKey
-            end
-        end
-    end
-    -- Rename foreign characters to class-based placeholders.
-    -- A "foreign" character is one whose createdBy doesn't match any
-    -- character in the importer's own characterInfo.
-    local importerCharInfo = db.global.characterInfo or {}
-    local foreignKeys = {}
-    local function markForeignCharKey(cb)
-        if not cb or cb == charKey then return end
-        if not importerCharInfo[cb] and not foreignKeys[cb] then
-            foreignKeys[cb] = true
-        end
-    end
-    local function markForeign(entity, checkGlobal)
-        if checkGlobal and entity.isGlobal then return end
-        markForeignCharKey(entity.createdBy)
-    end
-    for _, group in pairs(db.profile.groups or {}) do markForeign(group, true) end
-    for _, container in pairs(db.profile.groupContainers or {}) do markForeign(container, true) end
-    for _, folder in pairs(db.profile.folders or {}) do
-        if folder.section == "char" then markForeign(folder, false) end
-    end
-
-    if next(foreignKeys) then
-        -- Count characters per class for numbering
-        local classCounts = {}
-        local classEntries = {}
-        for foreignKey in pairs(foreignKeys) do
-            local info = exportedCharInfo and exportedCharInfo[foreignKey]
-            local classID = info and info.classID
-            local className = classID and GetClassInfo(classID) or "Character"
-            classCounts[className] = (classCounts[className] or 0) + 1
-            classEntries[foreignKey] = { className = className, classFilename = info and info.classFilename, classID = classID }
-        end
-
-        -- Build rename map: old createdBy → placeholder name
-        local renames = {}
-        local classCounters = {}
-        for foreignKey in pairs(foreignKeys) do
-            local entry = classEntries[foreignKey]
-            local placeholder
-            if classCounts[entry.className] == 1 then
-                placeholder = entry.className
-            else
-                classCounters[entry.className] = (classCounters[entry.className] or 0) + 1
-                placeholder = entry.className .. " " .. classCounters[entry.className]
-            end
-            renames[foreignKey] = placeholder
-            -- Register in characterInfo so browse module shows correct class icon/color
-            if entry.classFilename and entry.classID then
-                importerCharInfo[placeholder] = { classFilename = entry.classFilename, classID = entry.classID }
-            end
-        end
-
-        -- Apply renames across all entity types
-        for _, group in pairs(db.profile.groups or {}) do
-            if group.createdBy and renames[group.createdBy] then
-                group.createdBy = renames[group.createdBy]
-            end
-        end
-        for _, container in pairs(db.profile.groupContainers or {}) do
-            if container.createdBy and renames[container.createdBy] then
-                container.createdBy = renames[container.createdBy]
-            end
-        end
-        for _, folder in pairs(db.profile.folders or {}) do
-            if folder.createdBy and renames[folder.createdBy] then
-                folder.createdBy = renames[folder.createdBy]
-            end
-        end
-    end
-
-    CooldownCompanion:ClearMigrationSentinels()
-    if not CooldownCompanion:RunAllMigrations() then
-        return false
-    end
-
-    CooldownCompanion:RefreshConfigPanel()
-    CooldownCompanion:RefreshAllGroups()
-    if CooldownCompanion.EvaluateBarsAndFramesRuntime then
-        CooldownCompanion:EvaluateBarsAndFramesRuntime("profile-import")
-    end
-    return true
+    return ApplyFullProfileImport(data, {
+        dataLabel = "profile import",
+        runtimeReason = "profile-import",
+        renameForeignCharacters = true,
+    })
 end
 
 StaticPopupDialogs["CDC_CONFIRM_PROFILE_IMPORT"] = {

--- a/Config/ProfileImport.lua
+++ b/Config/ProfileImport.lua
@@ -1,0 +1,341 @@
+--[[
+    CooldownCompanion - Config/ProfileImport
+    Shared full-profile import and diagnostic restore apply/remap helpers.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local ResetConfigSelection = ST._ResetConfigSelection
+
+local PROFILE_IMPORT_METADATA_KEYS = {
+    _exporterCharKey = true,
+    _characterInfo = true,
+}
+
+local SCOPED_STORE_KEYS = {
+    "resourceBarsByChar",
+    "castBarByChar",
+    "frameAnchoringByChar",
+}
+
+local function IsUnsupportedImportPayload(data, dataLabel)
+    if CooldownCompanion.IsUnsupportedImportPayload
+        and CooldownCompanion:IsUnsupportedImportPayload(data)
+    then
+        if CooldownCompanion.NotifyLegacySupportCutoff then
+            CooldownCompanion:NotifyLegacySupportCutoff(dataLabel)
+        end
+        return true
+    end
+    return false
+end
+
+local function ShouldRemapExporterOwned(createdBy, exporterCharKey)
+    return exporterCharKey == nil or createdBy == exporterCharKey
+end
+
+local function RemapCurrentCharacterEntities(profile, charKey, exporterCharKey)
+    if type(profile) ~= "table" or type(charKey) ~= "string" or charKey == "" then
+        return
+    end
+
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            if type(group) == "table"
+                and not group.isGlobal
+                and ShouldRemapExporterOwned(group.createdBy, exporterCharKey)
+            then
+                group.createdBy = charKey
+            end
+        end
+    end
+
+    if type(profile.groupContainers) == "table" then
+        for _, container in pairs(profile.groupContainers) do
+            if type(container) == "table"
+                and not container.isGlobal
+                and ShouldRemapExporterOwned(container.createdBy, exporterCharKey)
+            then
+                container.createdBy = charKey
+            end
+        end
+    end
+
+    if type(profile.folders) == "table" then
+        for _, folder in pairs(profile.folders) do
+            if type(folder) == "table"
+                and folder.section == "char"
+                and ShouldRemapExporterOwned(folder.createdBy, exporterCharKey)
+            then
+                folder.createdBy = charKey
+            end
+        end
+    end
+end
+
+local function CountScopedStoreBuckets(store)
+    local count = 0
+    local onlyKey = nil
+    for charKey, settings in pairs(store) do
+        if type(settings) == "table" then
+            count = count + 1
+            onlyKey = charKey
+        end
+    end
+    return count, onlyKey
+end
+
+local function ResolveScopedStoreSourceKey(store, charKey, exporterCharKey)
+    if type(store) ~= "table" or type(charKey) ~= "string" or charKey == "" then
+        return nil
+    end
+
+    if type(exporterCharKey) == "string" and exporterCharKey ~= "" then
+        if type(store[exporterCharKey]) == "table" then
+            return exporterCharKey
+        end
+        return nil
+    end
+
+    local count, onlyKey = CountScopedStoreBuckets(store)
+    if count == 1 then
+        return onlyKey
+    end
+    return nil
+end
+
+local function RemapScopedStore(profile, storeKey, charKey, exporterCharKey, remappedSourceKeys)
+    local store = type(profile) == "table" and profile[storeKey] or nil
+    if type(store) ~= "table" then
+        return
+    end
+
+    local sourceKey = ResolveScopedStoreSourceKey(store, charKey, exporterCharKey)
+    if not sourceKey then
+        return
+    end
+
+    remappedSourceKeys[sourceKey] = true
+    if sourceKey ~= charKey then
+        store[charKey] = store[sourceKey]
+        store[sourceKey] = nil
+    end
+end
+
+local function RemapScopedStoreSeenCharacters(profile, charKey, exporterCharKey, remappedSourceKeys)
+    local seen = type(profile) == "table" and profile.legacyScopedBarSeenCharacters or nil
+    if type(seen) ~= "table" or type(charKey) ~= "string" or charKey == "" then
+        return
+    end
+
+    if type(exporterCharKey) == "string" and exporterCharKey ~= "" then
+        remappedSourceKeys[exporterCharKey] = true
+    end
+
+    local sawRemap = false
+    for sourceKey in pairs(remappedSourceKeys) do
+        if sourceKey ~= charKey then
+            seen[sourceKey] = nil
+            sawRemap = true
+        end
+    end
+    if sawRemap then
+        seen[charKey] = true
+    end
+end
+
+local function RemapCharacterScopedStores(profile, charKey, exporterCharKey)
+    local remappedSourceKeys = {}
+    for _, storeKey in ipairs(SCOPED_STORE_KEYS) do
+        RemapScopedStore(profile, storeKey, charKey, exporterCharKey, remappedSourceKeys)
+    end
+    RemapScopedStoreSeenCharacters(profile, charKey, exporterCharKey, remappedSourceKeys)
+end
+
+local function MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, createdBy)
+    if not createdBy or createdBy == charKey then
+        return
+    end
+    if not importerCharInfo[createdBy] and not foreignKeys[createdBy] then
+        foreignKeys[createdBy] = true
+    end
+end
+
+local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
+    local foreignKeys = {}
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            if type(group) == "table" and not group.isGlobal then
+                MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, group.createdBy)
+            end
+        end
+    end
+    if type(profile.groupContainers) == "table" then
+        for _, container in pairs(profile.groupContainers) do
+            if type(container) == "table" and not container.isGlobal then
+                MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, container.createdBy)
+            end
+        end
+    end
+    if type(profile.folders) == "table" then
+        for _, folder in pairs(profile.folders) do
+            if type(folder) == "table" and folder.section == "char" then
+                MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, folder.createdBy)
+            end
+        end
+    end
+    return foreignKeys
+end
+
+local function BuildForeignCharacterRenames(foreignKeys, exportedCharInfo, importerCharInfo)
+    local classCounts = {}
+    local classEntries = {}
+    for foreignKey in pairs(foreignKeys) do
+        local info = type(exportedCharInfo) == "table" and exportedCharInfo[foreignKey] or nil
+        local classID = info and info.classID
+        local className = classID and GetClassInfo(classID) or "Character"
+        classCounts[className] = (classCounts[className] or 0) + 1
+        classEntries[foreignKey] = {
+            className = className,
+            classFilename = info and info.classFilename,
+            classID = classID,
+        }
+    end
+
+    local renames = {}
+    local classCounters = {}
+    for foreignKey in pairs(foreignKeys) do
+        local entry = classEntries[foreignKey]
+        local placeholder
+        if classCounts[entry.className] == 1 then
+            placeholder = entry.className
+        else
+            classCounters[entry.className] = (classCounters[entry.className] or 0) + 1
+            placeholder = entry.className .. " " .. classCounters[entry.className]
+        end
+        renames[foreignKey] = placeholder
+        if entry.classFilename and entry.classID then
+            importerCharInfo[placeholder] = {
+                classFilename = entry.classFilename,
+                classID = entry.classID,
+            }
+        end
+    end
+
+    return renames
+end
+
+local function ApplyCharacterRenames(profile, renames)
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            if type(group) == "table" and group.createdBy and renames[group.createdBy] then
+                group.createdBy = renames[group.createdBy]
+            end
+        end
+    end
+    if type(profile.groupContainers) == "table" then
+        for _, container in pairs(profile.groupContainers) do
+            if type(container) == "table" and container.createdBy and renames[container.createdBy] then
+                container.createdBy = renames[container.createdBy]
+            end
+        end
+    end
+    if type(profile.folders) == "table" then
+        for _, folder in pairs(profile.folders) do
+            if type(folder) == "table" and folder.createdBy and renames[folder.createdBy] then
+                folder.createdBy = renames[folder.createdBy]
+            end
+        end
+    end
+end
+
+local function RenameForeignCharacters(profile, charKey, exportedCharInfo, importerCharInfo)
+    if type(profile) ~= "table" or type(charKey) ~= "string" or charKey == "" then
+        return
+    end
+
+    if type(importerCharInfo) ~= "table" then
+        return
+    end
+
+    local foreignKeys = CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
+    if not next(foreignKeys) then
+        return
+    end
+
+    local renames = BuildForeignCharacterRenames(foreignKeys, exportedCharInfo, importerCharInfo)
+    ApplyCharacterRenames(profile, renames)
+end
+
+local function CopyProfileDataIntoActiveProfile(activeProfile, data)
+    wipe(activeProfile)
+    for key, value in pairs(data) do
+        if not PROFILE_IMPORT_METADATA_KEYS[key] then
+            activeProfile[key] = value
+        end
+    end
+end
+
+function CooldownCompanion:ApplyFullProfileImport(data, options)
+    if type(data) ~= "table" then
+        return false
+    end
+
+    options = options or {}
+    if IsUnsupportedImportPayload(data, options.dataLabel or "profile import") then
+        return false
+    end
+
+    local db = self.db
+    if type(db) ~= "table" or type(db.profile) ~= "table" then
+        return false
+    end
+
+    local exporterCharKey = options.exporterCharKey
+    if exporterCharKey == nil then
+        exporterCharKey = data._exporterCharKey
+    end
+    local exportedCharInfo = options.exportedCharInfo
+    if exportedCharInfo == nil then
+        exportedCharInfo = data._characterInfo
+    end
+
+    CopyProfileDataIntoActiveProfile(db.profile, data)
+
+    if ResetConfigSelection then
+        ResetConfigSelection(true)
+    end
+
+    local charKey = db.keys and db.keys.char
+    RemapCurrentCharacterEntities(db.profile, charKey, exporterCharKey)
+    RemapCharacterScopedStores(db.profile, charKey, exporterCharKey)
+
+    if options.renameForeignCharacters then
+        local importerCharInfo = db.global and db.global.characterInfo or {}
+        RenameForeignCharacters(db.profile, charKey, exportedCharInfo, importerCharInfo)
+    end
+
+    if self.ClearMigrationSentinels then
+        self:ClearMigrationSentinels()
+    end
+    if self.RunAllMigrations and not self:RunAllMigrations() then
+        return false
+    end
+
+    if self.RefreshConfigPanel then
+        self:RefreshConfigPanel()
+    end
+    if self.RefreshAllGroups then
+        self:RefreshAllGroups()
+    end
+    if self.EvaluateBarsAndFramesRuntime then
+        self:EvaluateBarsAndFramesRuntime(options.runtimeReason or "profile-import")
+    end
+
+    return true
+end
+
+ST._ApplyFullProfileImport = function(data, options)
+    return CooldownCompanion:ApplyFullProfileImport(data, options)
+end

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -94,6 +94,7 @@ Core\FrameAnchoring.lua
 Config\State.lua
 Config\Tutorial.lua
 Config\ExportCodec.lua
+Config\ProfileImport.lua
 Config\Popups.lua
 Config\Diagnostics.lua
 Config\Pickers.lua


### PR DESCRIPTION
## What Players Will Notice
- Full profile imports and diagnostic profile restores now apply character-scoped Bars & Frames data consistently to the importing character.
- Resource/Custom Bars, Cast Bar settings, and frame anchoring are no longer left behind under the exporting character when restoring a profile on another character.

## Why This Changed
- Normal profile import and diagnostic profile restore were maintaining separate wipe/apply/remap logic.
- That duplication made profile shape changes easy to fix in one path while missing the other, and the old restore path did not consistently remap newer character-scoped Bars & Frames stores.

## What Changed
- Added a shared full-profile apply helper in `Config/ProfileImport.lua`.
- Routed normal profile import and diagnostic profile restore through that helper.
- Centralized character-owned group/container/folder remapping, migration reruns, config refreshes, group refreshes, and Bars & Frames runtime reevaluation.
- Added scoped-store remapping for `resourceBarsByChar`, `castBarByChar`, `frameAnchoringByChar`, and `legacyScopedBarSeenCharacters`.
- Preserved the existing distinction where normal profile import can rename unrelated foreign characters to class placeholders, while diagnostic restore keeps more of the original diagnostic profile shape for reproduction.

## Validation
- Static/local checks passed:
  - `lua tests\profile-import-apply.lua`
  - `luac -p Config\ProfileImport.lua Config\Popups.lua Config\Diagnostics.lua`
  - `git diff --check origin/import-export...HEAD`
- Code review found no actionable issues.
- In-game validation cleared for PR1 restore behavior: profile import and diagnostic profile restore both succeeded on another character and brought scoped Bars & Frames / Custom Bar data over through the shared restore path.
- Cross-class full restore can still bring source-class groups or Custom Bars onto the importing character; that is expected literal restore behavior for PR1 and is captured for the PR3 selected-pieces flow to label, gate, or skip more gracefully.