### PR TITLE
Fix import review window layering and mode selection

### DIFF
--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -28,6 +28,7 @@ local IMPORT_TEXT_HEIGHT = 160
 local IMPORT_ACTION_HEIGHT = 30
 local IMPORT_WINDOW_WIDTH = 640
 local IMPORT_WINDOW_HEIGHT = 500
+local IMPORT_WINDOW_FRAME_STRATA = "TOOLTIP"
 local ACE_WINDOW_DEFAULT_MIN_WIDTH = 240
 local ACE_WINDOW_DEFAULT_MIN_HEIGHT = 240
 local IMPORT_WINDOW_MIN_WIDTH = 420
@@ -158,6 +159,13 @@ local function BuildReview(kind, data, title, acceptText, summaryLines, extra)
         for key, value in pairs(extra) do review[key] = value end
     end
     return review
+end
+
+local function RaiseImportReviewWindow(widget)
+    local frame = widget and widget.frame
+    if frame and frame.SetFrameStrata then
+        frame:SetFrameStrata(IMPORT_WINDOW_FRAME_STRATA)
+    end
 end
 
 local function ShowPopupOverConfig(which, textArg1, data)
@@ -804,6 +812,7 @@ end
 local function ShowImportReviewWindow(context)
     if importReviewFrame then
         importReviewFrame:Show()
+        RaiseImportReviewWindow(importReviewFrame)
         return
     end
 
@@ -944,6 +953,7 @@ local function ShowImportReviewWindow(context)
         ReviewInput()
     end
 
+    RaiseImportReviewWindow(frame)
     inputBox:SetFocus()
 end
 

--- a/Config/ImportReview.lua
+++ b/Config/ImportReview.lua
@@ -47,6 +47,10 @@ local IMPORT_MODE_LABELS = {
     restore = "Restore backup",
 }
 local IMPORT_MODE_ORDER = { "selected", "restore" }
+local IMPORT_MODE_OPTION_WIDTHS = {
+    selected = 190,
+    restore = 150,
+}
 
 if not AceGUI:GetLayout(IMPORT_LAYOUT) then
     local function LayoutImportBand(group, width, height)
@@ -751,16 +755,24 @@ local function RenderModeControl(group, review, refresh)
         return
     end
 
-    local modeDrop = AceGUI:Create("Dropdown")
-    modeDrop:SetLabel("Import mode:")
-    modeDrop:SetList(IMPORT_MODE_LABELS, IMPORT_MODE_ORDER)
-    modeDrop:SetValue(review.mode or "restore")
-    modeDrop:SetWidth(260)
-    modeDrop:SetCallback("OnValueChanged", function(widget, event, value)
-        review.mode = value == "selected" and "selected" or "restore"
-        refresh()
-    end)
-    group:AddChild(modeDrop)
+    local currentMode = review.mode == "selected" and "selected" or "restore"
+    for _, mode in ipairs(IMPORT_MODE_ORDER) do
+        local optionMode = mode
+        local option = AceGUI:Create("CheckBox")
+        option:SetType("radio")
+        option:SetLabel(IMPORT_MODE_LABELS[optionMode])
+        option:SetValue(optionMode == currentMode)
+        option:SetWidth(IMPORT_MODE_OPTION_WIDTHS[optionMode] or 160)
+        option:SetCallback("OnValueChanged", function(widget, event, value)
+            if value ~= true then
+                widget:SetValue(true)
+                return
+            end
+            review.mode = optionMode
+            refresh()
+        end)
+        group:AddChild(option)
+    end
 end
 
 local function RenderPieceRows(group, review, refresh)

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -311,7 +311,7 @@ CS.InitPendingStrataOrder = InitPendingStrataOrder
 local function ShowPopupAboveConfig(which, text_arg1, data)
     local dialog = StaticPopup_Show(which, text_arg1, nil, data)
     if dialog then
-        dialog:SetFrameStrata("FULLSCREEN_DIALOG")
+        dialog:SetFrameStrata("TOOLTIP")
         dialog:SetFrameLevel(200)
     end
     return dialog


### PR DESCRIPTION
## What Players Will Notice
- Import review windows now open above the main Cooldown Companion config panel instead of appearing behind it.
- Confirmation popups used by config flows stay above the main config panel.
- Import mode now shows both choices as stable radio-style options instead of a dropdown that could overlap the review text.

## Why This Changed
- The import review window was hard to use when it appeared behind the config panel.
- The import mode dropdown was unreliable in the raised import window layout, so the binary mode choice was simplified into always-visible options.

## What Changed
- Raised the import review AceGUI window to `TOOLTIP` strata when it is shown.
- Raised config StaticPopup dialogs to `TOOLTIP` strata at frame level 200.
- Replaced the import-mode dropdown with fixed-width radio-style controls for selected-pieces import and full backup restore.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Config\ImportReview.lua Config\State.lua`
- User confirmed the raised import window worked in-game and confirmed the final radio-mode control behaved as expected.
- Codex did not personally perform in-game UI validation. Destructive restore confirmation, combat, and restricted-content behavior remain unverified by Codex.
