### PR TITLE
Preserve Resource Aura Overlays after profile upgrades

### DIFF
--- a/Core/ScopedSettings.lua
+++ b/Core/ScopedSettings.lua
@@ -509,11 +509,18 @@ local function GetCurrentClassSpecInfo()
 
     local specIDs = {}
     local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
+    if numSpecs <= 0 then
+        return nil, nil
+    end
+
     for i = 1, numSpecs do
         local specID = GetSpecializationInfoForClassID(classID, i)
         if specID then
             specIDs[specID] = true
         end
+    end
+    if not next(specIDs) then
+        return nil, nil
     end
 
     local currentSpecID = nil
@@ -759,6 +766,8 @@ local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
                         auraActiveColor = CopyResourceAuraOverlayColor(resource.auraActiveColor),
                         auraColorTrackingMode = resource.auraColorTrackingMode,
                         auraColorMaxStacks = resource.auraColorMaxStacks,
+                        auraUnit = resource.auraUnit,
+                        auraUnitExplicit = resource.auraUnitExplicit,
                     },
                 }
                 BackfillLegacyResourceAuraUnit(resource.auraOverlayEntries[currentSpecID])
@@ -1090,6 +1099,67 @@ local function NormalizeScopedBarSettings(systemKey, settings)
     end
 end
 
+local function IsResourceAuraUnitNormalized(auraEntry)
+    if type(auraEntry) ~= "table" then
+        return false
+    end
+    return auraEntry.auraUnit == "player" or auraEntry.auraUnit == "target"
+end
+
+local function ResourceAuraOverlayNeedsNormalization(settings)
+    if type(settings) ~= "table" or type(settings.resources) ~= "table" then
+        return false
+    end
+
+    local allowedSpecIDs = nil
+    local checkedSpecIDs = false
+    local function GetAllowedSpecIDs()
+        if not checkedSpecIDs then
+            allowedSpecIDs = GetCurrentClassSpecInfo()
+            checkedSpecIDs = true
+        end
+        return allowedSpecIDs
+    end
+
+    for _, resource in pairs(settings.resources) do
+        if type(resource) == "table" then
+            if HasLegacyResourceAuraOverlayData(resource) then
+                return true
+            end
+
+            if type(resource.auraOverlayEntries) == "table" then
+                if not next(resource.auraOverlayEntries) then
+                    return true
+                end
+
+                local allowed = GetAllowedSpecIDs()
+                if type(allowed) ~= "table" then
+                    return true
+                end
+
+                for specID, entry in pairs(resource.auraOverlayEntries) do
+                    local numericSpecID = tonumber(specID)
+                    if not numericSpecID
+                        or numericSpecID ~= specID
+                        or allowed[numericSpecID] ~= true
+                        or not IsResourceAuraUnitNormalized(entry) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+
+    return false
+end
+
+local function NeedsScopedBarNormalization(systemKey, settings)
+    if systemKey == "resourceBars" then
+        return ResourceAuraOverlayNeedsNormalization(settings)
+    end
+    return false
+end
+
 local function SanitizeCopiedOrSeededScopedBarSettings(systemKey, settings)
     if systemKey == "resourceBars" then
         SanitizeResourceBarAnchors(settings)
@@ -1203,6 +1273,8 @@ function CooldownCompanion:GetCharacterScopedSettings(systemKey)
         NormalizeScopedBarSettings(systemKey, settings)
         SanitizeCopiedOrSeededScopedBarSettings(systemKey, settings)
         store[charKey] = settings
+    elseif NeedsScopedBarNormalization(systemKey, settings) then
+        NormalizeScopedBarSettings(systemKey, settings)
     end
 
     return settings


### PR DESCRIPTION
## What Players Will Notice
- Resource Aura Overlays configured before this release continue working after upgrading instead of appearing disabled or losing their aura setup.
- Overlays that were explicitly turned off stay disabled, and player/target aura-unit choices are preserved.

## Why This Changed
- The Resource Aura Overlay settings moved to a spec-keyed format, but already character-scoped `resourceBarsByChar` settings could skip the normalizer that converts the old resource-level fields. That left runtime/config code looking for a spec entry that did not exist.

## What Changed
- Existing current-character resource bar settings now run the scoped normalizer when legacy or malformed aura overlay data is still present.
- Legacy aura overlay data now copies the selected aura, color/stack settings, and explicit aura unit into `auraOverlayEntries[currentSpecID]`.
- Normalization defers while specialization data is unavailable so a later settings read can retry instead of clearing data too early.

## Validation
- `lua tests\resource-aura-overlay-scoped-migration.lua` (ignored local regression fixture)
- `lua tests\resource-settings-helpers.lua`
- `lua tests\resource-settings-selection.lua`
- `lua tests\resource-settings-ui-shape.lua`
- `lua tests\resource-threshold-tick-helpers.lua`
- Full local Lua sweep passed except the known unrelated `tests\panel-alpha-inheritance.lua` fixture failure: `panel child should inherit external frame alpha: expected 0.7, got 1`.
- `git diff --check origin/main...HEAD`
- `luac -p Core\ScopedSettings.lua`
- In-game copied-1.18 SavedVariables upgrade testing, combat testing, and restricted-content testing have not yet been recorded.
