### PR TITLE
Preserve panel alpha inheritance through frame anchors

### DIFF
--- a/ConfigSettings/GroupTabs.lua
+++ b/ConfigSettings/GroupTabs.lua
@@ -919,6 +919,17 @@ local function BuildLayoutTab(container)
     local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
     if not group then return end
     local style = group.style
+    local function IsResolvedExternalFrameAnchorTarget(frameName)
+        if type(frameName) ~= "string" or frameName == "" or frameName == "UIParent" then
+            return false
+        end
+        if CooldownCompanion.ParseAddonAnchorFrameName
+            and CooldownCompanion:ParseAddonAnchorFrameName(frameName) ~= nil then
+            return false
+        end
+        local target = _G[frameName]
+        return type(target) == "table" and type(target.GetObjectType) == "function"
+    end
 
     CooldownCompanion:ClearAllTextureIndicatorPreviews()
     if CooldownCompanion.ClearAllTriggerPanelEffectPreviews then
@@ -1016,6 +1027,9 @@ local function BuildLayoutTab(container)
         else
             targetMode = "group"
         end
+        local hasFrameAnchorTarget = isPanel
+            and targetMode == "frame"
+            and IsResolvedExternalFrameAnchorTarget(settings.relativeTo)
 
         local function RefreshTextureVisual()
             CooldownCompanion:RefreshAllAuraTextureVisuals()
@@ -1172,11 +1186,13 @@ local function BuildLayoutTab(container)
                 end
             end)
             container:AddChild(panelAnchorDrop)
+        end
 
+        if isPanel and (targetMode == "panel" or hasFrameAnchorTarget) then
             local panelAlphaDrop = AceGUI:Create("Dropdown")
             panelAlphaDrop:SetLabel("Panel Alpha")
             panelAlphaDrop:SetList({
-                inherit = "Inherit Target Panel Alpha",
+                inherit = targetMode == "frame" and "Inherit Target Frame Alpha" or "Inherit Target Panel Alpha",
                 custom = "Custom Alpha",
             }, { "inherit", "custom" })
             panelAlphaDrop:SetValue(group.inheritPanelAlpha == false and "custom" or "inherit")
@@ -1247,11 +1263,14 @@ local function BuildLayoutTab(container)
             container:AddChild(resetBtn)
         end
 
-        local panelAlphaInherited = targetMode == "panel"
+        local panelAlphaInherited = false
+        if targetMode == "panel"
             and currentAnchorGroupId
-            and CooldownCompanion.ShouldInheritPanelAnchorAlpha
-            and CooldownCompanion:ShouldInheritPanelAnchorAlpha(textureGroupId)
-            or false
+            and CooldownCompanion.ShouldInheritPanelAnchorAlpha then
+            panelAlphaInherited = CooldownCompanion:ShouldInheritPanelAnchorAlpha(textureGroupId)
+        elseif hasFrameAnchorTarget then
+            panelAlphaInherited = group.inheritPanelAlpha ~= false
+        end
 
         BuildAlphaControls(container, group, function()
             CooldownCompanion:RefreshAllAuraTextureVisuals()
@@ -1259,7 +1278,9 @@ local function BuildLayoutTab(container)
         end, "layout_alpha", {
             isGlobal = group.isGlobal,
             disabled = panelAlphaInherited,
-            disabledText = "This panel inherits alpha from the parent panel. Change the parent panel's Alpha settings to affect it.",
+            disabledText = targetMode == "frame"
+                and "This panel inherits alpha from the target frame. Change the Panel Alpha setting to use custom alpha."
+                or "This panel inherits alpha from the parent panel. Change the parent panel's Alpha settings to affect it.",
             onBaselineChanged = function(val)
                 CS.texturePanelAlphaPreview = CS.texturePanelAlphaPreview or {}
                 CS.texturePanelAlphaPreview[textureGroupId] = val
@@ -1325,6 +1346,9 @@ local function BuildLayoutTab(container)
         targetMode = preferredTargetMode
     end
     CS.layoutAnchorTargetMode[CS.selectedGroup] = targetMode
+    local hasFrameAnchorTarget = isPanel
+        and targetMode == "frame"
+        and IsResolvedExternalFrameAnchorTarget(currentAnchor)
     if targetMode == "cursor" and isCursorAnchor then
         CooldownCompanion:ShowCursorAnchorLayoutPreview(CS.selectedGroup)
     else
@@ -1336,6 +1360,8 @@ local function BuildLayoutTab(container)
         and currentAnchorGroupId
         and CooldownCompanion.ShouldInheritPanelAnchorAlpha then
         panelAlphaInherited = CooldownCompanion:ShouldInheritPanelAnchorAlpha(CS.selectedGroup)
+    elseif hasFrameAnchorTarget then
+        panelAlphaInherited = group.inheritPanelAlpha ~= false
     end
 
     local anchorTargetDrop = AceGUI:Create("Dropdown")
@@ -1470,11 +1496,13 @@ local function BuildLayoutTab(container)
             end
         end)
         container:AddChild(panelAnchorDrop)
+    end
 
+    if isPanel and (targetMode == "panel" or hasFrameAnchorTarget) then
         local panelAlphaDrop = AceGUI:Create("Dropdown")
         panelAlphaDrop:SetLabel("Panel Alpha")
         panelAlphaDrop:SetList({
-            inherit = "Inherit Target Panel Alpha",
+            inherit = targetMode == "frame" and "Inherit Target Frame Alpha" or "Inherit Target Panel Alpha",
             custom = "Custom Alpha",
         }, { "inherit", "custom" })
         panelAlphaDrop:SetValue(group.inheritPanelAlpha == false and "custom" or "inherit")
@@ -1675,7 +1703,9 @@ local function BuildLayoutTab(container)
     end, "layout_alpha", {
         isGlobal = group.isGlobal,
         disabled = panelAlphaInherited,
-        disabledText = "This panel inherits alpha from the parent panel. Change the parent panel's Alpha settings to affect it.",
+        disabledText = targetMode == "frame"
+            and "This panel inherits alpha from the target frame. Change the Panel Alpha setting to use custom alpha."
+            or "This panel inherits alpha from the parent panel. Change the parent panel's Alpha settings to affect it.",
         onBaselineChanged = function(val)
             local frame = CooldownCompanion.groupFrames[CS.selectedGroup]
             if frame and frame:IsShown() then

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -404,8 +404,11 @@ function CooldownCompanion:InitAlphaUpdateFrame()
         return false
     end
 
-    local function GroupNeedsAlphaUpdate(group, groupId)
+    local function GroupNeedsAlphaUpdate(group, groupId, frame)
         if self:ShouldInheritPanelAnchorAlpha(groupId) then
+            return false
+        end
+        if frame and frame._inheritsExternalAnchorAlpha then
             return false
         end
         if ST.IsGroupConfigSelected(groupId) then return true end
@@ -443,7 +446,7 @@ function CooldownCompanion:InitAlphaUpdateFrame()
             local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
             if frame
                 and (frame:IsShown() or (panelAlphaAnchorTargets and panelAlphaAnchorTargets[groupId])) then
-                if GroupNeedsAlphaUpdate(group, groupId) then
+                if GroupNeedsAlphaUpdate(group, groupId, frame) then
                     local locked = true
                     if group.parentContainerId then
                         local c = containers[group.parentContainerId]

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -157,6 +157,19 @@ local function GetAddonAnchorGroupId(frameName)
     return kind == "group" and id or nil
 end
 
+local function IsPanelAnchoredToExternalFrame(group)
+    if not (group and group.parentContainerId) then
+        return false
+    end
+
+    local relativeTo = GetActivePanelAnchorRelativeTo(group)
+    if type(relativeTo) ~= "string" or relativeTo == "" or relativeTo == "UIParent" then
+        return false
+    end
+
+    return ParseAddonAnchorFrameName(relativeTo) == nil
+end
+
 local function BuildPanelAlphaDependencyTargets(groups)
     local targets = nil
     for groupId, group in pairs(groups or {}) do
@@ -781,7 +794,7 @@ function CooldownCompanion:NormalizePanelAlphaInheritance(profile)
     for _, group in pairs(profile.groups or {}) do
         if type(group) == "table"
             and group.inheritPanelAlpha == nil
-            and self:IsPanelAnchoredToPanel(group)
+            and (self:IsPanelAnchoredToPanel(group) or IsPanelAnchoredToExternalFrame(group))
             and HasActiveAlphaSettings(group) then
             group.inheritPanelAlpha = false
         end

--- a/Core/AuraTexturesDisplay.lua
+++ b/Core/AuraTexturesDisplay.lua
@@ -20,6 +20,7 @@ local string_trim = strtrim
 local tostring = tostring
 local tonumber = tonumber
 local type = type
+local issecretvalue = issecretvalue
 
 local DEFAULT_TEXTURE_SIZE = AT.DEFAULT_TEXTURE_SIZE
 local UI_PARENT_NAME = AT.UI_PARENT_NAME
@@ -239,6 +240,36 @@ local function GetStandaloneResolvedAnchorFrame(group, settings, groupId)
     return GetStandaloneFrameAnchorFrame(group, settings, groupId)
 end
 
+local function GetStandalonePanelAlphaTargetFrame(group, settings, groupId)
+    if not (group and group.parentContainerId and group.inheritPanelAlpha ~= false) then
+        return nil
+    end
+
+    local relativeTo = type(settings) == "table" and settings.relativeTo or nil
+    if type(relativeTo) ~= "string" or relativeTo == "" or relativeTo == UI_PARENT_NAME then
+        return nil
+    end
+
+    local anchorKind = nil
+    if CooldownCompanion.ParseAddonAnchorFrameName then
+        anchorKind = CooldownCompanion:ParseAddonAnchorFrameName(relativeTo)
+    end
+
+    if anchorKind == "group" then
+        if CooldownCompanion.ShouldInheritPanelAnchorAlpha
+            and CooldownCompanion:ShouldInheritPanelAnchorAlpha(groupId) then
+            return GetStandalonePanelAnchorFrame(group, settings, groupId)
+        end
+        return nil
+    end
+
+    if anchorKind ~= nil then
+        return nil
+    end
+
+    return GetStandaloneFrameAnchorFrame(group, settings, groupId)
+end
+
 local function StopStandalonePanelAlphaSync(host)
     if host and host.standalonePanelAlphaSyncFrame then
         host.standalonePanelAlphaSyncFrame:SetScript("OnUpdate", nil)
@@ -252,18 +283,57 @@ local function StopStandalonePanelAlphaSync(host)
     end
 end
 
+local function IsSecretValue(value)
+    if issecretvalue and issecretvalue(value) then
+        return true
+    end
+    return false
+end
+
 local function GetInheritedFrameAlpha(frame)
     if not frame then
         return 1
     end
     local alpha = frame._naturalAlpha
-    if alpha == nil and frame.GetEffectiveAlpha then
+    if IsSecretValue(alpha) then
+        return nil
+    end
+    if type(alpha) == "number" then
+        return Clamp(alpha, 0, 1)
+    end
+    if frame.IsShown then
+        local shown = frame:IsShown()
+        if IsSecretValue(shown) then
+            return nil
+        end
+        if shown == nil then
+            return nil
+        end
+        if not shown then
+            return 0
+        end
+    end
+    if frame.GetEffectiveAlpha then
         alpha = frame:GetEffectiveAlpha()
+        if IsSecretValue(alpha) then
+            return nil
+        end
+        if alpha == nil then
+            return nil
+        end
+        return Clamp(alpha, 0, 1)
     end
-    if alpha == nil and frame.GetAlpha then
+    if frame.GetAlpha then
         alpha = frame:GetAlpha()
+        if IsSecretValue(alpha) then
+            return nil
+        end
+        if alpha == nil then
+            return nil
+        end
+        return Clamp(alpha, 0, 1)
     end
-    return Clamp(alpha or 1, 0, 1)
+    return 1
 end
 
 local function StartStandalonePanelAlphaSync(host, targetFrame, visibilityAlpha)
@@ -280,10 +350,13 @@ local function StartStandalonePanelAlphaSync(host, targetFrame, visibilityAlpha)
     host._standalonePanelAlphaTarget = targetFrame
     host._standalonePanelAlphaVisibilityAlpha = visibilityAlpha
     if syncChanged or not wasSyncing then
-        local alpha = Clamp(GetInheritedFrameAlpha(targetFrame) * visibilityAlpha, 0, 1)
-        host._standalonePanelAlphaLastAlpha = alpha
         host._standalonePanelAlphaAccumulator = 0
-        host:SetAlpha(alpha)
+        local inheritedAlpha = GetInheritedFrameAlpha(targetFrame)
+        if inheritedAlpha ~= nil then
+            local alpha = Clamp(inheritedAlpha * visibilityAlpha, 0, 1)
+            host._standalonePanelAlphaLastAlpha = alpha
+            host:SetAlpha(alpha)
+        end
     end
     if wasSyncing then
         return
@@ -308,7 +381,11 @@ local function StartStandalonePanelAlphaSync(host, targetFrame, visibilityAlpha)
         end
         host._standalonePanelAlphaAccumulator = 0
 
-        local alpha = Clamp(GetInheritedFrameAlpha(activeTarget) * (host._standalonePanelAlphaVisibilityAlpha or 1), 0, 1)
+        local inheritedAlpha = GetInheritedFrameAlpha(activeTarget)
+        if inheritedAlpha == nil then
+            return
+        end
+        local alpha = Clamp(inheritedAlpha * (host._standalonePanelAlphaVisibilityAlpha or 1), 0, 1)
         if alpha ~= host._standalonePanelAlphaLastAlpha then
             host._standalonePanelAlphaLastAlpha = alpha
             host:SetAlpha(alpha)
@@ -1335,10 +1412,7 @@ function CooldownCompanion:FinalizeStandaloneDisplay(host, frame, driverButton, 
     local alphaModuleId = GetTexturePanelAlphaModuleId(driverButton._groupId)
     local layoutPreviewAlpha = GetTexturePanelLayoutPreviewAlpha(driverButton)
     local visibilityAlpha = Clamp(driverButton._rawVisibilityAlphaOverride or 1, 0, 1)
-    local panelAlphaTarget = CooldownCompanion.ShouldInheritPanelAnchorAlpha
-        and CooldownCompanion:ShouldInheritPanelAnchorAlpha(driverButton._groupId)
-        and GetStandalonePanelAnchorFrame(group, sharedSettings, driverButton._groupId)
-        or nil
+    local panelAlphaTarget = GetStandalonePanelAlphaTargetFrame(group, sharedSettings, driverButton._groupId)
     if panelAlphaTarget then
         if alphaModuleId then
             self:UnregisterModuleAlpha(alphaModuleId, true)

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -17,6 +17,7 @@ local math_ceil = math.ceil
 local table_insert = table.insert
 local InCombatLockdown = InCombatLockdown
 local GetCursorPosition = GetCursorPosition
+local issecretvalue = issecretvalue
 local select = select
 local wipe = wipe
 
@@ -81,18 +82,71 @@ local function GetContainerState(groupId)
     return group.locked or false, group.baselineAlpha or 1
 end
 
-local function ShouldSyncAnchorAlpha(self, groupId)
+local function IsSecretValue(value)
+    if issecretvalue and issecretvalue(value) then
+        return true
+    end
+    return false
+end
+
+local function ReadSafeAlphaValue(value)
+    if IsSecretValue(value) then
+        return nil
+    end
+    if value == nil then
+        return nil
+    end
+    if type(value) ~= "number" then
+        return nil
+    end
+    return value
+end
+
+local function GetGroupAnchorRelativeTo(group)
+    local anchor = group and group.anchor
+    return type(anchor) == "table" and anchor.relativeTo or anchor
+end
+
+local function SetExternalAnchorAlphaSyncActive(frame, active)
+    if not frame then return end
+    if active then
+        frame._inheritsExternalAnchorAlpha = true
+    else
+        frame._inheritsExternalAnchorAlpha = nil
+    end
+end
+
+local function IsExternalFrameAnchorTarget(self, group, parentFrame)
+    if not (group and group.parentContainerId and parentFrame and group.inheritPanelAlpha ~= false) then
+        return false
+    end
+
+    local relativeTo = GetGroupAnchorRelativeTo(group)
+    if type(relativeTo) ~= "string" or relativeTo == "" or relativeTo == "UIParent" then
+        return false
+    end
+
+    if self.ParseAddonAnchorFrameName and self:ParseAddonAnchorFrameName(relativeTo) ~= nil then
+        return false
+    end
+
+    return _G[relativeTo] == parentFrame
+end
+
+local function ShouldSyncAnchorAlpha(self, groupId, parentFrame)
     local profile = self.db and self.db.profile
     local group = profile and profile.groups and profile.groups[groupId]
 
     if group and group.parentContainerId then
         if self:IsPanelAnchoredToPanel(groupId) then
-            return self:ShouldInheritPanelAnchorAlpha(groupId)
+            local inheritsPanelAlpha = self:ShouldInheritPanelAnchorAlpha(groupId)
+            return inheritsPanelAlpha, inheritsPanelAlpha, false
         end
-        return false
+        local inheritsExternalAlpha = IsExternalFrameAnchorTarget(self, group, parentFrame)
+        return inheritsExternalAlpha, inheritsExternalAlpha, inheritsExternalAlpha
     end
 
-    return true
+    return true, false, false
 end
 
 local function ApplyGroupOwnAlpha(frame)
@@ -120,27 +174,52 @@ local function GetAnchorInheritedAlpha(parentFrame)
         return 1
     end
 
-    if parentFrame._naturalAlpha ~= nil then
-        return parentFrame._naturalAlpha
+    local alpha = ReadSafeAlphaValue(parentFrame._naturalAlpha)
+    if alpha ~= nil then
+        return alpha
     end
 
     local parentGroupId = parentFrame.groupId
     if parentGroupId and CooldownCompanion.alphaState then
         local state = CooldownCompanion.alphaState[parentGroupId]
-        if state and state.currentAlpha ~= nil then
-            return state.currentAlpha
+        alpha = state and ReadSafeAlphaValue(state.currentAlpha) or nil
+        if alpha ~= nil then
+            return alpha
         end
     end
 
-    if parentFrame.IsShown and not parentFrame:IsShown() then
-        return 0
+    if parentFrame.IsShown then
+        local shown = parentFrame:IsShown()
+        if IsSecretValue(shown) then
+            return nil
+        end
+        if shown == nil then
+            return nil
+        end
+        if not shown then
+            return 0
+        end
     end
 
     if parentFrame.GetEffectiveAlpha then
-        return parentFrame:GetEffectiveAlpha()
+        alpha = parentFrame:GetEffectiveAlpha()
+        if IsSecretValue(alpha) then
+            return nil
+        end
+        if alpha == nil then
+            return nil
+        end
+        return alpha
     end
     if parentFrame.GetAlpha then
-        return parentFrame:GetAlpha()
+        alpha = parentFrame:GetAlpha()
+        if IsSecretValue(alpha) then
+            return nil
+        end
+        if alpha == nil then
+            return nil
+        end
+        return alpha
     end
     return 1
 end
@@ -720,6 +799,7 @@ local function ApplyCursorAnchorPosition(self, frame, anchor, cursorX, cursorY, 
     if frame.alphaSyncFrame then
         frame.alphaSyncFrame:SetScript("OnUpdate", nil)
     end
+    SetExternalAnchorAlphaSyncActive(frame, false)
     frame.anchoredToParent = nil
 
     if not (cursorX and cursorY) then
@@ -1470,6 +1550,7 @@ function CooldownCompanion:AnchorGroupFrame(frame, anchor, forceCenter)
             if frame.alphaSyncFrame then
                 frame.alphaSyncFrame:SetScript("OnUpdate", nil)
             end
+            SetExternalAnchorAlphaSyncActive(frame, false)
             frame.anchoredToParent = nil
             frame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
             UpdateCoordLabel(frame, 0, 0)
@@ -1500,6 +1581,7 @@ function CooldownCompanion:AnchorGroupFrame(frame, anchor, forceCenter)
     if frame.alphaSyncFrame then
         frame.alphaSyncFrame:SetScript("OnUpdate", nil)
     end
+    SetExternalAnchorAlphaSyncActive(frame, false)
     frame.anchoredToParent = nil
 
     local relativeTo = anchor.relativeTo
@@ -1558,10 +1640,12 @@ function CooldownCompanion:AnchorGroupFrame(frame, anchor, forceCenter)
 end
 
 function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
-    if not ShouldSyncAnchorAlpha(self, frame.groupId) then
+    local shouldSync, inheritsAnchorAlpha, inheritsExternalAlpha = ShouldSyncAnchorAlpha(self, frame.groupId, parentFrame)
+    if not shouldSync then
         if frame.alphaSyncFrame then
             frame.alphaSyncFrame:SetScript("OnUpdate", nil)
         end
+        SetExternalAnchorAlphaSyncActive(frame, false)
         ApplyGroupOwnAlpha(frame)
         return
     end
@@ -1571,22 +1655,30 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
         frame.alphaSyncFrame = CreateFrame("Frame", nil, frame)
     end
 
-    local inheritsPanelAlpha = self:ShouldInheritPanelAnchorAlpha(frame.groupId)
-    if inheritsPanelAlpha and self.alphaState then
+    SetExternalAnchorAlphaSyncActive(frame, inheritsExternalAlpha)
+
+    if inheritsAnchorAlpha and self.alphaState then
         self.alphaState[frame.groupId] = nil
     end
 
     -- If this group has baseline alpha < 1, the alpha fade system takes
     -- priority unless panel alpha inheritance is explicitly active.
     local _, baseAlpha = GetContainerState(frame.groupId)
-    if baseAlpha < 1 and not inheritsPanelAlpha then
+    if baseAlpha < 1 and not inheritsAnchorAlpha then
         frame.alphaSyncFrame:SetScript("OnUpdate", nil)
+        SetExternalAnchorAlphaSyncActive(frame, false)
         return
     end
 
     -- Sync alpha immediately — use parent's natural alpha to avoid config override cascade
     local lastAlpha = GetAnchorInheritedAlpha(parentFrame)
-    frame:SetAlpha(lastAlpha)
+    if lastAlpha ~= nil then
+        SetExternalAnchorAlphaSyncActive(frame, inheritsExternalAlpha)
+        frame:SetAlpha(lastAlpha)
+    elseif ST.IsGroupConfigSelected(frame.groupId) then
+        lastAlpha = 1
+        frame:SetAlpha(1)
+    end
 
     -- Sync alpha at ~30Hz (smooth enough for fade animations, avoids per-frame overhead)
     local accumulator = 0
@@ -1598,9 +1690,11 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
         if frame.anchoredToParent then
             -- Skip sync if this panel owns alpha locally or the group is unlocked.
             local locked, bAlpha = GetContainerState(frame.groupId)
-            if (bAlpha < 1 and not inheritsPanelAlpha) or not locked then return end
+            if (bAlpha < 1 and not inheritsAnchorAlpha) or not locked then return end
             -- Read parent's natural alpha to avoid config override cascade
             local alpha = GetAnchorInheritedAlpha(frame.anchoredToParent)
+            if alpha == nil then return end
+            SetExternalAnchorAlphaSyncActive(frame, inheritsExternalAlpha)
             -- Config-selected: store natural alpha for further downstream chains, force own frame to full
             if ST.IsGroupConfigSelected(frame.groupId) then
                 frame._naturalAlpha = alpha
@@ -1611,7 +1705,7 @@ function CooldownCompanion:SetupAlphaSync(frame, parentFrame)
                 return
             end
             frame._naturalAlpha = nil
-            if alpha ~= lastAlpha then
+            if lastAlpha == nil or alpha ~= lastAlpha then
                 lastAlpha = alpha
                 frame:SetAlpha(alpha)
             end


### PR DESCRIPTION
## What Players Will Notice
- Panels that inherit alpha now keep that inheritance when they are anchored to a unit frame or other external frame that is itself anchored to another panel.
- Texture and Trigger standalone panels follow the same inherited-alpha behavior when they are anchored to resolved frame targets.
- Existing panels with custom alpha settings should keep those custom settings instead of silently switching into inherited alpha.

## Why This Changed
- The alpha inheritance chain only recognized direct panel-to-panel anchors, so a panel anchored to a unit frame could stop following the panel that controlled that unit frame's alpha.
- Frame-target inheritance also needed matching config controls and safer behavior when a target frame is missing, hidden, or temporarily returns unreadable alpha values.

## What Changed
- External frame anchors now participate in panel alpha inheritance when the saved frame target resolves to the same runtime frame being used for anchoring.
- Alpha reads now handle hidden frames, nil values, and secret values conservatively, preserving the last safe alpha when the target alpha is unreadable.
- Alpha fade skips panels that are actively inheriting from external frame targets so local alpha settings do not fight inherited alpha.
- Texture and Trigger standalone panels now use the same external-frame inherited alpha path as normal panels.
- The Layout config only shows and disables inherited frame-alpha controls when the selected frame target currently resolves, and profile normalization preserves custom alpha intent for existing frame-anchored panels.

## Validation
- `lua tests\panel-alpha-inheritance.lua`
- `lua tests\standalone-alpha-inheritance.lua`
- `lua tests\panel-alpha-dependency-cache.lua`
- `lua tests\panel-alpha-state-reapply.lua`
- `luac -p ConfigSettings\GroupTabs.lua Core\AlphaFade.lua Core\AnchorPolicy.lua Core\GroupFrame.lua Core\AuraTexturesDisplay.lua tests\panel-alpha-inheritance.lua tests\standalone-alpha-inheritance.lua tests\panel-alpha-dependency-cache.lua tests\panel-alpha-state-reapply.lua`
- `git diff --check origin/main...HEAD`
- Four separate code review passes reported no remaining actionable issues.
- Maintainer-reported in-game validation passed for the anchored-frame alpha inheritance behavior. Combat/restricted-content coverage was not separately recorded by Codex in this thread.
