### PR TITLE
Smooth fill and drain animations across addon bars

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -61,6 +61,15 @@ local EvaluateDesaturation = ST._EvaluateDesaturation
 
 -- Shared click-through helpers from Utils.lua
 local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
+local ClearStatusBarMotion = ST.ClearStatusBarMotion
+local SetStatusBarImmediateRange = ST.SetStatusBarImmediateRange
+local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarElapsedDuration = ST.SetStatusBarElapsedDuration
+local SetStatusBarRemainingDuration = ST.SetStatusBarRemainingDuration
+
+local BAR_TEXT_UPDATE_INTERVAL = 0.1
 
 local function IsCursorAnchoredButton(button)
     return button
@@ -318,10 +327,10 @@ local function ClearBarAuraStackVisual(button, keepIndicator)
     end
     if button.statusBar and button.statusBar.thresholdOverlay then
         button.statusBar.thresholdOverlay:Hide()
-        button.statusBar.thresholdOverlay:SetValue(0)
+        SetStatusBarImmediateValue(button.statusBar.thresholdOverlay, 0)
     end
     if button.statusBar then
-        button.statusBar:SetMinMaxValues(0, 1)
+        SetStatusBarImmediateRange(button.statusBar, 0, 1)
     end
     if not keepIndicator and RB and RB.ClearMaxStacksIndicator then
         if button._barAuraStackIndicatorInfo then
@@ -345,7 +354,7 @@ function CooldownCompanion:RefreshBarPanelAuraStackVisual(button)
     if button._barAuraStackContinuousInfo then
         button._barAuraStackContinuousInfo._barAuraStackIndicatorKey = nil
     end
-    button._barFillElapsed = button._barUpdateInterval or 0.025
+    button._barFillElapsed = button._barTextUpdateInterval or BAR_TEXT_UPDATE_INTERVAL
 end
 
 local function ClearBarAuraStackIndicatorInfo(info, RB)
@@ -366,7 +375,7 @@ local function CreateBarAuraStackSegment(holder, RB)
     local segment = CreateFrame("StatusBar", nil, holder)
     segment:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
     segment:SetMinMaxValues(0, 1)
-    segment:SetValue(0)
+    SetStatusBarImmediateValue(segment, 0)
 
     segment.bg = segment:CreateTexture(nil, "BACKGROUND")
     segment.bg:SetAllPoints()
@@ -387,7 +396,7 @@ local function EnsureBarAuraSegmentCapacity(holder, count, RB)
     for i, segment in ipairs(holder.segments) do
         segment:SetMinMaxValues(i - 1, i)
         if i > count then
-            segment:SetValue(0)
+            SetStatusBarImmediateValue(segment, 0)
             segment:Hide()
         end
     end
@@ -404,7 +413,7 @@ local function EnsureBarAuraOverlayCapacity(holder, halfSegments, RB)
         overlaySegment:SetFrameLevel(holder:GetFrameLevel() + 2)
         overlaySegment:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
         overlaySegment:SetMinMaxValues(i + halfSegments - 1, i + halfSegments)
-        overlaySegment:SetValue(0)
+        SetStatusBarImmediateValue(overlaySegment, 0)
         SetFrameClickThroughRecursive(overlaySegment, true, true)
         holder.overlaySegments[i] = overlaySegment
     end
@@ -412,14 +421,14 @@ local function EnsureBarAuraOverlayCapacity(holder, halfSegments, RB)
     for i, segment in ipairs(holder.segments) do
         segment:SetMinMaxValues(i - 1, i)
         if i > halfSegments then
-            segment:SetValue(0)
+            SetStatusBarImmediateValue(segment, 0)
             segment:Hide()
         end
     end
     for i, segment in ipairs(holder.overlaySegments) do
         segment:SetMinMaxValues(i + halfSegments - 1, i + halfSegments)
         if i > halfSegments then
-            segment:SetValue(0)
+            SetStatusBarImmediateValue(segment, 0)
             segment:Hide()
         end
     end
@@ -489,7 +498,7 @@ local function ApplyBarAuraStackSegmentValues(segments, color, value, valueAvail
     local widgetValue = GetBarAuraStackWidgetValue(value, valueAvailable)
     for _, segment in ipairs(segments) do
         segment:SetStatusBarColor(color[1], color[2], color[3], color[4] or 1)
-        segment:SetValue(widgetValue)
+        SetStatusBarSmoothValue(segment, widgetValue)
     end
 end
 
@@ -497,16 +506,16 @@ local function ApplyBarAuraStackSegmentOnlyValues(segments, value, valueAvailabl
     if not segments then return end
     local widgetValue = GetBarAuraStackWidgetValue(value, valueAvailable)
     for _, segment in ipairs(segments) do
-        segment:SetValue(widgetValue)
+        SetStatusBarSmoothValue(segment, widgetValue)
     end
 end
 
 local function ApplyBarAuraStackValuesOnly(button, mode, stackValue, valueAvailable)
     local widgetValue = GetBarAuraStackWidgetValue(stackValue, valueAvailable)
     if mode == "continuous" then
-        button.statusBar:SetValue(widgetValue)
+        SetStatusBarSmoothValue(button.statusBar, widgetValue)
         if button.statusBar.thresholdOverlay and button.statusBar.thresholdOverlay:IsShown() then
-            button.statusBar.thresholdOverlay:SetValue(widgetValue)
+            SetStatusBarSmoothValue(button.statusBar.thresholdOverlay, widgetValue)
         end
     else
         local holder = mode == "overlay" and button._barAuraStackOverlay or button._barAuraStackSegments
@@ -522,7 +531,7 @@ local function ApplyBarAuraStackValuesOnly(button, mode, stackValue, valueAvaila
 
     local info = mode == "continuous" and button._barAuraStackContinuousInfo or button._barAuraStackIndicatorInfo
     if info and info._maxStacksIndicator then
-        info._maxStacksIndicator:SetValue(widgetValue)
+        SetStatusBarSmoothValue(info._maxStacksIndicator, widgetValue)
     end
 end
 
@@ -696,8 +705,8 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
         end
         button._barAuraStackVisualActive = true
         button._barAuraStackVisualMode = "continuous"
-        button.statusBar:SetMinMaxValues(0, maxStacks)
-        button.statusBar:SetValue(GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+        SetStatusBarSmoothRange(button.statusBar, 0, maxStacks)
+        SetStatusBarSmoothValue(button.statusBar, GetBarAuraStackWidgetValue(stackValue, valueAvailable))
         button.statusBar:SetStatusBarColor(stackBarColor[1], stackBarColor[2], stackBarColor[3], stackBarColor[4] or 1)
         if showThreshold and RB.EnsureCustomAuraContinuousThresholdOverlay and RB.LayoutCustomAuraContinuousThresholdOverlay then
             RB.EnsureCustomAuraContinuousThresholdOverlay(button.statusBar)
@@ -708,12 +717,12 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
             if overlay then
                 RB.SetCustomAuraMaxThresholdRange(overlay, maxStacks)
                 overlay:SetStatusBarColor(thresholdColor[1], thresholdColor[2], thresholdColor[3], thresholdColor[4] or 1)
-                overlay:SetValue(GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+                SetStatusBarSmoothValue(overlay, GetBarAuraStackWidgetValue(stackValue, valueAvailable))
                 overlay:Show()
             end
         elseif button.statusBar.thresholdOverlay then
             button.statusBar.thresholdOverlay:Hide()
-            button.statusBar.thresholdOverlay:SetValue(0)
+            SetStatusBarImmediateValue(button.statusBar.thresholdOverlay, 0)
         end
         button._barAuraStackLayoutKey = layoutKey
         return
@@ -726,7 +735,7 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
     HideBarAuraBaseFill(button)
     if button.statusBar.thresholdOverlay then
         button.statusBar.thresholdOverlay:Hide()
-        button.statusBar.thresholdOverlay:SetValue(0)
+        SetStatusBarImmediateValue(button.statusBar.thresholdOverlay, 0)
     end
     holder._isVertical = button._isVertical == true
     holder._reverseFill = reverseFill
@@ -762,10 +771,10 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
                     RB.SetCustomAuraMaxThresholdRange(segment, maxStacks)
                     segment:SetStatusBarColor(thresholdColor[1], thresholdColor[2], thresholdColor[3], thresholdColor[4] or 1)
                 end
-                segment:SetValue(GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+                SetStatusBarSmoothValue(segment, GetBarAuraStackWidgetValue(stackValue, valueAvailable))
                 segment:Show()
             elseif layoutChanged then
-                segment:SetValue(0)
+                SetStatusBarImmediateValue(segment, 0)
                 segment:Hide()
             end
         end
@@ -860,7 +869,7 @@ local function UpdateBarAuraStackIndicator(button, mode, maxStacks, stackValue, 
         info._barAuraStackIndicatorKey = indicatorKey
     end
     if info._maxStacksIndicator then
-        info._maxStacksIndicator:SetValue(GetBarAuraStackWidgetValue(stackValue, stackValueAvailable))
+        SetStatusBarSmoothValue(info._maxStacksIndicator, GetBarAuraStackWidgetValue(stackValue, stackValueAvailable))
     end
 end
 
@@ -878,8 +887,8 @@ local function ApplyBarAuraStackVisual(button, stackValue, stackValueAvailable)
         if mode == "continuous" then
             LayoutBarAuraStackVisual(button, "continuous", maxStacks, widgetValue, stackValueAvailable)
         else
-            button.statusBar:SetMinMaxValues(0, 1)
-            button.statusBar:SetValue(0)
+            SetStatusBarImmediateRange(button.statusBar, 0, 1)
+            SetStatusBarImmediateValue(button.statusBar, 0)
             LayoutBarAuraStackVisual(button, mode, maxStacks, widgetValue, stackValueAvailable)
         end
         UpdateBarAuraStackIndicator(button, mode, maxStacks, widgetValue, stackValueAvailable)
@@ -890,7 +899,7 @@ local function ApplyBarAuraStackVisual(button, stackValue, stackValueAvailable)
     end
 end
 
--- Lightweight OnUpdate: interpolates bar fill + time text between ticker updates.
+-- Lightweight OnUpdate: keeps time text fresh while native StatusBar timers drive fill motion.
 local function SetBarTimeText(button, text)
     if button._lastBarTimeText ~= text then
         button._lastBarTimeText = text
@@ -905,9 +914,9 @@ end
 
 local function UpdateBarFill(button)
     -- Single-bar path
-    -- DurationObject percent methods return secret values during combat in 12.0.1,
-    -- but SetValue() accepts secrets (C-side widget method).  HasSecretValues gates
-    -- expiry detection and time text formatting.
+    -- DurationObjects are handed to StatusBar:SetTimerDuration so drain/fill motion
+    -- is engine-driven instead of re-sampled as Lua percentages.
+    -- HasSecretValues gates expiry detection and time text formatting.
     -- Items use stored C_Item.GetItemCooldown values (_itemCdStart/_itemCdDuration).
     local onCooldown = false
     local itemRemaining = 0
@@ -918,6 +927,7 @@ local function UpdateBarFill(button)
     if previewRemaining and previewRemaining > 0 and not button._barGCDSuppressed then
         ClearBarAuraStackVisual(button)
         onCooldown = true
+        SetStatusBarSmoothRange(button.statusBar, 0, 1)
         previewDuration = previewDuration or previewRemaining
         if previewDuration <= 0 then
             previewDuration = previewRemaining
@@ -930,7 +940,7 @@ local function UpdateBarFill(button)
         end
         if frac < 0 then frac = 0 end
         if frac > 1 then frac = 1 end
-        button.statusBar:SetValue(frac)
+        SetStatusBarSmoothValue(button.statusBar, frac)
     elseif button._barAuraStackDisplay then
         onCooldown = true
         if not button._barAuraStackValueSecret then
@@ -940,11 +950,15 @@ local function UpdateBarFill(button)
     elseif button._durationObj and not button._barGCDSuppressed then
         ClearBarAuraStackVisual(button)
         onCooldown = true
-        -- SetValue accepts secret values; fraction animates natively in the engine
+        SetStatusBarSmoothRange(button.statusBar, 0, 1)
         if button._auraActive then
-            button.statusBar:SetValue(button._durationObj:GetRemainingPercent())   -- drain: 1→0
+            if not SetStatusBarRemainingDuration(button.statusBar, button._durationObj) then
+                SetStatusBarSmoothValue(button.statusBar, button._durationObj:GetRemainingPercent())   -- drain: 1->0
+            end
         else
-            button.statusBar:SetValue(button._durationObj:GetElapsedPercent())     -- fill: 0→1
+            if not SetStatusBarElapsedDuration(button.statusBar, button._durationObj) then
+                SetStatusBarSmoothValue(button.statusBar, button._durationObj:GetElapsedPercent())     -- fill: 0->1
+            end
         end
     elseif button._viewerBar and button._auraActive and not button._barGCDSuppressed then
         ClearBarAuraStackVisual(button)
@@ -956,18 +970,20 @@ local function UpdateBarFill(button)
         if viewerBar:IsVisible() then
             onCooldown = true
             local _, maxVal = viewerBar:GetMinMaxValues()
-            button.statusBar:SetMinMaxValues(0, maxVal)
-            button.statusBar:SetValue(viewerBar:GetValue())
+            SetStatusBarSmoothRange(button.statusBar, 0, maxVal)
+            SetStatusBarSmoothValue(button.statusBar, viewerBar:GetValue())
         end
     elseif button._cooldownDeferred then
         ClearBarAuraStackVisual(button)
         -- Deferred cooldown (timer hasn't started): show as "on cooldown"
         -- with a static full bar (no animation, no time text).
         onCooldown = true
-        button.statusBar:SetValue(0)
+        SetStatusBarImmediateRange(button.statusBar, 0, 1)
+        SetStatusBarImmediateValue(button.statusBar, 0)
     elseif button.buttonData.type == "item" then
         ClearBarAuraStackVisual(button)
         -- Items: use stored C_Item.GetItemCooldown values (avoids hidden-widget staleness)
+        SetStatusBarSmoothRange(button.statusBar, 0, 1)
         local startMs = (button._itemCdStart or 0) * 1000
         local durationMs = (button._itemCdDuration or 0) * 1000
         local now = GetTime() * 1000
@@ -979,11 +995,11 @@ local function UpdateBarFill(button)
             if button._auraActive then
                 local frac = 1 - (elapsed / durationMs)
                 if frac < 0 then frac = 0 end
-                button.statusBar:SetValue(frac)
+                SetStatusBarSmoothValue(button.statusBar, frac)
             else
                 local frac = elapsed / durationMs
                 if frac > 1 then frac = 1 end
-                button.statusBar:SetValue(frac)
+                SetStatusBarSmoothValue(button.statusBar, frac)
             end
         end
     end
@@ -1054,29 +1070,29 @@ local function UpdateBarFill(button)
         ClearBarAuraStackVisual(button)
         -- Restore 0-1 range if exiting viewer bar pass-through
         if button._viewerBar then
-            button.statusBar:SetMinMaxValues(0, 1)
+            SetStatusBarImmediateRange(button.statusBar, 0, 1)
             button._viewerBar = nil
         end
         if button._barAuraActivePreview or button._conditionalBarAuraActivePreview then
-            button.statusBar:SetValue(1)
+            SetStatusBarImmediateValue(button.statusBar, 1)
             SetBarTimeText(button, "")
         elseif button.buttonData.isPassive then
-            button.statusBar:SetValue(0)
+            SetStatusBarImmediateValue(button.statusBar, 0)
             SetBarTimeText(button, "")
         else
-        button.statusBar:SetValue(1)
-        if button.style.showBarReadyText then
-            if button._barTextMode ~= "ready" then
-                button._barTextMode = "ready"
-                local f = CooldownCompanion:FetchFont(button.style.barReadyFont or "Friz Quadrata TT")
-                local s = button.style.barReadyFontSize or 12
-                local o = button.style.barReadyFontOutline or "OUTLINE"
-                button.timeText:SetFont(f, s, o)
+            SetStatusBarImmediateValue(button.statusBar, 1)
+            if button.style.showBarReadyText then
+                if button._barTextMode ~= "ready" then
+                    button._barTextMode = "ready"
+                    local f = CooldownCompanion:FetchFont(button.style.barReadyFont or "Friz Quadrata TT")
+                    local s = button.style.barReadyFontSize or 12
+                    local o = button.style.barReadyFontOutline or "OUTLINE"
+                    button.timeText:SetFont(f, s, o)
+                end
+                SetBarTimeText(button, button.style.barReadyText or "Ready")
+            else
+                SetBarTimeText(button, "")
             end
-            SetBarTimeText(button, button.style.barReadyText or "Ready")
-        else
-            SetBarTimeText(button, "")
-        end
         end
     end
 end
@@ -1340,7 +1356,7 @@ local function UpdateBarDisplay(button)
 end
 
 -- Shared OnUpdate for bar-mode buttons: aura expiry detection, pulse/color-shift animation, + throttled bar fill.
--- Reads interval from self._barUpdateInterval so it can be updated without re-installing.
+-- Reads interval from self._barTextUpdateInterval so it can be updated without re-installing.
 local function BarModeOnUpdate(self, elapsed)
     -- Detect aura expiry via HasSecretValues + GetRemainingDuration.
     -- Non-secret (out of combat): instant expiry detection.
@@ -1375,7 +1391,7 @@ local function BarModeOnUpdate(self, elapsed)
             self._barAuraColor = nil
             local c = self.style.barColor or DEFAULT_BAR_COLOR
             self.statusBar:SetStatusBarColor(c[1], c[2], c[3], c[4])
-            self.statusBar:SetMinMaxValues(0, 1)
+            SetStatusBarImmediateRange(self.statusBar, 0, 1)
             SetBarAuraEffect(self, false)
             self._barPulseActive = nil
             self._barColorShiftActive = nil
@@ -1409,7 +1425,7 @@ local function BarModeOnUpdate(self, elapsed)
     end
 
     self._barFillElapsed = self._barFillElapsed + elapsed
-    if self._barFillElapsed >= self._barUpdateInterval then
+    if self._barFillElapsed >= (self._barTextUpdateInterval or BAR_TEXT_UPDATE_INTERVAL) then
         self._barFillElapsed = 0
         UpdateBarFill(self)
     end
@@ -1496,8 +1512,8 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     if isVertical then
         button.statusBar:SetOrientation("VERTICAL")
     end
-    button.statusBar:SetMinMaxValues(0, 1)
-    button.statusBar:SetValue(1)
+    SetStatusBarImmediateRange(button.statusBar, 0, 1)
+    SetStatusBarImmediateValue(button.statusBar, 1)
     button.statusBar:SetReverseFill(style.barReverseFill or false)
     button.statusBar:SetStatusBarTexture(CooldownCompanion:FetchStatusBar(style.barTexture or "Solid"))
     local barColor = style.barColor or DEFAULT_BAR_COLOR
@@ -1645,9 +1661,9 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
         buttonData._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(buttonData.id)
     end
 
-    -- Bar fill interpolation OnUpdate
+    -- Bar text refresh / fallback fill OnUpdate. Native timers drive DurationObject fills.
     button._barFillElapsed = 0
-    button._barUpdateInterval = style.barUpdateInterval or 0.025
+    button._barTextUpdateInterval = BAR_TEXT_UPDATE_INTERVAL
     button:SetScript("OnUpdate", BarModeOnUpdate)
 
     -- Aura tracking runtime state
@@ -1774,9 +1790,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     end
     button._isVertical = isVertical
 
-    -- Update bar fill OnUpdate interval
+    -- Update bar text/fallback fill OnUpdate interval
     button._barFillElapsed = 0
-    button._barUpdateInterval = newStyle.barUpdateInterval or 0.025
+    button._barTextUpdateInterval = BAR_TEXT_UPDATE_INTERVAL
     button:SetScript("OnUpdate", BarModeOnUpdate)
 
     -- Invalidate cached state

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -52,33 +52,10 @@ local function BuildBarAppearanceTab(container, group, style)
     container:AddChild(barHeading)
 
     local barSettingsCollapsed = CS.collapsedSections["barappearance_settings"]
-    local collapseBtn = AttachCollapseButton(barHeading, barSettingsCollapsed, function()
+    AttachCollapseButton(barHeading, barSettingsCollapsed, function()
         CS.collapsedSections["barappearance_settings"] = not CS.collapsedSections["barappearance_settings"]
         CooldownCompanion:RefreshConfigPanel()
     end)
-
-    local function BuildBarSettingsAdvanced(panel)
-        local updateFreqSlider = AceGUI:Create("Slider")
-        updateFreqSlider:SetLabel("Update Frequency (Hz)")
-        updateFreqSlider:SetSliderValues(10, 60, 0.1)
-        local curInterval = style.barUpdateInterval or 0.025
-        updateFreqSlider:SetValue(math.floor(1 / curInterval + 0.5))
-        updateFreqSlider:SetFullWidth(true)
-        updateFreqSlider:SetCallback("OnValueChanged", function(widget, event, val)
-            style.barUpdateInterval = 1 / val
-            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        end)
-        panel:AddChild(updateFreqSlider)
-    end
-
-    local barAdvExpanded, barAdvBtn = AddAdvancedToggle(barHeading, "barSettings", tabInfoButtons, nil, {
-        title = "Bar Settings Advanced",
-        build = BuildBarSettingsAdvanced,
-    })
-    barAdvBtn:SetPoint("LEFT", collapseBtn, "RIGHT", 4, 0)
-    barHeading.right:ClearAllPoints()
-    barHeading.right:SetPoint("RIGHT", barHeading.frame, "RIGHT", -3, 0)
-    barHeading.right:SetPoint("LEFT", barAdvBtn, "RIGHT", 4, 0)
 
     if not barSettingsCollapsed then
     local lengthSlider = AceGUI:Create("Slider")

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -22,6 +22,8 @@ local StartDragTracking = ST._StartDragTracking
 local CancelDrag = ST._CancelDrag
 local HideDragIndicator = ST._HideDragIndicator
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 
 local POWER_NAMES = RB.POWER_NAMES
 local SEGMENTED_TYPES = RB.SEGMENTED_TYPES
@@ -1310,8 +1312,8 @@ local function ConfigureCastPreview(frame, slot, preview, width, height)
     bar:ClearAllPoints()
     bar:SetPoint("TOPLEFT", root, "TOPLEFT", barLeft, 0)
     bar:SetPoint("BOTTOMRIGHT", root, "BOTTOMRIGHT", barRight, 0)
-    bar:SetMinMaxValues(0, 100)
-    bar:SetValue(65)
+    SetStatusBarSmoothRange(bar, 0, 100)
+    SetStatusBarSmoothValue(bar, 65)
     bar:SetStatusBarTexture(CooldownCompanion:FetchStatusBar(settings.barTexture or "Solid"))
     local liveR, liveG, liveB, liveA = liveCastBar and liveCastBar.GetStatusBarColor and liveCastBar:GetStatusBarColor()
     local barColor = settings.barColor or { 1, 0.72, 0.18, 1 }

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -404,7 +404,6 @@ local defaults = {
             barReadyFontSize = 12,
             barReadyFont = "Friz Quadrata TT",
             barReadyFontOutline = "OUTLINE",
-            barUpdateInterval = 0.025,  -- seconds between bar fill updates (~40Hz default)
             barTexture = "Solid",
             -- Text display mode defaults
             textWidth = 200,

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -11,6 +11,8 @@ local ipairs = ipairs
 local pairs = pairs
 local tonumber = tonumber
 local type = type
+local Enum = Enum
+local issecretvalue = issecretvalue
 
 --------------------------------------------------------------------------------
 -- Constants
@@ -23,6 +25,12 @@ ST.NUM_GLOW_STYLES = 3
 ST.BORDER_RENDER_MODE_CUSTOM = "custom"
 ST.BORDER_RENDER_MODE_CRISP = "crisp"
 
+local statusBarInterpolation = Enum and Enum.StatusBarInterpolation
+local statusBarTimerDirection = Enum and Enum.StatusBarTimerDirection
+ST.STATUS_BAR_INTERPOLATION_SMOOTH = statusBarInterpolation and statusBarInterpolation.ExponentialEaseOut
+ST.STATUS_BAR_TIMER_DIRECTION_ELAPSED = statusBarTimerDirection and statusBarTimerDirection.ElapsedTime or 0
+ST.STATUS_BAR_TIMER_DIRECTION_REMAINING = statusBarTimerDirection and statusBarTimerDirection.RemainingTime or 1
+
 -- Shared edge anchor spec: {point1, relPoint1, point2, relPoint2, x1sign, y1sign, x2sign, y2sign}
 -- Signs: 0 = zero offset, 1 = +size, -1 = -size
 ST.EDGE_ANCHOR_SPEC = {
@@ -31,6 +39,128 @@ ST.EDGE_ANCHOR_SPEC = {
     {"TOPLEFT", "TOPLEFT",     "BOTTOMRIGHT", "BOTTOMLEFT",   0, -1,  1,  1}, -- Left   (inset to avoid corner overlap)
     {"TOPLEFT", "TOPRIGHT",    "BOTTOMRIGHT", "BOTTOMRIGHT", -1, -1,  0,  1}, -- Right  (inset to avoid corner overlap)
 }
+
+--------------------------------------------------------------------------------
+-- StatusBar Motion Helpers
+--------------------------------------------------------------------------------
+
+local STATUS_BAR_MOTION_TIMER = "timer"
+local STATUS_BAR_MOTION_SMOOTH_VALUE = "smoothValue"
+
+function ST.ClearStatusBarMotion(statusBar)
+    if not statusBar then return end
+
+    statusBar._cdcStatusBarMotionKind = nil
+    statusBar._cdcStatusBarMotionDurationObj = nil
+    statusBar._cdcStatusBarMotionDirection = nil
+    statusBar._cdcStatusBarMotionValue = nil
+    statusBar._cdcStatusBarRangeMin = nil
+    statusBar._cdcStatusBarRangeMax = nil
+    statusBar._cdcStatusBarRangeInterpolation = nil
+end
+
+function ST.SetStatusBarRange(statusBar, minValue, maxValue, interpolation)
+    if not statusBar then return false end
+
+    local rangeIsSecret = issecretvalue
+        and (issecretvalue(minValue) or issecretvalue(maxValue))
+    if not rangeIsSecret
+        and statusBar._cdcStatusBarRangeMin == minValue
+        and statusBar._cdcStatusBarRangeMax == maxValue
+        and statusBar._cdcStatusBarRangeInterpolation == interpolation then
+        return true
+    end
+
+    if rangeIsSecret then
+        statusBar._cdcStatusBarRangeMin = nil
+        statusBar._cdcStatusBarRangeMax = nil
+        statusBar._cdcStatusBarRangeInterpolation = nil
+    else
+        statusBar._cdcStatusBarRangeMin = minValue
+        statusBar._cdcStatusBarRangeMax = maxValue
+        statusBar._cdcStatusBarRangeInterpolation = interpolation
+    end
+
+    if interpolation ~= nil then
+        statusBar:SetMinMaxValues(minValue, maxValue, interpolation)
+    else
+        statusBar:SetMinMaxValues(minValue, maxValue)
+    end
+    return true
+end
+
+function ST.SetStatusBarImmediateRange(statusBar, minValue, maxValue)
+    return ST.SetStatusBarRange(statusBar, minValue, maxValue, nil)
+end
+
+function ST.SetStatusBarSmoothRange(statusBar, minValue, maxValue)
+    return ST.SetStatusBarRange(statusBar, minValue, maxValue, ST.STATUS_BAR_INTERPOLATION_SMOOTH)
+end
+
+function ST.SetStatusBarImmediateValue(statusBar, value)
+    if not statusBar then return false end
+
+    ST.ClearStatusBarMotion(statusBar)
+    statusBar:SetValue(value)
+    return true
+end
+
+function ST.SetStatusBarSmoothValue(statusBar, value)
+    if not statusBar then return false end
+
+    local valueIsSecret = issecretvalue and issecretvalue(value)
+    if statusBar._cdcStatusBarMotionKind == STATUS_BAR_MOTION_SMOOTH_VALUE
+        and not valueIsSecret
+        and statusBar._cdcStatusBarMotionValue == value then
+        return true
+    end
+
+    statusBar._cdcStatusBarMotionKind = STATUS_BAR_MOTION_SMOOTH_VALUE
+    statusBar._cdcStatusBarMotionDurationObj = nil
+    statusBar._cdcStatusBarMotionDirection = nil
+    if valueIsSecret then
+        statusBar._cdcStatusBarMotionValue = nil
+    else
+        statusBar._cdcStatusBarMotionValue = value
+    end
+
+    local interpolation = ST.STATUS_BAR_INTERPOLATION_SMOOTH
+    if interpolation ~= nil then
+        statusBar:SetValue(value, interpolation)
+    else
+        statusBar:SetValue(value)
+    end
+    return true
+end
+
+function ST.SetStatusBarTimerDuration(statusBar, durationObj, direction)
+    if not (statusBar and durationObj and statusBar.SetTimerDuration) then
+        return false
+    end
+
+    direction = direction or ST.STATUS_BAR_TIMER_DIRECTION_ELAPSED
+    if statusBar._cdcStatusBarMotionKind == STATUS_BAR_MOTION_TIMER
+        and statusBar._cdcStatusBarMotionDurationObj == durationObj
+        and statusBar._cdcStatusBarMotionDirection == direction then
+        return true
+    end
+
+    statusBar._cdcStatusBarMotionKind = STATUS_BAR_MOTION_TIMER
+    statusBar._cdcStatusBarMotionDurationObj = durationObj
+    statusBar._cdcStatusBarMotionDirection = direction
+    statusBar._cdcStatusBarMotionValue = nil
+
+    statusBar:SetTimerDuration(durationObj, ST.STATUS_BAR_INTERPOLATION_SMOOTH, direction)
+    return true
+end
+
+function ST.SetStatusBarElapsedDuration(statusBar, durationObj)
+    return ST.SetStatusBarTimerDuration(statusBar, durationObj, ST.STATUS_BAR_TIMER_DIRECTION_ELAPSED)
+end
+
+function ST.SetStatusBarRemainingDuration(statusBar, durationObj)
+    return ST.SetStatusBarTimerDuration(statusBar, durationObj, ST.STATUS_BAR_TIMER_DIRECTION_REMAINING)
+end
 
 --------------------------------------------------------------------------------
 -- Border Helpers

--- a/OtherBars/CastBar.lua
+++ b/OtherBars/CastBar.lua
@@ -1431,8 +1431,14 @@ local function ApplyPreview()
 
     cb:SetAlpha(1)
     cb:Show()
-    cb:SetMinMaxValues(0, 100)
-    cb:SetValue(65)
+    local interpolation = ST.STATUS_BAR_INTERPOLATION_SMOOTH
+    if interpolation ~= nil then
+        cb:SetMinMaxValues(0, 100, interpolation)
+        cb:SetValue(65, interpolation)
+    else
+        cb:SetMinMaxValues(0, 100)
+        cb:SetValue(65)
+    end
 
     -- Spell name text
     if cb.Text then

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -17,6 +17,10 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
+local ClearStatusBarMotion = ST.ClearStatusBarMotion
+local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 
 local math_floor = math.floor
 local math_min = math.min
@@ -391,6 +395,7 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
 end
 local function ClearStaleRecycledBarRuntimeState(frame)
     if not frame then return end
+    ClearStatusBarMotion(frame)
     if frame._cdcCustomAuraAlphaModuleId then
         CooldownCompanion:UnregisterModuleAlpha(frame._cdcCustomAuraAlphaModuleId)
         frame._cdcCustomAuraAlphaModuleId = nil
@@ -792,8 +797,8 @@ local function UpdateContinuousBar(bar, powerType, settings, auraActiveCache)
     end
 
     -- Pass through to C-level widget APIs (secret-safe).
-    bar:SetMinMaxValues(0, maxPower)
-    bar:SetValue(currentPower)
+    SetStatusBarSmoothRange(bar, 0, maxPower)
+    SetStatusBarSmoothValue(bar, currentPower)
 
     local auraOverrideColor = GetResourceAuraState(powerType, settings, auraActiveCache)
     ApplyContinuousFillColor(bar, powerType, settings, auraOverrideColor)
@@ -834,8 +839,8 @@ local function UpdateStaggerBar(bar, settings)
     if not isSecret and maxHealth < 1 then maxHealth = 1 end
 
     -- Pass-through to C-level widget APIs (secret-safe)
-    bar:SetMinMaxValues(0, maxHealth)
-    bar:SetValue(staggerAmount)
+    SetStatusBarSmoothRange(bar, 0, maxHealth)
+    SetStatusBarSmoothValue(bar, staggerAmount)
 
     -- Compute pool percent for color + text (only when neither value is secret)
     local percent
@@ -888,7 +893,7 @@ end
 
 function segmentedUpdateScratch.ClearValues(holder)
     for _, seg in ipairs(holder.segments) do
-        seg:SetValue(0)
+        SetStatusBarImmediateValue(seg, 0)
     end
 end
 
@@ -986,15 +991,15 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             local segValue = 0
             if r.ready then
                 segValue = 1
-                seg:SetValue(segValue)
+                SetStatusBarSmoothValue(seg, segValue)
                 seg:SetStatusBarColor(activeReadyColor[1], activeReadyColor[2], activeReadyColor[3], 1)
                 fullSegments[i] = true
             elseif r.duration and r.duration > 0 then
                 segValue = math_min((now - r.start) / r.duration, 1)
-                seg:SetValue(segValue)
+                SetStatusBarSmoothValue(seg, segValue)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             else
-                seg:SetValue(segValue)
+                SetStatusBarSmoothValue(seg, segValue)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             end
             runeValueTotal = runeValueTotal + segValue
@@ -1034,14 +1039,14 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 for i = 1, math_min(#holder.segments, max) do
                     local seg = holder.segments[i]
                     if i <= filled then
-                        seg:SetValue(1)
+                        SetStatusBarSmoothValue(seg, 1)
                         seg:SetStatusBarColor(activeReadyColor[1], activeReadyColor[2], activeReadyColor[3], 1)
                         fullSegments[i] = true
                     elseif i == filled + 1 and partial > 0 then
-                        seg:SetValue(partial)
+                        SetStatusBarSmoothValue(seg, partial)
                         seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
                     else
-                        seg:SetValue(0)
+                        SetStatusBarSmoothValue(seg, 0)
                         seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
                     end
                 end
@@ -1085,14 +1090,14 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         for i = 1, math_min(#holder.segments, max) do
             local seg = holder.segments[i]
             if i <= filled then
-                seg:SetValue(1)
+                SetStatusBarSmoothValue(seg, 1)
                 seg:SetStatusBarColor(activeReadyColor[1], activeReadyColor[2], activeReadyColor[3], 1)
                 fullSegments[i] = true
             elseif i == filled + 1 and partial > 0 then
-                seg:SetValue(partial)
+                SetStatusBarSmoothValue(seg, partial)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             else
-                seg:SetValue(0)
+                SetStatusBarSmoothValue(seg, 0)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             end
         end
@@ -1130,7 +1135,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         for i = 1, math_min(#holder.segments, max) do
             local seg = holder.segments[i]
             if i <= current then
-                seg:SetValue(1)
+                SetStatusBarSmoothValue(seg, 1)
                 fullSegments[i] = true
                 if chargedPoints and tContains(chargedPoints, i) then
                     seg:SetStatusBarColor(chargedColor[1], chargedColor[2], chargedColor[3], 1)
@@ -1138,7 +1143,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                     seg:SetStatusBarColor(baseColor[1], baseColor[2], baseColor[3], 1)
                 end
             else
-                seg:SetValue(0)
+                SetStatusBarSmoothValue(seg, 0)
             end
         end
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
@@ -1172,11 +1177,11 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
     for i = 1, math_min(#holder.segments, max) do
         local seg = holder.segments[i]
         if i <= current then
-            seg:SetValue(1)
+            SetStatusBarSmoothValue(seg, 1)
             seg:SetStatusBarColor(activeColor[1], activeColor[2], activeColor[3], 1)
             fullSegments[i] = true
         else
-            seg:SetValue(0)
+            SetStatusBarSmoothValue(seg, 0)
         end
     end
     segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
@@ -1205,9 +1210,9 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
     end
     if issecretvalue and issecretvalue(stacks) then
         for i = 1, #holder.segments do
-            holder.segments[i]:SetValue(0)
+            SetStatusBarImmediateValue(holder.segments[i], 0)
             if holder.overlaySegments and holder.overlaySegments[i] then
-                holder.overlaySegments[i]:SetValue(0)
+                SetStatusBarImmediateValue(holder.overlaySegments[i], 0)
                 holder.overlaySegments[i]:SetAlpha(0)
             end
         end
@@ -1225,8 +1230,8 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
         local baseSeg = holder.segments[i]
         local overlaySeg = holder.overlaySegments[i]
 
-        baseSeg:SetValue(stacks)
-        overlaySeg:SetValue(stacks)
+        SetStatusBarSmoothValue(baseSeg, stacks)
+        SetStatusBarSmoothValue(overlaySeg, stacks)
         -- Hide right-half overlay segments when value is at/below their segment minimum.
         -- This prevents tiny leading-edge ticks on empty overlay segments.
         if stacks > (half + i - 1) then

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -55,6 +55,11 @@ local LayoutOverlaySegments = RB.LayoutOverlaySegments
 local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 local SetAuraStackCountText = EntryRuntime.SetAuraStackCountText
+local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarElapsedDuration = ST.SetStatusBarElapsedDuration
+local SetStatusBarRemainingDuration = ST.SetStatusBarRemainingDuration
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -303,30 +308,32 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if barInfo.barType == "custom_continuous" then
             local bar = barInfo.frame
             if isActive then
-                bar:SetMinMaxValues(0, 1)
+                SetStatusBarSmoothRange(bar, 0, 1)
                 if durationObj then
-                    bar:SetValue(durationObj:GetRemainingPercent())  -- secret-safe, 1->0 drain
+                    if not SetStatusBarRemainingDuration(bar, durationObj) then
+                        SetStatusBarSmoothValue(bar, durationObj:GetRemainingPercent())  -- secret-safe, 1->0 drain
+                    end
                 elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
                     local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
-                    bar:SetValue(math_max(0, math_min(1, remaining / auraCooldownDuration)))
+                    SetStatusBarSmoothValue(bar, math_max(0, math_min(1, remaining / auraCooldownDuration)))
                 elseif indicatorPreview then
-                    bar:SetValue(CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL)
+                    SetStatusBarImmediateValue(bar, CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL)
                 else
                     -- No DurationObject (indefinite aura or aura absent)
-                    bar:SetValue(stacks)  -- 1 if active (full), 0 if absent (empty)
+                    SetStatusBarImmediateValue(bar, stacks)  -- 1 if active (full), 0 if absent (empty)
                 end
             else
-                bar:SetMinMaxValues(0, maxStacks)
-                bar:SetValue(stacks)  -- SetValue accepts secrets
+                SetStatusBarSmoothRange(bar, 0, maxStacks)
+                SetStatusBarSmoothValue(bar, stacks)  -- SetValue accepts secrets
             end
 
             if bar.thresholdOverlay then
                 if thresholdEnabled then
                     SetCustomAuraMaxThresholdRange(bar.thresholdOverlay, maxStacks)
-                    bar.thresholdOverlay:SetValue(stacks)
+                    SetStatusBarSmoothValue(bar.thresholdOverlay, stacks)
                     bar.thresholdOverlay:Show()
                 else
-                    bar.thresholdOverlay:SetValue(0)
+                    SetStatusBarImmediateValue(bar.thresholdOverlay, 0)
                     bar.thresholdOverlay:Hide()
                 end
             end
@@ -384,7 +391,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             -- Each segment has MinMax(i-1, i) — SetValue(stacks) with C-level clamping
             -- handles fill/empty without comparing the secret stacks value in Lua
             for i = 1, #holder.segments do
-                holder.segments[i]:SetValue(stacks)
+                SetStatusBarSmoothValue(holder.segments[i], stacks)
             end
 
             if holder.thresholdSegments then
@@ -392,10 +399,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     local thresholdSeg = holder.thresholdSegments[i]
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(thresholdSeg, maxStacks)
-                        thresholdSeg:SetValue(stacks)
+                        SetStatusBarSmoothValue(thresholdSeg, stacks)
                         thresholdSeg:Show()
                     else
-                        thresholdSeg:SetValue(0)
+                        SetStatusBarImmediateValue(thresholdSeg, 0)
                         thresholdSeg:Hide()
                     end
                 end
@@ -408,8 +415,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
             -- Pass stacks to ALL segments (StatusBar C-level clamping handles per-segment fill)
             for i = 1, half do
-                holder.segments[i]:SetValue(stacks)
-                holder.overlaySegments[i]:SetValue(stacks)
+                SetStatusBarSmoothValue(holder.segments[i], stacks)
+                SetStatusBarSmoothValue(holder.overlaySegments[i], stacks)
             end
 
             if holder.thresholdSegments then
@@ -417,10 +424,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     local thresholdSeg = holder.thresholdSegments[i]
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(thresholdSeg, maxStacks)
-                        thresholdSeg:SetValue(stacks)
+                        SetStatusBarSmoothValue(thresholdSeg, stacks)
                         thresholdSeg:Show()
                     else
-                        thresholdSeg:SetValue(0)
+                        SetStatusBarImmediateValue(thresholdSeg, 0)
                         thresholdSeg:Hide()
                     end
                 end
@@ -439,7 +446,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         -- Max stacks indicator: SetValue drives visibility via C-level clamping
         if cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-            barInfo._maxStacksIndicator:SetValue((auraPresent and applications ~= nil) and applications or 0)
+            SetStatusBarSmoothValue(barInfo._maxStacksIndicator, (auraPresent and applications ~= nil) and applications or 0)
         end
     end
 
@@ -581,17 +588,19 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
             local auraDurationObj = auraState and auraState.durationObj
             bar:SetStatusBarColor(barColor[1], barColor[2], barColor[3], barColor[4] ~= nil and barColor[4] or 1)
-            bar:SetMinMaxValues(0, 1)
+            SetStatusBarSmoothRange(bar, 0, 1)
             if auraDurationObj then
-                bar:SetValue(auraDurationObj:GetRemainingPercent())
+                if not SetStatusBarRemainingDuration(bar, auraDurationObj) then
+                    SetStatusBarSmoothValue(bar, auraDurationObj:GetRemainingPercent())
+                end
             elseif auraPreview or pandemicPreview then
-                bar:SetValue(CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL)
+                SetStatusBarImmediateValue(bar, CUSTOM_AURA_BAR_EFFECT_PREVIEW_FILL)
             else
-                bar:SetValue(1)
+                SetStatusBarImmediateValue(bar, 1)
             end
 
             if bar.thresholdOverlay then
-                bar.thresholdOverlay:SetValue(0)
+                SetStatusBarImmediateValue(bar.thresholdOverlay, 0)
                 bar.thresholdOverlay:Hide()
             end
 
@@ -616,7 +625,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPresent)
 
             if barInfo._maxStacksIndicator then
-                barInfo._maxStacksIndicator:SetValue(0)
+                SetStatusBarImmediateValue(barInfo._maxStacksIndicator, 0)
             end
 
             UpdateSpellCustomBarSounds(auraPresent)
@@ -625,18 +634,20 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         ClearCustomAuraBarIndicatorState(barInfo, false)
 
-        bar:SetMinMaxValues(0, 1)
+        SetStatusBarSmoothRange(bar, 0, 1)
         bar:SetStatusBarColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] ~= nil and fillColor[4] or 1)
         if cooldownActive and durationObj then
-            bar:SetValue(durationObj:GetElapsedPercent())
+            if not SetStatusBarElapsedDuration(bar, durationObj) then
+                SetStatusBarSmoothValue(bar, durationObj:GetElapsedPercent())
+            end
         elseif cooldownActive then
-            bar:SetValue(0)
+            SetStatusBarImmediateValue(bar, 0)
         else
-            bar:SetValue(1)
+            SetStatusBarImmediateValue(bar, 1)
         end
 
         if bar.thresholdOverlay then
-            bar.thresholdOverlay:SetValue(0)
+            SetStatusBarImmediateValue(bar.thresholdOverlay, 0)
             bar.thresholdOverlay:Hide()
         end
 
@@ -658,7 +669,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         UpdateSpellCustomBarChargeText(bar, cooldownResult)
 
         if barInfo._maxStacksIndicator then
-            barInfo._maxStacksIndicator:SetValue(0)
+            SetStatusBarImmediateValue(barInfo._maxStacksIndicator, 0)
         end
 
         UpdateSpellCustomBarSounds(false)
@@ -1097,7 +1108,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
             if mode == "continuous" then
                 local bar = CreateContinuousBar(targetContainer)
-                bar:SetMinMaxValues(0, maxStacks)
+                SetStatusBarSmoothRange(bar, 0, maxStacks)
                 barInfo = { frame = bar, barType = targetBarType }
             elseif mode == "segmented" then
                 local holder = CreateSegmentedBar(targetContainer, maxStacks)

--- a/OtherBars/ResourceBarHealth.lua
+++ b/OtherBars/ResourceBarHealth.lua
@@ -5,6 +5,9 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 
 local math_min = math.min
 local math_sin = math.sin
@@ -150,7 +153,7 @@ function HealthBar.EnsureEffectBar(bar, key, color, frameLevelOffset)
         local effectBar = CreateFrame("StatusBar", nil, bar.healthEffectClip)
         effectBar:SetStatusBarTexture(CooldownCompanion:FetchStatusBar(HEALTH_EFFECTS.texture))
         effectBar:SetMinMaxValues(0, 1)
-        effectBar:SetValue(0)
+        SetStatusBarImmediateValue(effectBar, 0)
         effectBar:Hide()
         bar[key] = effectBar
     end
@@ -209,7 +212,7 @@ function HealthBar.ApplyLowHealthAlertStyle(effectBar, config)
     end
     effectBar:SetStatusBarTexture(CooldownCompanion:FetchStatusBar(texture))
     effectBar:SetMinMaxValues(0, 1)
-    effectBar:SetValue(1)
+    SetStatusBarImmediateValue(effectBar, 1)
 end
 
 function HealthBar.ApplyLowHealthAlertColor(bar, config, preview)
@@ -442,7 +445,7 @@ function HealthBar.UpdateEffectBars(bar, config, maxHealth, preview)
         else
             bar.lowHealthAlertBar:Hide()
             bar.lowHealthAlertBar:SetAlpha(1)
-            bar.lowHealthAlertBar:SetValue(0)
+            SetStatusBarImmediateValue(bar.lowHealthAlertBar, 0)
         end
     end
 
@@ -451,17 +454,17 @@ function HealthBar.UpdateEffectBars(bar, config, maxHealth, preview)
     if bar.incomingHealBar then
         HealthBar.ApplyEffectStyle(bar.incomingHealBar, config, "healthIncomingHealColor", HEALTH_EFFECTS.incomingHealColor, "healthIncomingHealTexture")
         if incomingHealsVisible then
-            bar.incomingHealBar:SetMinMaxValues(0, maxHealth)
+            SetStatusBarSmoothRange(bar.incomingHealBar, 0, maxHealth)
             if preview.incomingHeals == true then
-                bar.incomingHealBar:SetValue(18)
+                SetStatusBarSmoothValue(bar.incomingHealBar, 18)
             else
-                bar.incomingHealBar:SetValue(EnsureNonNilNumber(GetNetHealingCalc():GetIncomingHeals()))
+                SetStatusBarSmoothValue(bar.incomingHealBar, EnsureNonNilNumber(GetNetHealingCalc():GetIncomingHeals()))
             end
             bar.incomingHealBar:Show()
             incomingHealAnchorTexture = bar.incomingHealBar:GetStatusBarTexture()
         else
             bar.incomingHealBar:Hide()
-            bar.incomingHealBar:SetValue(0)
+            SetStatusBarImmediateValue(bar.incomingHealBar, 0)
         end
     end
 
@@ -494,22 +497,22 @@ function HealthBar.UpdateEffectBars(bar, config, maxHealth, preview)
                 overflowAbsorb = HEALTH_EFFECTS.absorbOverflowCalc:GetDamageAbsorbs()
             end
 
-            bar.absorbBar:SetMinMaxValues(0, maxHealth)
-            bar.absorbBar:SetValue(EnsureNonNilNumber(missingHealthAbsorb))
+            SetStatusBarSmoothRange(bar.absorbBar, 0, maxHealth)
+            SetStatusBarSmoothValue(bar.absorbBar, EnsureNonNilNumber(missingHealthAbsorb))
             bar.absorbBar:SetAlpha(1)
             bar.absorbBar:Show()
             if bar.absorbOverflowBar then
-                bar.absorbOverflowBar:SetMinMaxValues(0, maxHealth)
-                bar.absorbOverflowBar:SetValue(EnsureNonNilNumber(overflowAbsorb))
+                SetStatusBarSmoothRange(bar.absorbOverflowBar, 0, maxHealth)
+                SetStatusBarSmoothValue(bar.absorbOverflowBar, EnsureNonNilNumber(overflowAbsorb))
                 HealthBar.SetEffectAlphaFromBoolean(bar.absorbOverflowBar, absorbOverflowing, 1, 0)
                 bar.absorbOverflowBar:Show()
             end
         else
             bar.absorbBar:Hide()
-            bar.absorbBar:SetValue(0)
+            SetStatusBarImmediateValue(bar.absorbBar, 0)
             if bar.absorbOverflowBar then
                 bar.absorbOverflowBar:Hide()
-                bar.absorbOverflowBar:SetValue(0)
+                SetStatusBarImmediateValue(bar.absorbOverflowBar, 0)
             end
         end
     end
@@ -517,17 +520,17 @@ function HealthBar.UpdateEffectBars(bar, config, maxHealth, preview)
     if bar.healAbsorbBar then
         HealthBar.ApplyEffectStyle(bar.healAbsorbBar, config, "healthHealAbsorbColor", HEALTH_EFFECTS.healAbsorbColor, "healthHealAbsorbTexture")
         if config.showHealAbsorbs == true or preview.healAbsorbs == true then
-            bar.healAbsorbBar:SetMinMaxValues(0, maxHealth)
+            SetStatusBarSmoothRange(bar.healAbsorbBar, 0, maxHealth)
             if preview.healAbsorbs == true then
-                bar.healAbsorbBar:SetValue(22)
+                SetStatusBarSmoothValue(bar.healAbsorbBar, 22)
             else
                 local healAbsorbCalc = incomingHealsVisible and GetNetHealingCalc() or GetStandaloneHealingCalc()
-                bar.healAbsorbBar:SetValue(EnsureNonNilNumber(healAbsorbCalc:GetHealAbsorbs()))
+                SetStatusBarSmoothValue(bar.healAbsorbBar, EnsureNonNilNumber(healAbsorbCalc:GetHealAbsorbs()))
             end
             bar.healAbsorbBar:Show()
         else
             bar.healAbsorbBar:Hide()
-            bar.healAbsorbBar:SetValue(0)
+            SetStatusBarImmediateValue(bar.healAbsorbBar, 0)
         end
     end
 end
@@ -695,8 +698,8 @@ function HealthBar.Update(bar, settings)
         maxHealth = 1
     end
 
-    bar:SetMinMaxValues(0, maxHealth)
-    bar:SetValue(currentHealth)
+    SetStatusBarSmoothRange(bar, 0, maxHealth)
+    SetStatusBarSmoothValue(bar, currentHealth)
     local config = HealthBar.GetConfig(settings)
     HealthBar.ApplyFillColor(bar, config)
     HealthBar.ApplyBackgroundColor(bar, config)

--- a/OtherBars/ResourceBarPreview.lua
+++ b/OtherBars/ResourceBarPreview.lua
@@ -25,6 +25,9 @@ local IsResourceAuraOverlayEnabled = RB.IsResourceAuraOverlayEnabled
 local GetActiveResourceAuraEntry = RB.GetActiveResourceAuraEntry
 local GetResourceColors = RB.GetResourceColors
 local SetSegmentedText = RB.SetSegmentedText
+local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 
 function RB.CreateResourceBarPreviewModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -78,8 +81,8 @@ function RB.CreateResourceBarPreviewModule(deps)
 
         ClearResourceAuraVisuals(barInfo.frame)
         if barInfo.barType == "continuous" then
-            barInfo.frame:SetMinMaxValues(0, 100)
-            barInfo.frame:SetValue(65)
+            SetStatusBarSmoothRange(barInfo.frame, 0, 100)
+            SetStatusBarSmoothValue(barInfo.frame, 65)
             if barInfo.frame.text and barInfo.frame.text:IsShown() then
                 local textFormat = barInfo.frame._textFormat
                 if textFormat == "current" then
@@ -91,8 +94,8 @@ function RB.CreateResourceBarPreviewModule(deps)
                 end
             end
         elseif barInfo.barType == "health_continuous" then
-            barInfo.frame:SetMinMaxValues(0, 100)
-            barInfo.frame:SetValue(65)
+            SetStatusBarSmoothRange(barInfo.frame, 0, 100)
+            SetStatusBarSmoothValue(barInfo.frame, 65)
             local config = HealthBar.GetConfig(settings)
             HealthBar.ApplyFillColor(barInfo.frame, config, 0.65)
             HealthBar.ApplyBackgroundColor(barInfo.frame, config, 0.65)
@@ -119,19 +122,19 @@ function RB.CreateResourceBarPreviewModule(deps)
             local previewValue = filled + 0.5
             for i, seg in ipairs(barInfo.frame.segments) do
                 if i <= filled then
-                    seg:SetValue(1)
+                    SetStatusBarSmoothValue(seg, 1)
                 elseif i == filled + 1 then
-                    seg:SetValue(0.5)
+                    SetStatusBarSmoothValue(seg, 0.5)
                 else
-                    seg:SetValue(0)
+                    SetStatusBarSmoothValue(seg, 0)
                 end
             end
             ApplySegmentedPreviewColors(barInfo.frame, barInfo.powerType, settings, previewValue)
             ApplyResourceAuraLanePreview(barInfo, 0.5)
             SetSegmentedText(barInfo.frame, previewValue, n)
         elseif barInfo.barType == "stagger_continuous" then
-            barInfo.frame:SetMinMaxValues(0, 100)
-            barInfo.frame:SetValue(45)
+            SetStatusBarSmoothRange(barInfo.frame, 0, 100)
+            SetStatusBarSmoothValue(barInfo.frame, 45)
             local _, yellowColor = GetResourceColors(101, settings)
             barInfo.frame:SetStatusBarColor(yellowColor[1], yellowColor[2], yellowColor[3], 1)
             barInfo.frame.brightnessOverlay:Hide()
@@ -152,8 +155,8 @@ function RB.CreateResourceBarPreviewModule(deps)
                 previewStacks = math_min(GetMWMaxStacks(), math_max(previewStacks, 7))
             end
             for i = 1, half do
-                barInfo.frame.segments[i]:SetValue(previewStacks)
-                barInfo.frame.overlaySegments[i]:SetValue(previewStacks)
+                SetStatusBarSmoothValue(barInfo.frame.segments[i], previewStacks)
+                SetStatusBarSmoothValue(barInfo.frame.overlaySegments[i], previewStacks)
                 if previewStacks > (half + i - 1) then
                     barInfo.frame.overlaySegments[i]:SetAlpha(1)
                 else
@@ -168,16 +171,16 @@ function RB.CreateResourceBarPreviewModule(deps)
             local maxStacks = (cabConfig and cabConfig.maxStacks) or 1
             local previewValue
             if isSpellAuraStackDisplay then
-                barInfo.frame:SetMinMaxValues(0, maxStacks)
+                SetStatusBarSmoothRange(barInfo.frame, 0, maxStacks)
                 previewValue = math.ceil(maxStacks * 0.65)
-                barInfo.frame:SetValue(previewValue)
+                SetStatusBarSmoothValue(barInfo.frame, previewValue)
             else
-                barInfo.frame:SetMinMaxValues(0, 1)
+                SetStatusBarSmoothRange(barInfo.frame, 0, 1)
                 previewValue = 0.45
-                barInfo.frame:SetValue(previewValue)
+                SetStatusBarSmoothValue(barInfo.frame, previewValue)
             end
             if barInfo.frame.thresholdOverlay then
-                barInfo.frame.thresholdOverlay:SetValue(0)
+                SetStatusBarImmediateValue(barInfo.frame.thresholdOverlay, 0)
                 barInfo.frame.thresholdOverlay:Hide()
             end
             if barInfo.frame.text and barInfo.frame.text:IsShown() then
@@ -196,7 +199,7 @@ function RB.CreateResourceBarPreviewModule(deps)
             end
             ClearCustomAuraBarIndicatorState(barInfo, true)
             if barInfo._maxStacksIndicator then
-                barInfo._maxStacksIndicator:SetValue(0)
+                SetStatusBarImmediateValue(barInfo._maxStacksIndicator, 0)
             end
         elseif barInfo.barType == "custom_continuous" then
             local cabConfig = barInfo.cabConfig
@@ -207,21 +210,21 @@ function RB.CreateResourceBarPreviewModule(deps)
             ClearCustomAuraBarIndicatorState(barInfo, false)
             local previewValue
             if isActive then
-                barInfo.frame:SetMinMaxValues(0, 1)
+                SetStatusBarSmoothRange(barInfo.frame, 0, 1)
                 previewValue = indicatorPreview and 1 or 0.65
-                barInfo.frame:SetValue(previewValue)
+                SetStatusBarSmoothValue(barInfo.frame, previewValue)
             else
-                barInfo.frame:SetMinMaxValues(0, maxStacks)
+                SetStatusBarSmoothRange(barInfo.frame, 0, maxStacks)
                 previewValue = indicatorPreview and maxStacks or math.ceil(maxStacks * 0.65)
-                barInfo.frame:SetValue(previewValue)
+                SetStatusBarSmoothValue(barInfo.frame, previewValue)
             end
             if barInfo.frame.thresholdOverlay then
                 if thresholdEnabled then
                     SetCustomAuraMaxThresholdRange(barInfo.frame.thresholdOverlay, maxStacks)
-                    barInfo.frame.thresholdOverlay:SetValue(previewValue or 0)
+                    SetStatusBarSmoothValue(barInfo.frame.thresholdOverlay, previewValue or 0)
                     barInfo.frame.thresholdOverlay:Show()
                 else
-                    barInfo.frame.thresholdOverlay:SetValue(0)
+                    SetStatusBarImmediateValue(barInfo.frame.thresholdOverlay, 0)
                     barInfo.frame.thresholdOverlay:Hide()
                 end
             end
@@ -241,7 +244,7 @@ function RB.CreateResourceBarPreviewModule(deps)
                 end
             end
             if cabConfig and cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-                barInfo._maxStacksIndicator:SetValue(maxStacks)
+                SetStatusBarSmoothValue(barInfo._maxStacksIndicator, maxStacks)
             end
         elseif barInfo.barType == "custom_segmented" then
             local cabConfig = barInfo.cabConfig
@@ -251,22 +254,22 @@ function RB.CreateResourceBarPreviewModule(deps)
             local n = #barInfo.frame.segments
             local fill = indicatorPreview and n or math.ceil(n * 0.6)
             for _, seg in ipairs(barInfo.frame.segments) do
-                seg:SetValue(fill)
+                SetStatusBarSmoothValue(seg, fill)
             end
             if barInfo.frame.thresholdSegments then
                 for _, seg in ipairs(barInfo.frame.thresholdSegments) do
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(seg, maxStacks)
-                        seg:SetValue(fill)
+                        SetStatusBarSmoothValue(seg, fill)
                         seg:Show()
                     else
-                        seg:SetValue(0)
+                        SetStatusBarImmediateValue(seg, 0)
                         seg:Hide()
                     end
                 end
             end
             if cabConfig and cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-                barInfo._maxStacksIndicator:SetValue(maxStacks)
+                SetStatusBarSmoothValue(barInfo._maxStacksIndicator, maxStacks)
             end
         elseif barInfo.barType == "custom_overlay" then
             local cabConfig = barInfo.cabConfig
@@ -276,22 +279,22 @@ function RB.CreateResourceBarPreviewModule(deps)
             local thresholdEnabled = IsCustomAuraMaxThresholdEnabled(cabConfig)
             local half = barInfo.halfSegments or 1
             for i = 1, half do
-                barInfo.frame.segments[i]:SetValue(previewStacks)
-                barInfo.frame.overlaySegments[i]:SetValue(previewStacks)
+                SetStatusBarSmoothValue(barInfo.frame.segments[i], previewStacks)
+                SetStatusBarSmoothValue(barInfo.frame.overlaySegments[i], previewStacks)
                 if barInfo.frame.thresholdSegments and barInfo.frame.thresholdSegments[i] then
                     local seg = barInfo.frame.thresholdSegments[i]
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(seg, maxStacks)
-                        seg:SetValue(previewStacks)
+                        SetStatusBarSmoothValue(seg, previewStacks)
                         seg:Show()
                     else
-                        seg:SetValue(0)
+                        SetStatusBarImmediateValue(seg, 0)
                         seg:Hide()
                     end
                 end
             end
             if cabConfig and cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-                barInfo._maxStacksIndicator:SetValue(maxStacks)
+                SetStatusBarSmoothValue(barInfo._maxStacksIndicator, maxStacks)
             end
         end
     end

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -9,6 +9,9 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
+local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
+local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 
 local math_floor = math.floor
 local math_min = math.min
@@ -255,7 +258,7 @@ end
 local function HideResourceAuraStackSegments(holder)
     if not holder or not holder.auraStackSegments then return end
     for _, seg in ipairs(holder.auraStackSegments) do
-        seg:SetValue(0)
+        SetStatusBarImmediateValue(seg, 0)
         seg:Hide()
     end
 end
@@ -374,7 +377,7 @@ local function EnsureResourceAuraStackSegments(holder, settings)
     if not holder.auraStackSegments or #holder.auraStackSegments ~= count then
         if holder.auraStackSegments then
             for _, oldSeg in ipairs(holder.auraStackSegments) do
-                oldSeg:SetValue(0)
+                SetStatusBarImmediateValue(oldSeg, 0)
                 oldSeg:ClearAllPoints()
                 oldSeg:Hide()
             end
@@ -383,7 +386,7 @@ local function EnsureResourceAuraStackSegments(holder, settings)
         for i = 1, count do
             local seg = CreateFrame("StatusBar", nil, holder)
             seg:SetMinMaxValues(0, 1)
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
             holder.auraStackSegments[i] = seg
         end
@@ -405,8 +408,8 @@ local function ApplyResourceAuraStackSegments(holder, settings, stackValue, maxS
         local seg = auraSegments[i]
         local segMin = ((i - 1) * maxStacks) / count
         local segMax = (i * maxStacks) / count
-        seg:SetMinMaxValues(segMin, segMax)
-        seg:SetValue(stackValue)
+        SetStatusBarSmoothRange(seg, segMin, segMax)
+        SetStatusBarSmoothValue(seg, stackValue)
         seg:SetAlpha(1)
         seg:SetStatusBarColor(color[1], color[2], color[3], 1)
         seg:Show()
@@ -665,7 +668,7 @@ local function ClearMaxStacksIndicator(barInfo)
     if indicator._pulseAG then
         indicator._pulseAG:Stop()
     end
-    indicator:SetValue(0)
+    SetStatusBarImmediateValue(indicator, 0)
 end
 
 local function EnsureCustomAuraContinuousThresholdOverlay(bar)
@@ -673,7 +676,7 @@ local function EnsureCustomAuraContinuousThresholdOverlay(bar)
     local overlay = CreateFrame("StatusBar", nil, bar)
     overlay:SetFrameLevel(bar:GetFrameLevel() + 1)
     overlay:SetMinMaxValues(0, 1)
-    overlay:SetValue(0)
+    SetStatusBarImmediateValue(overlay, 0)
     overlay:Hide()
     bar.thresholdOverlay = overlay
 end
@@ -687,7 +690,7 @@ local function EnsureCustomAuraSegmentThresholdOverlays(holder)
             local seg = CreateFrame("StatusBar", nil, holder)
             seg:SetFrameLevel(holder:GetFrameLevel() + 3)
             seg:SetMinMaxValues(0, 1)
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
             holder.thresholdSegments[i] = seg
         end
@@ -695,7 +698,7 @@ local function EnsureCustomAuraSegmentThresholdOverlays(holder)
     for i = count + 1, #holder.thresholdSegments do
         local seg = holder.thresholdSegments[i]
         if seg then
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
         end
     end
@@ -709,7 +712,7 @@ local function EnsureCustomAuraOverlayThresholdOverlays(holder, halfSegments)
             local seg = CreateFrame("StatusBar", nil, holder)
             seg:SetFrameLevel(holder:GetFrameLevel() + 4)
             seg:SetMinMaxValues(0, 1)
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
             holder.thresholdSegments[i] = seg
         end
@@ -717,7 +720,7 @@ local function EnsureCustomAuraOverlayThresholdOverlays(holder, halfSegments)
     for i = halfSegments + 1, #holder.thresholdSegments do
         local seg = holder.thresholdSegments[i]
         if seg then
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
         end
     end
@@ -753,7 +756,7 @@ local function CreateContinuousBar(parent)
     local bar = CreateFrame("StatusBar", nil, parent)
     bar:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
     bar:SetMinMaxValues(0, 100)
-    bar:SetValue(0)
+    SetStatusBarImmediateValue(bar, 0)
 
     -- Background
     bar.bg = bar:CreateTexture(nil, "BACKGROUND")
@@ -796,7 +799,7 @@ local function CreateSegmentedBar(parent, numSegments)
         local seg = CreateFrame("StatusBar", nil, holder)
         seg:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
         seg:SetMinMaxValues(0, 1)
-        seg:SetValue(0)
+        SetStatusBarImmediateValue(seg, 0)
 
         seg.bg = seg:CreateTexture(nil, "BACKGROUND")
         seg.bg:SetAllPoints()
@@ -866,10 +869,10 @@ local function LayoutSegments(holder, totalWidth, totalHeight, gap, settings, or
         local seg = holder.segments[i]
         seg:ClearAllPoints()
         if i > n then
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
             if holder.thresholdSegments and holder.thresholdSegments[i] then
-                holder.thresholdSegments[i]:SetValue(0)
+                SetStatusBarImmediateValue(holder.thresholdSegments[i], 0)
                 holder.thresholdSegments[i]:Hide()
             end
         elseif isVertical then
@@ -943,7 +946,7 @@ local function CreateOverlayBar(parent, halfSegments)
         local seg = CreateFrame("StatusBar", nil, holder)
         seg:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
         seg:SetMinMaxValues(i - 1, i)
-        seg:SetValue(0)
+        SetStatusBarImmediateValue(seg, 0)
 
         seg.bg = seg:CreateTexture(nil, "BACKGROUND")
         seg.bg:SetAllPoints()
@@ -960,7 +963,7 @@ local function CreateOverlayBar(parent, halfSegments)
         seg:SetFrameLevel(holder:GetFrameLevel() + 2)
         seg:SetStatusBarTexture(CooldownCompanion:FetchStatusBar("Solid"))
         seg:SetMinMaxValues(i + halfSegments - 1, i + halfSegments)
-        seg:SetValue(0)
+        SetStatusBarImmediateValue(seg, 0)
 
         -- No background on overlay (transparent when empty, base bg shows through)
 
@@ -1082,17 +1085,17 @@ local function LayoutOverlaySegments(holder, totalWidth, totalHeight, gap, setti
     for i = halfSegments + 1, #holder.segments do
         local seg = holder.segments[i]
         if seg then
-            seg:SetValue(0)
+            SetStatusBarImmediateValue(seg, 0)
             seg:Hide()
         end
         local ov = holder.overlaySegments and holder.overlaySegments[i]
         if ov then
-            ov:SetValue(0)
+            SetStatusBarImmediateValue(ov, 0)
             ov:Hide()
         end
         local thresholdSeg = holder.thresholdSegments and holder.thresholdSegments[i]
         if thresholdSeg then
-            thresholdSeg:SetValue(0)
+            SetStatusBarImmediateValue(thresholdSeg, 0)
             thresholdSeg:Hide()
         end
     end


### PR DESCRIPTION
## What Players Will Notice
- Bar panels, Custom Bars, continuous resources, segmented resources, health bars, and preview bars now fill and drain more smoothly instead of stepping through choppy value updates.
- Cooldown, aura, resource, stack, and refresh-window bar motion should feel more seamless, including both drain and refill transitions.
- The old bar update-frequency slider is gone because fill motion is now driven by native StatusBar interpolation rather than a user-tuned Lua sampling rate.

## Why This Changed
- The previous bar paths repeatedly sampled percentages in Lua and called `SetValue`, which could make drain/fill motion look uneven even when the underlying timer or resource value was correct.
- The first smoothing pass improved some refill paths, but resource drains and segmented displays still needed to share the same motion model.

## What Changed
- Added shared StatusBar motion helpers in `Core/Utils.lua` for smooth ranges, smooth values, immediate resets, and native `SetTimerDuration` handling.
- Routed bar panels, custom bars, continuous resources, segmented resources, health/effect bars, aura stack overlays, and config previews through those helpers.
- Uses native `StatusBar` interpolation and timer duration support for DurationObject-backed bars, while keeping secret-value handling pass-through and avoiding cached secret values.
- Reduced bar-mode OnUpdate work to text/fallback refreshes while native StatusBar timers handle the main visual fill motion.

## Validation
- Ran `lua tests\bar-motion-helpers.lua`.
- Ran `luac -p` on all touched Lua files.
- Ran `git diff --check origin/main...HEAD`.
- Confirmed `barUpdateInterval` / `Update Frequency` UI references were removed from the active bar/resource files.
- In-game testing confirmed the affected bar displays animate properly in combat and restricted content.
- Read-only code review found no actionable branch findings; local ignored tests are intentionally kept off-origin.