### PR TITLE
Fix group dragging over unloaded groups

### DIFF
--- a/Config/DragReorderPreview.lua
+++ b/Config/DragReorderPreview.lua
@@ -1544,7 +1544,6 @@ local function UpdateCol1Ghost(preview, model)
 end
 
 local ClearCol1AnimatedPreview
-local FindCol1SectionDividerTarget
 
 local function SectionHasLoadedCol1Rows(renderedRows, section)
     for _, row in ipairs(renderedRows or {}) do


### PR DESCRIPTION
## What Players Will Notice
- Dragging a loaded group over the unloaded groups section in Column 1 no longer throws a Lua error.

## Why This Changed
- The drag preview code had a local helper import for finding the unloaded section divider, but a later duplicate local declaration shadowed it with `nil`.
- That only surfaced on the loaded-to-unloaded placeholder path, which is why dragging over the unloaded groups divider hit `attempt to call a nil value`.

## What Changed
- Removed the duplicate local declaration in `Config/DragReorderPreview.lua` so the preview path uses the resolver exported by `DragReorderTargets.lua`.

## Validation
- `lua tests\drag-reorder-preview.lua` passed with a focused local regression harness for the loaded-to-unloaded placeholder target.
- `luac -p Config\DragReorderPreview.lua Config\DragReorderTargets.lua Config\DragReorderLifecycle.lua` passed.
- `git diff --check origin/main...HEAD` passed.
- In-game verification is still needed after `/reload` by repeating the drag over the unloaded groups section.
- Combat and restricted-content behavior has not been verified in-game yet.