### PR TITLE
Fix keybind text for form action bars

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -104,6 +104,7 @@ function CooldownCompanion:RefreshSpellAvailabilityState(opts)
         self:RefreshChargeFlags("spell")
     end
     self:RefreshAllGroupsForSpellAvailability()
+    self:RefreshKeybindState()
     self:RefreshConfigPanel()
 
     if opts.applyResourceBars then
@@ -426,9 +427,7 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
         end
         self:ApplyCdmAlpha()
         if isFullInit then
-            self:RebuildSlotMapping()
-            self:RebuildItemSlotCache()
-            self:OnKeybindsChanged()
+            self:RefreshKeybindState()
         end
         -- Delayed second pass: talent-dependent charge data (e.g. Hover,
         -- Keg Smash) may not be resolved when RefreshChargeFlags runs
@@ -499,8 +498,7 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
 end
 
 function CooldownCompanion:OnBindingsChanged()
-    self:RebuildAddonSlotBindings()
-    self:OnKeybindsChanged()
+    self:RefreshKeybindState()
 end
 
 function CooldownCompanion:OnActionBarSlotChanged(_, slot)
@@ -531,10 +529,7 @@ function CooldownCompanion:OnActionBarSlotChanged(_, slot)
 end
 
 function CooldownCompanion:OnActionBarLayoutChanged()
-    self:RebuildSlotMapping()
-    self:RebuildItemSlotCache()
-    self:RebuildAddonSlotBindings()
-    self:OnKeybindsChanged()
+    self:RefreshKeybindState()
     -- UPDATE_OVERRIDE_ACTIONBAR / UPDATE_VEHICLE_ACTIONBAR also route here for
     -- keybind rebuilds; piggyback vehicle UI state check to avoid duplicate
     -- AceEvent registrations (AceEvent allows only one handler per event).

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -498,7 +498,8 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
 end
 
 function CooldownCompanion:OnBindingsChanged()
-    self:RefreshKeybindState()
+    self:RebuildAddonSlotBindings()
+    self:OnKeybindsChanged()
 end
 
 function CooldownCompanion:OnActionBarSlotChanged(_, slot)

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -71,8 +71,15 @@ local function GetButtonIndexForSlot(slot)
     return ((slot - 1) % MAIN_ACTION_BUTTON_COUNT) + 1
 end
 
-local function GetBonusBarButtonInfo(slot)
-    if not C_ActionBar.GetBonusBarIndexForSlot(slot) then return nil, nil end
+local function IsActiveBonusBarSlot(slot)
+    local slotBonusBarIndex = C_ActionBar.GetBonusBarIndexForSlot(slot)
+    if not slotBonusBarIndex then return nil end
+
+    return C_ActionBar.HasBonusActionBar() and slotBonusBarIndex == C_ActionBar.GetBonusBarIndex()
+end
+
+local function GetActiveBonusBarButtonInfo(slot)
+    if not IsActiveBonusBarSlot(slot) then return nil, nil end
 
     local buttonIndex = GetButtonIndexForSlot(slot)
     if not buttonIndex then return nil, nil end
@@ -81,6 +88,8 @@ local function GetBonusBarButtonInfo(slot)
 end
 
 local function GetMappedSlotBindingInfo(slot)
+    if IsActiveBonusBarSlot(slot) == false then return nil end
+
     local info = slotToButtonInfo[slot]
     if info then
         return info.bindingAction, info.frameName
@@ -129,8 +138,15 @@ local function AbbreviateKeybind(text)
 end
 
 -- Return the formatted keybind string for a given action bar slot, or nil.
--- Prefer live Blizzard frame bindings, then addon bars, then inactive bonus bars.
+-- Prefer addon bars, then live Blizzard frame bindings, then active bonus bars.
 local function GetKeybindForSlot(slot)
+    if IsActiveBonusBarSlot(slot) == false then return nil end
+
+    local addonText = addonSlotBindings[slot]
+    if addonText then
+        return addonText
+    end
+
     local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
     if bindingAction then
         local key = GetBindingKey(bindingAction) or
@@ -140,12 +156,7 @@ local function GetKeybindForSlot(slot)
         end
     end
 
-    local addonText = addonSlotBindings[slot]
-    if addonText then
-        return addonText
-    end
-
-    bindingAction, frameName = GetBonusBarButtonInfo(slot)
+    bindingAction, frameName = GetActiveBonusBarButtonInfo(slot)
     if bindingAction then
         local key = GetBindingKey(bindingAction) or
                     GetBindingKey("CLICK " .. frameName .. ":LeftButton")
@@ -209,19 +220,22 @@ local function AddRawBindingKeys(keys, bindingAction, frameName)
 end
 
 -- Return an array of raw binding key strings for a slot (may be multiple per slot).
--- Prefer live Blizzard frame bindings, then addon bars, then inactive bonus bars.
+-- Prefer addon bars, then live Blizzard frame bindings, then active bonus bars.
 local function GetRawBindingKeysForSlot(slot)
     local keys = {}
+    if IsActiveBonusBarSlot(slot) == false then return keys end
 
-    local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
-    AddRawBindingKeys(keys, bindingAction, frameName)
-
-    if #keys == 0 and addonSlotRawBindings[slot] then
+    if addonSlotRawBindings[slot] then
         keys[#keys + 1] = addonSlotRawBindings[slot]
     end
 
     if #keys == 0 then
-        bindingAction, frameName = GetBonusBarButtonInfo(slot)
+        local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
+        AddRawBindingKeys(keys, bindingAction, frameName)
+    end
+
+    if #keys == 0 then
+        local bindingAction, frameName = GetActiveBonusBarButtonInfo(slot)
         AddRawBindingKeys(keys, bindingAction, frameName)
     end
 

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -80,13 +80,11 @@ local function GetBonusBarButtonInfo(slot)
     return "ACTIONBUTTON" .. buttonIndex, "ActionButton" .. buttonIndex
 end
 
-local function GetSlotBindingInfo(slot)
+local function GetMappedSlotBindingInfo(slot)
     local info = slotToButtonInfo[slot]
     if info then
         return info.bindingAction, info.frameName
     end
-
-    return GetBonusBarButtonInfo(slot)
 end
 
 -- Map verbose localized keybind names to short abbreviations.
@@ -131,9 +129,9 @@ local function AbbreviateKeybind(text)
 end
 
 -- Return the formatted keybind string for a given action bar slot, or nil.
--- Tries Blizzard binding names and CLICK fallback first, then addon bar bindings.
+-- Prefer live Blizzard frame bindings, then addon bars, then inactive bonus bars.
 local function GetKeybindForSlot(slot)
-    local bindingAction, frameName = GetSlotBindingInfo(slot)
+    local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
     if bindingAction then
         local key = GetBindingKey(bindingAction) or
                     GetBindingKey("CLICK " .. frameName .. ":LeftButton")
@@ -141,8 +139,22 @@ local function GetKeybindForSlot(slot)
             return AbbreviateKeybind(GetBindingText(key, 1))
         end
     end
-    -- Fallback: addon bar bindings (e.g. Bartender4, Dominos, ElvUI)
-    return addonSlotBindings[slot]
+
+    local addonText = addonSlotBindings[slot]
+    if addonText then
+        return addonText
+    end
+
+    bindingAction, frameName = GetBonusBarButtonInfo(slot)
+    if bindingAction then
+        local key = GetBindingKey(bindingAction) or
+                    GetBindingKey("CLICK " .. frameName .. ":LeftButton")
+        if key then
+            return AbbreviateKeybind(GetBindingText(key, 1))
+        end
+    end
+
+    return nil
 end
 
 ------------------------------------------------------------------------
@@ -185,23 +197,34 @@ local function IsBindingKeyPressed(info)
     return true
 end
 
+local function AddRawBindingKeys(keys, bindingAction, frameName)
+    if not bindingAction then return end
+
+    local key1, key2 = GetBindingKey(bindingAction)
+    if not key1 then
+        key1, key2 = GetBindingKey("CLICK " .. frameName .. ":LeftButton")
+    end
+    if key1 then keys[#keys + 1] = key1 end
+    if key2 then keys[#keys + 1] = key2 end
+end
+
 -- Return an array of raw binding key strings for a slot (may be multiple per slot).
--- Falls back to addon bar raw key cache for third-party bar addons.
+-- Prefer live Blizzard frame bindings, then addon bars, then inactive bonus bars.
 local function GetRawBindingKeysForSlot(slot)
     local keys = {}
-    local bindingAction, frameName = GetSlotBindingInfo(slot)
-    if bindingAction then
-        local key1, key2 = GetBindingKey(bindingAction)
-        if not key1 then
-            key1, key2 = GetBindingKey("CLICK " .. frameName .. ":LeftButton")
-        end
-        if key1 then keys[#keys + 1] = key1 end
-        if key2 then keys[#keys + 1] = key2 end
-    end
-    -- Fallback: addon bar raw bindings
+
+    local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
+    AddRawBindingKeys(keys, bindingAction, frameName)
+
     if #keys == 0 and addonSlotRawBindings[slot] then
         keys[#keys + 1] = addonSlotRawBindings[slot]
     end
+
+    if #keys == 0 then
+        bindingAction, frameName = GetBonusBarButtonInfo(slot)
+        AddRawBindingKeys(keys, bindingAction, frameName)
+    end
+
     return keys
 end
 

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -15,6 +15,9 @@ local wipe = wipe
 ------------------------------------------------------------------------
 
 local MAIN_ACTION_BUTTON_COUNT = 12
+local BONUS_BAR_SLOT_NONE = 0
+local BONUS_BAR_SLOT_ACTIVE = 1
+local BONUS_BAR_SLOT_INACTIVE = 2
 
 -- Known action bar button frames: {framePrefix, bindingPrefix, count}
 -- Frame names come from Blizzard_ActionBar/Shared/ActionBar.lua:
@@ -71,15 +74,22 @@ local function GetButtonIndexForSlot(slot)
     return ((slot - 1) % MAIN_ACTION_BUTTON_COUNT) + 1
 end
 
-local function IsActiveBonusBarSlot(slot)
+local function GetBonusBarSlotState(slot)
     local slotBonusBarIndex = C_ActionBar.GetBonusBarIndexForSlot(slot)
-    if not slotBonusBarIndex then return nil end
+    if not slotBonusBarIndex then return BONUS_BAR_SLOT_NONE end
 
-    return C_ActionBar.HasBonusActionBar() and slotBonusBarIndex == C_ActionBar.GetBonusBarIndex()
+    if C_ActionBar.HasBonusActionBar() and slotBonusBarIndex == C_ActionBar.GetBonusBarIndex() then
+        return BONUS_BAR_SLOT_ACTIVE
+    end
+
+    return BONUS_BAR_SLOT_INACTIVE
 end
 
-local function GetActiveBonusBarButtonInfo(slot)
-    if not IsActiveBonusBarSlot(slot) then return nil, nil end
+local function GetActiveBonusBarButtonInfo(slot, bonusBarSlotState)
+    if bonusBarSlotState == nil then
+        bonusBarSlotState = GetBonusBarSlotState(slot)
+    end
+    if bonusBarSlotState ~= BONUS_BAR_SLOT_ACTIVE then return nil, nil end
 
     local buttonIndex = GetButtonIndexForSlot(slot)
     if not buttonIndex then return nil, nil end
@@ -88,8 +98,6 @@ local function GetActiveBonusBarButtonInfo(slot)
 end
 
 local function GetMappedSlotBindingInfo(slot)
-    if IsActiveBonusBarSlot(slot) == false then return nil end
-
     local info = slotToButtonInfo[slot]
     if info then
         return info.bindingAction, info.frameName
@@ -137,32 +145,37 @@ local function AbbreviateKeybind(text)
     return text
 end
 
+local function GetDisplayTextForBinding(bindingAction, frameName)
+    if not bindingAction then return nil end
+
+    local key = GetBindingKey(bindingAction) or
+                GetBindingKey("CLICK " .. frameName .. ":LeftButton")
+    if key then
+        return AbbreviateKeybind(GetBindingText(key, 1))
+    end
+end
+
 -- Return the formatted keybind string for a given action bar slot, or nil.
 -- Prefer addon bars, then live Blizzard frame bindings, then active bonus bars.
 local function GetKeybindForSlot(slot)
-    if IsActiveBonusBarSlot(slot) == false then return nil end
-
     local addonText = addonSlotBindings[slot]
     if addonText then
         return addonText
     end
 
+    local bonusBarSlotState = GetBonusBarSlotState(slot)
+    if bonusBarSlotState == BONUS_BAR_SLOT_INACTIVE then return nil end
+
     local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
     if bindingAction then
-        local key = GetBindingKey(bindingAction) or
-                    GetBindingKey("CLICK " .. frameName .. ":LeftButton")
-        if key then
-            return AbbreviateKeybind(GetBindingText(key, 1))
-        end
+        local text = GetDisplayTextForBinding(bindingAction, frameName)
+        if text then return text end
     end
 
-    bindingAction, frameName = GetActiveBonusBarButtonInfo(slot)
+    bindingAction, frameName = GetActiveBonusBarButtonInfo(slot, bonusBarSlotState)
     if bindingAction then
-        local key = GetBindingKey(bindingAction) or
-                    GetBindingKey("CLICK " .. frameName .. ":LeftButton")
-        if key then
-            return AbbreviateKeybind(GetBindingText(key, 1))
-        end
+        local text = GetDisplayTextForBinding(bindingAction, frameName)
+        if text then return text end
     end
 
     return nil
@@ -223,11 +236,13 @@ end
 -- Prefer addon bars, then live Blizzard frame bindings, then active bonus bars.
 local function GetRawBindingKeysForSlot(slot)
     local keys = {}
-    if IsActiveBonusBarSlot(slot) == false then return keys end
 
     if addonSlotRawBindings[slot] then
         keys[#keys + 1] = addonSlotRawBindings[slot]
     end
+
+    local bonusBarSlotState = GetBonusBarSlotState(slot)
+    if bonusBarSlotState == BONUS_BAR_SLOT_INACTIVE then return keys end
 
     if #keys == 0 then
         local bindingAction, frameName = GetMappedSlotBindingInfo(slot)
@@ -235,7 +250,7 @@ local function GetRawBindingKeysForSlot(slot)
     end
 
     if #keys == 0 then
-        local bindingAction, frameName = GetActiveBonusBarButtonInfo(slot)
+        local bindingAction, frameName = GetActiveBonusBarButtonInfo(slot, bonusBarSlotState)
         AddRawBindingKeys(keys, bindingAction, frameName)
     end
 
@@ -264,7 +279,7 @@ local function GetSpellActionSlots(spellID)
 
     AddSpellActionSlots(slots, seenSlots, spellID)
 
-    local baseSpellID = C_Spell.GetBaseSpell(spellID)
+    local baseSpellID = ST.ResolveToBaseSpell(spellID)
     if baseSpellID and baseSpellID ~= spellID then
         AddSpellActionSlots(slots, seenSlots, baseSpellID)
     end

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -7,11 +7,14 @@ local CooldownCompanion = ST.Addon
 
 local ipairs = ipairs
 local pairs = pairs
+local type = type
 local wipe = wipe
 
 ------------------------------------------------------------------------
 -- KEYBIND TEXT SUPPORT
 ------------------------------------------------------------------------
+
+local MAIN_ACTION_BUTTON_COUNT = 12
 
 -- Known action bar button frames: {framePrefix, bindingPrefix, count}
 -- Frame names come from Blizzard_ActionBar/Shared/ActionBar.lua:
@@ -63,6 +66,29 @@ function CooldownCompanion:RebuildSlotMapping()
     end
 end
 
+local function GetButtonIndexForSlot(slot)
+    if type(slot) ~= "number" or slot < 1 then return nil end
+    return ((slot - 1) % MAIN_ACTION_BUTTON_COUNT) + 1
+end
+
+local function GetBonusBarButtonInfo(slot)
+    if not C_ActionBar.GetBonusBarIndexForSlot(slot) then return nil, nil end
+
+    local buttonIndex = GetButtonIndexForSlot(slot)
+    if not buttonIndex then return nil, nil end
+
+    return "ACTIONBUTTON" .. buttonIndex, "ActionButton" .. buttonIndex
+end
+
+local function GetSlotBindingInfo(slot)
+    local info = slotToButtonInfo[slot]
+    if info then
+        return info.bindingAction, info.frameName
+    end
+
+    return GetBonusBarButtonInfo(slot)
+end
+
 -- Map verbose localized keybind names to short abbreviations.
 -- Built from KEY_ GlobalStrings so it works on any WoW locale.
 local keybindMap = {}
@@ -107,10 +133,10 @@ end
 -- Return the formatted keybind string for a given action bar slot, or nil.
 -- Tries Blizzard binding names and CLICK fallback first, then addon bar bindings.
 local function GetKeybindForSlot(slot)
-    local info = slotToButtonInfo[slot]
-    if info then
-        local key = GetBindingKey(info.bindingAction) or
-                    GetBindingKey("CLICK " .. info.frameName .. ":LeftButton")
+    local bindingAction, frameName = GetSlotBindingInfo(slot)
+    if bindingAction then
+        local key = GetBindingKey(bindingAction) or
+                    GetBindingKey("CLICK " .. frameName .. ":LeftButton")
         if key then
             return AbbreviateKeybind(GetBindingText(key, 1))
         end
@@ -163,11 +189,11 @@ end
 -- Falls back to addon bar raw key cache for third-party bar addons.
 local function GetRawBindingKeysForSlot(slot)
     local keys = {}
-    local info = slotToButtonInfo[slot]
-    if info then
-        local key1, key2 = GetBindingKey(info.bindingAction)
+    local bindingAction, frameName = GetSlotBindingInfo(slot)
+    if bindingAction then
+        local key1, key2 = GetBindingKey(bindingAction)
         if not key1 then
-            key1, key2 = GetBindingKey("CLICK " .. info.frameName .. ":LeftButton")
+            key1, key2 = GetBindingKey("CLICK " .. frameName .. ":LeftButton")
         end
         if key1 then keys[#keys + 1] = key1 end
         if key2 then keys[#keys + 1] = key2 end
@@ -177,6 +203,36 @@ local function GetRawBindingKeysForSlot(slot)
         keys[#keys + 1] = addonSlotRawBindings[slot]
     end
     return keys
+end
+
+local function AddSpellActionSlots(slots, seenSlots, spellID)
+    if not spellID then return end
+
+    local foundSlots = C_ActionBar.FindSpellActionButtons(spellID)
+    if not foundSlots then return end
+
+    for _, slot in ipairs(foundSlots) do
+        if type(slot) == "number" and not seenSlots[slot] then
+            seenSlots[slot] = true
+            slots[#slots + 1] = slot
+        end
+    end
+end
+
+local function GetSpellActionSlots(spellID)
+    if not spellID then return nil end
+
+    local slots = {}
+    local seenSlots = {}
+
+    AddSpellActionSlots(slots, seenSlots, spellID)
+
+    local baseSpellID = C_Spell.GetBaseSpell(spellID)
+    if baseSpellID and baseSpellID ~= spellID then
+        AddSpellActionSlots(slots, seenSlots, baseSpellID)
+    end
+
+    return #slots > 0 and slots or nil
 end
 
 -- Resolve and cache parsed binding key info for a CC button.
@@ -189,7 +245,7 @@ local function CacheButtonBindingKeys(button, buttonData)
     end
     local slots
     if buttonData.type == "spell" then
-        slots = C_ActionBar.FindSpellActionButtons(buttonData.id)
+        slots = GetSpellActionSlots(buttonData.id)
     elseif buttonData.type == "item" then
         local itemID = button._resolvedItemId or buttonData.id
         local slot = CooldownCompanion._itemSlotCache[itemID]
@@ -313,7 +369,7 @@ function CooldownCompanion:GetKeybindText(buttonData, itemIDOverride)
     if not buttonData then return nil end
 
     if buttonData.type == "spell" then
-        local slots = C_ActionBar.FindSpellActionButtons(buttonData.id)
+        local slots = GetSpellActionSlots(buttonData.id)
         if slots then
             for _, slot in ipairs(slots) do
                 local text = GetKeybindForSlot(slot)
@@ -344,6 +400,13 @@ function CooldownCompanion:GetDisplayedKeybindText(buttonData, itemIDOverride)
     end
 
     return self:GetKeybindText(buttonData, itemIDOverride)
+end
+
+function CooldownCompanion:RefreshKeybindState()
+    self:RebuildSlotMapping()
+    self:RebuildItemSlotCache()
+    self:RebuildAddonSlotBindings()
+    self:OnKeybindsChanged()
 end
 
 -- Refresh keybind text and binding key caches on all buttons.


### PR DESCRIPTION
## What Players Will Notice
- Keybind text should now stay accurate for abilities on form-replacement action bars, such as Druid Bear Form replacing Action Bar 1.
- Bear/Form abilities should no longer require logging in or reloading while already in that form for their keybind text to appear.
- Players using action bar addons should keep their addon-provided keybinds instead of having them shadowed by the stock action bar fallback.

## Why This Changed
- Cooldown Companion was using the currently active Blizzard action button frames to connect a spell's action slot to its keybind.
- Form bars can live on inactive bonus action pages, so CC could find the spell slot but fail to connect it back to the `1`, `2`, `3`, etc. binding unless that form page was active during load.

## What Changed
- Added keybind resolution for inactive bonus action-bar slots, mapping those slots back to the main action button positions they replace.
- Keybind lookup now checks both the saved spell ID and its base spell ID so overridden/spec-dependent spell identities can still find their action slots.
- Keybind refreshes now run through one shared refresh path after binding, action-bar layout, form, and specialization-related updates.
- Preserved addon-bar precedence so Bartender/Dominos/ElvUI-style bindings win before the new stock bonus-bar fallback is used.

## Validation
- `lua tests\keybind-bonus-bar-slot-resolution.lua`
- `luac -p Core\Keybinds.lua Core\EventHandlers.lua tests\keybind-bonus-bar-slot-resolution.lua`
- `git diff --check origin/main...HEAD`
- Basic in-game retest was reported as good.
- Still needs final in-game confirmation for form/spec transitions in combat and restricted content before treating the behavior as fully verified.