### PR TITLE
Prevent pandemic glow flicker on aura refreshes

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -1393,6 +1393,12 @@ local function BarModeOnUpdate(self, elapsed)
                 self._durationObj = nil
                 self._auraActive = false
                 self._inPandemic = false
+                self._pandemicAuraUpdated = nil
+                self._pandemicSemanticStartTime = nil
+                self._pandemicSemanticEndTime = nil
+                self._pandemicSemanticValue = nil
+                self._pandemicSuppressedSemanticStartTime = nil
+                self._pandemicSuppressedSemanticEndTime = nil
                 self._barAuraColor = nil
                 local c = self.style.barColor or DEFAULT_BAR_COLOR
                 self.statusBar:SetStatusBarColor(c[1], c[2], c[3], c[4])
@@ -1410,6 +1416,12 @@ local function BarModeOnUpdate(self, elapsed)
             self._viewerBar = nil
             self._auraActive = false
             self._inPandemic = false
+            self._pandemicAuraUpdated = nil
+            self._pandemicSemanticStartTime = nil
+            self._pandemicSemanticEndTime = nil
+            self._pandemicSemanticValue = nil
+            self._pandemicSuppressedSemanticStartTime = nil
+            self._pandemicSuppressedSemanticEndTime = nil
             self._barAuraColor = nil
             local c = self.style.barColor or DEFAULT_BAR_COLOR
             self.statusBar:SetStatusBarColor(c[1], c[2], c[3], c[4])
@@ -1874,6 +1886,12 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._inPandemic = nil
     button._pandemicGraceStart = nil
     button._pandemicGraceSuppressed = nil
+    button._pandemicAuraUpdated = nil
+    button._pandemicSemanticStartTime = nil
+    button._pandemicSemanticEndTime = nil
+    button._pandemicSemanticValue = nil
+    button._pandemicSuppressedSemanticStartTime = nil
+    button._pandemicSuppressedSemanticEndTime = nil
     button._viewerAuraVisualsActive = nil
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -116,6 +116,11 @@ local function ClearConditionalVisualPreviewFields(button)
         if not (buttonData and buttonData.auraTracking) then
             button._inPandemic = false
             button._pandemicGraceStart = nil
+            button._pandemicSemanticStartTime = nil
+            button._pandemicSemanticEndTime = nil
+            button._pandemicSemanticValue = nil
+            button._pandemicSuppressedSemanticStartTime = nil
+            button._pandemicSuppressedSemanticEndTime = nil
         end
     end
     button._conditionalPreviewKind = nil
@@ -1028,6 +1033,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             now = now,
             enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic),
             previewActive = button._pandemicPreview == true,
+            clearWhenDisabled = true,
         })
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -1316,6 +1316,12 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._inPandemic = nil
     button._pandemicGraceStart = nil
     button._pandemicGraceSuppressed = nil
+    button._pandemicAuraUpdated = nil
+    button._pandemicSemanticStartTime = nil
+    button._pandemicSemanticEndTime = nil
+    button._pandemicSemanticValue = nil
+    button._pandemicSuppressedSemanticStartTime = nil
+    button._pandemicSuppressedSemanticEndTime = nil
     button._viewerAuraVisualsActive = nil
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -301,6 +301,11 @@ local function ClearConditionalVisualPreviewDerivedFields(button)
     if button._conditionalPandemicPreview then
         button._inPandemic = false
         button._pandemicGraceStart = nil
+        button._pandemicSemanticStartTime = nil
+        button._pandemicSemanticEndTime = nil
+        button._pandemicSemanticValue = nil
+        button._pandemicSuppressedSemanticStartTime = nil
+        button._pandemicSuppressedSemanticEndTime = nil
     end
     button._conditionalPreviewKind = nil
     button._conditionalPreviewStartTime = nil

--- a/ButtonFrame/VisualState.lua
+++ b/ButtonFrame/VisualState.lua
@@ -305,6 +305,14 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
         SetGlowIntent(aura, true, true, "preview")
         aura.preview = true
         aura.auraIndicatorEnabled = auraIndicatorEnabled
+    elseif button._inPandemic and style.showPandemicGlow ~= false
+        and not (pandemicCombatOnly and not inCombat) then
+        SetGlowIntent(aura, true, true, "pandemic")
+        aura.pandemic = true
+        aura.combatOnly = pandemicCombatOnly and true or false
+        aura.combatSuppressed = false
+        aura.invert = style.auraGlowInvert and true or nil
+        aura.auraIndicatorEnabled = auraIndicatorEnabled
     elseif style.auraGlowInvert then
         if button._auraTrackingReady == true and button._auraSpellID and not button._auraActive then
             if auraIndicatorEnabled or style.auraGlowStyle ~= "none" then
@@ -332,18 +340,6 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
                 aura.invert = true
                 aura.auraIndicatorEnabled = auraIndicatorEnabled
             end
-        elseif button._auraActive and button._inPandemic and style.showPandemicGlow ~= false then
-            SetGlowIntent(
-                aura,
-                true,
-                not (pandemicCombatOnly and not inCombat),
-                pandemicCombatOnly and not inCombat and "pandemic-combat-only" or "pandemic"
-            )
-            aura.pandemic = true
-            aura.combatOnly = pandemicCombatOnly and true or false
-            aura.combatSuppressed = pandemicCombatOnly and not inCombat
-            aura.invert = true
-            aura.auraIndicatorEnabled = auraIndicatorEnabled
         else
             SetGlowIntent(aura, true, false, "inactive")
             aura.invert = true
@@ -382,7 +378,8 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
     end
 
     local procSuppressesReady = procOverlayShown and style.procGlowStyle ~= "none"
-    local auraSuppressesReady = button._auraTrackingReady == true and button._auraActive == true
+    local auraSuppressesReady = button._auraTrackingReady == true
+        and (button._auraActive == true or button._inPandemic == true)
     if not button.readyGlow then
         SetGlowIntent(ready, false, false, "missing-widget")
     elseif button._readyGlowPreview == true then

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -496,15 +496,13 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
                     button._inPandemic = false
                     button._auraEventRemoved = true
                 end
-                -- Aura reapplication (pandemic refresh) arrives as an update, not a
-                -- removal + add.  Clear pandemic state and suppress the grace hold so
-                -- the next evaluation clears pandemic immediately instead of holding 0.3s.
+                -- Aura reapplication can arrive as an update. Keep pandemic
+                -- stable until the resolver asks the selected CDM item for
+                -- fresh truth.
                 if updatedIDSet
                     and button._auraInstanceID
                     and updatedIDSet[button._auraInstanceID] then
-                    button._inPandemic = false
-                    button._pandemicGraceStart = nil
-                    button._pandemicGraceSuppressed = true
+                    EntryRuntime.MarkTrackedAuraUpdated(button)
                 end
             end
             -- Signal that the server has delivered target aura data, so the hold
@@ -547,6 +545,8 @@ function CooldownCompanion:OnTargetChanged()
     if not UnitExists("target") then
         -- Deselected target: clear all target aura state immediately
         self:ClearAuraUnit("target")
+        self:UpdateAllCooldowns()
+        self:ClearCooldownsDirty()
         return
     end
     -- New target: clear stale instance IDs so the viewer path doesn't
@@ -770,7 +770,10 @@ function CooldownCompanion:ResolveAuraTrackingAssociationData(buttonData, viewer
         AddCooldownInfoCandidateIDs(candidateIDs, cooldownInfo)
     end
 
-    if viewerFrame and IsBuffViewerChild(viewerFrame) and type(viewerFrame.cooldownInfo) == "table" then
+    if viewerFrame
+        and IsBuffViewerChild(viewerFrame)
+        and type(viewerFrame.cooldownInfo) == "table"
+        and CooldownInfoMatchesCandidateSet(viewerFrame.cooldownInfo, candidateIDs) then
         data.trackedBuffViewerFrame = viewerFrame
         data.hasAssociatedAura = true
         MergeCooldownInfo(viewerFrame.cooldownInfo)
@@ -1175,9 +1178,13 @@ function CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
     if buttonData.cdmChildSlot then
         local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
         local slotChild = allChildren and allChildren[buttonData.cdmChildSlot]
-        if IsBuffViewerChild(slotChild) then
-            return slotChild
+        if slotChild then
+            local associationData = self:ResolveAuraTrackingAssociationData(buttonData, slotChild)
+            if associationData.trackedBuffViewerFrame == slotChild then
+                return slotChild
+            end
         end
+        return nil
     end
 
     local associationData = self:ResolveAuraTrackingAssociationData(buttonData)
@@ -1248,7 +1255,7 @@ end
 
 function CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
     local enabled = self._cdmViewerEnabled
-    if enabled == nil then enabled = GetCVarBool("cooldownViewerEnabled") end
+    if enabled == nil then enabled = C_CVar.GetCVarBool("cooldownViewerEnabled") end
     if not spellID or spellID == 0 or not enabled then
         return nil
     end

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -530,15 +530,12 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
         return semanticPandemic
     end
 
-    if owner._pandemicAuraUpdated then
-        ClearPandemicFallbackState(owner)
-        return false
-    end
-
     local pandemicIcon = viewerFrame.PandemicIcon
     if pandemicIcon and pandemicIcon:IsVisible() then
         ClearPandemicFallbackState(owner)
         return true
+    elseif owner._pandemicAuraUpdated then
+        ClearPandemicFallbackState(owner)
     elseif owner._pandemicGraceSuppressed then
         ClearPandemicFallbackState(owner)
     elseif owner._inPandemic then

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -15,6 +15,7 @@ local tostring = tostring
 local wipe = wipe
 local issecretvalue = issecretvalue
 local GetTime = GetTime
+local UnitExists = UnitExists
 
 local COOLDOWN_STATE_READY = CooldownLogic.STATE_READY
 local COOLDOWN_STATE_GCD = CooldownLogic.STATE_GCD
@@ -34,6 +35,13 @@ ST.EntryRuntime = EntryRuntime
 local scratchParent = CreateFrame("Frame")
 scratchParent:Hide()
 local scratchCooldown = CreateFrame("Cooldown", nil, scratchParent, "CooldownFrameTemplate")
+
+local function IsCooldownViewerEnabled()
+    if CooldownCompanion._cooldownUpdatePassActive then
+        return CooldownCompanion._cdmViewerEnabled == true
+    end
+    return C_CVar.GetCVarBool("cooldownViewerEnabled") == true
+end
 
 local function DurationObjectShowsCooldown(durationObj)
     if not durationObj then return false end
@@ -164,12 +172,7 @@ local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUni
 end
 local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance, useButtonAuraViewerFallback)
     local viewerFrame
-    local cdmEnabled
-    if CooldownCompanion._cooldownUpdatePassActive then
-        cdmEnabled = CooldownCompanion._cdmViewerEnabled == true
-    else
-        cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
-    end
+    local cdmEnabled = IsCooldownViewerEnabled()
 
     local orderedStandaloneAuraIDs
     local standaloneOriginalAuraIDs
@@ -203,7 +206,16 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
         local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
         if allChildren then
             viewerFrame = allChildren[buttonData.cdmChildSlot]
+            if viewerFrame and type(CooldownCompanion.ResolveAuraTrackingAssociationData) == "function" then
+                local associationData = CooldownCompanion:ResolveAuraTrackingAssociationData(buttonData, viewerFrame)
+                if not (associationData and associationData.trackedBuffViewerFrame == viewerFrame) then
+                    viewerFrame = nil
+                end
+            else
+                viewerFrame = nil
+            end
         end
+        return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs
     end
 
     if not viewerFrame and orderedStandaloneAuraIDs then
@@ -356,7 +368,10 @@ EntryRuntime.AuraDataMatchesTrackedSpell = AuraDataMatchesTrackedSpell
 function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
     if not owner then return end
     options = options or {}
-    local inactiveValue = options.useFalseState and false or nil
+    local inactiveValue = nil
+    if options.useFalseState then
+        inactiveValue = false
+    end
 
     owner._auraActive = inactiveValue
     owner._auraHasTimer = inactiveValue
@@ -378,6 +393,12 @@ function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
     owner._inPandemic = inactiveValue
     owner._pandemicGraceStart = nil
     owner._pandemicGraceSuppressed = nil
+    owner._pandemicAuraUpdated = nil
+    owner._pandemicSemanticStartTime = nil
+    owner._pandemicSemanticEndTime = nil
+    owner._pandemicSemanticValue = nil
+    owner._pandemicSuppressedSemanticStartTime = nil
+    owner._pandemicSuppressedSemanticEndTime = nil
     if options.clearCustomAuraStacks then
         owner._customAuraStackValue = nil
         owner._customAuraApplicationsValue = nil
@@ -390,9 +411,71 @@ function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
     owner._inPandemic = false
     owner._pandemicGraceStart = nil
     owner._pandemicGraceSuppressed = nil
+    owner._pandemicAuraUpdated = nil
+    owner._pandemicSemanticStartTime = nil
+    owner._pandemicSemanticEndTime = nil
+    owner._pandemicSemanticValue = nil
+    owner._pandemicSuppressedSemanticStartTime = nil
+    owner._pandemicSuppressedSemanticEndTime = nil
     owner._targetSwitchAt = now
     owner._targetSwitchDataReceived = nil
     owner._auraUnit = unit or "target"
+end
+
+function EntryRuntime.MarkTrackedAuraUpdated(owner)
+    if not owner then return end
+    owner._pandemicAuraUpdated = true
+end
+
+local function ClearPandemicFallbackState(owner)
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    owner._pandemicAuraUpdated = nil
+end
+
+local function ClearPandemicSemanticState(owner)
+    owner._pandemicSemanticStartTime = nil
+    owner._pandemicSemanticEndTime = nil
+    owner._pandemicSemanticValue = nil
+    owner._pandemicSuppressedSemanticStartTime = nil
+    owner._pandemicSuppressedSemanticEndTime = nil
+end
+
+local function ClearSuppressedPandemicSemanticWindow(owner)
+    owner._pandemicSuppressedSemanticStartTime = nil
+    owner._pandemicSuppressedSemanticEndTime = nil
+end
+
+local function RememberPandemicSemanticWindow(owner, semanticPandemic, pandemicStartTime, pandemicEndTime)
+    owner._pandemicSemanticStartTime = pandemicStartTime
+    owner._pandemicSemanticEndTime = pandemicEndTime
+    owner._pandemicSemanticValue = semanticPandemic == true
+end
+
+local function PandemicSemanticWindowMatches(startA, endA, startB, endB)
+    return startA ~= nil and startA == startB and endA == endB
+end
+
+local function ResolveSemanticPandemicState(viewerFrame, now)
+    if not (viewerFrame and type(viewerFrame.IsInPandemicTime) == "function") then
+        return nil
+    end
+
+    if issecretvalue(now)
+        or issecretvalue(viewerFrame.pandemicStartTime)
+        or issecretvalue(viewerFrame.pandemicEndTime) then
+        return nil
+    end
+
+    local pandemicStartTime = viewerFrame.pandemicStartTime
+    local pandemicEndTime = viewerFrame.pandemicEndTime
+    if not (type(now) == "number"
+        and type(pandemicStartTime) == "number"
+        and type(pandemicEndTime) == "number") then
+        return nil
+    end
+
+    return now >= pandemicStartTime and now <= pandemicEndTime, pandemicStartTime, pandemicEndTime
 end
 
 function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
@@ -405,21 +488,60 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
 
     if not (options.enabled and viewerFrame) then
         if options.clearWhenDisabled then
-            owner._pandemicGraceStart = nil
-            owner._pandemicGraceSuppressed = nil
+            ClearPandemicFallbackState(owner)
+            ClearPandemicSemanticState(owner)
         end
         return false
     end
 
+    local now = options.now or GetTime()
+    local semanticPandemic, pandemicStartTime, pandemicEndTime = ResolveSemanticPandemicState(viewerFrame, now)
+    if semanticPandemic ~= nil then
+        if semanticPandemic == true
+            and PandemicSemanticWindowMatches(
+                owner._pandemicSuppressedSemanticStartTime,
+                owner._pandemicSuppressedSemanticEndTime,
+                pandemicStartTime,
+                pandemicEndTime
+            ) then
+            ClearPandemicFallbackState(owner)
+            return false
+        end
+
+        if owner._pandemicAuraUpdated == true and semanticPandemic == true then
+            local previousPandemicWindowUnchanged = owner._pandemicSemanticValue == true
+                and PandemicSemanticWindowMatches(
+                    owner._pandemicSemanticStartTime,
+                    owner._pandemicSemanticEndTime,
+                    pandemicStartTime,
+                    pandemicEndTime
+                )
+            if previousPandemicWindowUnchanged then
+                owner._pandemicSuppressedSemanticStartTime = pandemicStartTime
+                owner._pandemicSuppressedSemanticEndTime = pandemicEndTime
+                ClearPandemicFallbackState(owner)
+                return false
+            end
+        end
+
+        RememberPandemicSemanticWindow(owner, semanticPandemic, pandemicStartTime, pandemicEndTime)
+        ClearSuppressedPandemicSemanticWindow(owner)
+        ClearPandemicFallbackState(owner)
+        return semanticPandemic
+    end
+
+    if owner._pandemicAuraUpdated then
+        ClearPandemicFallbackState(owner)
+        return false
+    end
+
     local pandemicIcon = viewerFrame.PandemicIcon
-    if owner._pandemicGraceSuppressed then
-        owner._pandemicGraceSuppressed = nil
-        owner._pandemicGraceStart = nil
-    elseif pandemicIcon and pandemicIcon:IsVisible() then
-        owner._pandemicGraceStart = nil
+    if pandemicIcon and pandemicIcon:IsVisible() then
+        ClearPandemicFallbackState(owner)
         return true
+    elseif owner._pandemicGraceSuppressed then
+        ClearPandemicFallbackState(owner)
     elseif owner._inPandemic then
-        local now = options.now or GetTime()
         if not owner._pandemicGraceStart then
             owner._pandemicGraceStart = now
         end
@@ -500,6 +622,44 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     end
     local auraEventRemoved = owner._auraEventRemoved
     owner._auraEventRemoved = nil
+
+    local targetUnitMissing = configUnit == "target" and UnitExists and not UnitExists("target")
+    if targetUnitMissing then
+        local cdmEnabled = IsCooldownViewerEnabled()
+        local state = {
+            ready = cdmEnabled == true,
+            auraPresent = false,
+            auraTrackingReady = cdmEnabled == true,
+            cdmEnabled = cdmEnabled == true,
+            auraData = nil,
+            auraApplications = nil,
+            auraInstanceID = nil,
+            auraUnit = configUnit,
+            configUnit = configUnit,
+            viewerFrame = nil,
+            viewerBar = nil,
+            durationObj = nil,
+            auraCooldownStart = nil,
+            auraCooldownDuration = nil,
+            auraHasTimer = false,
+            auraGraceHeld = false,
+            activeAuraSpellID = nil,
+            activeAuraSpellIDResolved = false,
+            activeAuraSpellIDFromFallback = nil,
+            activeAuraIcon = nil,
+            activeAuraIconAvailable = false,
+            activeAuraIconResolved = false,
+            allowDurationlessAuraInstance = allowDurationlessAuraInstance,
+            wasAuraActive = wasAuraActive,
+            targetUnitMissing = true,
+        }
+        if mutateOwner then
+            EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, {
+                useFalseState = true,
+            })
+        end
+        return state
+    end
 
     local viewerFrame, cdmEnabled, orderedStandaloneAuraIDs = ResolveTrackedAuraViewerFrame(
         owner,

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -292,6 +292,12 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
         bar._inPandemic = nil
         bar._pandemicGraceStart = nil
         bar._pandemicGraceSuppressed = nil
+        bar._pandemicAuraUpdated = nil
+        bar._pandemicSemanticStartTime = nil
+        bar._pandemicSemanticEndTime = nil
+        bar._pandemicSemanticValue = nil
+        bar._pandemicSuppressedSemanticStartTime = nil
+        bar._pandemicSuppressedSemanticEndTime = nil
         ResetCustomAuraBarIndicatorVisuals(bar, cabConfig)
         return
     end

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -157,9 +157,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
                                     and bar._auraInstanceID
                                     and bar._auraUnit == unit
                                     and updatedIDSet[bar._auraInstanceID] then
-                                    bar._inPandemic = false
-                                    bar._pandemicGraceStart = nil
-                                    bar._pandemicGraceSuppressed = true
+                                    EntryRuntime.MarkTrackedAuraUpdated(bar)
                                 end
                                 if unit == "target" and bar._targetSwitchAt then
                                     bar._targetSwitchDataReceived = true


### PR DESCRIPTION
## What Players Will Notice
- Pandemic glow should stay stable when a tracked aura enters or remains in its pandemic refresh window, instead of briefly blinking during aura refreshes.
- Target aura glows should clear promptly when the target disappears or the tracked aura no longer belongs to the selected target.

## Why This Changed
- Pandemic glow was being resolved from a mix of Blizzard Cooldown Viewer state, local grace fallback, and aura update events. A same-instance aura update could briefly clear local pandemic state before the visible Blizzard pandemic marker was respected, which matched the flicker seen in-game.
- Stale viewer attribution and stale target-aura state could also make the glow appear when it should already be inactive.

## What Changed
- Centralized pandemic state resolution in `Core/EntryRuntime.lua`, including readable semantic timestamp handling, secret-value guards, and a visible `PandemicIcon` fallback for secret pandemic windows.
- Changed aura refresh handling to mark tracked auras for re-evaluation instead of immediately clearing pandemic state, while still rejecting stale unchanged semantic windows after a refresh.
- Made explicit CDM child-slot and provided viewer-frame association checks fail closed when they no longer match the tracked aura.
- Cleared aura and pandemic runtime state on target deselect, style resets, preview resets, bar expiry, and custom resource aura bar lifecycle paths.
- Updated visual priority so pandemic glow wins over transient aura-missing and ready-glow states while it is active.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Core\EntryRuntime.lua Core\Aura.lua ButtonFrame\CooldownUpdate.lua ButtonFrame\VisualState.lua ButtonFrame\IconMode.lua ButtonFrame\BarMode.lua ButtonFrame\Preview.lua OtherBars\ResourceBar.lua OtherBars\ResourceBarLifecycle.lua`
- `lua tests\pandemic-state-invariants.lua`
- `lua tests\pandemic-visual-state.lua`
- `lua tests\pandemic-aura-attribution.lua`
- `lua tests\aura-instance-membership.lua`
- In-game retest of the reported flicker path after the final ordering fix no longer reproduced the flicker.
- Still pending before ready-for-review: broader combat and restricted-content verification.