### PR TITLE
Show Tiger's Fury snapshot icons for Feral aura entries

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1685,6 +1685,8 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
     button._activeAuraSpellIDFromFallback = nil
+    button._activeAuraIcon = nil
+    button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
 
     button._auraInstanceID = nil
@@ -1840,6 +1842,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
     button._activeAuraSpellIDFromFallback = nil
+    button._activeAuraIcon = nil
+    button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
 
     button._auraInstanceID = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -459,6 +459,41 @@ local function CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverri
     end
 end
 
+local function ActiveAuraIconNeedsRefresh(button, auraState, previousIcon, previousIconAvailable, previousAuraInstanceID)
+    local currentIconAvailable = button._activeAuraIconAvailable == true
+    if currentIconAvailable ~= (previousIconAvailable == true) then
+        return true
+    end
+
+    local currentAuraInstanceID = button._auraInstanceID
+    if not (issecretvalue(currentAuraInstanceID) or issecretvalue(previousAuraInstanceID))
+        and currentAuraInstanceID ~= previousAuraInstanceID then
+        return true
+    end
+
+    if currentIconAvailable then
+        local currentIcon = button._activeAuraIcon
+        if auraState and auraState.activeAuraIconResolved == true and issecretvalue(currentIcon) then
+            return true
+        end
+        if previousIconAvailable == true
+            and not (issecretvalue(currentIcon) or issecretvalue(previousIcon))
+            and currentIcon ~= previousIcon then
+            return true
+        end
+    end
+
+    return false
+end
+ST._ActiveAuraIconNeedsRefresh = ActiveAuraIconNeedsRefresh
+
+local function ShouldUseActiveAuraIcon(buttonData)
+    return buttonData
+        and (buttonData.auraShowAuraIcon == true
+            or buttonData.addedAs == "aura"
+            or buttonData.isPassive == true)
+end
+
 local function DispatchStandaloneTextureVisual(button)
     if not button then
         return
@@ -846,6 +881,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local auraDisplayNameState
     local previousActiveAuraSpellID = button._activeAuraSpellID
     local previousActiveAuraSpellIDFromFallback = button._activeAuraSpellIDFromFallback == true
+    local previousActiveAuraIcon = button._activeAuraIcon
+    local previousActiveAuraIconAvailable = button._activeAuraIconAvailable == true
+    local previousAuraInstanceID = button._auraInstanceID
     local auraApplications
     local auraGraceHeld = false
     local barAuraSecretStackValue
@@ -932,13 +970,23 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
 
         -- Aura icon swap: trigger icon update on _auraActive transition
-        if buttonData.auraShowAuraIcon and button._auraSpellID then
+        if ShouldUseActiveAuraIcon(buttonData) and button._auraSpellID then
             local shouldShow = auraOverrideActive
             button._auraViewerFrame = shouldShow and viewerFrame or nil
             local activeAuraSpellChanged = shouldShow
                 and (button._activeAuraSpellID ~= previousActiveAuraSpellID
                     or (button._activeAuraSpellIDFromFallback == true) ~= previousActiveAuraSpellIDFromFallback)
-            if shouldShow ~= (button._showingAuraIcon or false) or activeAuraSpellChanged then
+            local activeAuraIconChanged = shouldShow
+                and ActiveAuraIconNeedsRefresh(
+                    button,
+                    auraState,
+                    previousActiveAuraIcon,
+                    previousActiveAuraIconAvailable,
+                    previousAuraInstanceID
+                )
+            if shouldShow ~= (button._showingAuraIcon or false)
+                or activeAuraSpellChanged
+                or activeAuraIconChanged then
                 button._showingAuraIcon = shouldShow
                 CooldownCompanion:UpdateButtonIcon(button)
             elseif shouldShow and viewerFrame then

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -15,6 +15,7 @@ local ipairs = ipairs
 local unpack = unpack
 local InCombatLockdown = InCombatLockdown
 local GetTime = GetTime
+local issecretvalue = issecretvalue
 
 -- Imports from Helpers
 local ApplyStrataOrder = ST._ApplyStrataOrder
@@ -80,6 +81,27 @@ local BLIZZARD_AURA_SWIPE_B = 0.57
 local BLIZZARD_AURA_SWIPE_A = 0.7
 local BLIZZARD_AURA_SWIPE_TEX_LOW = {x = 0.15, y = 0.15}
 local BLIZZARD_AURA_SWIPE_TEX_HIGH = {x = 0.85, y = 0.85}
+local QUESTION_MARK_ICON = "Interface\\Icons\\INV_Misc_QuestionMark"
+
+local function SelectTextureValue(value, knownAvailable)
+    if knownAvailable == true then
+        return value, true
+    end
+    if issecretvalue(value) then
+        return value, true
+    end
+    if value ~= nil then
+        return value, true
+    end
+    return nil, false
+end
+
+local function ShouldUseActiveAuraIcon(buttonData)
+    return buttonData
+        and (buttonData.auraShowAuraIcon == true
+            or buttonData.addedAs == "aura"
+            or buttonData.isPassive == true)
+end
 
 local function ApplyAuraBlizzardCooldownLayer(button)
     if button and button.auraBlizzardCooldown and button.cooldown then
@@ -704,6 +726,8 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
     button._activeAuraSpellIDFromFallback = nil
+    button._activeAuraIcon = nil
+    button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
     button._spellTexBaseline = nil
@@ -811,9 +835,18 @@ end
 function CooldownCompanion:UpdateButtonIcon(button)
     local buttonData = button.buttonData
     local icon
+    local hasIcon = false
     local displayId = buttonData.id
     local overrideId = nil
     local forceBaseDisplay = button._forceBaseDisplaySpellId == true
+    local function UseIcon(value, knownAvailable)
+        local selectedIcon, selectedAvailable = SelectTextureValue(value, knownAvailable)
+        if selectedAvailable then
+            icon = selectedIcon
+            hasIcon = true
+        end
+        return selectedAvailable
+    end
 
     if buttonData.type == "spell" then
         overrideId = C_Spell.GetOverrideSpell(buttonData.id)
@@ -868,12 +901,12 @@ function CooldownCompanion:UpdateButtonIcon(button)
                 if iconTexture and iconTexture.GetTextureFileID then
                     -- GetTextureFileID may return a secret value in combat;
                     -- pass it straight through — do not test or branch on it.
-                    icon = iconTexture:GetTextureFileID()
+                    UseIcon(iconTexture:GetTextureFileID())
                 else
                     -- No icon widget found — use spell API fallback.
                     -- Always use buttonData.id: GetSpellTexture dynamically
                     -- resolves the current visual (including talent transforms).
-                    icon = C_Spell.GetSpellTexture(buttonData.id)
+                    UseIcon(C_Spell.GetSpellTexture(buttonData.id))
                 end
             else
                 -- For non-cdmChildSlot buttons, read the viewer frame's Icon
@@ -888,8 +921,7 @@ function CooldownCompanion:UpdateButtonIcon(button)
                         iconTexture = iconTexture.Icon
                     end
                     if iconTexture and iconTexture.GetTextureFileID then
-                        icon = iconTexture:GetTextureFileID()
-                        hasViewerIcon = true
+                        hasViewerIcon = UseIcon(iconTexture:GetTextureFileID())
                     end
                 end
                 if hasViewerIcon then
@@ -901,15 +933,16 @@ function CooldownCompanion:UpdateButtonIcon(button)
                     -- in the same tick all detect the transform consistently.
                     if not issecretvalue(icon) then
                         local spellIcon = C_Spell.GetSpellTexture(buttonData.id)
-                        if spellIcon and spellIcon ~= button._spellTexBaseline then
-                            icon = spellIcon
+                        if spellIcon ~= nil and spellIcon ~= button._spellTexBaseline then
+                            UseIcon(spellIcon)
                         end
                     end
                 else
-                    icon = C_Spell.GetSpellTexture(buttonData.id)
+                    local spellIcon = C_Spell.GetSpellTexture(buttonData.id)
+                    UseIcon(spellIcon)
                     -- Update baseline only when no viewer is active — keeps
                     -- it frozen during viewer presence to prevent oscillation.
-                    button._spellTexBaseline = icon
+                    button._spellTexBaseline = spellIcon
                 end
             end
         end
@@ -918,15 +951,15 @@ function CooldownCompanion:UpdateButtonIcon(button)
         if overrideId then
             displayId = overrideId
         end
-        if not icon then
+        if not hasIcon then
             -- Always use buttonData.id: GetSpellTexture dynamically
             -- resolves the current visual (including talent transforms).
-            icon = C_Spell.GetSpellTexture(buttonData.id)
+            UseIcon(C_Spell.GetSpellTexture(buttonData.id))
         end
     elseif IsEntryItemLike(buttonData) then
         local itemID = button._resolvedItemId or buttonData.id
         if itemID then
-            icon = C_Item.GetItemIconByID(itemID)
+            UseIcon(C_Item.GetItemIconByID(itemID))
         end
     end
 
@@ -934,41 +967,45 @@ function CooldownCompanion:UpdateButtonIcon(button)
     local manualIcon = buttonData.manualIcon
     if type(manualIcon) == "number" or type(manualIcon) == "string" then
         icon = manualIcon
+        hasIcon = true
     end
 
     -- Aura icon swap: show the tracked aura spell's icon while aura is active
-    local auraIconSpellID = button._activeAuraSpellID or button._auraSpellID
-    if buttonData.type == "spell" and button._auraActive
-       and buttonData.auraShowAuraIcon and auraIconSpellID then
-        -- Read the viewer frame's Icon texture (updates per-stage for multi-stage
-        -- auras like Hot Streak). GetTextureFileID may return a secret value in
-        -- combat; pass it straight through — do not test or branch on it.
-        local vf = button._activeAuraSpellIDFromFallback and nil or button._auraViewerFrame
-        local hasViewerIcon
-        if vf then
-            local iconTexture = vf.Icon
-            if iconTexture and not iconTexture.GetTextureFileID then
-                iconTexture = iconTexture.Icon
+    if buttonData.type == "spell" and button._auraActive and ShouldUseActiveAuraIcon(buttonData) then
+        if button._activeAuraIconAvailable == true then
+            UseIcon(button._activeAuraIcon, true)
+        else
+            local auraIconSpellID = button._activeAuraSpellID or button._auraSpellID
+            if auraIconSpellID then
+                -- Read the viewer frame's Icon texture (updates per-stage for multi-stage
+                -- auras like Hot Streak). GetTextureFileID may return a secret value in
+                -- combat; pass it straight through — do not test or branch on it.
+                local vf = button._activeAuraSpellIDFromFallback and nil or button._auraViewerFrame
+                local hasViewerIcon
+                if vf then
+                    local iconTexture = vf.Icon
+                    if iconTexture and not iconTexture.GetTextureFileID then
+                        iconTexture = iconTexture.Icon
+                    end
+                    if iconTexture and iconTexture.GetTextureFileID then
+                        hasViewerIcon = UseIcon(iconTexture:GetTextureFileID())
+                    end
+                end
+                if not hasViewerIcon then
+                    -- Fallback: static spell texture (viewer hidden or unavailable)
+                    UseIcon(C_Spell.GetSpellTexture(auraIconSpellID))
+                end
             end
-            if iconTexture and iconTexture.GetTextureFileID then
-                icon = iconTexture:GetTextureFileID()
-                hasViewerIcon = true
-            end
-        end
-        if not hasViewerIcon then
-            -- Fallback: static spell texture (viewer hidden or unavailable)
-            local auraIcon = C_Spell.GetSpellTexture(auraIconSpellID)
-            if auraIcon then icon = auraIcon end
         end
     end
 
     local prevDisplayId = button._displaySpellId
     button._displaySpellId = displayId
 
-    if icon then
+    if hasIcon then
         button.icon:SetTexture(icon)
     else
-        button.icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")
+        button.icon:SetTexture(QUESTION_MARK_ICON)
     end
 
     -- Update cooldown secrecy when override spell changes (e.g. Command Demon → pet ability)
@@ -1269,6 +1306,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
     button._activeAuraSpellIDFromFallback = nil
+    button._activeAuraIcon = nil
+    button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
     button._spellTexBaseline = nil

--- a/ButtonFrame/TextMode.lua
+++ b/ButtonFrame/TextMode.lua
@@ -1046,6 +1046,8 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._auraViewerFrame = nil
     button._activeAuraSpellID = nil
     button._activeAuraSpellIDFromFallback = nil
+    button._activeAuraIcon = nil
+    button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._auraInstanceID = nil
     button._viewerBar = nil

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -459,6 +459,9 @@ local function CommitTrackedAuraOwnerState(owner, state)
                 owner._activeAuraIcon = nil
                 owner._activeAuraIconAvailable = nil
             end
+        elseif state.auraGraceHeld ~= true then
+            owner._activeAuraIcon = nil
+            owner._activeAuraIconAvailable = nil
         end
         if owner._targetSwitchAt
             and state.auraGraceHeld ~= true

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -317,6 +317,19 @@ local function GetReadableAuraSpellID(auraData)
     return nil
 end
 
+local function ResolveAuraIconState(auraData)
+    if not auraData then
+        return nil, false, false
+    end
+
+    local icon = auraData.icon
+    if issecretvalue(icon) then
+        return icon, true, true
+    end
+
+    return icon, icon ~= nil, true
+end
+
 local function AuraDataMatchesTrackedSpell(owner, buttonData, auraSpellID, auraData)
     local auraDataSpellID = auraData and auraData.spellId
     if not auraDataSpellID or issecretvalue(auraDataSpellID) then
@@ -354,6 +367,8 @@ function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
     owner._auraUnit = configUnit
     owner._activeAuraSpellID = nil
     owner._activeAuraSpellIDFromFallback = nil
+    owner._activeAuraIcon = nil
+    owner._activeAuraIconAvailable = nil
     owner._auraEventRemoved = nil
     owner._auraGraceStart = nil
     if not options.preserveTargetSwitch then
@@ -436,6 +451,15 @@ local function CommitTrackedAuraOwnerState(owner, state)
             owner._activeAuraSpellID = state.activeAuraSpellID or owner._activeAuraSpellID
             owner._activeAuraSpellIDFromFallback = state.activeAuraSpellIDFromFallback or nil
         end
+        if state.activeAuraIconResolved then
+            if state.activeAuraIconAvailable then
+                owner._activeAuraIcon = state.activeAuraIcon
+                owner._activeAuraIconAvailable = true
+            else
+                owner._activeAuraIcon = nil
+                owner._activeAuraIconAvailable = nil
+            end
+        end
         if owner._targetSwitchAt
             and state.auraGraceHeld ~= true
             and (state.durationObj or state.auraCooldownDuration or state.allowDurationlessAuraInstance) then
@@ -495,6 +519,9 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     local activeAuraSpellID
     local activeAuraSpellIDResolved = false
     local activeAuraSpellIDFromFallback
+    local activeAuraIcon
+    local activeAuraIconAvailable = false
+    local activeAuraIconResolved = false
     local auraCooldownStart
     local auraCooldownDuration
     local viewerBar
@@ -510,6 +537,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                     auraApplications = auraData.applications
                     activeAuraSpellID = GetReadableAuraSpellID(auraData)
                     activeAuraSpellIDResolved = true
+                    activeAuraIcon, activeAuraIconAvailable, activeAuraIconResolved = ResolveAuraIconState(auraData)
                     auraInstanceID = viewerInstId
                     auraUnit = unit
                     auraPresent = true
@@ -564,6 +592,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                 auraApplications = auraData.applications
                 activeAuraSpellID = activeAuraSpellID or GetReadableAuraSpellID(auraData)
                 activeAuraSpellIDResolved = true
+                activeAuraIcon, activeAuraIconAvailable, activeAuraIconResolved = ResolveAuraIconState(auraData)
                 auraInstanceID = instId
                 auraUnit = "player"
                 auraPresent = true
@@ -585,6 +614,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
                     activeAuraSpellID = GetReadableAuraSpellID(auraData)
                     activeAuraSpellIDResolved = true
                     activeAuraSpellIDFromFallback = activeAuraSpellID and true or nil
+                    activeAuraIcon, activeAuraIconAvailable, activeAuraIconResolved = ResolveAuraIconState(auraData)
                     auraInstanceID = owner._auraInstanceID
                     auraUnit = cachedUnit
                     auraPresent = true
@@ -681,6 +711,9 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         activeAuraSpellID = activeAuraSpellID,
         activeAuraSpellIDResolved = activeAuraSpellIDResolved == true,
         activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
+        activeAuraIcon = activeAuraIcon,
+        activeAuraIconAvailable = activeAuraIconAvailable == true,
+        activeAuraIconResolved = activeAuraIconResolved == true,
         allowDurationlessAuraInstance = allowDurationlessAuraInstance,
         wasAuraActive = wasAuraActive,
     }


### PR DESCRIPTION
## What Players Will Notice
- Feral Druid aura entries for Rake, Rip, and Moonfire can show the live active aura icon from Blizzard aura data, making Tiger's Fury-snapshotted debuffs easier to distinguish after Tiger's Fury falls off.
- Aura icons no longer remain stuck on a previous active aura texture when the next active aura state cannot resolve an icon.

## Why This Changed
- Blizzard's viewer/static spell icons can reflect current Tiger's Fury state instead of the debuff's snapshotted state, so CDC could show an unbuffed-looking icon even while the active debuff was still snapshotted.
- A review follow-up found that unresolved active aura icon states could keep stale cached icon data instead of falling back cleanly.

## What Changed
- EntryRuntime now records the active aura's auraData.icon alongside the active aura spell ID when aura data is available, and clears the cached icon when a non-grace active state cannot resolve one.
- Icon and cooldown update paths now refresh buttons when the active aura icon or aura instance changes, and allow aura/passive entries to use that active aura icon without requiring the Show Aura Icon toggle.
- Bar, text, and icon frame setup clears the new active aura icon cache fields during rebuilds.

## Validation
- lua tests\feral-snapshot-aura-icons.lua
- lua tests\aura-instance-membership.lua
- lua tests\rune-cost-no-cooldown.lua
- luac -p Core\EntryRuntime.lua ButtonFrame\IconMode.lua ButtonFrame\CooldownUpdate.lua ButtonFrame\BarMode.lua ButtonFrame\TextMode.lua
- git diff --check origin/main...HEAD
- In-game combat/restricted-content verification is still needed; local/static checks do not prove restricted-state behavior.
