### PR TITLE
Make the group list refresh faster on large profiles

### DIFF
--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -386,13 +386,15 @@ local function GetFolderTargetsForSection(db, charKey, section)
     return folderList
 end
 
-local function BuildColumn1ContainerStats(db)
+local function BuildColumn1ContainerStats(db, containerIds)
     local statsByContainer = {}
+    if not containerIds or not next(containerIds) then return statsByContainer end
+
     local containers = db.groupContainers or {}
 
     for _, group in pairs(db.groups or {}) do
         local containerId = group and group.parentContainerId
-        if containerId then
+        if containerId and containerIds[containerId] then
             local stats = statsByContainer[containerId]
             if not stats then
                 stats = {
@@ -1031,7 +1033,7 @@ local function RefreshColumn1(preserveDrag)
         return
     end
 
-    local containerStats = BuildColumn1ContainerStats(db)
+    local containerStats = {}
 
     -- Count current children in scroll widget
     local function CountScrollChildren()
@@ -1985,6 +1987,24 @@ local function RefreshColumn1(preserveDrag)
         desc.label:SetMaxLines(0)
         CS.col1Scroll:AddChild(desc)
     else
+        local statsContainerIds = {}
+        for _, id in ipairs(globalIds) do
+            if not searchResults or searchResults.containerMatches[id] then
+                statsContainerIds[id] = true
+            end
+        end
+        for _, id in ipairs(charIds) do
+            if not searchResults or searchResults.containerMatches[id] then
+                statsContainerIds[id] = true
+            end
+        end
+        for id in pairs(CS.selectedGroups) do
+            if containers[id] then
+                statsContainerIds[id] = true
+            end
+        end
+        containerStats = BuildColumn1ContainerStats(db, statsContainerIds)
+
         -- Render sections
         local hasGlobalContent = #globalIds > 0
         if not hasGlobalContent then

--- a/Config/Column1.lua
+++ b/Config/Column1.lua
@@ -386,6 +386,46 @@ local function GetFolderTargetsForSection(db, charKey, section)
     return folderList
 end
 
+local function BuildColumn1ContainerStats(db)
+    local statsByContainer = {}
+    local containers = db.groupContainers or {}
+
+    for _, group in pairs(db.groups or {}) do
+        local containerId = group and group.parentContainerId
+        if containerId then
+            local stats = statsByContainer[containerId]
+            if not stats then
+                stats = {
+                    panelCount = 0,
+                    hasButtons = false,
+                    hasActivePanel = false,
+                }
+                statsByContainer[containerId] = stats
+            end
+
+            stats.panelCount = stats.panelCount + 1
+            if group.buttons and #group.buttons > 0 then
+                stats.hasButtons = true
+
+                local container = containers[containerId]
+                if container and container.enabled ~= false and not stats.hasActivePanel then
+                    local active = CooldownCompanion:IsGroupActive(nil, {
+                        group = group,
+                        requireButtons = true,
+                        checkCharVisibility = false,
+                        checkLoadConditions = true,
+                    })
+                    if active then
+                        stats.hasActivePanel = true
+                    end
+                end
+            end
+        end
+    end
+
+    return statsByContainer
+end
+
 local function ShowContainerContextMenu(db, charKey, containerId, container)
     if not CS.groupContextMenu then
         CS.groupContextMenu = CreateFrame("Frame", "CDCGroupContextMenu", UIParent, "UIDropDownMenuTemplate")
@@ -991,6 +1031,8 @@ local function RefreshColumn1(preserveDrag)
         return
     end
 
+    local containerStats = BuildColumn1ContainerStats(db)
+
     -- Count current children in scroll widget
     local function CountScrollChildren()
         local children = { CS.col1Scroll.content:GetChildren() }
@@ -1088,28 +1130,9 @@ local function RefreshColumn1(preserveDrag)
     local function IsContainerInactive(containerId, container)
         if not container then return true end
         if container.enabled == false then return true end
-        -- Check if container has any panels with buttons
-        local hasButtons = false
-        for _, group in pairs(db.groups) do
-            if group.parentContainerId == containerId and group.buttons and #group.buttons > 0 then
-                hasButtons = true
-                break
-            end
-        end
-        if not hasButtons then return true end
-        -- Check load conditions via any panel (they inherit from container)
-        for gid, group in pairs(db.groups) do
-            if group.parentContainerId == containerId then
-                local active = CooldownCompanion:IsGroupActive(nil, {
-                    group = group,
-                    requireButtons = true,
-                    checkCharVisibility = false,
-                    checkLoadConditions = true,
-                })
-                if active then return false end
-            end
-        end
-        return true
+        local stats = containerStats[containerId]
+        if not stats or not stats.hasButtons then return true end
+        return stats.hasActivePanel ~= true
     end
 
     local function IsFolderFullyInactive(folderId, childContainerIds)
@@ -1178,7 +1201,8 @@ local function RefreshColumn1(preserveDrag)
         local isInactive = IsContainerInactive(containerId, container)
 
         -- Show panel count in name when >1 panel
-        local panelCount = CooldownCompanion:GetPanelCount(containerId)
+        local stats = containerStats[containerId]
+        local panelCount = stats and stats.panelCount or 0
         local groupName = container.name or "New Group"
         local showGenericRenameBadge = IsGenericGroupName(groupName)
         local displayName = groupName


### PR DESCRIPTION
## What Players Will Notice
- The config window's left group list should refresh more smoothly on large profiles, especially when sorting groups into loaded/unloaded sections or using search.
- Search states with no matching groups avoid doing unnecessary group activity checks before showing the empty result.

## Why This Changed
- Column 1 was repeatedly scanning profile panels while rendering each container row and folder state. On profiles with many containers or panels, that made normal config refreshes do more work than the UI needed.

## What Changed
- Added a private render-pass stats table for normal Column 1 mode so panel counts and container activity are computed once per relevant refresh instead of repeatedly per row.
- Limited the stats pass to containers that can affect the rendered list, while still preserving selected hidden containers for collapsed-folder multi-select drag bucket behavior.
- Preserved existing public APIs and browse-mode behavior; `GetPanelCount`, `GetPanels`, and cross-character browse rendering were left alone.

## Validation
- `luac -p Config\Column1.lua`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `lua tests\config-row-icons.lua`
- `lua tests\panel-config-preview-availability.lua`
- `lua tests\panel-anchor-finalization.lua`
- In-game config smoke checks are still pending for search, folders, disabled containers, panel count labels, and collapsed-folder multi-select drag.
- Combat and restricted-content testing was not performed; this change is limited to config UI rendering and does not touch cooldown/runtime display behavior.