### PR TITLE
Add multiple resource thresholds and tick markers

### DIFF
--- a/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/ConfigSettings/ResourceBarPanelsResource.lua
@@ -69,6 +69,12 @@ local DEFAULT_SEG_THRESHOLD_COLOR = RB.DEFAULT_SEG_THRESHOLD_COLOR
 local DEFAULT_CONTINUOUS_TICK_COLOR = RB.DEFAULT_CONTINUOUS_TICK_COLOR
 local DEFAULT_CONTINUOUS_TICK_MODE = RB.DEFAULT_CONTINUOUS_TICK_MODE
 local DEFAULT_CONTINUOUS_TICK_WIDTH = RB.DEFAULT_CONTINUOUS_TICK_WIDTH
+local MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = RB.MAX_RESOURCE_THRESHOLD_TICK_ENTRIES or 3
+local ClampSegmentedThresholdValue = RB.ClampSegmentedThresholdValue
+local ClampContinuousTickPercentValue = RB.ClampContinuousTickPercentValue
+local ClampContinuousTickAbsoluteValue = RB.ClampContinuousTickAbsoluteValue
+local GetNormalizedSegmentedThresholdEntriesFromConfig = RB.GetNormalizedSegmentedThresholdEntriesFromConfig
+local GetNormalizedContinuousTickEntriesFromConfig = RB.GetNormalizedContinuousTickEntriesFromConfig
 local DEFAULT_HEALTH_BAR_COLOR = RB.DEFAULT_HEALTH_BAR_COLOR
 local DEFAULT_HEALTH_BAR_OPACITY = RB.DEFAULT_HEALTH_BAR_OPACITY
 local DEFAULT_HEALTH_BAR_FULL_COLOR = RB.DEFAULT_HEALTH_BAR_FULL_COLOR
@@ -115,6 +121,8 @@ local RESOURCE_HEALTH = RB.RESOURCE_HEALTH
 local RESOURCE_HEALTH_DISPLAY_KEYS = RB.RESOURCE_HEALTH_DISPLAY_KEYS
 local resourceSpecCopyButton
 local resourceSpecCopyMenu
+local thresholdTickDraftRows = {}
+local thresholdTickEditorErrors = {}
 
 local function IsHeroSpecProxyCondition(cond)
     return type(cond) == "table"
@@ -1314,6 +1322,311 @@ local function BuildResourceColorControls(container, settings, powerType, specID
     return true
 end
 
+local function CopyThresholdTickEntryList(entries)
+    local copied = {}
+    if type(entries) == "table" then
+        for index, entry in ipairs(entries) do
+            copied[index] = {
+                value = entry.value,
+                color = type(entry.color) == "table" and CopyTable(entry.color) or nil,
+            }
+        end
+    end
+    return copied
+end
+
+local function SortThresholdTickEntryList(entries)
+    table.sort(entries, function(a, b)
+        return (tonumber(a.value) or 0) < (tonumber(b.value) or 0)
+    end)
+end
+
+local function HasThresholdTickDuplicateValue(entries, value, skipIndex)
+    for index, entry in ipairs(entries) do
+        if index ~= skipIndex and entry.value == value then
+            return true
+        end
+    end
+    return false
+end
+
+local function RefreshAdvancedSettingsPanelSoon()
+    if C_Timer and C_Timer.After then
+        C_Timer.After(0, function()
+            if CS.RefreshAdvancedSettingsPanel then
+                CS.RefreshAdvancedSettingsPanel()
+            else
+                CooldownCompanion:RefreshConfigPanel()
+            end
+        end)
+    elseif CS.RefreshAdvancedSettingsPanel then
+        CS.RefreshAdvancedSettingsPanel()
+    else
+        CooldownCompanion:RefreshConfigPanel()
+    end
+end
+
+local function SetThresholdTickEditorError(errorKey, message)
+    thresholdTickEditorErrors[errorKey] = message
+    RefreshAdvancedSettingsPanelSoon()
+end
+
+local function ClearThresholdTickEditorError(errorKey)
+    thresholdTickEditorErrors[errorKey] = nil
+end
+
+local function AddThresholdTickHelperLabel(container, text)
+    local label = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(label)
+    label:SetText(text)
+    label:SetFullWidth(true)
+    container:AddChild(label)
+end
+
+local function AddThresholdTickSubHeading(container, text)
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(text)
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+end
+
+local function ReadSpecEntryList(settings, powerType, specID, entriesKey, clearedKey)
+    local resource = settings.resources and settings.resources[powerType]
+    if not resource then
+        return nil, false
+    end
+    if specID and type(resource.specOverrides) == "table" then
+        local specData = resource.specOverrides[specID]
+        if type(specData) == "table" then
+            if specData[entriesKey] ~= nil then
+                return specData[entriesKey], specData[clearedKey] == true
+            end
+            if specData[clearedKey] == true then
+                return nil, true
+            end
+        end
+    end
+    return resource[entriesKey], resource[clearedKey] == true
+end
+
+local function GetConfigSegmentedThresholdEntries(settings, powerType, specID)
+    local rawEntries, cleared = ReadSpecEntryList(settings, powerType, specID, "segThresholdEntries", "segThresholdEntriesCleared")
+    local entries = GetNormalizedSegmentedThresholdEntriesFromConfig(rawEntries)
+    if #entries == 0
+        and not cleared
+        and ReadSpecOverrideKey(settings, powerType, specID, "segThresholdEnabled", false) == true then
+        entries[1] = {
+            value = GetSegmentedThresholdValueConfig({
+                segThresholdValue = ReadSpecOverrideKey(settings, powerType, specID, "segThresholdValue", nil),
+            }),
+            color = GetSafeRGBConfig(ReadSpecOverrideKey(settings, powerType, specID, "segThresholdColor", nil), DEFAULT_SEG_THRESHOLD_COLOR),
+        }
+    end
+    return entries
+end
+
+local function GetConfigContinuousTickMode(settings, powerType, specID)
+    return GetContinuousTickModeConfig({
+        continuousTickMode = ReadSpecOverrideKey(settings, powerType, specID, "continuousTickMode", nil),
+    })
+end
+
+local function GetConfigContinuousTickEntries(settings, powerType, specID, mode)
+    local entriesKey = mode == "absolute" and "continuousTickAbsoluteEntries" or "continuousTickPercentEntries"
+    local clearedKey = mode == "absolute" and "continuousTickAbsoluteEntriesCleared" or "continuousTickPercentEntriesCleared"
+    local rawEntries, cleared = ReadSpecEntryList(settings, powerType, specID, entriesKey, clearedKey)
+    local entries = GetNormalizedContinuousTickEntriesFromConfig(rawEntries, mode)
+    if #entries == 0
+        and not cleared
+        and ReadSpecOverrideKey(settings, powerType, specID, "continuousTickEnabled", false) == true then
+        local value
+        if mode == "absolute" then
+            value = GetContinuousTickAbsoluteConfig({
+                continuousTickAbsolute = ReadSpecOverrideKey(settings, powerType, specID, "continuousTickAbsolute", nil),
+            })
+        else
+            value = GetContinuousTickPercentConfig({
+                continuousTickPercent = ReadSpecOverrideKey(settings, powerType, specID, "continuousTickPercent", nil),
+            })
+        end
+        entries[1] = {
+            value = value,
+            color = GetSafeRGBAConfig(ReadSpecOverrideKey(settings, powerType, specID, "continuousTickColor", nil), DEFAULT_CONTINUOUS_TICK_COLOR),
+        }
+    end
+    return entries
+end
+
+local function WriteThresholdTickEntries(settings, powerType, specID, entriesKey, clearedKey, entries)
+    entries = CopyThresholdTickEntryList(entries)
+    SortThresholdTickEntryList(entries)
+    if #entries > 0 then
+        WriteSpecOverrideKey(settings, powerType, specID, entriesKey, entries)
+        WriteSpecOverrideKey(settings, powerType, specID, clearedKey, nil)
+    else
+        WriteSpecOverrideKey(settings, powerType, specID, entriesKey, nil)
+        WriteSpecOverrideKey(settings, powerType, specID, clearedKey, true)
+    end
+end
+
+local function AddThresholdTickEntryEditor(panel, options)
+    local entries = options.entries
+    local rowCount = #entries
+    local draftKey = options.draftKey
+    local draftActive = thresholdTickDraftRows[draftKey] == true
+
+    AddThresholdTickSubHeading(panel, options.heading)
+    if rowCount == 0 and not draftActive then
+        AddThresholdTickHelperLabel(panel, options.emptyText)
+    end
+
+    local function commitValue(index, text, widget)
+        local parsed = options.clampValue(text, nil)
+        local errorKey = options.errorPrefix .. "_" .. tostring(index or "new")
+        if parsed == nil then
+            if widget and index and entries[index] then
+                widget:SetText(tostring(entries[index].value))
+            end
+            SetThresholdTickEditorError(errorKey, options.invalidText)
+            return
+        end
+        if HasThresholdTickDuplicateValue(entries, parsed, index) then
+            if widget and index and entries[index] then
+                widget:SetText(tostring(entries[index].value))
+            end
+            SetThresholdTickEditorError(errorKey, options.duplicateText)
+            return
+        end
+
+        local updated = CopyThresholdTickEntryList(entries)
+        if index then
+            updated[index].value = parsed
+        else
+            updated[#updated + 1] = { value = parsed }
+            thresholdTickDraftRows[draftKey] = nil
+            thresholdTickEditorErrors[options.errorPrefix .. "_new"] = nil
+        end
+        SortThresholdTickEntryList(updated)
+        ClearThresholdTickEditorError(errorKey)
+        options.writeEntries(updated)
+        options.applyBars()
+        RefreshAdvancedSettingsPanelSoon()
+    end
+
+    for index, entry in ipairs(entries) do
+        local errorKey = options.errorPrefix .. "_" .. tostring(index)
+        local row = AceGUI:Create("SimpleGroup")
+        row:SetFullWidth(true)
+        row:SetLayout("Flow")
+
+        local valueEdit = AceGUI:Create("EditBox")
+        if valueEdit.editbox.Instructions then valueEdit.editbox.Instructions:Hide() end
+        valueEdit:SetLabel(options.valueLabel)
+        valueEdit:SetText(tostring(entry.value))
+        valueEdit:SetRelativeWidth(0.68)
+        valueEdit:DisableButton(true)
+        valueEdit:SetCallback("OnEnterPressed", function(widget, event, text)
+            commitValue(index, text, widget)
+        end)
+        row:AddChild(valueEdit)
+
+        local removeBtn = AceGUI:Create("Button")
+        removeBtn:SetText("Remove")
+        removeBtn:SetRelativeWidth(0.3)
+        removeBtn:SetCallback("OnClick", function()
+            local updated = CopyThresholdTickEntryList(entries)
+            table.remove(updated, index)
+            thresholdTickEditorErrors[errorKey] = nil
+            options.writeEntries(updated)
+            options.applyBars()
+            RefreshAdvancedSettingsPanelSoon()
+        end)
+        row:AddChild(removeBtn)
+        panel:AddChild(row)
+
+        if thresholdTickEditorErrors[errorKey] then
+            AddThresholdTickHelperLabel(panel, "|cffff7777" .. thresholdTickEditorErrors[errorKey] .. "|r")
+        end
+
+        local proxyKey = options.colorKey
+        local proxy = {
+            [proxyKey] = type(entry.color) == "table" and CopyTable(entry.color) or CopyTable(options.defaultColor),
+        }
+        AddColorPicker(panel, proxy, proxyKey, options.colorLabel, options.defaultColor, options.hasAlpha,
+            function()
+                local updated = CopyThresholdTickEntryList(entries)
+                if updated[index] then
+                    updated[index].color = proxy[proxyKey]
+                    options.writeEntries(updated)
+                    options.applyBars()
+                end
+            end,
+            function()
+                local updated = CopyThresholdTickEntryList(entries)
+                if updated[index] then
+                    updated[index].color = proxy[proxyKey]
+                    options.writeEntries(updated)
+                end
+            end)
+    end
+
+    if draftActive then
+        local errorKey = options.errorPrefix .. "_new"
+        local draftRow = AceGUI:Create("SimpleGroup")
+        draftRow:SetFullWidth(true)
+        draftRow:SetLayout("Flow")
+
+        local draftEdit = AceGUI:Create("EditBox")
+        if draftEdit.editbox.Instructions then draftEdit.editbox.Instructions:Hide() end
+        draftEdit:SetLabel("New " .. options.valueLabel)
+        draftEdit:SetText("")
+        draftEdit:SetRelativeWidth(0.68)
+        draftEdit:DisableButton(true)
+        draftEdit:SetCallback("OnEnterPressed", function(widget, event, text)
+            commitValue(nil, text, widget)
+        end)
+        draftRow:AddChild(draftEdit)
+
+        local cancelBtn = AceGUI:Create("Button")
+        cancelBtn:SetText("Cancel")
+        cancelBtn:SetRelativeWidth(0.3)
+        cancelBtn:SetCallback("OnClick", function()
+            thresholdTickDraftRows[draftKey] = nil
+            thresholdTickEditorErrors[errorKey] = nil
+            RefreshAdvancedSettingsPanelSoon()
+        end)
+        draftRow:AddChild(cancelBtn)
+        panel:AddChild(draftRow)
+
+        if thresholdTickEditorErrors[errorKey] then
+            AddThresholdTickHelperLabel(panel, "|cffff7777" .. thresholdTickEditorErrors[errorKey] .. "|r")
+        end
+        AddThresholdTickHelperLabel(panel, "|cff888888Enter a valid value to unlock color settings for this row.|r")
+    end
+
+    local addBtn = AceGUI:Create("Button")
+    addBtn:SetText(options.addText)
+    addBtn:SetFullWidth(true)
+    local addDisabled = rowCount >= MAX_RESOURCE_THRESHOLD_TICK_ENTRIES or draftActive
+    if addBtn.SetDisabled then
+        addBtn:SetDisabled(addDisabled)
+    end
+    addBtn:SetCallback("OnClick", function()
+        if rowCount >= MAX_RESOURCE_THRESHOLD_TICK_ENTRIES or draftActive then
+            return
+        end
+        thresholdTickDraftRows[draftKey] = true
+        thresholdTickEditorErrors[options.errorPrefix .. "_new"] = nil
+        RefreshAdvancedSettingsPanelSoon()
+    end)
+    panel:AddChild(addBtn)
+
+    if rowCount >= MAX_RESOURCE_THRESHOLD_TICK_ENTRIES then
+        AddThresholdTickHelperLabel(panel, "|cff888888Maximum of 3 entries configured.|r")
+    end
+end
+
 local function BuildResourceBarStylingPanel(container, sectionMode, opts)
     local settings = CooldownCompanion:GetResourceBarSettings()
 
@@ -1848,9 +2161,9 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
 
     local thresholdInfoBtn = CreateInfoButton(thresholdHeading.frame, thresholdCollapseBtn, "LEFT", "RIGHT", 4, 0, {
         "Thresholds & Ticks",
-        {"Segmented resources: recolor when current value is at/above a configured threshold.", 1, 1, 1, true},
+        {"Segmented resources: recolor when the current value is at/above configured thresholds. The highest crossed threshold wins.", 1, 1, 1, true},
         " ",
-        {"Continuous resources: draw a static marker by percent or absolute value.", 1, 1, 1, true},
+        {"Continuous resources: draw up to three static markers by percent or absolute value. Each marker can have its own color.", 1, 1, 1, true},
     }, thresholdHeading)
 
     thresholdHeading.right:ClearAllPoints()
@@ -1873,7 +2186,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                 if isSegmented then
                     local thresholdAdvKey = "rbSegThreshold_" .. capturedPt .. "_" .. tostring(_colorSpecID)
                     local thresholdEnableCb = AceGUI:Create("CheckBox")
-                    thresholdEnableCb:SetLabel("Enable " .. resourceName .. " Threshold Color")
+                    thresholdEnableCb:SetLabel("Enable " .. resourceName .. " Threshold Colors")
                     thresholdEnableCb:SetValue(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true)
                     thresholdEnableCb:SetFullWidth(true)
                     thresholdEnableCb:SetCallback("OnValueChanged", function(widget, event, val)
@@ -1891,36 +2204,27 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                     container:AddChild(thresholdEnableCb)
 
                     local function BuildSegmentedThresholdAdvanced(panel)
-                        local thresholdEdit = AceGUI:Create("EditBox")
-                        if thresholdEdit.editbox.Instructions then thresholdEdit.editbox.Instructions:Hide() end
-                        thresholdEdit:SetLabel(resourceName .. " Threshold Value (>=)")
-                        local _segVal = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdValue", nil)
-                        thresholdEdit:SetText(tostring(GetSegmentedThresholdValueConfig({ segThresholdValue = _segVal })))
-                        thresholdEdit:SetFullWidth(true)
-                        thresholdEdit:DisableButton(true)
-                        thresholdEdit:SetCallback("OnEnterPressed", function(widget, event, text)
-                            local parsed = tonumber(text)
-                            if not parsed then
-                                local curVal = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdValue", nil)
-                                widget:SetText(tostring(GetSegmentedThresholdValueConfig({ segThresholdValue = curVal })))
-                                return
-                            end
-                            parsed = math.floor(parsed)
-                            if parsed < 1 then
-                                parsed = 1
-                            elseif parsed > 99 then
-                                parsed = 99
-                            end
-                            WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdValue", parsed)
-                            widget:SetText(tostring(parsed))
-                            CooldownCompanion:ApplyResourceBars()
-                        end)
-                        panel:AddChild(thresholdEdit)
-
-                        local _pSeg = { segThresholdColor = GetSafeRGBConfig(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdColor", nil), DEFAULT_SEG_THRESHOLD_COLOR) }
-                        AddColorPicker(panel, _pSeg, "segThresholdColor", resourceName .. " Threshold Color", DEFAULT_SEG_THRESHOLD_COLOR, false,
-                            function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdColor", _pSeg.segThresholdColor); applyBars() end,
-                            function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdColor", _pSeg.segThresholdColor) end)
+                        local entries = GetConfigSegmentedThresholdEntries(settings, capturedPt, _colorSpecID)
+                        AddThresholdTickEntryEditor(panel, {
+                            heading = "Threshold Colors",
+                            entries = entries,
+                            draftKey = thresholdAdvKey,
+                            errorPrefix = thresholdAdvKey,
+                            valueLabel = resourceName .. " Threshold Value (>=)",
+                            colorKey = "segThresholdColor",
+                            colorLabel = resourceName .. " Threshold Color",
+                            defaultColor = DEFAULT_SEG_THRESHOLD_COLOR,
+                            hasAlpha = false,
+                            addText = "Add Threshold Color",
+                            emptyText = "|cff888888No threshold colors configured. Add a value to make this enabled threshold setting active.|r",
+                            invalidText = "Enter a threshold value from 1 to 99.",
+                            duplicateText = "A threshold color already uses that value.",
+                            clampValue = ClampSegmentedThresholdValue,
+                            writeEntries = function(updated)
+                                WriteThresholdTickEntries(settings, capturedPt, _colorSpecID, "segThresholdEntries", "segThresholdEntriesCleared", updated)
+                            end,
+                            applyBars = applyBars,
+                        })
                     end
 
                     local _segEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true
@@ -1943,7 +2247,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                     local tickAdvKey = "rbTickMarker_" .. capturedPt .. "_" .. tostring(_colorSpecID)
                     local _tickEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickEnabled", false) == true
                     local tickEnableCb = AceGUI:Create("CheckBox")
-                    tickEnableCb:SetLabel("Enable " .. resourceName .. " Tick Marker")
+                    tickEnableCb:SetLabel("Enable " .. resourceName .. " Tick Markers")
                     tickEnableCb:SetValue(_tickEnabled)
                     tickEnableCb:SetFullWidth(true)
                     tickEnableCb:SetCallback("OnValueChanged", function(widget, event, val)
@@ -1995,50 +2299,31 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                         end)
                         panel:AddChild(modeDrop)
 
-                        if tickMode == "percent" then
-                            local _tickPercentRes = { continuousTickPercent = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickPercent", nil) }
-                            local percentSlider = AceGUI:Create("Slider")
-                            percentSlider:SetLabel(resourceName .. " Tick Percent")
-                            percentSlider:SetSliderValues(0, 100, 1)
-                            percentSlider:SetValue(GetContinuousTickPercentConfig(_tickPercentRes))
-                            percentSlider:SetIsPercent(false)
-                            percentSlider:SetFullWidth(true)
-                            percentSlider:SetCallback("OnValueChanged", function(widget, event, val)
-                                WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickPercent", val)
-                                CooldownCompanion:ApplyResourceBars()
-                            end)
-                            panel:AddChild(percentSlider)
-                        else
-                            local _tickAbsRes = { continuousTickAbsolute = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickAbsolute", nil) }
-                            local absoluteEdit = AceGUI:Create("EditBox")
-                            if absoluteEdit.editbox.Instructions then absoluteEdit.editbox.Instructions:Hide() end
-                            absoluteEdit:SetLabel(resourceName .. " Tick Absolute Value")
-                            absoluteEdit:SetText(tostring(GetContinuousTickAbsoluteConfig(_tickAbsRes)))
-                            absoluteEdit:SetFullWidth(true)
-                            absoluteEdit:DisableButton(true)
-                            absoluteEdit:SetCallback("OnEnterPressed", function(widget, event, text)
-                                local parsed = tonumber(text)
-                                if not parsed then
-                                    local curAbs = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickAbsolute", nil)
-                                    widget:SetText(tostring(GetContinuousTickAbsoluteConfig({ continuousTickAbsolute = curAbs })))
-                                    return
-                                end
-                                if parsed < 0 then
-                                    parsed = 0
-                                end
-                                WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickAbsolute", parsed)
-                                widget:SetText(tostring(parsed))
-                                CooldownCompanion:ApplyResourceBars()
-                            end)
-                            panel:AddChild(absoluteEdit)
-                        end
-
-                        local _tickColorResolved = GetSafeRGBAConfig(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickColor", nil), DEFAULT_CONTINUOUS_TICK_COLOR)
-                        if _tickColorResolved[4] == nil then _tickColorResolved = { _tickColorResolved[1], _tickColorResolved[2], _tickColorResolved[3], 1 } end
-                        local _pTick = { continuousTickColor = _tickColorResolved }
-                        AddColorPicker(panel, _pTick, "continuousTickColor", resourceName .. " Tick Color", DEFAULT_CONTINUOUS_TICK_COLOR, true,
-                            function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickColor", _pTick.continuousTickColor); applyBars() end,
-                            function() WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickColor", _pTick.continuousTickColor) end)
+                        local tickEntries = GetConfigContinuousTickEntries(settings, capturedPt, _colorSpecID, tickMode)
+                        local tickEntriesKey = tickMode == "absolute" and "continuousTickAbsoluteEntries" or "continuousTickPercentEntries"
+                        local tickClearedKey = tickMode == "absolute" and "continuousTickAbsoluteEntriesCleared" or "continuousTickPercentEntriesCleared"
+                        AddThresholdTickEntryEditor(panel, {
+                            heading = "Tick Markers",
+                            entries = tickEntries,
+                            draftKey = tickAdvKey .. "_" .. tickMode,
+                            errorPrefix = tickAdvKey .. "_" .. tickMode,
+                            valueLabel = tickMode == "absolute" and (resourceName .. " Tick Absolute Value") or (resourceName .. " Tick Percent"),
+                            colorKey = "continuousTickColor",
+                            colorLabel = resourceName .. " Tick Color",
+                            defaultColor = DEFAULT_CONTINUOUS_TICK_COLOR,
+                            hasAlpha = true,
+                            addText = "Add Tick Marker",
+                            emptyText = tickMode == "absolute"
+                                and "|cff888888No absolute tick markers configured. Add a value to make this enabled tick setting active in Absolute Value mode.|r"
+                                or "|cff888888No percent tick markers configured. Add a value to make this enabled tick setting active in Percent mode.|r",
+                            invalidText = tickMode == "absolute" and "Enter a tick value of 0 or higher." or "Enter a tick percent from 0 to 100.",
+                            duplicateText = "A tick marker already uses that value.",
+                            clampValue = tickMode == "absolute" and ClampContinuousTickAbsoluteValue or ClampContinuousTickPercentValue,
+                            writeEntries = function(updated)
+                                WriteThresholdTickEntries(settings, capturedPt, _colorSpecID, tickEntriesKey, tickClearedKey, updated)
+                            end,
+                            applyBars = applyBars,
+                        })
 
                         local _tickWidthVal = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickWidth", nil)
                         local tickWidthSlider = AceGUI:Create("Slider")
@@ -2059,7 +2344,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                         rbThresholdTickAdvBtns,
                         _tickEnabled,
                         {
-                            title = resourceName .. " Tick Marker Advanced",
+                            title = resourceName .. " Tick Markers Advanced",
                             build = BuildTickMarkerAdvanced,
                             context = {
                                 selectedResourcePowerType = capturedPt,

--- a/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/ConfigSettings/ResourceBarPanelsResource.lua
@@ -75,6 +75,7 @@ local ClampContinuousTickPercentValue = RB.ClampContinuousTickPercentValue
 local ClampContinuousTickAbsoluteValue = RB.ClampContinuousTickAbsoluteValue
 local GetNormalizedSegmentedThresholdEntriesFromConfig = RB.GetNormalizedSegmentedThresholdEntriesFromConfig
 local GetNormalizedContinuousTickEntriesFromConfig = RB.GetNormalizedContinuousTickEntriesFromConfig
+local ResolveSpecEntryList = RB.ResolveSpecEntryList
 local DEFAULT_HEALTH_BAR_COLOR = RB.DEFAULT_HEALTH_BAR_COLOR
 local DEFAULT_HEALTH_BAR_OPACITY = RB.DEFAULT_HEALTH_BAR_OPACITY
 local DEFAULT_HEALTH_BAR_FULL_COLOR = RB.DEFAULT_HEALTH_BAR_FULL_COLOR
@@ -1371,10 +1372,6 @@ local function SetThresholdTickEditorError(errorKey, message)
     RefreshAdvancedSettingsPanelSoon()
 end
 
-local function ClearThresholdTickEditorError(errorKey)
-    thresholdTickEditorErrors[errorKey] = nil
-end
-
 local function AddThresholdTickHelperLabel(container, text)
     local label = AceGUI:Create("Label")
     ST._ConfigureWrappedHelperLabel(label)
@@ -1391,27 +1388,52 @@ local function AddThresholdTickSubHeading(container, text)
     container:AddChild(heading)
 end
 
-local function ReadSpecEntryList(settings, powerType, specID, entriesKey, clearedKey)
-    local resource = settings.resources and settings.resources[powerType]
-    if not resource then
-        return nil, false
-    end
-    if specID and type(resource.specOverrides) == "table" then
-        local specData = resource.specOverrides[specID]
-        if type(specData) == "table" then
-            if specData[entriesKey] ~= nil then
-                return specData[entriesKey], specData[clearedKey] == true
-            end
-            if specData[clearedKey] == true then
-                return nil, true
-            end
+local function AddThresholdTickValueRow(panel, label, text, buttonText, onEnter, onButton)
+    local row = AceGUI:Create("SimpleGroup")
+    row:SetFullWidth(true)
+    row:SetLayout("Flow")
+
+    local valueEdit = AceGUI:Create("EditBox")
+    if valueEdit.editbox.Instructions then valueEdit.editbox.Instructions:Hide() end
+    valueEdit:SetLabel(label)
+    valueEdit:SetText(text)
+    valueEdit:SetRelativeWidth(0.68)
+    valueEdit:DisableButton(true)
+    valueEdit:SetCallback("OnEnterPressed", onEnter)
+    row:AddChild(valueEdit)
+
+    local button = AceGUI:Create("Button")
+    button:SetText(buttonText)
+    button:SetRelativeWidth(0.3)
+    button:SetCallback("OnClick", onButton)
+    row:AddChild(button)
+    panel:AddChild(row)
+end
+
+local function AddThresholdTickEnableCheckbox(container, settings, powerType, specID, settingKey, label, advKey)
+    local enabled = ReadSpecOverrideKey(settings, powerType, specID, settingKey, false) == true
+    local checkbox = AceGUI:Create("CheckBox")
+    checkbox:SetLabel(label)
+    checkbox:SetValue(enabled)
+    checkbox:SetFullWidth(true)
+    checkbox:SetCallback("OnValueChanged", function(widget, event, val)
+        local wasEnabled = ReadSpecOverrideKey(settings, powerType, specID, settingKey, false) == true
+        WriteSpecOverrideKey(settings, powerType, specID, settingKey, val == true)
+        if val and not wasEnabled and CS.QueueAdvancedSettingsPanelOpen then
+            CS.QueueAdvancedSettingsPanelOpen(advKey, {
+                selectedResourcePowerType = powerType,
+                resourceSettingsSpecID = specID,
+            })
         end
-    end
-    return resource[entriesKey], resource[clearedKey] == true
+        CooldownCompanion:ApplyResourceBars()
+        C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
+    end)
+    container:AddChild(checkbox)
+    return checkbox, enabled
 end
 
 local function GetConfigSegmentedThresholdEntries(settings, powerType, specID)
-    local rawEntries, cleared = ReadSpecEntryList(settings, powerType, specID, "segThresholdEntries", "segThresholdEntriesCleared")
+    local rawEntries, cleared = ResolveSpecEntryList(settings.resources and settings.resources[powerType], specID, "segThresholdEntries", "segThresholdEntriesCleared")
     local entries = GetNormalizedSegmentedThresholdEntriesFromConfig(rawEntries)
     if #entries == 0
         and not cleared
@@ -1426,16 +1448,10 @@ local function GetConfigSegmentedThresholdEntries(settings, powerType, specID)
     return entries
 end
 
-local function GetConfigContinuousTickMode(settings, powerType, specID)
-    return GetContinuousTickModeConfig({
-        continuousTickMode = ReadSpecOverrideKey(settings, powerType, specID, "continuousTickMode", nil),
-    })
-end
-
 local function GetConfigContinuousTickEntries(settings, powerType, specID, mode)
     local entriesKey = mode == "absolute" and "continuousTickAbsoluteEntries" or "continuousTickPercentEntries"
     local clearedKey = mode == "absolute" and "continuousTickAbsoluteEntriesCleared" or "continuousTickPercentEntriesCleared"
-    local rawEntries, cleared = ReadSpecEntryList(settings, powerType, specID, entriesKey, clearedKey)
+    local rawEntries, cleared = ResolveSpecEntryList(settings.resources and settings.resources[powerType], specID, entriesKey, clearedKey)
     local entries = GetNormalizedContinuousTickEntriesFromConfig(rawEntries, mode)
     if #entries == 0
         and not cleared
@@ -1507,8 +1523,7 @@ local function AddThresholdTickEntryEditor(panel, options)
             thresholdTickDraftRows[draftKey] = nil
             thresholdTickEditorErrors[options.errorPrefix .. "_new"] = nil
         end
-        SortThresholdTickEntryList(updated)
-        ClearThresholdTickEditorError(errorKey)
+        thresholdTickEditorErrors[errorKey] = nil
         options.writeEntries(updated)
         options.applyBars()
         RefreshAdvancedSettingsPanelSoon()
@@ -1516,34 +1531,18 @@ local function AddThresholdTickEntryEditor(panel, options)
 
     for index, entry in ipairs(entries) do
         local errorKey = options.errorPrefix .. "_" .. tostring(index)
-        local row = AceGUI:Create("SimpleGroup")
-        row:SetFullWidth(true)
-        row:SetLayout("Flow")
-
-        local valueEdit = AceGUI:Create("EditBox")
-        if valueEdit.editbox.Instructions then valueEdit.editbox.Instructions:Hide() end
-        valueEdit:SetLabel(options.valueLabel)
-        valueEdit:SetText(tostring(entry.value))
-        valueEdit:SetRelativeWidth(0.68)
-        valueEdit:DisableButton(true)
-        valueEdit:SetCallback("OnEnterPressed", function(widget, event, text)
-            commitValue(index, text, widget)
-        end)
-        row:AddChild(valueEdit)
-
-        local removeBtn = AceGUI:Create("Button")
-        removeBtn:SetText("Remove")
-        removeBtn:SetRelativeWidth(0.3)
-        removeBtn:SetCallback("OnClick", function()
-            local updated = CopyThresholdTickEntryList(entries)
-            table.remove(updated, index)
-            thresholdTickEditorErrors[errorKey] = nil
-            options.writeEntries(updated)
-            options.applyBars()
-            RefreshAdvancedSettingsPanelSoon()
-        end)
-        row:AddChild(removeBtn)
-        panel:AddChild(row)
+        AddThresholdTickValueRow(panel, options.valueLabel, tostring(entry.value), "Remove",
+            function(widget, event, text)
+                commitValue(index, text, widget)
+            end,
+            function()
+                local updated = CopyThresholdTickEntryList(entries)
+                table.remove(updated, index)
+                thresholdTickEditorErrors[errorKey] = nil
+                options.writeEntries(updated)
+                options.applyBars()
+                RefreshAdvancedSettingsPanelSoon()
+            end)
 
         if thresholdTickEditorErrors[errorKey] then
             AddThresholdTickHelperLabel(panel, "|cffff7777" .. thresholdTickEditorErrors[errorKey] .. "|r")
@@ -1573,31 +1572,15 @@ local function AddThresholdTickEntryEditor(panel, options)
 
     if draftActive then
         local errorKey = options.errorPrefix .. "_new"
-        local draftRow = AceGUI:Create("SimpleGroup")
-        draftRow:SetFullWidth(true)
-        draftRow:SetLayout("Flow")
-
-        local draftEdit = AceGUI:Create("EditBox")
-        if draftEdit.editbox.Instructions then draftEdit.editbox.Instructions:Hide() end
-        draftEdit:SetLabel("New " .. options.valueLabel)
-        draftEdit:SetText("")
-        draftEdit:SetRelativeWidth(0.68)
-        draftEdit:DisableButton(true)
-        draftEdit:SetCallback("OnEnterPressed", function(widget, event, text)
-            commitValue(nil, text, widget)
-        end)
-        draftRow:AddChild(draftEdit)
-
-        local cancelBtn = AceGUI:Create("Button")
-        cancelBtn:SetText("Cancel")
-        cancelBtn:SetRelativeWidth(0.3)
-        cancelBtn:SetCallback("OnClick", function()
-            thresholdTickDraftRows[draftKey] = nil
-            thresholdTickEditorErrors[errorKey] = nil
-            RefreshAdvancedSettingsPanelSoon()
-        end)
-        draftRow:AddChild(cancelBtn)
-        panel:AddChild(draftRow)
+        AddThresholdTickValueRow(panel, "New " .. options.valueLabel, "", "Cancel",
+            function(widget, event, text)
+                commitValue(nil, text, widget)
+            end,
+            function()
+                thresholdTickDraftRows[draftKey] = nil
+                thresholdTickEditorErrors[errorKey] = nil
+                RefreshAdvancedSettingsPanelSoon()
+            end)
 
         if thresholdTickEditorErrors[errorKey] then
             AddThresholdTickHelperLabel(panel, "|cffff7777" .. thresholdTickEditorErrors[errorKey] .. "|r")
@@ -2180,28 +2163,19 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
             if settings.resources[pt].enabled ~= false then
                 local resourceName = POWER_NAMES[pt] or ("Power " .. pt)
                 local capturedPt = pt
-                local res = settings.resources[capturedPt]
                 local isSegmented = SEGMENTED_TYPES[capturedPt] == true or capturedPt == 100
 
                 if isSegmented then
                     local thresholdAdvKey = "rbSegThreshold_" .. capturedPt .. "_" .. tostring(_colorSpecID)
-                    local thresholdEnableCb = AceGUI:Create("CheckBox")
-                    thresholdEnableCb:SetLabel("Enable " .. resourceName .. " Threshold Colors")
-                    thresholdEnableCb:SetValue(ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true)
-                    thresholdEnableCb:SetFullWidth(true)
-                    thresholdEnableCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        local wasEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true
-                        WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", val == true)
-                        if val and not wasEnabled and CS.QueueAdvancedSettingsPanelOpen then
-                            CS.QueueAdvancedSettingsPanelOpen(thresholdAdvKey, {
-                                selectedResourcePowerType = capturedPt,
-                                resourceSettingsSpecID = _colorSpecID,
-                            })
-                        end
-                        CooldownCompanion:ApplyResourceBars()
-                        C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
-                    end)
-                    container:AddChild(thresholdEnableCb)
+                    local thresholdEnableCb, _segEnabled = AddThresholdTickEnableCheckbox(
+                        container,
+                        settings,
+                        capturedPt,
+                        _colorSpecID,
+                        "segThresholdEnabled",
+                        "Enable " .. resourceName .. " Threshold Colors",
+                        thresholdAdvKey
+                    )
 
                     local function BuildSegmentedThresholdAdvanced(panel)
                         local entries = GetConfigSegmentedThresholdEntries(settings, capturedPt, _colorSpecID)
@@ -2227,8 +2201,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                         })
                     end
 
-                    local _segEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "segThresholdEnabled", false) == true
-                    local thresholdAdvExpanded = AddAdvancedToggle(
+                    AddAdvancedToggle(
                         thresholdEnableCb,
                         thresholdAdvKey,
                         rbThresholdTickAdvBtns,
@@ -2245,24 +2218,15 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                 elseif capturedPt ~= 101 and capturedPt ~= healthResourceID then
                     -- Stagger (101) and Health have dedicated coloring; tick markers not applicable
                     local tickAdvKey = "rbTickMarker_" .. capturedPt .. "_" .. tostring(_colorSpecID)
-                    local _tickEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickEnabled", false) == true
-                    local tickEnableCb = AceGUI:Create("CheckBox")
-                    tickEnableCb:SetLabel("Enable " .. resourceName .. " Tick Markers")
-                    tickEnableCb:SetValue(_tickEnabled)
-                    tickEnableCb:SetFullWidth(true)
-                    tickEnableCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        local wasEnabled = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickEnabled", false) == true
-                        WriteSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickEnabled", val == true)
-                        if val and not wasEnabled and CS.QueueAdvancedSettingsPanelOpen then
-                            CS.QueueAdvancedSettingsPanelOpen(tickAdvKey, {
-                                selectedResourcePowerType = capturedPt,
-                                resourceSettingsSpecID = _colorSpecID,
-                            })
-                        end
-                        CooldownCompanion:ApplyResourceBars()
-                        C_Timer.After(0, function() CooldownCompanion:RefreshConfigPanel() end)
-                    end)
-                    container:AddChild(tickEnableCb)
+                    local tickEnableCb, _tickEnabled = AddThresholdTickEnableCheckbox(
+                        container,
+                        settings,
+                        capturedPt,
+                        _colorSpecID,
+                        "continuousTickEnabled",
+                        "Enable " .. resourceName .. " Tick Markers",
+                        tickAdvKey
+                    )
 
                     local function BuildTickMarkerAdvanced(panel)
                         local tickCombatCb = AceGUI:Create("CheckBox")
@@ -2275,8 +2239,9 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                         end)
                         panel:AddChild(tickCombatCb)
 
-                        local _tickModeRes = { continuousTickMode = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickMode", nil) }
-                        local tickMode = GetContinuousTickModeConfig(_tickModeRes)
+                        local tickMode = GetContinuousTickModeConfig({
+                            continuousTickMode = ReadSpecOverrideKey(settings, capturedPt, _colorSpecID, "continuousTickMode", nil),
+                        })
                         local modeDrop = AceGUI:Create("Dropdown")
                         modeDrop:SetLabel("Tick Mode")
                         modeDrop:SetList({
@@ -2338,7 +2303,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
                         panel:AddChild(tickWidthSlider)
                     end
 
-                    local tickAdvExpanded = AddAdvancedToggle(
+                    AddAdvancedToggle(
                         tickEnableCb,
                         tickAdvKey,
                         rbThresholdTickAdvBtns,

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -153,18 +153,15 @@ local RESOURCE_SPEC_AURA_KEYS = {
 
 local MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = 3
 
-local function CopyRGBSetting(color)
+local function CopyColorSetting(color, includeAlpha)
     if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
         return nil
     end
-    return { color[1], color[2], color[3] }
-end
-
-local function CopyRGBASetting(color)
-    if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
-        return nil
+    local copied = { color[1], color[2], color[3] }
+    if includeAlpha then
+        copied[4] = color[4]
     end
-    return { color[1], color[2], color[3], color[4] }
+    return copied
 end
 
 local function ClampLegacySegmentedThresholdValue(value, fallback)
@@ -205,7 +202,7 @@ local function ClampLegacyTickAbsoluteValue(value, fallback)
     return value
 end
 
-local function NormalizeSavedEntryList(entries, clampValue, copyColor)
+local function NormalizeSavedEntryList(entries, clampValue, includeAlpha)
     local normalized = {}
     local seen = {}
     if type(entries) ~= "table" then
@@ -229,7 +226,7 @@ local function NormalizeSavedEntryList(entries, clampValue, copyColor)
                 seen[valueKey] = true
                 normalized[#normalized + 1] = {
                     value = value,
-                    color = copyColor(type(entry) == "table" and entry.color or nil),
+                    color = CopyColorSetting(type(entry) == "table" and entry.color or nil, includeAlpha),
                 }
                 if #normalized >= MAX_RESOURCE_THRESHOLD_TICK_ENTRIES then
                     break
@@ -258,7 +255,7 @@ local function NormalizeThresholdEntriesOnTarget(resource, specID, target)
         return
     end
 
-    local normalized = NormalizeSavedEntryList(target.segThresholdEntries, ClampLegacySegmentedThresholdValue, CopyRGBSetting)
+    local normalized = NormalizeSavedEntryList(target.segThresholdEntries, ClampLegacySegmentedThresholdValue, false)
     if #normalized == 0
         and target.segThresholdEntriesCleared ~= true
         and ResolveSpecOverrideKey(resource, specID, "segThresholdEnabled") == true
@@ -268,7 +265,7 @@ local function NormalizeThresholdEntriesOnTarget(resource, specID, target)
                 target.segThresholdValue ~= nil and target.segThresholdValue or ResolveSpecOverrideKey(resource, specID, "segThresholdValue"),
                 1
             ),
-            color = CopyRGBSetting(target.segThresholdColor) or CopyRGBSetting(ResolveSpecOverrideKey(resource, specID, "segThresholdColor")),
+            color = CopyColorSetting(target.segThresholdColor, false) or CopyColorSetting(ResolveSpecOverrideKey(resource, specID, "segThresholdColor"), false),
         }
     end
     StoreNormalizedEntries(target, "segThresholdEntries", "segThresholdEntriesCleared", normalized)
@@ -287,8 +284,8 @@ local function NormalizeTickEntriesOnTarget(resource, specID, target)
         return
     end
 
-    local percentEntries = NormalizeSavedEntryList(target.continuousTickPercentEntries, ClampLegacyTickPercentValue, CopyRGBASetting)
-    local absoluteEntries = NormalizeSavedEntryList(target.continuousTickAbsoluteEntries, ClampLegacyTickAbsoluteValue, CopyRGBASetting)
+    local percentEntries = NormalizeSavedEntryList(target.continuousTickPercentEntries, ClampLegacyTickPercentValue, true)
+    local absoluteEntries = NormalizeSavedEntryList(target.continuousTickAbsoluteEntries, ClampLegacyTickAbsoluteValue, true)
     local tickEnabled = ResolveSpecOverrideKey(resource, specID, "continuousTickEnabled") == true
     local mode = GetResolvedTickMode(resource, specID, target)
     local hasLegacyTickData = target.continuousTickEnabled ~= nil
@@ -304,7 +301,7 @@ local function NormalizeTickEntriesOnTarget(resource, specID, target)
                     target.continuousTickAbsolute ~= nil and target.continuousTickAbsolute or ResolveSpecOverrideKey(resource, specID, "continuousTickAbsolute"),
                     50
                 ),
-                color = CopyRGBASetting(target.continuousTickColor) or CopyRGBASetting(ResolveSpecOverrideKey(resource, specID, "continuousTickColor")),
+                color = CopyColorSetting(target.continuousTickColor, true) or CopyColorSetting(ResolveSpecOverrideKey(resource, specID, "continuousTickColor"), true),
             }
         elseif mode == "percent" and #percentEntries == 0 and target.continuousTickPercentEntriesCleared ~= true then
             percentEntries[1] = {
@@ -312,7 +309,7 @@ local function NormalizeTickEntriesOnTarget(resource, specID, target)
                     target.continuousTickPercent ~= nil and target.continuousTickPercent or ResolveSpecOverrideKey(resource, specID, "continuousTickPercent"),
                     50
                 ),
-                color = CopyRGBASetting(target.continuousTickColor) or CopyRGBASetting(ResolveSpecOverrideKey(resource, specID, "continuousTickColor")),
+                color = CopyColorSetting(target.continuousTickColor, true) or CopyColorSetting(ResolveSpecOverrideKey(resource, specID, "continuousTickColor"), true),
             }
         end
     end

--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -138,6 +138,8 @@ local function ForEachSharedCustomBarSpec(entry, callback)
     end
 end
 
+local ResolveSpecOverrideKey
+
 local RESOURCE_SPEC_AURA_KEYS = {
     auraOverlayEnabled = true,
     auraOverlayEntries = true,
@@ -148,6 +150,196 @@ local RESOURCE_SPEC_AURA_KEYS = {
     auraUnit = true,
     auraUnitExplicit = true,
 }
+
+local MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = 3
+
+local function CopyRGBSetting(color)
+    if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
+        return nil
+    end
+    return { color[1], color[2], color[3] }
+end
+
+local function CopyRGBASetting(color)
+    if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
+        return nil
+    end
+    return { color[1], color[2], color[3], color[4] }
+end
+
+local function ClampLegacySegmentedThresholdValue(value, fallback)
+    value = tonumber(value)
+    if not value then
+        return fallback
+    end
+    value = math.floor(value)
+    if value < 1 then
+        value = 1
+    elseif value > 99 then
+        value = 99
+    end
+    return value
+end
+
+local function ClampLegacyTickPercentValue(value, fallback)
+    value = tonumber(value)
+    if not value then
+        return fallback
+    end
+    if value < 0 then
+        value = 0
+    elseif value > 100 then
+        value = 100
+    end
+    return value
+end
+
+local function ClampLegacyTickAbsoluteValue(value, fallback)
+    value = tonumber(value)
+    if not value then
+        return fallback
+    end
+    if value < 0 then
+        value = 0
+    end
+    return value
+end
+
+local function NormalizeSavedEntryList(entries, clampValue, copyColor)
+    local normalized = {}
+    local seen = {}
+    if type(entries) ~= "table" then
+        return normalized
+    end
+
+    local keys = {}
+    for key in pairs(entries) do
+        if type(key) == "number" then
+            keys[#keys + 1] = key
+        end
+    end
+    sort(keys)
+
+    for _, key in ipairs(keys) do
+        local entry = entries[key]
+        local value = type(entry) == "table" and clampValue(entry.value, nil) or nil
+        if value ~= nil then
+            local valueKey = tostring(value)
+            if not seen[valueKey] then
+                seen[valueKey] = true
+                normalized[#normalized + 1] = {
+                    value = value,
+                    color = copyColor(type(entry) == "table" and entry.color or nil),
+                }
+                if #normalized >= MAX_RESOURCE_THRESHOLD_TICK_ENTRIES then
+                    break
+                end
+            end
+        end
+    end
+
+    sort(normalized, function(a, b)
+        return a.value < b.value
+    end)
+    return normalized
+end
+
+local function StoreNormalizedEntries(target, entriesKey, clearedKey, normalized)
+    if #normalized > 0 then
+        target[entriesKey] = normalized
+        target[clearedKey] = nil
+    else
+        target[entriesKey] = nil
+    end
+end
+
+local function NormalizeThresholdEntriesOnTarget(resource, specID, target)
+    if type(target) ~= "table" then
+        return
+    end
+
+    local normalized = NormalizeSavedEntryList(target.segThresholdEntries, ClampLegacySegmentedThresholdValue, CopyRGBSetting)
+    if #normalized == 0
+        and target.segThresholdEntriesCleared ~= true
+        and ResolveSpecOverrideKey(resource, specID, "segThresholdEnabled") == true
+        and (target.segThresholdEnabled ~= nil or target.segThresholdValue ~= nil or target.segThresholdColor ~= nil) then
+        normalized[1] = {
+            value = ClampLegacySegmentedThresholdValue(
+                target.segThresholdValue ~= nil and target.segThresholdValue or ResolveSpecOverrideKey(resource, specID, "segThresholdValue"),
+                1
+            ),
+            color = CopyRGBSetting(target.segThresholdColor) or CopyRGBSetting(ResolveSpecOverrideKey(resource, specID, "segThresholdColor")),
+        }
+    end
+    StoreNormalizedEntries(target, "segThresholdEntries", "segThresholdEntriesCleared", normalized)
+end
+
+local function GetResolvedTickMode(resource, specID, target)
+    local mode = target and target.continuousTickMode or ResolveSpecOverrideKey(resource, specID, "continuousTickMode")
+    if mode == "absolute" then
+        return "absolute"
+    end
+    return "percent"
+end
+
+local function NormalizeTickEntriesOnTarget(resource, specID, target)
+    if type(target) ~= "table" then
+        return
+    end
+
+    local percentEntries = NormalizeSavedEntryList(target.continuousTickPercentEntries, ClampLegacyTickPercentValue, CopyRGBASetting)
+    local absoluteEntries = NormalizeSavedEntryList(target.continuousTickAbsoluteEntries, ClampLegacyTickAbsoluteValue, CopyRGBASetting)
+    local tickEnabled = ResolveSpecOverrideKey(resource, specID, "continuousTickEnabled") == true
+    local mode = GetResolvedTickMode(resource, specID, target)
+    local hasLegacyTickData = target.continuousTickEnabled ~= nil
+        or target.continuousTickMode ~= nil
+        or target.continuousTickPercent ~= nil
+        or target.continuousTickAbsolute ~= nil
+        or target.continuousTickColor ~= nil
+
+    if tickEnabled and hasLegacyTickData then
+        if mode == "absolute" and #absoluteEntries == 0 and target.continuousTickAbsoluteEntriesCleared ~= true then
+            absoluteEntries[1] = {
+                value = ClampLegacyTickAbsoluteValue(
+                    target.continuousTickAbsolute ~= nil and target.continuousTickAbsolute or ResolveSpecOverrideKey(resource, specID, "continuousTickAbsolute"),
+                    50
+                ),
+                color = CopyRGBASetting(target.continuousTickColor) or CopyRGBASetting(ResolveSpecOverrideKey(resource, specID, "continuousTickColor")),
+            }
+        elseif mode == "percent" and #percentEntries == 0 and target.continuousTickPercentEntriesCleared ~= true then
+            percentEntries[1] = {
+                value = ClampLegacyTickPercentValue(
+                    target.continuousTickPercent ~= nil and target.continuousTickPercent or ResolveSpecOverrideKey(resource, specID, "continuousTickPercent"),
+                    50
+                ),
+                color = CopyRGBASetting(target.continuousTickColor) or CopyRGBASetting(ResolveSpecOverrideKey(resource, specID, "continuousTickColor")),
+            }
+        end
+    end
+
+    StoreNormalizedEntries(target, "continuousTickPercentEntries", "continuousTickPercentEntriesCleared", percentEntries)
+    StoreNormalizedEntries(target, "continuousTickAbsoluteEntries", "continuousTickAbsoluteEntriesCleared", absoluteEntries)
+end
+
+local function NormalizeResourceThresholdTickEntries(settings)
+    if type(settings) ~= "table" or type(settings.resources) ~= "table" then
+        return
+    end
+    for _, resource in pairs(settings.resources) do
+        if type(resource) == "table" then
+            NormalizeThresholdEntriesOnTarget(resource, nil, resource)
+            NormalizeTickEntriesOnTarget(resource, nil, resource)
+            if type(resource.specOverrides) == "table" then
+                for specID, specData in pairs(resource.specOverrides) do
+                    if type(specData) == "table" then
+                        NormalizeThresholdEntriesOnTarget(resource, specID, specData)
+                        NormalizeTickEntriesOnTarget(resource, specID, specData)
+                    end
+                end
+            end
+        end
+    end
+end
 
 -- Keep these resource mappings aligned with OtherBars/ResourceBarConstants.lua.
 local RESOURCE_HEALTH = -1
@@ -595,7 +787,7 @@ local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
 end
 
 -- Resolves a per-spec override key: specOverrides[specID][key] -> resource[key] -> nil.
-local function ResolveSpecOverrideKey(resource, specID, key)
+function ResolveSpecOverrideKey(resource, specID, key)
     if specID and type(resource) == "table" then
         local specOverrides = resource.specOverrides
         if type(specOverrides) == "table" then
@@ -897,6 +1089,7 @@ local function NormalizeScopedBarSettings(systemKey, settings)
         NormalizeCustomAuraBarsForCurrentClass(settings)
         NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
         NormalizeResourceSpecOverridesForCurrentClass(settings)
+        NormalizeResourceThresholdTickEntries(settings)
     end
 end
 

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -82,7 +82,7 @@ local DetermineActiveResources = RB.DetermineActiveResources
 local GetResourceColors = RB.GetResourceColors
 local IsUnitPowerSecret = RB.IsUnitPowerSecret
 local IsUnitPowerMaxSecret = RB.IsUnitPowerMaxSecret
-local GetSegmentedThresholdConfig = RB.GetSegmentedThresholdConfig
+local GetSegmentedThresholdColorForValue = RB.GetSegmentedThresholdColorForValue
 local SupportsResourceAuraStackMode = RB.SupportsResourceAuraStackMode
 local IsResourceEnabled = RB.IsResourceEnabled
 local IsSegmentedTextResource = RB.IsSegmentedTextResource
@@ -1025,7 +1025,6 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         and auraMaxStacks
         and auraHasApplications
         and SupportsResourceAuraStackMode(powerType)
-    local thresholdEnabled, thresholdValue, thresholdColor = GetSegmentedThresholdConfig(powerType, settings)
     local fullSegments = segmentedUpdateScratch.GetFullSegments(holder)
     HideRechargeTexts(holder)
 
@@ -1062,7 +1061,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 readyCount = readyCount + 1
             end
         end
-        local thresholdActive = thresholdEnabled and readyCount >= thresholdValue
+        local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(powerType, settings, readyCount)
         local activeReadyColor = allReady and maxColor or (thresholdActive and thresholdColor or readyColor)
         local runeValueTotal = 0
         local showAllRechargeText = IsRechargeTextAllSegmentsMode(holder)
@@ -1124,7 +1123,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 displayCurrent = filled + partial
                 local readyColor, rechargingColor, maxColor = GetResourceColors(7, settings)
                 local isMax = (filled == max)
-                local thresholdActive = thresholdEnabled and filled >= thresholdValue
+                local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(powerType, settings, filled)
                 local activeReadyColor = isMax and maxColor or (thresholdActive and thresholdColor or readyColor)
                 for i = 1, math_min(#holder.segments, max) do
                     local seg = holder.segments[i]
@@ -1175,7 +1174,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         local displayCurrent = filled + partial
         local readyColor, rechargingColor, maxColor = GetResourceColors(19, settings)
         local isMax = (filled == max)
-        local thresholdActive = thresholdEnabled and filled >= thresholdValue
+        local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(powerType, settings, filled)
         local activeReadyColor = isMax and maxColor or (thresholdActive and thresholdColor or readyColor)
         for i = 1, math_min(#holder.segments, max) do
             local seg = holder.segments[i]
@@ -1213,7 +1212,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
 
         local normalColor, maxColor, chargedColor = GetResourceColors(4, settings)
         local isMax = (current == max and max > 0)
-        local thresholdActive = thresholdEnabled and current >= thresholdValue
+        local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(powerType, settings, current)
         local baseColor = isMax and maxColor or (thresholdActive and thresholdColor or normalColor)
 
         -- Charged combo points (Rogue only)
@@ -1262,7 +1261,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         normalColor, maxColor = color, color
     end
     local isMax = (current == max and max > 0)
-    local thresholdActive = thresholdEnabled and current >= thresholdValue
+    local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(powerType, settings, current)
     local activeColor = isMax and maxColor or (thresholdActive and thresholdColor or normalColor)
     for i = 1, math_min(#holder.segments, max) do
         local seg = holder.segments[i]
@@ -1288,7 +1287,6 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
     end
 
     -- Read stacks from viewer frame (applications is plain for MW)
-    local thresholdEnabled, thresholdValue, thresholdColor = GetSegmentedThresholdConfig(RESOURCE_MAELSTROM_WEAPON, settings)
     local stacks = 0
     local viewerFrame = CooldownCompanion.viewerAuraFrames and CooldownCompanion.viewerAuraFrames[MW_SPELL_ID]
     local instId = viewerFrame and viewerFrame.auraInstanceID
@@ -1313,7 +1311,7 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
 
     local half = #holder.segments
     local baseColor, overlayColor, maxColor = GetResourceColors(100, settings)
-    local thresholdActive = thresholdEnabled and stacks >= thresholdValue
+    local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(RESOURCE_MAELSTROM_WEAPON, settings, stacks)
     local isMax = stacks > 0 and stacks == mwMaxStacks
 
     for i = 1, half do
@@ -1733,8 +1731,7 @@ local function ApplySegmentedPreviewColors(holder, powerType, settings, previewV
     local filled = math_min(numSegments, math_max(0, math_floor(previewValue)))
     local hasPartial = previewValue > filled and filled < numSegments
 
-    local thresholdEnabled, thresholdValue, thresholdColor = GetSegmentedThresholdConfig(powerType, settings)
-    local thresholdActive = thresholdEnabled and thresholdValue and filled >= thresholdValue
+    local thresholdActive, thresholdColor = GetSegmentedThresholdColorForValue(powerType, settings, filled)
 
     local color1, color2, color3 = GetResourceColors(powerType, settings)
     local filledColor = color1

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -1872,38 +1872,6 @@ local function ResolveSpecEntryList(resource, specID, entriesKey, clearedKey)
     return resource and resource[entriesKey], resource and resource[clearedKey] == true
 end
 
-local function GetSegmentedThresholdConfig(powerType, settings)
-    if powerType ~= RESOURCE_MAELSTROM_WEAPON and SEGMENTED_TYPES[powerType] ~= true then
-        return false, nil, nil
-    end
-    if not settings or not settings.resources then
-        return false, nil, nil
-    end
-
-    local resource = settings.resources[powerType]
-    if type(resource) ~= "table" then
-        return false, nil, nil
-    end
-
-    local specID = GetCurrentSpecID()
-    local enabled = ResolveSpecOverrideKey(resource, specID, "segThresholdEnabled")
-    if enabled ~= true then
-        return false, nil, nil
-    end
-
-    local rawEntries, cleared = ResolveSpecEntryList(resource, specID, "segThresholdEntries", "segThresholdEntriesCleared")
-    local entries = GetNormalizedSegmentedThresholdEntriesFromConfig(rawEntries)
-    if #entries == 0 and not cleared then
-        entries[1] = BuildLegacySegmentedThresholdEntry(resource, specID)
-    end
-    if #entries == 0 then
-        return false, nil, nil
-    end
-
-    local first = entries[1]
-    return true, first.value, first.color
-end
-
 local function GetSegmentedThresholdEntriesConfig(powerType, settings)
     if powerType ~= RESOURCE_MAELSTROM_WEAPON and SEGMENTED_TYPES[powerType] ~= true then
         return false, {}
@@ -1952,50 +1920,6 @@ local function GetSegmentedThresholdColorForValue(powerType, settings, currentVa
     end
 
     return activeColor ~= nil, activeColor
-end
-
-local function GetContinuousTickConfig(powerType, settings)
-    if SEGMENTED_TYPES[powerType] or powerType == RESOURCE_MAELSTROM_WEAPON then
-        return false, nil, nil, nil, nil
-    end
-    if not settings or not settings.resources then
-        return false, nil, nil, nil, nil
-    end
-
-    local resource = settings.resources[powerType]
-    if type(resource) ~= "table" then
-        return false, nil, nil, nil, nil
-    end
-
-    local specID = GetCurrentSpecID()
-    local enabled = ResolveSpecOverrideKey(resource, specID, "continuousTickEnabled")
-    if enabled ~= true then
-        return false, nil, nil, nil, nil
-    end
-
-    local mode = ResolveSpecOverrideKey(resource, specID, "continuousTickMode")
-    if mode ~= "percent" and mode ~= "absolute" then
-        mode = DEFAULT_CONTINUOUS_TICK_MODE
-    end
-
-    local entriesKey = mode == "absolute" and "continuousTickAbsoluteEntries" or "continuousTickPercentEntries"
-    local clearedKey = mode == "absolute" and "continuousTickAbsoluteEntriesCleared" or "continuousTickPercentEntriesCleared"
-    local rawEntries, cleared = ResolveSpecEntryList(resource, specID, entriesKey, clearedKey)
-    local entries = GetNormalizedContinuousTickEntriesFromConfig(rawEntries, mode)
-    if #entries == 0 and not cleared then
-        entries[1] = BuildLegacyContinuousTickEntry(resource, specID, mode)
-    end
-    if #entries == 0 then
-        return false, mode, nil, nil, nil, nil, nil
-    end
-
-    local entry = entries[1]
-    local percentValue = mode == "percent" and entry.value or nil
-    local absoluteValue = mode == "absolute" and entry.value or nil
-    local tickWidth = tonumber(ResolveSpecOverrideKey(resource, specID, "continuousTickWidth")) or DEFAULT_CONTINUOUS_TICK_WIDTH
-    if tickWidth < 1 then tickWidth = 1 elseif tickWidth > 10 then tickWidth = 10 end
-    local combatOnly = ResolveSpecOverrideKey(resource, specID, "continuousTickCombatOnly") or false
-    return true, mode, percentValue, absoluteValue, entry.color, tickWidth, combatOnly
 end
 
 local function GetContinuousTickEntriesConfig(powerType, settings)
@@ -2209,10 +2133,9 @@ RB.ClampContinuousTickPercentValue = ClampContinuousTickPercentValue
 RB.ClampContinuousTickAbsoluteValue = ClampContinuousTickAbsoluteValue
 RB.GetNormalizedSegmentedThresholdEntriesFromConfig = GetNormalizedSegmentedThresholdEntriesFromConfig
 RB.GetNormalizedContinuousTickEntriesFromConfig = GetNormalizedContinuousTickEntriesFromConfig
-RB.GetSegmentedThresholdConfig = GetSegmentedThresholdConfig
+RB.ResolveSpecEntryList = ResolveSpecEntryList
 RB.GetSegmentedThresholdEntriesConfig = GetSegmentedThresholdEntriesConfig
 RB.GetSegmentedThresholdColorForValue = GetSegmentedThresholdColorForValue
-RB.GetContinuousTickConfig = GetContinuousTickConfig
 RB.GetContinuousTickEntriesConfig = GetContinuousTickEntriesConfig
 RB.SupportsResourceAuraStackMode = SupportsResourceAuraStackMode
 RB.IsResourceEnabled = IsResourceEnabled

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -13,6 +13,7 @@ local CooldownCompanion = ST.Addon
 
 local math_floor = math.floor
 local string_format = string.format
+local table_sort = table.sort
 local SecretsAPI = C_Secrets
 
 -- Import constants from ResourceBarConstants
@@ -34,6 +35,7 @@ local SPEC_RESOURCES = RB.SPEC_RESOURCES
 local DRUID_FORM_RESOURCES = RB.DRUID_FORM_RESOURCES
 local DRUID_DEFAULT_RESOURCES = RB.DRUID_DEFAULT_RESOURCES
 local DRUID_BALANCE_SPEC_ID = 102
+local MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = 3
 
 local ResolveSpecOverrideKey = ST._ResolveSpecOverrideKey
 
@@ -1741,6 +1743,135 @@ end
 -- Identical to GetSafeRGBColor; alias kept for call-site clarity (RGB vs RGBA intent)
 local GetSafeRGBAColor = GetSafeRGBColor
 
+local function ClampSegmentedThresholdValue(value, fallback)
+    value = tonumber(value)
+    if not value then
+        return fallback
+    end
+    value = math_floor(value)
+    if value < 1 then
+        value = 1
+    elseif value > 99 then
+        value = 99
+    end
+    return value
+end
+
+local function ClampContinuousTickPercentValue(value, fallback)
+    value = tonumber(value)
+    if not value then
+        return fallback
+    end
+    if value < 0 then
+        value = 0
+    elseif value > 100 then
+        value = 100
+    end
+    return value
+end
+
+local function ClampContinuousTickAbsoluteValue(value, fallback)
+    value = tonumber(value)
+    if not value then
+        return fallback
+    end
+    if value < 0 then
+        value = 0
+    end
+    return value
+end
+
+local function CollectNumericKeys(tbl)
+    local keys = {}
+    if type(tbl) ~= "table" then
+        return keys
+    end
+    for key in pairs(tbl) do
+        if type(key) == "number" then
+            keys[#keys + 1] = key
+        end
+    end
+    table_sort(keys)
+    return keys
+end
+
+local function NormalizeEntryList(entries, clampValue, colorFallback, colorResolver)
+    local normalized = {}
+    local seen = {}
+    if type(entries) ~= "table" then
+        return normalized
+    end
+
+    local keys = CollectNumericKeys(entries)
+    for _, key in ipairs(keys) do
+        local entry = entries[key]
+        local value = type(entry) == "table" and clampValue(entry.value, nil) or nil
+        if value ~= nil then
+            local valueKey = tostring(value)
+            if not seen[valueKey] then
+                seen[valueKey] = true
+                normalized[#normalized + 1] = {
+                    value = value,
+                    color = colorResolver(type(entry) == "table" and entry.color or nil, colorFallback),
+                }
+                if #normalized >= MAX_RESOURCE_THRESHOLD_TICK_ENTRIES then
+                    break
+                end
+            end
+        end
+    end
+
+    table_sort(normalized, function(a, b)
+        return a.value < b.value
+    end)
+    return normalized
+end
+
+local function GetNormalizedSegmentedThresholdEntriesFromConfig(entries)
+    return NormalizeEntryList(entries, ClampSegmentedThresholdValue, DEFAULT_SEG_THRESHOLD_COLOR, GetSafeRGBColor)
+end
+
+local function GetNormalizedContinuousTickEntriesFromConfig(entries, mode)
+    local clamp = mode == "absolute" and ClampContinuousTickAbsoluteValue or ClampContinuousTickPercentValue
+    return NormalizeEntryList(entries, clamp, DEFAULT_CONTINUOUS_TICK_COLOR, GetSafeRGBAColor)
+end
+
+local function BuildLegacySegmentedThresholdEntry(resource, specID)
+    return {
+        value = ClampSegmentedThresholdValue(ResolveSpecOverrideKey(resource, specID, "segThresholdValue"), 1),
+        color = GetSafeRGBColor(ResolveSpecOverrideKey(resource, specID, "segThresholdColor"), DEFAULT_SEG_THRESHOLD_COLOR),
+    }
+end
+
+local function BuildLegacyContinuousTickEntry(resource, specID, mode)
+    local value
+    if mode == "absolute" then
+        value = ClampContinuousTickAbsoluteValue(ResolveSpecOverrideKey(resource, specID, "continuousTickAbsolute"), DEFAULT_CONTINUOUS_TICK_ABSOLUTE)
+    else
+        value = ClampContinuousTickPercentValue(ResolveSpecOverrideKey(resource, specID, "continuousTickPercent"), DEFAULT_CONTINUOUS_TICK_PERCENT)
+    end
+    return {
+        value = value,
+        color = GetSafeRGBAColor(ResolveSpecOverrideKey(resource, specID, "continuousTickColor"), DEFAULT_CONTINUOUS_TICK_COLOR),
+    }
+end
+
+local function ResolveSpecEntryList(resource, specID, entriesKey, clearedKey)
+    if specID and type(resource) == "table" then
+        local specOverrides = resource.specOverrides
+        local specData = type(specOverrides) == "table" and specOverrides[specID] or nil
+        if type(specData) == "table" then
+            if specData[entriesKey] ~= nil then
+                return specData[entriesKey], specData[clearedKey] == true
+            end
+            if specData[clearedKey] == true then
+                return nil, true
+            end
+        end
+    end
+    return resource and resource[entriesKey], resource and resource[clearedKey] == true
+end
+
 local function GetSegmentedThresholdConfig(powerType, settings)
     if powerType ~= RESOURCE_MAELSTROM_WEAPON and SEGMENTED_TYPES[powerType] ~= true then
         return false, nil, nil
@@ -1760,19 +1891,67 @@ local function GetSegmentedThresholdConfig(powerType, settings)
         return false, nil, nil
     end
 
-    local threshold = tonumber(ResolveSpecOverrideKey(resource, specID, "segThresholdValue"))
-    if not threshold then
-        threshold = 1
+    local rawEntries, cleared = ResolveSpecEntryList(resource, specID, "segThresholdEntries", "segThresholdEntriesCleared")
+    local entries = GetNormalizedSegmentedThresholdEntriesFromConfig(rawEntries)
+    if #entries == 0 and not cleared then
+        entries[1] = BuildLegacySegmentedThresholdEntry(resource, specID)
     end
-    threshold = math_floor(threshold)
-    if threshold < 1 then
-        threshold = 1
-    elseif threshold > 99 then
-        threshold = 99
+    if #entries == 0 then
+        return false, nil, nil
     end
 
-    local thresholdColor = GetSafeRGBColor(ResolveSpecOverrideKey(resource, specID, "segThresholdColor"), DEFAULT_SEG_THRESHOLD_COLOR)
-    return true, threshold, thresholdColor
+    local first = entries[1]
+    return true, first.value, first.color
+end
+
+local function GetSegmentedThresholdEntriesConfig(powerType, settings)
+    if powerType ~= RESOURCE_MAELSTROM_WEAPON and SEGMENTED_TYPES[powerType] ~= true then
+        return false, {}
+    end
+    if not settings or not settings.resources then
+        return false, {}
+    end
+
+    local resource = settings.resources[powerType]
+    if type(resource) ~= "table" then
+        return false, {}
+    end
+
+    local specID = GetCurrentSpecID()
+    local enabled = ResolveSpecOverrideKey(resource, specID, "segThresholdEnabled")
+    if enabled ~= true then
+        return false, {}
+    end
+
+    local rawEntries, cleared = ResolveSpecEntryList(resource, specID, "segThresholdEntries", "segThresholdEntriesCleared")
+    local entries = GetNormalizedSegmentedThresholdEntriesFromConfig(rawEntries)
+    if #entries == 0 and not cleared then
+        entries[1] = BuildLegacySegmentedThresholdEntry(resource, specID)
+    end
+    return true, entries
+end
+
+local function GetSegmentedThresholdColorForValue(powerType, settings, currentValue)
+    currentValue = tonumber(currentValue)
+    if not currentValue then
+        return false, nil
+    end
+
+    local enabled, entries = GetSegmentedThresholdEntriesConfig(powerType, settings)
+    if not enabled then
+        return false, nil
+    end
+
+    local activeColor
+    for _, entry in ipairs(entries) do
+        if currentValue >= entry.value then
+            activeColor = entry.color
+        else
+            break
+        end
+    end
+
+    return activeColor ~= nil, activeColor
 end
 
 local function GetContinuousTickConfig(powerType, settings)
@@ -1799,29 +1978,62 @@ local function GetContinuousTickConfig(powerType, settings)
         mode = DEFAULT_CONTINUOUS_TICK_MODE
     end
 
-    local percentValue = tonumber(ResolveSpecOverrideKey(resource, specID, "continuousTickPercent"))
-    if not percentValue then
-        percentValue = DEFAULT_CONTINUOUS_TICK_PERCENT
+    local entriesKey = mode == "absolute" and "continuousTickAbsoluteEntries" or "continuousTickPercentEntries"
+    local clearedKey = mode == "absolute" and "continuousTickAbsoluteEntriesCleared" or "continuousTickPercentEntriesCleared"
+    local rawEntries, cleared = ResolveSpecEntryList(resource, specID, entriesKey, clearedKey)
+    local entries = GetNormalizedContinuousTickEntriesFromConfig(rawEntries, mode)
+    if #entries == 0 and not cleared then
+        entries[1] = BuildLegacyContinuousTickEntry(resource, specID, mode)
     end
-    if percentValue < 0 then
-        percentValue = 0
-    elseif percentValue > 100 then
-        percentValue = 100
-    end
-
-    local absoluteValue = tonumber(ResolveSpecOverrideKey(resource, specID, "continuousTickAbsolute"))
-    if not absoluteValue then
-        absoluteValue = DEFAULT_CONTINUOUS_TICK_ABSOLUTE
-    end
-    if absoluteValue < 0 then
-        absoluteValue = 0
+    if #entries == 0 then
+        return false, mode, nil, nil, nil, nil, nil
     end
 
-    local tickColor = GetSafeRGBAColor(ResolveSpecOverrideKey(resource, specID, "continuousTickColor"), DEFAULT_CONTINUOUS_TICK_COLOR)
+    local entry = entries[1]
+    local percentValue = mode == "percent" and entry.value or nil
+    local absoluteValue = mode == "absolute" and entry.value or nil
     local tickWidth = tonumber(ResolveSpecOverrideKey(resource, specID, "continuousTickWidth")) or DEFAULT_CONTINUOUS_TICK_WIDTH
     if tickWidth < 1 then tickWidth = 1 elseif tickWidth > 10 then tickWidth = 10 end
     local combatOnly = ResolveSpecOverrideKey(resource, specID, "continuousTickCombatOnly") or false
-    return true, mode, percentValue, absoluteValue, tickColor, tickWidth, combatOnly
+    return true, mode, percentValue, absoluteValue, entry.color, tickWidth, combatOnly
+end
+
+local function GetContinuousTickEntriesConfig(powerType, settings)
+    if SEGMENTED_TYPES[powerType] or powerType == RESOURCE_MAELSTROM_WEAPON then
+        return false, nil, {}, nil, nil
+    end
+    if not settings or not settings.resources then
+        return false, nil, {}, nil, nil
+    end
+
+    local resource = settings.resources[powerType]
+    if type(resource) ~= "table" then
+        return false, nil, {}, nil, nil
+    end
+
+    local specID = GetCurrentSpecID()
+    local enabled = ResolveSpecOverrideKey(resource, specID, "continuousTickEnabled")
+    if enabled ~= true then
+        return false, nil, {}, nil, nil
+    end
+
+    local mode = ResolveSpecOverrideKey(resource, specID, "continuousTickMode")
+    if mode ~= "percent" and mode ~= "absolute" then
+        mode = DEFAULT_CONTINUOUS_TICK_MODE
+    end
+
+    local entriesKey = mode == "absolute" and "continuousTickAbsoluteEntries" or "continuousTickPercentEntries"
+    local clearedKey = mode == "absolute" and "continuousTickAbsoluteEntriesCleared" or "continuousTickPercentEntriesCleared"
+    local rawEntries, cleared = ResolveSpecEntryList(resource, specID, entriesKey, clearedKey)
+    local entries = GetNormalizedContinuousTickEntriesFromConfig(rawEntries, mode)
+    if #entries == 0 and not cleared then
+        entries[1] = BuildLegacyContinuousTickEntry(resource, specID, mode)
+    end
+
+    local tickWidth = tonumber(ResolveSpecOverrideKey(resource, specID, "continuousTickWidth")) or DEFAULT_CONTINUOUS_TICK_WIDTH
+    if tickWidth < 1 then tickWidth = 1 elseif tickWidth > 10 then tickWidth = 10 end
+    local combatOnly = ResolveSpecOverrideKey(resource, specID, "continuousTickCombatOnly") or false
+    return true, mode, entries, tickWidth, combatOnly
 end
 
 local function SupportsResourceAuraStackMode(powerType)
@@ -1991,8 +2203,17 @@ RB.IsUnitPowerSecret = IsUnitPowerSecret
 RB.IsUnitPowerMaxSecret = IsUnitPowerMaxSecret
 RB.GetSafeRGBColor = GetSafeRGBColor
 RB.GetSafeRGBAColor = GetSafeRGBAColor
+RB.MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = MAX_RESOURCE_THRESHOLD_TICK_ENTRIES
+RB.ClampSegmentedThresholdValue = ClampSegmentedThresholdValue
+RB.ClampContinuousTickPercentValue = ClampContinuousTickPercentValue
+RB.ClampContinuousTickAbsoluteValue = ClampContinuousTickAbsoluteValue
+RB.GetNormalizedSegmentedThresholdEntriesFromConfig = GetNormalizedSegmentedThresholdEntriesFromConfig
+RB.GetNormalizedContinuousTickEntriesFromConfig = GetNormalizedContinuousTickEntriesFromConfig
 RB.GetSegmentedThresholdConfig = GetSegmentedThresholdConfig
+RB.GetSegmentedThresholdEntriesConfig = GetSegmentedThresholdEntriesConfig
+RB.GetSegmentedThresholdColorForValue = GetSegmentedThresholdColorForValue
 RB.GetContinuousTickConfig = GetContinuousTickConfig
+RB.GetContinuousTickEntriesConfig = GetContinuousTickEntriesConfig
 RB.SupportsResourceAuraStackMode = SupportsResourceAuraStackMode
 RB.IsResourceEnabled = IsResourceEnabled
 RB.IsSegmentedTextResource = IsSegmentedTextResource

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -26,12 +26,13 @@ local DEFAULT_CUSTOM_AURA_MAX_COLOR = RB.DEFAULT_CUSTOM_AURA_MAX_COLOR
 local DEFAULT_CONTINUOUS_TICK_COLOR = RB.DEFAULT_CONTINUOUS_TICK_COLOR
 local RESOURCE_MAELSTROM_WEAPON = RB.RESOURCE_MAELSTROM_WEAPON
 local SEGMENTED_TYPES = RB.SEGMENTED_TYPES
+local MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = RB.MAX_RESOURCE_THRESHOLD_TICK_ENTRIES or 3
 
 local IsVerticalResourceLayout = RB.IsVerticalResourceLayout
 local IsVerticalFillReversed = RB.IsVerticalFillReversed
 local GetCurrentSpecID = RB.GetCurrentSpecID
 local GetResourceColors = RB.GetResourceColors
-local GetContinuousTickConfig = RB.GetContinuousTickConfig
+local GetContinuousTickEntriesConfig = RB.GetContinuousTickEntriesConfig
 local GetSpecResourceDisplayProfile = RB.GetSpecResourceDisplayProfile
 local GetSafeRGBColor = RB.GetSafeRGBColor
 local SupportsResourceAuraStackMode = RB.SupportsResourceAuraStackMode
@@ -425,47 +426,65 @@ end
 -- Continuous Tick & Fill
 ------------------------------------------------------------------------
 
-local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, maxPowerIsSecret)
-    if not bar or not bar.tickMarker then return end
+local function EnsureContinuousTickMarkers(bar)
+    if not bar then return nil end
+    if type(bar.tickMarkers) ~= "table" then
+        bar.tickMarkers = {}
+        if bar.tickMarker then
+            bar.tickMarkers[1] = bar.tickMarker
+        end
+    end
+    for index = 1, MAX_RESOURCE_THRESHOLD_TICK_ENTRIES do
+        if not bar.tickMarkers[index] then
+            bar.tickMarkers[index] = bar:CreateTexture(nil, "OVERLAY", nil, 6)
+            bar.tickMarkers[index]:SetColorTexture(1, 0.84, 0, 1)
+            bar.tickMarkers[index]:Hide()
+        end
+    end
+    bar.tickMarker = bar.tickMarkers[1]
+    return bar.tickMarkers
+end
 
-    local enabled, mode, percentValue, absoluteValue, tickColor, tickWidth, combatOnly = GetContinuousTickConfig(powerType, settings)
-    if not enabled then
+local function HideContinuousTickMarkers(bar, startIndex)
+    if not bar then return end
+    startIndex = startIndex or 1
+    if type(bar.tickMarkers) == "table" then
+        for index = startIndex, #bar.tickMarkers do
+            bar.tickMarkers[index]:Hide()
+        end
+    elseif startIndex <= 1 and bar.tickMarker then
         bar.tickMarker:Hide()
+    end
+end
+
+local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, maxPowerIsSecret)
+    if not bar then return end
+
+    local enabled, mode, entries, tickWidth, combatOnly = GetContinuousTickEntriesConfig(powerType, settings)
+    if not enabled then
+        HideContinuousTickMarkers(bar)
         return
     end
 
     if combatOnly and not InCombatLockdown() then
-        bar.tickMarker:Hide()
+        HideContinuousTickMarkers(bar)
         return
     end
 
-    local ratio
     if mode == "absolute" then
         if maxPowerIsSecret then
-            bar.tickMarker:Hide()
+            HideContinuousTickMarkers(bar)
             return
         end
         if issecretvalue and issecretvalue(maxPower) then
-            bar.tickMarker:Hide()
+            HideContinuousTickMarkers(bar)
             return
         end
         if type(maxPower) ~= "number" or maxPower <= 0 then
-            bar.tickMarker:Hide()
+            HideContinuousTickMarkers(bar)
             return
         end
-        ratio = absoluteValue / maxPower
-    else
-        ratio = percentValue / 100
     end
-
-    if ratio < 0 then
-        ratio = 0
-    elseif ratio > 1 then
-        ratio = 1
-    end
-
-    local marker = bar.tickMarker
-    marker:SetColorTexture(tickColor[1], tickColor[2], tickColor[3], tickColor[4] ~= nil and tickColor[4] or 1)
 
     local style = GetResourceDisplayStyle(settings)
     local borderStyle = style and style.borderStyle or "pixel"
@@ -474,34 +493,54 @@ local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, ma
     local width = bar:GetWidth() or 0
     local height = bar:GetHeight() or 0
     if width <= 0 or height <= 0 then
-        marker:Hide()
+        HideContinuousTickMarkers(bar)
         return
     end
 
+    local markers = EnsureContinuousTickMarkers(bar)
+    local shownCount = 0
     local halfTick = tickWidth / 2
-    marker:ClearAllPoints()
-    if bar._isVertical then
-        local usableHeight = math_max(height - (borderSize * 2), 1)
-        local localRatio = bar._reverseFill and (1 - ratio) or ratio
-        local y = borderSize + (usableHeight * localRatio)
-        local yMax = height - borderSize
-        if y > yMax then y = yMax end
-        if y < borderSize then y = borderSize end
-        marker:SetPoint("BOTTOMLEFT", bar, "BOTTOMLEFT", borderSize, y - halfTick)
-        marker:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -borderSize, y - halfTick)
-        marker:SetHeight(tickWidth)
-    else
-        local usableWidth = math_max(width - (borderSize * 2), 1)
-        local x = borderSize + (usableWidth * ratio)
-        local xMax = width - borderSize
-        if x > xMax then x = xMax end
-        if x < borderSize then x = borderSize end
-        marker:SetPoint("TOPLEFT", bar, "TOPLEFT", x - halfTick, -borderSize)
-        marker:SetPoint("BOTTOMLEFT", bar, "BOTTOMLEFT", x - halfTick, borderSize)
-        marker:SetWidth(tickWidth)
+
+    for index, entry in ipairs(entries) do
+        if index > MAX_RESOURCE_THRESHOLD_TICK_ENTRIES then
+            break
+        end
+        local ratio = mode == "absolute" and (entry.value / maxPower) or (entry.value / 100)
+        if ratio < 0 then
+            ratio = 0
+        elseif ratio > 1 then
+            ratio = 1
+        end
+
+        local marker = markers[index]
+        local tickColor = entry.color or DEFAULT_CONTINUOUS_TICK_COLOR
+        marker:SetColorTexture(tickColor[1], tickColor[2], tickColor[3], tickColor[4] ~= nil and tickColor[4] or 1)
+        marker:ClearAllPoints()
+        if bar._isVertical then
+            local usableHeight = math_max(height - (borderSize * 2), 1)
+            local localRatio = bar._reverseFill and (1 - ratio) or ratio
+            local y = borderSize + (usableHeight * localRatio)
+            local yMax = height - borderSize
+            if y > yMax then y = yMax end
+            if y < borderSize then y = borderSize end
+            marker:SetPoint("BOTTOMLEFT", bar, "BOTTOMLEFT", borderSize, y - halfTick)
+            marker:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -borderSize, y - halfTick)
+            marker:SetHeight(tickWidth)
+        else
+            local usableWidth = math_max(width - (borderSize * 2), 1)
+            local x = borderSize + (usableWidth * ratio)
+            local xMax = width - borderSize
+            if x > xMax then x = xMax end
+            if x < borderSize then x = borderSize end
+            marker:SetPoint("TOPLEFT", bar, "TOPLEFT", x - halfTick, -borderSize)
+            marker:SetPoint("BOTTOMLEFT", bar, "BOTTOMLEFT", x - halfTick, borderSize)
+            marker:SetWidth(tickWidth)
+        end
+        marker:Show()
+        shownCount = index
     end
 
-    marker:Show()
+    HideContinuousTickMarkers(bar, shownCount + 1)
 end
 
 local function ApplyContinuousFillColor(bar, powerType, settings, overrideColor)
@@ -782,10 +821,11 @@ local function CreateContinuousBar(parent)
     bar.brightnessOverlay:SetBlendMode("ADD")
     bar.brightnessOverlay:Hide()
 
-    -- Optional static tick marker for continuous bars.
+    -- Optional static tick markers for continuous bars.
     bar.tickMarker = bar:CreateTexture(nil, "OVERLAY", nil, 6)
     bar.tickMarker:SetColorTexture(1, 0.84, 0, 1)
     bar.tickMarker:Hide()
+    bar.tickMarkers = { bar.tickMarker }
 
     bar._barType = "continuous"
     return bar

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -26,8 +26,6 @@ local DEFAULT_CUSTOM_AURA_MAX_COLOR = RB.DEFAULT_CUSTOM_AURA_MAX_COLOR
 local DEFAULT_CONTINUOUS_TICK_COLOR = RB.DEFAULT_CONTINUOUS_TICK_COLOR
 local RESOURCE_MAELSTROM_WEAPON = RB.RESOURCE_MAELSTROM_WEAPON
 local SEGMENTED_TYPES = RB.SEGMENTED_TYPES
-local MAX_RESOURCE_THRESHOLD_TICK_ENTRIES = RB.MAX_RESOURCE_THRESHOLD_TICK_ENTRIES or 3
-
 local IsVerticalResourceLayout = RB.IsVerticalResourceLayout
 local IsVerticalFillReversed = RB.IsVerticalFillReversed
 local GetCurrentSpecID = RB.GetCurrentSpecID
@@ -426,7 +424,7 @@ end
 -- Continuous Tick & Fill
 ------------------------------------------------------------------------
 
-local function EnsureContinuousTickMarkers(bar)
+local function EnsureContinuousTickMarker(bar, index)
     if not bar then return nil end
     if type(bar.tickMarkers) ~= "table" then
         bar.tickMarkers = {}
@@ -434,15 +432,15 @@ local function EnsureContinuousTickMarkers(bar)
             bar.tickMarkers[1] = bar.tickMarker
         end
     end
-    for index = 1, MAX_RESOURCE_THRESHOLD_TICK_ENTRIES do
-        if not bar.tickMarkers[index] then
-            bar.tickMarkers[index] = bar:CreateTexture(nil, "OVERLAY", nil, 6)
-            bar.tickMarkers[index]:SetColorTexture(1, 0.84, 0, 1)
-            bar.tickMarkers[index]:Hide()
-        end
+    if not bar.tickMarkers[index] then
+        bar.tickMarkers[index] = bar:CreateTexture(nil, "OVERLAY", nil, 6)
+        bar.tickMarkers[index]:SetColorTexture(1, 0.84, 0, 1)
+        bar.tickMarkers[index]:Hide()
     end
-    bar.tickMarker = bar.tickMarkers[1]
-    return bar.tickMarkers
+    if index == 1 then
+        bar.tickMarker = bar.tickMarkers[index]
+    end
+    return bar.tickMarkers[index]
 end
 
 local function HideContinuousTickMarkers(bar, startIndex)
@@ -497,14 +495,10 @@ local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, ma
         return
     end
 
-    local markers = EnsureContinuousTickMarkers(bar)
     local shownCount = 0
     local halfTick = tickWidth / 2
 
     for index, entry in ipairs(entries) do
-        if index > MAX_RESOURCE_THRESHOLD_TICK_ENTRIES then
-            break
-        end
         local ratio = mode == "absolute" and (entry.value / maxPower) or (entry.value / 100)
         if ratio < 0 then
             ratio = 0
@@ -512,7 +506,7 @@ local function UpdateContinuousTickMarker(bar, powerType, settings, maxPower, ma
             ratio = 1
         end
 
-        local marker = markers[index]
+        local marker = EnsureContinuousTickMarker(bar, index)
         local tickColor = entry.color or DEFAULT_CONTINUOUS_TICK_COLOR
         marker:SetColorTexture(tickColor[1], tickColor[2], tickColor[3], tickColor[4] ~= nil and tickColor[4] or 1)
         marker:ClearAllPoints()


### PR DESCRIPTION
## What Players Will Notice
- Resource bars can now show up to three threshold colors or tick markers per resource and specialization instead of being limited to one breakpoint.
- Each threshold color and tick marker can have its own color, making multiple important resource values easier to read at a glance.
- The advanced resource settings side panel now uses add/remove rows for threshold colors and tick markers, with clear empty states and duplicate/invalid value feedback.

## Why This Changed
- The old resource bar threshold and tick marker controls were useful but too narrow for resources with several meaningful breakpoints.
- Allowing several entries keeps the existing behavior familiar while making resource bars more flexible for player-specific setups.

## What Changed
- Added list-backed threshold color settings for segmented resources, capped at three entries per resource/spec; when multiple thresholds are crossed, the highest crossed threshold color wins.
- Added list-backed tick marker settings for continuous resources, capped at three entries per resource/spec, with separate percent-mode and absolute-value lists.
- Kept tick mode, tick width, and combat-only behavior shared for each resource/spec so the editor stays understandable.
- Preserved compatibility with existing single threshold/tick settings through saved-setting backfill and narrow runtime fallback.
- Added explicit cleared-entry handling so removing the last row leaves the feature enabled but visually inactive instead of resurrecting stale legacy values.
- Simplified the implementation after the first pass by removing unused single-entry helpers and sharing small editor/resolution helpers.

## Validation
- `lua tests\resource-threshold-tick-helpers.lua`
- `lua tests\resource-settings-helpers.lua`
- `lua tests\resource-settings-selection.lua`
- `lua tests\resource-settings-ui-shape.lua`
- `luac -p` on touched Lua files and focused local test files
- `git diff --check origin/main...HEAD`
- In-game resource bar UI, combat behavior, and restricted-content behavior still need manual verification before treating the feature as fully proven live.
