### PR TITLE
Let Texture and Trigger Panels Anchor to Frames

### DIFF
--- a/Config/Popups.lua
+++ b/Config/Popups.lua
@@ -875,23 +875,39 @@ end
 local function RemapImportedStandalonePanelAnchor(panel, newGroupId, importState)
     local settings = CooldownCompanion:GetStandaloneTextureAnchorSettings(panel)
     local relativeTo = type(settings) == "table" and settings.relativeTo or nil
-    local groupRef = type(relativeTo) == "string" and tonumber(relativeTo:match("^CooldownCompanionGroup(%d+)$")) or nil
     if not relativeTo or relativeTo == "UIParent" then
         return
     end
-    if not groupRef then
+    if type(relativeTo) ~= "string" then
         ResetImportedStandalonePanelAnchor(panel)
         return
     end
-
-    local targetFrameName = GetRemappedImportedGroupAnchorTarget(importState, groupRef, {
-        domain = "panel-import",
-        sourceGroupId = newGroupId,
-    })
-    if targetFrameName then
-        settings.relativeTo = targetFrameName
-    else
+    local groupRef = tonumber(relativeTo:match("^CooldownCompanionGroup(%d+)$"))
+    local containerRef = tonumber(relativeTo:match("^CooldownCompanionContainer(%d+)$"))
+    if groupRef then
+        local targetFrameName = GetRemappedImportedGroupAnchorTarget(importState, groupRef, {
+            domain = "panel-import",
+            sourceGroupId = newGroupId,
+        })
+        if targetFrameName then
+            settings.relativeTo = targetFrameName
+        else
+            ResetImportedStandalonePanelAnchor(panel)
+        end
+        return
+    end
+    if containerRef then
+        local targetContainerId = importState.containerIdMap[containerRef]
+        if targetContainerId then
+            settings.relativeTo = "CooldownCompanionContainer" .. tostring(targetContainerId)
+        else
+            ResetImportedStandalonePanelAnchor(panel)
+        end
+        return
+    end
+    if relativeTo:find("^CooldownCompanion") then
         ResetImportedStandalonePanelAnchor(panel)
+        return
     end
 end
 

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -985,6 +985,30 @@ local function BuildLayoutTab(container)
             group.inheritPanelAlpha = group.inheritPanelAlpha ~= false
             return true
         end
+        local function SetStandaloneFrameAnchorTarget(targetFrameName)
+            if type(targetFrameName) ~= "string" or targetFrameName == "" then
+                ResetStandalonePosition()
+                return true
+            end
+            local target = _G[targetFrameName]
+            if not target or type(target) ~= "table" or not target.GetObjectType then
+                CooldownCompanion:Print("Frame not found: " .. targetFrameName)
+                return false
+            end
+            local ok = true
+            local options = GetStandaloneAnchorValidationOptions()
+            if CooldownCompanion.ValidateAddonFrameAnchorTarget then
+                ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(targetFrameName, options)
+            end
+            if not ok then
+                if CooldownCompanion.PrintInvalidAnchorTargetReason then
+                    CooldownCompanion:PrintInvalidAnchorTargetReason(targetFrameName, options)
+                end
+                return false
+            end
+            ResetStandalonePosition(targetFrameName, "TOPLEFT", "BOTTOMLEFT", 0, -5)
+            return true
+        end
         local anchorKind, currentAnchorGroupId
         if CooldownCompanion.ParseAddonAnchorFrameName then
             anchorKind, currentAnchorGroupId = CooldownCompanion:ParseAddonAnchorFrameName(settings.relativeTo)
@@ -1007,8 +1031,12 @@ local function BuildLayoutTab(container)
             targetMode = "cursor"
         elseif currentAnchorIsPanel then
             targetMode = "panel"
+        elseif settings.relativeTo ~= "UIParent" then
+            targetMode = "frame"
         elseif storedTargetMode == "panel" and isPanel then
             targetMode = "panel"
+        elseif storedTargetMode == "frame" then
+            targetMode = "frame"
         else
             targetMode = "group"
         end
@@ -1037,14 +1065,16 @@ local function BuildLayoutTab(container)
             and {
                 group = "Group",
                 panel = "Panel",
+                frame = "Frame",
                 cursor = "Cursor",
             }
             or {
                 group = group.parentContainerId and "Group" or "Screen",
+                frame = "Frame",
             }
         local anchorTargetOrder = isPanel
-            and (canUseCursorAnchor and { "group", "panel", "cursor" } or { "group", "panel" })
-            or { "group" }
+            and (canUseCursorAnchor and { "group", "panel", "frame", "cursor" } or { "group", "panel", "frame" })
+            or { "group", "frame" }
         if not canUseCursorAnchor then
             anchorTargetList.cursor = nil
         end
@@ -1078,9 +1108,76 @@ local function BuildLayoutTab(container)
                 ResetStandalonePosition()
                 CS.layoutAnchorTargetMode[CS.selectedGroup] = "panel"
                 CooldownCompanion:RefreshConfigPanel()
+            elseif val == "frame" then
+                if isCursorAnchor and not CooldownCompanion:SetGroupAnchor(CS.selectedGroup, defaultFrame, true) then
+                    widget:SetValue(targetMode)
+                    return
+                end
+                ResetStandalonePosition()
+                CS.layoutAnchorTargetMode[CS.selectedGroup] = "frame"
+                CooldownCompanion:RefreshConfigPanel()
             end
         end)
         container:AddChild(anchorTargetDrop)
+
+        if targetMode == "frame" then
+            local anchorRow = AceGUI:Create("SimpleGroup")
+            anchorRow:SetFullWidth(true)
+            anchorRow:SetLayout("Flow")
+
+            local anchorBox = AceGUI:Create("EditBox")
+            if anchorBox.editbox.Instructions then anchorBox.editbox.Instructions:Hide() end
+            anchorBox:SetLabel("Anchor to Frame")
+            local frameAnchorText = settings.relativeTo
+            if frameAnchorText == "UIParent" or currentAnchorGroupId then frameAnchorText = "" end
+            anchorBox:SetText(frameAnchorText)
+            anchorBox:SetRelativeWidth(0.68)
+            anchorBox:SetCallback("OnEnterPressed", function(widget, event, text)
+                if SetStandaloneFrameAnchorTarget(text) then
+                    CooldownCompanion:RefreshAllAuraTextureVisuals()
+                    CooldownCompanion:RefreshConfigPanel()
+                else
+                    widget:SetText(frameAnchorText)
+                end
+            end)
+            anchorRow:AddChild(anchorBox)
+
+            local pickBtn = AceGUI:Create("Button")
+            pickBtn:SetText("Pick")
+            pickBtn:SetRelativeWidth(0.24)
+            pickBtn:SetCallback("OnClick", function()
+                local grp = CS.selectedGroup
+                CS.StartPickFrame(function(name)
+                    if CS.configFrame then
+                        CS.configFrame.frame:Show()
+                    end
+                    if name then
+                        SetStandaloneFrameAnchorTarget(name)
+                    end
+                    CooldownCompanion:RefreshAllAuraTextureVisuals()
+                    CooldownCompanion:RefreshConfigPanel()
+                end, grp)
+            end)
+            anchorRow:AddChild(pickBtn)
+
+            CreateInfoButton(pickBtn.frame, pickBtn.frame, "LEFT", "RIGHT", 2, 0, {
+                "Pick Frame",
+                {"Hides the config panel and highlights frames under your cursor. Left-click a frame to anchor this panel to it, or right-click to cancel.", 1, 1, 1, true},
+                " ",
+                {"You can also type a frame name directly into the editbox.", 1, 1, 1, true},
+                " ",
+                {"Middle-click the draggable header to toggle lock/unlock.", 1, 1, 1, true},
+            }, tabInfoButtons)
+
+            container:AddChild(anchorRow)
+            pickBtn.frame:SetScript("OnUpdate", function(self)
+                self:SetScript("OnUpdate", nil)
+                local p, rel, rp, xOfs, yOfs = self:GetPoint(1)
+                if yOfs then
+                    self:SetPoint(p, rel, rp, xOfs, yOfs - 2)
+                end
+            end)
+        end
 
         if targetMode == "panel" then
             local panelAnchorDrop = AceGUI:Create("Dropdown")
@@ -1151,7 +1248,7 @@ local function BuildLayoutTab(container)
             container:AddChild(resetBtn)
         else
             AddAnchorDropdown(container, settings, "point", "CENTER", RefreshTextureVisual, anchorLabel)
-            AddAnchorDropdown(container, settings, "relativePoint", "CENTER", RefreshTextureVisual, targetMode == "panel" and "Target Point" or "Screen Point")
+            AddAnchorDropdown(container, settings, "relativePoint", "CENTER", RefreshTextureVisual, (targetMode == "panel" or targetMode == "frame") and "Target Point" or "Screen Point")
             AddOffsetSliders(container, settings, "x", "y", {
                 x = 0,
                 y = 0,
@@ -1163,7 +1260,7 @@ local function BuildLayoutTab(container)
             resetBtn:SetText("Reset Position")
             resetBtn:SetFullWidth(true)
             resetBtn:SetCallback("OnClick", function()
-                if targetMode == "panel" and settings.relativeTo ~= "UIParent" then
+                if (targetMode == "panel" or targetMode == "frame") and settings.relativeTo ~= "UIParent" then
                     ResetStandalonePosition(settings.relativeTo, "TOPLEFT", "BOTTOMLEFT", 0, -5)
                 else
                     ResetStandalonePosition()

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -487,6 +487,23 @@ local function NormalizeAnchorPoint(anchor)
     return anchor
 end
 
+local function NormalizeStandaloneAnchorRelativeTo(relativeTo)
+    if type(relativeTo) ~= "string" or relativeTo == "" then
+        return UI_PARENT_NAME
+    end
+    if relativeTo == UI_PARENT_NAME then
+        return relativeTo
+    end
+    if relativeTo:match("^CooldownCompanionGroup%d+$")
+        or relativeTo:match("^CooldownCompanionContainer%d+$") then
+        return relativeTo
+    end
+    if relativeTo:find("^CooldownCompanion") then
+        return UI_PARENT_NAME
+    end
+    return relativeTo
+end
+
 local function NormalizeTextureLayout(locationType)
     if LOCATION_DIMENSIONS[locationType] then
         if locationType == LOCATION_LEFTRIGHTOUTSIDE then
@@ -597,6 +614,7 @@ AT.GetTriggerConditionOrderForButtonData = GetTriggerConditionOrderForButtonData
 AT.NormalizeTriggerConditionKey = NormalizeTriggerConditionKey
 AT.NormalizeTriggerStateKey = NormalizeTriggerStateKey
 AT.NormalizeAnchorPoint = NormalizeAnchorPoint
+AT.NormalizeStandaloneAnchorRelativeTo = NormalizeStandaloneAnchorRelativeTo
 AT.NormalizeTextureLayout = NormalizeTextureLayout
 AT.GetStretchMultiplier = GetStretchMultiplier
 AT.RotateOffset = RotateOffset
@@ -655,11 +673,7 @@ local function NormalizeAuraTextureSettings(settings)
     settings.stretchY = Clamp(tonumber(settings.stretchY) or 0, MIN_TEXTURE_STRETCH, MAX_TEXTURE_STRETCH)
     settings.point = NormalizeAnchorPoint(settings.point or settings.anchor)
     settings.relativePoint = NormalizeAnchorPoint(settings.relativePoint)
-    local relativeTo = settings.relativeTo
-    settings.relativeTo = type(relativeTo) == "string"
-        and (relativeTo == UI_PARENT_NAME or relativeTo:match("^CooldownCompanionGroup%d+$"))
-        and relativeTo
-        or UI_PARENT_NAME
+    settings.relativeTo = NormalizeStandaloneAnchorRelativeTo(settings.relativeTo)
     settings.x = tonumber(settings.x or settings.xOffset) or 0
     settings.y = tonumber(settings.y or settings.yOffset) or 0
     settings.anchor = nil

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -163,27 +163,83 @@ local function GetTextureHostDisplayCoords(host, point, relativePoint)
     return x, y, normalizedPoint, normalizedRelativePoint
 end
 
-local function GetStandalonePanelAnchorFrame(group, settings, groupId)
-    if not (group and group.parentContainerId and type(settings) == "table") then
-        return nil
-    end
-    local relativeTo = settings.relativeTo
-    local targetGroupId = type(relativeTo) == "string" and relativeTo:match("^CooldownCompanionGroup(%d+)$") or nil
-    if not targetGroupId then
-        return nil
-    end
-    local ok = true
-    if CooldownCompanion.ValidateAddonFrameAnchorTarget then
-        ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(relativeTo, {
+local function HasStandaloneAnchorTarget(settings)
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    return type(relativeTo) == "string" and relativeTo ~= "" and relativeTo ~= UI_PARENT_NAME
+end
+
+local function GetStandaloneAnchorValidationOptions(relativeTo, groupId, domain)
+    if domain == "panel" then
+        return {
             domain = "panel",
             sourceGroupId = groupId,
             sourceKind = "group",
-        })
+        }
     end
-    if not ok then
+    return {
+        domain = "external",
+        sourceGroupId = groupId,
+        sourceKind = "group",
+    }
+end
+
+local function IsFrameLikeAnchorTarget(frame)
+    return type(frame) == "table" and type(frame.GetObjectType) == "function"
+end
+
+local function GetStandaloneAnchorTargetFrame(group, settings, groupId, domain)
+    if not (group and type(settings) == "table") then
         return nil
     end
-    return _G[relativeTo], relativeTo
+    local relativeTo = settings.relativeTo
+    if type(relativeTo) ~= "string" or relativeTo == "" or relativeTo == UI_PARENT_NAME then
+        return nil
+    end
+
+    local ok = true
+    if CooldownCompanion.ValidateAddonFrameAnchorTarget then
+        ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(
+            relativeTo,
+            GetStandaloneAnchorValidationOptions(relativeTo, groupId, domain)
+        )
+    end
+    if not ok then
+        return nil, relativeTo
+    end
+    local frame = _G[relativeTo]
+    if not IsFrameLikeAnchorTarget(frame) then
+        return nil, relativeTo
+    end
+    return frame, relativeTo
+end
+
+local function GetStandalonePanelAnchorFrame(group, settings, groupId)
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    if not (group and group.parentContainerId)
+        or type(relativeTo) ~= "string"
+        or not relativeTo:match("^CooldownCompanionGroup%d+$") then
+        return nil
+    end
+    return GetStandaloneAnchorTargetFrame(group, settings, groupId, "panel")
+end
+
+local function GetStandaloneFrameAnchorFrame(group, settings, groupId)
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    if type(relativeTo) ~= "string"
+        or relativeTo == ""
+        or relativeTo == UI_PARENT_NAME
+        or (group and group.parentContainerId and relativeTo:match("^CooldownCompanionGroup%d+$")) then
+        return nil
+    end
+    return GetStandaloneAnchorTargetFrame(group, settings, groupId, "external")
+end
+
+local function GetStandaloneResolvedAnchorFrame(group, settings, groupId)
+    local frame, name = GetStandalonePanelAnchorFrame(group, settings, groupId)
+    if frame then
+        return frame, name
+    end
+    return GetStandaloneFrameAnchorFrame(group, settings, groupId)
 end
 
 local function StopStandalonePanelAlphaSync(host)
@@ -268,7 +324,7 @@ local function SaveGroupedStandalonePreviewSettings(host, group, settings, group
     if not (host and containerFrame and settings and host.GetPoint and host.GetCenter and host.GetSize) then
         return false
     end
-    if GetStandalonePanelAnchorFrame(group, settings, groupId) then
+    if HasStandaloneAnchorTarget(settings) then
         return false
     end
 
@@ -324,9 +380,9 @@ local function SaveTextureHostPosition(host)
         local point, relativeFrame, relPoint, x, y = host:GetPoint(1)
         settings.point = NormalizeAnchorPoint(point)
         settings.relativePoint = NormalizeAnchorPoint(relPoint)
-        local panelTargetFrame, panelTargetName = GetStandalonePanelAnchorFrame(group, settings, owner and owner._groupId)
-        if panelTargetFrame and relativeFrame == panelTargetFrame then
-            settings.relativeTo = panelTargetName
+        local targetFrame, targetName = GetStandaloneResolvedAnchorFrame(group, settings, owner and owner._groupId)
+        if targetFrame and relativeFrame == targetFrame then
+            settings.relativeTo = targetName
         else
             settings.relativeTo = UI_PARENT_NAME
         end
@@ -450,7 +506,7 @@ local function EnsureAuraTextureNudger(host)
         end
         local displayX, displayY
         if settings and group and group.parentContainerId
-            and not GetStandalonePanelAnchorFrame(group, settings, owner and owner._groupId)
+            and not HasStandaloneAnchorTarget(settings)
             and CooldownCompanion.IsContainerUnlockPreviewActive
             and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
         then
@@ -1239,16 +1295,18 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
         else
             local currentPoint, currentRelativeFrame, _, currentX, currentY = host:GetPoint(1)
             host:ClearAllPoints()
-            local panelTargetFrame = GetStandalonePanelAnchorFrame(group, sharedSettings, driverButton and driverButton._groupId)
+            local anchorTargetFrame = GetStandaloneResolvedAnchorFrame(group, sharedSettings, driverButton and driverButton._groupId)
             local groupedPreviewFrame = visibilityState and visibilityState.groupedPreviewFrame or nil
-            if panelTargetFrame then
+            if anchorTargetFrame then
                 host:SetPoint(
                     sharedSettings.point or "TOPLEFT",
-                    panelTargetFrame,
+                    anchorTargetFrame,
                     sharedSettings.relativePoint or "BOTTOMLEFT",
                     sharedSettings.x or 0,
                     sharedSettings.y or -5
                 )
+            elseif HasStandaloneAnchorTarget(sharedSettings) then
+                host:SetPoint(sharedSettings.point, UIParent, sharedSettings.relativePoint, sharedSettings.x, sharedSettings.y)
             elseif groupedPreviewFrame then
                 local preserveRelativeOffset = host._wrapperManaged
                     and currentRelativeFrame == groupedPreviewFrame
@@ -1507,12 +1565,10 @@ function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, del
             end
 
             local didSync = false
-            local standalonePanelAnchorFrame = settings
-                and GetStandalonePanelAnchorFrame(group, settings, panelInfo.groupId)
-                or nil
+            local hasStandaloneAnchorTarget = HasStandaloneAnchorTarget(settings)
             if host
                 and settings
-                and not standalonePanelAnchorFrame
+                and not hasStandaloneAnchorTarget
                 and self.IsGroupVisibleInUnlockPreview
                 and self:IsGroupVisibleInUnlockPreview(panelInfo.groupId, {
                     group = group,
@@ -1525,7 +1581,7 @@ function CooldownCompanion:SyncGroupedStandalonePreviewSettings(containerId, del
                 UpdateTextureHostCoordLabel(host, settings.x, settings.y)
             end
             if not didSync
-                and not standalonePanelAnchorFrame
+                and not hasStandaloneAnchorTarget
                 and ApplyGroupedStandaloneSettingsDelta(settings, deltaX, deltaY)
             then
                 if host and host.coordLabel and host:IsShown() then

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -85,6 +85,10 @@ local function IsAddonAnchorFrameName(frameName)
         or frameName == "CooldownCompanionCursor"
 end
 
+local function IsFrameLikeAnchorTarget(frame)
+    return type(frame) == "table" and type(frame.GetObjectType) == "function"
+end
+
 function CooldownCompanion:NormalizeContainerAnchor(anchor, resolveAddonFrames)
     local normalized = type(anchor) == "table" and anchor or {}
     local point = normalized.point or "CENTER"
@@ -193,7 +197,11 @@ local function SyncTexturePanelPositionFromGroupFrame(self, groupId, group)
     local point = (anchor and anchor.point) or "CENTER"
     local relativePoint = (anchor and anchor.relativePoint) or "CENTER"
     local relativeTo = anchor and anchor.relativeTo or nil
-    if type(relativeTo) == "string" and relativeTo:match("^CooldownCompanionGroup%d+$") then
+    local ownContainerFrame = group.parentContainerId and ("CooldownCompanionContainer" .. tostring(group.parentContainerId)) or nil
+    if type(relativeTo) == "string"
+        and relativeTo ~= "UIParent"
+        and relativeTo ~= ownContainerFrame
+        and not self:IsCursorAnchor(relativeTo) then
         local options = self.GetGroupAnchorValidationOptions and self:GetGroupAnchorValidationOptions(groupId) or nil
         local ok = not self.ValidateAddonFrameAnchorTarget or self:ValidateAddonFrameAnchorTarget(relativeTo, options)
         if ok then
@@ -260,11 +268,11 @@ local function SyncGroupAnchorFromTexturePanelSettings(self, groupId, group)
     local point = settings.point or group.anchor.point or "CENTER"
     local relativePoint = settings.relativePoint or group.anchor.relativePoint or "CENTER"
     local settingsRelativeTo = type(settings.relativeTo) == "string" and settings.relativeTo or nil
-    if settingsRelativeTo and settingsRelativeTo:match("^CooldownCompanionGroup%d+$") then
-        local relFrame = _G[settingsRelativeTo]
+    if settingsRelativeTo and settingsRelativeTo ~= "UIParent" then
+        local targetFrame = _G[settingsRelativeTo]
         local options = self.GetGroupAnchorValidationOptions and self:GetGroupAnchorValidationOptions(groupId) or nil
         local ok = not self.ValidateAddonFrameAnchorTarget or self:ValidateAddonFrameAnchorTarget(settingsRelativeTo, options)
-        if ok and relFrame and relFrame.GetCenter and relFrame.GetSize then
+        if ok and (targetFrame == nil or IsFrameLikeAnchorTarget(targetFrame)) then
             group.anchor.point = point
             group.anchor.relativeTo = settingsRelativeTo
             group.anchor.relativePoint = relativePoint
@@ -782,7 +790,7 @@ function CooldownCompanion:DeleteContainer(containerId)
             deletedGroupIds[groupId] = true
         end
     end
-    ResetStandalonePanelAnchorsTargeting(db.groups, deletedGroupIds)
+    ResetStandalonePanelAnchorsTargeting(db.groups, deletedGroupIds, { [containerId] = true })
     for _, groupId in ipairs(panelIds) do
         self:UnloadGroup(groupId)
         self:DiscardDormantFrame(groupId)
@@ -805,10 +813,26 @@ local function GetStandalonePanelAnchorSettings(panel)
     return CooldownCompanion:GetStandaloneTextureAnchorSettings(panel)
 end
 
-local function GetStandalonePanelAnchorTargetId(panel)
+local function ParseStandaloneAddonAnchorTarget(relativeTo)
+    if type(relativeTo) ~= "string" then
+        return nil
+    end
+    local groupId = relativeTo:match("^CooldownCompanionGroup(%d+)$")
+    if groupId then
+        return "group", tonumber(groupId)
+    end
+    local containerId = relativeTo:match("^CooldownCompanionContainer(%d+)$")
+    if containerId then
+        return "container", tonumber(containerId)
+    end
+    return nil
+end
+
+local function GetStandaloneAddonAnchorTarget(panel)
     local settings = GetStandalonePanelAnchorSettings(panel)
     local relativeTo = type(settings) == "table" and settings.relativeTo or nil
-    return type(relativeTo) == "string" and tonumber(relativeTo:match("^CooldownCompanionGroup(%d+)$")) or nil
+    local kind, id = ParseStandaloneAddonAnchorTarget(relativeTo)
+    return kind, id, relativeTo
 end
 
 local function GetStandalonePanelAnchorTarget(panel)
@@ -829,33 +853,49 @@ local function ResetStandalonePanelAnchor(panel)
     settings.y = 0
 end
 
-ResetStandalonePanelAnchorsTargeting = function(groups, deletedGroupIds)
-    if type(groups) ~= "table" or type(deletedGroupIds) ~= "table" then
+ResetStandalonePanelAnchorsTargeting = function(groups, deletedGroupIds, deletedContainerIds)
+    if type(groups) ~= "table" then
         return
     end
+    deletedGroupIds = type(deletedGroupIds) == "table" and deletedGroupIds or {}
+    deletedContainerIds = type(deletedContainerIds) == "table" and deletedContainerIds or {}
 
     for groupId, panel in pairs(groups) do
         if not deletedGroupIds[groupId] then
-            local targetId = GetStandalonePanelAnchorTargetId(panel)
-            if targetId and deletedGroupIds[targetId] then
+            local targetKind, targetId = GetStandaloneAddonAnchorTarget(panel)
+            if (targetKind == "group" and deletedGroupIds[targetId])
+                or (targetKind == "container" and deletedContainerIds[targetId]) then
                 ResetStandalonePanelAnchor(panel)
             end
         end
     end
 end
 
-local function RemapDuplicatedStandalonePanelAnchor(panel, groupIdMap)
+local function RemapDuplicatedStandalonePanelAnchor(panel, groupIdMap, containerIdMap)
     local settings, relativeTo = GetStandalonePanelAnchorTarget(panel)
     if not settings or not relativeTo or relativeTo == "UIParent" then
         return
     end
 
-    local targetId = GetStandalonePanelAnchorTargetId(panel)
-    local newTargetId = targetId and groupIdMap[targetId] or nil
-    if newTargetId then
-        settings.relativeTo = "CooldownCompanionGroup" .. tostring(newTargetId)
-    else
+    local targetKind, targetId = ParseStandaloneAddonAnchorTarget(relativeTo)
+    if targetKind == "group" then
+        local newTargetId = targetId and groupIdMap[targetId] or nil
+        if newTargetId then
+            settings.relativeTo = "CooldownCompanionGroup" .. tostring(newTargetId)
+        else
+            ResetStandalonePanelAnchor(panel)
+        end
+    elseif targetKind == "container" then
+        local newTargetId = targetId and containerIdMap and containerIdMap[targetId] or nil
+        if newTargetId then
+            settings.relativeTo = "CooldownCompanionContainer" .. tostring(newTargetId)
+        else
+            ResetStandalonePanelAnchor(panel)
+        end
+    elseif relativeTo:find("^CooldownCompanion") then
         ResetStandalonePanelAnchor(panel)
+    else
+        return
     end
 end
 
@@ -865,8 +905,22 @@ local function ResetCopiedStandalonePanelAnchor(panel, groups, sourceGroupId, so
         return
     end
 
-    local targetId = GetStandalonePanelAnchorTargetId(panel)
-    if not targetId then
+    local targetKind, targetId = ParseStandaloneAddonAnchorTarget(relativeTo)
+    if not targetKind then
+        if relativeTo:find("^CooldownCompanion") then
+            ResetStandalonePanelAnchor(panel)
+        end
+        return
+    end
+
+    if targetKind == "container" then
+        if targetId ~= targetContainerId then
+            ResetStandalonePanelAnchor(panel)
+        end
+        return
+    end
+
+    if targetKind ~= "group" then
         ResetStandalonePanelAnchor(panel)
         return
     end
@@ -934,8 +988,9 @@ function CooldownCompanion:DuplicateContainer(containerId)
         end
     end
 
+    local containerIdMap = { [containerId] = newContainerId }
     for _, newGroupId in pairs(groupIdMap) do
-        RemapDuplicatedStandalonePanelAnchor(db.groups[newGroupId], groupIdMap)
+        RemapDuplicatedStandalonePanelAnchor(db.groups[newGroupId], groupIdMap, containerIdMap)
     end
 
     -- Create container frame (Phase 3 — safe noop if method doesn't exist yet)


### PR DESCRIPTION
## What Players Will Notice
- Texture Panels and Trigger Panels can now choose `Frame` as their anchor target, type or pick a frame, and position their standalone display relative to it.
- `Panel` anchors keep the existing panel-alpha inheritance behavior; `Frame` mode is positioning-only.

## Why This Changed
- Texture and Trigger Panels already had standalone positioning, but they could not mirror the icon/bar panel workflow for anchoring to arbitrary frames.

## What Changed
- Added `Frame` to the texture/trigger Layout tab anchor target options, including the existing frame-name editbox and Pick Frame flow.
- Reused the existing standalone anchor fields: `point`, `relativeTo`, `relativePoint`, `x`, and `y`.
- Resolved standalone targets as either panel targets or external frame targets, with invalid or missing targets falling back visually to `UIParent` without rewriting preserved external frame names.
- Updated copy, import, duplicate, and delete safety so addon-owned group/container references are remapped when possible and reset when unsafe, while arbitrary external frame names are preserved.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Config\Popups.lua ConfigSettings\GroupTabs.lua Core\AuraTextures.lua Core\AuraTexturesDisplay.lua Core\GroupManagement.lua`
- `lua tests\cursor-anchor-policy.lua`
- `lua tests\panel-standalone-anchor-rehome.lua`
- `lua tests\texture-panel-delta-policy.lua`
- `lua tests\profile-import-apply.lua`
- `lua tests\visual-state-snapshot.lua`
- `lua tests\visual-state-diagnostics.lua`
- In-game frame picking, reload persistence, combat, and restricted-content behavior still need manual validation before calling the feature complete.