### PR TITLE
Show first-panel icons on groups and folders automatically

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -1190,7 +1190,6 @@ local function RefreshColumn1(preserveDrag)
         end
 
         entry:SetText(displayName)
-        local showManualIcon = not inFolder and IsValidIconTexture(container.manualIcon)
         entry:SetFullWidth(true)
         entry:SetFontObject(GameFontHighlight)
         local groupNameWidth = 0
@@ -1199,10 +1198,10 @@ local function RefreshColumn1(preserveDrag)
             groupNameWidth = entry.label:GetStringWidth()
             entry:SetText(displayName)
         end
-        if showManualIcon then
-            ApplyConfigRowIcon(entry, container.manualIcon)
+        if inFolder then
+            ApplyConfigTextRow(entry, "LEFT", 17)
         else
-            ApplyConfigTextRow(entry, "LEFT", inFolder and 17 or 0)
+            ApplyConfigRowIcon(entry, GetContainerIcon(containerId, db))
         end
         entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
 

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -710,6 +710,25 @@ local function GetGroupIcon(group)
     return 134400
 end
 
+local function GetFirstPanelForContainer(containerId, db)
+    if not (containerId and db and db.groups) then
+        return nil
+    end
+
+    local firstPanel, firstOrder
+    for gid, group in pairs(db.groups) do
+        if group.parentContainerId == containerId then
+            local order = group.order or gid
+            if not firstOrder or order < firstOrder then
+                firstOrder = order
+                firstPanel = group
+            end
+        end
+    end
+
+    return firstPanel
+end
+
 ------------------------------------------------------------------------
 -- Helper: Validate icon texture (number or string)
 ------------------------------------------------------------------------
@@ -737,17 +756,7 @@ local function GetContainerIcon(containerId, db)
     if container and IsValidIconTexture(container.manualIcon) then
         return container.manualIcon
     end
-    if not db.groups then return 134400 end
-    local firstPanel, firstOrder
-    for gid, group in pairs(db.groups) do
-        if group.parentContainerId == containerId then
-            local order = group.order or gid
-            if not firstOrder or order < firstOrder then
-                firstOrder = order
-                firstPanel = group
-            end
-        end
-    end
+    local firstPanel = GetFirstPanelForContainer(containerId, db)
     if firstPanel then
         return GetGroupIcon(firstPanel)
     end
@@ -773,17 +782,7 @@ local function GetAutoFolderIcon(folderId, db)
         table.sort(children, function(a, b) return a.order < b.order end)
         if children[1] and db.groups then
             -- Find first panel of this container for its icon
-            local containerId = children[1].id
-            local firstPanel, firstOrder
-            for gid, group in pairs(db.groups) do
-                if group.parentContainerId == containerId then
-                    local order = group.order or gid
-                    if not firstOrder or order < firstOrder then
-                        firstOrder = order
-                        firstPanel = group
-                    end
-                end
-            end
+            local firstPanel = GetFirstPanelForContainer(children[1].id, db)
             if firstPanel then
                 return GetGroupIcon(firstPanel)
             end


### PR DESCRIPTION
## What Players Will Notice
- Column 1 group rows now show the first icon from their first panel when no custom group icon is set.
- Folder rows follow the same custom-or-first-child icon behavior, while groups inside folders stay text-only.

## Why This Changed
- Uncustomized group rows were rendered as text-only even though the config icon helpers could already resolve an automatic first-panel icon.
- Clearing a custom group or folder icon should return the row to a useful automatic visual instead of leaving it visually blank.

## What Changed
- Shared the first-panel lookup used by container and folder icon resolution in `Config/State.lua`.
- Updated Column 1 row rendering so top-level groups use `GetContainerIcon(...)`, while foldered groups keep the indented text-only layout.
- Kept derived icons out of saved variables; `manualIcon` remains the only persisted group/folder override.

## Validation
- Verified `C_Spell.GetSpellTexture` and `C_Item.GetItemIconByID` through the WoW API MCP; neither is deprecated.
- `lua tests\config-row-icons.lua` (local ignored test harness)
- `lua tests\rune-cost-no-cooldown.lua`
- `luac -p Config\State.lua Config\Column1.lua tests\config-row-icons.lua`
- `git diff --check origin/main...HEAD`
- In-game visual, combat, and restricted-content testing has not been completed yet.