### PR TITLE
Reduce repeated aura event scans

### DIFF
--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -35,6 +35,18 @@ local COOLDOWN_VIEWER_ASSOCIATION_CATEGORIES = {
     Enum.CooldownViewerCategory.TrackedBar,
 }
 
+local function BuildAuraInstanceIDSet(auraInstanceIDs)
+    if not (auraInstanceIDs and auraInstanceIDs[1]) then
+        return nil
+    end
+
+    local auraInstanceIDSet = {}
+    for _, auraInstanceID in ipairs(auraInstanceIDs) do
+        auraInstanceIDSet[auraInstanceID] = true
+    end
+    return auraInstanceIDSet
+end
+
 local function IsBuffViewerChild(frame)
     if not frame then return false end
     local parent = frame:GetParent()
@@ -473,32 +485,26 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- work correctly — the update path re-checks _auraInstanceID after removals.
     local removedIDs = updateInfo.removedAuraInstanceIDs
     local updatedIDs = updateInfo.updatedAuraInstanceIDs
+    local removedIDSet = BuildAuraInstanceIDSet(removedIDs)
+    local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
     local isTarget = (unit == "target")
     if removedIDs or updatedIDs or isTarget then
         self:ForEachButton(function(button)
             if button._auraInstanceID and button._auraUnit == unit then
-                if removedIDs then
-                    for _, instId in ipairs(removedIDs) do
-                        if button._auraInstanceID == instId then
-                            button._auraInstanceID = nil
-                            button._inPandemic = false
-                            button._auraEventRemoved = true
-                            break
-                        end
-                    end
+                if removedIDSet and removedIDSet[button._auraInstanceID] then
+                    button._auraInstanceID = nil
+                    button._inPandemic = false
+                    button._auraEventRemoved = true
                 end
                 -- Aura reapplication (pandemic refresh) arrives as an update, not a
                 -- removal + add.  Clear pandemic state and suppress the grace hold so
                 -- the next evaluation clears pandemic immediately instead of holding 0.3s.
-                if updatedIDs and button._auraInstanceID then
-                    for _, instId in ipairs(updatedIDs) do
-                        if button._auraInstanceID == instId then
-                            button._inPandemic = false
-                            button._pandemicGraceStart = nil
-                            button._pandemicGraceSuppressed = true
-                            break
-                        end
-                    end
+                if updatedIDSet
+                    and button._auraInstanceID
+                    and updatedIDSet[button._auraInstanceID] then
+                    button._inPandemic = false
+                    button._pandemicGraceStart = nil
+                    button._pandemicGraceSuppressed = true
                 end
             end
             -- Signal that the server has delivered target aura data, so the hold

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -28,6 +28,18 @@ function RB.CreateResourceBarLifecycleModule(deps)
     local lifecycleEventsEnabled = false
     local InstallHooks
 
+    local function BuildAuraInstanceIDSet(auraInstanceIDs)
+        if not (auraInstanceIDs and auraInstanceIDs[1]) then
+            return nil
+        end
+
+        local auraInstanceIDSet = {}
+        for _, auraInstanceID in ipairs(auraInstanceIDs) do
+            auraInstanceIDSet[auraInstanceID] = true
+        end
+        return auraInstanceIDSet
+    end
+
     local function IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
         if not (barInfo and cabConfig) then return false end
         return barInfo.barType == "custom_continuous"
@@ -121,6 +133,8 @@ function RB.CreateResourceBarLifecycleModule(deps)
 
                     local removedIDs = updateInfo.removedAuraInstanceIDs
                     local updatedIDs = updateInfo.updatedAuraInstanceIDs
+                    local removedIDSet = BuildAuraInstanceIDSet(removedIDs)
+                    local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
                     local hasAuraChange = updateInfo.isFullUpdate or updateInfo.addedAuras or removedIDs or updatedIDs
                     local targetSwitchDataReceived = false
 
@@ -132,24 +146,20 @@ function RB.CreateResourceBarLifecycleModule(deps)
                             if IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
                                 and bar
                                 and (bar._auraUnit == unit or configUnit == unit) then
-                                if removedIDs and bar._auraInstanceID and bar._auraUnit == unit then
-                                    for _, instId in ipairs(removedIDs) do
-                                        if bar._auraInstanceID == instId then
-                                            ClearCustomBarAuraRuntime(bar, configUnit)
-                                            bar._auraEventRemoved = true
-                                            break
-                                        end
-                                    end
+                                if removedIDSet
+                                    and bar._auraInstanceID
+                                    and bar._auraUnit == unit
+                                    and removedIDSet[bar._auraInstanceID] then
+                                    ClearCustomBarAuraRuntime(bar, configUnit)
+                                    bar._auraEventRemoved = true
                                 end
-                                if updatedIDs and bar._auraInstanceID and bar._auraUnit == unit then
-                                    for _, instId in ipairs(updatedIDs) do
-                                        if bar._auraInstanceID == instId then
-                                            bar._inPandemic = false
-                                            bar._pandemicGraceStart = nil
-                                            bar._pandemicGraceSuppressed = true
-                                            break
-                                        end
-                                    end
+                                if updatedIDSet
+                                    and bar._auraInstanceID
+                                    and bar._auraUnit == unit
+                                    and updatedIDSet[bar._auraInstanceID] then
+                                    bar._inPandemic = false
+                                    bar._pandemicGraceStart = nil
+                                    bar._pandemicGraceSuppressed = true
                                 end
                                 if unit == "target" and bar._targetSwitchAt then
                                     bar._targetSwitchDataReceived = true


### PR DESCRIPTION
## What Changed
- Aura buttons and custom aura resource bars now convert `UNIT_AURA` removed/updated aura instance ID lists into event-local lookup tables before checking tracked entries.
- Replaced repeated per-entry linear scans with direct membership checks while preserving existing removed/updated event flow and removal-before-update behavior.

## Why This Changed
- The old path scanned the same removed/updated aura ID list once per tracked button or bar. That was correct, but it scaled poorly as tracked entries or event payloads grew.

## Developer Impact
- Keeps the combat aura event path bounded to the changed aura IDs plus tracked entries, instead of tracked entries multiplied by changed aura IDs.
- Avoids a long-lived aura cache, so the optimization stays local to the event payload and does not introduce stale aura-instance state.
- Makes the runtime intent easier to audit: build the event membership set once, then ask whether each tracked aura instance is present.

## Validation
- `lua tests\aura-instance-membership.lua`
- `luac -p Core\Aura.lua`
- `luac -p OtherBars\ResourceBarLifecycle.lua`
- `git diff --check origin/main...HEAD`
- Manual in-game validation was reported good by the user; no additional local proof is available for combat/restricted-content beyond that report.