### PR TITLE
Let Unusable Visual dim and desaturate icons separately

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1197,7 +1197,7 @@ local function UpdateBarDisplay(button)
 
     EvaluateDesaturation(button, button.buttonData, style)
 
-    -- Icon tinting (out-of-range red / unusable dimming)
+    -- Icon tinting (out-of-range red / unusable dim mode)
     UpdateIconTint(button, button.buttonData, style)
 
     -- Loss of control overlay on bar icon

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -15,6 +15,7 @@ local InCombatLockdown = InCombatLockdown
 local UnitCanAttack = UnitCanAttack
 local IsItemInRange = C_Item.IsItemInRange
 local IsUsableItem = C_Item.IsUsableItem
+local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
 
 -- Update charge count state for a spell with hasCharges enabled.
 -- chargeSpellID should be the effective runtime spell ID (override-aware).
@@ -174,7 +175,28 @@ local function SetTintIntent(target, active, reason, unusableActive, r, g, b, a)
     return target
 end
 
--- Icon tinting: out-of-range red > unusable dimming > aura tint > cooldown tint > base tint.
+local function IsUnusableVisualActive(button, buttonData)
+    if buttonData.isPassive or buttonData.isPassiveCooldown then
+        return false
+    end
+    if button._conditionalUnusablePreview then
+        return true, "unusable-preview"
+    end
+    if buttonData.type == "spell" then
+        local spellID = button._displaySpellId or buttonData.id
+        if not C_Spell_IsSpellUsable(spellID) then
+            return true, "unusable"
+        end
+    elseif buttonData.type == "item" then
+        local itemID = button._resolvedItemId or buttonData.id
+        if not IsUsableItem(itemID) then
+            return true, "unusable"
+        end
+    end
+    return false
+end
+
+-- Icon tinting: out-of-range red > unusable dim mode > aura tint > cooldown tint > base tint.
 -- This resolver may read range/usability APIs; call it only from the normal tint update path.
 local function ResolveIconTintIntent(button, buttonData, style, target)
     target = target or {}
@@ -229,34 +251,15 @@ local function ResolveIconTintIntent(button, buttonData, style, target)
         end
     end
 
-    if not stateOverride and style.showUnusable then
+    if not stateOverride and style.showUnusable and ST.UnusableVisualUsesDimTint(style) then
         local uc = style.iconUnusableTintColor
-        if button._conditionalUnusablePreview then
+        local isUnusable, unusableReason = IsUnusableVisualActive(button, buttonData)
+        if isUnusable then
             r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
             a = uc and uc[4] or a
-            reason = "unusable-preview"
+            reason = unusableReason or "unusable"
             stateOverride = true
             unusableActive = true
-        elseif buttonData.type == "spell" and not buttonData.isPassiveCooldown then
-            local spellID = button._displaySpellId or buttonData.id
-            local isUsable = C_Spell.IsSpellUsable(spellID)
-            if not isUsable then
-                r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
-                a = uc and uc[4] or a
-                reason = "unusable"
-                stateOverride = true
-                unusableActive = true
-            end
-        elseif buttonData.type == "item" then
-            local itemID = button._resolvedItemId or buttonData.id
-            local usable = IsUsableItem(itemID)
-            if not usable then
-                r, g, b = uc and uc[1] or 0.4, uc and uc[2] or 0.4, uc and uc[3] or 0.4
-                a = uc and uc[4] or a
-                reason = "unusable"
-                stateOverride = true
-                unusableActive = true
-            end
         end
     end
 
@@ -360,6 +363,13 @@ local function ResolveDesaturationIntent(button, buttonData, style, target)
     if not target.active and button._isEquippableNotEquipped then
         target.active = true
         target.reason = "not-equipped"
+    end
+    if not target.active and style.showUnusable and ST.UnusableVisualUsesDesaturation(style) then
+        local isUnusable, unusableReason = IsUnusableVisualActive(button, buttonData)
+        if isUnusable then
+            target.active = true
+            target.reason = unusableReason or "unusable"
+        end
     end
 
     return target

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -561,6 +561,7 @@ local function BuildBarEffectsTab(container, group, style)
         -- ================================================================
         local unusableCb, unusableAdvBtn = BuildUnusableDimmingControls(container, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            CooldownCompanion:RefreshConfigPanel()
         end)
         local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
         AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn or unusableAdvBtn, "Preview Unusable State", "unusable", style.showUnusable)

--- a/ConfigSettings/BarModeTabs.lua
+++ b/ConfigSettings/BarModeTabs.lua
@@ -557,14 +557,13 @@ local function BuildBarEffectsTab(container, group, style)
         CreateCheckboxPromoteButton(locCb, nil, "lossOfControl", group, style)
 
         -- ================================================================
-        -- Unusable Dimming
+        -- Unusable Visual
         -- ================================================================
-        local unusableCb = BuildUnusableDimmingControls(container, style, function()
+        local unusableCb, unusableAdvBtn = BuildUnusableDimmingControls(container, style, function()
             CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-            CooldownCompanion:RefreshConfigPanel()
         end)
-        local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
-        AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn, "Preview Unusable State", "unusable", style.showUnusable)
+        local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
+        AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn or unusableAdvBtn, "Preview Unusable State", "unusable", style.showUnusable)
 
         -- Show Tooltips
         local tooltipCb = BuildShowTooltipsControls(container, style, function()

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -277,7 +277,7 @@ local function AllSelectedNoCooldown(group)
     return true
 end
 
--- Returns true if a button would never be affected by unusable dimming.
+-- Returns true if a button would never be affected by Unusable Visual.
 -- Items can always be unusable (level, class, etc.), so only spells are checked.
 -- A spell is "never unusable" only if it has no resource cost AND no usage
 -- requirements (form/stance/etc). Spells like Mangle (zero cost, requires
@@ -294,7 +294,7 @@ local function IsNeverUnusableButton(bd)
     return not HasUsageRequirement(bd.id)
 end
 
--- Returns true if all selected buttons would never be affected by unusable dimming
+-- Returns true if all selected buttons would never be affected by Unusable Visual.
 local function AllSelectedNeverUnusable(group)
     for idx in pairs(CS.selectedButtons) do
         local bd = group.buttons[idx]
@@ -844,7 +844,7 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
     -- (?) tooltip
     CreateInfoButton(hideUnusableCb.frame, hideUnusableCb.checkbg, "LEFT", "RIGHT", hideUnusableCb.text:GetStringWidth() + 4, 0, {
         "Hide While Unusable",
-        {"Uses the same logic as unusable dimming, but completely hides the button instead of dimming it.", 1, 1, 1, true},
+        {"Uses the same logic as Unusable Visual, but completely hides the button instead of changing the icon.", 1, 1, 1, true},
     }, infoButtons)
 
     -- Baseline Alpha Fallback (nested under hideWhileUnusable)

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -403,7 +403,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                             elseif sectionId == "iconTint" then
                                 AddConditionalPreviewButton(panel, "Preview Cooldown Tint", "cooldown", target)
                                 AddConditionalPreviewButton(panel, "Preview Aura Tint", "aura", target)
-                                AddConditionalPreviewButton(panel, "Preview Unusable Tint", "unusable", target)
+                                AddConditionalPreviewButton(panel, "Preview Unusable State", "unusable", target)
                                 AddConditionalPreviewButton(panel, "Preview Out of Range Tint", "out_of_range", target)
                             end
                         end
@@ -547,6 +547,8 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                             fallbackStyle = group.style,
                             afterEnableCallback = afterEnableCallback,
                             masqueEnabled = group.masqueEnabled == true,
+                            infoButtons = infoButtons,
+                            advancedKey = "overrideSetting_" .. sectionId,
                         })
 
                     end

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2708,6 +2708,7 @@ local function BuildEffectsTab(container)
     -- Unusable Visual
     local unusableCb, unusableAdvBtn = BuildUnusableDimmingControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
     end)
     local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
     AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn or unusableAdvBtn, "Preview Unusable State", "unusable", style.showUnusable)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -2705,13 +2705,12 @@ local function BuildEffectsTab(container)
     end)
     CreateCheckboxPromoteButton(locCb, nil, "lossOfControl", group, style)
 
-    -- Unusable Dimming
-    local unusableCb = BuildUnusableDimmingControls(container, style, function()
+    -- Unusable Visual
+    local unusableCb, unusableAdvBtn = BuildUnusableDimmingControls(container, style, function()
         CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
-        CooldownCompanion:RefreshConfigPanel()
     end)
-    local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, nil, "unusableDimming", group, style)
-    AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn, "Preview Unusable State", "unusable", style.showUnusable)
+    local unusablePromoteBtn = CreateCheckboxPromoteButton(unusableCb, unusableAdvBtn, "unusableDimming", group, style)
+    AddConditionalPreviewBadge(unusableCb, unusablePromoteBtn or unusableAdvBtn, "Preview Unusable State", "unusable", style.showUnusable)
 
     -- Show Tooltips
     local tooltipCb = BuildShowTooltipsControls(container, style, function()
@@ -3389,8 +3388,8 @@ local function BuildAppearanceTab(container)
         {"Aura Tint:", 1, 0.82, 0},
         {"A separate color applied while an aura-tracked ability's buff or debuff is active. Only affects buttons with aura tracking enabled.", 1, 1, 1, true},
         " ",
-        {"Unusable Dimming Tint:", 1, 0.82, 0},
-        {"A color applied when an ability is not usable. Only appears when unusable dimming is enabled in the Indicators tab.", 1, 1, 1, true},
+        {"Unusable Dim Color:", 1, 0.82, 0},
+        {"A color applied when an ability is not usable and Unusable Visual uses dimming in the Indicators tab.", 1, 1, 1, true},
     }, tabInfoButtons)
 
     iconTintHeading.right:ClearAllPoints()

--- a/ConfigSettings/SectionBuilders.lua
+++ b/ConfigSettings/SectionBuilders.lua
@@ -35,7 +35,6 @@ local KEYBIND_CUSTOM_TOOLTIP = {
     " ",
     {"When enabled for a button, that button's settings can also provide custom text to replace the detected bind until cleared.", 1, 1, 1, true},
 }
-
 local function ResolvePreviewOption(value)
     if type(value) == "function" then
         return value()
@@ -584,8 +583,8 @@ local function BuildIconTintControls(container, styleTable, refreshCallback)
         AddColorPicker(container, styleTable, "iconAuraTintColor", "Aura Active Icon Color", {0, 0.925, 1, 1}, true, refreshCallback, refreshCallback)
     end
 
-    if styleTable.showUnusable then
-        AddColorPicker(container, styleTable, "iconUnusableTintColor", "Unusable Dimming Tint", {0.4, 0.4, 0.4, 1}, true, refreshCallback, refreshCallback)
+    if styleTable.showUnusable and ST.UnusableVisualUsesDimTint(styleTable) then
+        AddColorPicker(container, styleTable, "iconUnusableTintColor", "Unusable Dim Color", {0.4, 0.4, 0.4, 1}, true, refreshCallback, refreshCallback)
     end
 end
 
@@ -826,17 +825,55 @@ local function BuildLossOfControlControls(container, styleTable, refreshCallback
     return locCb
 end
 
-local function BuildUnusableDimmingControls(container, styleTable, refreshCallback)
+local function BuildUnusableVisualModeControls(container, styleTable, refreshCallback)
+    local dimCb = AceGUI:Create("CheckBox")
+    dimCb:SetLabel("Dim Icon")
+    dimCb:SetValue(ST.UnusableVisualUsesDimTint(styleTable))
+    dimCb:SetFullWidth(true)
+    dimCb:SetCallback("OnValueChanged", function(widget, event, val)
+        ST.SetUnusableVisualMode(styleTable, val == true, ST.UnusableVisualUsesDesaturation(styleTable))
+        refreshCallback()
+        RefreshStructuralControls(container)
+    end)
+    container:AddChild(dimCb)
+
+    local desatCb = AceGUI:Create("CheckBox")
+    desatCb:SetLabel("Desaturate Icon")
+    desatCb:SetValue(ST.UnusableVisualUsesDesaturation(styleTable))
+    desatCb:SetFullWidth(true)
+    desatCb:SetCallback("OnValueChanged", function(widget, event, val)
+        ST.SetUnusableVisualMode(styleTable, ST.UnusableVisualUsesDimTint(styleTable), val == true)
+        refreshCallback()
+        RefreshStructuralControls(container)
+    end)
+    container:AddChild(desatCb)
+end
+
+local function BuildUnusableDimmingControls(container, styleTable, refreshCallback, opts)
+    opts = opts or {}
+
     local unusableCb = AceGUI:Create("CheckBox")
-    unusableCb:SetLabel("Show Unusable Dimming")
-    unusableCb:SetValue(styleTable.showUnusable or false)
+    unusableCb:SetLabel("Show Unusable Visual")
+    unusableCb:SetValue(styleTable.showUnusable == true)
     unusableCb:SetFullWidth(true)
     unusableCb:SetCallback("OnValueChanged", function(widget, event, val)
-        styleTable.showUnusable = val
+        styleTable.showUnusable = val == true
         refreshCallback()
+        RefreshStructuralControls(container)
     end)
     container:AddChild(unusableCb)
-    return unusableCb
+
+    local _, unusableAdvBtn = AddAdvancedToggle(unusableCb,
+        opts.advancedKey or "unusableVisual",
+        opts.infoButtons or tabInfoButtons,
+        styleTable.showUnusable == true, {
+            title = "Unusable Visual Advanced",
+            build = function(panel)
+                BuildUnusableVisualModeControls(panel, styleTable, refreshCallback)
+            end,
+        })
+
+    return unusableCb, unusableAdvBtn
 end
 
 local function BuildAssistedHighlightControls(container, styleTable, refreshCallback, opts)

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -114,6 +114,7 @@ local defaults = {
                         assistedHighlightProcColor = {1, 1, 1, 1},
                         assistedHighlightCombatOnly = false,
                         showUnusable = true,
+                        unusableVisualMode = "dim",
                         iconUnusableTintColor = {0.4, 0.4, 0.4, 1},
                         iconTintColor = {1, 1, 1, 1},           -- base icon vertex color (RGBA)
                         iconCooldownTintEnabled = false,         -- apply separate tint when on cooldown
@@ -287,6 +288,7 @@ local defaults = {
             assistedHighlightProcOverhang = 32,
             assistedHighlightCombatOnly = false,
             showUnusable = false,
+            unusableVisualMode = "dim",
             iconUnusableTintColor = {0.4, 0.4, 0.4, 1},
             iconTintColor = {1, 1, 1, 1},
             iconCooldownTintEnabled = false,
@@ -691,8 +693,8 @@ ST.OVERRIDE_SECTIONS = {
         modes = {icons = true, bars = true},
     },
     unusableDimming = {
-        label = "Unusable Dimming",
-        keys = {"showUnusable", "iconUnusableTintColor"},
+        label = "Unusable Visual",
+        keys = {"showUnusable", "unusableVisualMode", "iconUnusableTintColor"},
         modes = {icons = true, bars = true},
     },
     iconTint = {

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1064,6 +1064,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
     if style.showLossOfControl == nil then style.showLossOfControl = false end
     if style.showTooltips == nil then style.showTooltips = false end
     if style.showUnusable == nil then style.showUnusable = true end
+    if style.unusableVisualMode == nil then style.unusableVisualMode = "dim" end
     if style.showCooldownSwipe == nil then style.showCooldownSwipe = true end
     if style.showCooldownSwipeFill == nil then style.showCooldownSwipeFill = true end
     if style.auraUseBlizzardSwipe == nil then style.auraUseBlizzardSwipe = false end

--- a/Core/Migrations.lua
+++ b/Core/Migrations.lua
@@ -155,6 +155,30 @@ local function NormalizePassiveCooldownButtons(profile)
     return changed
 end
 
+local function BackfillUnusableVisualOverrideModes(profile)
+    if type(profile) ~= "table" or type(profile.groups) ~= "table" then
+        return false
+    end
+
+    local changed = false
+    for _, group in pairs(profile.groups) do
+        if type(group) == "table" and type(group.buttons) == "table" then
+            for _, buttonData in ipairs(group.buttons) do
+                local overrides = type(buttonData) == "table" and buttonData.styleOverrides
+                local overrideSections = type(buttonData) == "table" and buttonData.overrideSections
+                if type(overrides) == "table"
+                    and type(overrideSections) == "table"
+                    and overrideSections.unusableDimming == true
+                    and overrides.unusableVisualMode == nil then
+                    overrides.unusableVisualMode = ST.UNUSABLE_VISUAL_MODE_DIM or "dim"
+                    changed = true
+                end
+            end
+        end
+    end
+    return changed
+end
+
 local function HasSupportedCheckpoint(payload)
     if type(payload) ~= "table" then
         return false
@@ -297,6 +321,7 @@ function CooldownCompanion:RunAllMigrations()
 
     self:StampImportCheckpoint(self.db and self.db.profile)
     NormalizePassiveCooldownButtons(self.db and self.db.profile)
+    BackfillUnusableVisualOverrideModes(self.db and self.db.profile)
     if self.SanitizeCursorAnchorPolicy and not self._deferCursorAnchorPolicySanitizer then
         self:SanitizeCursorAnchorPolicy(self.db and self.db.profile)
     end

--- a/Core/StyleOverrides.lua
+++ b/Core/StyleOverrides.lua
@@ -45,6 +45,9 @@ function CooldownCompanion:PromoteSection(buttonData, groupStyle, sectionId)
     -- Copy current group values into overrides
     for _, key in ipairs(section.keys) do
         local val = groupStyle[key]
+        if key == "unusableVisualMode" then
+            val = ST.GetUnusableVisualMode(groupStyle)
+        end
         if type(val) == "table" then
             buttonData.styleOverrides[key] = CopyTable(val)
         else

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -165,6 +165,54 @@ function ST.SetStatusBarRemainingDuration(statusBar, durationObj)
 end
 
 --------------------------------------------------------------------------------
+-- Unusable Visual Helpers
+--------------------------------------------------------------------------------
+
+ST.UNUSABLE_VISUAL_MODE_DIM = "dim"
+ST.UNUSABLE_VISUAL_MODE_DESATURATE = "desaturate"
+ST.UNUSABLE_VISUAL_MODE_BOTH = "both"
+ST.UNUSABLE_VISUAL_MODE_NONE = "none"
+
+function ST.GetUnusableVisualMode(source)
+    if type(source) == "table" then
+        source = source.unusableVisualMode
+    end
+    if source == ST.UNUSABLE_VISUAL_MODE_DESATURATE then
+        return ST.UNUSABLE_VISUAL_MODE_DESATURATE
+    elseif source == ST.UNUSABLE_VISUAL_MODE_BOTH then
+        return ST.UNUSABLE_VISUAL_MODE_BOTH
+    elseif source == ST.UNUSABLE_VISUAL_MODE_NONE then
+        return ST.UNUSABLE_VISUAL_MODE_NONE
+    end
+    return ST.UNUSABLE_VISUAL_MODE_DIM
+end
+
+function ST.UnusableVisualUsesDimTint(source)
+    local mode = ST.GetUnusableVisualMode(source)
+    return mode == ST.UNUSABLE_VISUAL_MODE_DIM or mode == ST.UNUSABLE_VISUAL_MODE_BOTH
+end
+
+function ST.UnusableVisualUsesDesaturation(source)
+    local mode = ST.GetUnusableVisualMode(source)
+    return mode == ST.UNUSABLE_VISUAL_MODE_DESATURATE or mode == ST.UNUSABLE_VISUAL_MODE_BOTH
+end
+
+function ST.SetUnusableVisualMode(styleTable, useDimTint, useDesaturation)
+    if type(styleTable) ~= "table" then
+        return
+    end
+    if useDimTint and useDesaturation then
+        styleTable.unusableVisualMode = ST.UNUSABLE_VISUAL_MODE_BOTH
+    elseif useDimTint then
+        styleTable.unusableVisualMode = ST.UNUSABLE_VISUAL_MODE_DIM
+    elseif useDesaturation then
+        styleTable.unusableVisualMode = ST.UNUSABLE_VISUAL_MODE_DESATURATE
+    else
+        styleTable.unusableVisualMode = ST.UNUSABLE_VISUAL_MODE_NONE
+    end
+end
+
+--------------------------------------------------------------------------------
 -- Border Helpers
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## What Players Will Notice
- The Indicators setting is now `Show Unusable Visual`, with advanced controls for `Dim Icon` and `Desaturate Icon`.
- Players can keep the old dim-only behavior, switch to desaturation, use both effects together, or disable both visual effects while leaving the top-level setting available.
- Existing dim-only unusable visual settings and per-button overrides keep their old behavior after updating.

## Why This Changed
- Unusable icons previously had one dimming behavior. This adds a clearer choice for players who prefer desaturation, or want dimming and desaturation at the same time.
- Existing per-button Unusable Visual overrides needed an explicit saved mode so they would not accidentally inherit a later group-level mode change.

## What Changed
- Added shared Unusable Visual mode helpers for `dim`, `desaturate`, `both`, and `none`.
- Updated icon tint/desaturation resolution so unusable state can drive dimming, desaturation, or both while preserving out-of-range tint priority.
- Moved the Dim/Desaturate controls into the standard advanced settings panel for the Unusable Visual setting.
- Added override promotion and migration handling so legacy dim-only behavior is materialized as `dim` where needed.

## Validation
- `lua tests\unusable-visual-mode.lua` passed.
- `luac -p` passed on all repo Lua files.
- `git diff --check origin/main...HEAD` passed.
- Static review follow-up was addressed for override promotion and migration backfill.
- In-game combat/restricted-content validation has not been performed yet and is still needed before calling the feature complete.