### PR TITLE
Improve import review readability and resizing

### DIFF
--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -25,19 +25,91 @@ local DIAGNOSTIC_PREFIX = "CDCdiag:"
 local IMPORT_REVIEW_CONFIRM_POPUP = "CDC_IMPORT_REVIEW_CONFIRM"
 local IMPORT_TEXT_LINES = 8
 local IMPORT_TEXT_HEIGHT = 160
-local IMPORT_REVIEW_HEIGHT = 220
 local IMPORT_ACTION_HEIGHT = 30
 local IMPORT_WINDOW_WIDTH = 640
 local IMPORT_WINDOW_HEIGHT = 500
+local ACE_WINDOW_DEFAULT_MIN_WIDTH = 240
+local ACE_WINDOW_DEFAULT_MIN_HEIGHT = 240
+local IMPORT_WINDOW_MIN_WIDTH = 420
+local IMPORT_WINDOW_MIN_HEIGHT = 380
+local IMPORT_LAYOUT = "CDC_IMPORT_REVIEW"
+local IMPORT_LAYOUT_GAP = 8
+local IMPORT_REVIEW_MIN_HEIGHT = 110
+local IMPORT_REVIEW_FONT_SIZE = 14
+local IMPORT_REVIEW_SHADOW_ALPHA = 0.9
+local IMPORT_REVIEW_SHADOW_X = 1
+local IMPORT_REVIEW_SHADOW_Y = -1
+local IMPORT_REVIEW_SECTION_GAP = 10
+local IMPORT_REVIEW_COLLAPSED_GAP = 1
 local IMPORT_MODE_LABELS = {
     selected = "Import selected pieces",
     restore = "Restore backup",
 }
 local IMPORT_MODE_ORDER = { "selected", "restore" }
 
+if not AceGUI:GetLayout(IMPORT_LAYOUT) then
+    AceGUI:RegisterLayout(IMPORT_LAYOUT, function(content, children)
+        local width = content.width or content:GetWidth() or 0
+        local height = content.height or content:GetHeight() or 0
+        local pasteGroup = children[1]
+        local reviewScroll = children[2]
+        local buttonGroup = children[3]
+        local reviewHeight = height - IMPORT_TEXT_HEIGHT - IMPORT_ACTION_HEIGHT - (IMPORT_LAYOUT_GAP * 2)
+
+        if reviewHeight < IMPORT_REVIEW_MIN_HEIGHT then
+            reviewHeight = IMPORT_REVIEW_MIN_HEIGHT
+        end
+
+        if pasteGroup then
+            pasteGroup:SetWidth(width)
+            pasteGroup:SetHeight(IMPORT_TEXT_HEIGHT)
+            pasteGroup.frame:ClearAllPoints()
+            pasteGroup.frame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
+            pasteGroup.frame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
+            pasteGroup.frame:Show()
+            if pasteGroup.DoLayout then
+                pasteGroup:DoLayout()
+            end
+        end
+
+        if buttonGroup then
+            buttonGroup:SetWidth(width)
+            buttonGroup:SetHeight(IMPORT_ACTION_HEIGHT)
+            buttonGroup.frame:ClearAllPoints()
+            buttonGroup.frame:SetPoint("BOTTOMLEFT", content, "BOTTOMLEFT", 0, 0)
+            buttonGroup.frame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
+            buttonGroup.frame:Show()
+            if buttonGroup.DoLayout then
+                buttonGroup:DoLayout()
+            end
+        end
+
+        if reviewScroll then
+            reviewScroll:SetWidth(width)
+            reviewScroll:SetHeight(reviewHeight)
+            reviewScroll.frame:ClearAllPoints()
+            if pasteGroup then
+                reviewScroll.frame:SetPoint("TOPLEFT", pasteGroup.frame, "BOTTOMLEFT", 0, -IMPORT_LAYOUT_GAP)
+            else
+                reviewScroll.frame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
+            end
+            if buttonGroup then
+                reviewScroll.frame:SetPoint("BOTTOMRIGHT", buttonGroup.frame, "TOPRIGHT", 0, IMPORT_LAYOUT_GAP)
+            else
+                reviewScroll.frame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
+            end
+            reviewScroll.frame:Show()
+            if reviewScroll.DoLayout then
+                reviewScroll:DoLayout()
+            end
+        end
+    end)
+end
+
 local importReviewFrame = nil
 local activeReview = nil
 local pendingReviewImport = nil
+local importReviewFontObject = nil
 
 local function CountPairs(tbl)
     local count = 0
@@ -491,12 +563,111 @@ local function ConfigureWrappedLabel(label)
     label:SetFullWidth(true)
 end
 
+local function ResetImportReviewTextShadow(widget)
+    local label = widget and widget.label
+    if not label then
+        return
+    end
+    if label.SetShadowColor then
+        label:SetShadowColor(0, 0, 0, 0)
+    end
+    if label.SetShadowOffset then
+        label:SetShadowOffset(0, 0)
+    end
+end
+
+local function GetImportReviewFontObject()
+    if importReviewFontObject then
+        return importReviewFontObject
+    end
+    if not CreateFont then
+        return GameFontHighlight
+    end
+
+    local fontObject = _G and _G.CooldownCompanionImportReviewTextFont
+    if not fontObject then
+        fontObject = CreateFont("CooldownCompanionImportReviewTextFont")
+    end
+    if fontObject.CopyFontObject and GameFontHighlight then
+        fontObject:CopyFontObject(GameFontHighlight)
+    end
+    if fontObject.SetFont and GameFontHighlight and GameFontHighlight.GetFont then
+        local fontPath, _, fontFlags = GameFontHighlight:GetFont()
+        if fontPath then
+            fontObject:SetFont(fontPath, IMPORT_REVIEW_FONT_SIZE, fontFlags or "")
+        end
+    end
+    if fontObject.SetShadowColor then
+        fontObject:SetShadowColor(0, 0, 0, IMPORT_REVIEW_SHADOW_ALPHA)
+    end
+    if fontObject.SetShadowOffset then
+        fontObject:SetShadowOffset(IMPORT_REVIEW_SHADOW_X, IMPORT_REVIEW_SHADOW_Y)
+    end
+
+    importReviewFontObject = fontObject
+    return importReviewFontObject
+end
+
+local function ConfigureImportReviewTextLabel(widget)
+    ConfigureWrappedLabel(widget)
+    local fontObject = GetImportReviewFontObject()
+    if widget.SetFontObject and fontObject then
+        widget:SetFontObject(fontObject)
+    end
+
+    local label = widget.label
+    if label then
+        if label.SetShadowColor then
+            label:SetShadowColor(0, 0, 0, IMPORT_REVIEW_SHADOW_ALPHA)
+        end
+        if label.SetShadowOffset then
+            label:SetShadowOffset(IMPORT_REVIEW_SHADOW_X, IMPORT_REVIEW_SHADOW_Y)
+        end
+    end
+
+    if widget.SetCallback and widget.events then
+        local prevOnRelease = widget.events["OnRelease"]
+        widget:SetCallback("OnRelease", function(releasedWidget, event, ...)
+            if prevOnRelease then
+                prevOnRelease(releasedWidget, event, ...)
+            end
+            ResetImportReviewTextShadow(releasedWidget)
+        end)
+    end
+end
+
+local function AddVerticalSpacer(group)
+    local spacer = AceGUI:Create("SimpleGroup")
+    spacer:SetFullWidth(true)
+    spacer:SetHeight(IMPORT_REVIEW_COLLAPSED_GAP)
+    spacer.noAutoHeight = true
+    spacer:SetLayout("Fill")
+    group:AddChild(spacer)
+    return spacer
+end
+
+local function SetSpacerHeight(spacer, height)
+    if spacer and spacer.SetHeight then
+        spacer:SetHeight(height or IMPORT_REVIEW_COLLAPSED_GAP)
+    end
+end
+
 local function AddButton(group, text, width)
     local button = AceGUI:Create("Button")
     button:SetText(text)
-    button:SetWidth(width)
+    if width and width <= 1 then
+        button:SetRelativeWidth(width)
+    elseif width then
+        button:SetWidth(width)
+    end
     group:AddChild(button)
     return button
+end
+
+local function SetWindowResizeBounds(widget, minWidth, minHeight)
+    if widget and widget.frame and widget.frame.SetResizeBounds then
+        widget.frame:SetResizeBounds(minWidth, minHeight)
+    end
 end
 
 local function RelayoutImportWindow(frame, reviewScroll, ...)
@@ -526,6 +697,7 @@ local function CloseImportReviewFrame(widget)
         importReviewFrame = nil
     end
     if widget then
+        SetWindowResizeBounds(widget, ACE_WINDOW_DEFAULT_MIN_WIDTH, ACE_WINDOW_DEFAULT_MIN_HEIGHT)
         AceGUI:Release(widget)
     end
 end
@@ -682,7 +854,8 @@ local function ShowImportReviewWindow(context)
     frame:SetTitle("Import")
     frame:SetWidth(IMPORT_WINDOW_WIDTH)
     frame:SetHeight(IMPORT_WINDOW_HEIGHT)
-    frame:SetLayout("List")
+    SetWindowResizeBounds(frame, IMPORT_WINDOW_MIN_WIDTH, IMPORT_WINDOW_MIN_HEIGHT)
+    frame:SetLayout(IMPORT_LAYOUT)
     importReviewFrame = frame
     activeReview = nil
 
@@ -701,7 +874,7 @@ local function ShowImportReviewWindow(context)
 
     local reviewScroll = AceGUI:Create("ScrollFrame")
     reviewScroll:SetFullWidth(true)
-    reviewScroll:SetHeight(IMPORT_REVIEW_HEIGHT)
+    reviewScroll:SetHeight(IMPORT_REVIEW_MIN_HEIGHT)
     reviewScroll:SetLayout("List")
     frame:AddChild(reviewScroll)
 
@@ -718,10 +891,14 @@ local function ShowImportReviewWindow(context)
     disclaimerLabel:SetText("")
     reviewScroll:AddChild(disclaimerLabel)
 
+    local summaryTopSpacer = AddVerticalSpacer(reviewScroll)
+
     local statusLabel = AceGUI:Create("Label")
-    ConfigureWrappedLabel(statusLabel)
+    ConfigureImportReviewTextLabel(statusLabel)
     statusLabel:SetText("|cff888888No import string reviewed.|r")
     reviewScroll:AddChild(statusLabel)
+
+    local summaryBottomSpacer = AddVerticalSpacer(reviewScroll)
 
     local pieceGroup = AceGUI:Create("SimpleGroup")
     pieceGroup:SetFullWidth(true)
@@ -734,9 +911,9 @@ local function ShowImportReviewWindow(context)
     buttonGroup.noAutoHeight = true
     buttonGroup:SetLayout("Flow")
 
-    local acceptButton = AddButton(buttonGroup, "Import", 220)
+    local acceptButton = AddButton(buttonGroup, "Import", 0.5)
     acceptButton:SetDisabled(true)
-    local cancelButton = AddButton(buttonGroup, "Cancel", 120)
+    local cancelButton = AddButton(buttonGroup, "Cancel", 0.5)
 
     frame:AddChild(buttonGroup)
 
@@ -744,9 +921,14 @@ local function ShowImportReviewWindow(context)
         RenderModeControl(modeGroup, activeReview, RefreshPresentation)
         RenderPieceRows(pieceGroup, activeReview, RefreshPresentation)
         local selectedCount = ReviewUsesSelectedPieces(activeReview) and RecountSelectedPieces(activeReview) or nil
+        local disclaimerText = GetProfileImportDisclaimer(activeReview) or ""
         acceptButton:SetText(GetReviewAcceptText(activeReview))
         acceptButton:SetDisabled(not CanApplyReview(activeReview, selectedCount))
-        disclaimerLabel:SetText(GetProfileImportDisclaimer(activeReview) or "")
+        disclaimerLabel:SetText(disclaimerText)
+        SetSpacerHeight(summaryTopSpacer, disclaimerText ~= "" and IMPORT_REVIEW_SECTION_GAP
+            or IMPORT_REVIEW_COLLAPSED_GAP)
+        SetSpacerHeight(summaryBottomSpacer, ReviewUsesSelectedPieces(activeReview) and IMPORT_REVIEW_SECTION_GAP
+            or IMPORT_REVIEW_COLLAPSED_GAP)
         if activeReview then
             statusLabel:SetText(FormatReviewText(activeReview, selectedCount))
         end
@@ -758,6 +940,8 @@ local function ShowImportReviewWindow(context)
         acceptButton:SetDisabled(true)
         acceptButton:SetText("Import")
         disclaimerLabel:SetText("")
+        SetSpacerHeight(summaryTopSpacer, IMPORT_REVIEW_COLLAPSED_GAP)
+        SetSpacerHeight(summaryBottomSpacer, IMPORT_REVIEW_COLLAPSED_GAP)
         ReleaseChildren(modeGroup)
         ReleaseChildren(pieceGroup)
         RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -48,6 +48,21 @@ local IMPORT_MODE_LABELS = {
 local IMPORT_MODE_ORDER = { "selected", "restore" }
 
 if not AceGUI:GetLayout(IMPORT_LAYOUT) then
+    local function LayoutImportBand(group, width, height)
+        if not group then
+            return nil
+        end
+
+        group:SetWidth(width)
+        group:SetHeight(height)
+        group.frame:ClearAllPoints()
+        group.frame:Show()
+        if group.DoLayout then
+            group:DoLayout()
+        end
+        return group.frame
+    end
+
     AceGUI:RegisterLayout(IMPORT_LAYOUT, function(content, children)
         local width = content.width or content:GetWidth() or 0
         local height = content.height or content:GetHeight() or 0
@@ -60,41 +75,29 @@ if not AceGUI:GetLayout(IMPORT_LAYOUT) then
             reviewHeight = IMPORT_REVIEW_MIN_HEIGHT
         end
 
-        if pasteGroup then
-            pasteGroup:SetWidth(width)
-            pasteGroup:SetHeight(IMPORT_TEXT_HEIGHT)
-            pasteGroup.frame:ClearAllPoints()
-            pasteGroup.frame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
-            pasteGroup.frame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
-            pasteGroup.frame:Show()
-            if pasteGroup.DoLayout then
-                pasteGroup:DoLayout()
-            end
+        local pasteFrame = LayoutImportBand(pasteGroup, width, IMPORT_TEXT_HEIGHT)
+        if pasteFrame then
+            pasteFrame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
+            pasteFrame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
         end
 
-        if buttonGroup then
-            buttonGroup:SetWidth(width)
-            buttonGroup:SetHeight(IMPORT_ACTION_HEIGHT)
-            buttonGroup.frame:ClearAllPoints()
-            buttonGroup.frame:SetPoint("BOTTOMLEFT", content, "BOTTOMLEFT", 0, 0)
-            buttonGroup.frame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
-            buttonGroup.frame:Show()
-            if buttonGroup.DoLayout then
-                buttonGroup:DoLayout()
-            end
+        local buttonFrame = LayoutImportBand(buttonGroup, width, IMPORT_ACTION_HEIGHT)
+        if buttonFrame then
+            buttonFrame:SetPoint("BOTTOMLEFT", content, "BOTTOMLEFT", 0, 0)
+            buttonFrame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
         end
 
         if reviewScroll then
             reviewScroll:SetWidth(width)
             reviewScroll:SetHeight(reviewHeight)
             reviewScroll.frame:ClearAllPoints()
-            if pasteGroup then
-                reviewScroll.frame:SetPoint("TOPLEFT", pasteGroup.frame, "BOTTOMLEFT", 0, -IMPORT_LAYOUT_GAP)
+            if pasteFrame then
+                reviewScroll.frame:SetPoint("TOPLEFT", pasteFrame, "BOTTOMLEFT", 0, -IMPORT_LAYOUT_GAP)
             else
                 reviewScroll.frame:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
             end
-            if buttonGroup then
-                reviewScroll.frame:SetPoint("BOTTOMRIGHT", buttonGroup.frame, "TOPRIGHT", 0, IMPORT_LAYOUT_GAP)
+            if buttonFrame then
+                reviewScroll.frame:SetPoint("BOTTOMRIGHT", buttonFrame, "TOPRIGHT", 0, IMPORT_LAYOUT_GAP)
             else
                 reviewScroll.frame:SetPoint("RIGHT", content, "RIGHT", 0, 0)
             end
@@ -563,19 +566,6 @@ local function ConfigureWrappedLabel(label)
     label:SetFullWidth(true)
 end
 
-local function ResetImportReviewTextShadow(widget)
-    local label = widget and widget.label
-    if not label then
-        return
-    end
-    if label.SetShadowColor then
-        label:SetShadowColor(0, 0, 0, 0)
-    end
-    if label.SetShadowOffset then
-        label:SetShadowOffset(0, 0)
-    end
-end
-
 local function GetImportReviewFontObject()
     if importReviewFontObject then
         return importReviewFontObject
@@ -614,26 +604,6 @@ local function ConfigureImportReviewTextLabel(widget)
     if widget.SetFontObject and fontObject then
         widget:SetFontObject(fontObject)
     end
-
-    local label = widget.label
-    if label then
-        if label.SetShadowColor then
-            label:SetShadowColor(0, 0, 0, IMPORT_REVIEW_SHADOW_ALPHA)
-        end
-        if label.SetShadowOffset then
-            label:SetShadowOffset(IMPORT_REVIEW_SHADOW_X, IMPORT_REVIEW_SHADOW_Y)
-        end
-    end
-
-    if widget.SetCallback and widget.events then
-        local prevOnRelease = widget.events["OnRelease"]
-        widget:SetCallback("OnRelease", function(releasedWidget, event, ...)
-            if prevOnRelease then
-                prevOnRelease(releasedWidget, event, ...)
-            end
-            ResetImportReviewTextShadow(releasedWidget)
-        end)
-    end
 end
 
 local function AddVerticalSpacer(group)
@@ -652,14 +622,10 @@ local function SetSpacerHeight(spacer, height)
     end
 end
 
-local function AddButton(group, text, width)
+local function AddFooterButton(group, text)
     local button = AceGUI:Create("Button")
     button:SetText(text)
-    if width and width <= 1 then
-        button:SetRelativeWidth(width)
-    elseif width then
-        button:SetWidth(width)
-    end
+    button:SetRelativeWidth(0.5)
     group:AddChild(button)
     return button
 end
@@ -670,16 +636,7 @@ local function SetWindowResizeBounds(widget, minWidth, minHeight)
     end
 end
 
-local function RelayoutImportWindow(frame, reviewScroll, ...)
-    for i = 1, select("#", ...) do
-        local group = select(i, ...)
-        if group and group.DoLayout then
-            group:DoLayout()
-        end
-    end
-    if reviewScroll and reviewScroll.DoLayout then
-        reviewScroll:DoLayout()
-    end
+local function RelayoutImportWindow(frame)
     if frame and frame.DoLayout then
         frame:DoLayout()
     end
@@ -911,9 +868,9 @@ local function ShowImportReviewWindow(context)
     buttonGroup.noAutoHeight = true
     buttonGroup:SetLayout("Flow")
 
-    local acceptButton = AddButton(buttonGroup, "Import", 0.5)
+    local acceptButton = AddFooterButton(buttonGroup, "Import")
     acceptButton:SetDisabled(true)
-    local cancelButton = AddButton(buttonGroup, "Cancel", 0.5)
+    local cancelButton = AddFooterButton(buttonGroup, "Cancel")
 
     frame:AddChild(buttonGroup)
 
@@ -932,10 +889,10 @@ local function ShowImportReviewWindow(context)
         if activeReview then
             statusLabel:SetText(FormatReviewText(activeReview, selectedCount))
         end
-        RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)
+        RelayoutImportWindow(frame)
     end
 
-    local function ClearReview()
+    local function ClearReview(statusText)
         activeReview = nil
         acceptButton:SetDisabled(true)
         acceptButton:SetText("Import")
@@ -944,15 +901,16 @@ local function ShowImportReviewWindow(context)
         SetSpacerHeight(summaryBottomSpacer, IMPORT_REVIEW_COLLAPSED_GAP)
         ReleaseChildren(modeGroup)
         ReleaseChildren(pieceGroup)
-        RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)
+        if statusText then
+            statusLabel:SetText(statusText)
+        end
+        RelayoutImportWindow(frame)
     end
 
     local function ReviewInput()
         local review = CooldownCompanion:ClassifyImportReviewText(inputBox:GetText())
         if not review.ok then
-            ClearReview()
-            statusLabel:SetText("|cffff6666" .. (review.message or "Import failed.") .. "|r")
-            RelayoutImportWindow(frame, reviewScroll, modeGroup, pieceGroup)
+            ClearReview("|cffff6666" .. (review.message or "Import failed.") .. "|r")
             return
         end
 


### PR DESCRIPTION
## What Players Will Notice
- The import review window is easier to read over the game background, with larger shadowed review text and clearer spacing between the summary and selected pieces.
- The import and cancel buttons now stay attached to the bottom of the window and resize symmetrically when the window changes size.

## Why This Changed
- The previous review text could blend into the background, and resizing the import window could leave the action buttons visually floating above empty space.

## What Changed
- Added an import-review-specific AceGUI layout that keeps the paste field at the top, the review content in the middle, and the action row pinned to the bottom.
- Added equal-width footer buttons, bounded resize sizing, review-summary spacing, and a dedicated shadowed font object for the review summary text.
- Simplified the layout refresh path so invalid paste text and review updates do not run redundant relayouts.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Config\ImportReview.lua`
- `lua tests\profile-import-apply.lua`
- Static review against `origin/main` found no actionable issues.
- In-game visual verification is still needed for the final shadow, spacing, and resize feel. Combat and restricted-content behavior have not been verified in-game.