### PR TITLE
Reduce panel alpha overhead with simpler anchor ownership

### DIFF
--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -1514,6 +1514,9 @@ local function BuildLayoutTab(container)
             if frame then
                 CooldownCompanion:AnchorGroupFrame(frame, group.anchor)
             end
+            if CooldownCompanion.RebuildPanelAlphaDependencyTargets then
+                CooldownCompanion:RebuildPanelAlphaDependencyTargets()
+            end
             CooldownCompanion:RefreshConfigPanel()
         end)
         container:AddChild(panelAlphaDrop)

--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -942,9 +942,7 @@ local function BuildLayoutTab(container)
         local isCursorAnchor = CooldownCompanion.IsCursorAnchor
             and CooldownCompanion:IsCursorAnchor(group.anchor)
             or false
-        local canUseCursorAnchor = CooldownCompanion.CanGroupUseCursorAnchor
-            and CooldownCompanion:CanGroupUseCursorAnchor(group)
-            or group.parentContainerId ~= nil
+        local canUseCursorAnchor = CooldownCompanion:CanGroupUseCursorAnchor(group)
         if isCursorAnchor and not canUseCursorAnchor then
             isCursorAnchor = false
         end
@@ -959,26 +957,14 @@ local function BuildLayoutTab(container)
             settings.y = y or 0
         end
         local function GetStandaloneAnchorValidationOptions()
-            if CooldownCompanion.GetGroupAnchorValidationOptions then
-                return CooldownCompanion:GetGroupAnchorValidationOptions(textureGroupId)
-            end
-            return {
-                domain = "panel",
-                sourceGroupId = textureGroupId,
-                sourceKind = "group",
-            }
+            return CooldownCompanion:GetGroupAnchorValidationOptions(textureGroupId)
         end
         local function SetStandalonePanelAnchorTarget(targetGroupId)
             local targetFrameName = "CooldownCompanionGroup" .. tostring(targetGroupId)
-            local ok = true
             local options = GetStandaloneAnchorValidationOptions()
-            if CooldownCompanion.ValidateAddonFrameAnchorTarget then
-                ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(targetFrameName, options)
-            end
+            local ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(targetFrameName, options)
             if not ok then
-                if CooldownCompanion.PrintInvalidAnchorTargetReason then
-                    CooldownCompanion:PrintInvalidAnchorTargetReason(targetFrameName, options)
-                end
+                CooldownCompanion:PrintInvalidAnchorTargetReason(targetFrameName, options)
                 return false
             end
             ResetStandalonePosition(targetFrameName, "TOPLEFT", "BOTTOMLEFT", 0, -5)
@@ -995,27 +981,17 @@ local function BuildLayoutTab(container)
                 CooldownCompanion:Print("Frame not found: " .. targetFrameName)
                 return false
             end
-            local ok = true
             local options = GetStandaloneAnchorValidationOptions()
-            if CooldownCompanion.ValidateAddonFrameAnchorTarget then
-                ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(targetFrameName, options)
-            end
+            local ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(targetFrameName, options)
             if not ok then
-                if CooldownCompanion.PrintInvalidAnchorTargetReason then
-                    CooldownCompanion:PrintInvalidAnchorTargetReason(targetFrameName, options)
-                end
+                CooldownCompanion:PrintInvalidAnchorTargetReason(targetFrameName, options)
                 return false
             end
             ResetStandalonePosition(targetFrameName, "TOPLEFT", "BOTTOMLEFT", 0, -5)
             return true
         end
         local anchorKind, currentAnchorGroupId
-        if CooldownCompanion.ParseAddonAnchorFrameName then
-            anchorKind, currentAnchorGroupId = CooldownCompanion:ParseAddonAnchorFrameName(settings.relativeTo)
-        else
-            currentAnchorGroupId = settings.relativeTo:match("^CooldownCompanionGroup(%d+)$")
-            anchorKind = currentAnchorGroupId and "group" or nil
-        end
+        anchorKind, currentAnchorGroupId = CooldownCompanion:ParseAddonAnchorFrameName(settings.relativeTo)
         local currentAnchorIsPanel = anchorKind == "group"
             and isPanel
             and CooldownCompanion.IsPanelAnchoredToPanel
@@ -1053,9 +1029,9 @@ local function BuildLayoutTab(container)
             RefreshTextureVisual()
         end
 
-        if targetMode == "cursor" and CooldownCompanion.ShowCursorAnchorLayoutPreview then
+        if targetMode == "cursor" then
             CooldownCompanion:ShowCursorAnchorLayoutPreview(textureGroupId)
-        elseif CooldownCompanion.ClearCursorAnchorLayoutPreview then
+        else
             CooldownCompanion:ClearCursorAnchorLayoutPreview()
         end
 
@@ -1349,9 +1325,9 @@ local function BuildLayoutTab(container)
         targetMode = preferredTargetMode
     end
     CS.layoutAnchorTargetMode[CS.selectedGroup] = targetMode
-    if targetMode == "cursor" and isCursorAnchor and CooldownCompanion.ShowCursorAnchorLayoutPreview then
+    if targetMode == "cursor" and isCursorAnchor then
         CooldownCompanion:ShowCursorAnchorLayoutPreview(CS.selectedGroup)
-    elseif CooldownCompanion.ClearCursorAnchorLayoutPreview then
+    else
         CooldownCompanion:ClearCursorAnchorLayoutPreview()
     end
     local panelAlphaInherited = false
@@ -1514,9 +1490,7 @@ local function BuildLayoutTab(container)
             if frame then
                 CooldownCompanion:AnchorGroupFrame(frame, group.anchor)
             end
-            if CooldownCompanion.RebuildPanelAlphaDependencyTargets then
-                CooldownCompanion:RebuildPanelAlphaDependencyTargets()
-            end
+            CooldownCompanion:RebuildPanelAlphaDependencyTargets()
             CooldownCompanion:RefreshConfigPanel()
         end)
         container:AddChild(panelAlphaDrop)

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -231,9 +231,7 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
         and self:IsCursorAnchorLayoutPreviewGroupActive(groupId)
     if cursorPreviewActive then
         locked = false
-    elseif not locked
-        and self.IsGroupCursorAnchored
-        and self:IsGroupCursorAnchored(group) then
+    elseif not locked and self:IsGroupCursorAnchored(group) then
         locked = true
     end
 
@@ -276,7 +274,7 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
     local forceFull, forceHidden, baseline = EvaluateDesiredAlpha(group, inCombat, hasTarget, hasEnemyTarget, hasFocus, regularMounted, dragonridingMounted, inTravelForm)
 
     -- Mouseover check (geometric, works even when click-through)
-    local ignoreSelfMouseover = CooldownCompanion.IsGroupCursorAnchored and CooldownCompanion:IsGroupCursorAnchored(group)
+    local ignoreSelfMouseover = CooldownCompanion:IsGroupCursorAnchored(group)
     if not forceFull and group.forceAlphaMouseover and not ignoreSelfMouseover then
         local isHovering = frame:IsMouseOver()
         if isHovering then
@@ -328,7 +326,7 @@ function CooldownCompanion:UpdateModuleAlpha(moduleId, config, frames, now, inCo
     local forceFull, forceHidden, baseline = EvaluateDesiredAlpha(config, inCombat, hasTarget, hasEnemyTarget, hasFocus, regularMounted, dragonridingMounted, inTravelForm)
 
     -- Mouseover check across all frames
-    local ignoreModuleSelfMouseover = self.IsGroupCursorAnchored and self:IsGroupCursorAnchored(config)
+    local ignoreModuleSelfMouseover = self:IsGroupCursorAnchored(config)
     if not forceFull and config.forceAlphaMouseover and not ignoreModuleSelfMouseover then
         local isHovering = false
         for i = 1, #frames do
@@ -407,8 +405,7 @@ function CooldownCompanion:InitAlphaUpdateFrame()
     end
 
     local function GroupNeedsAlphaUpdate(group, groupId)
-        if self.ShouldInheritPanelAnchorAlpha
-            and self:ShouldInheritPanelAnchorAlpha(groupId) then
+        if self:ShouldInheritPanelAnchorAlpha(groupId) then
             return false
         end
         if ST.IsGroupConfigSelected(groupId) then return true end
@@ -441,9 +438,7 @@ function CooldownCompanion:InitAlphaUpdateFrame()
 
         local containers = self.db.profile.groupContainers or {}
         local groups = self.db.profile.groups or {}
-        local panelAlphaAnchorTargets = self.GetPanelAlphaDependencyTargets
-            and self:GetPanelAlphaDependencyTargets(groups)
-            or nil
+        local panelAlphaAnchorTargets = self:GetPanelAlphaDependencyTargets(groups)
         for groupId, group in pairs(groups) do
             local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
             if frame

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -26,41 +26,6 @@ local function FrameAlphaDiffers(frame, alpha)
     return frame:GetAlpha() ~= alpha
 end
 
-local function GetAddonAnchorGroupId(frameName)
-    if not CooldownCompanion.ParseAddonAnchorFrameName then
-        return nil
-    end
-
-    local kind, id = CooldownCompanion:ParseAddonAnchorFrameName(frameName)
-    return kind == "group" and id or nil
-end
-
-local function GetPanelAlphaAnchorRelativeTo(group)
-    if CooldownCompanion.GetActivePanelAnchorRelativeTo then
-        return CooldownCompanion:GetActivePanelAnchorRelativeTo(group)
-    end
-
-    local anchor = group and group.anchor
-    return type(anchor) == "table" and anchor.relativeTo or nil
-end
-
-local function CollectPanelAlphaAnchorTargets(groups)
-    local targets = nil
-    for _, group in pairs(groups or {}) do
-        local relativeTo = GetPanelAlphaAnchorRelativeTo(group)
-        local targetGroupId = GetAddonAnchorGroupId(relativeTo)
-        if group
-            and group.parentContainerId
-            and group.inheritPanelAlpha ~= false
-            and targetGroupId then
-            targets = targets or {}
-            targets[targetGroupId] = true
-            targets[tostring(targetGroupId)] = true
-        end
-    end
-    return targets
-end
-
 -- Alpha fade system: per-group runtime state
 -- self.alphaState[groupId] = {
 --     currentAlpha   - current interpolated alpha
@@ -476,7 +441,9 @@ function CooldownCompanion:InitAlphaUpdateFrame()
 
         local containers = self.db.profile.groupContainers or {}
         local groups = self.db.profile.groups or {}
-        local panelAlphaAnchorTargets = CollectPanelAlphaAnchorTargets(groups)
+        local panelAlphaAnchorTargets = self.GetPanelAlphaDependencyTargets
+            and self:GetPanelAlphaDependencyTargets(groups)
+            or nil
         for groupId, group in pairs(groups) do
             local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
             if frame

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -142,24 +142,14 @@ local function GetStandaloneTextureAnchorSettings(group)
     return nil
 end
 
-local function GetAnchorRelativeTo(anchor)
-    if type(anchor) == "table" then
-        return anchor.relativeTo
-    end
-    return anchor
-end
-
-local function GetPanelFrameAnchorRelativeTo(group)
-    return GetAnchorRelativeTo(group and group.anchor)
-end
-
 local function GetActivePanelAnchorRelativeTo(group)
     local standalone = GetStandaloneTextureAnchorSettings(group)
     if type(standalone) == "table" and type(standalone.relativeTo) == "string" then
         return standalone.relativeTo
     end
 
-    return GetPanelFrameAnchorRelativeTo(group)
+    local anchor = group and group.anchor
+    return type(anchor) == "table" and anchor.relativeTo or anchor
 end
 
 local function GetAddonAnchorGroupId(frameName)
@@ -167,57 +157,8 @@ local function GetAddonAnchorGroupId(frameName)
     return kind == "group" and id or nil
 end
 
-local function IsAddonFrameAnchorTarget(frameName)
-    local kind = ParseAddonAnchorFrameName(frameName)
-    return kind == "group" or kind == "container"
-end
-
-local function BuildAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
-    if sourceKind == "container" then
-        return {
-            domain = "container",
-            sourceGroupId = sourceId,
-            sourceKind = "container",
-        }
-    end
-
-    if self.GetGroupAnchorValidationOptions then
-        return self:GetGroupAnchorValidationOptions(sourceId)
-    end
-
-    return {
-        domain = "panel",
-        sourceGroupId = sourceId,
-        sourceKind = "group",
-    }
-end
-
-local function AddPanelAlphaDependency(dependencies, parentGroupId, childGroupId, relativeTo)
-    if not dependencies then
-        dependencies = {
-            byParent = {},
-            targets = {},
-        }
-    end
-
-    local children = dependencies.byParent[parentGroupId]
-    if not children then
-        children = {}
-        dependencies.byParent[parentGroupId] = children
-        dependencies.byParent[tostring(parentGroupId)] = children
-    end
-    children[#children + 1] = {
-        groupId = childGroupId,
-        relativeTo = relativeTo,
-    }
-
-    dependencies.targets[parentGroupId] = true
-    dependencies.targets[tostring(parentGroupId)] = true
-    return dependencies
-end
-
-local function BuildPanelAlphaDependencies(groups)
-    local dependencies = nil
+local function BuildPanelAlphaDependencyTargets(groups)
+    local targets = nil
     for groupId, group in pairs(groups or {}) do
         local relativeTo = GetActivePanelAnchorRelativeTo(group)
         local targetGroupId = GetAddonAnchorGroupId(relativeTo)
@@ -225,10 +166,12 @@ local function BuildPanelAlphaDependencies(groups)
             and group.parentContainerId
             and group.inheritPanelAlpha ~= false
             and targetGroupId then
-            dependencies = AddPanelAlphaDependency(dependencies, targetGroupId, groupId, relativeTo)
+            targets = targets or {}
+            targets[targetGroupId] = true
+            targets[tostring(targetGroupId)] = true
         end
     end
-    return dependencies
+    return targets
 end
 
 local function AddonAnchorFrameReachesCursorRoot(profile, kind, id, visited)
@@ -241,7 +184,8 @@ local function AddonAnchorFrameReachesCursorRoot(profile, kind, id, visited)
     if not node then
         return false
     end
-    local relativeTo = GetPanelFrameAnchorRelativeTo(node)
+    local anchor = node and node.anchor
+    local relativeTo = type(anchor) == "table" and anchor.relativeTo or anchor
     if type(relativeTo) ~= "string" then
         return false
     end
@@ -516,24 +460,23 @@ function CooldownCompanion:GetActivePanelAnchorRelativeTo(groupOrId)
     return GetActivePanelAnchorRelativeTo(GetGroup(self, groupOrId))
 end
 
-function CooldownCompanion:GetAddonAnchorGroupId(frameName)
-    return GetAddonAnchorGroupId(frameName)
-end
-
-function CooldownCompanion:IsAddonFrameAnchorTarget(frameName)
-    return IsAddonFrameAnchorTarget(frameName)
-end
-
-function CooldownCompanion:GetAddonFrameAnchorValidationOptions(sourceId, sourceKind)
-    return BuildAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
-end
-
-function CooldownCompanion:ResolveAddonFrameAnchorTarget(relativeTo, validationOptions)
+function CooldownCompanion:ResolveAddonFrameAnchorTarget(sourceId, sourceKind, relativeTo)
     if relativeTo == nil or relativeTo == "" or relativeTo == "UIParent" then
         return nil, "ui-parent"
     end
     if relativeTo == CURSOR_ANCHOR_TARGET then
         return nil, "cursor"
+    end
+
+    local validationOptions
+    if sourceKind == "container" then
+        validationOptions = {
+            domain = "container",
+            sourceGroupId = sourceId,
+            sourceKind = "container",
+        }
+    else
+        validationOptions = self:GetGroupAnchorValidationOptions(sourceId)
     end
 
     local ok, reason, kind, id = self:ValidateAddonFrameAnchorTarget(relativeTo, validationOptions)
@@ -552,24 +495,19 @@ end
 function CooldownCompanion:RebuildPanelAlphaDependencyTargets(groups)
     local profile = GetProfile(self)
     local sourceGroups = groups or (profile and profile.groups) or nil
-    local dependencies = BuildPanelAlphaDependencies(sourceGroups)
-    self._panelAlphaDependencies = dependencies
+    local targets = BuildPanelAlphaDependencyTargets(sourceGroups)
+    self._panelAlphaDependencyTargets = targets
     self._panelAlphaDependencyGroups = sourceGroups
-    return dependencies and dependencies.targets or nil
+    return targets
 end
 
-function CooldownCompanion:GetPanelAlphaDependencies(groups)
+function CooldownCompanion:GetPanelAlphaDependencyTargets(groups)
     local profile = GetProfile(self)
     local sourceGroups = groups or (profile and profile.groups) or nil
     if self._panelAlphaDependencyGroups ~= sourceGroups then
         self:RebuildPanelAlphaDependencyTargets(sourceGroups)
     end
-    return self._panelAlphaDependencies
-end
-
-function CooldownCompanion:GetPanelAlphaDependencyTargets(groups)
-    local dependencies = self:GetPanelAlphaDependencies(groups)
-    return dependencies and dependencies.targets or nil
+    return self._panelAlphaDependencyTargets
 end
 
 function CooldownCompanion:IsPanelAnchoredToPanel(groupOrId)

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -162,6 +162,75 @@ local function GetActivePanelAnchorRelativeTo(group)
     return GetPanelFrameAnchorRelativeTo(group)
 end
 
+local function GetAddonAnchorGroupId(frameName)
+    local kind, id = ParseAddonAnchorFrameName(frameName)
+    return kind == "group" and id or nil
+end
+
+local function IsAddonFrameAnchorTarget(frameName)
+    local kind = ParseAddonAnchorFrameName(frameName)
+    return kind == "group" or kind == "container"
+end
+
+local function BuildAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
+    if sourceKind == "container" then
+        return {
+            domain = "container",
+            sourceGroupId = sourceId,
+            sourceKind = "container",
+        }
+    end
+
+    if self.GetGroupAnchorValidationOptions then
+        return self:GetGroupAnchorValidationOptions(sourceId)
+    end
+
+    return {
+        domain = "panel",
+        sourceGroupId = sourceId,
+        sourceKind = "group",
+    }
+end
+
+local function AddPanelAlphaDependency(dependencies, parentGroupId, childGroupId, relativeTo)
+    if not dependencies then
+        dependencies = {
+            byParent = {},
+            targets = {},
+        }
+    end
+
+    local children = dependencies.byParent[parentGroupId]
+    if not children then
+        children = {}
+        dependencies.byParent[parentGroupId] = children
+        dependencies.byParent[tostring(parentGroupId)] = children
+    end
+    children[#children + 1] = {
+        groupId = childGroupId,
+        relativeTo = relativeTo,
+    }
+
+    dependencies.targets[parentGroupId] = true
+    dependencies.targets[tostring(parentGroupId)] = true
+    return dependencies
+end
+
+local function BuildPanelAlphaDependencies(groups)
+    local dependencies = nil
+    for groupId, group in pairs(groups or {}) do
+        local relativeTo = GetActivePanelAnchorRelativeTo(group)
+        local targetGroupId = GetAddonAnchorGroupId(relativeTo)
+        if group
+            and group.parentContainerId
+            and group.inheritPanelAlpha ~= false
+            and targetGroupId then
+            dependencies = AddPanelAlphaDependency(dependencies, targetGroupId, groupId, relativeTo)
+        end
+    end
+    return dependencies
+end
+
 local function AddonAnchorFrameReachesCursorRoot(profile, kind, id, visited)
     local node
     if kind == "group" then
@@ -445,6 +514,62 @@ end
 
 function CooldownCompanion:GetActivePanelAnchorRelativeTo(groupOrId)
     return GetActivePanelAnchorRelativeTo(GetGroup(self, groupOrId))
+end
+
+function CooldownCompanion:GetAddonAnchorGroupId(frameName)
+    return GetAddonAnchorGroupId(frameName)
+end
+
+function CooldownCompanion:IsAddonFrameAnchorTarget(frameName)
+    return IsAddonFrameAnchorTarget(frameName)
+end
+
+function CooldownCompanion:GetAddonFrameAnchorValidationOptions(sourceId, sourceKind)
+    return BuildAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
+end
+
+function CooldownCompanion:ResolveAddonFrameAnchorTarget(relativeTo, validationOptions)
+    if relativeTo == nil or relativeTo == "" or relativeTo == "UIParent" then
+        return nil, "ui-parent"
+    end
+    if relativeTo == CURSOR_ANCHOR_TARGET then
+        return nil, "cursor"
+    end
+
+    local ok, reason, kind, id = self:ValidateAddonFrameAnchorTarget(relativeTo, validationOptions)
+    if not ok then
+        return nil, reason, kind, id
+    end
+
+    local frame = _G[relativeTo]
+    if not frame then
+        return nil, "missing", kind, id
+    end
+
+    return frame, "ok", kind, id
+end
+
+function CooldownCompanion:RebuildPanelAlphaDependencyTargets(groups)
+    local profile = GetProfile(self)
+    local sourceGroups = groups or (profile and profile.groups) or nil
+    local dependencies = BuildPanelAlphaDependencies(sourceGroups)
+    self._panelAlphaDependencies = dependencies
+    self._panelAlphaDependencyGroups = sourceGroups
+    return dependencies and dependencies.targets or nil
+end
+
+function CooldownCompanion:GetPanelAlphaDependencies(groups)
+    local profile = GetProfile(self)
+    local sourceGroups = groups or (profile and profile.groups) or nil
+    if self._panelAlphaDependencyGroups ~= sourceGroups then
+        self:RebuildPanelAlphaDependencyTargets(sourceGroups)
+    end
+    return self._panelAlphaDependencies
+end
+
+function CooldownCompanion:GetPanelAlphaDependencyTargets(groups)
+    local dependencies = self:GetPanelAlphaDependencies(groups)
+    return dependencies and dependencies.targets or nil
 end
 
 function CooldownCompanion:IsPanelAnchoredToPanel(groupOrId)

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -376,6 +376,7 @@ local function SaveTextureHostPosition(host)
         return
     end
 
+    local previousRelativeTo = settings.relativeTo
     if not SaveGroupedStandalonePreviewSettings(host, group, settings, owner and owner._groupId) then
         local point, relativeFrame, relPoint, x, y = host:GetPoint(1)
         settings.point = NormalizeAnchorPoint(point)
@@ -390,6 +391,9 @@ local function SaveTextureHostPosition(host)
         settings.y = math_floor(((y or 0) * 10) + 0.5) / 10
     end
 
+    if settings.relativeTo ~= previousRelativeTo and CooldownCompanion.RebuildPanelAlphaDependencyTargets then
+        CooldownCompanion:RebuildPanelAlphaDependencyTargets()
+    end
     UpdateTextureHostCoordLabel(host, settings.x, settings.y)
     CooldownCompanion:UpdateAuraTextureVisual(owner)
     if group and group.parentContainerId and CooldownCompanion.RefreshContainerWrapper then
@@ -1654,6 +1658,9 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
 end
 
 function CooldownCompanion:RefreshAllAuraTextureVisuals()
+    if self.RebuildPanelAlphaDependencyTargets then
+        self:RebuildPanelAlphaDependencyTargets()
+    end
     for _, frame in pairs(self.groupFrames or {}) do
         for _, button in ipairs(frame.buttons or {}) do
             self:UpdateAuraTextureVisual(button)

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -196,13 +196,10 @@ local function GetStandaloneAnchorTargetFrame(group, settings, groupId, domain)
         return nil
     end
 
-    local ok = true
-    if CooldownCompanion.ValidateAddonFrameAnchorTarget then
-        ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(
-            relativeTo,
-            GetStandaloneAnchorValidationOptions(relativeTo, groupId, domain)
-        )
-    end
+    local ok = CooldownCompanion:ValidateAddonFrameAnchorTarget(
+        relativeTo,
+        GetStandaloneAnchorValidationOptions(relativeTo, groupId, domain)
+    )
     if not ok then
         return nil, relativeTo
     end
@@ -391,7 +388,7 @@ local function SaveTextureHostPosition(host)
         settings.y = math_floor(((y or 0) * 10) + 0.5) / 10
     end
 
-    if settings.relativeTo ~= previousRelativeTo and CooldownCompanion.RebuildPanelAlphaDependencyTargets then
+    if settings.relativeTo ~= previousRelativeTo then
         CooldownCompanion:RebuildPanelAlphaDependencyTargets()
     end
     UpdateTextureHostCoordLabel(host, settings.x, settings.y)
@@ -1658,9 +1655,7 @@ function CooldownCompanion:UpdateAuraTextureVisual(button)
 end
 
 function CooldownCompanion:RefreshAllAuraTextureVisuals()
-    if self.RebuildPanelAlphaDependencyTargets then
-        self:RebuildPanelAlphaDependencyTargets()
-    end
+    self:RebuildPanelAlphaDependencyTargets()
     for _, frame in pairs(self.groupFrames or {}) do
         for _, button in ipairs(frame.buttons or {}) do
             self:UpdateAuraTextureVisual(button)

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -86,12 +86,8 @@ local function ShouldSyncAnchorAlpha(self, groupId)
     local group = profile and profile.groups and profile.groups[groupId]
 
     if group and group.parentContainerId then
-        if self.IsPanelAnchoredToPanel
-            and self:IsPanelAnchoredToPanel(groupId) then
-            if self.ShouldInheritPanelAnchorAlpha then
-                return self:ShouldInheritPanelAnchorAlpha(groupId)
-            end
-            return true
+        if self:IsPanelAnchoredToPanel(groupId) then
+            return self:ShouldInheritPanelAnchorAlpha(groupId)
         end
         return false
     end
@@ -319,55 +315,8 @@ local function WouldFrameDependencyCreateCircularAnchor(self, sourceId, sourceKi
     return false
 end
 
-local function GetAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
-    if self.GetAddonFrameAnchorValidationOptions then
-        return self:GetAddonFrameAnchorValidationOptions(sourceId, sourceKind)
-    end
-
-    if sourceKind == "container" then
-        return {
-            domain = "container",
-            sourceGroupId = sourceId,
-            sourceKind = "container",
-        }
-    end
-    if self.GetGroupAnchorValidationOptions then
-        return self:GetGroupAnchorValidationOptions(sourceId)
-    end
-    return {
-        domain = "panel",
-        sourceGroupId = sourceId,
-        sourceKind = "group",
-    }
-end
-
-local function ResolveAddonFrameAnchorTarget(self, sourceId, sourceKind, relativeTo)
-    local validationOptions = GetAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
-    if self.ResolveAddonFrameAnchorTarget then
-        return self:ResolveAddonFrameAnchorTarget(relativeTo, validationOptions)
-    end
-
-    if not relativeTo or relativeTo == "UIParent" then
-        return nil, "ui-parent"
-    end
-    if relativeTo == CURSOR_ANCHOR_TARGET then
-        return nil, "cursor"
-    end
-    local ok, reason, kind, id = self:ValidateAddonFrameAnchorTarget(relativeTo, validationOptions)
-    if not ok then
-        return nil, reason, kind, id
-    end
-
-    local relativeFrame = _G[relativeTo]
-    if not relativeFrame then
-        return nil, "missing", kind, id
-    end
-
-    return relativeFrame, "ok", kind, id
-end
-
 local function ResolveSafeAnchorTarget(self, sourceId, sourceKind, relativeTo)
-    local relativeFrame, anchorState = ResolveAddonFrameAnchorTarget(self, sourceId, sourceKind, relativeTo)
+    local relativeFrame, anchorState = self:ResolveAddonFrameAnchorTarget(sourceId, sourceKind, relativeTo)
     if not relativeFrame then
         return nil, anchorState
     end
@@ -816,7 +765,7 @@ local function BuildCursorAnchorLayoutPreviewGroupMap(self)
 
     for groupId, group in pairs(groups) do
         if IsCursorAnchor(group.anchor)
-            and (not self.CanGroupUseCursorAnchor or self:CanGroupUseCursorAnchor(group))
+            and self:CanGroupUseCursorAnchor(group)
             and self:IsGroupActive(groupId, {
                 group = group,
                 checkCharVisibility = true,
@@ -1234,7 +1183,7 @@ function CooldownCompanion:UpdateCursorAnchoredFrames()
 
     for groupId, group in pairs(groups) do
         if IsCursorAnchor(group.anchor)
-            and (not self.CanGroupUseCursorAnchor or self:CanGroupUseCursorAnchor(group)) then
+            and self:CanGroupUseCursorAnchor(group) then
             local frame = self.groupFrames and self.groupFrames[groupId] or nil
             if frame and frame:IsShown() and not GroupIdsEqual(draggedGroupId, groupId) then
                 local previewX, previewY = GetCursorAnchorLayoutPreviewPosition(self, groupId)
@@ -1262,7 +1211,7 @@ function CooldownCompanion:RefreshCursorAnchorTicker()
         for groupId, group in pairs(groups) do
             local frame = self.groupFrames[groupId]
             if IsCursorAnchor(group.anchor)
-                and (not self.CanGroupUseCursorAnchor or self:CanGroupUseCursorAnchor(group))
+                and self:CanGroupUseCursorAnchor(group)
                 and frame
                 and frame:IsShown() then
                 active = true
@@ -1513,10 +1462,7 @@ function CooldownCompanion:AnchorGroupFrame(frame, anchor, forceCenter)
 
     if IsCursorAnchor(anchor) then
         local group = self.db and self.db.profile and self.db.profile.groups and self.db.profile.groups[frame.groupId]
-        local canUseCursorAnchor = group and group.parentContainerId ~= nil
-        if self.CanGroupUseCursorAnchor then
-            canUseCursorAnchor = self:CanGroupUseCursorAnchor(group)
-        end
+        local canUseCursorAnchor = self:CanGroupUseCursorAnchor(group)
         if not canUseCursorAnchor then
             frame._anchorDirty = nil
             frame:ClearAllPoints()
@@ -1625,9 +1571,7 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
         frame.alphaSyncFrame = CreateFrame("Frame", nil, frame)
     end
 
-    local inheritsPanelAlpha = self.ShouldInheritPanelAnchorAlpha
-        and self:ShouldInheritPanelAnchorAlpha(frame.groupId)
-        or false
+    local inheritsPanelAlpha = self:ShouldInheritPanelAnchorAlpha(frame.groupId)
     if inheritsPanelAlpha and self.alphaState then
         self.alphaState[frame.groupId] = nil
     end
@@ -1739,7 +1683,7 @@ function CooldownCompanion:SaveGroupPosition(groupId)
     group.anchor.x = newX
     group.anchor.y = newY
     group.anchor.relativeTo = relativeTo
-    if relativeTo ~= previousRelativeTo and self.RebuildPanelAlphaDependencyTargets then
+    if relativeTo ~= previousRelativeTo then
         self:RebuildPanelAlphaDependencyTargets()
     end
 
@@ -2377,9 +2321,7 @@ end
 
 local function FinishGroupAnchorChange(self, groupId, frame, group, wasCursorAnchored)
     self:AnchorGroupFrame(frame, group.anchor)
-    if self.RebuildPanelAlphaDependencyTargets then
-        self:RebuildPanelAlphaDependencyTargets()
-    end
+    self:RebuildPanelAlphaDependencyTargets()
     RefreshGroupAnchorInteractionState(self, groupId, frame, group)
     self:RefreshCursorAnchorTicker()
     if (wasCursorAnchored or IsCursorAnchor(group.anchor)) and self.EvaluateBarsAndFramesRuntime then
@@ -2402,7 +2344,7 @@ function CooldownCompanion:SetGroupAnchor(groupId, targetFrameName, forceCenter)
     end
 
     if targetFrameName == CURSOR_ANCHOR_TARGET then
-        if not (self.CanGroupUseCursorAnchor and self:CanGroupUseCursorAnchor(group)) then
+        if not self:CanGroupUseCursorAnchor(group) then
             self:Print("Only panels can anchor to the cursor.")
             return false
         end
@@ -2460,9 +2402,7 @@ function CooldownCompanion:SetGroupAnchor(groupId, targetFrameName, forceCenter)
         -- If not forceCenter, keep current anchor settings (just relativeTo changes)
         group.anchor.relativeTo = "UIParent"
         self:AnchorGroupFrame(frame, group.anchor, forceCenter)
-        if self.RebuildPanelAlphaDependencyTargets then
-            self:RebuildPanelAlphaDependencyTargets()
-        end
+        self:RebuildPanelAlphaDependencyTargets()
         RefreshGroupAnchorInteractionState(self, groupId, frame, group)
         self:RefreshCursorAnchorTicker()
         if wasCursorAnchored and self.EvaluateBarsAndFramesRuntime then

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -319,44 +319,64 @@ local function WouldFrameDependencyCreateCircularAnchor(self, sourceId, sourceKi
     return false
 end
 
-local function ResolveSafeAnchorTarget(self, sourceId, sourceKind, relativeTo)
+local function GetAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
+    if self.GetAddonFrameAnchorValidationOptions then
+        return self:GetAddonFrameAnchorValidationOptions(sourceId, sourceKind)
+    end
+
+    if sourceKind == "container" then
+        return {
+            domain = "container",
+            sourceGroupId = sourceId,
+            sourceKind = "container",
+        }
+    end
+    if self.GetGroupAnchorValidationOptions then
+        return self:GetGroupAnchorValidationOptions(sourceId)
+    end
+    return {
+        domain = "panel",
+        sourceGroupId = sourceId,
+        sourceKind = "group",
+    }
+end
+
+local function ResolveAddonFrameAnchorTarget(self, sourceId, sourceKind, relativeTo)
+    local validationOptions = GetAddonFrameAnchorValidationOptions(self, sourceId, sourceKind)
+    if self.ResolveAddonFrameAnchorTarget then
+        return self:ResolveAddonFrameAnchorTarget(relativeTo, validationOptions)
+    end
+
     if not relativeTo or relativeTo == "UIParent" then
         return nil, "ui-parent"
     end
     if relativeTo == CURSOR_ANCHOR_TARGET then
         return nil, "cursor"
     end
-    local validationOptions
-    if sourceKind == "container" then
-        validationOptions = {
-            domain = "container",
-            sourceGroupId = sourceId,
-            sourceKind = "container",
-        }
-    elseif self.GetGroupAnchorValidationOptions then
-        validationOptions = self:GetGroupAnchorValidationOptions(sourceId)
-    else
-        validationOptions = {
-            domain = "panel",
-            sourceGroupId = sourceId,
-            sourceKind = "group",
-        }
-    end
-    local ok, reason = self:ValidateAddonFrameAnchorTarget(relativeTo, validationOptions)
+    local ok, reason, kind, id = self:ValidateAddonFrameAnchorTarget(relativeTo, validationOptions)
     if not ok then
-        return nil, reason
+        return nil, reason, kind, id
     end
 
     local relativeFrame = _G[relativeTo]
     if not relativeFrame then
-        return nil, "missing"
+        return nil, "missing", kind, id
+    end
+
+    return relativeFrame, "ok", kind, id
+end
+
+local function ResolveSafeAnchorTarget(self, sourceId, sourceKind, relativeTo)
+    local relativeFrame, anchorState = ResolveAddonFrameAnchorTarget(self, sourceId, sourceKind, relativeTo)
+    if not relativeFrame then
+        return nil, anchorState
     end
 
     if WouldFrameDependencyCreateCircularAnchor(self, sourceId, sourceKind or "group", relativeFrame) then
         return nil, "unsafe"
     end
 
-    return relativeFrame, "ok"
+    return relativeFrame, anchorState
 end
 
 function CooldownCompanion:IsCursorAnchorLayoutPreviewGroupActive(groupId)
@@ -1670,6 +1690,7 @@ function CooldownCompanion:SaveGroupPosition(groupId)
 
     -- Determine the reference frame and its dimensions
     local relativeTo = group.anchor.relativeTo
+    local previousRelativeTo = relativeTo
     local relFrame
     local anchorState
     if relativeTo and relativeTo ~= "UIParent" then
@@ -1718,6 +1739,9 @@ function CooldownCompanion:SaveGroupPosition(groupId)
     group.anchor.x = newX
     group.anchor.y = newY
     group.anchor.relativeTo = relativeTo
+    if relativeTo ~= previousRelativeTo and self.RebuildPanelAlphaDependencyTargets then
+        self:RebuildPanelAlphaDependencyTargets()
+    end
 
     -- Re-anchor with the corrected values so WoW doesn't change our anchor point
     frame:ClearAllPoints()
@@ -2353,6 +2377,9 @@ end
 
 local function FinishGroupAnchorChange(self, groupId, frame, group, wasCursorAnchored)
     self:AnchorGroupFrame(frame, group.anchor)
+    if self.RebuildPanelAlphaDependencyTargets then
+        self:RebuildPanelAlphaDependencyTargets()
+    end
     RefreshGroupAnchorInteractionState(self, groupId, frame, group)
     self:RefreshCursorAnchorTicker()
     if (wasCursorAnchored or IsCursorAnchor(group.anchor)) and self.EvaluateBarsAndFramesRuntime then
@@ -2433,6 +2460,9 @@ function CooldownCompanion:SetGroupAnchor(groupId, targetFrameName, forceCenter)
         -- If not forceCenter, keep current anchor settings (just relativeTo changes)
         group.anchor.relativeTo = "UIParent"
         self:AnchorGroupFrame(frame, group.anchor, forceCenter)
+        if self.RebuildPanelAlphaDependencyTargets then
+            self:RebuildPanelAlphaDependencyTargets()
+        end
         RefreshGroupAnchorInteractionState(self, groupId, frame, group)
         self:RefreshCursorAnchorTicker()
         if wasCursorAnchored and self.EvaluateBarsAndFramesRuntime then

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -89,6 +89,12 @@ local function IsFrameLikeAnchorTarget(frame)
     return type(frame) == "table" and type(frame.GetObjectType) == "function"
 end
 
+local function RefreshPanelAlphaDependencyTargets(self)
+    if self.RebuildPanelAlphaDependencyTargets then
+        self:RebuildPanelAlphaDependencyTargets()
+    end
+end
+
 function CooldownCompanion:NormalizeContainerAnchor(anchor, resolveAddonFrames)
     local normalized = type(anchor) == "table" and anchor or {}
     local point = normalized.point or "CENTER"
@@ -804,6 +810,7 @@ function CooldownCompanion:DeleteContainer(containerId)
     end
 
     db.groupContainers[containerId] = nil
+    RefreshPanelAlphaDependencyTargets(self)
 end
 
 local function GetStandalonePanelAnchorSettings(panel)
@@ -1000,6 +1007,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
     if self.FinalizeContainerAnchorsToScreenOffsets then
         self:FinalizeContainerAnchorsToScreenOffsets()
     end
+    RefreshPanelAlphaDependencyTargets(self)
 
     return newContainerId
 end
@@ -1113,6 +1121,7 @@ function CooldownCompanion:DeletePanel(containerId, groupId)
     self:UnloadGroup(groupId)
     self:DiscardDormantFrame(groupId)
     db.groups[groupId] = nil
+    RefreshPanelAlphaDependencyTargets(self)
     return true
 end
 
@@ -1131,6 +1140,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
+    RefreshPanelAlphaDependencyTargets(self)
     return newGroupId
 end
 
@@ -1174,6 +1184,7 @@ function CooldownCompanion:MovePanel(groupId, targetContainerId)
         sourceDeleted = true
     end
 
+    RefreshPanelAlphaDependencyTargets(self)
     return true, sourceDeleted
 end
 
@@ -1242,6 +1253,7 @@ function CooldownCompanion:ChangePanelDisplayMode(groupId, newMode)
             end
         end
     end
+    RefreshPanelAlphaDependencyTargets(self)
     self:RefreshGroupFrame(groupId)
     return true
 end
@@ -1283,6 +1295,7 @@ function CooldownCompanion:DeleteGroup(id)
     if parentId and self:GetPanelCount(parentId) == 0 then
         self:DeleteContainer(parentId)
     end
+    RefreshPanelAlphaDependencyTargets(self)
 end
 
 function CooldownCompanion:DuplicateGroup(id)
@@ -1315,6 +1328,7 @@ function CooldownCompanion:DuplicateGroup(id)
 
     self.db.profile.groups[newGroupId] = newGroup
     self:CreateGroupFrame(newGroupId)
+    RefreshPanelAlphaDependencyTargets(self)
     return newGroupId
 end
 
@@ -1828,6 +1842,7 @@ function CooldownCompanion:CopyPanelToContainer(sourceGroupId, targetContainerId
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
+    RefreshPanelAlphaDependencyTargets(self)
     return newGroupId
 end
 
@@ -1866,6 +1881,7 @@ function CooldownCompanion:CopyPanelAsNewGroup(sourceGroupId, sourceName)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
+    RefreshPanelAlphaDependencyTargets(self)
 
     return containerId, newGroupId
 end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -54,6 +54,9 @@ local IGNORE_SPELL_AVAILABILITY_OPTIONS = {
 }
 
 local function GetAddonAnchorGroupId(frameName)
+    if CooldownCompanion.GetAddonAnchorGroupId then
+        return CooldownCompanion:GetAddonAnchorGroupId(frameName)
+    end
     if not CooldownCompanion.ParseAddonAnchorFrameName then
         return nil
     end
@@ -63,6 +66,9 @@ local function GetAddonAnchorGroupId(frameName)
 end
 
 local function IsAddonFrameAnchorTarget(frameName)
+    if CooldownCompanion.IsAddonFrameAnchorTarget then
+        return CooldownCompanion:IsAddonFrameAnchorTarget(frameName)
+    end
     if not CooldownCompanion.ParseAddonAnchorFrameName then
         return false
     end
@@ -131,6 +137,51 @@ local function GetPanelAnchorDepth(groups, groupId, visiting)
     local depth = GetPanelAnchorDepth(groups, targetGroupId, visiting) + 1
     visiting[groupId] = nil
     return depth
+end
+
+local function PreparePanelFrameForAnchorFinalization(self, groupId, group, frame)
+    if not (group and frame) then
+        return
+    end
+
+    if not group.compactLayout and self.GetGroupLayoutButtonCount then
+        frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+    else
+        frame.layoutButtonCount = nil
+    end
+    if self.ResizeGroupFrame then
+        self:ResizeGroupFrame(groupId)
+    end
+end
+
+local function CollectPanelAnchorFinalizationRecords(self, groups)
+    local panels = {}
+    for groupId, group in pairs(groups or {}) do
+        local frame = self.groupFrames and self.groupFrames[groupId]
+        if group and group.parentContainerId and group.anchor and frame then
+            PreparePanelFrameForAnchorFinalization(self, groupId, group, frame)
+            panels[#panels + 1] = {
+                groupId = groupId,
+                group = group,
+                frame = frame,
+                depth = GetPanelAnchorDepth(groups, groupId),
+            }
+        end
+    end
+    return panels
+end
+
+local function SortPanelAnchorFinalizationRecords(panels)
+    table.sort(panels, function(a, b)
+        if a.depth ~= b.depth then
+            return a.depth < b.depth
+        end
+        return tostring(a.groupId) < tostring(b.groupId)
+    end)
+end
+
+local function ShouldReapplyFinalizedPanelAnchor(panel)
+    return not (panel.group.compactLayout and IsFrameAnchoredToSavedTarget(panel.frame, panel.group.anchor))
 end
 
 ST.LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS or {
@@ -1955,38 +2006,18 @@ function CooldownCompanion:FinalizePanelAnchors()
         return
     end
 
-    local panels = {}
-    for groupId, group in pairs(groups) do
-        local frame = self.groupFrames[groupId]
-        if group and group.parentContainerId and group.anchor and frame then
-            if not group.compactLayout and self.GetGroupLayoutButtonCount then
-                frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
-            else
-                frame.layoutButtonCount = nil
-            end
-            if self.ResizeGroupFrame then
-                self:ResizeGroupFrame(groupId)
-            end
-            panels[#panels + 1] = {
-                groupId = groupId,
-                group = group,
-                frame = frame,
-                depth = GetPanelAnchorDepth(groups, groupId),
-            }
+    -- This is the post-create/post-refresh owner for panel lifecycle order:
+    -- size every panel first, then re-apply saved anchors from roots outward.
+    local panels = CollectPanelAnchorFinalizationRecords(self, groups)
+    SortPanelAnchorFinalizationRecords(panels)
+    for _, panel in ipairs(panels) do
+        if ShouldReapplyFinalizedPanelAnchor(panel) then
+            self:AnchorGroupFrame(panel.frame, panel.group.anchor)
         end
     end
 
-    table.sort(panels, function(a, b)
-        if a.depth ~= b.depth then
-            return a.depth < b.depth
-        end
-        return tostring(a.groupId) < tostring(b.groupId)
-    end)
-
-    for _, panel in ipairs(panels) do
-        if not (panel.group.compactLayout and IsFrameAnchoredToSavedTarget(panel.frame, panel.group.anchor)) then
-            self:AnchorGroupFrame(panel.frame, panel.group.anchor)
-        end
+    if self.RebuildPanelAlphaDependencyTargets then
+        self:RebuildPanelAlphaDependencyTargets(groups)
     end
 end
 

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -53,30 +53,6 @@ local IGNORE_SPELL_AVAILABILITY_OPTIONS = {
     ignoreSpellAvailability = true,
 }
 
-local function GetAddonAnchorGroupId(frameName)
-    if CooldownCompanion.GetAddonAnchorGroupId then
-        return CooldownCompanion:GetAddonAnchorGroupId(frameName)
-    end
-    if not CooldownCompanion.ParseAddonAnchorFrameName then
-        return nil
-    end
-
-    local kind, id = CooldownCompanion:ParseAddonAnchorFrameName(frameName)
-    return kind == "group" and id or nil
-end
-
-local function IsAddonFrameAnchorTarget(frameName)
-    if CooldownCompanion.IsAddonFrameAnchorTarget then
-        return CooldownCompanion:IsAddonFrameAnchorTarget(frameName)
-    end
-    if not CooldownCompanion.ParseAddonAnchorFrameName then
-        return false
-    end
-
-    local kind = CooldownCompanion:ParseAddonAnchorFrameName(frameName)
-    return kind == "group" or kind == "container"
-end
-
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -122,8 +98,8 @@ local function GetPanelAnchorDepth(groups, groupId, visiting)
     local group = groups and groups[groupId]
     local anchor = group and group.anchor
     local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
-    local targetGroupId = GetAddonAnchorGroupId(relativeTo)
-    if not targetGroupId then
+    local kind, targetGroupId = CooldownCompanion:ParseAddonAnchorFrameName(relativeTo)
+    if kind ~= "group" then
         visiting[groupId] = nil
         return 0
     end
@@ -137,51 +113,6 @@ local function GetPanelAnchorDepth(groups, groupId, visiting)
     local depth = GetPanelAnchorDepth(groups, targetGroupId, visiting) + 1
     visiting[groupId] = nil
     return depth
-end
-
-local function PreparePanelFrameForAnchorFinalization(self, groupId, group, frame)
-    if not (group and frame) then
-        return
-    end
-
-    if not group.compactLayout and self.GetGroupLayoutButtonCount then
-        frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
-    else
-        frame.layoutButtonCount = nil
-    end
-    if self.ResizeGroupFrame then
-        self:ResizeGroupFrame(groupId)
-    end
-end
-
-local function CollectPanelAnchorFinalizationRecords(self, groups)
-    local panels = {}
-    for groupId, group in pairs(groups or {}) do
-        local frame = self.groupFrames and self.groupFrames[groupId]
-        if group and group.parentContainerId and group.anchor and frame then
-            PreparePanelFrameForAnchorFinalization(self, groupId, group, frame)
-            panels[#panels + 1] = {
-                groupId = groupId,
-                group = group,
-                frame = frame,
-                depth = GetPanelAnchorDepth(groups, groupId),
-            }
-        end
-    end
-    return panels
-end
-
-local function SortPanelAnchorFinalizationRecords(panels)
-    table.sort(panels, function(a, b)
-        if a.depth ~= b.depth then
-            return a.depth < b.depth
-        end
-        return tostring(a.groupId) < tostring(b.groupId)
-    end)
-end
-
-local function ShouldReapplyFinalizedPanelAnchor(panel)
-    return not (panel.group.compactLayout and IsFrameAnchoredToSavedTarget(panel.frame, panel.group.anchor))
 end
 
 ST.LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS or {
@@ -2008,17 +1939,39 @@ function CooldownCompanion:FinalizePanelAnchors()
 
     -- This is the post-create/post-refresh owner for panel lifecycle order:
     -- size every panel first, then re-apply saved anchors from roots outward.
-    local panels = CollectPanelAnchorFinalizationRecords(self, groups)
-    SortPanelAnchorFinalizationRecords(panels)
+    local panels = {}
+    for groupId, group in pairs(groups) do
+        local frame = self.groupFrames[groupId]
+        if group and group.parentContainerId and group.anchor and frame then
+            if not group.compactLayout then
+                frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+            else
+                frame.layoutButtonCount = nil
+            end
+            self:ResizeGroupFrame(groupId)
+            panels[#panels + 1] = {
+                groupId = groupId,
+                group = group,
+                frame = frame,
+                depth = GetPanelAnchorDepth(groups, groupId),
+            }
+        end
+    end
+
+    table.sort(panels, function(a, b)
+        if a.depth ~= b.depth then
+            return a.depth < b.depth
+        end
+        return tostring(a.groupId) < tostring(b.groupId)
+    end)
+
     for _, panel in ipairs(panels) do
-        if ShouldReapplyFinalizedPanelAnchor(panel) then
+        if not (panel.group.compactLayout and IsFrameAnchoredToSavedTarget(panel.frame, panel.group.anchor)) then
             self:AnchorGroupFrame(panel.frame, panel.group.anchor)
         end
     end
 
-    if self.RebuildPanelAlphaDependencyTargets then
-        self:RebuildPanelAlphaDependencyTargets(groups)
-    end
+    self:RebuildPanelAlphaDependencyTargets(groups)
 end
 
 function CooldownCompanion:FinalizeNonPanelGroupAnchors()
@@ -2030,11 +1983,12 @@ function CooldownCompanion:FinalizeNonPanelGroupAnchors()
     for groupId, group in pairs(groups) do
         local anchor = group and group.anchor
         local relativeTo = type(anchor) == "table" and anchor.relativeTo or nil
+        local targetKind = self:ParseAddonAnchorFrameName(relativeTo)
         local frame = self.groupFrames[groupId]
         if frame
             and group
             and not group.parentContainerId
-            and IsAddonFrameAnchorTarget(relativeTo) then
+            and (targetKind == "group" or targetKind == "container") then
             self:AnchorGroupFrame(frame, anchor)
         end
     end


### PR DESCRIPTION
## What Players Will Notice
- Panel positioning, panel-to-panel anchoring, standalone texture/trigger panel anchors, and panel alpha inheritance should behave the same as before.
- The alpha update path does less repeated anchor discovery work, so profiles with several panels may feel a bit lighter during normal UI updates.

## Why This Changed
- The PR #332 anchor fix left several systems sharing responsibility for panel lifecycle order, saved/active anchor meaning, and alpha inheritance discovery.
- The alpha fade loop was still rediscovering panel anchor relationships repeatedly instead of using an explicit dependency target cache.

## What Changed
- Moved addon-frame anchor target resolution and missing-target meaning into `Core/AnchorPolicy.lua`.
- Simplified panel finalization so `FinalizePanelAnchors` owns the create/resize/finalize/re-anchor ordering directly.
- Replaced per-tick alpha relationship discovery with cached panel alpha dependency targets that rebuild when saved anchor relationships change.
- Removed transitional fallback wrappers and optional guards along the refactored anchor path now that `AnchorPolicy` is loaded before the dependent modules.
- Kept runtime fallback behavior from mutating saved `relativeTo`, so missing targets can recover when they return.

## Validation
- Local Lua tests passed for config row icons, keybind bonus-bar slot resolution, panel alpha inheritance, panel alpha state reapply, panel anchor finalization, panel config preview availability, panel text preview sizing, resource-gated cooldowns, and unusable visual mode.
- `luac -p` passed on the changed runtime files and focused local tests.
- `git diff --check origin/main...HEAD` passed.
- User-reported in-game validation covered combat, restricted content, and no Lua errors.
