### PR TITLE
Let anchored panels inherit or customize parent alpha

### DIFF
--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -54,6 +54,7 @@ local PANEL_DEFAULTS = {
     compactLayout = false,
     maxVisibleButtons = 0,
     compactGrowthDirection = "center",
+    inheritPanelAlpha = true,
     baselineAlpha = 1,
     forceAlphaTargetEnemyOnly = false,
     forceAlphaFocusExists = false,
@@ -90,6 +91,28 @@ local CONTAINER_DEFAULT_ANCHOR = {
     x = 0,
     y = 0,
 }
+
+local function IsPanelAnchor(anchor)
+    local relativeTo = type(anchor) == "table" and anchor.relativeTo or anchor
+    return type(relativeTo) == "string"
+        and relativeTo:match("^CooldownCompanionGroup%d+$") ~= nil
+        or false
+end
+
+local function HasActivePanelAlphaSettings(group)
+    return (group.baselineAlpha or 1) < 1
+        or group.forceAlphaInCombat == true
+        or group.forceAlphaOutOfCombat == true
+        or group.forceAlphaRegularMounted == true
+        or group.forceAlphaDragonriding == true
+        or group.forceAlphaTargetExists == true
+        or group.forceAlphaFocusExists == true
+        or group.forceAlphaMouseover == true
+        or group.forceHideInCombat == true
+        or group.forceHideOutOfCombat == true
+        or group.forceHideRegularMounted == true
+        or group.forceHideDragonriding == true
+end
 
 local PROFILE_DEFAULT_KEYS = {
     minimap = "minimap",
@@ -165,6 +188,7 @@ local COMPACT_ENTITY_DEFAULTS = {
             compactLayout = false,
             maxVisibleButtons = 0,
             compactGrowthDirection = "center",
+            inheritPanelAlpha = true,
             baselineAlpha = 1,
             forceAlphaTargetEnemyOnly = false,
             forceAlphaFocusExists = false,
@@ -500,6 +524,10 @@ local function RehydratePanel(group, styleDefaults, panelContainerRef, formatVer
 
     local panelDefaults = GetPanelDefaults(formatVersion)
     group.style = MergeWithDefaults(group.style, styleDefaults)
+    local preserveCustomPanelAlpha = group.inheritPanelAlpha == nil
+        and panelContainerRef ~= nil
+        and IsPanelAnchor(group.anchor)
+        and HasActivePanelAlphaSettings(group)
 
     if group.loadConditions ~= nil then
         group.loadConditions = RehydrateLoadConditions(group.loadConditions, formatVersion)
@@ -517,6 +545,9 @@ local function RehydratePanel(group, styleDefaults, panelContainerRef, formatVer
         if group[key] == nil then
             group[key] = CopyValue(defaultValue)
         end
+    end
+    if preserveCustomPanelAlpha then
+        group.inheritPanelAlpha = false
     end
 end
 

--- a/Config/ExportCodec.lua
+++ b/Config/ExportCodec.lua
@@ -506,6 +506,12 @@ local function CompactPanel(group, styleDefaults, panelContainerRef, formatVersi
             if compactAnchor then
                 compact.anchor = compactAnchor
             end
+        elseif key == "inheritPanelAlpha"
+            and value == true
+            and panelContainerRef ~= nil
+            and IsPanelAnchor(group.anchor)
+            and HasActivePanelAlphaSettings(group) then
+            compact.inheritPanelAlpha = true
         elseif panelDefaults[key] ~= nil then
             if not DeepEqual(value, panelDefaults[key]) then
                 compact[key] = CopyValue(value)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1132,6 +1132,13 @@ local function BuildLayoutTab(container)
     elseif CooldownCompanion.ClearCursorAnchorLayoutPreview then
         CooldownCompanion:ClearCursorAnchorLayoutPreview()
     end
+    local panelAlphaInherited = false
+    if isPanel
+        and targetMode == "panel"
+        and currentAnchorGroupId
+        and CooldownCompanion.ShouldInheritPanelAnchorAlpha then
+        panelAlphaInherited = CooldownCompanion:ShouldInheritPanelAnchorAlpha(CS.selectedGroup)
+    end
 
     local anchorTargetDrop = AceGUI:Create("Dropdown")
     anchorTargetDrop:SetLabel("Anchor Target")
@@ -1265,6 +1272,29 @@ local function BuildLayoutTab(container)
             end
         end)
         container:AddChild(panelAnchorDrop)
+
+        local panelAlphaDrop = AceGUI:Create("Dropdown")
+        panelAlphaDrop:SetLabel("Panel Alpha")
+        panelAlphaDrop:SetList({
+            inherit = "Inherit Target Panel Alpha",
+            custom = "Custom Alpha",
+        }, { "inherit", "custom" })
+        panelAlphaDrop:SetValue(group.inheritPanelAlpha == false and "custom" or "inherit")
+        panelAlphaDrop:SetFullWidth(true)
+        panelAlphaDrop:SetCallback("OnValueChanged", function(widget, event, val)
+            if val == "custom" then
+                group.inheritPanelAlpha = false
+            else
+                group.inheritPanelAlpha = true
+            end
+
+            local frame = CooldownCompanion.groupFrames[CS.selectedGroup]
+            if frame then
+                CooldownCompanion:AnchorGroupFrame(frame, group.anchor)
+            end
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        container:AddChild(panelAlphaDrop)
     end
 
     if targetMode == "cursor" then
@@ -1445,6 +1475,8 @@ local function BuildLayoutTab(container)
         CooldownCompanion:RefreshConfigPanel()
     end, "layout_alpha", {
         isGlobal = group.isGlobal,
+        disabled = panelAlphaInherited,
+        disabledText = "This panel inherits alpha from the parent panel. Change the parent panel's Alpha settings to affect it.",
         onBaselineChanged = function(val)
             local frame = CooldownCompanion.groupFrames[CS.selectedGroup]
             if frame and frame:IsShown() then

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -1291,7 +1291,7 @@ ST._HookSliderEditBox = HookSliderEditBox
 -- config: table with alpha fields (baselineAlpha, forceAlpha*, forceHide*, fade*, etc.)
 -- refreshFn: function called after value changes (typically RefreshConfigPanel)
 -- collapseKey: string key for CS.collapsedSections
--- opts (optional): { onBaselineChanged = fn(val), isGlobal = bool, disabled = bool, infoButtons = table }
+-- opts (optional): { onBaselineChanged = fn(val), isGlobal = bool, disabled = bool, disabledText = string, infoButtons = table }
 local function BuildAlphaControls(container, config, refreshFn, collapseKey, opts)
     opts = opts or {}
     local tabInfoBtns = opts.infoButtons or CS.tabInfoButtons
@@ -1310,6 +1310,16 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
     end)
 
     if alphaCollapsed then return end
+
+    if controlsDisabled and opts.disabledText and opts.disabledText ~= "" then
+        local disabledLabel = AceGUI:Create("Label")
+        if ST._ConfigureWrappedHelperLabel then
+            ST._ConfigureWrappedHelperLabel(disabledLabel)
+        end
+        disabledLabel:SetText("|cff888888" .. opts.disabledText .. "|r")
+        disabledLabel:SetFullWidth(true)
+        container:AddChild(disabledLabel)
+    end
 
     local baseAlphaSlider = AceGUI:Create("Slider")
     baseAlphaSlider:SetLabel("Baseline Alpha")

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -400,6 +400,10 @@ function CooldownCompanion:InitAlphaUpdateFrame()
     end
 
     local function GroupNeedsAlphaUpdate(group, groupId)
+        if self.ShouldInheritPanelAnchorAlpha
+            and self:ShouldInheritPanelAnchorAlpha(groupId) then
+            return false
+        end
         if ST.IsGroupConfigSelected(groupId) then return true end
         return ConfigNeedsAlphaUpdate(group, groupId)
     end

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -298,6 +298,21 @@ local function SanitizeScopedExternalAnchors(profile, targetIsCursorRoot)
     end)
 end
 
+local function HasActiveAlphaSettings(group)
+    return (group.baselineAlpha or 1) < 1
+        or group.forceAlphaInCombat == true
+        or group.forceAlphaOutOfCombat == true
+        or group.forceAlphaRegularMounted == true
+        or group.forceAlphaDragonriding == true
+        or group.forceAlphaTargetExists == true
+        or group.forceAlphaFocusExists == true
+        or group.forceAlphaMouseover == true
+        or group.forceHideInCombat == true
+        or group.forceHideOutOfCombat == true
+        or group.forceHideRegularMounted == true
+        or group.forceHideDragonriding == true
+end
+
 local function AddDependent(dependents, name)
     dependents[#dependents + 1] = {
         name = name,
@@ -371,6 +386,25 @@ end
 function CooldownCompanion:IsGroupCursorAnchored(groupOrId)
     local group = GetGroup(self, groupOrId)
     return self:IsCursorAnchor(group and group.anchor)
+end
+
+function CooldownCompanion:IsPanelAnchoredToPanel(groupOrId)
+    local group = GetGroup(self, groupOrId)
+    if not (group and group.parentContainerId) then
+        return false
+    end
+
+    local anchor = group.anchor
+    local relativeTo = type(anchor) == "table" and anchor.relativeTo or anchor
+    local kind = ParseAddonAnchorFrameName(relativeTo)
+    return kind == "group"
+end
+
+function CooldownCompanion:ShouldInheritPanelAnchorAlpha(groupOrId)
+    local group = GetGroup(self, groupOrId)
+    return self:IsPanelAnchoredToPanel(group)
+        and group.inheritPanelAlpha ~= false
+        or false
 end
 
 function CooldownCompanion:DoesAnchorTargetReachCursorRoot(relativeTo, profile)
@@ -591,4 +625,20 @@ function CooldownCompanion:SanitizeCursorAnchorPolicy(profile)
     end
 
     SanitizeScopedExternalAnchors(profile, targetIsCursorRoot)
+end
+
+function CooldownCompanion:NormalizePanelAlphaInheritance(profile)
+    profile = profile or GetProfile(self)
+    if type(profile) ~= "table" then
+        return
+    end
+
+    for _, group in pairs(profile.groups or {}) do
+        if type(group) == "table"
+            and group.inheritPanelAlpha == nil
+            and self:IsPanelAnchoredToPanel(group)
+            and HasActiveAlphaSettings(group) then
+            group.inheritPanelAlpha = false
+        end
+    end
 end

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -205,6 +205,7 @@ local defaults = {
                     enabled = true,
                     displayMode = "icons",    -- "icons" or "bars"
                     frameStrata = nil,        -- nil = "MEDIUM" (default), or "BACKGROUND"/"LOW"/"HIGH"/"DIALOG"
+                    inheritPanelAlpha = true, -- panels anchored to panels inherit target panel alpha by default
                     -- Alpha fade system
                     baselineAlpha = 1,        -- alpha when no force conditions met (0-1)
                     forceAlphaInCombat = false,

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1585,9 +1585,9 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
         if accumulator < SYNC_INTERVAL then return end
         accumulator = 0
         if frame.anchoredToParent then
-            -- Skip sync if alpha system is active or group is unlocked
+            -- Skip sync if this panel owns alpha locally or the group is unlocked.
             local locked, bAlpha = GetContainerState(frame.groupId)
-            if bAlpha < 1 or not locked then return end
+            if (bAlpha < 1 and not inheritsPanelAlpha) or not locked then return end
             -- Read parent's natural alpha to avoid config override cascade
             local alpha = frame.anchoredToParent._naturalAlpha or frame.anchoredToParent:GetEffectiveAlpha()
             -- Config-selected: store natural alpha for further downstream chains, force own frame to full

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -81,6 +81,37 @@ local function GetContainerState(groupId)
     return group.locked or false, group.baselineAlpha or 1
 end
 
+local function ShouldSyncAnchorAlpha(self, groupId)
+    if self.IsPanelAnchoredToPanel
+        and self:IsPanelAnchoredToPanel(groupId) then
+        if self.ShouldInheritPanelAnchorAlpha then
+            return self:ShouldInheritPanelAnchorAlpha(groupId)
+        end
+        return true
+    end
+    return true
+end
+
+local function ApplyGroupOwnAlpha(frame)
+    if not frame then return end
+
+    local locked, baseAlpha = GetContainerState(frame.groupId)
+    local alpha = locked and (baseAlpha or 1) or 1
+    local state = CooldownCompanion.alphaState and CooldownCompanion.alphaState[frame.groupId]
+    if locked and state and state.currentAlpha ~= nil then
+        alpha = state.currentAlpha
+    end
+
+    if ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(frame.groupId) then
+        frame._naturalAlpha = alpha
+        frame:SetAlpha(1)
+        return
+    end
+
+    frame._naturalAlpha = nil
+    frame:SetAlpha(alpha)
+end
+
 local function GetContainerPreviewSelectionState(groupId)
     local profile = CooldownCompanion.db and CooldownCompanion.db.profile
     local group = profile and profile.groups and profile.groups[groupId]
@@ -1514,14 +1545,30 @@ function CooldownCompanion:AnchorGroupFrame(frame, anchor, forceCenter)
 end
 
 function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
+    if not ShouldSyncAnchorAlpha(self, frame.groupId) then
+        if frame.alphaSyncFrame then
+            frame.alphaSyncFrame:SetScript("OnUpdate", nil)
+        end
+        ApplyGroupOwnAlpha(frame)
+        return
+    end
+
     -- Create a hidden frame to handle OnUpdate if needed
     if not frame.alphaSyncFrame then
         frame.alphaSyncFrame = CreateFrame("Frame", nil, frame)
     end
 
-    -- If this group has baseline alpha < 1, the alpha fade system takes priority
+    local inheritsPanelAlpha = self.ShouldInheritPanelAnchorAlpha
+        and self:ShouldInheritPanelAnchorAlpha(frame.groupId)
+        or false
+    if inheritsPanelAlpha and self.alphaState then
+        self.alphaState[frame.groupId] = nil
+    end
+
+    -- If this group has baseline alpha < 1, the alpha fade system takes
+    -- priority unless panel alpha inheritance is explicitly active.
     local _, baseAlpha = GetContainerState(frame.groupId)
-    if baseAlpha < 1 then
+    if baseAlpha < 1 and not inheritsPanelAlpha then
         frame.alphaSyncFrame:SetScript("OnUpdate", nil)
         return
     end

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -869,6 +869,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
         compactLayout = false,
         maxVisibleButtons = 0,
         compactGrowthDirection = "center",
+        inheritPanelAlpha = true,
         -- Alpha fade defaults (panels own their own alpha)
         baselineAlpha = 1,
         fadeDelay = 1,

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -206,6 +206,9 @@ function CooldownCompanion:RunAllMigrations()
     if self.SanitizeCursorAnchorPolicy and not self._deferCursorAnchorPolicySanitizer then
         self:SanitizeCursorAnchorPolicy(self.db and self.db.profile)
     end
+    if self.NormalizePanelAlphaInheritance then
+        self:NormalizePanelAlphaInheritance(self.db and self.db.profile)
+    end
     return true
 end
 


### PR DESCRIPTION
## What Players Will Notice
- Panels anchored to another panel now get a Panel Alpha dropdown in the Layout tab.
- The default keeps the existing behavior: the child panel inherits the target panel's alpha.
- Choosing Custom Alpha lets the child panel use its own alpha settings instead.
- When a child panel is inheriting alpha, its alpha controls are disabled with helper text pointing users to the parent panel's alpha settings.

## Why This Changed
- Panel-to-panel anchors already inherited alpha as a good default, but there was no per-panel opt-out.
- The Layout tab still made the child panel's alpha controls look editable even when the parent panel was actually driving the visible alpha.

## What Changed
- Added `inheritPanelAlpha` as the saved per-panel setting, defaulting to inherited alpha for panel-to-panel anchors.
- Added the Layout tab dropdown and disabled-state helper text for inherited alpha controls.
- Centralized panel-anchor alpha policy so inherited panels keep syncing parent alpha, while custom panels use their own baseline and forced alpha settings.
- Updated migration and export/import handling so existing panels with active custom alpha keep that behavior, and explicit inherited alpha survives compact export round-trips.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` on the touched Lua files
- `lua tests\profile-import-apply.lua`
- `lua tests\cursor-anchor-policy.lua`
- Focused export-codec round-trip for explicit inherited alpha vs. legacy omitted active custom alpha
- Not yet verified in-game during combat or restricted content.