### PR TITLE
Track passive abilities with exposed cooldowns

### DIFF
--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -1603,7 +1603,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     -- Unusable/out-of-range state for text mode {unusable}/{oor} conditionals
     if button._isText then
-        if buttonData.isPassive then
+        if buttonData.isPassive or buttonData.isPassiveCooldown then
             button._isUnusable = false
         elseif buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
@@ -1615,7 +1615,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._isUnusable = false
         end
 
-        if buttonData.type == "spell" then
+        if buttonData.type == "spell" and not buttonData.isPassiveCooldown then
             button._isOutOfRange = button._spellOutOfRange or false
         elseif buttonData.type == "item" or buttonData.type == "equipitem" then
             -- C_Item.IsItemInRange is protected in combat for non-enemy targets (10.2.0)

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -237,7 +237,7 @@ local function ResolveIconTintIntent(button, buttonData, style, target)
             reason = "unusable-preview"
             stateOverride = true
             unusableActive = true
-        elseif buttonData.type == "spell" then
+        elseif buttonData.type == "spell" and not buttonData.isPassiveCooldown then
             local spellID = button._displaySpellId or buttonData.id
             local isUsable = C_Spell.IsSpellUsable(spellID)
             if not isUsable then

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -188,7 +188,10 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
 
     -- Check hideWhileNoProc (spell entries added as spells only)
     if buttonData.hideWhileNoProc then
-        local isSpellEntry = buttonData.type == "spell" and buttonData.addedAs ~= "aura" and not buttonData.isPassive
+        local isSpellEntry = buttonData.type == "spell"
+            and buttonData.addedAs ~= "aura"
+            and not buttonData.isPassive
+            and not buttonData.isPassiveCooldown
         if isSpellEntry and not procOverlayActive then
             hideReasons = bit_bor(hideReasons, HIDE_NO_PROC)
         end
@@ -216,7 +219,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     end
 
     -- Check hideWhileUnusable
-    if buttonData.hideWhileUnusable and not buttonData.isPassive then
+    if buttonData.hideWhileUnusable and not buttonData.isPassive and not buttonData.isPassiveCooldown then
         if buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
             if not C_Spell_IsSpellUsable(spellID) then

--- a/Config/Pickers.lua
+++ b/Config/Pickers.lua
@@ -1346,8 +1346,10 @@ local IsSpellInCDMCooldown = ST.IsSpellInCDMCooldown
 -- Helper: Detect passive or proc spells (zero-cooldown CDM-tracked spells)
 ------------------------------------------------------------------------
 local IsActiveSpellBookSpell = ST.IsActiveSpellBookSpell
+local IsPassiveCooldownSpell = ST.IsPassiveCooldownSpell
 
 local function IsPassiveOrProc(spellId)
+    if IsPassiveCooldownSpell(spellId) then return false end
     if C_Spell.IsSpellPassive(spellId) then return true end
     -- Active spellbook spells (e.g. Death Strike) can have base cooldown 0 and
     -- still be normal spell entries; don't auto-classify them as aura-only.

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -309,7 +309,9 @@ local function TryAdd(input)
 
         -- Non-passive spell → add it
         if spellFound and not passiveOrProc then
-            if IsSpellInCDMBuffBar(id) and not IsSpellInCDMCooldown(id) then
+            if IsSpellInCDMBuffBar(id)
+                and not IsSpellInCDMCooldown(id)
+                and not IsPassiveCooldownSpell(id) then
                 return TryAddSpell(tostring(id), nil, true)
             end
             local forceAura = nil
@@ -405,7 +407,9 @@ local function TryAdd(input)
                 end
                 -- Not in CDM — fall through to try as item, then report error
             else
-                if IsSpellInCDMBuffBar(spellId) and not IsSpellInCDMCooldown(spellId) then
+                if IsSpellInCDMBuffBar(spellId)
+                    and not IsSpellInCDMCooldown(spellId)
+                    and not IsPassiveCooldownSpell(spellId) then
                     return TryAddSpell(tostring(spellId), nil, true)
                 end
                 local idx, notified = CooldownCompanion:AddButtonToGroup(CS.selectedGroup, "spell", spellId, spellName)
@@ -559,7 +563,7 @@ local function BuildAutocompleteCache()
                     and itemInfo.itemType ~= Enum.SpellBookItemType.FutureSpell
                 then
                     local isAura = IsPassiveOrProc(id)
-                    local isBuffOnlyCDMSpell = cdmBuffSet[id] and not cdmCooldownSet[id]
+                    local isBuffOnlyCDMSpell = not passiveCooldown and cdmBuffSet[id] and not cdmCooldownSet[id]
                     if ShouldSuppressSpellbookEntry(id, lineIdx, isAura) then
                         -- Omit filtered entries to reduce autocomplete noise.
                     elseif not seen[id] then

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -11,6 +11,7 @@ local CS = ST._configState
 local IsSpellInCDMBuffBar = ST._IsSpellInCDMBuffBar
 local IsSpellInCDMCooldown = ST._IsSpellInCDMCooldown
 local IsPassiveOrProc = ST._IsPassiveOrProc
+local IsPassiveCooldownSpell = ST.IsPassiveCooldownSpell
 local IsNeverTrackableSpell = ST._IsNeverTrackableSpell
 local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local GetButtonIcon = ST._GetButtonIcon
@@ -549,13 +550,14 @@ local function BuildAutocompleteCache()
             for slotOffset = 1, lineInfo.numSpellBookItems do
                 local slotIdx = lineInfo.itemIndexOffset + slotOffset
                 local itemInfo = C_SpellBook.GetSpellBookItemInfo(slotIdx, Enum.SpellBookSpellBank.Player)
-                if itemInfo and itemInfo.spellID
-                    and not itemInfo.isPassive
+                local id = itemInfo and itemInfo.spellID
+                local passiveCooldown = id and IsPassiveCooldownSpell(id)
+                if itemInfo and id
+                    and (not itemInfo.isPassive or passiveCooldown)
                     and not itemInfo.isOffSpec
                     and itemInfo.itemType ~= Enum.SpellBookItemType.Flyout
                     and itemInfo.itemType ~= Enum.SpellBookItemType.FutureSpell
                 then
-                    local id = itemInfo.spellID
                     local isAura = IsPassiveOrProc(id)
                     local isBuffOnlyCDMSpell = cdmBuffSet[id] and not cdmCooldownSet[id]
                     if ShouldSuppressSpellbookEntry(id, lineIdx, isAura) then
@@ -613,10 +615,11 @@ local function BuildAutocompleteCache()
     if numPetSpells and numPetSpells > 0 then
         for slotIdx = 1, numPetSpells do
             local itemInfo = C_SpellBook.GetSpellBookItemInfo(slotIdx, Enum.SpellBookSpellBank.Pet)
-            if itemInfo and itemInfo.spellID
-                and not itemInfo.isPassive
+            local id = itemInfo and itemInfo.spellID
+            local passiveCooldown = id and IsPassiveCooldownSpell(id)
+            if itemInfo and id
+                and (not itemInfo.isPassive or passiveCooldown)
             then
-                local id = itemInfo.spellID
                 local isAura = IsPassiveOrProc(id)
                 if not ShouldSuppressSpellbookEntry(id, itemInfo.skillLineIndex, isAura) and not seen[id] then
                     seen[id] = true

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -872,9 +872,13 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
     -- Hide While No Proc (spell entries only, not aura entries)
     local showNoProcToggle
     if isBatch then
-        showNoProcToggle = batchContext and batchContext.uniformType == "spell"
+        showNoProcToggle = batchContext
+            and batchContext.uniformType == "spell"
+            and not AllSelectedAre(group, "isPassiveCooldown")
     else
-        showNoProcToggle = buttonData.type == "spell" and buttonData.addedAs ~= "aura"
+        showNoProcToggle = buttonData.type == "spell"
+            and buttonData.addedAs ~= "aura"
+            and not buttonData.isPassiveCooldown
     end
     if showNoProcToggle then
         local hideNoProcCb = AceGUI:Create("CheckBox")

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -421,6 +421,10 @@ local function GetTriggerConditionOrderForButtonData(buttonData)
         return order
     end
 
+    if buttonData.type == "spell" and buttonData.isPassiveCooldown == true then
+        return { "cooldownActive" }
+    end
+
     if buttonData.type == "spell" and buttonData.isPassive == true then
         return { "auraActive", "procActive" }
     end

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -422,7 +422,12 @@ local function GetTriggerConditionOrderForButtonData(buttonData)
     end
 
     if buttonData.type == "spell" and buttonData.isPassiveCooldown == true then
-        return { "cooldownActive" }
+        local order = { "cooldownActive" }
+        if buttonData.hasCharges == true then
+            order[#order + 1] = "chargesRecharging"
+            order[#order + 1] = "chargeState"
+        end
+        return order
     end
 
     if buttonData.type == "spell" and buttonData.isPassive == true then

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -609,8 +609,11 @@ local function ResolveTextureIndicatorSectionState(button, sectionKey, config, t
 
     if sectionKey == "unusable" then
         local buttonData = button.buttonData
-        if not buttonData or buttonData.isPassive then
-            return FinishTextureIndicatorSectionState(target, false, not buttonData and "missing-button-data" or "passive", nil, effectType)
+        if not buttonData or buttonData.isPassive or buttonData.isPassiveCooldown then
+            local reason = not buttonData and "missing-button-data"
+                or buttonData.isPassiveCooldown and "passive-cooldown"
+                or "passive"
+            return FinishTextureIndicatorSectionState(target, false, reason, nil, effectType)
         end
         if buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
@@ -646,7 +649,7 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
 
     if conditionKey == "rangeActive" then
         local buttonData = button.buttonData
-        if not buttonData or buttonData.isPassive then
+        if not buttonData or buttonData.isPassive or buttonData.isPassiveCooldown then
             return nil
         end
 
@@ -673,7 +676,7 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
 
     if conditionKey == "usable" then
         local buttonData = button.buttonData
-        if not buttonData or buttonData.isPassive then
+        if not buttonData or buttonData.isPassive or buttonData.isPassiveCooldown then
             return false
         end
         if buttonData.type == "spell" then

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -152,6 +152,7 @@ function CooldownCompanion:UpdateRangeCheckRegistrations()
     self:ForEachButton(function(button, bd)
         if bd.type == "spell"
             and not bd.isPassive
+            and not bd.isPassiveCooldown
             and ((button.style and button.style.showOutOfRange)
                 or (self.TriggerRowUsesCondition and self:TriggerRowUsesCondition(bd, "rangeActive"))) then
             newSet[bd.id] = true

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1462,6 +1462,16 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
         end
     end
 
+    local isPassiveCooldown = false
+    if buttonType == "spell"
+        and forceAura ~= true
+        and ST.IsPassiveCooldownSpell
+        and ST.IsPassiveCooldownSpell(id) then
+        isPassiveCooldown = true
+        isPassive = nil
+        forceAura = false
+    end
+
     local buttonIndex = #group.buttons + 1
     group.buttons[buttonIndex] = {
         type = buttonType,
@@ -1469,12 +1479,13 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
         name = name,
         isPetSpell = isPetSpell or nil,
         isPassive = isPassive or nil,
+        isPassiveCooldown = isPassiveCooldown or nil,
         cdmChildSlot = cdmChildSlot or nil,
     }
 
-    -- Auto-detect charges for spells (skip for passives — no cooldown).
+    -- Auto-detect charges for castable spells.
     -- Treat as charge-based only when max charges is greater than 1.
-    if buttonType == "spell" and not isPassive then
+    if buttonType == "spell" and not isPassive and not isPassiveCooldown then
         local chargeInfo = C_Spell.GetSpellCharges(id)
         -- Base spell may not have charges when the override form does
         -- (e.g. Primal Strike → Stormstrike). Try the current override.

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1483,9 +1483,9 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
         cdmChildSlot = cdmChildSlot or nil,
     }
 
-    -- Auto-detect charges for castable spells.
+    -- Auto-detect charges for castable and passive-cooldown spells.
     -- Treat as charge-based only when max charges is greater than 1.
-    if buttonType == "spell" and not isPassive and not isPassiveCooldown then
+    if buttonType == "spell" and not isPassive then
         local chargeInfo = C_Spell.GetSpellCharges(id)
         -- Base spell may not have charges when the override form does
         -- (e.g. Primal Strike → Stormstrike). Try the current override.

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -64,6 +64,52 @@ local function LooksLikeProfilePayload(profile)
         or rawget(profile, "frameAnchoring") ~= nil
 end
 
+local function HasTriggerConditionConfig(buttonData)
+    return buttonData.triggerCondition ~= nil
+        or buttonData.triggerExpected ~= nil
+        or buttonData.triggerState ~= nil
+        or buttonData.triggerConditions ~= nil
+end
+
+local function ClearTriggerConditionConfig(buttonData)
+    local changed = false
+    if buttonData.triggerCondition ~= nil then
+        buttonData.triggerCondition = nil
+        changed = true
+    end
+    if buttonData.triggerExpected ~= nil then
+        buttonData.triggerExpected = nil
+        changed = true
+    end
+    if buttonData.triggerState ~= nil then
+        buttonData.triggerState = nil
+        changed = true
+    end
+    if buttonData.triggerConditions ~= nil then
+        buttonData.triggerConditions = nil
+        changed = true
+    end
+    return changed
+end
+
+local function NormalizePromotedPassiveCooldownTriggerConditions(buttonData)
+    if not HasTriggerConditionConfig(buttonData) then
+        return false
+    end
+    if not (CooldownCompanion.GetTriggerConditionClauses and CooldownCompanion.NormalizeTriggerConditionRowData) then
+        return false
+    end
+
+    local clauses = CooldownCompanion:GetTriggerConditionClauses(buttonData)
+    local changed = false
+    if #clauses == 0 then
+        changed = ClearTriggerConditionConfig(buttonData)
+    end
+
+    CooldownCompanion:NormalizeTriggerConditionRowData(buttonData)
+    return changed
+end
+
 local function NormalizePassiveCooldownButtons(profile)
     if type(profile) ~= "table" or type(profile.groups) ~= "table" then
         return false
@@ -96,6 +142,9 @@ local function NormalizePassiveCooldownButtons(profile)
                         end
                         if buttonData.addedAs ~= "spell" then
                             buttonData.addedAs = "spell"
+                            changed = true
+                        end
+                        if NormalizePromotedPassiveCooldownTriggerConditions(buttonData) then
                             changed = true
                         end
                     end

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -8,6 +8,8 @@ local CooldownCompanion = ST.Addon
 local type = type
 local next = next
 local rawget = rawget
+local pairs = pairs
+local ipairs = ipairs
 
 local IMPORT_CHECKPOINT_KEY = "_cdcImportCheckpoint"
 local IMPORT_CHECKPOINT_VERSION = "1.15"
@@ -60,6 +62,48 @@ local function LooksLikeProfilePayload(profile)
         or rawget(profile, "resourceBars") ~= nil
         or rawget(profile, "castBar") ~= nil
         or rawget(profile, "frameAnchoring") ~= nil
+end
+
+local function NormalizePassiveCooldownButtons(profile)
+    if type(profile) ~= "table" or type(profile.groups) ~= "table" then
+        return false
+    end
+    if not ST.IsPassiveCooldownSpell then
+        return false
+    end
+
+    local changed = false
+    for _, group in pairs(profile.groups) do
+        if type(group) == "table" and type(group.buttons) == "table" then
+            for _, buttonData in ipairs(group.buttons) do
+                if type(buttonData) == "table"
+                    and buttonData.type == "spell"
+                    and (buttonData.isPassive == true or buttonData.isPassiveCooldown == true) then
+                    local isPassiveCooldown = buttonData.isPassiveCooldown == true
+                        or ST.IsPassiveCooldownSpell(buttonData.id)
+                    if isPassiveCooldown then
+                        if buttonData.isPassiveCooldown ~= true then
+                            buttonData.isPassiveCooldown = true
+                            changed = true
+                        end
+                        if buttonData.isPassive ~= nil then
+                            buttonData.isPassive = nil
+                            changed = true
+                        end
+                        if buttonData.auraTracking ~= false then
+                            buttonData.auraTracking = false
+                            changed = true
+                        end
+                        if buttonData.addedAs ~= "spell" then
+                            buttonData.addedAs = "spell"
+                            changed = true
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return changed
 end
 
 local function HasSupportedCheckpoint(payload)
@@ -203,6 +247,7 @@ function CooldownCompanion:RunAllMigrations()
     self._pendingUnsupportedLegacyHide = nil
 
     self:StampImportCheckpoint(self.db and self.db.profile)
+    NormalizePassiveCooldownButtons(self.db and self.db.profile)
     if self.SanitizeCursorAnchorPolicy and not self._deferCursorAnchorPolicySanitizer then
         self:SanitizeCursorAnchorPolicy(self.db and self.db.profile)
     end

--- a/Core/SpellQueries.lua
+++ b/Core/SpellQueries.lua
@@ -137,17 +137,11 @@ local function HasBaseCooldown(spellId)
     return baseCd and baseCd > 0
 end
 
-local function HasActiveSpellCooldown(spellId)
-    local info = C_Spell.GetSpellCooldown(spellId)
-    return info and info.isActive == true and info.isOnGCD ~= true
-end
-
 function ST.HasSpellCooldownSurface(spellId)
     if not spellId then return false end
     return HasBaseCooldown(spellId)
         or ST.HasTooltipCooldown(spellId)
         or ST.HasChargeCooldownInfo(spellId)
-        or HasActiveSpellCooldown(spellId)
 end
 
 -- Returns true if the spell has no real cooldown surface (GCD-only).

--- a/Core/SpellQueries.lua
+++ b/Core/SpellQueries.lua
@@ -88,6 +88,13 @@ function ST.IsSpellInCDMCooldown(spellId)
     return false
 end
 
+function ST.IsPassiveCooldownSpell(spellId)
+    if not spellId or not C_Spell.IsSpellPassive(spellId) then
+        return false
+    end
+    return ST.HasSpellCooldownSurface(spellId)
+end
+
 --------------------------------------------------------------------------------
 -- Tooltip Cooldown Detection
 --------------------------------------------------------------------------------
@@ -125,12 +132,27 @@ function ST.HasChargeCooldownInfo(spellId)
     return false
 end
 
+local function HasBaseCooldown(spellId)
+    local baseCd = GetSpellBaseCooldown(spellId)
+    return baseCd and baseCd > 0
+end
+
+local function HasActiveSpellCooldown(spellId)
+    local info = C_Spell.GetSpellCooldown(spellId)
+    return info and info.isActive == true and info.isOnGCD ~= true
+end
+
+function ST.HasSpellCooldownSurface(spellId)
+    if not spellId then return false end
+    return HasBaseCooldown(spellId)
+        or ST.HasTooltipCooldown(spellId)
+        or ST.HasChargeCooldownInfo(spellId)
+        or HasActiveSpellCooldown(spellId)
+end
+
 -- Returns true if the spell has no real cooldown surface (GCD-only).
 function ST.IsNoCooldownSpell(spellId)
-    local baseCd = GetSpellBaseCooldown(spellId)
-    return (not baseCd or baseCd == 0)
-        and not ST.HasTooltipCooldown(spellId)
-        and not ST.HasChargeCooldownInfo(spellId)
+    return not ST.HasSpellCooldownSurface(spellId)
 end
 
 -- Returns true if the spell tooltip contains a UsageRequirement line


### PR DESCRIPTION
## What Players Will Notice
- Passive abilities that Blizzard exposes as real cooldowns, such as Shaman Reincarnation, can now be added and tracked as cooldown entries instead of being rejected or forced into aura/proc-style behavior.
- Existing or imported passive cooldown rows are normalized into cooldown mode on load/import, including trigger-panel defaults.
- Charge-backed passive cooldowns keep charge metadata and charge trigger options instead of losing those cooldown controls.

## Why This Changed
- Some passive abilities effectively behave like cooldowns even though they are not manually cast by the player.
- Older passive/proc handling treated these rows as aura-only or CDM-style entries, which made real cooldown passives difficult or impossible to track cleanly.
- Scope note: for a passive to be addable as a cooldown, it must still be available through the normal add paths, including spellbook-discoverable passive entries, and it must expose a structural cooldown surface through Blizzard data/API such as a base cooldown, tooltip cooldown, or charge cooldown info. A transient active cooldown state is not used as addability proof, and hidden/internal passives with no exposed cooldown surface, such as Nature's Guardian in the probes from this work, are not forced into tracking.

## What Changed
- Added a passive-cooldown classifier based on structural cooldown evidence.
- Allowed passive cooldown spellbook entries through autocomplete and direct add paths while keeping buff-only CDM aura entries on the aura path.
- Added `isPassiveCooldown` row handling so cooldown-mode passives skip range, usability, and proc-only behavior without becoming normal passive aura rows.
- Backfilled existing/imported passive cooldown rows and repaired stale trigger conditions when a row is promoted into cooldown mode.
- Preserved add-time charge metadata and charge trigger conditions for passive cooldowns that expose charge data.

## Validation
- Ran `git diff --check`.
- Ran `luac -p` over the changed Lua files.
- Development probing established the intended boundary: Reincarnation exposes cooldown data and is covered; Nature's Guardian/its triggered spell did not expose a usable cooldown surface in the tested state, so it remains outside this implementation.
- Final in-game combat and restricted-content validation has not been performed.