### PR TITLE
Let Texture and Trigger Panels anchor to other panels

### DIFF
--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -715,6 +715,18 @@ local function BuildImportedRootAnchor(relativeTo)
     }
 end
 
+local function ResetImportedStandalonePanelAnchor(panel)
+    local settings = CooldownCompanion:GetStandaloneTextureAnchorSettings(panel)
+    if type(settings) ~= "table" then
+        return
+    end
+    settings.point = "CENTER"
+    settings.relativeTo = "UIParent"
+    settings.relativePoint = "CENTER"
+    settings.x = 0
+    settings.y = 0
+end
+
 local function BuildDefaultImportedPanel(containerId)
     return {
         name = "Panel 1",
@@ -860,6 +872,29 @@ local function RemapImportedContainerAnchors(db, importState, preserveContainerR
     end
 end
 
+local function RemapImportedStandalonePanelAnchor(panel, newGroupId, importState)
+    local settings = CooldownCompanion:GetStandaloneTextureAnchorSettings(panel)
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    local groupRef = type(relativeTo) == "string" and tonumber(relativeTo:match("^CooldownCompanionGroup(%d+)$")) or nil
+    if not relativeTo or relativeTo == "UIParent" then
+        return
+    end
+    if not groupRef then
+        ResetImportedStandalonePanelAnchor(panel)
+        return
+    end
+
+    local targetFrameName = GetRemappedImportedGroupAnchorTarget(importState, groupRef, {
+        domain = "panel-import",
+        sourceGroupId = newGroupId,
+    })
+    if targetFrameName then
+        settings.relativeTo = targetFrameName
+    else
+        ResetImportedStandalonePanelAnchor(panel)
+    end
+end
+
 local function RemapImportedPanelAnchors(db, importState, preserveOwnContainerRefs)
     for _, newGid in ipairs(importState.importedGroupIds) do
         local panel = db.groups[newGid]
@@ -891,6 +926,7 @@ local function RemapImportedPanelAnchors(db, importState, preserveOwnContainerRe
                 end
             end
         end
+        RemapImportedStandalonePanelAnchor(panel, newGid, importState)
     end
 end
 

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -949,6 +949,70 @@ local function BuildLayoutTab(container)
             isCursorAnchor = false
         end
 
+        settings.relativeTo = type(settings.relativeTo) == "string" and settings.relativeTo ~= "" and settings.relativeTo or "UIParent"
+        local isPanel = group.parentContainerId ~= nil
+        local function ResetStandalonePosition(relativeTo, point, relativePoint, x, y)
+            settings.point = point or "CENTER"
+            settings.relativeTo = relativeTo or "UIParent"
+            settings.relativePoint = relativePoint or "CENTER"
+            settings.x = x or 0
+            settings.y = y or 0
+        end
+        local function GetStandaloneAnchorValidationOptions()
+            if CooldownCompanion.GetGroupAnchorValidationOptions then
+                return CooldownCompanion:GetGroupAnchorValidationOptions(textureGroupId)
+            end
+            return {
+                domain = "panel",
+                sourceGroupId = textureGroupId,
+                sourceKind = "group",
+            }
+        end
+        local function SetStandalonePanelAnchorTarget(targetGroupId)
+            local targetFrameName = "CooldownCompanionGroup" .. tostring(targetGroupId)
+            local ok = true
+            local options = GetStandaloneAnchorValidationOptions()
+            if CooldownCompanion.ValidateAddonFrameAnchorTarget then
+                ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(targetFrameName, options)
+            end
+            if not ok then
+                if CooldownCompanion.PrintInvalidAnchorTargetReason then
+                    CooldownCompanion:PrintInvalidAnchorTargetReason(targetFrameName, options)
+                end
+                return false
+            end
+            ResetStandalonePosition(targetFrameName, "TOPLEFT", "BOTTOMLEFT", 0, -5)
+            group.inheritPanelAlpha = group.inheritPanelAlpha ~= false
+            return true
+        end
+        local anchorKind, currentAnchorGroupId
+        if CooldownCompanion.ParseAddonAnchorFrameName then
+            anchorKind, currentAnchorGroupId = CooldownCompanion:ParseAddonAnchorFrameName(settings.relativeTo)
+        else
+            currentAnchorGroupId = settings.relativeTo:match("^CooldownCompanionGroup(%d+)$")
+            anchorKind = currentAnchorGroupId and "group" or nil
+        end
+        local currentAnchorIsPanel = anchorKind == "group"
+            and isPanel
+            and CooldownCompanion.IsPanelAnchoredToPanel
+            and CooldownCompanion:IsPanelAnchoredToPanel(textureGroupId)
+            or false
+        if not currentAnchorIsPanel then
+            currentAnchorGroupId = nil
+        end
+        CS.layoutAnchorTargetMode = CS.layoutAnchorTargetMode or {}
+        local storedTargetMode = CS.layoutAnchorTargetMode[textureGroupId]
+        local targetMode
+        if isCursorAnchor then
+            targetMode = "cursor"
+        elseif currentAnchorIsPanel then
+            targetMode = "panel"
+        elseif storedTargetMode == "panel" and isPanel then
+            targetMode = "panel"
+        else
+            targetMode = "group"
+        end
+
         local function RefreshTextureVisual()
             CooldownCompanion:RefreshAllAuraTextureVisuals()
         end
@@ -961,7 +1025,7 @@ local function BuildLayoutTab(container)
             RefreshTextureVisual()
         end
 
-        if isCursorAnchor and CooldownCompanion.ShowCursorAnchorLayoutPreview then
+        if targetMode == "cursor" and CooldownCompanion.ShowCursorAnchorLayoutPreview then
             CooldownCompanion:ShowCursorAnchorLayoutPreview(textureGroupId)
         elseif CooldownCompanion.ClearCursorAnchorLayoutPreview then
             CooldownCompanion:ClearCursorAnchorLayoutPreview()
@@ -969,43 +1033,96 @@ local function BuildLayoutTab(container)
 
         local anchorTargetDrop = AceGUI:Create("Dropdown")
         anchorTargetDrop:SetLabel("Anchor Target")
-        if canUseCursorAnchor then
-            anchorTargetDrop:SetList({
+        local anchorTargetList = isPanel
+            and {
                 group = "Group",
+                panel = "Panel",
                 cursor = "Cursor",
-            }, { "group", "cursor" })
-        else
-            anchorTargetDrop:SetList({
+            }
+            or {
                 group = group.parentContainerId and "Group" or "Screen",
-            }, { "group" })
+            }
+        local anchorTargetOrder = isPanel
+            and (canUseCursorAnchor and { "group", "panel", "cursor" } or { "group", "panel" })
+            or { "group" }
+        if not canUseCursorAnchor then
+            anchorTargetList.cursor = nil
         end
-        anchorTargetDrop:SetValue(isCursorAnchor and "cursor" or "group")
+        anchorTargetDrop:SetList(anchorTargetList, anchorTargetOrder)
+        anchorTargetDrop:SetValue(targetMode)
         anchorTargetDrop:SetFullWidth(true)
         anchorTargetDrop:SetCallback("OnValueChanged", function(widget, event, val)
+            if val == targetMode then return end
             if val == "cursor" then
                 if not canUseCursorAnchor then
                     widget:SetValue("group")
                     return
                 end
                 if CooldownCompanion:SetGroupAnchor(CS.selectedGroup, cursorAnchorTarget) then
+                    CS.layoutAnchorTargetMode[CS.selectedGroup] = nil
+                    ResetStandalonePosition()
                     CooldownCompanion:RefreshConfigPanel()
                 else
-                    widget:SetValue(isCursorAnchor and "cursor" or "group")
+                    widget:SetValue(targetMode)
                 end
             elseif val == "group" then
+                CS.layoutAnchorTargetMode[CS.selectedGroup] = nil
+                ResetStandalonePosition()
                 CooldownCompanion:SetGroupAnchor(CS.selectedGroup, defaultFrame, true)
+                CooldownCompanion:RefreshConfigPanel()
+            elseif val == "panel" then
+                if isCursorAnchor and not CooldownCompanion:SetGroupAnchor(CS.selectedGroup, defaultFrame, true) then
+                    widget:SetValue(targetMode)
+                    return
+                end
+                ResetStandalonePosition()
+                CS.layoutAnchorTargetMode[CS.selectedGroup] = "panel"
                 CooldownCompanion:RefreshConfigPanel()
             end
         end)
         container:AddChild(anchorTargetDrop)
 
+        if targetMode == "panel" then
+            local panelAnchorDrop = AceGUI:Create("Dropdown")
+            panelAnchorDrop:SetLabel("Anchor to Panel")
+            CooldownCompanion:PopulatePanelAnchorTargetDropdown(panelAnchorDrop, textureGroupId)
+            panelAnchorDrop:SetFullWidth(true)
+            panelAnchorDrop:SetValue(currentAnchorGroupId and tostring(currentAnchorGroupId) or nil)
+            panelAnchorDrop:SetCallback("OnValueChanged", function(widget, event, val)
+                if not val or val == "" then return end
+                local targetGroupId = tonumber(val)
+                if targetGroupId and SetStandalonePanelAnchorTarget(targetGroupId) then
+                    CooldownCompanion:RefreshAllAuraTextureVisuals()
+                    CooldownCompanion:RefreshConfigPanel()
+                else
+                    widget:SetValue(currentAnchorGroupId and tostring(currentAnchorGroupId) or nil)
+                end
+            end)
+            container:AddChild(panelAnchorDrop)
+
+            local panelAlphaDrop = AceGUI:Create("Dropdown")
+            panelAlphaDrop:SetLabel("Panel Alpha")
+            panelAlphaDrop:SetList({
+                inherit = "Inherit Target Panel Alpha",
+                custom = "Custom Alpha",
+            }, { "inherit", "custom" })
+            panelAlphaDrop:SetValue(group.inheritPanelAlpha == false and "custom" or "inherit")
+            panelAlphaDrop:SetFullWidth(true)
+            panelAlphaDrop:SetCallback("OnValueChanged", function(widget, event, val)
+                group.inheritPanelAlpha = val ~= "custom"
+                CooldownCompanion:RefreshAllAuraTextureVisuals()
+                CooldownCompanion:RefreshConfigPanel()
+            end)
+            container:AddChild(panelAlphaDrop)
+        end
+
         local heading = AceGUI:Create("Heading")
-        heading:SetText(isCursorAnchor and "Cursor Offset" or positionHeadingText)
+        heading:SetText(targetMode == "cursor" and "Cursor Offset" or positionHeadingText)
         ColorHeading(heading)
         heading:SetFullWidth(true)
         container:AddChild(heading)
 
-        if isCursorAnchor then
+        if targetMode == "cursor" then
             AddAnchorDropdown(container, group.anchor, "point", "BOTTOMLEFT", RefreshCursorAnchor, "Panel Point")
             group.anchor.relativePoint = "CENTER"
             AddOffsetSliders(container, group.anchor, "x", "y", {
@@ -1034,7 +1151,7 @@ local function BuildLayoutTab(container)
             container:AddChild(resetBtn)
         else
             AddAnchorDropdown(container, settings, "point", "CENTER", RefreshTextureVisual, anchorLabel)
-            AddAnchorDropdown(container, settings, "relativePoint", "CENTER", RefreshTextureVisual, "Screen Point")
+            AddAnchorDropdown(container, settings, "relativePoint", "CENTER", RefreshTextureVisual, targetMode == "panel" and "Target Point" or "Screen Point")
             AddOffsetSliders(container, settings, "x", "y", {
                 x = 0,
                 y = 0,
@@ -1046,22 +1163,30 @@ local function BuildLayoutTab(container)
             resetBtn:SetText("Reset Position")
             resetBtn:SetFullWidth(true)
             resetBtn:SetCallback("OnClick", function()
-                settings.point = "CENTER"
-                settings.relativePoint = "CENTER"
-                settings.relativeTo = "UIParent"
-                settings.x = 0
-                settings.y = 0
+                if targetMode == "panel" and settings.relativeTo ~= "UIParent" then
+                    ResetStandalonePosition(settings.relativeTo, "TOPLEFT", "BOTTOMLEFT", 0, -5)
+                else
+                    ResetStandalonePosition()
+                end
                 CooldownCompanion:RefreshAllAuraTextureVisuals()
                 CooldownCompanion:RefreshConfigPanel()
             end)
             container:AddChild(resetBtn)
         end
 
+        local panelAlphaInherited = targetMode == "panel"
+            and currentAnchorGroupId
+            and CooldownCompanion.ShouldInheritPanelAnchorAlpha
+            and CooldownCompanion:ShouldInheritPanelAnchorAlpha(textureGroupId)
+            or false
+
         BuildAlphaControls(container, group, function()
             CooldownCompanion:RefreshAllAuraTextureVisuals()
             CooldownCompanion:RefreshConfigPanel()
         end, "layout_alpha", {
             isGlobal = group.isGlobal,
+            disabled = panelAlphaInherited,
+            disabledText = "This panel inherits alpha from the parent panel. Change the parent panel's Alpha settings to affect it.",
             onBaselineChanged = function(val)
                 CS.texturePanelAlphaPreview = CS.texturePanelAlphaPreview or {}
                 CS.texturePanelAlphaPreview[textureGroupId] = val

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -129,6 +129,39 @@ local function ParseAddonAnchorFrameName(frameName)
     end
 end
 
+local function GetStandaloneTextureAnchorSettings(group)
+    if type(group) ~= "table" then
+        return nil
+    end
+    if group.displayMode == "trigger" then
+        return type(group.triggerSettings) == "table" and group.triggerSettings.signal or nil
+    end
+    if group.displayMode == "textures" then
+        return group.textureSettings
+    end
+    return nil
+end
+
+local function GetAnchorRelativeTo(anchor)
+    if type(anchor) == "table" then
+        return anchor.relativeTo
+    end
+    return anchor
+end
+
+local function GetPanelFrameAnchorRelativeTo(group)
+    return GetAnchorRelativeTo(group and group.anchor)
+end
+
+local function GetActivePanelAnchorRelativeTo(group)
+    local standalone = GetStandaloneTextureAnchorSettings(group)
+    if type(standalone) == "table" and type(standalone.relativeTo) == "string" then
+        return standalone.relativeTo
+    end
+
+    return GetPanelFrameAnchorRelativeTo(group)
+end
+
 local function AddonAnchorFrameReachesCursorRoot(profile, kind, id, visited)
     local node
     if kind == "group" then
@@ -139,13 +172,8 @@ local function AddonAnchorFrameReachesCursorRoot(profile, kind, id, visited)
     if not node then
         return false
     end
-    local anchor = node.anchor
-    local relativeTo
-    if type(anchor) == "table" then
-        relativeTo = anchor.relativeTo
-    elseif type(anchor) == "string" then
-        relativeTo = anchor
-    else
+    local relativeTo = GetPanelFrameAnchorRelativeTo(node)
+    if type(relativeTo) ~= "string" then
         return false
     end
 
@@ -229,12 +257,27 @@ local function ResetExternalAnchor(anchor)
     anchor.y = 0
 end
 
+local function ResetStandaloneTextureAnchor(anchor)
+    anchor.point = "CENTER"
+    anchor.relativeTo = "UIParent"
+    anchor.relativePoint = "CENTER"
+    anchor.x = 0
+    anchor.y = 0
+end
+
 local function SanitizeExternalAnchor(anchor, targetIsCursorRoot)
     if type(anchor) ~= "table" then
         return
     end
     if targetIsCursorRoot(anchor.relativeTo) then
         ResetExternalAnchor(anchor)
+    end
+end
+
+local function SanitizeStandaloneTextureAnchor(group, targetIsCursorRoot)
+    local anchor = GetStandaloneTextureAnchorSettings(group)
+    if type(anchor) == "table" and targetIsCursorRoot(anchor.relativeTo) then
+        ResetStandaloneTextureAnchor(anchor)
     end
 end
 
@@ -364,6 +407,14 @@ local function AddFrameAnchoringDependents(dependents, settings, targetFrameName
     AddFrameNameDependent(dependents, settings.customTargetFrame, targetFrameName, name .. " Target")
 end
 
+local function AddStandaloneTextureDependents(dependents, group, targetFrameName, name)
+    local settings = GetStandaloneTextureAnchorSettings(group)
+    if type(settings) ~= "table" then
+        return
+    end
+    AddAnchorDependent(dependents, settings, targetFrameName, name)
+end
+
 function CooldownCompanion:GetCursorAnchorTargetName()
     return CURSOR_ANCHOR_TARGET
 end
@@ -388,21 +439,36 @@ function CooldownCompanion:IsGroupCursorAnchored(groupOrId)
     return self:IsCursorAnchor(group and group.anchor)
 end
 
+function CooldownCompanion:GetStandaloneTextureAnchorSettings(groupOrId)
+    return GetStandaloneTextureAnchorSettings(GetGroup(self, groupOrId))
+end
+
 function CooldownCompanion:IsPanelAnchoredToPanel(groupOrId)
     local group = GetGroup(self, groupOrId)
     if not (group and group.parentContainerId) then
         return false
     end
 
-    local anchor = group.anchor
-    local relativeTo = type(anchor) == "table" and anchor.relativeTo or anchor
+    local relativeTo = GetActivePanelAnchorRelativeTo(group)
     local kind = ParseAddonAnchorFrameName(relativeTo)
-    return kind == "group"
+    if kind ~= "group" then
+        return false
+    end
+
+    if self.ValidateAddonFrameAnchorTarget then
+        local sourceGroupId = type(groupOrId) ~= "table" and groupOrId or nil
+        return self:ValidateAddonFrameAnchorTarget(relativeTo, {
+            domain = "panel",
+            sourceGroupId = sourceGroupId,
+            sourceKind = "group",
+        }) == true
+    end
+    return true
 end
 
 function CooldownCompanion:ShouldInheritPanelAnchorAlpha(groupOrId)
     local group = GetGroup(self, groupOrId)
-    return self:IsPanelAnchoredToPanel(group)
+    return self:IsPanelAnchoredToPanel(groupOrId)
         and group.inheritPanelAlpha ~= false
         or false
 end
@@ -490,6 +556,17 @@ function CooldownCompanion:GetExternalAnchorDependents(groupId, profile)
     ForEachExternalAnchorSettings(profile, EXTERNAL_ANCHOR_STORES.frameAnchoring, function(settings, name)
         AddFrameAnchoringDependents(dependents, settings, targetFrameName, name)
     end)
+
+    for id, group in pairs(profile.groups or {}) do
+        if type(group) == "table" then
+            local name = group.name or ("Panel " .. tostring(id))
+            if group.displayMode == "trigger" then
+                AddStandaloneTextureDependents(dependents, group, targetFrameName, name .. " Trigger Display")
+            elseif group.displayMode == "textures" then
+                AddStandaloneTextureDependents(dependents, group, targetFrameName, name .. " Texture Display")
+            end
+        end
+    end
 
     return dependents
 end
@@ -611,6 +688,7 @@ function CooldownCompanion:SanitizeCursorAnchorPolicy(profile)
                     group.anchor = BuildRootAnchor("UIParent")
                 end
             end
+            SanitizeStandaloneTextureAnchor(group, targetIsCursorRoot)
         end
     end
 

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -655,7 +655,11 @@ local function NormalizeAuraTextureSettings(settings)
     settings.stretchY = Clamp(tonumber(settings.stretchY) or 0, MIN_TEXTURE_STRETCH, MAX_TEXTURE_STRETCH)
     settings.point = NormalizeAnchorPoint(settings.point or settings.anchor)
     settings.relativePoint = NormalizeAnchorPoint(settings.relativePoint)
-    settings.relativeTo = UI_PARENT_NAME
+    local relativeTo = settings.relativeTo
+    settings.relativeTo = type(relativeTo) == "string"
+        and (relativeTo == UI_PARENT_NAME or relativeTo:match("^CooldownCompanionGroup%d+$"))
+        and relativeTo
+        or UI_PARENT_NAME
     settings.x = tonumber(settings.x or settings.xOffset) or 0
     settings.y = tonumber(settings.y or settings.yOffset) or 0
     settings.anchor = nil

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -163,9 +163,112 @@ local function GetTextureHostDisplayCoords(host, point, relativePoint)
     return x, y, normalizedPoint, normalizedRelativePoint
 end
 
+local function GetStandalonePanelAnchorFrame(group, settings, groupId)
+    if not (group and group.parentContainerId and type(settings) == "table") then
+        return nil
+    end
+    local relativeTo = settings.relativeTo
+    local targetGroupId = type(relativeTo) == "string" and relativeTo:match("^CooldownCompanionGroup(%d+)$") or nil
+    if not targetGroupId then
+        return nil
+    end
+    local ok = true
+    if CooldownCompanion.ValidateAddonFrameAnchorTarget then
+        ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(relativeTo, {
+            domain = "panel",
+            sourceGroupId = groupId,
+            sourceKind = "group",
+        })
+    end
+    if not ok then
+        return nil
+    end
+    return _G[relativeTo], relativeTo
+end
+
+local function StopStandalonePanelAlphaSync(host)
+    if host and host.standalonePanelAlphaSyncFrame then
+        host.standalonePanelAlphaSyncFrame:SetScript("OnUpdate", nil)
+    end
+    if host then
+        host._standalonePanelAlphaTarget = nil
+        host._standalonePanelAlphaVisibilityAlpha = nil
+        host._standalonePanelAlphaLastAlpha = nil
+        host._standalonePanelAlphaAccumulator = nil
+        host._standalonePanelAlphaSyncActive = nil
+    end
+end
+
+local function GetInheritedFrameAlpha(frame)
+    if not frame then
+        return 1
+    end
+    local alpha = frame._naturalAlpha
+    if alpha == nil and frame.GetEffectiveAlpha then
+        alpha = frame:GetEffectiveAlpha()
+    end
+    if alpha == nil and frame.GetAlpha then
+        alpha = frame:GetAlpha()
+    end
+    return Clamp(alpha or 1, 0, 1)
+end
+
+local function StartStandalonePanelAlphaSync(host, targetFrame, visibilityAlpha)
+    if not (host and targetFrame) then
+        StopStandalonePanelAlphaSync(host)
+        return
+    end
+
+    visibilityAlpha = Clamp(visibilityAlpha or 1, 0, 1)
+    local wasSyncing = host._standalonePanelAlphaSyncActive == true
+    local syncChanged = host._standalonePanelAlphaTarget ~= targetFrame
+        or host._standalonePanelAlphaVisibilityAlpha ~= visibilityAlpha
+
+    host._standalonePanelAlphaTarget = targetFrame
+    host._standalonePanelAlphaVisibilityAlpha = visibilityAlpha
+    if syncChanged or not wasSyncing then
+        local alpha = Clamp(GetInheritedFrameAlpha(targetFrame) * visibilityAlpha, 0, 1)
+        host._standalonePanelAlphaLastAlpha = alpha
+        host._standalonePanelAlphaAccumulator = 0
+        host:SetAlpha(alpha)
+    end
+    if wasSyncing then
+        return
+    end
+
+    if not host.standalonePanelAlphaSyncFrame then
+        host.standalonePanelAlphaSyncFrame = CreateFrame("Frame", nil, host)
+    end
+
+    host._standalonePanelAlphaSyncActive = true
+    host.standalonePanelAlphaSyncFrame:SetScript("OnUpdate", function(self, dt)
+        local activeTarget = host._standalonePanelAlphaTarget
+        if not activeTarget then
+            self:SetScript("OnUpdate", nil)
+            host._standalonePanelAlphaSyncActive = nil
+            return
+        end
+
+        host._standalonePanelAlphaAccumulator = (host._standalonePanelAlphaAccumulator or 0) + dt
+        if host._standalonePanelAlphaAccumulator < (1 / 30) then
+            return
+        end
+        host._standalonePanelAlphaAccumulator = 0
+
+        local alpha = Clamp(GetInheritedFrameAlpha(activeTarget) * (host._standalonePanelAlphaVisibilityAlpha or 1), 0, 1)
+        if alpha ~= host._standalonePanelAlphaLastAlpha then
+            host._standalonePanelAlphaLastAlpha = alpha
+            host:SetAlpha(alpha)
+        end
+    end)
+end
+
 local function SaveGroupedStandalonePreviewSettings(host, group, settings, groupId)
     local containerFrame = GetGroupedPreviewContainerFrame(group, groupId)
     if not (host and containerFrame and settings and host.GetPoint and host.GetCenter and host.GetSize) then
+        return false
+    end
+    if GetStandalonePanelAnchorFrame(group, settings, groupId) then
         return false
     end
 
@@ -218,10 +321,15 @@ local function SaveTextureHostPosition(host)
     end
 
     if not SaveGroupedStandalonePreviewSettings(host, group, settings, owner and owner._groupId) then
-        local point, _, relPoint, x, y = host:GetPoint(1)
+        local point, relativeFrame, relPoint, x, y = host:GetPoint(1)
         settings.point = NormalizeAnchorPoint(point)
         settings.relativePoint = NormalizeAnchorPoint(relPoint)
-        settings.relativeTo = UI_PARENT_NAME
+        local panelTargetFrame, panelTargetName = GetStandalonePanelAnchorFrame(group, settings, owner and owner._groupId)
+        if panelTargetFrame and relativeFrame == panelTargetFrame then
+            settings.relativeTo = panelTargetName
+        else
+            settings.relativeTo = UI_PARENT_NAME
+        end
         settings.x = math_floor(((x or 0) * 10) + 0.5) / 10
         settings.y = math_floor(((y or 0) * 10) + 0.5) / 10
     end
@@ -342,6 +450,7 @@ local function EnsureAuraTextureNudger(host)
         end
         local displayX, displayY
         if settings and group and group.parentContainerId
+            and not GetStandalonePanelAnchorFrame(group, settings, owner and owner._groupId)
             and CooldownCompanion.IsContainerUnlockPreviewActive
             and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
         then
@@ -753,6 +862,7 @@ function CooldownCompanion:HideAuraTextureVisual(button)
     end
 
     StopAllTextureIndicatorEffects(host)
+    StopStandalonePanelAlphaSync(host)
     if host._isDragging then
         host._isDragging = nil
         host:StopMovingOrSizing()
@@ -1129,8 +1239,17 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
         else
             local currentPoint, currentRelativeFrame, _, currentX, currentY = host:GetPoint(1)
             host:ClearAllPoints()
+            local panelTargetFrame = GetStandalonePanelAnchorFrame(group, sharedSettings, driverButton and driverButton._groupId)
             local groupedPreviewFrame = visibilityState and visibilityState.groupedPreviewFrame or nil
-            if groupedPreviewFrame then
+            if panelTargetFrame then
+                host:SetPoint(
+                    sharedSettings.point or "TOPLEFT",
+                    panelTargetFrame,
+                    sharedSettings.relativePoint or "BOTTOMLEFT",
+                    sharedSettings.x or 0,
+                    sharedSettings.y or -5
+                )
+            elseif groupedPreviewFrame then
                 local preserveRelativeOffset = host._wrapperManaged
                     and currentRelativeFrame == groupedPreviewFrame
                     and currentX ~= nil
@@ -1157,7 +1276,17 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     local alphaModuleId = GetTexturePanelAlphaModuleId(driverButton._groupId)
     local layoutPreviewAlpha = GetTexturePanelLayoutPreviewAlpha(driverButton)
     local visibilityAlpha = Clamp(driverButton._rawVisibilityAlphaOverride or 1, 0, 1)
-    if alphaModuleId then
+    local panelAlphaTarget = CooldownCompanion.ShouldInheritPanelAnchorAlpha
+        and CooldownCompanion:ShouldInheritPanelAnchorAlpha(driverButton._groupId)
+        and GetStandalonePanelAnchorFrame(group, sharedSettings, driverButton._groupId)
+        or nil
+    if panelAlphaTarget then
+        if alphaModuleId then
+            self:UnregisterModuleAlpha(alphaModuleId, true)
+        end
+        StartStandalonePanelAlphaSync(host, panelAlphaTarget, visibilityAlpha)
+    elseif alphaModuleId then
+        StopStandalonePanelAlphaSync(host)
         if visibilityState.bypassModuleAlpha then
             self:UnregisterModuleAlpha(alphaModuleId, true)
             host:SetAlpha(layoutPreviewAlpha ~= nil and layoutPreviewAlpha or 1)
@@ -1171,6 +1300,7 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
             end
         end
     else
+        StopStandalonePanelAlphaSync(host)
         host:SetAlpha(visibilityState.bypassModuleAlpha and (layoutPreviewAlpha ~= nil and layoutPreviewAlpha or 1) or visibilityAlpha)
     end
 
@@ -1372,8 +1502,12 @@ function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, del
             end
 
             local didSync = false
+            local standalonePanelAnchorFrame = settings
+                and GetStandalonePanelAnchorFrame(group, settings, panelInfo.groupId)
+                or nil
             if host
                 and settings
+                and not standalonePanelAnchorFrame
                 and self.IsGroupVisibleInUnlockPreview
                 and self:IsGroupVisibleInUnlockPreview(panelInfo.groupId, {
                     group = group,
@@ -1385,7 +1519,10 @@ function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, del
                 didSync = true
                 UpdateTextureHostCoordLabel(host, settings.x, settings.y)
             end
-            if not didSync and ApplyGroupedStandaloneSettingsDelta(settings, deltaX, deltaY) then
+            if not didSync
+                and not standalonePanelAnchorFrame
+                and ApplyGroupedStandaloneSettingsDelta(settings, deltaX, deltaY)
+            then
                 if host and host.coordLabel and host:IsShown() then
                     UpdateTextureHostCoordLabel(host, settings.x, settings.y)
                 end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -1284,7 +1284,12 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
         if alphaModuleId then
             self:UnregisterModuleAlpha(alphaModuleId, true)
         end
-        StartStandalonePanelAlphaSync(host, panelAlphaTarget, visibilityAlpha)
+        if visibilityState.bypassModuleAlpha then
+            StopStandalonePanelAlphaSync(host)
+            host:SetAlpha(layoutPreviewAlpha ~= nil and layoutPreviewAlpha or 1)
+        else
+            StartStandalonePanelAlphaSync(host, panelAlphaTarget, visibilityAlpha)
+        end
     elseif alphaModuleId then
         StopStandalonePanelAlphaSync(host)
         if visibilityState.bypassModuleAlpha then

--- a/Core/AuraTexturesPicker.lua
+++ b/Core/AuraTexturesPicker.lua
@@ -445,7 +445,7 @@ function CooldownCompanion:ApplyTexturePanelEntry(settings, entry)
     )
     settings.point = AT.NormalizeAnchorPoint(settings.point or "CENTER")
     settings.relativePoint = AT.NormalizeAnchorPoint(settings.relativePoint or "CENTER")
-    settings.relativeTo = AT.UI_PARENT_NAME
+    settings.relativeTo = type(settings.relativeTo) == "string" and settings.relativeTo ~= "" and settings.relativeTo or AT.UI_PARENT_NAME
     settings.x = tonumber(settings.x) or 0
     settings.y = tonumber(settings.y) or 0
 end
@@ -474,7 +474,7 @@ function CooldownCompanion:CreateTexturePanelSelection(entry, baseSettings)
         stretchY = base and base.stretchY or 0,
         point = base and base.point or "CENTER",
         relativePoint = base and base.relativePoint or "CENTER",
-        relativeTo = AT.UI_PARENT_NAME,
+        relativeTo = base and base.relativeTo or AT.UI_PARENT_NAME,
         x = base and base.x or 0,
         y = base and base.y or 0,
         color = CopyColor(base and base.color) or CopyColor(entry.color) or { 1, 1, 1, 1 },

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -192,6 +192,19 @@ local function SyncTexturePanelPositionFromGroupFrame(self, groupId, group)
     local anchor = type(group.anchor) == "table" and group.anchor or nil
     local point = (anchor and anchor.point) or "CENTER"
     local relativePoint = (anchor and anchor.relativePoint) or "CENTER"
+    local relativeTo = anchor and anchor.relativeTo or nil
+    if type(relativeTo) == "string" and relativeTo:match("^CooldownCompanionGroup%d+$") then
+        local options = self.GetGroupAnchorValidationOptions and self:GetGroupAnchorValidationOptions(groupId) or nil
+        local ok = not self.ValidateAddonFrameAnchorTarget or self:ValidateAddonFrameAnchorTarget(relativeTo, options)
+        if ok then
+            settings.point = point
+            settings.relativePoint = relativePoint
+            settings.relativeTo = relativeTo
+            settings.x = RoundAnchorOffset(tonumber(anchor and anchor.x) or 0)
+            settings.y = RoundAnchorOffset(tonumber(anchor and anchor.y) or 0)
+            return
+        end
+    end
 
     if frame and frame.GetCenter then
         local cx, cy = frame:GetCenter()
@@ -223,8 +236,8 @@ local function SyncTexturePanelPositionFromGroupFrame(self, groupId, group)
     settings.y = tonumber(anchor and anchor.y) or 0
 end
 
-local function SyncGroupAnchorFromTexturePanelSettings(self, group)
-    if not (self and type(group) == "table") then
+local function SyncGroupAnchorFromTexturePanelSettings(self, groupId, group)
+    if not (self and groupId and type(group) == "table") then
         return
     end
 
@@ -246,6 +259,21 @@ local function SyncGroupAnchorFromTexturePanelSettings(self, group)
 
     local point = settings.point or group.anchor.point or "CENTER"
     local relativePoint = settings.relativePoint or group.anchor.relativePoint or "CENTER"
+    local settingsRelativeTo = type(settings.relativeTo) == "string" and settings.relativeTo or nil
+    if settingsRelativeTo and settingsRelativeTo:match("^CooldownCompanionGroup%d+$") then
+        local relFrame = _G[settingsRelativeTo]
+        local options = self.GetGroupAnchorValidationOptions and self:GetGroupAnchorValidationOptions(groupId) or nil
+        local ok = not self.ValidateAddonFrameAnchorTarget or self:ValidateAddonFrameAnchorTarget(settingsRelativeTo, options)
+        if ok and relFrame and relFrame.GetCenter and relFrame.GetSize then
+            group.anchor.point = point
+            group.anchor.relativeTo = settingsRelativeTo
+            group.anchor.relativePoint = relativePoint
+            group.anchor.x = RoundAnchorOffset(tonumber(settings.x) or 0)
+            group.anchor.y = RoundAnchorOffset(tonumber(settings.y) or 0)
+            return
+        end
+    end
+
     local relativeTo = group.anchor.relativeTo or "UIParent"
     local relFrame = nil
 
@@ -765,6 +793,72 @@ function CooldownCompanion:DeleteContainer(containerId)
     db.groupContainers[containerId] = nil
 end
 
+local function GetStandalonePanelAnchorSettings(panel)
+    if not CooldownCompanion.GetStandaloneTextureAnchorSettings then
+        return nil
+    end
+    return CooldownCompanion:GetStandaloneTextureAnchorSettings(panel)
+end
+
+local function GetStandalonePanelAnchorTargetId(panel)
+    local settings = GetStandalonePanelAnchorSettings(panel)
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    return type(relativeTo) == "string" and tonumber(relativeTo:match("^CooldownCompanionGroup(%d+)$")) or nil
+end
+
+local function GetStandalonePanelAnchorTarget(panel)
+    local settings = GetStandalonePanelAnchorSettings(panel)
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    return settings, type(relativeTo) == "string" and relativeTo or nil
+end
+
+local function ResetStandalonePanelAnchor(panel)
+    local settings = GetStandalonePanelAnchorSettings(panel)
+    if type(settings) ~= "table" then
+        return
+    end
+    settings.point = "CENTER"
+    settings.relativeTo = "UIParent"
+    settings.relativePoint = "CENTER"
+    settings.x = 0
+    settings.y = 0
+end
+
+local function RemapDuplicatedStandalonePanelAnchor(panel, groupIdMap)
+    local settings, relativeTo = GetStandalonePanelAnchorTarget(panel)
+    if not settings or not relativeTo or relativeTo == "UIParent" then
+        return
+    end
+
+    local targetId = GetStandalonePanelAnchorTargetId(panel)
+    local newTargetId = targetId and groupIdMap[targetId] or nil
+    if newTargetId then
+        settings.relativeTo = "CooldownCompanionGroup" .. tostring(newTargetId)
+    else
+        ResetStandalonePanelAnchor(panel)
+    end
+end
+
+local function ResetCopiedStandalonePanelAnchor(panel, groups, sourceGroupId, sourceContainerId, targetContainerId)
+    local settings, relativeTo = GetStandalonePanelAnchorTarget(panel)
+    if not settings or not relativeTo or relativeTo == "UIParent" then
+        return
+    end
+
+    local targetId = GetStandalonePanelAnchorTargetId(panel)
+    if not targetId then
+        ResetStandalonePanelAnchor(panel)
+        return
+    end
+
+    local targetGroup = groups and groups[targetId] or nil
+    if targetId == sourceGroupId
+        or not targetGroup
+        or targetGroup.parentContainerId ~= targetContainerId then
+        ResetStandalonePanelAnchor(panel)
+    end
+end
+
 function CooldownCompanion:DuplicateContainer(containerId)
     local db = self.db.profile
     local sourceContainer = db.groupContainers[containerId]
@@ -797,6 +891,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
 
     -- Deep copy all child panels, re-anchoring to new container
     local containerFrameName = "CooldownCompanionContainer" .. newContainerId
+    local groupIdMap = {}
     for _, groupId in ipairs(sourcePanelIds) do
         local group = db.groups[groupId]
         if group then
@@ -814,8 +909,13 @@ function CooldownCompanion:DuplicateContainer(containerId)
             }
 
             db.groups[newGroupId] = newPanel
+            groupIdMap[groupId] = newGroupId
             self:CreateGroupFrame(newGroupId)
         end
+    end
+
+    for _, newGroupId in pairs(groupIdMap) do
+        RemapDuplicatedStandalonePanelAnchor(db.groups[newGroupId], groupIdMap)
     end
 
     -- Create container frame (Phase 3 — safe noop if method doesn't exist yet)
@@ -950,6 +1050,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
     local newPanel = CopyTable(sourcePanel)
     newPanel.name = sourcePanel.name .. " (Copy)"
     newPanel.order = self:GetPanelCount(containerId) + 1
+    ResetCopiedStandalonePanelAnchor(newPanel, db.groups, groupId, containerId, containerId)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
@@ -977,6 +1078,7 @@ function CooldownCompanion:MovePanel(groupId, targetContainerId)
         x = 0,
         y = 0,
     }
+    ResetCopiedStandalonePanelAnchor(group, db.groups, groupId, sourceContainerId, targetContainerId)
 
     -- Put at end of target's panel list (GetPanelCount already sees the moved panel)
     group.order = self:GetPanelCount(targetContainerId)
@@ -1023,7 +1125,7 @@ function CooldownCompanion:ChangePanelDisplayMode(groupId, newMode)
     if (oldMode == "textures" or oldMode == "trigger") and newMode ~= oldMode then
         -- Leaving texture mode should carry the standalone texture position
         -- back into the normal panel anchor so the panel does not jump back.
-        SyncGroupAnchorFromTexturePanelSettings(self, group)
+        SyncGroupAnchorFromTexturePanelSettings(self, groupId, group)
     end
 
     group.displayMode = newMode
@@ -1633,6 +1735,7 @@ function CooldownCompanion:CopyPanelToContainer(sourceGroupId, targetContainerId
         x = 0,
         y = 0,
     }
+    ResetCopiedStandalonePanelAnchor(newPanel, db.groups, sourceGroupId, sourcePanel.parentContainerId, targetContainerId)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
@@ -1670,6 +1773,7 @@ function CooldownCompanion:CopyPanelAsNewGroup(sourceGroupId, sourceName)
         x = 0,
         y = 0,
     }
+    ResetCopiedStandalonePanelAnchor(newPanel, db.groups, sourceGroupId, sourcePanel.parentContainerId, containerId)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -767,17 +767,22 @@ function CooldownCompanion:CreateContainer(name)
     return containerId
 end
 
+local ResetStandalonePanelAnchorsTargeting
+
 function CooldownCompanion:DeleteContainer(containerId)
     local db = self.db.profile
     if not db.groupContainers[containerId] then return end
 
     -- Delete all child panels first
     local panelIds = {}
+    local deletedGroupIds = {}
     for groupId, group in pairs(db.groups) do
         if group.parentContainerId == containerId then
             panelIds[#panelIds + 1] = groupId
+            deletedGroupIds[groupId] = true
         end
     end
+    ResetStandalonePanelAnchorsTargeting(db.groups, deletedGroupIds)
     for _, groupId in ipairs(panelIds) do
         self:UnloadGroup(groupId)
         self:DiscardDormantFrame(groupId)
@@ -822,6 +827,21 @@ local function ResetStandalonePanelAnchor(panel)
     settings.relativePoint = "CENTER"
     settings.x = 0
     settings.y = 0
+end
+
+ResetStandalonePanelAnchorsTargeting = function(groups, deletedGroupIds)
+    if type(groups) ~= "table" or type(deletedGroupIds) ~= "table" then
+        return
+    end
+
+    for groupId, panel in pairs(groups) do
+        if not deletedGroupIds[groupId] then
+            local targetId = GetStandalonePanelAnchorTargetId(panel)
+            if targetId and deletedGroupIds[targetId] then
+                ResetStandalonePanelAnchor(panel)
+            end
+        end
+    end
 end
 
 local function RemapDuplicatedStandalonePanelAnchor(panel, groupIdMap)
@@ -1033,6 +1053,7 @@ function CooldownCompanion:DeletePanel(containerId, groupId)
     local group = db.groups[groupId]
     if not group or group.parentContainerId ~= containerId then return false end
 
+    ResetStandalonePanelAnchorsTargeting(db.groups, { [groupId] = true })
     self:UnloadGroup(groupId)
     self:DiscardDormantFrame(groupId)
     db.groups[groupId] = nil
@@ -1197,6 +1218,7 @@ function CooldownCompanion:DeleteGroup(id)
 
     local parentId = group.parentContainerId
 
+    ResetStandalonePanelAnchorsTargeting(self.db.profile.groups, { [id] = true })
     self:UnloadGroup(id)
     self:DiscardDormantFrame(id)
     self.db.profile.groups[id] = nil


### PR DESCRIPTION
## What Players Will Notice
- Texture Panels and Trigger Panels can now choose `Panel` as their Layout anchor target, then pick another panel from `Anchor to Panel`.
- Panel-anchored texture and trigger displays inherit the target panel's alpha by default, with a `Panel Alpha` dropdown for switching to custom alpha.
- When inherited alpha is active, the local alpha controls are disabled and explain that the target panel's alpha controls the display.
- Copy, import, duplicate, move, and delete paths now avoid leaving stale standalone panel targets that could make a texture or trigger display jump or disappear.

## Why This Changed
- Normal panels already had useful panel-anchor behavior, including inherited alpha, but texture and trigger standalone displays could not opt into that same minimal panel-target workflow.
- The new anchor state also needed bounded stale-reference handling so saved panel targets stay valid as panels are copied, imported, duplicated, moved, or deleted.

## What Changed
- Added a small shared anchor-policy surface so normal panels read `group.anchor`, Texture Panels read `textureSettings`, and Trigger Panels read `triggerSettings.signal` when checking panel anchors and inherited alpha.
- Added the Texture/Trigger Layout UI for `Panel` anchor target mode, `Anchor to Panel`, and `Panel Alpha`, without adding Frame mode or broader external-frame parity.
- Updated standalone texture/trigger display anchoring to resolve only valid `CooldownCompanionGroup#` targets and sync inherited target-panel alpha over time.
- Added minimal panel-target remap/reset handling for imports, duplicate/copy/move paths, and panel/container deletion.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Config\Popups.lua ConfigSettings\GroupTabs.lua Core\AnchorPolicy.lua Core\AuraTextures.lua Core\AuraTexturesDisplay.lua Core\AuraTexturesPicker.lua Core\GroupManagement.lua`
- `lua tests\cursor-anchor-policy.lua`
- `lua tests\panel-standalone-anchor-rehome.lua`
- `lua tests\texture-panel-delta-policy.lua`
- `lua tests\profile-import-apply.lua`
- `lua tests\visual-state-snapshot.lua`
- In-game combat/restricted-content validation has not been performed yet and is still required before calling this feature complete.