### PR TITLE
Add selected profile-piece import for backups

### DIFF
--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -731,7 +731,7 @@ local function RefreshProfileBar(bar)
         ShowPopupAboveConfig("CDC_EXPORT_PROFILE")
     end)
 
-    AddBarButton("Import", function()
+    AddBarButton("Import Backup", function()
         OpenImportReviewWindow()
     end)
 

--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -727,7 +727,7 @@ local function RefreshProfileBar(bar)
         end
     end)
 
-    AddBarButton("Export", function()
+    AddBarButton("Export Backup", function()
         ShowPopupAboveConfig("CDC_EXPORT_PROFILE")
     end)
 

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -24,7 +24,11 @@ local MAX_CUSTOM_BARS_IMPORT_LENGTH = 100000
 local DIAGNOSTIC_PREFIX = "CDCdiag:"
 local IMPORT_REVIEW_CONFIRM_POPUP = "CDC_IMPORT_REVIEW_CONFIRM"
 local IMPORT_TEXT_LINES = 8
-local IMPORT_TEXT_HEIGHT = 150
+local IMPORT_TEXT_HEIGHT = 160
+local IMPORT_REVIEW_HEIGHT = 220
+local IMPORT_ACTION_HEIGHT = 30
+local IMPORT_WINDOW_WIDTH = 640
+local IMPORT_WINDOW_HEIGHT = 500
 local IMPORT_MODE_LABELS = {
     restore = "Restore full profile",
     selected = "Import selected pieces",
@@ -501,6 +505,21 @@ local function AddButton(group, text, width)
     return button
 end
 
+local function RelayoutImportWindow(frame, reviewScroll, ...)
+    for i = 1, select("#", ...) do
+        local group = select(i, ...)
+        if group and group.DoLayout then
+            group:DoLayout()
+        end
+    end
+    if reviewScroll and reviewScroll.DoLayout then
+        reviewScroll:DoLayout()
+    end
+    if frame and frame.DoLayout then
+        frame:DoLayout()
+    end
+end
+
 local function CloseImportReviewFrame(widget)
     activeReview = nil
     if pendingReviewImport and pendingReviewImport.frame == widget then
@@ -660,8 +679,8 @@ local function ShowImportReviewWindow(context)
 
     local frame = AceGUI:Create("Window")
     frame:SetTitle("Import")
-    frame:SetWidth(560)
-    frame:SetHeight(430)
+    frame:SetWidth(IMPORT_WINDOW_WIDTH)
+    frame:SetHeight(IMPORT_WINDOW_HEIGHT)
     frame:SetLayout("List")
     importReviewFrame = frame
     activeReview = nil
@@ -679,28 +698,31 @@ local function ShowImportReviewWindow(context)
     inputBox:DisableButton(true)
     pasteGroup:AddChild(inputBox)
 
-    local reviewGroup = AceGUI:Create("SimpleGroup")
-    reviewGroup:SetFullWidth(true)
-    reviewGroup:SetLayout("List")
-    frame:AddChild(reviewGroup)
+    local reviewScroll = AceGUI:Create("ScrollFrame")
+    reviewScroll:SetFullWidth(true)
+    reviewScroll:SetHeight(IMPORT_REVIEW_HEIGHT)
+    reviewScroll:SetLayout("List")
+    frame:AddChild(reviewScroll)
 
     local modeGroup = AceGUI:Create("SimpleGroup")
     modeGroup:SetFullWidth(true)
     modeGroup:SetLayout("Flow")
-    reviewGroup:AddChild(modeGroup)
+    reviewScroll:AddChild(modeGroup)
 
     local statusLabel = AceGUI:Create("Label")
     ConfigureWrappedLabel(statusLabel)
     statusLabel:SetText("|cff888888No import string reviewed.|r")
-    reviewGroup:AddChild(statusLabel)
+    reviewScroll:AddChild(statusLabel)
 
     local pieceGroup = AceGUI:Create("SimpleGroup")
     pieceGroup:SetFullWidth(true)
     pieceGroup:SetLayout("List")
-    reviewGroup:AddChild(pieceGroup)
+    reviewScroll:AddChild(pieceGroup)
 
     local buttonGroup = AceGUI:Create("SimpleGroup")
     buttonGroup:SetFullWidth(true)
+    buttonGroup:SetHeight(IMPORT_ACTION_HEIGHT)
+    buttonGroup.noAutoHeight = true
     buttonGroup:SetLayout("Flow")
 
     local acceptButton = AddButton(buttonGroup, "Import", 220)
@@ -717,6 +739,7 @@ local function ShowImportReviewWindow(context)
         if activeReview then
             statusLabel:SetText(FormatReviewText(activeReview))
         end
+        RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)
     end
 
     local function ClearReview()
@@ -725,6 +748,7 @@ local function ShowImportReviewWindow(context)
         acceptButton:SetText("Import")
         ReleaseChildren(modeGroup)
         ReleaseChildren(pieceGroup)
+        RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)
     end
 
     local function ReviewInput()
@@ -732,10 +756,14 @@ local function ShowImportReviewWindow(context)
         if not review.ok then
             ClearReview()
             statusLabel:SetText("|cffff6666" .. (review.message or "Import failed.") .. "|r")
+            RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)
             return
         end
 
         activeReview = review
+        if reviewScroll.SetScroll then
+            reviewScroll:SetScroll(0)
+        end
         RefreshPresentation()
     end
 

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -701,7 +701,7 @@ local function RenderPieceRows(group, review, refresh)
         ConfigureWrappedLabel(customBarsLabel)
         customBarsLabel:SetText(
             "|cff888888Custom Bars found in this profile are not selectable "
-            .. "until the next import/export PR.|r"
+            .. "yet.|r"
         )
         group:AddChild(customBarsLabel)
     end

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -14,12 +14,22 @@ local ApplyProfileImportData = ST._ApplyProfileImportData
 local ApplyGroupImportData = ST._ApplyGroupImportData
 local ApplyCustomBarsImportData = ST._ApplyCustomBarsImportData
 local ApplyFullProfileImport = ST._ApplyFullProfileImport
+local BuildProfileImportPiecesReview = ST._BuildProfileImportPiecesReview
+local RecountProfileImportPiecesSelection = ST._RecountProfileImportPiecesSelection
+local ApplyProfileImportPieces = ST._ApplyProfileImportPieces
 local CS = ST._configState
 
 local MAX_IMPORT_LENGTH = 500000
 local MAX_CUSTOM_BARS_IMPORT_LENGTH = 100000
 local DIAGNOSTIC_PREFIX = "CDCdiag:"
 local IMPORT_REVIEW_CONFIRM_POPUP = "CDC_IMPORT_REVIEW_CONFIRM"
+local IMPORT_TEXT_LINES = 8
+local IMPORT_TEXT_HEIGHT = 150
+local IMPORT_MODE_LABELS = {
+    restore = "Restore full profile",
+    selected = "Import selected pieces",
+}
+local IMPORT_MODE_ORDER = { "restore", "selected" }
 
 local importReviewFrame = nil
 local activeReview = nil
@@ -178,6 +188,67 @@ local function BuildProfileSummaryLines(profile, heading)
     return lines
 end
 
+local function IsProfileReviewKind(review)
+    return review and (review.kind == "profile" or review.kind == "diagnostic")
+end
+
+local function ReviewUsesSelectedPieces(review)
+    return IsProfileReviewKind(review) and review.mode == "selected"
+end
+
+local function RecountSelectedPieces(review)
+    if not (review and review.pieces) then
+        return 0
+    end
+    if RecountProfileImportPiecesSelection then
+        return RecountProfileImportPiecesSelection(review.pieces)
+    end
+    local selected = 0
+    for _, row in ipairs(review.pieces.rows or {}) do
+        if row.eligible and row.selected then
+            selected = selected + 1
+        end
+    end
+    review.pieces.selectedCount = selected
+    return selected
+end
+
+local function BuildSelectedPiecesSummaryLines(review)
+    local pieces = review and review.pieces or nil
+    local lines = {}
+    AddLine(lines, review.kind == "diagnostic" and "Diagnostic selected pieces" or "Profile selected pieces")
+    AddLine(lines, FormatCount("Importable items", pieces and pieces.eligibleCount or 0))
+    AddLine(lines, FormatCount("Selected items", RecountSelectedPieces(review)))
+    if pieces and pieces.disabledCount and pieces.disabledCount > 0 then
+        AddLine(lines, FormatCount("Skipped/incompatible items", pieces.disabledCount))
+    end
+    if pieces and pieces.customBarCount and pieces.customBarCount > 0 then
+        AddLine(lines, "Custom Bars: " .. tostring(pieces.customBarCount) .. " (not selectable in this PR)")
+    end
+    return lines
+end
+
+local function GetReviewAcceptText(review)
+    if ReviewUsesSelectedPieces(review) then
+        return "Import Selected"
+    end
+    return review and review.acceptText or "Import"
+end
+
+local function CanApplyReview(review)
+    if not review then
+        return false
+    end
+    if ReviewUsesSelectedPieces(review) then
+        return RecountSelectedPieces(review) > 0
+    end
+    return true
+end
+
+local function ReviewIsDestructive(review)
+    return review and review.destructive and not ReviewUsesSelectedPieces(review)
+end
+
 local function BuildCustomBarsSummaryLines(data)
     local lines = {
         "Custom Bars export",
@@ -232,16 +303,23 @@ local function ClassifyProfilePayload(data)
         return validation
     end
 
+    local pieces = BuildProfileImportPiecesReview and BuildProfileImportPiecesReview(data, {
+        exporterCharKey = data._exporterCharKey,
+    }) or nil
+
     return BuildReview("profile", data, "Profile Restore", "Restore Profile",
         BuildProfileSummaryLines(data, "Full profile export"), {
         destructive = true,
+        mode = "restore",
+        pieces = pieces,
         warning = "This will replace your current profile.",
     })
 end
 
 local function ClassifyDiagnosticPayload(data)
     if type(data.profile) ~= "table" then
-        return BuildError("diagnostic_without_profile", "This diagnostic string does not include an importable profile.")
+        return BuildError("diagnostic_without_profile",
+            "This diagnostic string does not include an importable profile.")
     end
     if IsUnsupportedPayload(data.profile) then
         return BuildLegacyError("diagnostic profile")
@@ -257,10 +335,16 @@ local function ClassifyDiagnosticPayload(data)
         table.insert(lines, 2, "Source: " .. tostring(meta.charName))
     end
 
+    local pieces = BuildProfileImportPiecesReview and BuildProfileImportPiecesReview(data.profile, {
+        exporterCharKey = meta and meta.charKey,
+    }) or nil
+
     return BuildReview("diagnostic", data.profile, "Diagnostic Profile Restore",
         "Restore Diagnostic Profile", lines, {
         diagnostic = data,
         destructive = true,
+        mode = "restore",
+        pieces = pieces,
         warning = "This will replace your current profile with the bug report profile.",
     })
 end
@@ -352,6 +436,14 @@ function CooldownCompanion:ApplyReviewedImport(review)
     end
 
     if review.kind == "profile" then
+        if ReviewUsesSelectedPieces(review) then
+            local imported = ApplyProfileImportPieces and ApplyProfileImportPieces(review.data, review.pieces)
+            if imported then
+                self:Print("Profile pieces imported.")
+            end
+            return imported == true
+        end
+
         local imported = ApplyProfileImportData and ApplyProfileImportData(review.data)
         if imported then
             self:Print("Profile imported.")
@@ -360,6 +452,14 @@ function CooldownCompanion:ApplyReviewedImport(review)
     end
 
     if review.kind == "diagnostic" then
+        if ReviewUsesSelectedPieces(review) then
+            local imported = ApplyProfileImportPieces and ApplyProfileImportPieces(review.data, review.pieces)
+            if imported then
+                self:Print("Diagnostic profile pieces imported.")
+            end
+            return imported == true
+        end
+
         local diagnostic = review.diagnostic
         local meta = GetDiagnosticMeta(diagnostic)
         local imported = ApplyFullProfileImport and ApplyFullProfileImport(review.data, {
@@ -433,7 +533,7 @@ local function GetDestructiveConfirmText(review)
 end
 
 local function ConfirmOrApplyReview(review, frame)
-    if review.destructive then
+    if ReviewIsDestructive(review) then
         pendingReviewImport = {
             review = review,
             frame = frame,
@@ -467,12 +567,89 @@ StaticPopupDialogs[IMPORT_REVIEW_CONFIRM_POPUP] = {
 
 local function FormatReviewText(review)
     local lines = {}
-    AddLine(lines, review.title and "|cffffd100" .. review.title .. "|r")
-    AddLine(lines, review.warning and "|cffff6666" .. review.warning .. "|r")
-    for _, line in ipairs(review.summaryLines or {}) do
+    local title = review.title
+    local warning = review.warning
+    local summaryLines = review.summaryLines
+    if ReviewUsesSelectedPieces(review) then
+        title = review.kind == "diagnostic" and "Diagnostic Profile Pieces" or "Profile Pieces Import"
+        warning = nil
+        summaryLines = BuildSelectedPiecesSummaryLines(review)
+    end
+
+    AddLine(lines, title and "|cffffd100" .. title .. "|r")
+    AddLine(lines, warning and "|cffff6666" .. warning .. "|r")
+    for _, line in ipairs(summaryLines or {}) do
         AddLine(lines, line)
     end
     return table.concat(lines, "\n")
+end
+
+local function ReleaseChildren(group)
+    if not group then
+        return
+    end
+    if group.ReleaseChildren then
+        group:ReleaseChildren()
+    else
+        group.children = {}
+    end
+end
+
+local function RenderModeControl(group, review, refresh)
+    ReleaseChildren(group)
+    if not (IsProfileReviewKind(review) and review.pieces) then
+        return
+    end
+
+    local modeDrop = AceGUI:Create("Dropdown")
+    modeDrop:SetLabel("Import mode:")
+    modeDrop:SetList(IMPORT_MODE_LABELS, IMPORT_MODE_ORDER)
+    modeDrop:SetValue(review.mode or "restore")
+    modeDrop:SetWidth(260)
+    modeDrop:SetCallback("OnValueChanged", function(widget, event, value)
+        review.mode = value == "selected" and "selected" or "restore"
+        refresh()
+    end)
+    group:AddChild(modeDrop)
+end
+
+local function RenderPieceRows(group, review, refresh)
+    ReleaseChildren(group)
+    if not ReviewUsesSelectedPieces(review) then
+        return
+    end
+
+    local pieces = review.pieces
+    if not (pieces and type(pieces.rows) == "table" and #pieces.rows > 0) then
+        local emptyLabel = AceGUI:Create("Label")
+        ConfigureWrappedLabel(emptyLabel)
+        emptyLabel:SetText("|cff888888No profile pieces are available for selected import.|r")
+        group:AddChild(emptyLabel)
+        return
+    end
+
+    for _, row in ipairs(pieces.rows) do
+        local cb = AceGUI:Create("CheckBox")
+        cb:SetFullWidth(true)
+        cb:SetLabel(row.label or "Profile piece")
+        cb:SetValue(row.eligible and row.selected == true)
+        cb:SetDisabled(not row.eligible)
+        cb:SetCallback("OnValueChanged", function(widget, event, value)
+            row.selected = value == true
+            refresh()
+        end)
+        group:AddChild(cb)
+    end
+
+    if pieces.customBarCount and pieces.customBarCount > 0 then
+        local customBarsLabel = AceGUI:Create("Label")
+        ConfigureWrappedLabel(customBarsLabel)
+        customBarsLabel:SetText(
+            "|cff888888Custom Bars found in this profile are not selectable "
+            .. "until the next import/export PR.|r"
+        )
+        group:AddChild(customBarsLabel)
+    end
 end
 
 local function ShowImportReviewWindow(context)
@@ -489,33 +666,65 @@ local function ShowImportReviewWindow(context)
     importReviewFrame = frame
     activeReview = nil
 
+    local pasteGroup = AceGUI:Create("SimpleGroup")
+    pasteGroup:SetFullWidth(true)
+    pasteGroup:SetHeight(IMPORT_TEXT_HEIGHT)
+    pasteGroup.noAutoHeight = true
+    pasteGroup:SetLayout("Fill")
+    frame:AddChild(pasteGroup)
+
     local inputBox = AceGUI:Create("MultiLineEditBox")
     inputBox:SetLabel("Paste import string:")
-    inputBox:SetFullWidth(true)
-    inputBox:SetNumLines(8)
-    inputBox.button:Hide()
-    frame:AddChild(inputBox)
+    inputBox:SetNumLines(IMPORT_TEXT_LINES)
+    inputBox:DisableButton(true)
+    pasteGroup:AddChild(inputBox)
+
+    local reviewGroup = AceGUI:Create("SimpleGroup")
+    reviewGroup:SetFullWidth(true)
+    reviewGroup:SetLayout("List")
+    frame:AddChild(reviewGroup)
+
+    local modeGroup = AceGUI:Create("SimpleGroup")
+    modeGroup:SetFullWidth(true)
+    modeGroup:SetLayout("Flow")
+    reviewGroup:AddChild(modeGroup)
 
     local statusLabel = AceGUI:Create("Label")
     ConfigureWrappedLabel(statusLabel)
     statusLabel:SetText("|cff888888No import string reviewed.|r")
-    frame:AddChild(statusLabel)
+    reviewGroup:AddChild(statusLabel)
+
+    local pieceGroup = AceGUI:Create("SimpleGroup")
+    pieceGroup:SetFullWidth(true)
+    pieceGroup:SetLayout("List")
+    reviewGroup:AddChild(pieceGroup)
 
     local buttonGroup = AceGUI:Create("SimpleGroup")
     buttonGroup:SetFullWidth(true)
     buttonGroup:SetLayout("Flow")
 
-    local reviewButton = AddButton(buttonGroup, "Review", 120)
-    local acceptButton = AddButton(buttonGroup, "Import", 180)
+    local acceptButton = AddButton(buttonGroup, "Import", 220)
     acceptButton:SetDisabled(true)
     local cancelButton = AddButton(buttonGroup, "Cancel", 120)
 
     frame:AddChild(buttonGroup)
 
+    local function RefreshPresentation()
+        RenderModeControl(modeGroup, activeReview, RefreshPresentation)
+        RenderPieceRows(pieceGroup, activeReview, RefreshPresentation)
+        acceptButton:SetText(GetReviewAcceptText(activeReview))
+        acceptButton:SetDisabled(not CanApplyReview(activeReview))
+        if activeReview then
+            statusLabel:SetText(FormatReviewText(activeReview))
+        end
+    end
+
     local function ClearReview()
         activeReview = nil
         acceptButton:SetDisabled(true)
         acceptButton:SetText("Import")
+        ReleaseChildren(modeGroup)
+        ReleaseChildren(pieceGroup)
     end
 
     local function ReviewInput()
@@ -527,13 +736,10 @@ local function ShowImportReviewWindow(context)
         end
 
         activeReview = review
-        acceptButton:SetText(review.acceptText or "Import")
-        acceptButton:SetDisabled(false)
-        statusLabel:SetText(FormatReviewText(review))
+        RefreshPresentation()
     end
 
     inputBox:SetCallback("OnTextChanged", ReviewInput)
-    reviewButton:SetCallback("OnClick", ReviewInput)
     acceptButton:SetCallback("OnClick", function()
         if not activeReview then
             ReviewInput()

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -30,10 +30,10 @@ local IMPORT_ACTION_HEIGHT = 30
 local IMPORT_WINDOW_WIDTH = 640
 local IMPORT_WINDOW_HEIGHT = 500
 local IMPORT_MODE_LABELS = {
-    restore = "Restore full profile",
     selected = "Import selected pieces",
+    restore = "Restore backup",
 }
-local IMPORT_MODE_ORDER = { "restore", "selected" }
+local IMPORT_MODE_ORDER = { "selected", "restore" }
 
 local importReviewFrame = nil
 local activeReview = nil
@@ -221,15 +221,33 @@ local function BuildSelectedPiecesSummaryLines(review)
     local pieces = review and review.pieces or nil
     local lines = {}
     AddLine(lines, review.kind == "diagnostic" and "Diagnostic selected pieces" or "Profile selected pieces")
-    AddLine(lines, FormatCount("Importable items", pieces and pieces.eligibleCount or 0))
-    AddLine(lines, FormatCount("Selected items", RecountSelectedPieces(review)))
+    AddLine(lines, "Only pieces compatible with your current class are shown.")
+    AddLine(lines, FormatCount("Importable pieces", pieces and pieces.eligibleCount or 0))
+    AddLine(lines, FormatCount("Selected pieces", RecountSelectedPieces(review)))
     if pieces and pieces.disabledCount and pieces.disabledCount > 0 then
-        AddLine(lines, FormatCount("Skipped/incompatible items", pieces.disabledCount))
+        AddLine(lines, FormatCount("Hidden incompatible pieces", pieces.disabledCount))
     end
     if pieces and pieces.customBarCount and pieces.customBarCount > 0 then
-        AddLine(lines, "Custom Bars: " .. tostring(pieces.customBarCount) .. " (not selectable in this PR)")
+        AddLine(lines, "Custom Bars: " .. tostring(pieces.customBarCount) .. " (not selectable yet)")
     end
     return lines
+end
+
+local function GetProfileImportDisclaimer(review)
+    if not IsProfileReviewKind(review) then
+        return nil
+    end
+    if ReviewUsesSelectedPieces(review) then
+        return "|cffffd100Selected Pieces:|r Best for sharing setups. "
+            .. "Only pieces compatible with your current class are shown."
+    end
+    if review.kind == "diagnostic" then
+        return "|cffffd100Diagnostic Restore:|r For bug-report reproduction.\n"
+            .. "|cffff6666This replaces your current profile. For sharing, import selected pieces or export groups, folders, or panels.|r"
+    end
+    return "|cffffd100Restore Backup:|r For your own backups.\n"
+        .. "|cffff6666This replaces your current profile and may include character data from the exporter. "
+        .. "For sharing, import selected pieces or export groups, folders, or panels.|r"
 end
 
 local function GetReviewAcceptText(review)
@@ -251,6 +269,13 @@ end
 
 local function ReviewIsDestructive(review)
     return review and review.destructive and not ReviewUsesSelectedPieces(review)
+end
+
+local function DefaultProfileImportMode(pieces)
+    if type(pieces) == "table" and (tonumber(pieces.eligibleCount) or 0) > 0 then
+        return "selected"
+    end
+    return "restore"
 end
 
 local function BuildCustomBarsSummaryLines(data)
@@ -311,12 +336,12 @@ local function ClassifyProfilePayload(data)
         exporterCharKey = data._exporterCharKey,
     }) or nil
 
-    return BuildReview("profile", data, "Profile Restore", "Restore Profile",
-        BuildProfileSummaryLines(data, "Full profile export"), {
+    return BuildReview("profile", data, "Profile Backup", "Restore Backup",
+        BuildProfileSummaryLines(data, "Profile backup export"), {
         destructive = true,
-        mode = "restore",
+        mode = DefaultProfileImportMode(pieces),
         pieces = pieces,
-        warning = "This will replace your current profile.",
+        warning = "This replaces your current profile.",
     })
 end
 
@@ -343,13 +368,13 @@ local function ClassifyDiagnosticPayload(data)
         exporterCharKey = meta and meta.charKey,
     }) or nil
 
-    return BuildReview("diagnostic", data.profile, "Diagnostic Profile Restore",
-        "Restore Diagnostic Profile", lines, {
+    return BuildReview("diagnostic", data.profile, "Diagnostic Restore",
+        "Restore Diagnostic", lines, {
         diagnostic = data,
         destructive = true,
         mode = "restore",
         pieces = pieces,
-        warning = "This will replace your current profile with the bug report profile.",
+        warning = "This replaces your current profile with the bug report profile.",
     })
 end
 
@@ -450,7 +475,7 @@ function CooldownCompanion:ApplyReviewedImport(review)
 
         local imported = ApplyProfileImportData and ApplyProfileImportData(review.data)
         if imported then
-            self:Print("Profile imported.")
+            self:Print("Profile backup restored.")
         end
         return imported == true
     end
@@ -473,7 +498,7 @@ function CooldownCompanion:ApplyReviewedImport(review)
             renameForeignCharacters = false,
         })
         if imported then
-            self:Print("Diagnostic profile imported.")
+            self:Print("Diagnostic profile restored.")
         end
         return imported == true
     end
@@ -546,9 +571,9 @@ end
 
 local function GetDestructiveConfirmText(review)
     if review and review.kind == "diagnostic" then
-        return "Restore this bug report profile? Your current profile will be overwritten."
+        return "Restore this diagnostic profile? Your current profile will be overwritten."
     end
-    return "Restore this profile? Your current profile will be overwritten."
+    return "Restore this profile backup? Your current profile will be overwritten."
 end
 
 local function ConfirmOrApplyReview(review, frame)
@@ -639,7 +664,8 @@ local function RenderPieceRows(group, review, refresh)
     end
 
     local pieces = review.pieces
-    if not (pieces and type(pieces.rows) == "table" and #pieces.rows > 0) then
+    local rows = type(pieces) == "table" and type(pieces.rows) == "table" and pieces.rows or nil
+    if not rows then
         local emptyLabel = AceGUI:Create("Label")
         ConfigureWrappedLabel(emptyLabel)
         emptyLabel:SetText("|cff888888No profile pieces are available for selected import.|r")
@@ -647,17 +673,27 @@ local function RenderPieceRows(group, review, refresh)
         return
     end
 
-    for _, row in ipairs(pieces.rows) do
-        local cb = AceGUI:Create("CheckBox")
-        cb:SetFullWidth(true)
-        cb:SetLabel(row.label or "Profile piece")
-        cb:SetValue(row.eligible and row.selected == true)
-        cb:SetDisabled(not row.eligible)
-        cb:SetCallback("OnValueChanged", function(widget, event, value)
-            row.selected = value == true
-            refresh()
-        end)
-        group:AddChild(cb)
+    local visibleRows = 0
+    for _, row in ipairs(rows) do
+        if row.eligible then
+            visibleRows = visibleRows + 1
+            local cb = AceGUI:Create("CheckBox")
+            cb:SetFullWidth(true)
+            cb:SetLabel(row.label or "Profile piece")
+            cb:SetValue(row.selected == true)
+            cb:SetCallback("OnValueChanged", function(widget, event, value)
+                row.selected = value == true
+                refresh()
+            end)
+            group:AddChild(cb)
+        end
+    end
+
+    if visibleRows == 0 then
+        local emptyLabel = AceGUI:Create("Label")
+        ConfigureWrappedLabel(emptyLabel)
+        emptyLabel:SetText("|cff888888No pieces compatible with your current class are available.|r")
+        group:AddChild(emptyLabel)
     end
 
     if pieces.customBarCount and pieces.customBarCount > 0 then
@@ -709,6 +745,14 @@ local function ShowImportReviewWindow(context)
     modeGroup:SetLayout("Flow")
     reviewScroll:AddChild(modeGroup)
 
+    local disclaimerLabel = AceGUI:Create("Label")
+    ConfigureWrappedLabel(disclaimerLabel)
+    if disclaimerLabel.SetFontObject and GameFontNormal then
+        disclaimerLabel:SetFontObject(GameFontNormal)
+    end
+    disclaimerLabel:SetText("")
+    reviewScroll:AddChild(disclaimerLabel)
+
     local statusLabel = AceGUI:Create("Label")
     ConfigureWrappedLabel(statusLabel)
     statusLabel:SetText("|cff888888No import string reviewed.|r")
@@ -736,6 +780,7 @@ local function ShowImportReviewWindow(context)
         RenderPieceRows(pieceGroup, activeReview, RefreshPresentation)
         acceptButton:SetText(GetReviewAcceptText(activeReview))
         acceptButton:SetDisabled(not CanApplyReview(activeReview))
+        disclaimerLabel:SetText(GetProfileImportDisclaimer(activeReview) or "")
         if activeReview then
             statusLabel:SetText(FormatReviewText(activeReview))
         end
@@ -746,6 +791,7 @@ local function ShowImportReviewWindow(context)
         activeReview = nil
         acceptButton:SetDisabled(true)
         acceptButton:SetText("Import")
+        disclaimerLabel:SetText("")
         ReleaseChildren(modeGroup)
         ReleaseChildren(pieceGroup)
         RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -16,6 +16,7 @@ local ApplyCustomBarsImportData = ST._ApplyCustomBarsImportData
 local ApplyFullProfileImport = ST._ApplyFullProfileImport
 local BuildProfileImportPiecesReview = ST._BuildProfileImportPiecesReview
 local RecountProfileImportPiecesSelection = ST._RecountProfileImportPiecesSelection
+local SetProfileImportPieceSelected = ST._SetProfileImportPieceSelected
 local ApplyProfileImportPieces = ST._ApplyProfileImportPieces
 local CS = ST._configState
 
@@ -682,7 +683,12 @@ local function RenderPieceRows(group, review, refresh)
             cb:SetLabel(row.label or "Profile piece")
             cb:SetValue(row.selected == true)
             cb:SetCallback("OnValueChanged", function(widget, event, value)
-                row.selected = value == true
+                if SetProfileImportPieceSelected then
+                    SetProfileImportPieceSelected(pieces, row, value == true)
+                else
+                    row.selected = value == true
+                    row.userChanged = true
+                end
                 refresh()
             end)
             group:AddChild(cb)

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -883,8 +883,8 @@ local function CreateImportedPanel(db, containerId, panelIndex, srcPanel, import
     importState.panelCount = importState.panelCount + 1
 end
 
-local function ImportContainerEntries(db, entries, charKey, folderId)
-    local importState = {
+local function NewGroupImportState()
+    return {
         containerIdMap = {},
         importedContainerIds = {},
         groupIdMap = {},
@@ -892,6 +892,13 @@ local function ImportContainerEntries(db, entries, charKey, folderId)
         containerCount = 0,
         panelCount = 0,
     }
+end
+
+local function ImportContainerEntries(db, entries, charKey, folderId, importState)
+    importState = importState or NewGroupImportState()
+    local firstContainerIndex = #importState.importedContainerIds + 1
+    local startContainerCount = importState.containerCount
+    local startPanelCount = importState.panelCount
 
     for _, entry in ipairs(entries) do
         local containerId = db.nextContainerId
@@ -922,7 +929,10 @@ local function ImportContainerEntries(db, entries, charKey, folderId)
         importState.containerCount = importState.containerCount + 1
     end
 
-    return importState
+    return importState,
+        importState.containerCount - startContainerCount,
+        importState.panelCount - startPanelCount,
+        importState.importedContainerIds[firstContainerIndex]
 end
 
 local function RemapImportedContainerAnchors(db, importState, preserveContainerRefs)
@@ -986,10 +996,37 @@ local function RemapImportedPanelAnchors(db, importState, preserveOwnContainerRe
     end
 end
 
+local activeGroupImportBatches = setmetatable({}, { __mode = "k" })
+local activeGroupImportPayloads = setmetatable({}, { __mode = "k" })
+
+ST._BeginGroupImportBatch = function()
+    local token = {}
+    activeGroupImportBatches[token] = NewGroupImportState()
+    return token
+end
+
+ST._FinishGroupImportBatch = function(token, remapAnchors)
+    local importState = activeGroupImportBatches[token]
+    activeGroupImportBatches[token] = nil
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if remapAnchors and type(db) == "table" and type(importState) == "table" then
+        RemapImportedContainerAnchors(db, importState, true)
+        RemapImportedPanelAnchors(db, importState)
+    end
+end
+
+ST._AttachGroupImportBatch = function(payload, token)
+    if type(payload) == "table" and activeGroupImportBatches[token] then
+        activeGroupImportPayloads[payload] = token
+    end
+end
+
 local function ApplyGroupImportData(data)
     if type(data) ~= "table" then
         return false
     end
+    local batchToken = activeGroupImportPayloads[data]
+    activeGroupImportPayloads[data] = nil
     if RejectUnsupportedImportPayload(data, "group import") then
         return false
     end
@@ -1002,6 +1039,8 @@ local function ApplyGroupImportData(data)
 
     local db = CooldownCompanion.db.profile
     local charKey = CooldownCompanion.db.keys.char
+    local sharedImportState = batchToken and activeGroupImportBatches[batchToken] or nil
+    local deferAnchorRemap = sharedImportState ~= nil
 
     if data.type == "group" and data.group then
         CooldownCompanion:NotifyLegacySupportCutoff("group import")
@@ -1012,10 +1051,12 @@ local function ApplyGroupImportData(data)
         return false
 
     elseif data.type == "containers" and data.containers then
-        local importState = ImportContainerEntries(db, data.containers, charKey, nil)
-        RemapImportedContainerAnchors(db, importState, true)
-        RemapImportedPanelAnchors(db, importState)
-        CooldownCompanion:Print("Imported " .. importState.containerCount .. " groups.")
+        local importState, containerCount = ImportContainerEntries(db, data.containers, charKey, nil, sharedImportState)
+        if not deferAnchorRemap then
+            RemapImportedContainerAnchors(db, importState, true)
+            RemapImportedPanelAnchors(db, importState)
+        end
+        CooldownCompanion:Print("Imported " .. containerCount .. " groups.")
 
     elseif data.type == "folder" and data.folder then
         if data.groups then
@@ -1082,24 +1123,29 @@ local function ApplyGroupImportData(data)
         }
         local count = 0
         if data.containers then
-            local importState = ImportContainerEntries(db, data.containers, charKey, folderId)
-            RemapImportedContainerAnchors(db, importState, true)
-            RemapImportedPanelAnchors(db, importState)
-            count = importState.panelCount
+            local importState, _, panelCount = ImportContainerEntries(
+                db, data.containers, charKey, folderId, sharedImportState
+            )
+            if not deferAnchorRemap then
+                RemapImportedContainerAnchors(db, importState, true)
+                RemapImportedPanelAnchors(db, importState)
+            end
+            count = panelCount
         end
         CooldownCompanion:Print("Imported folder: " .. (data.folder.name or "Unnamed") .. " (" .. count .. " groups)")
 
     elseif data.type == "container" and data.container and data.panels then
-        local importState = ImportContainerEntries(db, {{
+        local importState, _, panelCount, containerId = ImportContainerEntries(db, {{
             container = data.container,
             panels = data.panels,
             _originalContainerId = data._originalContainerId,
-        }}, charKey, nil)
-        local containerId = importState.importedContainerIds[1]
+        }}, charKey, nil, sharedImportState)
         local container = db.groupContainers[containerId]
-        RemapImportedContainerAnchors(db, importState, false)
-        RemapImportedPanelAnchors(db, importState, true)
-        CooldownCompanion:Print("Imported group: " .. ((container and container.name) or "Unnamed") .. " (" .. importState.panelCount .. " panels)")
+        if not deferAnchorRemap then
+            RemapImportedContainerAnchors(db, importState, false)
+            RemapImportedPanelAnchors(db, importState, true)
+        end
+        CooldownCompanion:Print("Imported group: " .. ((container and container.name) or "Unnamed") .. " (" .. panelCount .. " panels)")
 
     else
         CooldownCompanion:Print("Import failed: unrecognized export type.")

--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -419,7 +419,7 @@ StaticPopupDialogs["CDC_DUPLICATE_PROFILE"] = {
 }
 
 StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
-    text = "Export string (Ctrl+C to copy):",
+    text = "Profile backup string (Ctrl+C to copy):",
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
@@ -514,15 +514,15 @@ end
 ST._ApplyProfileImportData = ApplyProfileImport
 
 StaticPopupDialogs["CDC_CONFIRM_PROFILE_IMPORT"] = {
-    text = "This will overwrite your current profile. Continue?",
-    button1 = "Import",
+    text = "Restore this profile backup? Your current profile will be overwritten.",
+    button1 = "Restore",
     button2 = "Cancel",
     OnAccept = function()
         if pendingProfileImport then
             local imported = ApplyProfileImport(pendingProfileImport)
             pendingProfileImport = nil
             if imported then
-                CooldownCompanion:Print("Profile imported.")
+                CooldownCompanion:Print("Profile backup restored.")
             end
         end
     end,
@@ -536,8 +536,8 @@ StaticPopupDialogs["CDC_CONFIRM_PROFILE_IMPORT"] = {
 }
 
 StaticPopupDialogs["CDC_IMPORT_PROFILE"] = {
-    text = "Paste import string:",
-    button1 = "Import",
+    text = "Paste profile backup string:",
+    button1 = "Restore",
     button2 = "Cancel",
     hasEditBox = true,
     OnAccept = function(self)

--- a/Config/ProfileImportPieces.lua
+++ b/Config/ProfileImportPieces.lua
@@ -9,6 +9,12 @@ local CooldownCompanion = ST.Addon
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 
+local EMPTY_TABLE = {}
+
+local function TableOrEmpty(value)
+    return type(value) == "table" and value or EMPTY_TABLE
+end
+
 local function CountPairs(tbl)
     local count = 0
     if type(tbl) == "table" then
@@ -199,7 +205,7 @@ end
 local function BuildPanelInfos(profile, defaultOwnerKey, currentCharKey, currentInfo)
     local panelsByContainer = {}
     local panelInfos = {}
-    for panelId, panel in pairs(profile.groups or {}) do
+    for panelId, panel in pairs(TableOrEmpty(profile.groups)) do
         if type(panel) == "table" then
             local containerKey = NormalizeKey(panel.parentContainerId)
             local ownerKey = ResolveOwnerKey(panel, defaultOwnerKey)
@@ -236,7 +242,7 @@ local function BuildContainerInfos(profile, panelsByContainer, defaultOwnerKey, 
     local containerInfos = {}
     local byKey = {}
     local byFolder = {}
-    for containerId, container in pairs(profile.groupContainers or {}) do
+    for containerId, container in pairs(TableOrEmpty(profile.groupContainers)) do
         if type(container) == "table" then
             local key = NormalizeKey(containerId)
             local ownerKey = ResolveOwnerKey(container, defaultOwnerKey)
@@ -277,7 +283,7 @@ end
 
 local function BuildFolderInfos(profile, containersByFolder, defaultOwnerKey, currentCharKey, currentInfo)
     local folderInfos = {}
-    for folderId, folder in pairs(profile.folders or {}) do
+    for folderId, folder in pairs(TableOrEmpty(profile.folders)) do
         if type(folder) == "table" then
             local key = NormalizeKey(folderId)
             local ownerKey = ResolveOwnerKey(folder, defaultOwnerKey)
@@ -394,24 +400,36 @@ end
 
 local function SelectionSets(model)
     local folders, containers, panels = {}, {}, {}
+    local deselectedContainers, deselectedPanels = {}, {}
     for _, row in ipairs(model.rows or {}) do
-        if row.eligible and row.selected then
-            if row.kind == "folder" then
-                folders[row.sourceKey] = true
-            elseif row.kind == "container" then
-                containers[row.sourceKey] = true
-            elseif row.kind == "panel" then
-                panels[row.sourceKey] = true
+        if row.eligible then
+            if row.selected then
+                if row.kind == "folder" then
+                    folders[row.sourceKey] = true
+                elseif row.kind == "container" then
+                    containers[row.sourceKey] = true
+                elseif row.kind == "panel" then
+                    panels[row.sourceKey] = true
+                end
+            elseif row.userChanged then
+                if row.kind == "container" then
+                    deselectedContainers[row.sourceKey] = true
+                elseif row.kind == "panel" then
+                    deselectedPanels[row.sourceKey] = true
+                end
             end
         end
     end
-    return folders, containers, panels
+    return folders, containers, panels, deselectedContainers, deselectedPanels
 end
 
-local function EligiblePanels(containerInfo, selectedPanels, includeAll)
+local function EligiblePanels(containerInfo, selectedPanels, deselectedPanels, includeAll)
     local panels = {}
     for _, panelInfo in ipairs(containerInfo.panels) do
-        if panelInfo.eligible and (includeAll or selectedPanels[panelInfo.sourceKey]) then
+        if panelInfo.eligible and (
+            selectedPanels[panelInfo.sourceKey]
+                or (includeAll and not deselectedPanels[panelInfo.sourceKey])
+        ) then
             local panel = CopyGroupForImport(panelInfo.panel)
             panel._originalGroupId = NumericId(panelInfo.sourceId)
             panels[#panels + 1] = panel
@@ -420,11 +438,11 @@ local function EligiblePanels(containerInfo, selectedPanels, includeAll)
     return panels
 end
 
-local function BuildContainerEntry(containerInfo, selectedPanels, includeAll)
+local function BuildContainerEntry(containerInfo, selectedPanels, deselectedPanels, includeAll)
     if not (containerInfo and containerInfo.eligible) then
         return nil
     end
-    local panels = EligiblePanels(containerInfo, selectedPanels, includeAll)
+    local panels = EligiblePanels(containerInfo, selectedPanels, deselectedPanels, includeAll)
     return {
         container = CopyContainerForImport(containerInfo.container),
         panels = panels,
@@ -432,11 +450,11 @@ local function BuildContainerEntry(containerInfo, selectedPanels, includeAll)
     }
 end
 
-local function AddContainerEntry(entries, containerInfo, selectedPanels, includeAll, importedContainers)
+local function AddContainerEntry(entries, containerInfo, selectedPanels, deselectedPanels, includeAll, importedContainers)
     if not (containerInfo and containerInfo.sourceKey and not importedContainers[containerInfo.sourceKey]) then
         return
     end
-    local entry = BuildContainerEntry(containerInfo, selectedPanels, includeAll)
+    local entry = BuildContainerEntry(containerInfo, selectedPanels, deselectedPanels, includeAll)
     if entry then
         importedContainers[containerInfo.sourceKey] = true
         entries[#entries + 1] = entry
@@ -455,6 +473,65 @@ local function AddCheckpoint(payload, profile)
     return payload
 end
 
+local function ContainerHasSelectedPanel(containerInfo, selectedPanels)
+    for _, panelInfo in ipairs(containerInfo.panels or {}) do
+        if selectedPanels[panelInfo.sourceKey] then
+            return true
+        end
+    end
+    return false
+end
+
+local function BeginImportBatch()
+    local begin = ST._BeginGroupImportBatch
+    return begin and begin() or nil
+end
+
+local function ApplyProfilePiecePayload(profile, payload, batchToken)
+    local attach = ST._AttachGroupImportBatch
+    if attach and batchToken then
+        attach(payload, batchToken)
+    end
+    return ApplyPayload(AddCheckpoint(payload, profile))
+end
+
+local function FinishImportBatch(batchToken, remapAnchors)
+    local finish = ST._FinishGroupImportBatch
+    if finish and batchToken then
+        finish(batchToken, remapAnchors == true)
+    end
+end
+
+local function SetChildSelection(row, selected)
+    if not (row and row.eligible) then
+        return
+    end
+    row.selected = selected == true
+    row.userChanged = nil
+end
+
+local function SetProfileImportPieceSelected(model, row, selected)
+    if type(row) ~= "table" then
+        return
+    end
+    local enabled = selected == true
+    row.selected = enabled
+    row.userChanged = true
+    if row.kind == "folder" then
+        for _, containerInfo in ipairs(row.containers or {}) do
+            SetChildSelection(containerInfo, enabled)
+            for _, panelInfo in ipairs(containerInfo.panels or {}) do
+                SetChildSelection(panelInfo, enabled)
+            end
+        end
+    elseif row.kind == "container" then
+        for _, panelInfo in ipairs(row.panels or {}) do
+            SetChildSelection(panelInfo, enabled)
+        end
+    end
+    RecountSelection(model)
+end
+
 function CooldownCompanion:ApplyProfileImportPieces(profile, model)
     if type(profile) ~= "table" or type(model) ~= "table" then
         return false
@@ -466,8 +543,9 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
         return false
     end
 
-    local selectedFolders, selectedContainers, selectedPanels = SelectionSets(model)
+    local selectedFolders, selectedContainers, selectedPanels, deselectedContainers, deselectedPanels = SelectionSets(model)
     local importedContainers = {}
+    local batchToken = BeginImportBatch()
     local applied = false
     local failed = false
 
@@ -475,15 +553,25 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
         if selectedFolders[folderInfo.sourceKey] and folderInfo.eligible then
             local entries = {}
             for _, containerInfo in ipairs(folderInfo.containers or {}) do
-                if selectedContainers[containerInfo.sourceKey] then
-                    AddContainerEntry(entries, containerInfo, selectedPanels, false, importedContainers)
+                local hasSelectedPanel = ContainerHasSelectedPanel(containerInfo, selectedPanels)
+                local includeAll = selectedContainers[containerInfo.sourceKey]
+                    or not deselectedContainers[containerInfo.sourceKey]
+                if includeAll or hasSelectedPanel then
+                    AddContainerEntry(
+                        entries,
+                        containerInfo,
+                        selectedPanels,
+                        deselectedPanels,
+                        includeAll,
+                        importedContainers
+                    )
                 end
             end
-            local ok = ApplyPayload(AddCheckpoint({
+            local ok = ApplyProfilePiecePayload(profile, {
                 type = "folder",
                 folder = CopyForExport(folderInfo.folder),
                 containers = entries,
-            }, profile))
+            }, batchToken)
             applied = ok or applied
             failed = failed or not ok
         end
@@ -492,24 +580,31 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
     local looseEntries = {}
     for _, containerInfo in ipairs(model.containers or {}) do
         if selectedContainers[containerInfo.sourceKey] then
-            AddContainerEntry(looseEntries, containerInfo, selectedPanels, false, importedContainers)
+            AddContainerEntry(looseEntries, containerInfo, selectedPanels, deselectedPanels, true, importedContainers)
         end
     end
 
     for _, panelInfo in ipairs(model.panels or {}) do
         local containerInfo = model.containersByKey and model.containersByKey[panelInfo.parentContainerKey]
         if selectedPanels[panelInfo.sourceKey] then
-            AddContainerEntry(looseEntries, containerInfo, selectedPanels, false, importedContainers)
+            AddContainerEntry(looseEntries, containerInfo, selectedPanels, deselectedPanels, false, importedContainers)
         end
     end
 
     if #looseEntries > 0 then
-        local ok = ApplyPayload(AddCheckpoint({
+        local ok = ApplyProfilePiecePayload(profile, {
             type = "containers",
             containers = looseEntries,
-        }, profile))
+        }, batchToken)
         applied = ok or applied
         failed = failed or not ok
+    end
+
+    FinishImportBatch(batchToken, applied)
+    if applied then
+        if self.RefreshAllGroups then
+            self:RefreshAllGroups()
+        end
     end
 
     if applied and not failed then
@@ -528,6 +623,7 @@ ST._BuildProfileImportPiecesReview = function(profile, options)
 end
 
 ST._RecountProfileImportPiecesSelection = RecountSelection
+ST._SetProfileImportPieceSelected = SetProfileImportPieceSelected
 
 ST._ApplyProfileImportPieces = function(profile, model)
     return CooldownCompanion:ApplyProfileImportPieces(profile, model)

--- a/Config/ProfileImportPieces.lua
+++ b/Config/ProfileImportPieces.lua
@@ -146,7 +146,7 @@ local function ClassLabel(info)
 end
 
 local function ResolveOwnerKey(entity, defaultOwnerKey)
-    if type(entity) ~= "table" or entity.isGlobal then
+    if type(entity) ~= "table" or entity.isGlobal or entity.section == "global" then
         return nil
     end
     if type(entity.createdBy) == "string" and entity.createdBy ~= "" then

--- a/Config/ProfileImportPieces.lua
+++ b/Config/ProfileImportPieces.lua
@@ -1,0 +1,536 @@
+--[[
+    CooldownCompanion - Config/ProfileImportPieces
+    Non-destructive selected-pieces import helpers for full profile strings.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local BuildGroupExportData = ST._BuildGroupExportData
+local BuildContainerExportData = ST._BuildContainerExportData
+
+local function CountPairs(tbl)
+    local count = 0
+    if type(tbl) == "table" then
+        for _ in pairs(tbl) do
+            count = count + 1
+        end
+    end
+    return count
+end
+
+local function CountListOrPairs(tbl)
+    if type(tbl) ~= "table" then
+        return 0
+    end
+    local count = #tbl
+    if count > 0 then
+        return count
+    end
+    return CountPairs(tbl)
+end
+
+local function NormalizeKey(value)
+    if value == nil then
+        return nil
+    end
+    return tostring(value)
+end
+
+local function NumericId(value)
+    return tonumber(value) or value
+end
+
+local function DeepCopy(value)
+    if type(value) ~= "table" then
+        return value
+    end
+    local copy = {}
+    for key, child in pairs(value) do
+        copy[DeepCopy(key)] = DeepCopy(child)
+    end
+    return copy
+end
+
+local function CopyForExport(data)
+    return CopyTable and CopyTable(data) or DeepCopy(data)
+end
+
+local function CopyGroupForImport(group)
+    local data = BuildGroupExportData and BuildGroupExportData(group) or CopyForExport(group)
+    data.createdBy = nil
+    data.order = nil
+    data.folderId = nil
+    data.isGlobal = nil
+    data.parentContainerId = nil
+    return data
+end
+
+local function CopyContainerForImport(container)
+    local data = BuildContainerExportData and BuildContainerExportData(container) or CopyForExport(container)
+    data.createdBy = nil
+    data.order = nil
+    data.specOrders = nil
+    data.folderId = nil
+    data.isGlobal = nil
+    return data
+end
+
+local function CountProfileCustomBars(profile)
+    local count = 0
+    local stores = type(profile) == "table" and profile.resourceBarsByChar or nil
+    if type(stores) ~= "table" then
+        return count
+    end
+
+    for _, settings in pairs(stores) do
+        local customBars = type(settings) == "table"
+            and (settings.customBars or settings.customAuraBars)
+            or nil
+        if type(customBars) == "table" then
+            if type(customBars.entries) == "table" then
+                count = count + CountListOrPairs(customBars.entries)
+            elseif type(customBars.order) == "table" then
+                count = count + CountListOrPairs(customBars.order)
+            else
+                for _, specBars in pairs(customBars) do
+                    count = count + CountListOrPairs(specBars)
+                end
+            end
+        end
+    end
+
+    return count
+end
+
+local function GetCurrentCharInfo()
+    local db = CooldownCompanion.db
+    local charKey = db and db.keys and db.keys.char
+    local info = db and db.global and db.global.characterInfo and db.global.characterInfo[charKey]
+    return charKey, info
+end
+
+local function GetOwnerInfo(profile, ownerKey)
+    if type(ownerKey) ~= "string" or ownerKey == "" then
+        return nil
+    end
+    local exported = type(profile) == "table" and profile._characterInfo or nil
+    local info = type(exported) == "table" and exported[ownerKey] or nil
+    if info then
+        return info
+    end
+    local globalInfo = CooldownCompanion.db
+        and CooldownCompanion.db.global
+        and CooldownCompanion.db.global.characterInfo
+    return type(globalInfo) == "table" and globalInfo[ownerKey] or nil
+end
+
+local function ClassesMatch(currentInfo, ownerInfo)
+    if type(currentInfo) ~= "table" or type(ownerInfo) ~= "table" then
+        return nil
+    end
+    if currentInfo.classFilename and ownerInfo.classFilename then
+        return currentInfo.classFilename == ownerInfo.classFilename
+    end
+    if currentInfo.classID and ownerInfo.classID then
+        return currentInfo.classID == ownerInfo.classID
+    end
+    return nil
+end
+
+local function ClassLabel(info)
+    if type(info) ~= "table" then
+        return "Unknown class"
+    end
+    return info.classFilename or (info.classID and ("Class " .. tostring(info.classID))) or "Unknown class"
+end
+
+local function ResolveOwnerKey(entity, defaultOwnerKey)
+    if type(entity) ~= "table" or entity.isGlobal then
+        return nil
+    end
+    if type(entity.createdBy) == "string" and entity.createdBy ~= "" then
+        return entity.createdBy
+    end
+    return defaultOwnerKey
+end
+
+local function BuildEligibility(profile, ownerKey, currentCharKey, currentInfo)
+    if not ownerKey or ownerKey == currentCharKey then
+        return true, true, nil
+    end
+
+    local ownerInfo = GetOwnerInfo(profile, ownerKey)
+    local matches = ClassesMatch(currentInfo, ownerInfo)
+    if matches == false then
+        return false, false, ClassLabel(ownerInfo) .. " content"
+    end
+    if matches == nil then
+        return true, false, "Source class unknown"
+    end
+    return true, true, nil
+end
+
+local function SortByOrderNameId(a, b)
+    local orderA = tonumber(a.order) or math.huge
+    local orderB = tonumber(b.order) or math.huge
+    if orderA ~= orderB then
+        return orderA < orderB
+    end
+    local nameA = tostring(a.name or "")
+    local nameB = tostring(b.name or "")
+    if nameA ~= nameB then
+        return nameA < nameB
+    end
+    return tostring(a.sourceId) < tostring(b.sourceId)
+end
+
+local function RowLabel(prefix, name, detail, reason)
+    local text = prefix .. ": " .. tostring(name or "Unnamed")
+    if detail and detail ~= "" then
+        text = text .. " (" .. detail .. ")"
+    end
+    if reason and reason ~= "" then
+        text = text .. " - " .. reason
+    end
+    return text
+end
+
+local function BuildPanelInfos(profile, defaultOwnerKey, currentCharKey, currentInfo)
+    local panelsByContainer = {}
+    local panelInfos = {}
+    for panelId, panel in pairs(profile.groups or {}) do
+        if type(panel) == "table" then
+            local containerKey = NormalizeKey(panel.parentContainerId)
+            local ownerKey = ResolveOwnerKey(panel, defaultOwnerKey)
+            local eligible, selected, reason = BuildEligibility(profile, ownerKey, currentCharKey, currentInfo)
+            local info = {
+                kind = "panel",
+                sourceId = panelId,
+                sourceKey = NormalizeKey(panelId),
+                parentContainerKey = containerKey,
+                panel = panel,
+                name = panel.name,
+                order = panel.order,
+                ownerKey = ownerKey,
+                eligible = eligible and containerKey ~= nil,
+                selected = (eligible and selected and containerKey ~= nil) or false,
+                disabledReason = (not containerKey and "Missing parent group") or (not eligible and reason or nil),
+                note = eligible and reason or nil,
+            }
+            panelInfos[#panelInfos + 1] = info
+            if containerKey then
+                panelsByContainer[containerKey] = panelsByContainer[containerKey] or {}
+                panelsByContainer[containerKey][#panelsByContainer[containerKey] + 1] = info
+            end
+        end
+    end
+    for _, panels in pairs(panelsByContainer) do
+        table.sort(panels, SortByOrderNameId)
+    end
+    table.sort(panelInfos, SortByOrderNameId)
+    return panelInfos, panelsByContainer
+end
+
+local function BuildContainerInfos(profile, panelsByContainer, defaultOwnerKey, currentCharKey, currentInfo)
+    local containerInfos = {}
+    local byKey = {}
+    local byFolder = {}
+    for containerId, container in pairs(profile.groupContainers or {}) do
+        if type(container) == "table" then
+            local key = NormalizeKey(containerId)
+            local ownerKey = ResolveOwnerKey(container, defaultOwnerKey)
+            local eligible, selected, reason = BuildEligibility(profile, ownerKey, currentCharKey, currentInfo)
+            local panels = panelsByContainer[key] or {}
+            local panelCount = #panels
+            local detail = tostring(panelCount) .. " panel" .. (panelCount == 1 and "" or "s")
+            local info = {
+                kind = "container",
+                sourceId = containerId,
+                sourceKey = key,
+                folderKey = NormalizeKey(container.folderId),
+                container = container,
+                panels = panels,
+                name = container.name,
+                order = container.order,
+                ownerKey = ownerKey,
+                eligible = eligible,
+                selected = eligible and selected or false,
+                disabledReason = not eligible and reason or nil,
+                note = eligible and reason or nil,
+                detail = detail,
+            }
+            containerInfos[#containerInfos + 1] = info
+            byKey[key] = info
+            if info.folderKey then
+                byFolder[info.folderKey] = byFolder[info.folderKey] or {}
+                byFolder[info.folderKey][#byFolder[info.folderKey] + 1] = info
+            end
+        end
+    end
+    for _, containers in pairs(byFolder) do
+        table.sort(containers, SortByOrderNameId)
+    end
+    table.sort(containerInfos, SortByOrderNameId)
+    return containerInfos, byKey, byFolder
+end
+
+local function BuildFolderInfos(profile, containersByFolder, defaultOwnerKey, currentCharKey, currentInfo)
+    local folderInfos = {}
+    for folderId, folder in pairs(profile.folders or {}) do
+        if type(folder) == "table" then
+            local key = NormalizeKey(folderId)
+            local ownerKey = ResolveOwnerKey(folder, defaultOwnerKey)
+            local eligible, selected, reason = BuildEligibility(profile, ownerKey, currentCharKey, currentInfo)
+            local containers = containersByFolder[key] or {}
+            local panelCount = 0
+            for _, containerInfo in ipairs(containers) do
+                panelCount = panelCount + #containerInfo.panels
+            end
+            local detail = tostring(#containers) .. " group" .. (#containers == 1 and "" or "s")
+                .. ", " .. tostring(panelCount) .. " panel" .. (panelCount == 1 and "" or "s")
+            local info = {
+                kind = "folder",
+                sourceId = folderId,
+                sourceKey = key,
+                folder = folder,
+                containers = containers,
+                name = folder.name,
+                order = folder.order,
+                ownerKey = ownerKey,
+                eligible = eligible,
+                selected = eligible and selected or false,
+                disabledReason = not eligible and reason or nil,
+                note = eligible and reason or nil,
+                detail = detail,
+            }
+            folderInfos[#folderInfos + 1] = info
+        end
+    end
+    table.sort(folderInfos, SortByOrderNameId)
+    return folderInfos
+end
+
+local function InheritPanelContainerEligibility(panelInfos, containersByKey)
+    for _, panelInfo in ipairs(panelInfos) do
+        local containerInfo = containersByKey[panelInfo.parentContainerKey]
+        if containerInfo then
+            panelInfo.eligible = containerInfo.eligible
+            panelInfo.selected = containerInfo.eligible and containerInfo.selected or false
+            panelInfo.disabledReason = containerInfo.disabledReason
+            panelInfo.note = containerInfo.note
+        end
+    end
+end
+
+local function AddRows(model, infos, prefix)
+    for _, info in ipairs(infos) do
+        local reason = info.disabledReason or info.note
+        info.label = RowLabel(prefix, info.name, info.detail, reason)
+        model.rows[#model.rows + 1] = info
+        if info.eligible then
+            model.eligibleCount = model.eligibleCount + 1
+            if info.selected then
+                model.selectedCount = model.selectedCount + 1
+            end
+        else
+            model.disabledCount = model.disabledCount + 1
+        end
+    end
+end
+
+function CooldownCompanion:BuildProfileImportPiecesReview(profile, options)
+    if type(profile) ~= "table" then
+        profile = {}
+    end
+    options = options or {}
+    local currentCharKey, currentInfo = GetCurrentCharInfo()
+    currentCharKey = options.currentCharKey or currentCharKey
+    currentInfo = options.currentCharInfo or currentInfo
+    local defaultOwnerKey = options.exporterCharKey
+        or (type(profile) == "table" and profile._exporterCharKey)
+
+    local panelInfos, panelsByContainer = BuildPanelInfos(profile, defaultOwnerKey, currentCharKey, currentInfo)
+    local containerInfos, containersByKey, containersByFolder = BuildContainerInfos(
+        profile, panelsByContainer, defaultOwnerKey, currentCharKey, currentInfo
+    )
+    InheritPanelContainerEligibility(panelInfos, containersByKey)
+    local folderInfos = BuildFolderInfos(profile, containersByFolder, defaultOwnerKey, currentCharKey, currentInfo)
+
+    local model = {
+        rows = {},
+        folders = folderInfos,
+        containers = containerInfos,
+        panels = panelInfos,
+        containersByKey = containersByKey,
+        panelsByContainer = panelsByContainer,
+        eligibleCount = 0,
+        selectedCount = 0,
+        disabledCount = 0,
+        customBarCount = CountProfileCustomBars(profile),
+    }
+
+    AddRows(model, folderInfos, "Folder")
+    AddRows(model, containerInfos, "Group")
+    AddRows(model, panelInfos, "Panel")
+    return model
+end
+
+local function RecountSelection(model)
+    if type(model) ~= "table" then
+        return 0
+    end
+    local selected = 0
+    if type(model.rows) == "table" then
+        for _, row in ipairs(model.rows) do
+            if row.eligible and row.selected then
+                selected = selected + 1
+            end
+        end
+    end
+    model.selectedCount = selected
+    return selected
+end
+
+local function SelectionSets(model)
+    local folders, containers, panels = {}, {}, {}
+    for _, row in ipairs(model.rows or {}) do
+        if row.eligible and row.selected then
+            if row.kind == "folder" then
+                folders[row.sourceKey] = true
+            elseif row.kind == "container" then
+                containers[row.sourceKey] = true
+            elseif row.kind == "panel" then
+                panels[row.sourceKey] = true
+            end
+        end
+    end
+    return folders, containers, panels
+end
+
+local function EligiblePanels(containerInfo, selectedPanels, includeAll)
+    local panels = {}
+    for _, panelInfo in ipairs(containerInfo.panels) do
+        if panelInfo.eligible and (includeAll or selectedPanels[panelInfo.sourceKey]) then
+            local panel = CopyGroupForImport(panelInfo.panel)
+            panel._originalGroupId = NumericId(panelInfo.sourceId)
+            panels[#panels + 1] = panel
+        end
+    end
+    return panels
+end
+
+local function BuildContainerEntry(containerInfo, selectedPanels, includeAll)
+    if not (containerInfo and containerInfo.eligible) then
+        return nil
+    end
+    local panels = EligiblePanels(containerInfo, selectedPanels, includeAll)
+    return {
+        container = CopyContainerForImport(containerInfo.container),
+        panels = panels,
+        _originalContainerId = NumericId(containerInfo.sourceId),
+    }
+end
+
+local function AddContainerEntry(entries, containerInfo, selectedPanels, includeAll, importedContainers)
+    if not (containerInfo and containerInfo.sourceKey and not importedContainers[containerInfo.sourceKey]) then
+        return
+    end
+    local entry = BuildContainerEntry(containerInfo, selectedPanels, includeAll)
+    if entry then
+        importedContainers[containerInfo.sourceKey] = true
+        entries[#entries + 1] = entry
+    end
+end
+
+local function ApplyPayload(payload)
+    local apply = ST._ApplyGroupImportData
+    return apply and apply(payload) == true
+end
+
+local function AddCheckpoint(payload, profile)
+    if type(payload) == "table" and type(profile) == "table" then
+        payload._cdcImportCheckpoint = profile._cdcImportCheckpoint
+    end
+    return payload
+end
+
+function CooldownCompanion:ApplyProfileImportPieces(profile, model)
+    if type(profile) ~= "table" or type(model) ~= "table" then
+        return false
+    end
+
+    RecountSelection(model)
+    if model.selectedCount == 0 then
+        self:Print("Import failed: no profile pieces selected.")
+        return false
+    end
+
+    local selectedFolders, selectedContainers, selectedPanels = SelectionSets(model)
+    local importedContainers = {}
+    local applied = false
+    local failed = false
+
+    for _, folderInfo in ipairs(model.folders or {}) do
+        if selectedFolders[folderInfo.sourceKey] and folderInfo.eligible then
+            local entries = {}
+            for _, containerInfo in ipairs(folderInfo.containers or {}) do
+                if selectedContainers[containerInfo.sourceKey] then
+                    AddContainerEntry(entries, containerInfo, selectedPanels, false, importedContainers)
+                end
+            end
+            if #entries > 0 then
+                local ok = ApplyPayload(AddCheckpoint({
+                    type = "folder",
+                    folder = CopyForExport(folderInfo.folder),
+                    containers = entries,
+                }, profile))
+                applied = ok or applied
+                failed = failed or not ok
+            end
+        end
+    end
+
+    local looseEntries = {}
+    for _, containerInfo in ipairs(model.containers or {}) do
+        if selectedContainers[containerInfo.sourceKey] then
+            AddContainerEntry(looseEntries, containerInfo, selectedPanels, false, importedContainers)
+        end
+    end
+
+    for _, panelInfo in ipairs(model.panels or {}) do
+        local containerInfo = model.containersByKey and model.containersByKey[panelInfo.parentContainerKey]
+        if selectedPanels[panelInfo.sourceKey] then
+            AddContainerEntry(looseEntries, containerInfo, selectedPanels, false, importedContainers)
+        end
+    end
+
+    if #looseEntries > 0 then
+        local ok = ApplyPayload(AddCheckpoint({
+            type = "containers",
+            containers = looseEntries,
+        }, profile))
+        applied = ok or applied
+        failed = failed or not ok
+    end
+
+    if applied and not failed then
+        self:Print("Imported selected profile pieces.")
+    elseif failed then
+        self:Print("Import failed: some selected profile pieces could not be imported.")
+        return false
+    else
+        self:Print("Import failed: selected profile pieces could not be imported.")
+    end
+    return applied
+end
+
+ST._BuildProfileImportPiecesReview = function(profile, options)
+    return CooldownCompanion:BuildProfileImportPiecesReview(profile, options)
+end
+
+ST._RecountProfileImportPiecesSelection = RecountSelection
+
+ST._ApplyProfileImportPieces = function(profile, model)
+    return CooldownCompanion:ApplyProfileImportPieces(profile, model)
+end

--- a/Config/ProfileImportPieces.lua
+++ b/Config/ProfileImportPieces.lua
@@ -166,7 +166,7 @@ local function BuildEligibility(profile, ownerKey, currentCharKey, currentInfo)
         return false, false, ClassLabel(ownerInfo) .. " content"
     end
     if matches == nil then
-        return true, false, "Source class unknown"
+        return false, false, "Source class unknown"
     end
     return true, true, nil
 end
@@ -479,15 +479,13 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
                     AddContainerEntry(entries, containerInfo, selectedPanels, false, importedContainers)
                 end
             end
-            if #entries > 0 then
-                local ok = ApplyPayload(AddCheckpoint({
-                    type = "folder",
-                    folder = CopyForExport(folderInfo.folder),
-                    containers = entries,
-                }, profile))
-                applied = ok or applied
-                failed = failed or not ok
-            end
+            local ok = ApplyPayload(AddCheckpoint({
+                type = "folder",
+                folder = CopyForExport(folderInfo.folder),
+                containers = entries,
+            }, profile))
+            applied = ok or applied
+            failed = failed or not ok
         end
     end
 

--- a/CooldownCompanion.toc
+++ b/CooldownCompanion.toc
@@ -96,6 +96,7 @@ Config\Tutorial.lua
 Config\ExportCodec.lua
 Config\ProfileImport.lua
 Config\Popups.lua
+Config\ProfileImportPieces.lua
 Config\ImportReview.lua
 Config\Diagnostics.lua
 Config\Pickers.lua

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,58 @@
+---
+name: Cooldown Companion
+last_updated: 2026-05-28
+---
+
+# Cooldown Companion Strategy
+
+## Target problem
+
+Players are trying to create personalized, intuitive tracking displays, but Blizzard's baseline UI is limited and does not offer enough customization.
+
+## Our approach
+
+Cooldown Companion makes deep tracking customization feel organic and intuitive through a carefully shaped config experience. It says no to extremely niche options and UI noise unless the choice is broadly useful and can fit coherently into the setup flow; the final tracking display is the result of that seamless configuration experience.
+
+## Who it's for
+
+**Primary:** UI-focused WoW players - They're hiring Cooldown Companion to build a personalized combat tracking display without fighting the config to do it.
+
+## Key metrics
+
+- **Config clarity feedback** - Players describe the config as clear, intuitive, or easier than alternatives; measured through reviews, direct feedback, and support conversations.
+- **High-level personal fit** - The addon keeps feeling satisfying in top-level personal play because the setup and display feel right; measured through the maintainer's own use.
+- **Negative feedback quality** - Negative feedback clusters around fixable specifics, not broad confusion or overwhelm; measured through reviews, comments, and user reports.
+- **Customization coherence** - New customization features can be added without making the config feel cluttered; measured during design, review, and maintainer use.
+- **Idea-to-display friction** - Users can get from an intended tracking idea to a working display without needing lots of explanation; measured through feedback and support burden.
+
+## Tracks
+
+### Config experience
+
+UI clarity and intuitive setup for players who want deep customization without fighting the addon.
+
+_Why it serves the approach:_ The config experience is the core product experience; the display is the result of getting that flow right.
+
+### API health
+
+Keeping up with Blizzard API changes, understanding what information the API can expose, and integrating cleanly with systems like post-12.0 secret values.
+
+_Why it serves the approach:_ Reliable customization depends on respecting the real data and restrictions Blizzard exposes instead of building fragile behavior around assumptions.
+
+### Scope discipline
+
+Keeping the project focused on the tracking and customization work it is meant to do well.
+
+_Why it serves the approach:_ Avoiding niche options and UI noise keeps the addon coherent for the vast majority of users.
+
+## Milestones
+
+- **2026-03-02** - Initial Cooldown Companion release aligned with World of Warcraft: Midnight launch.
+
+## Not working on
+
+- Cooldown Companion will not shape its core strategy around exploiting inconsistent non-secret aura availability. Where Blizzard's secret-value boundaries are fragile or likely to change, the addon should integrate conservatively instead of building major product direction on unstable exceptions.
+
+## Marketing
+
+**One-liner:** Cooldown Companion should be the best option for tracking in-combat information for your character.


### PR DESCRIPTION
## What Players Will Notice
- Profile backup and diagnostic strings now open in the unified import review flow with two clear choices: import selected pieces or restore the full backup.
- Selected pieces import shows compatible current-class/global folders, groups, and panels, with parent rows including their eligible child pieces by default.
- Full restore is framed as a backup/diagnostic action, and the profile bar now labels the paired buttons as `Export Backup` and `Import Backup`.

## Why This Changed
- Profile exports were doing double duty as personal backups and shareable setup strings, which made imports confusing and increased the chance that profile shape changes drifted across import paths.
- Selected pieces gives players a safer sharing path, while restore remains available for personal backups and bug-report reproduction.

## What Changed
- Added a profile-piece review/apply model for folders, groups, and panels inside profile and diagnostic strings.
- Hid incompatible class content from selected-piece import, handled global folders correctly, and made parent checkbox behavior include child pieces predictably.
- Reused the group/folder import path with private batch state so anchors can remap across selected folders and groups without accepting serialized internal control fields.
- Hardened selected-piece review against malformed optional profile sections and tightened the import window layout/copy.

## Validation
- `git diff --check origin/import-export...HEAD`
- `luac -p Config\ImportReview.lua Config\ProfileImportPieces.lua Config\Popups.lua Config\Column4.lua`
- `lua tests\import-review.lua`
- `lua tests\profile-import-apply.lua`
- Earlier in-game UI smoke checks guided the review window layout and mode behavior, but final in-game combat/restricted-content validation is still pending.
