### PR TITLE
Add segmented smoothing opt-outs for resource bars

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -66,6 +66,7 @@ local SetStatusBarImmediateRange = ST.SetStatusBarImmediateRange
 local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
 local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 local SetStatusBarElapsedDuration = ST.SetStatusBarElapsedDuration
 local SetStatusBarRemainingDuration = ST.SetStatusBarRemainingDuration
 
@@ -498,25 +499,26 @@ local function GetBarAuraStackWidgetValue(value, valueAvailable)
     return 0
 end
 
-local function ApplyBarAuraStackSegmentValues(segments, color, value, valueAvailable)
+local function ApplyBarAuraStackSegmentValues(segments, color, value, valueAvailable, segmentedSmoothing)
     if not segments then return end
     local widgetValue = GetBarAuraStackWidgetValue(value, valueAvailable)
     for _, segment in ipairs(segments) do
         segment:SetStatusBarColor(color[1], color[2], color[3], color[4] or 1)
-        SetStatusBarSmoothValue(segment, widgetValue)
+        SetStatusBarSegmentedValue(segment, widgetValue, segmentedSmoothing)
     end
 end
 
-local function ApplyBarAuraStackSegmentOnlyValues(segments, value, valueAvailable)
+local function ApplyBarAuraStackSegmentOnlyValues(segments, value, valueAvailable, segmentedSmoothing)
     if not segments then return end
     local widgetValue = GetBarAuraStackWidgetValue(value, valueAvailable)
     for _, segment in ipairs(segments) do
-        SetStatusBarSmoothValue(segment, widgetValue)
+        SetStatusBarSegmentedValue(segment, widgetValue, segmentedSmoothing)
     end
 end
 
 local function ApplyBarAuraStackValuesOnly(button, mode, stackValue, valueAvailable)
     local widgetValue = GetBarAuraStackWidgetValue(stackValue, valueAvailable)
+    local segmentedSmoothing = mode ~= "continuous" and CooldownCompanion:GetBarPanelAuraSegmentedSmoothing(button.buttonData) or nil
     if mode == "continuous" then
         SetStatusBarSmoothValue(button.statusBar, widgetValue)
         if button.statusBar.thresholdOverlay and button.statusBar.thresholdOverlay:IsShown() then
@@ -525,18 +527,22 @@ local function ApplyBarAuraStackValuesOnly(button, mode, stackValue, valueAvaila
     else
         local holder = mode == "overlay" and button._barAuraStackOverlay or button._barAuraStackSegments
         if not holder then return end
-        ApplyBarAuraStackSegmentOnlyValues(holder.segments, stackValue, valueAvailable)
+        ApplyBarAuraStackSegmentOnlyValues(holder.segments, stackValue, valueAvailable, segmentedSmoothing)
         if mode == "overlay" then
-            ApplyBarAuraStackSegmentOnlyValues(holder.overlaySegments, stackValue, valueAvailable)
+            ApplyBarAuraStackSegmentOnlyValues(holder.overlaySegments, stackValue, valueAvailable, segmentedSmoothing)
         end
         if holder.thresholdSegments then
-            ApplyBarAuraStackSegmentOnlyValues(holder.thresholdSegments, stackValue, valueAvailable)
+            ApplyBarAuraStackSegmentOnlyValues(holder.thresholdSegments, stackValue, valueAvailable, segmentedSmoothing)
         end
     end
 
     local info = mode == "continuous" and button._barAuraStackContinuousInfo or button._barAuraStackIndicatorInfo
     if info and info._maxStacksIndicator then
-        SetStatusBarSmoothValue(info._maxStacksIndicator, widgetValue)
+        if mode == "continuous" then
+            SetStatusBarSmoothValue(info._maxStacksIndicator, widgetValue)
+        else
+            SetStatusBarSegmentedValue(info._maxStacksIndicator, widgetValue, segmentedSmoothing)
+        end
     end
 end
 
@@ -595,6 +601,7 @@ local function GetBarAuraStackVisualDirtyState(button, mode, maxStacks, stackVal
     local auraBar = button.buttonData and button.buttonData.auraBar or nil
     local stackBarColor, overlayColor, thresholdColor = GetBarAuraStackColors(button)
     local showThreshold = auraBar and auraBar.thresholdColorEnabled == true
+    local segmentedSmoothing = mode ~= "continuous" and CooldownCompanion:GetBarPanelAuraSegmentedSmoothing(button.buttonData) or nil
     local state = button._barAuraStackAppliedState
     local layoutDirty = state == nil
     if not state then
@@ -617,6 +624,7 @@ local function GetBarAuraStackVisualDirtyState(button, mode, maxStacks, stackVal
         or state.borderSize ~= (style.borderSize or ST.DEFAULT_BORDER_SIZE or 1)
         or state.borderRenderMode ~= ST.GetBorderRenderMode(style)
         or state.showThreshold ~= showThreshold
+        or state.segmentedSmoothing ~= segmentedSmoothing
         or state.maxStacksGlowEnabled ~= (auraBar and auraBar.maxStacksGlowEnabled == true)
         or state.maxStacksGlowStyle ~= (auraBar and auraBar.maxStacksGlowStyle or nil)
         or state.maxStacksGlowSize ~= (auraBar and auraBar.maxStacksGlowSize or nil)
@@ -654,6 +662,7 @@ local function GetBarAuraStackVisualDirtyState(button, mode, maxStacks, stackVal
         state.borderSize = style.borderSize or ST.DEFAULT_BORDER_SIZE or 1
         state.borderRenderMode = ST.GetBorderRenderMode(style)
         state.showThreshold = showThreshold
+        state.segmentedSmoothing = segmentedSmoothing
         state.maxStacksGlowEnabled = auraBar and auraBar.maxStacksGlowEnabled == true
         state.maxStacksGlowStyle = auraBar and auraBar.maxStacksGlowStyle or nil
         state.maxStacksGlowSize = auraBar and auraBar.maxStacksGlowSize or nil
@@ -694,6 +703,7 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
     button.statusBar._reverseFill = button.style and button.style.barReverseFill == true
 
     local settings = GetBarAuraVisualSettings(button)
+    local segmentedSmoothing = mode ~= "continuous" and CooldownCompanion:GetBarPanelAuraSegmentedSmoothing(button.buttonData) or nil
     local orientation = button._isVertical and "vertical" or "horizontal"
     local reverseFill = button.style and button.style.barReverseFill == true
     local gap = CooldownCompanion:GetBarPanelAuraSegmentGap(button.buttonData)
@@ -756,8 +766,8 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
                 RB.LayoutOverlaySegments(holder, width, height, gap, settings, halfSegments, orientation, reverseFill)
             end
         end
-        ApplyBarAuraStackSegmentValues(holder.segments, stackBarColor, stackValue, valueAvailable)
-        ApplyBarAuraStackSegmentValues(holder.overlaySegments, overlayColor, stackValue, valueAvailable)
+        ApplyBarAuraStackSegmentValues(holder.segments, stackBarColor, stackValue, valueAvailable, segmentedSmoothing)
+        ApplyBarAuraStackSegmentValues(holder.overlaySegments, overlayColor, stackValue, valueAvailable, segmentedSmoothing)
     else
         if layoutChanged then
             if showThreshold and RB.EnsureCustomAuraSegmentThresholdOverlays then
@@ -767,7 +777,7 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
                 RB.LayoutSegments(holder, width, height, gap, settings, orientation, reverseFill)
             end
         end
-        ApplyBarAuraStackSegmentValues(holder.segments, stackBarColor, stackValue, valueAvailable)
+        ApplyBarAuraStackSegmentValues(holder.segments, stackBarColor, stackValue, valueAvailable, segmentedSmoothing)
     end
 
     if holder.thresholdSegments then
@@ -777,7 +787,7 @@ local function LayoutBarAuraStackVisual(button, mode, maxStacks, stackValue, val
                     RB.SetCustomAuraMaxThresholdRange(segment, maxStacks)
                     segment:SetStatusBarColor(thresholdColor[1], thresholdColor[2], thresholdColor[3], thresholdColor[4] or 1)
                 end
-                SetStatusBarSmoothValue(segment, GetBarAuraStackWidgetValue(stackValue, valueAvailable))
+                SetStatusBarSegmentedValue(segment, GetBarAuraStackWidgetValue(stackValue, valueAvailable), segmentedSmoothing)
                 segment:Show()
             elseif layoutChanged then
                 SetStatusBarImmediateValue(segment, 0)
@@ -875,7 +885,13 @@ local function UpdateBarAuraStackIndicator(button, mode, maxStacks, stackValue, 
         info._barAuraStackIndicatorKey = indicatorKey
     end
     if info._maxStacksIndicator then
-        SetStatusBarSmoothValue(info._maxStacksIndicator, GetBarAuraStackWidgetValue(stackValue, stackValueAvailable))
+        local indicatorValue = GetBarAuraStackWidgetValue(stackValue, stackValueAvailable)
+        local segmentedSmoothing = mode ~= "continuous" and CooldownCompanion:GetBarPanelAuraSegmentedSmoothing(button.buttonData) or nil
+        if mode == "continuous" then
+            SetStatusBarSmoothValue(info._maxStacksIndicator, indicatorValue)
+        else
+            SetStatusBarSegmentedValue(info._maxStacksIndicator, indicatorValue, segmentedSmoothing)
+        end
     end
 end
 

--- a/ConfigSettings/ButtonSettings.lua
+++ b/ConfigSettings/ButtonSettings.lua
@@ -1252,6 +1252,26 @@ local function BuildBarPanelAuraDisplaySection(scroll, buttonData, infoButtons)
     scroll:AddChild(stackTextFormatDrop)
 
     if stackDisplayMode == "segmented" or stackDisplayMode == "overlay" then
+        local segmentedSmoothingDrop = AceGUI:Create("Dropdown")
+        segmentedSmoothingDrop:SetLabel("Segmented Smoothing")
+        segmentedSmoothingDrop:SetList({
+            [ST.SEGMENTED_SMOOTHING_ON] = "On",
+            [ST.SEGMENTED_SMOOTHING_OFF] = "Off",
+        }, { ST.SEGMENTED_SMOOTHING_ON, ST.SEGMENTED_SMOOTHING_OFF })
+        segmentedSmoothingDrop:SetValue(CooldownCompanion:GetBarPanelAuraSegmentedSmoothing(buttonData))
+        segmentedSmoothingDrop:SetFullWidth(true)
+        segmentedSmoothingDrop:SetCallback("OnValueChanged", function(_, _, value)
+            CooldownCompanion:SetBarPanelAuraSegmentedSmoothing(buttonData, value)
+            RefreshSelectedBarPanelAuraDisplay({ updateCooldowns = true })
+        end)
+        scroll:AddChild(segmentedSmoothingDrop)
+        CreateInfoButton(segmentedSmoothingDrop.frame, segmentedSmoothingDrop.label, "LEFT", "RIGHT", 4, 0, {
+            "Segmented Smoothing",
+            {"Controls whether this entry's segmented or overlay Stack Count bar smooths changes or snaps immediately.", 1, 1, 1, true},
+            " ",
+            {"Continuous Stack Count bars are not affected.", 1, 1, 1, true},
+        }, segmentedSmoothingDrop)
+
         local segmentGapSlider = AceGUI:Create("Slider")
         segmentGapSlider:SetLabel("Segment Gap")
         segmentGapSlider:SetSliderValues(0, 20, 0.1)

--- a/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/ConfigSettings/ResourceBarPanelsResource.lua
@@ -2075,7 +2075,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
     container:AddChild(segmentedSmoothingDrop)
     CreateInfoButton(segmentedSmoothingDrop.frame, segmentedSmoothingDrop.label, "LEFT", "RIGHT", 4, 0, {
         "Segmented Smoothing",
-        {"Controls whether segmented resource bars and segmented or overlay resource custom bars animate smoothly or snap between segment values.", 1, 1, 1, true},
+        {"Controls whether segmented resource bars and segmented or overlay custom bars animate smoothly or snap between segment values.", 1, 1, 1, true},
         " ",
         {"Continuous resources and continuous custom bars are not affected.", 1, 1, 1, true},
     }, segmentedSmoothingDrop)

--- a/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/ConfigSettings/ResourceBarPanelsResource.lua
@@ -2060,6 +2060,26 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
         container:AddChild(brightSlider)
     end
 
+    local segmentedSmoothingDrop = AceGUI:Create("Dropdown")
+    segmentedSmoothingDrop:SetLabel("Segmented Smoothing")
+    segmentedSmoothingDrop:SetList({
+        [ST.SEGMENTED_SMOOTHING_ON] = "On",
+        [ST.SEGMENTED_SMOOTHING_OFF] = "Off",
+    }, { ST.SEGMENTED_SMOOTHING_ON, ST.SEGMENTED_SMOOTHING_OFF })
+    segmentedSmoothingDrop:SetValue(ST.NormalizeSegmentedSmoothing(displayProfile.segmentedSmoothing))
+    segmentedSmoothingDrop:SetFullWidth(true)
+    segmentedSmoothingDrop:SetCallback("OnValueChanged", function(widget, event, val)
+        displayProfile.segmentedSmoothing = ST.NormalizeSegmentedSmoothing(val)
+        CooldownCompanion:ApplyResourceBars()
+    end)
+    container:AddChild(segmentedSmoothingDrop)
+    CreateInfoButton(segmentedSmoothingDrop.frame, segmentedSmoothingDrop.label, "LEFT", "RIGHT", 4, 0, {
+        "Segmented Smoothing",
+        {"Controls whether segmented resource bars and segmented or overlay resource custom bars animate smoothly or snap between segment values.", 1, 1, 1, true},
+        " ",
+        {"Continuous resources and continuous custom bars are not affected.", 1, 1, 1, true},
+    }, segmentedSmoothingDrop)
+
     -- Resource Background Color
     AddColorPicker(container, displayProfile, "backgroundColor", "Resource Background Color", { 0, 0, 0, 0.5 }, true, applyBars)
 

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -1081,6 +1081,18 @@ function CooldownCompanion:SetBarPanelAuraStackTextFormat(buttonData, format)
     EnsureBarPanelAuraSettings(buttonData).stackTextFormat = NormalizeBarPanelAuraStackTextFormat(format)
 end
 
+function CooldownCompanion:GetBarPanelAuraSegmentedSmoothing(buttonData)
+    local auraBar = buttonData and buttonData.auraBar
+    return ST.NormalizeSegmentedSmoothing(type(auraBar) == "table" and auraBar.segmentedSmoothing or nil)
+end
+
+function CooldownCompanion:SetBarPanelAuraSegmentedSmoothing(buttonData, value)
+    if not self:IsBarPanelAuraDisplayEligible(buttonData) then
+        return
+    end
+    EnsureBarPanelAuraSettings(buttonData).segmentedSmoothing = ST.NormalizeSegmentedSmoothing(value)
+end
+
 function CooldownCompanion:IsAuraTrackingReady(buttonData, cdmEnabled, viewerFrame)
     if not (buttonData and buttonData.type == "spell") then
         return false

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -456,6 +456,7 @@ local defaults = {
             borderColor = { 0, 0, 0, 1 },
             borderSize = 1,
             borderRenderMode = "custom",
+            segmentedSmoothing = "on",
             segmentGap = 4,
             hideManaForNonHealer = true,
             resources = {

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -32,6 +32,8 @@ local statusBarTimerDirection = Enum and Enum.StatusBarTimerDirection
 ST.STATUS_BAR_INTERPOLATION_SMOOTH = statusBarInterpolation and statusBarInterpolation.ExponentialEaseOut
 ST.STATUS_BAR_TIMER_DIRECTION_ELAPSED = statusBarTimerDirection and statusBarTimerDirection.ElapsedTime or 0
 ST.STATUS_BAR_TIMER_DIRECTION_REMAINING = statusBarTimerDirection and statusBarTimerDirection.RemainingTime or 1
+ST.SEGMENTED_SMOOTHING_ON = "on"
+ST.SEGMENTED_SMOOTHING_OFF = "off"
 
 -- Shared edge anchor spec: {point1, relPoint1, point2, relPoint2, x1sign, y1sign, x2sign, y2sign}
 -- Signs: 0 = zero offset, 1 = +size, -1 = -size
@@ -104,6 +106,9 @@ function ST.SetStatusBarImmediateValue(statusBar, value)
 
     ST.ClearStatusBarMotion(statusBar)
     statusBar:SetValue(value)
+    if statusBar.SetToTargetValue then
+        statusBar:SetToTargetValue()
+    end
     return true
 end
 
@@ -133,6 +138,20 @@ function ST.SetStatusBarSmoothValue(statusBar, value)
         statusBar:SetValue(value)
     end
     return true
+end
+
+function ST.NormalizeSegmentedSmoothing(value)
+    if value == ST.SEGMENTED_SMOOTHING_OFF or value == false then
+        return ST.SEGMENTED_SMOOTHING_OFF
+    end
+    return ST.SEGMENTED_SMOOTHING_ON
+end
+
+function ST.SetStatusBarSegmentedValue(statusBar, value, segmentedSmoothing)
+    if ST.NormalizeSegmentedSmoothing(segmentedSmoothing) == ST.SEGMENTED_SMOOTHING_OFF then
+        return ST.SetStatusBarImmediateValue(statusBar, value)
+    end
+    return ST.SetStatusBarSmoothValue(statusBar, value)
 end
 
 function ST.SetStatusBarTimerDuration(statusBar, durationObj, direction)

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -21,6 +21,7 @@ local ClearStatusBarMotion = ST.ClearStatusBarMotion
 local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
 local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 
 local math_floor = math.floor
 local math_min = math.min
@@ -73,6 +74,7 @@ local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
 local GetSpecLayoutOrder = RB.GetSpecLayoutOrder
 local GetResourceDisplayValue = RB.GetResourceDisplayValue
+local GetResourceSegmentedSmoothing = RB.GetResourceSegmentedSmoothing
 local GetResourceDisplayConfig = RB.GetResourceDisplayConfig
 local GetAnchorOffset = RB.GetAnchorOffset
 local RoundToTenths = RB.RoundToTenths
@@ -1021,6 +1023,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
 
     local auraOverrideColor, auraApplications, auraHasApplications = GetResourceAuraState(powerType, settings, auraActiveCache)
     local auraMaxStacks = GetResourceAuraConfiguredMaxStacks(powerType, settings)
+    local segmentedSmoothing = GetResourceSegmentedSmoothing(settings)
     local useAuraStackMode = auraOverrideColor
         and auraMaxStacks
         and auraHasApplications
@@ -1071,7 +1074,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
             local segValue = 0
             if r.ready then
                 segValue = 1
-                SetStatusBarSmoothValue(seg, segValue)
+                SetStatusBarSegmentedValue(seg, segValue, segmentedSmoothing)
                 seg:SetStatusBarColor(activeReadyColor[1], activeReadyColor[2], activeReadyColor[3], 1)
                 fullSegments[i] = true
                 if showAllRechargeText then
@@ -1079,13 +1082,13 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 end
             elseif r.duration and r.duration > 0 then
                 segValue = math_min((now - r.start) / r.duration, 1)
-                SetStatusBarSmoothValue(seg, segValue)
+                SetStatusBarSegmentedValue(seg, segValue, segmentedSmoothing)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
                 if showAllRechargeText or (ShouldShowRechargeTextForTimer(holder) and r.activelyRecharging) then
                     SetRechargeText(holder, i, r.remaining)
                 end
             else
-                SetStatusBarSmoothValue(seg, segValue)
+                SetStatusBarSegmentedValue(seg, segValue, segmentedSmoothing)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
                 if showAllRechargeText then
                     SetRechargeText(holder, i, 0, true)
@@ -1128,14 +1131,14 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                 for i = 1, math_min(#holder.segments, max) do
                     local seg = holder.segments[i]
                     if i <= filled then
-                        SetStatusBarSmoothValue(seg, 1)
+                        SetStatusBarSegmentedValue(seg, 1, segmentedSmoothing)
                         seg:SetStatusBarColor(activeReadyColor[1], activeReadyColor[2], activeReadyColor[3], 1)
                         fullSegments[i] = true
                     elseif i == filled + 1 and partial > 0 then
-                        SetStatusBarSmoothValue(seg, partial)
+                        SetStatusBarSegmentedValue(seg, partial, segmentedSmoothing)
                         seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
                     else
-                        SetStatusBarSmoothValue(seg, 0)
+                        SetStatusBarSegmentedValue(seg, 0, segmentedSmoothing)
                         seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
                     end
                 end
@@ -1179,14 +1182,14 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         for i = 1, math_min(#holder.segments, max) do
             local seg = holder.segments[i]
             if i <= filled then
-                SetStatusBarSmoothValue(seg, 1)
+                SetStatusBarSegmentedValue(seg, 1, segmentedSmoothing)
                 seg:SetStatusBarColor(activeReadyColor[1], activeReadyColor[2], activeReadyColor[3], 1)
                 fullSegments[i] = true
             elseif i == filled + 1 and partial > 0 then
-                SetStatusBarSmoothValue(seg, partial)
+                SetStatusBarSegmentedValue(seg, partial, segmentedSmoothing)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             else
-                SetStatusBarSmoothValue(seg, 0)
+                SetStatusBarSegmentedValue(seg, 0, segmentedSmoothing)
                 seg:SetStatusBarColor(rechargingColor[1], rechargingColor[2], rechargingColor[3], 1)
             end
         end
@@ -1224,7 +1227,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
         for i = 1, math_min(#holder.segments, max) do
             local seg = holder.segments[i]
             if i <= current then
-                SetStatusBarSmoothValue(seg, 1)
+                SetStatusBarSegmentedValue(seg, 1, segmentedSmoothing)
                 fullSegments[i] = true
                 if chargedPoints and tContains(chargedPoints, i) then
                     seg:SetStatusBarColor(chargedColor[1], chargedColor[2], chargedColor[3], 1)
@@ -1232,7 +1235,7 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
                     seg:SetStatusBarColor(baseColor[1], baseColor[2], baseColor[3], 1)
                 end
             else
-                SetStatusBarSmoothValue(seg, 0)
+                SetStatusBarSegmentedValue(seg, 0, segmentedSmoothing)
             end
         end
         segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
@@ -1266,11 +1269,11 @@ local function UpdateSegmentedBar(holder, powerType, settings, auraActiveCache)
     for i = 1, math_min(#holder.segments, max) do
         local seg = holder.segments[i]
         if i <= current then
-            SetStatusBarSmoothValue(seg, 1)
+            SetStatusBarSegmentedValue(seg, 1, segmentedSmoothing)
             seg:SetStatusBarColor(activeColor[1], activeColor[2], activeColor[3], 1)
             fullSegments[i] = true
         else
-            SetStatusBarSmoothValue(seg, 0)
+            SetStatusBarSegmentedValue(seg, 0, segmentedSmoothing)
         end
     end
     segmentedUpdateScratch.Finalize(holder, settings, auraOverrideColor, useAuraStackMode, auraApplications, auraMaxStacks, fullSegments, current, max, false)
@@ -1285,6 +1288,7 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
     if not settings then
         settings = GetResourceBarSettings()
     end
+    local segmentedSmoothing = GetResourceSegmentedSmoothing(settings)
 
     -- Read stacks from viewer frame (applications is plain for MW)
     local stacks = 0
@@ -1318,8 +1322,8 @@ local function UpdateMaelstromWeaponBar(holder, settings, auraActiveCache)
         local baseSeg = holder.segments[i]
         local overlaySeg = holder.overlaySegments[i]
 
-        SetStatusBarSmoothValue(baseSeg, stacks)
-        SetStatusBarSmoothValue(overlaySeg, stacks)
+        SetStatusBarSegmentedValue(baseSeg, stacks, segmentedSmoothing)
+        SetStatusBarSegmentedValue(overlaySeg, stacks, segmentedSmoothing)
         -- Hide right-half overlay segments when value is at/below their segment minimum.
         -- This prevents tiny leading-edge ticks on empty overlay segments.
         if stacks > (half + i - 1) then

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -32,6 +32,7 @@ end
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
 local GetResourceDisplayValue = RB.GetResourceDisplayValue
+local GetResourceSegmentedSmoothing = RB.GetResourceSegmentedSmoothing
 local NormalizeCustomAuraStackTextFormat = RB.NormalizeCustomAuraStackTextFormat
 local IsCustomAuraMaxThresholdEnabled = RB.IsCustomAuraMaxThresholdEnabled
 local GetCustomAuraMaxThresholdColor = RB.GetCustomAuraMaxThresholdColor
@@ -58,6 +59,7 @@ local SetAuraStackCountText = EntryRuntime.SetAuraStackCountText
 local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
 local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 local SetStatusBarElapsedDuration = ST.SetStatusBarElapsedDuration
 local SetStatusBarRemainingDuration = ST.SetStatusBarRemainingDuration
 
@@ -160,6 +162,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     local function UpdateCustomAuraBar(barInfo)
         local cabConfig = barInfo.cabConfig
         if not cabConfig or not cabConfig.spellID then return end
+        local segmentedSmoothing = GetResourceSegmentedSmoothing(CooldownCompanion:GetResourceBarSettings())
 
         -- Read aura data from viewer frame (applications may be secret in combat)
         local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
@@ -391,7 +394,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             -- Each segment has MinMax(i-1, i) — SetValue(stacks) with C-level clamping
             -- handles fill/empty without comparing the secret stacks value in Lua
             for i = 1, #holder.segments do
-                SetStatusBarSmoothValue(holder.segments[i], stacks)
+                SetStatusBarSegmentedValue(holder.segments[i], stacks, segmentedSmoothing)
             end
 
             if holder.thresholdSegments then
@@ -399,7 +402,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     local thresholdSeg = holder.thresholdSegments[i]
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(thresholdSeg, maxStacks)
-                        SetStatusBarSmoothValue(thresholdSeg, stacks)
+                        SetStatusBarSegmentedValue(thresholdSeg, stacks, segmentedSmoothing)
                         thresholdSeg:Show()
                     else
                         SetStatusBarImmediateValue(thresholdSeg, 0)
@@ -415,8 +418,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
             -- Pass stacks to ALL segments (StatusBar C-level clamping handles per-segment fill)
             for i = 1, half do
-                SetStatusBarSmoothValue(holder.segments[i], stacks)
-                SetStatusBarSmoothValue(holder.overlaySegments[i], stacks)
+                SetStatusBarSegmentedValue(holder.segments[i], stacks, segmentedSmoothing)
+                SetStatusBarSegmentedValue(holder.overlaySegments[i], stacks, segmentedSmoothing)
             end
 
             if holder.thresholdSegments then
@@ -424,7 +427,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     local thresholdSeg = holder.thresholdSegments[i]
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(thresholdSeg, maxStacks)
-                        SetStatusBarSmoothValue(thresholdSeg, stacks)
+                        SetStatusBarSegmentedValue(thresholdSeg, stacks, segmentedSmoothing)
                         thresholdSeg:Show()
                     else
                         SetStatusBarImmediateValue(thresholdSeg, 0)
@@ -446,7 +449,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         -- Max stacks indicator: SetValue drives visibility via C-level clamping
         if cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-            SetStatusBarSmoothValue(barInfo._maxStacksIndicator, (auraPresent and applications ~= nil) and applications or 0)
+            local indicatorValue = (auraPresent and applications ~= nil) and applications or 0
+            if barInfo.barType == "custom_segmented" or barInfo.barType == "custom_overlay" then
+                SetStatusBarSegmentedValue(barInfo._maxStacksIndicator, indicatorValue, segmentedSmoothing)
+            else
+                SetStatusBarSmoothValue(barInfo._maxStacksIndicator, indicatorValue)
+            end
         end
     end
 

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -47,6 +47,7 @@ local RESOURCE_DISPLAY_PROFILE_KEYS = {
     "borderColor",
     "borderSize",
     "borderRenderMode",
+    "segmentedSmoothing",
 }
 
 local RESOURCE_TEXT_DISPLAY_KEYS = {
@@ -1456,6 +1457,7 @@ local function SeedResourceDisplayProfileFromGlobal(profile, settings)
     if profile.borderSize == nil then profile.borderSize = 1 end
     if profile.borderRenderMode == nil then profile.borderRenderMode = ST.BORDER_RENDER_MODE_CUSTOM end
     if profile.classBarBrightness == nil then profile.classBarBrightness = 1.3 end
+    profile.segmentedSmoothing = ST.NormalizeSegmentedSmoothing(profile.segmentedSmoothing)
     return profile
 end
 
@@ -1482,6 +1484,11 @@ local function GetResourceDisplayValue(settings, key, fallback)
         return settings[key]
     end
     return fallback
+end
+
+local function GetResourceSegmentedSmoothing(settings, specID)
+    local profile = GetSpecResourceDisplayProfile(settings, specID)
+    return ST.NormalizeSegmentedSmoothing(profile and profile.segmentedSmoothing or nil)
 end
 
 local function GetResourceDisplayConfig(settings, powerType)
@@ -2107,6 +2114,7 @@ RB.GetSpecLayoutOrder = GetSpecLayoutOrder
 RB.SeedResourceLayoutFromGlobal = SeedResourceLayoutFromGlobal
 RB.GetSpecResourceDisplayProfile = GetSpecResourceDisplayProfile
 RB.GetResourceDisplayValue = GetResourceDisplayValue
+RB.GetResourceSegmentedSmoothing = GetResourceSegmentedSmoothing
 RB.GetResourceDisplayConfig = GetResourceDisplayConfig
 RB.GetResourceSpecOverrideTable = GetResourceSpecOverrideTable
 RB.RESOURCE_TEXT_DISPLAY_KEYS = RESOURCE_TEXT_DISPLAY_KEYS

--- a/OtherBars/ResourceBarPreview.lua
+++ b/OtherBars/ResourceBarPreview.lua
@@ -24,10 +24,12 @@ local SetCustomAuraMaxThresholdRange = RB.SetCustomAuraMaxThresholdRange
 local IsResourceAuraOverlayEnabled = RB.IsResourceAuraOverlayEnabled
 local GetActiveResourceAuraEntry = RB.GetActiveResourceAuraEntry
 local GetResourceColors = RB.GetResourceColors
+local GetResourceSegmentedSmoothing = RB.GetResourceSegmentedSmoothing
 local SetSegmentedText = RB.SetSegmentedText
 local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
 local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 
 function RB.CreateResourceBarPreviewModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -48,6 +50,8 @@ function RB.CreateResourceBarPreviewModule(deps)
         if not (barInfo and barInfo.frame and barInfo.frame:IsShown()) then
             return
         end
+
+        local segmentedSmoothing = GetResourceSegmentedSmoothing(settings)
 
         local function ApplyResourceAuraLanePreview(barInfo, previewRatio)
             local powerType = barInfo.powerType
@@ -122,11 +126,11 @@ function RB.CreateResourceBarPreviewModule(deps)
             local previewValue = filled + 0.5
             for i, seg in ipairs(barInfo.frame.segments) do
                 if i <= filled then
-                    SetStatusBarSmoothValue(seg, 1)
+                    SetStatusBarSegmentedValue(seg, 1, segmentedSmoothing)
                 elseif i == filled + 1 then
-                    SetStatusBarSmoothValue(seg, 0.5)
+                    SetStatusBarSegmentedValue(seg, 0.5, segmentedSmoothing)
                 else
-                    SetStatusBarSmoothValue(seg, 0)
+                    SetStatusBarSegmentedValue(seg, 0, segmentedSmoothing)
                 end
             end
             ApplySegmentedPreviewColors(barInfo.frame, barInfo.powerType, settings, previewValue)
@@ -155,8 +159,8 @@ function RB.CreateResourceBarPreviewModule(deps)
                 previewStacks = math_min(GetMWMaxStacks(), math_max(previewStacks, 7))
             end
             for i = 1, half do
-                SetStatusBarSmoothValue(barInfo.frame.segments[i], previewStacks)
-                SetStatusBarSmoothValue(barInfo.frame.overlaySegments[i], previewStacks)
+                SetStatusBarSegmentedValue(barInfo.frame.segments[i], previewStacks, segmentedSmoothing)
+                SetStatusBarSegmentedValue(barInfo.frame.overlaySegments[i], previewStacks, segmentedSmoothing)
                 if previewStacks > (half + i - 1) then
                     barInfo.frame.overlaySegments[i]:SetAlpha(1)
                 else
@@ -254,13 +258,13 @@ function RB.CreateResourceBarPreviewModule(deps)
             local n = #barInfo.frame.segments
             local fill = indicatorPreview and n or math.ceil(n * 0.6)
             for _, seg in ipairs(barInfo.frame.segments) do
-                SetStatusBarSmoothValue(seg, fill)
+                SetStatusBarSegmentedValue(seg, fill, segmentedSmoothing)
             end
             if barInfo.frame.thresholdSegments then
                 for _, seg in ipairs(barInfo.frame.thresholdSegments) do
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(seg, maxStacks)
-                        SetStatusBarSmoothValue(seg, fill)
+                        SetStatusBarSegmentedValue(seg, fill, segmentedSmoothing)
                         seg:Show()
                     else
                         SetStatusBarImmediateValue(seg, 0)
@@ -269,7 +273,7 @@ function RB.CreateResourceBarPreviewModule(deps)
                 end
             end
             if cabConfig and cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-                SetStatusBarSmoothValue(barInfo._maxStacksIndicator, maxStacks)
+                SetStatusBarSegmentedValue(barInfo._maxStacksIndicator, maxStacks, segmentedSmoothing)
             end
         elseif barInfo.barType == "custom_overlay" then
             local cabConfig = barInfo.cabConfig
@@ -279,13 +283,13 @@ function RB.CreateResourceBarPreviewModule(deps)
             local thresholdEnabled = IsCustomAuraMaxThresholdEnabled(cabConfig)
             local half = barInfo.halfSegments or 1
             for i = 1, half do
-                SetStatusBarSmoothValue(barInfo.frame.segments[i], previewStacks)
-                SetStatusBarSmoothValue(barInfo.frame.overlaySegments[i], previewStacks)
+                SetStatusBarSegmentedValue(barInfo.frame.segments[i], previewStacks, segmentedSmoothing)
+                SetStatusBarSegmentedValue(barInfo.frame.overlaySegments[i], previewStacks, segmentedSmoothing)
                 if barInfo.frame.thresholdSegments and barInfo.frame.thresholdSegments[i] then
                     local seg = barInfo.frame.thresholdSegments[i]
                     if thresholdEnabled then
                         SetCustomAuraMaxThresholdRange(seg, maxStacks)
-                        SetStatusBarSmoothValue(seg, previewStacks)
+                        SetStatusBarSegmentedValue(seg, previewStacks, segmentedSmoothing)
                         seg:Show()
                     else
                         SetStatusBarImmediateValue(seg, 0)
@@ -294,7 +298,7 @@ function RB.CreateResourceBarPreviewModule(deps)
                 end
             end
             if cabConfig and cabConfig.maxStacksGlowEnabled and barInfo._maxStacksIndicator then
-                SetStatusBarSmoothValue(barInfo._maxStacksIndicator, maxStacks)
+                SetStatusBarSegmentedValue(barInfo._maxStacksIndicator, maxStacks, segmentedSmoothing)
             end
         end
     end

--- a/OtherBars/ResourceBarVisuals.lua
+++ b/OtherBars/ResourceBarVisuals.lua
@@ -11,7 +11,7 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
-local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
+local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 
 local math_floor = math.floor
 local math_min = math.min
@@ -402,13 +402,14 @@ local function ApplyResourceAuraStackSegments(holder, settings, stackValue, maxS
     local auraSegments = EnsureResourceAuraStackSegments(holder, settings)
     if not auraSegments then return end
 
+    local segmentedSmoothing = RB.GetResourceSegmentedSmoothing(settings)
     local count = #auraSegments
     for i = 1, count do
         local seg = auraSegments[i]
         local segMin = ((i - 1) * maxStacks) / count
         local segMax = (i * maxStacks) / count
         SetStatusBarSmoothRange(seg, segMin, segMax)
-        SetStatusBarSmoothValue(seg, stackValue)
+        SetStatusBarSegmentedValue(seg, stackValue, segmentedSmoothing)
         seg:SetAlpha(1)
         seg:SetStatusBarColor(color[1], color[2], color[3], 1)
         seg:Show()


### PR DESCRIPTION
## What Players Will Notice
- Segmented resource bars can now either keep the new smooth animation or snap immediately between segment values on a per-spec basis.
- Bar-panel Stack Count bars using Segmented or Overlay mode now have the same On/Off smoothing control per entry.
- Continuous resource bars, continuous custom bars, and continuous Stack Count bars keep their existing smooth behavior.

## Why This Changed
- Some segmented resources, especially Holy Power, read better as simple on/off segments than as animated fills.
- This keeps the opt-out scoped to segmented displays instead of adding a broad profile-wide smoothing setting or noisy per-segment controls.

## What Changed
- Added a Segmented Smoothing dropdown to resource Appearance settings and to bar-panel Aura Display Mode settings when Stack Count is set to Segmented or Overlay.
- Stored resource-bar smoothing per spec and bar-panel smoothing per entry, with smoothing still On by default.
- Added a shared segmented status-bar helper so segmented resource bars, segmented/overlay custom bars, previews, thresholds, and max-stack indicators can snap immediately when smoothing is Off while continuous bars remain smooth.

## Validation
- `lua tests\segmented-smoothing.lua`
- `lua tests\resource-settings-helpers.lua`
- `lua tests\resource-settings-ui-shape.lua`
- `luac -p Core\Defaults.lua Core\Utils.lua OtherBars\ResourceBarHelpers.lua Core\Aura.lua ConfigSettings\ResourceBarPanelsResource.lua OtherBars\ResourceBar.lua OtherBars\ResourceBarCustomBars.lua OtherBars\ResourceBarVisuals.lua OtherBars\ResourceBarPreview.lua ConfigSettings\ButtonSettings.lua ButtonFrame\BarMode.lua`
- `git diff --check origin/main...HEAD`
- In-game combat and restricted-content validation has not been performed yet for this branch.