### PR TITLE
Stop Rune and Essence recharge from showing as spell cooldowns

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1808,6 +1808,10 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._noCooldownSpellId = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil
+    button._resourceGateCost = nil
+    button._resourceGateCostSpellId = nil
+    button._baseResourceGateCost = nil
+    button._baseResourceGateCostSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -36,6 +36,7 @@ local UnitCanAttack = UnitCanAttack
 
 -- Imports from Utils
 local IsNoCooldownSpell = ST.IsNoCooldownSpell
+local HasPositiveResourceGateCost = ST.HasPositiveResourceGateCost
 
 -- Imports from Preview
 local GetConditionalVisualPreview = ST._GetConditionalVisualPreview
@@ -736,15 +737,27 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._baseNoCooldownSpellId = buttonData.id
             button._baseNoCooldown = IsNoCooldownSpell(buttonData.id)
         end
+        if button._baseResourceGateCost == nil or button._baseResourceGateCostSpellId ~= buttonData.id then
+            button._baseResourceGateCostSpellId = buttonData.id
+            button._baseResourceGateCost = HasPositiveResourceGateCost(buttonData.id)
+        end
         if button._noCooldown == nil or button._noCooldownSpellId ~= cooldownSpellId then
             button._noCooldownSpellId = cooldownSpellId
             button._noCooldown = IsNoCooldownSpell(cooldownSpellId)
+        end
+        if button._resourceGateCost == nil or button._resourceGateCostSpellId ~= cooldownSpellId then
+            button._resourceGateCostSpellId = cooldownSpellId
+            button._resourceGateCost = HasPositiveResourceGateCost(cooldownSpellId)
         end
     else
         button._noCooldown = false
         button._noCooldownSpellId = nil
         button._baseNoCooldown = nil
         button._baseNoCooldownSpellId = nil
+        button._resourceGateCost = false
+        button._resourceGateCostSpellId = nil
+        button._baseResourceGateCost = nil
+        button._baseResourceGateCostSpellId = nil
     end
 
     -- Proc state: event-driven table lookup (base spell + current displayed override).
@@ -1035,7 +1048,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if not auraOwnsPrimarySwipe and not barAuraStackDisplay then
         if buttonData.type == "spell" and not buttonData.isPassive then
-            spellCooldownResult = EntryRuntime.EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, button._noCooldown)
+            spellCooldownResult = EntryRuntime.EvaluateButtonSpellCooldown(
+                buttonData,
+                cooldownSpellId,
+                button._noCooldown,
+                button._resourceGateCost,
+                button._baseNoCooldown,
+                button._baseResourceGateCost
+            )
             if spellCooldownResult and spellCooldownResult.fetchOk then
                 spellCooldownInfo = spellCooldownResult.info
                 spellCooldownDuration = spellCooldownResult.durationObj

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1233,6 +1233,10 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._noCooldownSpellId = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil
+    button._resourceGateCost = nil
+    button._resourceGateCostSpellId = nil
+    button._baseResourceGateCost = nil
+    button._baseResourceGateCostSpellId = nil
     button._vertexR = nil
     button._vertexG = nil
     button._vertexB = nil

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -7,7 +7,7 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local IsNoCooldownSpell = ST.IsNoCooldownSpell
-local IsRuneCostNoCooldownSpell = ST.IsRuneCostNoCooldownSpell
+local IsResourceGateNoCooldownSpell = ST.IsResourceGateNoCooldownSpell
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -928,9 +928,9 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 end
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
     local resourceGatedNoCooldown = noCooldown == true
-        and IsRuneCostNoCooldownSpell
-        and (IsRuneCostNoCooldownSpell(cooldownSpellId)
-            or (cooldownSpellId ~= buttonData.id and IsRuneCostNoCooldownSpell(buttonData.id)))
+        and IsResourceGateNoCooldownSpell
+        and (IsResourceGateNoCooldownSpell(cooldownSpellId)
+            or (cooldownSpellId ~= buttonData.id and IsResourceGateNoCooldownSpell(buttonData.id)))
     local allowActionSlotRealFallback = buttonData.hasCharges ~= true
         and cooldownSpellId == buttonData.id
         and noCooldown ~= true
@@ -1215,9 +1215,9 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
     local noCooldown = ResolveNoCooldownState(owner, cooldownSpellID, hasCharges)
     local resourceGatedNoCooldown = noCooldown == true
-        and IsRuneCostNoCooldownSpell
-        and (IsRuneCostNoCooldownSpell(cooldownSpellID)
-            or (cooldownSpellID ~= spellID and IsRuneCostNoCooldownSpell(spellID)))
+        and IsResourceGateNoCooldownSpell
+        and (IsResourceGateNoCooldownSpell(cooldownSpellID)
+            or (cooldownSpellID ~= spellID and IsResourceGateNoCooldownSpell(spellID)))
 
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
         allowActionSlotRealFallback = not hasCharges and cooldownSpellID == spellID and noCooldown ~= true,

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -7,6 +7,7 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local IsNoCooldownSpell = ST.IsNoCooldownSpell
+local IsRuneCostNoCooldownSpell = ST.IsRuneCostNoCooldownSpell
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -830,6 +831,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         realCooldownShown = false,
         isOnGCD = false,
         deferred = false,
+        resourceGatedNoCooldown = false,
     }
 
     if not spellID then
@@ -837,11 +839,13 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     end
 
     options = options or {}
+    local suppressCooldownSurface = options.suppressCooldownSurface == true
+    result.resourceGatedNoCooldown = suppressCooldownSurface
 
     local info = C_Spell.GetSpellCooldown(spellID)
     result.info = info
     if not info then
-        if secrecy ~= 0 then
+        if secrecy ~= 0 and not suppressCooldownSurface then
             local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
             if slotProbe.shown ~= nil then
                 result.fetchOk = true
@@ -868,16 +872,25 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 
     result.fetchOk = true
     result.isOnGCD = info.isOnGCD or false
-    result.deferred = IsSpellCooldownDeferred(info)
+    result.deferred = not suppressCooldownSurface and IsSpellCooldownDeferred(info) or false
 
-    if info.isActive then
+    if info.isActive and not suppressCooldownSurface then
         result.durationObj = C_Spell.GetSpellCooldownDuration(spellID)
         result.realDurationObj = C_Spell.GetSpellCooldownDuration(spellID, true)
         result.normalCooldownShown = DurationObjectShowsCooldown(result.durationObj)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
-    if result.deferred then
+    if suppressCooldownSurface then
+        if result.isOnGCD == true and CooldownCompanion._gcdDurationObj then
+            result.source = "resource-gated-gcd"
+            result.presentationState = COOLDOWN_STATE_GCD
+            result.renderDurationObj = CooldownCompanion._gcdDurationObj
+        else
+            result.source = "resource-gated-no-cooldown"
+        end
+        return result
+    elseif result.deferred then
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-deferred"
     elseif result.realCooldownShown and result.realDurationObj then
@@ -914,12 +927,17 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     return result
 end
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
+    local resourceGatedNoCooldown = noCooldown == true
+        and IsRuneCostNoCooldownSpell
+        and (IsRuneCostNoCooldownSpell(cooldownSpellId)
+            or (cooldownSpellId ~= buttonData.id and IsRuneCostNoCooldownSpell(buttonData.id)))
     local allowActionSlotRealFallback = buttonData.hasCharges ~= true
         and cooldownSpellId == buttonData.id
         and noCooldown ~= true
 
     return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
         allowActionSlotRealFallback = allowActionSlotRealFallback,
+        suppressCooldownSurface = resourceGatedNoCooldown == true,
     })
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
@@ -1196,9 +1214,14 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local hasCharges = (maxCharges or 0) > 1
     local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
     local noCooldown = ResolveNoCooldownState(owner, cooldownSpellID, hasCharges)
+    local resourceGatedNoCooldown = noCooldown == true
+        and IsRuneCostNoCooldownSpell
+        and (IsRuneCostNoCooldownSpell(cooldownSpellID)
+            or (cooldownSpellID ~= spellID and IsRuneCostNoCooldownSpell(spellID)))
 
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
         allowActionSlotRealFallback = not hasCharges and cooldownSpellID == spellID and noCooldown ~= true,
+        suppressCooldownSurface = resourceGatedNoCooldown == true,
     })
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -7,7 +7,7 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local IsNoCooldownSpell = ST.IsNoCooldownSpell
-local IsResourceGateNoCooldownSpell = ST.IsResourceGateNoCooldownSpell
+local HasPositiveResourceGateCost = ST.HasPositiveResourceGateCost
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -926,11 +926,12 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 
     return result
 end
-local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown)
+local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown, resourceGateCost, baseNoCooldown, baseResourceGateCost)
     local resourceGatedNoCooldown = noCooldown == true
-        and IsResourceGateNoCooldownSpell
-        and (IsResourceGateNoCooldownSpell(cooldownSpellId)
-            or (cooldownSpellId ~= buttonData.id and IsResourceGateNoCooldownSpell(buttonData.id)))
+        and (resourceGateCost == true
+            or (cooldownSpellId ~= buttonData.id
+                and baseNoCooldown == true
+                and baseResourceGateCost == true))
     local allowActionSlotRealFallback = buttonData.hasCharges ~= true
         and cooldownSpellId == buttonData.id
         and noCooldown ~= true
@@ -958,11 +959,11 @@ local function ResolveSpellCooldownSecrecy(owner, spellID)
     return C_Secrets.GetSpellCooldownSecrecy(spellID)
 end
 
-local function ResolveNoCooldownState(owner, spellID, hasCharges)
+local function ResolveCachedSpellBooleanState(owner, spellID, hasCharges, valueKey, spellKey, resolver)
     if hasCharges then
         if owner then
-            owner._noCooldown = false
-            owner._noCooldownSpellId = nil
+            owner[valueKey] = false
+            owner[spellKey] = nil
         end
         return false
     end
@@ -971,16 +972,60 @@ local function ResolveNoCooldownState(owner, spellID, hasCharges)
         return false
     end
 
-    if owner and owner._noCooldown ~= nil and owner._noCooldownSpellId == spellID then
-        return owner._noCooldown == true
+    if owner and owner[valueKey] ~= nil and owner[spellKey] == spellID then
+        return owner[valueKey] == true
     end
 
-    local noCooldown = IsNoCooldownSpell(spellID)
+    local value = resolver(spellID)
     if owner then
-        owner._noCooldownSpellId = spellID
-        owner._noCooldown = noCooldown
+        owner[spellKey] = spellID
+        owner[valueKey] = value
     end
-    return noCooldown
+    return value
+end
+
+local function ResolveNoCooldownState(owner, spellID, hasCharges)
+    return ResolveCachedSpellBooleanState(
+        owner,
+        spellID,
+        hasCharges,
+        "_noCooldown",
+        "_noCooldownSpellId",
+        IsNoCooldownSpell
+    )
+end
+
+local function ResolveBaseNoCooldownState(owner, spellID, hasCharges)
+    return ResolveCachedSpellBooleanState(
+        owner,
+        spellID,
+        hasCharges,
+        "_baseNoCooldown",
+        "_baseNoCooldownSpellId",
+        IsNoCooldownSpell
+    )
+end
+
+local function ResolveResourceGateCostState(owner, spellID, hasCharges)
+    return ResolveCachedSpellBooleanState(
+        owner,
+        spellID,
+        hasCharges,
+        "_resourceGateCost",
+        "_resourceGateCostSpellId",
+        HasPositiveResourceGateCost
+    )
+end
+
+local function ResolveBaseResourceGateCostState(owner, spellID, hasCharges)
+    return ResolveCachedSpellBooleanState(
+        owner,
+        spellID,
+        hasCharges,
+        "_baseResourceGateCost",
+        "_baseResourceGateCostSpellId",
+        HasPositiveResourceGateCost
+    )
 end
 
 local function ClearOwnerChargeState(owner)
@@ -1214,10 +1259,18 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local hasCharges = (maxCharges or 0) > 1
     local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
     local noCooldown = ResolveNoCooldownState(owner, cooldownSpellID, hasCharges)
+    local resourceGateCost = ResolveResourceGateCostState(owner, cooldownSpellID, hasCharges)
+    local baseNoCooldown = noCooldown
+    local baseResourceGateCost = resourceGateCost
+    if cooldownSpellID ~= spellID then
+        baseNoCooldown = ResolveBaseNoCooldownState(owner, spellID, hasCharges)
+        baseResourceGateCost = ResolveBaseResourceGateCostState(owner, spellID, hasCharges)
+    end
     local resourceGatedNoCooldown = noCooldown == true
-        and IsResourceGateNoCooldownSpell
-        and (IsResourceGateNoCooldownSpell(cooldownSpellID)
-            or (cooldownSpellID ~= spellID and IsResourceGateNoCooldownSpell(spellID)))
+        and (resourceGateCost == true
+            or (cooldownSpellID ~= spellID
+                and baseNoCooldown == true
+                and baseResourceGateCost == true))
 
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
         allowActionSlotRealFallback = not hasCharges and cooldownSpellID == spellID and noCooldown ~= true,

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1692,6 +1692,10 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._noCooldownSpellId = nil
                 button._baseNoCooldown = nil
                 button._baseNoCooldownSpellId = nil
+                button._resourceGateCost = nil
+                button._resourceGateCostSpellId = nil
+                button._baseResourceGateCost = nil
+                button._baseResourceGateCostSpellId = nil
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil

--- a/Core/SpellQueries.lua
+++ b/Core/SpellQueries.lua
@@ -8,6 +8,7 @@ local ADDON_NAME, ST = ...
 local ipairs = ipairs
 local tonumber = tonumber
 local issecretvalue = issecretvalue
+local Enum = Enum
 
 --------------------------------------------------------------------------------
 -- Spell Resolution
@@ -132,6 +133,33 @@ function ST.HasChargeCooldownInfo(spellId)
     return false
 end
 
+local function IsPositiveReadableNumber(value)
+    if issecretvalue and issecretvalue(value) then
+        return false
+    end
+    return (tonumber(value) or 0) > 0
+end
+
+function ST.HasPositiveRuneCost(spellId)
+    if not spellId then return false end
+    local runePowerType = Enum and Enum.PowerType and Enum.PowerType.Runes
+    if runePowerType == nil then return false end
+
+    local costs = C_Spell.GetSpellPowerCost(spellId)
+    if not costs then return false end
+
+    for _, costInfo in ipairs(costs) do
+        if costInfo
+            and costInfo.type == runePowerType
+            and (IsPositiveReadableNumber(costInfo.cost)
+                or IsPositiveReadableNumber(costInfo.minCost)) then
+            return true
+        end
+    end
+
+    return false
+end
+
 local function HasBaseCooldown(spellId)
     local baseCd = GetSpellBaseCooldown(spellId)
     return baseCd and baseCd > 0
@@ -147,6 +175,10 @@ end
 -- Returns true if the spell has no real cooldown surface (GCD-only).
 function ST.IsNoCooldownSpell(spellId)
     return not ST.HasSpellCooldownSurface(spellId)
+end
+
+function ST.IsRuneCostNoCooldownSpell(spellId)
+    return ST.HasPositiveRuneCost(spellId) and ST.IsNoCooldownSpell(spellId)
 end
 
 -- Returns true if the spell tooltip contains a UsageRequirement line

--- a/Core/SpellQueries.lua
+++ b/Core/SpellQueries.lua
@@ -140,17 +140,23 @@ local function IsPositiveReadableNumber(value)
     return (tonumber(value) or 0) > 0
 end
 
-function ST.HasPositiveRuneCost(spellId)
+local function IsResourceGatedNoCooldownPowerType(powerType)
+    local powerTypes = Enum and Enum.PowerType
+    if not powerTypes then return false end
+
+    return powerType == powerTypes.Runes
+        or powerType == powerTypes.Essence
+end
+
+local function HasPositivePowerCost(spellId, matchesPowerType)
     if not spellId then return false end
-    local runePowerType = Enum and Enum.PowerType and Enum.PowerType.Runes
-    if runePowerType == nil then return false end
 
     local costs = C_Spell.GetSpellPowerCost(spellId)
     if not costs then return false end
 
     for _, costInfo in ipairs(costs) do
         if costInfo
-            and costInfo.type == runePowerType
+            and matchesPowerType(costInfo.type)
             and (IsPositiveReadableNumber(costInfo.cost)
                 or IsPositiveReadableNumber(costInfo.minCost)) then
             return true
@@ -158,6 +164,19 @@ function ST.HasPositiveRuneCost(spellId)
     end
 
     return false
+end
+
+function ST.HasPositiveResourceGateCost(spellId)
+    return HasPositivePowerCost(spellId, IsResourceGatedNoCooldownPowerType)
+end
+
+function ST.HasPositiveRuneCost(spellId)
+    local runePowerType = Enum and Enum.PowerType and Enum.PowerType.Runes
+    if runePowerType == nil then return false end
+
+    return HasPositivePowerCost(spellId, function(powerType)
+        return powerType == runePowerType
+    end)
 end
 
 local function HasBaseCooldown(spellId)
@@ -179,6 +198,10 @@ end
 
 function ST.IsRuneCostNoCooldownSpell(spellId)
     return ST.HasPositiveRuneCost(spellId) and ST.IsNoCooldownSpell(spellId)
+end
+
+function ST.IsResourceGateNoCooldownSpell(spellId)
+    return ST.HasPositiveResourceGateCost(spellId) and ST.IsNoCooldownSpell(spellId)
 end
 
 -- Returns true if the spell tooltip contains a UsageRequirement line


### PR DESCRIPTION
## What Players Will Notice
- Death Knight rune spenders and Evoker Essence spenders that do not have a real cooldown no longer show rune or Essence recharge as a button cooldown/desaturation.
- When the resource is missing, these buttons should communicate that through the normal unusable-state visuals instead of a fake cooldown surface.
- Rune- or Essence-cost spells that also have a real cooldown should keep their normal cooldown behavior.

## Why This Changed
- Some resource-bound spells without real cooldowns were presenting the recharge of their resource as if it were the spell cooldown. That made buttons briefly look ready or usable too early around GCD/resource timing, then correct themselves once the GCD ended.
- This PR moves that responsibility out of button cooldown truth. A follow-up resource bar feature can show the corresponding class resource recharge rate directly on the resource bar, where that information belongs.

## What Changed
- Added Rune/Essence positive power-cost detection for resource-gated no-cooldown spells.
- Suppressed rune/Essence-derived cooldown render objects, cooldown state, cooldown swipe/desaturation, cooldown text, sound alerts, and hide-on-cooldown behavior for those no-real-cooldown spells.
- Kept usability driven by `C_Spell.IsSpellUsable()` so insufficient resources still use the existing unusable-state path.
- Cached the resource-gated classification alongside no-cooldown metadata for button and custom bar cooldown evaluation.

## Validation
- `luac -p Core\SpellQueries.lua Core\EntryRuntime.lua ButtonFrame\CooldownUpdate.lua ButtonFrame\IconMode.lua ButtonFrame\BarMode.lua Core\GroupOperations.lua`
- `lua tests\rune-cost-no-cooldown.lua`
- `git diff --check origin/main...HEAD`
- Static API/source checks were performed during implementation for `C_Spell.GetSpellPowerCost`, `Enum.PowerType.Runes`, and `Enum.PowerType.Essence`.
- In-game DK/Evoker verification is still needed, including GCD edge timing, combat, and restricted content.