### PR TITLE
Track equipped trinket slots as cooldown entries

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -80,6 +80,8 @@ end
 
 -- Shared helpers from ButtonFrame/Helpers.lua
 local IsItemEquippable = CooldownCompanion.IsItemEquippable
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
+local ResolveEffectiveItem = CooldownCompanion.ResolveEffectiveItem
 local FormatTime = CooldownCompanion.FormatTime
 local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
 
@@ -95,8 +97,11 @@ local function SetBarIconTooltipScripts(button, enable)
             GameTooltip_SetDefaultAnchor(GameTooltip, UIParent)
             if bd.type == "spell" then
                 GameTooltip:SetSpellByID(button._displaySpellId or bd.id)
-            elseif bd.type == "item" then
-                GameTooltip:SetItemByID(button._resolvedItemId or bd.id)
+            elseif IsEntryItemLike(bd) then
+                local itemID = button._resolvedItemId or bd.id
+                if itemID then
+                    GameTooltip:SetItemByID(itemID)
+                end
             end
             GameTooltip:Show()
         end)
@@ -981,7 +986,7 @@ local function UpdateBarFill(button)
         onCooldown = true
         SetStatusBarImmediateRange(button.statusBar, 0, 1)
         SetStatusBarImmediateValue(button.statusBar, 0)
-    elseif button.buttonData.type == "item" then
+    elseif IsEntryItemLike(button.buttonData) then
         ClearBarAuraStackVisual(button)
         -- Items: use stored C_Item.GetItemCooldown values (avoids hidden-widget staleness)
         SetStatusBarSmoothRange(button.statusBar, 0, 1)
@@ -1145,7 +1150,7 @@ local function UpdateBarDisplay(button)
 
     -- "On cooldown" for bar color/ready text follows canonical state.
     -- _durationObj may also hold aura/totem timing and must not imply cooldown.
-    local itemUsesResolvedCooldownState = button.buttonData.type == "item"
+    local itemUsesResolvedCooldownState = IsEntryItemLike(button.buttonData)
         and button._resolvedItemQuantityKind == "stacks"
     local barAuraStackDisplay = button._barAuraStackDisplay == true
     local stackSegmentLayerActive = barAuraStackDisplay and button._barAuraStackMode ~= "continuous"
@@ -1688,11 +1693,13 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil
 
-    if buttonData.type == "item" then
-        local resolvedItemID, availableQuantity, quantityKind = CooldownCompanion.ResolveItemFallback(buttonData)
-        button._resolvedItemId = resolvedItemID or buttonData.id
-        button._resolvedItemAvailableQuantity = availableQuantity or 0
-        button._resolvedItemQuantityKind = quantityKind or "stacks"
+    if IsEntryItemLike(buttonData) then
+        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
+        button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
+        button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"
+        button._equipmentSlotTrackable = CooldownCompanion.IsEquipmentSlotEntry(buttonData)
+            and effectiveItem and effectiveItem.trackable == true or nil
     end
 
     -- Per-button visibility runtime state
@@ -1717,8 +1724,9 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
             elseif buttonData.type == "spell" then
                 local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
                 if spellName then displayName = spellName end
-            elseif buttonData.type == "item" then
-                local itemName = C_Item.GetItemNameByID(button._resolvedItemId or buttonData.id)
+            elseif IsEntryItemLike(buttonData) then
+                local itemID = button._resolvedItemId or buttonData.id
+                local itemName = itemID and C_Item.GetItemNameByID(itemID)
                 if itemName then displayName = itemName end
             end
         end
@@ -2055,8 +2063,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
             elseif button.buttonData.type == "spell" then
                 local spellName = C_Spell.GetSpellName(button._displaySpellId or button.buttonData.id)
                 if spellName then displayName = spellName end
-            elseif button.buttonData.type == "item" then
-                local itemName = C_Item.GetItemNameByID(button._resolvedItemId or button.buttonData.id)
+            elseif IsEntryItemLike(button.buttonData) then
+                local itemID = button._resolvedItemId or button.buttonData.id
+                local itemName = itemID and C_Item.GetItemNameByID(itemID)
                 if itemName then displayName = itemName end
             end
         end

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -65,7 +65,9 @@ local UpdateTextDisplay = ST._UpdateTextDisplay
 local IsItemEquippable = CooldownCompanion.IsItemEquippable
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
-local ResolveItemFallback = CooldownCompanion.ResolveItemFallback
+local IsEquipmentSlotEntry = CooldownCompanion.IsEquipmentSlotEntry
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
+local ResolveEffectiveItem = CooldownCompanion.ResolveEffectiveItem
 local HasCastCountText = CooldownCompanion.HasCastCountText
 local GetCastCountSpellID = CooldownCompanion.GetCastCountSpellID
 local GetConditionalCastCountSpellID = CooldownCompanion.GetConditionalCastCountSpellID
@@ -399,8 +401,11 @@ local function RestoreBaseDisplayName(button, buttonData)
     local baseName = buttonData.name
     if buttonData.type == "spell" then
         baseName = C_Spell.GetSpellName(restoreSpellID) or baseName
-    elseif buttonData.type == "item" then
-        baseName = C_Item.GetItemNameByID(button._resolvedItemId or buttonData.id) or baseName
+    elseif IsEntryItemLike(buttonData) then
+        local itemID = button._resolvedItemId or buttonData.id
+        if itemID then
+            baseName = C_Item.GetItemNameByID(itemID) or baseName
+        end
     end
 
     if baseName then
@@ -559,8 +564,19 @@ end
 local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
     button._isEquippableNotEquipped = false
     button._itemGCDOnly = false
-    local isEquippable = IsItemEquippable(buttonData)
+    local isEquipmentSlot = IsEquipmentSlotEntry(buttonData)
+    local isEquippable = (not isEquipmentSlot) and IsItemEquippable(buttonData)
     local itemID = button._resolvedItemId or buttonData.id
+    if not itemID then
+        if renderCooldown then
+            button.cooldown:SetCooldown(0, 0)
+        end
+        button._itemCdStart = 0
+        button._itemCdDuration = 0
+        button._cooldownState = COOLDOWN_STATE_READY
+        return false
+    end
+
     if isEquippable and not C_Item.IsEquippedItem(itemID) then
         button._isEquippableNotEquipped = true
         if renderCooldown then
@@ -615,15 +631,35 @@ local function EvaluateItemCooldown(button, buttonData, style, renderCooldown)
 end
 
 local function UpdateResolvedItemState(button, buttonData)
-    if not (buttonData and buttonData.type == "item") then
+    if not IsEntryItemLike(buttonData) then
         button._resolvedItemId = nil
         button._resolvedItemAvailableQuantity = nil
         button._resolvedItemQuantityKind = nil
         button._resolvedItemMaxCharges = nil
+        button._equipmentSlotTrackable = nil
         return false
     end
 
-    local resolvedItemID, availableQuantity, quantityKind = ResolveItemFallback(buttonData)
+    local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+    if IsEquipmentSlotEntry(buttonData) and not (effectiveItem and effectiveItem.trackable) then
+        if InCombatLockdown() and button._resolvedItemId then
+            return false
+        end
+        local changed = button._resolvedItemId ~= nil
+            or button._resolvedItemAvailableQuantity ~= nil
+            or button._resolvedItemQuantityKind ~= nil
+            or button._equipmentSlotTrackable ~= false
+        button._resolvedItemId = nil
+        button._resolvedItemAvailableQuantity = 0
+        button._resolvedItemQuantityKind = "equipment"
+        button._resolvedItemMaxCharges = nil
+        button._equipmentSlotTrackable = false
+        return changed
+    end
+
+    local resolvedItemID = effectiveItem and effectiveItem.itemID
+    local availableQuantity = effectiveItem and effectiveItem.availableQuantity
+    local quantityKind = effectiveItem and effectiveItem.quantityKind
     local changed = resolvedItemID ~= button._resolvedItemId
         or quantityKind ~= button._resolvedItemQuantityKind
 
@@ -633,6 +669,7 @@ local function UpdateResolvedItemState(button, buttonData)
     button._resolvedItemId = resolvedItemID or buttonData.id
     button._resolvedItemAvailableQuantity = availableQuantity or 0
     button._resolvedItemQuantityKind = quantityKind or "stacks"
+    button._equipmentSlotTrackable = IsEquipmentSlotEntry(buttonData) and true or nil
     return changed
 end
 
@@ -1029,13 +1066,18 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button.secondaryCooldown:SetCooldown(0, 0)
                 button._secondaryCdActive = false
             end
-        elseif buttonData.type == "item" then
+        elseif IsEntryItemLike(buttonData) then
             local itemID = button._resolvedItemId or buttonData.id
-            local cdStart, cdDuration = C_Item.GetItemCooldown(itemID)
-            local probeIsGCDOnly = CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, CooldownCompanion._gcdInfo)
-            if cdDuration and cdDuration > 0 and not probeIsGCDOnly then
-                button.secondaryCooldown:SetCooldown(cdStart, cdDuration)
-                button._secondaryCdActive = true
+            if itemID then
+                local cdStart, cdDuration = C_Item.GetItemCooldown(itemID)
+                local probeIsGCDOnly = CooldownLogic.IsItemGCDOnly(cdStart, cdDuration, CooldownCompanion._gcdInfo)
+                if cdDuration and cdDuration > 0 and not probeIsGCDOnly then
+                    button.secondaryCooldown:SetCooldown(cdStart, cdDuration)
+                    button._secondaryCdActive = true
+                else
+                    button.secondaryCooldown:SetCooldown(0, 0)
+                    button._secondaryCdActive = false
+                end
             else
                 button.secondaryCooldown:SetCooldown(0, 0)
                 button._secondaryCdActive = false
@@ -1089,11 +1131,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             elseif not fetchOk or auraOverrideActive then
                 button.cooldown:SetCooldown(0, 0)
             end
-        elseif buttonData.type == "item" then
+        elseif IsEntryItemLike(buttonData) then
             isGCDOnly = EvaluateItemCooldown(button, buttonData, style, true)
             fetchOk = true
         end
-    elseif not barAuraStackDisplay and buttonData.type == "item" then
+    elseif not barAuraStackDisplay and IsEntryItemLike(buttonData) then
         -- Items keep underlying cooldown state during aura override for visibility/desaturation.
         -- Spell aura overrides intentionally do not: the aura owns the spell visual state.
         isGCDOnly = EvaluateItemCooldown(button, buttonData, style, false)
@@ -1313,7 +1355,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._chargeState = ResolveChargeState(button, buttonData)
 
     -- Cooldown desaturation follows the canonical cooldown state, never the GCD.
-    if buttonData.type == "item" then
+    if IsEntryItemLike(buttonData) then
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then
         button._desatCooldownActive = button._chargeState == CHARGE_STATE_ZERO
@@ -1628,8 +1670,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         elseif buttonData.type == "spell" then
             local spellID = button._displaySpellId or buttonData.id
             button._isUnusable = not C_Spell_IsSpellUsable(spellID)
-        elseif buttonData.type == "item" or buttonData.type == "equipitem" then
-            local usable = IsUsableItem(button._resolvedItemId or buttonData.id)
+        elseif IsEntryItemLike(buttonData) or buttonData.type == "equipitem" then
+            local itemID = button._resolvedItemId or buttonData.id
+            local usable = itemID and IsUsableItem(itemID)
             button._isUnusable = not usable
         else
             button._isUnusable = false
@@ -1637,10 +1680,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
         if buttonData.type == "spell" and not buttonData.isPassiveCooldown then
             button._isOutOfRange = button._spellOutOfRange or false
-        elseif buttonData.type == "item" or buttonData.type == "equipitem" then
+        elseif IsEntryItemLike(buttonData) or buttonData.type == "equipitem" then
             -- C_Item.IsItemInRange is protected in combat for non-enemy targets (10.2.0)
+            local itemID = button._resolvedItemId or buttonData.id
             if not InCombatLockdown() or UnitCanAttack("player", "target") then
-                local inRange = IsItemInRange(button._resolvedItemId or buttonData.id, "target")
+                local inRange = itemID and IsItemInRange(itemID, "target") or nil
                 button._isOutOfRange = (inRange == false)
             else
                 button._isOutOfRange = false

--- a/ButtonFrame/Glows.lua
+++ b/ButtonFrame/Glows.lua
@@ -6,6 +6,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
 
 -- Localize frequently-used globals
 local ipairs = ipairs
@@ -810,8 +811,11 @@ local function SetupTooltipScripts(button)
         GameTooltip_SetDefaultAnchor(GameTooltip, UIParent)
         if self.buttonData.type == "spell" then
             GameTooltip:SetSpellByID(self._displaySpellId or self.buttonData.id)
-        elseif self.buttonData.type == "item" then
-            GameTooltip:SetItemByID(self._resolvedItemId or self.buttonData.id)
+        elseif IsEntryItemLike(self.buttonData) then
+            local itemID = self._resolvedItemId or self.buttonData.id
+            if itemID then
+                GameTooltip:SetItemByID(itemID)
+            end
         end
         GameTooltip:Show()
     end)

--- a/ButtonFrame/Helpers.lua
+++ b/ButtonFrame/Helpers.lua
@@ -11,6 +11,7 @@ local ipairs = ipairs
 local math_floor = math.floor
 local pairs = pairs
 local string_format = string.format
+local tostring = tostring
 local tonumber = tonumber
 local type = type
 
@@ -19,6 +20,62 @@ local DEFAULT_BAR_AURA_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_BAR_PANDEMIC_COLOR = {1.0, 0.5, 0.0, 1.0}
 local DEFAULT_BAR_CHARGE_COLOR = {1.0, 0.82, 0.0, 1.0}
 local HEALTHSTONE_ITEM_ID = 5512
+local EQUIPMENT_SLOT_TYPE = "equipmentSlot"
+local EQUIPMENT_SLOT_KIND_TRINKET = "trinket"
+local TRINKET_SLOT_1 = 13
+local TRINKET_SLOT_2 = 14
+local UNKNOWN_ICON = 134400
+
+local EQUIPMENT_SLOT_NAMES = {
+    [TRINKET_SLOT_1] = "Trinket Slot 1",
+    [TRINKET_SLOT_2] = "Trinket Slot 2",
+}
+
+CooldownCompanion.EQUIPMENT_SLOT_TYPE = EQUIPMENT_SLOT_TYPE
+CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET = EQUIPMENT_SLOT_KIND_TRINKET
+CooldownCompanion.TRINKET_SLOT_1 = TRINKET_SLOT_1
+CooldownCompanion.TRINKET_SLOT_2 = TRINKET_SLOT_2
+
+local function IsEquipmentSlotEntry(buttonData)
+    if not (buttonData and buttonData.type == EQUIPMENT_SLOT_TYPE) then
+        return false
+    end
+    return buttonData.itemSlotKind == EQUIPMENT_SLOT_KIND_TRINKET
+        and (buttonData.itemSlot == TRINKET_SLOT_1 or buttonData.itemSlot == TRINKET_SLOT_2)
+end
+CooldownCompanion.IsEquipmentSlotEntry = IsEquipmentSlotEntry
+
+local function GetEquipmentSlotDisplayName(buttonData)
+    if not IsEquipmentSlotEntry(buttonData) then
+        return nil
+    end
+    return EQUIPMENT_SLOT_NAMES[buttonData.itemSlot] or buttonData.name
+end
+CooldownCompanion.GetEquipmentSlotDisplayName = GetEquipmentSlotDisplayName
+
+local function GetEntryStableKey(buttonData)
+    if IsEquipmentSlotEntry(buttonData) then
+        return EQUIPMENT_SLOT_TYPE .. ":" .. buttonData.itemSlotKind .. ":" .. tostring(buttonData.itemSlot)
+    end
+    if buttonData and buttonData.type and buttonData.id ~= nil then
+        return tostring(buttonData.type) .. ":" .. tostring(buttonData.id)
+    end
+    return nil
+end
+CooldownCompanion.GetEntryStableKey = GetEntryStableKey
+
+local function GetEntrySettingsKind(buttonData)
+    if IsEquipmentSlotEntry(buttonData) then
+        return EQUIPMENT_SLOT_TYPE
+    end
+    return buttonData and buttonData.type or nil
+end
+CooldownCompanion.GetEntrySettingsKind = GetEntrySettingsKind
+
+local function IsEntryItemLike(buttonData)
+    return buttonData and (buttonData.type == "item" or IsEquipmentSlotEntry(buttonData))
+end
+CooldownCompanion.IsEntryItemLike = IsEntryItemLike
 
 -- Format remaining seconds for time display (shared across bar, text, and preview modes).
 local DURATION_FORMAT_CLOCK = "clock"
@@ -590,10 +647,115 @@ end
 -- Returns true if the given item ID is equippable (trinkets, weapons, armor, etc.)
 -- Caches result on buttonData to avoid repeated API calls.
 local function IsItemEquippable(buttonData)
+    if IsEquipmentSlotEntry(buttonData) then
+        return true
+    end
+    if not (buttonData and buttonData.id) then
+        return false
+    end
     local _, _, _, equipLoc = C_Item.GetItemInfoInstant(buttonData.id)
     return equipLoc ~= nil and equipLoc ~= "" and not equipLoc:find("NON_EQUIP")
 end
 CooldownCompanion.IsItemEquippable = IsItemEquippable
+
+local function RequestEquipmentSlotItemData(itemLocation, itemID)
+    if itemID then
+        CooldownCompanion._pendingEquipmentSlotItemLoads = CooldownCompanion._pendingEquipmentSlotItemLoads or {}
+        CooldownCompanion._pendingEquipmentSlotItemLoads[itemID] = true
+        C_Item.RequestLoadItemDataByID(itemID)
+    elseif itemLocation then
+        CooldownCompanion._pendingEquipmentSlotLocationLoad = true
+        C_Item.RequestLoadItemData(itemLocation)
+    end
+end
+
+local function ResolveEquipmentSlotItem(buttonData, opts)
+    local result = {
+        isEquipmentSlot = true,
+        itemSlot = buttonData and buttonData.itemSlot or nil,
+        itemSlotKind = buttonData and buttonData.itemSlotKind or nil,
+        name = GetEquipmentSlotDisplayName(buttonData),
+        icon = UNKNOWN_ICON,
+        trackable = false,
+        availableQuantity = 0,
+        quantityKind = "equipment",
+    }
+
+    if not IsEquipmentSlotEntry(buttonData) then
+        result.reason = "invalid"
+        return result
+    end
+
+    local itemLocation = ItemLocation:CreateFromEquipmentSlot(buttonData.itemSlot)
+    result.itemLocation = itemLocation
+    if not C_Item.DoesItemExist(itemLocation) then
+        result.reason = "empty"
+        return result
+    end
+
+    local itemID = C_Item.GetItemID(itemLocation)
+    result.itemID = itemID
+    if not itemID then
+        result.reason = "loading"
+        if opts and opts.requestLoad then
+            RequestEquipmentSlotItemData(itemLocation)
+        end
+        return result
+    end
+
+    result.icon = C_Item.GetItemIcon(itemLocation) or C_Item.GetItemIconByID(itemID) or UNKNOWN_ICON
+    result.itemName = C_Item.GetItemName(itemLocation) or C_Item.GetItemNameByID(itemID)
+    result.availableQuantity = 1
+
+    if C_Item.IsItemDataCached(itemLocation) == false or C_Item.IsItemDataCachedByID(itemID) == false then
+        result.reason = "loading"
+        if opts and opts.requestLoad then
+            RequestEquipmentSlotItemData(itemLocation, itemID)
+        end
+        return result
+    end
+
+    local inventoryType = C_Item.GetItemInventoryType(itemLocation)
+    result.inventoryType = inventoryType
+    if inventoryType ~= Enum.InventoryType.IndexTrinketType then
+        result.reason = "not-trinket"
+        return result
+    end
+
+    local spellName, spellID = C_Item.GetItemSpell(itemID)
+    result.itemSpellName = spellName
+    result.itemSpellID = spellID
+    if not spellName then
+        result.reason = "no-use"
+        return result
+    end
+
+    result.trackable = true
+    result.reason = "resolved"
+    return result
+end
+
+local function ResolveEffectiveItem(buttonData, opts)
+    if IsEquipmentSlotEntry(buttonData) then
+        return ResolveEquipmentSlotItem(buttonData, opts)
+    end
+    if not (buttonData and buttonData.type == "item") then
+        return nil
+    end
+
+    local resolvedItemID, availableQuantity, quantityKind = ResolveItemFallback(buttonData)
+    local itemID = resolvedItemID or buttonData.id
+    return {
+        itemID = itemID,
+        itemName = itemID and C_Item.GetItemNameByID(itemID) or nil,
+        icon = itemID and C_Item.GetItemIconByID(itemID) or UNKNOWN_ICON,
+        trackable = itemID ~= nil,
+        availableQuantity = availableQuantity or 0,
+        quantityKind = quantityKind or "stacks",
+        isEquipmentSlot = false,
+    }
+end
+CooldownCompanion.ResolveEffectiveItem = ResolveEffectiveItem
 
 -- Apply configurable strata (frame level) ordering to button sub-elements.
 -- order: array of 6 keys or nil for default.

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -63,6 +63,8 @@ end
 
 -- Shared helpers from ButtonFrame/Helpers.lua
 local IsItemEquippable = CooldownCompanion.IsItemEquippable
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
+local ResolveEffectiveItem = CooldownCompanion.ResolveEffectiveItem
 local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
 local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCooldown
 
@@ -279,7 +281,7 @@ local function SetIconFillValue(button)
         return
     end
 
-    if button._iconFillMode == "cooldown" and button.buttonData and button.buttonData.type == "item" then
+    if button._iconFillMode == "cooldown" and IsEntryItemLike(button.buttonData) then
         local durationSeconds = button._itemCdDuration or 0
         if durationSeconds > 0 then
             local elapsed = GetTime() - (button._itemCdStart or 0)
@@ -642,11 +644,13 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.count:SetText("")
     button.buttonData = buttonData
 
-    if buttonData.type == "item" then
-        local resolvedItemID, availableQuantity, quantityKind = CooldownCompanion.ResolveItemFallback(buttonData)
-        button._resolvedItemId = resolvedItemID or buttonData.id
-        button._resolvedItemAvailableQuantity = availableQuantity or 0
-        button._resolvedItemQuantityKind = quantityKind or "stacks"
+    if IsEntryItemLike(buttonData) then
+        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
+        button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
+        button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"
+        button._equipmentSlotTrackable = CooldownCompanion.IsEquipmentSlotEntry(buttonData)
+            and effectiveItem and effectiveItem.trackable == true or nil
     end
 
     ApplyCountTextStyle(button, style)
@@ -919,9 +923,11 @@ function CooldownCompanion:UpdateButtonIcon(button)
             -- resolves the current visual (including talent transforms).
             icon = C_Spell.GetSpellTexture(buttonData.id)
         end
-    elseif buttonData.type == "item" then
+    elseif IsEntryItemLike(buttonData) then
         local itemID = button._resolvedItemId or buttonData.id
-        icon = C_Item.GetItemIconByID(itemID)
+        if itemID then
+            icon = C_Item.GetItemIconByID(itemID)
+        end
     end
 
     -- Manual icon override: replaces base icon; aura icon swap still takes precedence

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -38,7 +38,8 @@ local AreButtonVisualStateSnapshotsEnabled = ST._AreButtonVisualStateSnapshotsEn
 local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
 
 -- Shared helpers from ButtonFrame/Helpers.lua
-local IsItemEquippable = CooldownCompanion.IsItemEquippable
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
+local ResolveEffectiveItem = CooldownCompanion.ResolveEffectiveItem
 local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 
@@ -567,8 +568,9 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                         local spellName = C_Spell.GetSpellName(button._displaySpellId or buttonData.id)
                         if spellName then name = spellName end
                     end
-                elseif not buttonData.customName and buttonData.type == "item" then
-                    local itemName = C_Item.GetItemNameByID(button._resolvedItemId or buttonData.id)
+                elseif not buttonData.customName and IsEntryItemLike(buttonData) then
+                    local itemID = button._resolvedItemId or buttonData.id
+                    local itemName = itemID and C_Item.GetItemNameByID(itemID)
                     if itemName then name = itemName end
                 end
                 if name then
@@ -1051,11 +1053,13 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._auraNameOverrideActive = nil
     button._textSecretNameActive = nil
 
-    if buttonData.type == "item" then
-        local resolvedItemID, availableQuantity, quantityKind = CooldownCompanion.ResolveItemFallback(buttonData)
-        button._resolvedItemId = resolvedItemID or buttonData.id
-        button._resolvedItemAvailableQuantity = availableQuantity or 0
-        button._resolvedItemQuantityKind = quantityKind or "stacks"
+    if IsEntryItemLike(buttonData) then
+        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
+        button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
+        button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"
+        button._equipmentSlotTrackable = CooldownCompanion.IsEquipmentSlotEntry(buttonData)
+            and effectiveItem and effectiveItem.trackable == true or nil
     end
 
     -- Per-button visibility runtime state

--- a/ButtonFrame/Tracking.lua
+++ b/ButtonFrame/Tracking.lua
@@ -16,6 +16,13 @@ local UnitCanAttack = UnitCanAttack
 local IsItemInRange = C_Item.IsItemInRange
 local IsUsableItem = C_Item.IsUsableItem
 local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike or function(buttonData)
+    return buttonData
+        and (buttonData.type == "item"
+            or (buttonData.type == "equipmentSlot"
+                and buttonData.itemSlotKind == "trinket"
+                and (buttonData.itemSlot == 13 or buttonData.itemSlot == 14)))
+end
 
 -- Update charge count state for a spell with hasCharges enabled.
 -- chargeSpellID should be the effective runtime spell ID (override-aware).
@@ -187,9 +194,9 @@ local function IsUnusableVisualActive(button, buttonData)
         if not C_Spell_IsSpellUsable(spellID) then
             return true, "unusable"
         end
-    elseif buttonData.type == "item" then
+    elseif IsEntryItemLike(buttonData) then
         local itemID = button._resolvedItemId or buttonData.id
-        if not IsUsableItem(itemID) then
+        if not itemID or not IsUsableItem(itemID) then
             return true, "unusable"
         end
     end
@@ -235,12 +242,12 @@ local function ResolveIconTintIntent(button, buttonData, style, target)
                 reason = "out-of-range"
                 stateOverride = true
             end
-        elseif buttonData.type == "item" then
+        elseif IsEntryItemLike(buttonData) then
             -- C_Item.IsItemInRange is protected in combat for non-enemy targets (10.2.0);
             -- only call when out of combat or target is attackable.
             if not InCombatLockdown() or UnitCanAttack("player", "target") then
                 local itemID = button._resolvedItemId or buttonData.id
-                local inRange = IsItemInRange(itemID, "target")
+                local inRange = itemID and IsItemInRange(itemID, "target") or nil
                 -- inRange is nil when no target or item has no range; only tint on explicit false
                 if inRange == false then
                     r, g, b = 1, 0.2, 0.2
@@ -355,7 +362,8 @@ local function ResolveDesaturationIntent(button, buttonData, style, target)
         local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
             and button._resolvedItemAvailableQuantity
             or button._itemCount
-        if not target.active and buttonData.desaturateWhileZeroStacks and (itemUseCount or 0) == 0 then
+        if not target.active and buttonData.type == "item"
+                and buttonData.desaturateWhileZeroStacks and (itemUseCount or 0) == 0 then
             target.active = true
             target.reason = "zero-stacks"
         end

--- a/ButtonFrame/Visibility.lua
+++ b/ButtonFrame/Visibility.lua
@@ -15,6 +15,7 @@ local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
 local IsUsableItem = C_Item.IsUsableItem
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
+local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
 
 local bit_band = bit.band
 local bit_bor  = bit.bor
@@ -127,7 +128,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local hideReasons = 0
     local auraTrackingReady = button._auraTrackingReady == true
     local barAuraStackDisplay = button._barAuraStackDisplay == true
-    local itemUsesResolvedCooldownState = buttonData.type == "item"
+    local itemUsesResolvedCooldownState = IsEntryItemLike(buttonData)
         and button._resolvedItemQuantityKind == "stacks"
     local noCooldownForVisibility = IsNoCooldownForVisibility(button)
 
@@ -142,7 +143,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                     or button._chargeState == CHARGE_STATE_MISSING then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
-        elseif buttonData.type == "item" then
+        elseif IsEntryItemLike(buttonData) then
             if button._cooldownState == COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
@@ -163,7 +164,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
             if button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
-        elseif buttonData.type == "item" then
+        elseif IsEntryItemLike(buttonData) then
             if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
@@ -209,7 +210,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local itemUseCount = CooldownCompanion.HasItemFallbacks(buttonData)
         and button._resolvedItemAvailableQuantity
         or button._itemCount
-    if buttonData.hideWhileZeroStacks and (itemUseCount or 0) == 0 then
+    if buttonData.type == "item" and buttonData.hideWhileZeroStacks and (itemUseCount or 0) == 0 then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_STACKS)
     end
 
@@ -225,9 +226,9 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
             if not C_Spell_IsSpellUsable(spellID) then
                 hideReasons = bit_bor(hideReasons, HIDE_UNUSABLE)
             end
-        elseif buttonData.type == "item" then
+        elseif IsEntryItemLike(buttonData) then
             local itemID = button._resolvedItemId or buttonData.id
-            if not IsUsableItem(itemID) then
+            if not itemID or not IsUsableItem(itemID) then
                 hideReasons = bit_bor(hideReasons, HIDE_UNUSABLE)
             end
         end

--- a/Config/Column2.lua
+++ b/Config/Column2.lua
@@ -719,7 +719,7 @@ local function BuildInlineAddControls(panelContainer, panelMeta, panel, panelId,
     inputBox:DisableButton(true)
     inputBox:SetFullWidth(true)
     panelMeta.addInputFrame = inputBox.frame
-    local updatePlaceholder = ConfigureInlineAddInstructions(inputBox, "Add spells, items, and IDs")
+    local updatePlaceholder = ConfigureInlineAddInstructions(inputBox, "Add spell, item, trinket slot, or ID")
     inputBox:SetCallback("OnEnterPressed", function(widget, event, text)
         if CS.ConsumeAutocompleteEnter() then return end
         CS.HideAutocomplete()
@@ -801,6 +801,7 @@ local function BuildInlineAddControls(panelContainer, panelMeta, panel, panelId,
     end
 
     panelContainer:AddChild(addRow)
+
 end
 
 local function EnsureRowBadge(frame, key, atlas, iconSize)
@@ -2534,6 +2535,13 @@ local function RefreshColumn2()
                         BindConfigShiftTooltip(entry, "spell", ResolveColumn2TooltipSpellId(buttonData), entry.frame, "ANCHOR_RIGHT")
                     elseif buttonData.type == "item" then
                         BindConfigShiftTooltip(entry, "item", buttonData.id, entry.frame, "ANCHOR_RIGHT")
+                    elseif CooldownCompanion.IsEquipmentSlotEntry
+                        and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+                        local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+                            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+                        if effectiveItem and effectiveItem.trackable and effectiveItem.itemID then
+                            BindConfigShiftTooltip(entry, "item", effectiveItem.itemID, entry.frame, "ANCHOR_RIGHT")
+                        end
                     end
                     entry:SetUserData(
                         "cdcShiftTooltipExtraLine",

--- a/Config/SpellItemAdd.lua
+++ b/Config/SpellItemAdd.lua
@@ -281,11 +281,69 @@ local function TryAddItem(input)
     return false
 end
 
+local function TryAddEquipmentSlot(itemSlot)
+    if not CS.selectedGroup then return false end
+    if IsTriggerPanelTarget(CS.selectedGroup) then return false end
+
+    local slotData = {
+        type = CooldownCompanion.EQUIPMENT_SLOT_TYPE or "equipmentSlot",
+        itemSlot = itemSlot,
+        itemSlotKind = CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET or "trinket",
+    }
+    if CooldownCompanion.IsEquipmentSlotEntry
+        and not CooldownCompanion.IsEquipmentSlotEntry(slotData) then
+        return false
+    end
+
+    local slotName = CooldownCompanion.GetEquipmentSlotDisplayName
+        and CooldownCompanion.GetEquipmentSlotDisplayName(slotData) or "Trinket Slot"
+    local idx = CooldownCompanion:AddEquipmentSlotToGroup(
+        CS.selectedGroup,
+        itemSlot,
+        slotData.itemSlotKind
+    )
+    if not idx then
+        return false
+    end
+
+    SelectNewButton(CS.selectedGroup, idx)
+    CooldownCompanion:Print("Added equipment slot: " .. slotName)
+    return true
+end
+
+local function ResolveEquipmentSlotInput(input)
+    if type(input) ~= "string" then
+        return nil
+    end
+
+    local query = input:lower():gsub("^%s+", ""):gsub("%s+$", ""):gsub("%s+", " ")
+    if query == "trinket slot 1"
+        or query == "trinket 1"
+        or query == "slot 1"
+        or query == "first trinket"
+        or query == "top trinket" then
+        return CooldownCompanion.TRINKET_SLOT_1 or 13
+    end
+    if query == "trinket slot 2"
+        or query == "trinket 2"
+        or query == "slot 2"
+        or query == "second trinket"
+        or query == "bottom trinket" then
+        return CooldownCompanion.TRINKET_SLOT_2 or 14
+    end
+    return nil
+end
+
 ------------------------------------------------------------------------
 -- Unified add: resolve input as spell or item automatically
 ------------------------------------------------------------------------
 local function TryAdd(input)
     if input == "" or not CS.selectedGroup then return false end
+
+    local equipmentSlot = ResolveEquipmentSlotInput(input)
+    if equipmentSlot then
+        return TryAddEquipmentSlot(equipmentSlot)
+    end
 
     local id = tonumber(input)
 
@@ -441,6 +499,53 @@ local function TryAdd(input)
     end
 end
 
+local function BuildEquipmentSlotAutocompleteEntry(itemSlot, aliases)
+    local slotData = {
+        type = CooldownCompanion.EQUIPMENT_SLOT_TYPE or "equipmentSlot",
+        itemSlot = itemSlot,
+        itemSlotKind = CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET or "trinket",
+    }
+    local name = CooldownCompanion.GetEquipmentSlotDisplayName
+        and CooldownCompanion.GetEquipmentSlotDisplayName(slotData)
+        or ("Trinket Slot " .. tostring(itemSlot == (CooldownCompanion.TRINKET_SLOT_2 or 14) and 2 or 1))
+    local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+        and CooldownCompanion.ResolveEffectiveItem(slotData)
+        or nil
+    local searchParts = { name:lower() }
+    for _, alias in ipairs(aliases or {}) do
+        searchParts[#searchParts + 1] = alias
+    end
+    return {
+        id = CooldownCompanion.GetEntryStableKey and CooldownCompanion.GetEntryStableKey(slotData)
+            or ("equipmentSlot:trinket:" .. tostring(itemSlot)),
+        name = name,
+        nameLower = name:lower(),
+        searchLower = table.concat(searchParts, " "),
+        icon = (effectiveItem and effectiveItem.trackable and effectiveItem.icon) or 134400,
+        category = "Equipment",
+        isEquipmentSlot = true,
+        itemSlot = itemSlot,
+        itemSlotKind = slotData.itemSlotKind,
+    }
+end
+
+local function AddEquipmentSlotAutocompleteEntries(cache)
+    cache[#cache + 1] = BuildEquipmentSlotAutocompleteEntry(CooldownCompanion.TRINKET_SLOT_1 or 13, {
+        "trinket 1",
+        "slot 1",
+        "first trinket",
+        "top trinket",
+        "equipment",
+    })
+    cache[#cache + 1] = BuildEquipmentSlotAutocompleteEntry(CooldownCompanion.TRINKET_SLOT_2 or 14, {
+        "trinket 2",
+        "slot 2",
+        "second trinket",
+        "bottom trinket",
+        "equipment",
+    })
+end
+
 ------------------------------------------------------------------------
 -- Helper: Receive a spell/item drop from the cursor
 ------------------------------------------------------------------------
@@ -476,6 +581,8 @@ local function BuildAutocompleteCache()
     local cache = {}
     local seen = {}
     local seenAuras = {}
+
+    AddEquipmentSlotAutocompleteEntries(cache)
 
     -- Pre-compute dual-CDM spell set (spells in both cooldown and buff CDM categories)
     local cdmCooldownSet = {}
@@ -789,7 +896,8 @@ local function SearchAutocompleteInCache(query, cache)
 
         -- Match by name substring
         if not isMatch then
-            local pos = entry.nameLower:find(queryLower, 1, true)
+            local searchable = entry.searchLower or entry.nameLower
+            local pos = searchable and searchable:find(queryLower, 1, true)
             if pos then
                 isMatch = true
                 isPrefix = (pos == 1)
@@ -829,7 +937,18 @@ local function SearchCDMAuraAutocomplete(query)
 end
 
 local function SearchAutocomplete(query)
-    return SearchAutocompleteInCache(query, CS.autocompleteCache or BuildAutocompleteCache())
+    local cache = CS.autocompleteCache or BuildAutocompleteCache()
+    local groupId = CS.addingToPanelId or CS.selectedGroup
+    if IsTriggerPanelTarget(groupId) then
+        local filtered = {}
+        for _, entry in ipairs(cache) do
+            if not entry.isEquipmentSlot then
+                filtered[#filtered + 1] = entry
+            end
+        end
+        cache = filtered
+    end
+    return SearchAutocompleteInCache(query, cache)
 end
 
 ------------------------------------------------------------------------
@@ -863,9 +982,14 @@ end
 ------------------------------------------------------------------------
 local function OnAutocompleteSelect(entry)
     HideAutocomplete()
-    if not CS.selectedGroup then return end
+    local addTargetGroupId = CS.addingToPanelId or CS.selectedGroup
+    if not addTargetGroupId then return end
+
+    CS.selectedGroup = addTargetGroupId
     local added
-    if entry.isItem then
+    if entry.isEquipmentSlot then
+        added = TryAddEquipmentSlot(entry.itemSlot)
+    elseif entry.isItem then
         added = TryAddItem(tostring(entry.id))
     else
         local displayNameOverride
@@ -1104,6 +1228,7 @@ end
 -- ST._ exports (consumed by later Config/ files)
 ------------------------------------------------------------------------
 ST._TryAdd = TryAdd
+ST._TryAddEquipmentSlot = TryAddEquipmentSlot
 ST._TryReceiveCursorDrop = TryReceiveCursorDrop
 ST._BuildAutocompleteCache = BuildAutocompleteCache
 ST._OnAutocompleteSelect = OnAutocompleteSelect

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -418,6 +418,14 @@ local function GetButtonIcon(buttonData)
     end
     if buttonData.type == "spell" then
         return C_Spell.GetSpellTexture(buttonData.id) or 134400
+    elseif CooldownCompanion.IsEquipmentSlotEntry
+        and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+        if effectiveItem and effectiveItem.trackable and effectiveItem.icon then
+            return effectiveItem.icon
+        end
+        return 134400
     elseif buttonData.type == "item" then
         return C_Item.GetItemIconByID(buttonData.id) or 134400
     end
@@ -460,9 +468,16 @@ local function GetConfigEntryDisplayName(buttonData, opts)
 
     opts = opts or {}
     local includeDecorations = opts.includeDecorations == true
-    local entryName = buttonData.customName or buttonData.name
+    local isEquipmentSlot = CooldownCompanion.IsEquipmentSlotEntry
+        and CooldownCompanion.IsEquipmentSlotEntry(buttonData)
+    local entryName = isEquipmentSlot
+        and (CooldownCompanion.GetEquipmentSlotDisplayName
+            and CooldownCompanion.GetEquipmentSlotDisplayName(buttonData) or buttonData.name)
+        or buttonData.customName or buttonData.name
 
-    if buttonData.type == "spell" then
+    if isEquipmentSlot then
+        entryName = entryName or ("Unknown " .. tostring(buttonData.type))
+    elseif buttonData.type == "spell" then
         local child
         if buttonData.cdmChildSlot then
             local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]

--- a/ConfigSettings/ButtonConditions.lua
+++ b/ConfigSettings/ButtonConditions.lua
@@ -19,6 +19,7 @@ local IsNoCooldownSpellID = ST.IsNoCooldownSpell
 local HasUsageRequirement = ST.HasUsageRequirement
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
+local IsEquipmentSlotEntry = CooldownCompanion.IsEquipmentSlotEntry
 
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
@@ -506,11 +507,15 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
 
     local isBatch = batchContext ~= nil
     local isItem
+    local isEquipmentSlot
     if isBatch then
         isItem = batchContext.uniformType == "item"
+        isEquipmentSlot = batchContext.uniformType == "equipmentSlot"
     else
         isItem = buttonData.type == "item"
+        isEquipmentSlot = IsEquipmentSlotEntry and IsEquipmentSlotEntry(buttonData)
     end
+    local isItemLike = isItem or isEquipmentSlot
 
     -- Helper: apply a value to all selected buttons if multi-select, else just this one
     local function ApplyToSelected(field, value)
@@ -1106,8 +1111,8 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         end
     end
 
-    -- Hide While Aura Active (not applicable for items)
-    if not isItem then
+    -- Hide While Aura Active (not applicable for item-like entries)
+    if not isItemLike then
         local anyAuraTrackingEnabled
         local allAuraTrackingReady
         if isBatch then

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -79,12 +79,17 @@ local function GroupUsesTriggerPanelEntries(group)
 end
 
 local function BuildButtonSettingsTabs(group, buttonData)
+    local isEquipmentSlot = CooldownCompanion.IsEquipmentSlotEntry
+        and CooldownCompanion.IsEquipmentSlotEntry(buttonData)
     if GroupUsesTriggerPanelEntries(group) then
-        return {
+        local tabs = {
             { value = "settings", text = "Condition" },
             { value = "loadconditions", text = "Load Conditions" },
-            { value = "soundalerts", text = "Sound Alerts" },
         }
+        if not isEquipmentSlot then
+            tabs[#tabs + 1] = { value = "soundalerts", text = "Sound Alerts" }
+        end
+        return tabs
     end
 
     local tabs = {
@@ -92,7 +97,7 @@ local function BuildButtonSettingsTabs(group, buttonData)
     }
     if buttonData and buttonData.type == "item" then
         tabs[#tabs + 1] = { value = "fallbacks", text = "Fallbacks" }
-    else
+    elseif not isEquipmentSlot then
         tabs[#tabs + 1] = { value = "soundalerts", text = "Sound Alerts" }
     end
 
@@ -2307,6 +2312,9 @@ end
 -- TYPE CLASSIFICATION (for batch visibility)
 ------------------------------------------------------------------------
 local function GetButtonEntryType(buttonData)
+    if CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        return "equipmentSlot"
+    end
     if buttonData.type == "item" then return "item" end
     if buttonData.addedAs == "aura" then return "aura" end
     if buttonData.addedAs == "spell" then return "spell" end
@@ -2388,13 +2396,18 @@ local function RefreshButtonSettingsColumn()
         local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
         local buttonData = group and group.buttons and group.buttons[CS.selectedButton]
         bsCol.bsTabGroup:SetTabs(BuildButtonSettingsTabs(group, buttonData))
+        local isEquipmentSlot = CooldownCompanion.IsEquipmentSlotEntry
+            and CooldownCompanion.IsEquipmentSlotEntry(buttonData)
 
         if GroupUsesTriggerPanelEntries(group)
             and CS.buttonSettingsTab ~= "settings"
             and CS.buttonSettingsTab ~= "loadconditions"
-            and CS.buttonSettingsTab ~= "soundalerts" then
+            and (CS.buttonSettingsTab ~= "soundalerts" or isEquipmentSlot) then
             CS.buttonSettingsTab = "settings"
         elseif GroupUsesTexturePanelEntries(group) and CS.buttonSettingsTab == "overrides" then
+            CS.buttonSettingsTab = "settings"
+        elseif isEquipmentSlot
+            and (CS.buttonSettingsTab == "soundalerts" or CS.buttonSettingsTab == "fallbacks") then
             CS.buttonSettingsTab = "settings"
         elseif buttonData and buttonData.type == "item" and CS.buttonSettingsTab == "soundalerts" then
             CS.buttonSettingsTab = "fallbacks"
@@ -2452,6 +2465,9 @@ local function ConfigureInlineEditBoxInstructions(editBoxWidget, placeholderText
 end
 
 local function BuildCustomNameSection(scroll, buttonData)
+    if CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        return
+    end
     local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
     if not group or group.displayMode ~= "bars" then return end
 

--- a/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/ConfigSettings/ButtonSettingsOverrides.lua
@@ -48,6 +48,15 @@ local BuildTextBackgroundControls = ST._BuildTextBackgroundControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
+local function CanButtonUseOverrideSection(buttonData, sectionId)
+    if ST.CanButtonUseOverrideSection then
+        return ST.CanButtonUseOverrideSection(buttonData, sectionId)
+    end
+    return not (buttonData and buttonData.type == "equipmentSlot"
+        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS
+        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId])
+end
+
 local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex)
     local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
     local button = frame and frame.buttons and frame.buttons[buttonIndex]
@@ -348,7 +357,9 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
     end
 
     for _, sectionId in ipairs(sectionOrder) do
-        if buttonData.overrideSections[sectionId] and not (isNoCooldownSpell and (sectionId == "readyGlow" or sectionId == "desaturation")) then
+        if buttonData.overrideSections[sectionId]
+            and CanButtonUseOverrideSection(buttonData, sectionId)
+            and not (isNoCooldownSpell and (sectionId == "readyGlow" or sectionId == "desaturation")) then
             local sectionDef = ST.OVERRIDE_SECTIONS[sectionId]
             if sectionDef and sectionDef.modes[displayMode] then
                 local heading = AceGUI:Create("Heading")

--- a/ConfigSettings/FormatEditor.lua
+++ b/ConfigSettings/FormatEditor.lua
@@ -477,6 +477,10 @@ local function GetPreviewName()
                 local displayId = (raw and raw ~= 0) and raw or bd.id
                 local spellName = C_Spell.GetSpellName(displayId)
                 if spellName then name = spellName end
+            elseif CooldownCompanion.IsEquipmentSlotEntry
+                and CooldownCompanion.IsEquipmentSlotEntry(bd) then
+                name = CooldownCompanion.GetEquipmentSlotDisplayName
+                    and CooldownCompanion.GetEquipmentSlotDisplayName(bd) or name
             elseif not bd.customName and bd.type == "item" then
                 local itemName = C_Item.GetItemNameByID(bd.id)
                 if itemName then name = itemName end
@@ -495,6 +499,13 @@ local function GetPreviewIcon()
             if bd.type == "spell" then
                 local info = C_Spell.GetSpellTexture(bd.id)
                 if info then return info end
+            elseif CooldownCompanion.IsEquipmentSlotEntry
+                and CooldownCompanion.IsEquipmentSlotEntry(bd) then
+                local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+                    and CooldownCompanion.ResolveEffectiveItem(bd, { requestLoad = true }) or nil
+                if effectiveItem and effectiveItem.trackable and effectiveItem.icon then
+                    return effectiveItem.icon
+                end
             elseif bd.type == "item" then
                 local tex = C_Item.GetItemIconByID(bd.id)
                 if tex then return tex end

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -247,6 +247,15 @@ local function GroupSupportsPerButtonOverrides(group)
     return group and (group.displayMode or "icons") ~= "textures"
 end
 
+local function CanButtonUseOverrideSection(buttonData, sectionId)
+    if ST.CanButtonUseOverrideSection then
+        return ST.CanButtonUseOverrideSection(buttonData, sectionId)
+    end
+    return not (buttonData and buttonData.type == "equipmentSlot"
+        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS
+        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId])
+end
+
 local function CreatePromoteButton(headingWidget, sectionId, buttonData, groupStyle)
     local group = CS.selectedGroup and CooldownCompanion.db.profile.groups[CS.selectedGroup]
     if not GroupSupportsPerButtonOverrides(group) then
@@ -270,8 +279,10 @@ local function CreatePromoteButton(headingWidget, sectionId, buttonData, groupSt
     if CS.selectedButtons then
         for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
     end
+    local sectionAllowed = CanButtonUseOverrideSection(buttonData, sectionId)
     local canPromote = CS.selectedButton ~= nil and multiCount < 2
         and buttonData ~= nil
+        and sectionAllowed
         and not (buttonData.overrideSections and buttonData.overrideSections[sectionId])
 
     if canPromote then
@@ -289,6 +300,8 @@ local function CreatePromoteButton(headingWidget, sectionId, buttonData, groupSt
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if canPromote then
             GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        elseif buttonData and not sectionAllowed then
+            GameTooltip:AddLine("This override is not available for equipment slots", 0.5, 0.5, 0.5)
         else
             GameTooltip:AddLine("Select a button to add an override", 0.5, 0.5, 0.5)
         end
@@ -366,8 +379,10 @@ local function CreateCheckboxPromoteButton(cbWidget, anchorAfterFrame, sectionId
     if CS.selectedButtons then
         for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
     end
+    local sectionAllowed = CanButtonUseOverrideSection(btnData, sectionId)
     local canPromote = CS.selectedButton ~= nil and multiCount < 2
         and btnData ~= nil
+        and sectionAllowed
         and not (btnData.overrideSections and btnData.overrideSections[sectionId])
 
     if canPromote then
@@ -385,6 +400,8 @@ local function CreateCheckboxPromoteButton(cbWidget, anchorAfterFrame, sectionId
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if canPromote then
             GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        elseif btnData and not sectionAllowed then
+            GameTooltip:AddLine("This override is not available for equipment slots", 0.5, 0.5, 0.5)
         else
             GameTooltip:AddLine("Select a button to add an override", 0.5, 0.5, 0.5)
         end
@@ -431,8 +448,10 @@ local function CreateColorPickerPromoteButton(colorPickerWidget, sectionId, grou
     if CS.selectedButtons then
         for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
     end
+    local sectionAllowed = CanButtonUseOverrideSection(btnData, sectionId)
     local canPromote = CS.selectedButton ~= nil and multiCount < 2
         and btnData ~= nil
+        and sectionAllowed
         and not (btnData.overrideSections and btnData.overrideSections[sectionId])
 
     if canPromote then
@@ -450,6 +469,8 @@ local function CreateColorPickerPromoteButton(colorPickerWidget, sectionId, grou
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if canPromote then
             GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        elseif btnData and not sectionAllowed then
+            GameTooltip:AddLine("This override is not available for equipment slots", 0.5, 0.5, 0.5)
         else
             GameTooltip:AddLine("Select a button to add an override", 0.5, 0.5, 0.5)
         end

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -467,6 +467,13 @@ GetLayoutPreviewIcon = function(buttonData)
     local icon
     if buttonData.type == "spell" then
         icon = C_Spell.GetSpellTexture(buttonData.id)
+    elseif CooldownCompanion.IsEquipmentSlotEntry
+        and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+        if effectiveItem and effectiveItem.trackable then
+            icon = effectiveItem.icon
+        end
     elseif buttonData.type == "item" then
         icon = C_Item.GetItemIconByID(buttonData.id)
     end

--- a/Core/AuraTextures.lua
+++ b/Core/AuraTextures.lua
@@ -33,6 +33,11 @@ local math_rad = math.rad
 local math_sin = math.sin
 local pairs = pairs
 local string_find = string.find
+
+local function IsRuntimeItemLike(buttonData)
+    return buttonData
+        and (buttonData.type == "item" or buttonData.type == "equipmentSlot" or buttonData.type == "equipitem")
+end
 local string_format = string.format
 local string_gsub = string.gsub
 local string_lower = string.lower
@@ -412,7 +417,7 @@ local function GetTriggerConditionOrderForButtonData(buttonData)
         return TRIGGER_CONDITION_ORDERS.spell
     end
 
-    if buttonData.type == "item" or buttonData.type == "equipitem" then
+    if IsRuntimeItemLike(buttonData) then
         local order = { "cooldownActive", "rangeActive", "usable" }
         if buttonData.hasCharges == true then
             order[#order + 1] = "chargesRecharging"

--- a/Core/AuraTexturesEffects.lua
+++ b/Core/AuraTexturesEffects.lua
@@ -28,6 +28,11 @@ local tonumber = tonumber
 local type = type
 local wipe = wipe
 
+local function IsRuntimeItemLike(buttonData)
+    return buttonData
+        and (buttonData.type == "item" or buttonData.type == "equipmentSlot" or buttonData.type == "equipitem")
+end
+
 local LOCATION_CENTER = AT.LOCATION_CENTER
 local LOCATION_DIMENSIONS = AT.LOCATION_DIMENSIONS
 local DEFAULT_TEXTURE_SIZE = AT.DEFAULT_TEXTURE_SIZE
@@ -620,8 +625,9 @@ local function ResolveTextureIndicatorSectionState(button, sectionKey, config, t
             local active = not C_Spell_IsSpellUsable(spellID)
             return FinishTextureIndicatorSectionState(target, active, active and "unusable" or "usable", nil, effectType)
         end
-        if buttonData.type == "item" or buttonData.type == "equipitem" then
-            local active = not C_Item_IsUsableItem(button._resolvedItemId or buttonData.id)
+        if IsRuntimeItemLike(buttonData) then
+            local itemID = button._resolvedItemId or buttonData.id
+            local active = not itemID or not C_Item_IsUsableItem(itemID)
             return FinishTextureIndicatorSectionState(target, active, active and "unusable" or "usable", nil, effectType)
         end
         return FinishTextureIndicatorSectionState(target, false, "unsupported-type", nil, effectType)
@@ -660,9 +666,10 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
             return button._spellOutOfRange == false
         end
 
-        if buttonData.type == "item" or buttonData.type == "equipitem" then
+        if IsRuntimeItemLike(buttonData) then
             if not InCombatLockdown() or UnitCanAttack("player", "target") then
-                local inRange = C_Item_IsItemInRange(button._resolvedItemId or buttonData.id, "target")
+                local itemID = button._resolvedItemId or buttonData.id
+                local inRange = itemID and C_Item_IsItemInRange(itemID, "target") or nil
                 if inRange == nil then
                     return nil
                 end
@@ -683,8 +690,9 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
             local spellID = button._displaySpellId or buttonData.id
             return C_Spell_IsSpellUsable(spellID)
         end
-        if buttonData.type == "item" or buttonData.type == "equipitem" then
-            return C_Item_IsUsableItem(button._resolvedItemId or buttonData.id)
+        if IsRuntimeItemLike(buttonData) then
+            local itemID = button._resolvedItemId or buttonData.id
+            return itemID and C_Item_IsUsableItem(itemID) or false
         end
         return false
     end

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -60,9 +60,11 @@ local defaults = {
                     },
                     buttons = {
                         [index] = {
-                            type = "spell" or "item",
-                            id = spellId or itemId,
-                            name = "Spell/Item Name",
+                            type = "spell" or "item" or "equipmentSlot",
+                            id = spellId or itemId, -- spell/item entries only
+                            itemSlot = 13 or 14, -- equipmentSlot entries only
+                            itemSlotKind = "trinket", -- equipmentSlot entries only
+                            name = "Spell/Item/Slot Name",
                         }
                     },
                     style = {
@@ -815,3 +817,22 @@ ST.OVERRIDE_SECTIONS = {
         modes = {text = true},
     },
 }
+
+ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS = {
+    auraText = true,
+    auraStackText = true,
+    auraDurationSwipe = true,
+    assistedHighlight = true,
+    procGlow = true,
+    pandemicGlow = true,
+    auraIndicator = true,
+    pandemicBar = true,
+    barActiveAura = true,
+}
+
+function ST.CanButtonUseOverrideSection(buttonData, sectionId)
+    if buttonData and buttonData.type == "equipmentSlot" then
+        return not ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId]
+    end
+    return true
+end

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -43,6 +43,61 @@ local function QueueSpellAvailabilitySettlingRefresh(addon)
     end)
 end
 
+local function GroupHasEquipmentSlotEntries(group)
+    if not (group and group.buttons and CooldownCompanion.IsEquipmentSlotEntry) then
+        return false
+    end
+    for _, buttonData in ipairs(group.buttons) do
+        if CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+            return true
+        end
+    end
+    return false
+end
+
+function CooldownCompanion:RefreshEquipmentSlotEntries(reason, itemID)
+    self:MarkCooldownsDirty()
+    if self.db and self.db.profile and self.db.profile.groups then
+        for groupId, group in pairs(self.db.profile.groups) do
+            if GroupHasEquipmentSlotEntries(group) then
+                self:RefreshGroupFrame(groupId)
+            end
+        end
+    end
+    self:RefreshConfigPanel()
+end
+
+function CooldownCompanion:OnEquipmentChanged(event, equipmentSlot)
+    local trinket1 = self.TRINKET_SLOT_1 or 13
+    local trinket2 = self.TRINKET_SLOT_2 or 14
+    if equipmentSlot == trinket1 or equipmentSlot == trinket2 then
+        self:RefreshEquipmentSlotEntries("equipment", nil)
+    else
+        self:MarkCooldownsDirty()
+    end
+end
+
+function CooldownCompanion:EnsureEquipmentSlotItemLoadFrame()
+    if self._equipmentSlotItemLoadFrame then
+        return
+    end
+
+    self._equipmentSlotItemLoadFrame = CreateFrame("Frame")
+    self._equipmentSlotItemLoadFrame:RegisterEvent("ITEM_DATA_LOAD_RESULT")
+    self._equipmentSlotItemLoadFrame:SetScript("OnEvent", function(_, _, itemID, success)
+        local pendingLoads = CooldownCompanion._pendingEquipmentSlotItemLoads
+        local locationLoadPending = CooldownCompanion._pendingEquipmentSlotLocationLoad == true
+        if not locationLoadPending and not (pendingLoads and itemID and pendingLoads[itemID]) then
+            return
+        end
+        if pendingLoads and itemID then
+            pendingLoads[itemID] = nil
+        end
+        CooldownCompanion._pendingEquipmentSlotLocationLoad = nil
+        CooldownCompanion:RefreshEquipmentSlotEntries("item-data", itemID)
+    end)
+end
+
 local function PlayerHasTrackedAuraForButton(button, buttonData)
     if button._activeAuraSpellID and C_UnitAuras.GetPlayerAuraBySpellID(button._activeAuraSpellID) then
         return true

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1641,6 +1641,37 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
     return buttonIndex, transformNotified
 end
 
+function CooldownCompanion:AddEquipmentSlotToGroup(groupId, itemSlot, itemSlotKind)
+    local group = self.db.profile.groups[groupId]
+    if not group then return end
+
+    if group.displayMode == "textures" and #group.buttons >= 1 then
+        self:Print("Texture Panels can only hold one entry. Remove the current entry first if you want to replace it.")
+        return nil
+    end
+
+    local newButton = {
+        type = self.EQUIPMENT_SLOT_TYPE or "equipmentSlot",
+        itemSlot = itemSlot,
+        itemSlotKind = itemSlotKind or self.EQUIPMENT_SLOT_KIND_TRINKET or "trinket",
+    }
+    if not (self.IsEquipmentSlotEntry and self.IsEquipmentSlotEntry(newButton)) then
+        return nil
+    end
+    newButton.name = self.GetEquipmentSlotDisplayName
+        and self.GetEquipmentSlotDisplayName(newButton) or "Trinket Slot"
+
+    local buttonIndex = #group.buttons + 1
+    group.buttons[buttonIndex] = newButton
+
+    if group.displayMode == "trigger" and self.NormalizeTriggerConditionRowData then
+        self:NormalizeTriggerConditionRowData(newButton)
+    end
+
+    self:RefreshGroupFrame(groupId)
+    return buttonIndex
+end
+
 function CooldownCompanion:RemoveButtonFromGroup(groupId, buttonIndex)
     local group = self.db.profile.groups[groupId]
     if not group then return end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1723,6 +1723,10 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
         end
 
         return true
+    elseif CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+        return effectiveItem and effectiveItem.trackable == true
     elseif buttonData.type == "item" then
         if buttonData.hasCharges then return true end
         if not CooldownCompanion.IsItemEquippable(buttonData) then return true end

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -298,10 +298,12 @@ local function CacheButtonBindingKeys(button, buttonData)
     local slots
     if buttonData.type == "spell" then
         slots = GetSpellActionSlots(buttonData.id)
-    elseif buttonData.type == "item" then
+    elseif buttonData.type == "item" or buttonData.type == "equipmentSlot" then
         local itemID = button._resolvedItemId or buttonData.id
-        local slot = CooldownCompanion._itemSlotCache[itemID]
-        if slot then slots = {slot} end
+        if itemID then
+            local slot = CooldownCompanion._itemSlotCache[itemID]
+            if slot then slots = {slot} end
+        end
     end
     if slots then
         local seen = {}
@@ -430,10 +432,13 @@ function CooldownCompanion:GetKeybindText(buttonData, itemIDOverride)
                 end
             end
         end
-    elseif buttonData.type == "item" then
-        local slot = self._itemSlotCache[itemIDOverride or buttonData.id]
-        if slot then
-            return GetKeybindForSlot(slot)
+    elseif buttonData.type == "item" or buttonData.type == "equipmentSlot" then
+        local itemID = itemIDOverride or buttonData.id
+        if itemID then
+            local slot = self._itemSlotCache[itemID]
+            if slot then
+                return GetKeybindForSlot(slot)
+            end
         end
     end
 

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -127,10 +127,12 @@ function CooldownCompanion:OnEnable()
     -- Broader state changes can wait for the regular ticker pass.
     for _, evt in ipairs({
         "UNIT_POWER_FREQUENT", "LOSS_OF_CONTROL_ADDED", "LOSS_OF_CONTROL_UPDATE",
-        "ITEM_COUNT_CHANGED", "PLAYER_EQUIPMENT_CHANGED",
+        "ITEM_COUNT_CHANGED",
     }) do
         self:RegisterEvent(evt, "MarkCooldownsDirty")
     end
+    self:RegisterEvent("PLAYER_EQUIPMENT_CHANGED", "OnEquipmentChanged")
+    self:EnsureEquipmentSlotItemLoadFrame()
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnPlayerEnteringWorld")
 

--- a/Core/StyleOverrides.lua
+++ b/Core/StyleOverrides.lua
@@ -6,6 +6,38 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local effectiveStyleCache = setmetatable({}, { __mode = "k" })
 
+local function PruneDisallowedOverrideSections(buttonData)
+    if not (buttonData and buttonData.overrideSections) then
+        return
+    end
+    if not ST.CanButtonUseOverrideSection then
+        return
+    end
+
+    local changed = false
+    for sectionId in pairs(buttonData.overrideSections) do
+        if not ST.CanButtonUseOverrideSection(buttonData, sectionId) then
+            local section = ST.OVERRIDE_SECTIONS[sectionId]
+            if section and buttonData.styleOverrides then
+                for _, key in ipairs(section.keys) do
+                    buttonData.styleOverrides[key] = nil
+                end
+            end
+            buttonData.overrideSections[sectionId] = nil
+            changed = true
+        end
+    end
+
+    if changed then
+        if buttonData.styleOverrides and not next(buttonData.styleOverrides) then
+            buttonData.styleOverrides = nil
+        end
+        if buttonData.overrideSections and not next(buttonData.overrideSections) then
+            buttonData.overrideSections = nil
+        end
+    end
+end
+
 ------------------------------------------------------------------------
 -- EFFECTIVE STYLE UTILITIES
 ------------------------------------------------------------------------
@@ -13,6 +45,8 @@ local effectiveStyleCache = setmetatable({}, { __mode = "k" })
 --- Compute the effective style for a button, merging per-button overrides
 --- with group defaults via metatable __index fallback.
 function CooldownCompanion:GetEffectiveStyle(groupStyle, buttonData)
+    PruneDisallowedOverrideSections(buttonData)
+
     if buttonData and buttonData.styleOverrides
        and buttonData.overrideSections and next(buttonData.overrideSections) then
         local cache = effectiveStyleCache[buttonData]
@@ -38,6 +72,9 @@ end
 function CooldownCompanion:PromoteSection(buttonData, groupStyle, sectionId)
     local section = ST.OVERRIDE_SECTIONS[sectionId]
     if not section then return end
+    if ST.CanButtonUseOverrideSection and not ST.CanButtonUseOverrideSection(buttonData, sectionId) then
+        return
+    end
 
     if not buttonData.styleOverrides then buttonData.styleOverrides = {} end
     if not buttonData.overrideSections then buttonData.overrideSections = {} end
@@ -84,5 +121,6 @@ end
 
 --- Check if a button has any active style overrides.
 function CooldownCompanion:HasStyleOverrides(buttonData)
+    PruneDisallowedOverrideSections(buttonData)
     return buttonData and buttonData.overrideSections and next(buttonData.overrideSections) ~= nil
 end


### PR DESCRIPTION
## What Players Will Notice
- Players can add `Trinket Slot 1` or `Trinket Slot 2` from the normal add-box autocomplete and have the entry follow whichever on-use trinket is currently equipped in that slot.
- Empty slots, passive trinkets, and trinkets without an on-use effect stay visible in config as unavailable entries but are omitted from runtime panels.
- Slot entries keep their static slot labels in config while using the resolved trinket icon and tooltip only when a usable trinket is available.

## Why This Changed
- Tracking specific trinket item IDs is brittle when players swap trinkets often. Slot entries give players a catch-all entry for the equipped trinket slot without updating the panel every time.

## What Changed
- Added ID-less `equipmentSlot` button entries for trinket slots, with display names and stable keys derived from the saved slot fields.
- Resolved slot entries through equipped item locations and `C_Item` APIs, requesting item data when needed and refreshing affected panels on equipment changes or item-data load results.
- Extended icon, bar, text, visibility, keybind, tooltip, and cooldown paths to use the resolved equipped item while guarding against raw slot records being passed as item IDs.
- Added settings filtering so slot entries keep cooldown, appearance, load-condition, and item-visibility controls while hiding item-ID, aura, sound-alert, fallback, and custom-name controls that do not fit slot-based tracking.

## Validation
- `git diff --check origin/main...HEAD`.
- `luac -p` passed on 26 changed Lua files.
- Local Lua test suite: 11 tests passed.
- In-game validation is still needed for the config add flow, item-data loading, trinket swaps, cooldown states, and combat/restricted-content deferred refresh behavior.