### PR TITLE
Fix chained panel anchoring and inherited alpha on login

### DIFF
--- a/Config/Panel.lua
+++ b/Config/Panel.lua
@@ -2354,6 +2354,9 @@ function CooldownCompanion:RefreshConfigPanel()
     if not CS.configFrame.frame:IsShown() then return end
     if CS.talentPickerMode then return end
     if CS.configRefreshInProgress or CS.advancedSettingsPanelRefreshing then return end
+    if self.RefreshConfigSelectedGroupFrames then
+        self:RefreshConfigSelectedGroupFrames()
+    end
     CS.configRefreshInProgress = true
     if IsConfigFinderAvailable and not IsConfigFinderAvailable() and ClearConfigFinderText then
         ClearConfigFinderText()

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -35,11 +35,19 @@ local function GetAddonAnchorGroupId(frameName)
     return kind == "group" and id or nil
 end
 
+local function GetPanelAlphaAnchorRelativeTo(group)
+    if CooldownCompanion.GetActivePanelAnchorRelativeTo then
+        return CooldownCompanion:GetActivePanelAnchorRelativeTo(group)
+    end
+
+    local anchor = group and group.anchor
+    return type(anchor) == "table" and anchor.relativeTo or nil
+end
+
 local function CollectPanelAlphaAnchorTargets(groups)
     local targets = nil
     for _, group in pairs(groups or {}) do
-        local anchor = group and group.anchor
-        local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
+        local relativeTo = GetPanelAlphaAnchorRelativeTo(group)
         local targetGroupId = GetAddonAnchorGroupId(relativeTo)
         if group
             and group.parentContainerId

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -26,19 +26,31 @@ local function FrameAlphaDiffers(frame, alpha)
     return frame:GetAlpha() ~= alpha
 end
 
-local function GroupProvidesInheritedPanelAlpha(groups, groupId)
-    local targetName = "CooldownCompanionGroup" .. tostring(groupId)
+local function GetAddonAnchorGroupId(frameName)
+    if not CooldownCompanion.ParseAddonAnchorFrameName then
+        return nil
+    end
+
+    local kind, id = CooldownCompanion:ParseAddonAnchorFrameName(frameName)
+    return kind == "group" and id or nil
+end
+
+local function CollectPanelAlphaAnchorTargets(groups)
+    local targets = nil
     for _, group in pairs(groups or {}) do
         local anchor = group and group.anchor
+        local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
+        local targetGroupId = GetAddonAnchorGroupId(relativeTo)
         if group
             and group.parentContainerId
             and group.inheritPanelAlpha ~= false
-            and type(anchor) == "table"
-            and anchor.relativeTo == targetName then
-            return true
+            and targetGroupId then
+            targets = targets or {}
+            targets[targetGroupId] = true
+            targets[tostring(targetGroupId)] = true
         end
     end
-    return false
+    return targets
 end
 
 -- Alpha fade system: per-group runtime state
@@ -456,10 +468,11 @@ function CooldownCompanion:InitAlphaUpdateFrame()
 
         local containers = self.db.profile.groupContainers or {}
         local groups = self.db.profile.groups or {}
+        local panelAlphaAnchorTargets = CollectPanelAlphaAnchorTargets(groups)
         for groupId, group in pairs(groups) do
             local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
             if frame
-                and (frame:IsShown() or GroupProvidesInheritedPanelAlpha(groups, groupId)) then
+                and (frame:IsShown() or (panelAlphaAnchorTargets and panelAlphaAnchorTargets[groupId])) then
                 if GroupNeedsAlphaUpdate(group, groupId) then
                     local locked = true
                     if group.parentContainerId then

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -19,6 +19,28 @@ local issecretvalue = issecretvalue
 
 local SOAR_SPELL_ID = 430747
 
+local function FrameAlphaDiffers(frame, alpha)
+    if not (frame and frame.GetAlpha) then
+        return false
+    end
+    return frame:GetAlpha() ~= alpha
+end
+
+local function GroupProvidesInheritedPanelAlpha(groups, groupId)
+    local targetName = "CooldownCompanionGroup" .. tostring(groupId)
+    for _, group in pairs(groups or {}) do
+        local anchor = group and group.anchor
+        if group
+            and group.parentContainerId
+            and group.inheritPanelAlpha ~= false
+            and type(anchor) == "table"
+            and anchor.relativeTo == targetName then
+            return true
+        end
+    end
+    return false
+end
+
 -- Alpha fade system: per-group runtime state
 -- self.alphaState[groupId] = {
 --     currentAlpha   - current interpolated alpha
@@ -233,7 +255,7 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
     -- Force 100% alpha while group is unlocked for easier positioning
     if not locked then
         frame._naturalAlpha = nil
-        if state.currentAlpha ~= 1 or state.lastAlpha ~= 1 then
+        if state.currentAlpha ~= 1 or state.lastAlpha ~= 1 or FrameAlphaDiffers(frame, 1) then
             frame:SetAlpha(1)
             state.currentAlpha = 1
             state.desiredAlpha = 1
@@ -254,7 +276,7 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
         else
             frame._naturalAlpha = nil
         end
-        if state.currentAlpha and state.currentAlpha ~= 1 then
+        if (state.currentAlpha and state.currentAlpha ~= 1) or FrameAlphaDiffers(frame, 1) then
             frame:SetAlpha(1)
             state.currentAlpha = 1
             state.desiredAlpha = 1
@@ -286,7 +308,7 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
     -- then force the frame itself to full alpha for config visibility.
     if configSelected then
         frame._naturalAlpha = desired
-        if state.lastAlpha ~= 1 then
+        if state.lastAlpha ~= 1 or FrameAlphaDiffers(frame, 1) then
             frame:SetAlpha(1)
             state.currentAlpha = 1
             state.desiredAlpha = 1
@@ -301,7 +323,7 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
     local fadeOut = group.fadeOutDuration or 0.2
     local alpha = UpdateFadedAlpha(state, desired, now, fadeIn, fadeOut)
 
-    if state.lastAlpha ~= alpha then
+    if state.lastAlpha ~= alpha or FrameAlphaDiffers(frame, alpha) then
         frame:SetAlpha(alpha)
         state.lastAlpha = alpha
     end
@@ -433,9 +455,11 @@ function CooldownCompanion:InitAlphaUpdateFrame()
         end
 
         local containers = self.db.profile.groupContainers or {}
-        for groupId, group in pairs(self.db.profile.groups) do
-            local frame = self.groupFrames[groupId]
-            if frame and frame:IsShown() then
+        local groups = self.db.profile.groups or {}
+        for groupId, group in pairs(groups) do
+            local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
+            if frame
+                and (frame:IsShown() or GroupProvidesInheritedPanelAlpha(groups, groupId)) then
                 if GroupNeedsAlphaUpdate(group, groupId) then
                     local locked = true
                     if group.parentContainerId then

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -443,6 +443,10 @@ function CooldownCompanion:GetStandaloneTextureAnchorSettings(groupOrId)
     return GetStandaloneTextureAnchorSettings(GetGroup(self, groupOrId))
 end
 
+function CooldownCompanion:GetActivePanelAnchorRelativeTo(groupOrId)
+    return GetActivePanelAnchorRelativeTo(GetGroup(self, groupOrId))
+end
+
 function CooldownCompanion:IsPanelAnchoredToPanel(groupOrId)
     local group = GetGroup(self, groupOrId)
     if not (group and group.parentContainerId) then

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1793,8 +1793,11 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     -- Create new buttons (skip untalented spells)
     local xMul, yMul, growthAnchor = GetGrowthMultipliers(style.growthOrigin)
     local visibleIndex = 0
+    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
+        and self:GetGroupButtonUsabilityOptions(groupId, group)
+        or nil
     for i, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group) then
+        if self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
             visibleIndex = visibleIndex + 1
             local effectiveStyle = self:GetEffectiveStyle(style, buttonData)
             local button
@@ -1839,6 +1842,7 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     -- Resize the frame to fit visible buttons
     frame.visibleButtonCount = isTriggerMode and (visibleIndex > 0 and 1 or 0) or visibleIndex
+    frame.layoutButtonCount = self.GetGroupLayoutButtonCount and self:GetGroupLayoutButtonCount(groupId, group) or nil
     frame._layoutDirty = false
     frame._lastVisibleCount = visibleIndex
     self:ResizeGroupFrame(groupId)
@@ -1897,6 +1901,9 @@ function CooldownCompanion:ResizeGroupFrame(groupId)
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")
     local buttonsPerRow = style.buttonsPerRow or 12
     local numButtons = frame.visibleButtonCount or #group.buttons
+    if group.parentContainerId and not group.compactLayout and frame.layoutButtonCount then
+        numButtons = math_max(numButtons, frame.layoutButtonCount)
+    end
 
     local targetWidth, targetHeight
     local oldWidth, oldHeight = frame:GetSize()

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -82,13 +82,20 @@ local function GetContainerState(groupId)
 end
 
 local function ShouldSyncAnchorAlpha(self, groupId)
-    if self.IsPanelAnchoredToPanel
-        and self:IsPanelAnchoredToPanel(groupId) then
-        if self.ShouldInheritPanelAnchorAlpha then
-            return self:ShouldInheritPanelAnchorAlpha(groupId)
+    local profile = self.db and self.db.profile
+    local group = profile and profile.groups and profile.groups[groupId]
+
+    if group and group.parentContainerId then
+        if self.IsPanelAnchoredToPanel
+            and self:IsPanelAnchoredToPanel(groupId) then
+            if self.ShouldInheritPanelAnchorAlpha then
+                return self:ShouldInheritPanelAnchorAlpha(groupId)
+            end
+            return true
         end
-        return true
+        return false
     end
+
     return true
 end
 
@@ -110,6 +117,36 @@ local function ApplyGroupOwnAlpha(frame)
 
     frame._naturalAlpha = nil
     frame:SetAlpha(alpha)
+end
+
+local function GetAnchorInheritedAlpha(parentFrame)
+    if not parentFrame then
+        return 1
+    end
+
+    if parentFrame._naturalAlpha ~= nil then
+        return parentFrame._naturalAlpha
+    end
+
+    local parentGroupId = parentFrame.groupId
+    if parentGroupId and CooldownCompanion.alphaState then
+        local state = CooldownCompanion.alphaState[parentGroupId]
+        if state and state.currentAlpha ~= nil then
+            return state.currentAlpha
+        end
+    end
+
+    if parentFrame.IsShown and not parentFrame:IsShown() then
+        return 0
+    end
+
+    if parentFrame.GetEffectiveAlpha then
+        return parentFrame:GetEffectiveAlpha()
+    end
+    if parentFrame.GetAlpha then
+        return parentFrame:GetAlpha()
+    end
+    return 1
 end
 
 local function GetContainerPreviewSelectionState(groupId)
@@ -1574,7 +1611,7 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
     end
 
     -- Sync alpha immediately — use parent's natural alpha to avoid config override cascade
-    local lastAlpha = parentFrame._naturalAlpha or parentFrame:GetEffectiveAlpha()
+    local lastAlpha = GetAnchorInheritedAlpha(parentFrame)
     frame:SetAlpha(lastAlpha)
 
     -- Sync alpha at ~30Hz (smooth enough for fade animations, avoids per-frame overhead)
@@ -1589,7 +1626,7 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
             local locked, bAlpha = GetContainerState(frame.groupId)
             if (bAlpha < 1 and not inheritsPanelAlpha) or not locked then return end
             -- Read parent's natural alpha to avoid config override cascade
-            local alpha = frame.anchoredToParent._naturalAlpha or frame.anchoredToParent:GetEffectiveAlpha()
+            local alpha = GetAnchorInheritedAlpha(frame.anchoredToParent)
             -- Config-selected: store natural alpha for further downstream chains, force own frame to full
             if ST.IsGroupConfigSelected(frame.groupId) then
                 frame._naturalAlpha = alpha

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -149,6 +149,16 @@ local function GetAnchorInheritedAlpha(parentFrame)
     return 1
 end
 
+local function GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
+    if buttonUsabilityOptions then
+        return buttonUsabilityOptions
+    end
+    if self.GetGroupLayoutButtonUsabilityOptions then
+        return self:GetGroupLayoutButtonUsabilityOptions(groupId, group)
+    end
+    return nil
+end
+
 local function GetContainerPreviewSelectionState(groupId)
     local profile = CooldownCompanion.db and CooldownCompanion.db.profile
     local group = profile and profile.groups and profile.groups[groupId]
@@ -1723,7 +1733,7 @@ end
 
 -- Compute button width/height from group style (bar mode vs square vs non-square).
 -- Returns width, height, isBarMode.
-local function GetButtonDimensions(group)
+local function GetButtonDimensions(group, buttonUsabilityOptions)
     local style = group.style or {}
     local isBarMode = group.displayMode == "bars"
     local isTextMode = group.displayMode == "text"
@@ -1736,7 +1746,7 @@ local function GetButtonDimensions(group)
         if GetEffectiveTextHeight then
             local maxHeight = GetEffectiveTextHeight(style, style.textFormat or "{name}  {status}")
             for _, buttonData in ipairs(group.buttons or {}) do
-                if CooldownCompanion:IsButtonUsable(buttonData, group) then
+                if CooldownCompanion:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
                     local effectiveStyle = CooldownCompanion:GetEffectiveStyle(style, buttonData)
                     local fmt = buttonData.textFormat or effectiveStyle.textFormat or "{name}  {status}"
                     local buttonHeight = GetEffectiveTextHeight(effectiveStyle, fmt)
@@ -1767,7 +1777,11 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     if not frame or not group then return end
 
-    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group)
+    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
+        and self:GetGroupButtonUsabilityOptions(groupId, group)
+        or nil
+    local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
+    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions)
     local style = group.style or {}
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")
@@ -1830,9 +1844,6 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     -- Create new buttons (skip untalented spells)
     local xMul, yMul, growthAnchor = GetGrowthMultipliers(style.growthOrigin)
     local visibleIndex = 0
-    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
-        and self:GetGroupButtonUsabilityOptions(groupId, group)
-        or nil
     for i, buttonData in ipairs(group.buttons) do
         if self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
             visibleIndex = visibleIndex + 1
@@ -1936,7 +1947,11 @@ function CooldownCompanion:ResizeGroupFrame(groupId)
 
     if not frame or not group then return end
 
-    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group)
+    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
+        and self:GetGroupButtonUsabilityOptions(groupId, group)
+        or nil
+    local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
+    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions)
     local style = group.style or {}
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")
@@ -2018,7 +2033,11 @@ function CooldownCompanion:UpdateGroupLayout(groupId)
         return
     end
 
-    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group)
+    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
+        and self:GetGroupButtonUsabilityOptions(groupId, group)
+        or nil
+    local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
+    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions)
     local style = group.style or {}
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1879,7 +1879,11 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     -- Resize the frame to fit visible buttons
     frame.visibleButtonCount = isTriggerMode and (visibleIndex > 0 and 1 or 0) or visibleIndex
-    frame.layoutButtonCount = self.GetGroupLayoutButtonCount and self:GetGroupLayoutButtonCount(groupId, group) or nil
+    if group.parentContainerId and not group.compactLayout and self.GetGroupLayoutButtonCount then
+        frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+    else
+        frame.layoutButtonCount = nil
+    end
     frame._layoutDirty = false
     frame._lastVisibleCount = visibleIndex
     self:ResizeGroupFrame(groupId)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1847,16 +1847,42 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
     end
 
     self._refreshingConfigSelectedGroupFrames = true
-    local refreshed = false
-    for groupId, group in pairs(self.db.profile.groups) do
+    local groups = self.db.profile.groups
+    local previousPreviewed = self._configPreviewedGroupFrames
+    local currentPreviewed = nil
+    local candidates = {}
+
+    for groupId in pairs(groups) do
         if ST.IsGroupConfigSelected(groupId) then
+            currentPreviewed = currentPreviewed or {}
+            currentPreviewed[groupId] = true
+            candidates[groupId] = true
+        end
+    end
+    if previousPreviewed then
+        for groupId in pairs(previousPreviewed) do
+            candidates[groupId] = true
+        end
+    end
+    self._configPreviewedGroupFrames = currentPreviewed
+
+    local refreshed = false
+    for groupId in pairs(candidates) do
+        local group = groups[groupId]
+        if group then
+            local frame = self.groupFrames and self.groupFrames[groupId]
+            local wasPreviewed = previousPreviewed and previousPreviewed[groupId]
+            local isPreviewed = currentPreviewed and currentPreviewed[groupId]
             local active = self:IsGroupActive(groupId, {
                 group = group,
                 checkCharVisibility = true,
                 checkLoadConditions = true,
                 requireButtons = true,
             })
-            if active and (not self.groupFrames[groupId] or self:GroupButtonSetNeedsRebuild(groupId, group)) then
+            if (active or (wasPreviewed and frame))
+                and (not frame
+                    or (wasPreviewed and not isPreviewed)
+                    or self:GroupButtonSetNeedsRebuild(groupId, group)) then
                 self:RefreshGroupFrame(groupId)
                 refreshed = true
             end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -62,6 +62,50 @@ local function GetAddonAnchorGroupId(frameName)
     return kind == "group" and id or nil
 end
 
+local function IsAddonFrameAnchorTarget(frameName)
+    if not CooldownCompanion.ParseAddonAnchorFrameName then
+        return false
+    end
+
+    local kind = CooldownCompanion:ParseAddonAnchorFrameName(frameName)
+    return kind == "group" or kind == "container"
+end
+
+local function GetFrameName(frame)
+    if not frame then
+        return nil
+    end
+    if frame.GetName then
+        return frame:GetName()
+    end
+    if frame.groupId then
+        return "CooldownCompanionGroup" .. frame.groupId
+    end
+    return frame.name
+end
+
+local function GetCurrentAnchorTargetName(frame)
+    if not frame then
+        return nil
+    end
+    if frame.anchoredToParent then
+        return GetFrameName(frame.anchoredToParent)
+    end
+    if frame.GetPoint then
+        local _, relativeFrame = frame:GetPoint(1)
+        return GetFrameName(relativeFrame)
+    end
+    return frame.relativeTo
+end
+
+local function IsFrameAnchoredToSavedTarget(frame, anchor)
+    local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
+    if not relativeTo or relativeTo == "UIParent" then
+        return true
+    end
+    return GetCurrentAnchorTargetName(frame) == relativeTo
+end
+
 local function GetPanelAnchorDepth(groups, groupId, visiting)
     visiting = visiting or {}
     if visiting[groupId] then
@@ -1058,15 +1102,21 @@ function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
     return nil
 end
 
+function CooldownCompanion:GetGroupLayoutButtonUsabilityOptions(groupId, group)
+    if group and group.parentContainerId and not group.compactLayout then
+        return IGNORE_SPELL_AVAILABILITY_OPTIONS
+    end
+    return nil
+end
+
 function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)
     if not (group and group.buttons and #group.buttons > 0) then
         return 0
     end
 
-    local opts = nil
-    if group.parentContainerId and not group.compactLayout then
-        opts = IGNORE_SPELL_AVAILABILITY_OPTIONS
-    end
+    local opts = self.GetGroupLayoutButtonUsabilityOptions
+        and self:GetGroupLayoutButtonUsabilityOptions(groupId, group)
+        or nil
 
     local count = 0
     for _, buttonData in ipairs(group.buttons) do
@@ -1832,6 +1882,7 @@ function CooldownCompanion:CreateAllGroupFrames()
         end
     end
     self:FinalizePanelAnchors()
+    self:FinalizeNonPanelGroupAnchors()
 end
 
 function CooldownCompanion:RefreshConfigSelectedGroupFrames()
@@ -1933,7 +1984,28 @@ function CooldownCompanion:FinalizePanelAnchors()
     end)
 
     for _, panel in ipairs(panels) do
-        self:AnchorGroupFrame(panel.frame, panel.group.anchor)
+        if not (panel.group.compactLayout and IsFrameAnchoredToSavedTarget(panel.frame, panel.group.anchor)) then
+            self:AnchorGroupFrame(panel.frame, panel.group.anchor)
+        end
+    end
+end
+
+function CooldownCompanion:FinalizeNonPanelGroupAnchors()
+    local groups = self.db and self.db.profile and self.db.profile.groups
+    if not (groups and self.groupFrames) then
+        return
+    end
+
+    for groupId, group in pairs(groups) do
+        local anchor = group and group.anchor
+        local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
+        local frame = self.groupFrames[groupId]
+        if frame
+            and group
+            and not group.parentContainerId
+            and IsAddonFrameAnchorTarget(relativeTo) then
+            self:AnchorGroupFrame(frame, anchor)
+        end
     end
 end
 

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -49,13 +49,18 @@ local LOCAL_LOAD_CONDITION_DEFAULTS = {
     vehicleUI = false,
 }
 
-local CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS = {
+local IGNORE_SPELL_AVAILABILITY_OPTIONS = {
     ignoreSpellAvailability = true,
 }
 
-local PANEL_LAYOUT_BUTTON_USABILITY_OPTIONS = {
-    ignoreSpellAvailability = true,
-}
+local function GetAddonAnchorGroupId(frameName)
+    if not CooldownCompanion.ParseAddonAnchorFrameName then
+        return nil
+    end
+
+    local kind, id = CooldownCompanion:ParseAddonAnchorFrameName(frameName)
+    return kind == "group" and id or nil
+end
 
 local function GetPanelAnchorDepth(groups, groupId, visiting)
     visiting = visiting or {}
@@ -67,13 +72,12 @@ local function GetPanelAnchorDepth(groups, groupId, visiting)
     local group = groups and groups[groupId]
     local anchor = group and group.anchor
     local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
-    local targetGroupId = type(relativeTo) == "string" and relativeTo:match("^CooldownCompanionGroup(%d+)$") or nil
+    local targetGroupId = GetAddonAnchorGroupId(relativeTo)
     if not targetGroupId then
         visiting[groupId] = nil
         return 0
     end
 
-    targetGroupId = tonumber(targetGroupId)
     local target = groups[targetGroupId]
     if not (target and target.parentContainerId) then
         visiting[groupId] = nil
@@ -1049,7 +1053,7 @@ function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
         and group.parentContainerId
         and ST.IsGroupConfigSelected
         and ST.IsGroupConfigSelected(groupId) then
-        return CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS
+        return IGNORE_SPELL_AVAILABILITY_OPTIONS
     end
     return nil
 end
@@ -1061,7 +1065,7 @@ function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)
 
     local opts = nil
     if group.parentContainerId and not group.compactLayout then
-        opts = PANEL_LAYOUT_BUTTON_USABILITY_OPTIONS
+        opts = IGNORE_SPELL_AVAILABILITY_OPTIONS
     end
 
     local count = 0
@@ -1878,8 +1882,10 @@ function CooldownCompanion:FinalizePanelAnchors()
     for groupId, group in pairs(groups) do
         local frame = self.groupFrames[groupId]
         if group and group.parentContainerId and group.anchor and frame then
-            if self.GetGroupLayoutButtonCount then
+            if not group.compactLayout and self.GetGroupLayoutButtonCount then
                 frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+            else
+                frame.layoutButtonCount = nil
             end
             if self.ResizeGroupFrame then
                 self:ResizeGroupFrame(groupId)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -49,6 +49,42 @@ local LOCAL_LOAD_CONDITION_DEFAULTS = {
     vehicleUI = false,
 }
 
+local CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS = {
+    ignoreSpellAvailability = true,
+}
+
+local PANEL_LAYOUT_BUTTON_USABILITY_OPTIONS = {
+    ignoreSpellAvailability = true,
+}
+
+local function GetPanelAnchorDepth(groups, groupId, visiting)
+    visiting = visiting or {}
+    if visiting[groupId] then
+        return 0
+    end
+    visiting[groupId] = true
+
+    local group = groups and groups[groupId]
+    local anchor = group and group.anchor
+    local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
+    local targetGroupId = type(relativeTo) == "string" and relativeTo:match("^CooldownCompanionGroup(%d+)$") or nil
+    if not targetGroupId then
+        visiting[groupId] = nil
+        return 0
+    end
+
+    targetGroupId = tonumber(targetGroupId)
+    local target = groups[targetGroupId]
+    if not (target and target.parentContainerId) then
+        visiting[groupId] = nil
+        return 0
+    end
+
+    local depth = GetPanelAnchorDepth(groups, targetGroupId, visiting) + 1
+    visiting[groupId] = nil
+    return depth
+end
+
 ST.LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS or {
     { key = "raid",          label = "Raid" },
     { key = "dungeon",       label = "Dungeon" },
@@ -1008,6 +1044,35 @@ function CooldownCompanion:GroupHasUsableButtons(group, opts)
     return false
 end
 
+function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
+    if group
+        and group.parentContainerId
+        and ST.IsGroupConfigSelected
+        and ST.IsGroupConfigSelected(groupId) then
+        return CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS
+    end
+    return nil
+end
+
+function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)
+    if not (group and group.buttons and #group.buttons > 0) then
+        return 0
+    end
+
+    local opts = nil
+    if group.parentContainerId and not group.compactLayout then
+        opts = PANEL_LAYOUT_BUTTON_USABILITY_OPTIONS
+    end
+
+    local count = 0
+    for _, buttonData in ipairs(group.buttons) do
+        if self:IsButtonUsable(buttonData, group, opts) then
+            count = count + 1
+        end
+    end
+    return count
+end
+
 function CooldownCompanion:IsGroupActive(groupId, opts)
     opts = opts or {}
     local group = opts.group or self.db.profile.groups[groupId]
@@ -1031,8 +1096,12 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if group.enabled == false then return false end
     end
 
+    local buttonUsabilityOptions = opts.buttonUsabilityOptions
+        or (self.GetGroupButtonUsabilityOptions and self:GetGroupButtonUsabilityOptions(groupId, group))
+
     if opts.requireButtons and not self:GroupHasUsableButtons(group, {
         checkLoadConditions = opts.checkLoadConditions,
+        ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
     }) then
         return false
     end
@@ -1557,6 +1626,10 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
     -- Per-button talent condition: gate visibility on a specific talent node.
     if not self:IsTalentConditionMet(buttonData) then return false end
 
+    if opts.ignoreSpellAvailability and buttonData.type == "spell" then
+        return true
+    end
+
     -- Passive/proc spells are tracked via aura, not spellbook presence.
     -- Multi-CDM-child buttons: verify their specific slot still exists in the CDM
     -- (spell may not be available on the current spec/talent loadout).
@@ -1639,8 +1712,11 @@ function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
 
     local usableButtons = {}
     local usableCount = 0
+    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
+        and self:GetGroupButtonUsabilityOptions(groupId, group)
+        or nil
     for _, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group) then
+        if self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
             usableCount = usableCount + 1
             usableButtons[usableCount] = buttonData
         end
@@ -1751,21 +1827,81 @@ function CooldownCompanion:CreateAllGroupFrames()
             self:CreateGroupFrame(groupId)
         end
     end
-    -- Re-anchor pass: custom anchors to other group frames may have fallen
-    -- back to the container because the target wasn't created yet.
-    -- All frames now exist, so re-apply to resolve cross-group anchors.
-    for groupId, frame in pairs(self.groupFrames) do
-        local group = self.db.profile.groups[groupId]
-        if group and group.anchor then
-            local relativeTo = group.anchor.relativeTo
-            if relativeTo and relativeTo ~= "UIParent" then
-                local containerName = group.parentContainerId
-                    and ("CooldownCompanionContainer" .. group.parentContainerId)
-                if not containerName or relativeTo ~= containerName then
-                    self:AnchorGroupFrame(frame, group.anchor)
-                end
+    self:FinalizePanelAnchors()
+end
+
+function CooldownCompanion:RefreshConfigSelectedGroupFrames()
+    if self._refreshingConfigSelectedGroupFrames then
+        return
+    end
+    if InCombatLockdown() then
+        self._pendingFullRefresh = true
+        return
+    end
+    if not (ST.IsGroupConfigSelected and self.db and self.db.profile and self.db.profile.groups) then
+        return
+    end
+
+    self._refreshingConfigSelectedGroupFrames = true
+    local refreshed = false
+    for groupId, group in pairs(self.db.profile.groups) do
+        if ST.IsGroupConfigSelected(groupId) then
+            local active = self:IsGroupActive(groupId, {
+                group = group,
+                checkCharVisibility = true,
+                checkLoadConditions = true,
+                requireButtons = true,
+            })
+            if active and (not self.groupFrames[groupId] or self:GroupButtonSetNeedsRebuild(groupId, group)) then
+                self:RefreshGroupFrame(groupId)
+                refreshed = true
             end
         end
+    end
+    self._refreshingConfigSelectedGroupFrames = nil
+
+    if refreshed then
+        self:FinalizePanelAnchors()
+        if self.RefreshAllContainerWrappers then
+            self:RefreshAllContainerWrappers()
+        end
+    end
+end
+
+function CooldownCompanion:FinalizePanelAnchors()
+    local groups = self.db and self.db.profile and self.db.profile.groups
+    if not (groups and self.groupFrames) then
+        return
+    end
+
+    local panels = {}
+    for groupId, group in pairs(groups) do
+        local frame = self.groupFrames[groupId]
+        if group and group.parentContainerId and group.anchor and frame then
+            if self.GetGroupLayoutButtonCount then
+                frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+            end
+            if self.ResizeGroupFrame then
+                self:ResizeGroupFrame(groupId)
+            end
+            panels[#panels + 1] = {
+                groupId = groupId,
+                group = group,
+                frame = frame,
+                depth = GetPanelAnchorDepth(groups, groupId),
+            }
+        end
+    end
+
+    table.sort(panels, function(a, b)
+        if a.depth ~= b.depth then
+            return a.depth < b.depth
+        end
+        return tostring(a.groupId) < tostring(b.groupId)
+    end)
+
+    for _, panel in ipairs(panels) do
+        self:AnchorGroupFrame(panel.frame, panel.group.anchor)
     end
 end
 
@@ -1839,6 +1975,7 @@ function CooldownCompanion:RefreshAllGroups()
     end
 
     self:FinalizeContainerAnchorsToScreenOffsets()
+    self:FinalizePanelAnchors()
     if self.RefreshAllContainerWrappers then
         self:RefreshAllContainerWrappers()
     end
@@ -1953,6 +2090,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     end
 
     self:FinalizeContainerAnchorsToScreenOffsets()
+    self:FinalizePanelAnchors()
     if self.RefreshAllContainerWrappers then
         self:RefreshAllContainerWrappers()
     end


### PR DESCRIPTION
## What Players Will Notice
- Panels that are anchored to other panels should now keep their intended positions on fresh login instead of shifting until `/reload`.
- Panels that inherit alpha from another panel should follow that parent panel's hidden, visible, and mouseover alpha behavior more reliably.
- Config preview refreshes should no longer leave unavailable preview-only spell buttons behind after changing selection.

## Why This Changed
- Some chained panel anchors were being resolved before all target frames had their final startup size, so dependent panels could anchor to temporary fallback geometry until a reload refreshed the layout.
- Hidden or dormant panel anchor parents could keep stale frame alpha even when their saved alpha state had already changed, which broke inherited alpha chains on login.
- Follow-up review found related edge cases around standalone panel anchors, compact-layout compensation, text-panel preview sizing, and config-preview cleanup.

## What Changed
- Added a panel anchor finalization pass that sizes panel frames from a stable layout footprint, then reapplies saved panel-to-panel anchors in dependency order while preserving missing-target saved anchors.
- Kept non-panel addon-frame anchors on the old post-create recovery path so standalone groups still recover after creation-order fallback.
- Centralized panel alpha inheritance around the active anchor source, including Texture/Trigger standalone anchor settings, and made hidden/dormant alpha parents update when children inherit from them.
- Reconciled previously selected config-preview panels when selection clears or changes so preview-only spell availability does not leak into live panels.
- Kept compact panel resize compensation intact during finalization and made text-panel sizing use the same stable availability footprint as panel layout counts.

## Validation
- Ran all local Lua harnesses in `tests/*.lua`.
- Ran `luac -p Core\AnchorPolicy.lua Core\AlphaFade.lua Core\GroupFrame.lua Core\GroupOperations.lua Config\Panel.lua`.
- Ran `git diff --check origin/main...HEAD`.
- In-game validation now indicates the affected profile works correctly on fresh login, with both positioning and inherited alpha behaving as expected.
- `/reload` still works correctly.
- Combat smoke testing works with no combat errors reported.
- Restricted-content smoke testing works with no restricted-content errors reported.
- No Lua errors were reported.