### PR TITLE
Allow trinket slots to be tracked as Custom Bars

### DIFF
--- a/Config/Column4.lua
+++ b/Config/Column4.lua
@@ -59,17 +59,28 @@ local function FindSelectedCustomBar()
 end
 
 local function GetCustomBarEntryTabs(entry)
+    local isEquipmentSlotCustomBar = ST._RB
+        and ST._RB.IsEquipmentSlotCustomBarConfig
+        and ST._RB.IsEquipmentSlotCustomBarConfig(entry) == true
+
     local tabs = {
         { value = "appearance", text = "Appearance" },
-        { value = "indicators", text = "Indicators" },
     }
-
-    tabs[#tabs + 1] = { value = "soundalerts", text = "Sound Alerts" }
+    if not isEquipmentSlotCustomBar then
+        tabs[#tabs + 1] = { value = "indicators", text = "Indicators" }
+        tabs[#tabs + 1] = { value = "soundalerts", text = "Sound Alerts" }
+    end
     tabs[#tabs + 1] = { value = "loadconditions", text = "Load Conditions" }
     return tabs
 end
 
 local function IsCustomBarEntryTabAllowed(entry, tab)
+    if (tab == "indicators" or tab == "soundalerts")
+        and ST._RB
+        and ST._RB.IsEquipmentSlotCustomBarConfig
+        and ST._RB.IsEquipmentSlotCustomBarConfig(entry) == true then
+        return false
+    end
     if tab == "appearance" or tab == "indicators" or tab == "soundalerts" or tab == "loadconditions" then
         return true
     end

--- a/Config/Diagnostics.lua
+++ b/Config/Diagnostics.lua
@@ -867,6 +867,12 @@ local function FormatDiagnosticBugReportAsText(diag)
             if entry.spellID then
                 parts[#parts + 1] = "spellID=" .. tostring(entry.spellID)
             end
+            if entry.itemSlot then
+                parts[#parts + 1] = "itemSlot=" .. tostring(entry.itemSlot)
+                if entry.itemSlotKind then
+                    parts[#parts + 1] = "itemSlotKind=" .. tostring(entry.itemSlotKind)
+                end
+            end
             if entry.hideWhenInactive then
                 parts[#parts + 1] = "hideWhenInactive=true"
             end

--- a/Config/ProfileImportPieces.lua
+++ b/Config/ProfileImportPieces.lua
@@ -14,6 +14,9 @@ local EMPTY_TABLE = {}
 local CUSTOM_BAR_CONTENT_FIELDS = {
     "name",
     "spellID",
+    "itemSlot",
+    "itemSlotKind",
+    "entryType",
     "auraSpellID",
     "resourceKey",
     "width",

--- a/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -50,6 +50,8 @@ local PrepareCustomAuraBar = RB.PrepareCustomAuraBar
 local EnsureCustomBarId = RB.EnsureCustomBarId
 local EnsureCustomBarLayout = RB.EnsureCustomBarLayout
 local GetCustomBarLayout = RB.GetCustomBarLayout
+local IsCustomBarRuntimeEligible = RB.IsCustomBarRuntimeEligible
+local IsEquipmentSlotCustomBarConfig = RB.IsEquipmentSlotCustomBarConfig
 local ApplyPreviewBarState = RB.ApplyPreviewBarState
 local GetMWMaxStacks = RB.GetMWMaxStacks
 local CreatePixelBorders = RB.CreatePixelBorders
@@ -855,10 +857,16 @@ local function CollectPreviewSlots(rbSettings, cbSettings, layout, isVerticalLay
 
     if resourceBarsEnabled then
         for customIndex, customAura in ipairs(customBars or {}) do
-            if customAura and customAura.enabled and customAura.spellID then
+            if customAura and customAura.enabled and (IsCustomBarRuntimeEligible and IsCustomBarRuntimeEligible(customAura) or customAura.spellID) then
                 local customBarId = EnsureCustomBarId(rbSettings, customAura)
-                local spellInfo = C_Spell.GetSpellInfo(customAura.spellID)
-                local label = spellInfo and spellInfo.name or customAura.label or ("Custom Bar " .. customIndex)
+                local isEquipmentSlotCustomBar = IsEquipmentSlotCustomBarConfig
+                    and IsEquipmentSlotCustomBarConfig(customAura) == true
+                local spellInfo = (not isEquipmentSlotCustomBar) and C_Spell.GetSpellInfo(customAura.spellID) or nil
+                local label = isEquipmentSlotCustomBar
+                    and (RB.GetEquipmentSlotCustomBarDisplayName and RB.GetEquipmentSlotCustomBarDisplayName(customAura) or customAura.label)
+                    or spellInfo and spellInfo.name
+                    or customAura.label
+                    or ("Custom Bar " .. customIndex)
                 local slotName = "Custom Bar: " .. label
                 local function EnsureLayoutSlot()
                     return EnsureCustomBarLayout(rbSettings, nil, customBarId, 1000 + customIndex)
@@ -879,7 +887,11 @@ local function CollectPreviewSlots(rbSettings, cbSettings, layout, isVerticalLay
                     label = slotName,
                     shortLabel = GetShortLabel(label),
                     color = CloneColor(customAura.barColor, { 0.52, 0.64, 1.0, 1 }),
-                    icon = C_Spell.GetSpellTexture(customAura.spellID) or LAYOUT_PREVIEW_ICON_FALLBACK,
+                    icon = isEquipmentSlotCustomBar
+                        and ((RB.GetEquipmentSlotCustomBarIcon and RB.GetEquipmentSlotCustomBarIcon(customAura))
+                            or LAYOUT_PREVIEW_ICON_FALLBACK)
+                        or ((customAura.spellID and C_Spell.GetSpellTexture(customAura.spellID))
+                            or LAYOUT_PREVIEW_ICON_FALLBACK),
                     getPos = function()
                         local slot = GetCustomBarLayout(rbSettings, nil, customAura, false)
                         if isVerticalLayout then

--- a/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -136,7 +136,14 @@ local function IsSpellCustomBarConfig(cab)
     return GetCustomBarEntryType and GetCustomBarEntryType(cab) == "spell"
 end
 
+local function IsEquipmentSlotCustomBarConfig(cab)
+    return RB.IsEquipmentSlotCustomBarConfig and RB.IsEquipmentSlotCustomBarConfig(cab) == true
+end
+
 local function IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
+    if IsEquipmentSlotCustomBarConfig(cab) then
+        return false
+    end
     if isSpellCustomBar == nil then
         isSpellCustomBar = IsSpellCustomBarConfig(cab)
     end
@@ -406,6 +413,9 @@ local function StripCustomBarEntryTypeWords(text)
 end
 
 local function GetCustomBarEntryTypeIcons(entry)
+    if IsEquipmentSlotCustomBarConfig(entry) then
+        return ""
+    end
     if entry and entry.entryType == "spell" then
         local icons = "|A:ui_adv_atk:15:15|a"
         if entry.auraTracking == true then
@@ -418,6 +428,9 @@ local function GetCustomBarEntryTypeIcons(entry)
 end
 
 local function ResolveCustomBarAuraTrackingStatus(entry, resolvedAuraUnit)
+    if IsEquipmentSlotCustomBarConfig(entry) then
+        return { state = "noAssociatedAura", ready = false, cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true }
+    end
     local spellID = tonumber(entry and entry.spellID)
     local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled") == true
     local isSpellEntry = entry and entry.entryType == "spell"
@@ -438,6 +451,36 @@ local function ResolveCustomBarAuraTrackingStatus(entry, resolvedAuraUnit)
 
     return buttonData and CooldownCompanion:ResolveAuraTrackingConfigStatus(buttonData, cdmEnabled, viewerFrame)
         or { state = "noAssociatedAura", ready = false, cdmEnabled = cdmEnabled }
+end
+
+local function ResolveCustomBarEquipmentSlotInput(input)
+    if type(input) ~= "string" then
+        return nil
+    end
+
+    local stableSlot = RB.ParseEquipmentSlotCustomBarStableKey
+        and RB.ParseEquipmentSlotCustomBarStableKey(input)
+    if stableSlot then
+        return stableSlot
+    end
+
+    local query = input:lower():gsub("^%s+", ""):gsub("%s+$", ""):gsub("%s+", " ")
+    if query == "trinket slot 1"
+        or query == "trinket 1"
+        or query == "slot 1"
+        or query == "first trinket"
+        or query == "top trinket" then
+        return CooldownCompanion.TRINKET_SLOT_1 or 13
+    end
+    if query == "trinket slot 2"
+        or query == "trinket 2"
+        or query == "slot 2"
+        or query == "second trinket"
+        or query == "bottom trinket" then
+        return CooldownCompanion.TRINKET_SLOT_2 or 14
+    end
+
+    return nil
 end
 
 local function ConfigureCustomBarAddInstructions(addBox, placeholderText)
@@ -1682,7 +1725,7 @@ local function BuildCustomBarsListPanel(container)
     addBox:SetLabel("")
     addBox:SetFullWidth(true)
     addBox:DisableButton(true)
-    local updatePlaceholder = ConfigureCustomBarAddInstructions(addBox, "Add spell or aura by name or ID")
+    local updatePlaceholder = ConfigureCustomBarAddInstructions(addBox, "Add spell, aura, or trinket slot by name or ID")
 
     local function GetCustomBarEntryTypeForAutocomplete(entry)
         if type(entry) ~= "table" then
@@ -1742,6 +1785,7 @@ local function BuildCustomBarsListPanel(container)
     end
 
     local function AddCustomBarFromSpell(spellId, labelOverride, entryType)
+        spellId = tonumber(spellId)
         if not spellId then return false end
         entryType = entryType == "aura" and "aura" or "spell"
         local entry = {
@@ -1776,12 +1820,59 @@ local function BuildCustomBarsListPanel(container)
         return true
     end
 
+    local function AddCustomBarFromEquipmentSlot(itemSlot)
+        itemSlot = tonumber(itemSlot)
+        local entry = {
+            entryType = "equipmentSlot",
+            enabled = true,
+            itemSlot = itemSlot,
+            itemSlotKind = CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET or "trinket",
+        }
+        if RB.NormalizeEquipmentSlotCustomBarConfig
+            and not RB.NormalizeEquipmentSlotCustomBarConfig(entry) then
+            return false
+        end
+        local slotButton = RB.BuildEquipmentSlotCustomBarButtonData
+            and RB.BuildEquipmentSlotCustomBarButtonData(entry)
+        if not slotButton then
+            return false
+        end
+        if CooldownCompanion.IsEquipmentSlotEntry
+            and not CooldownCompanion.IsEquipmentSlotEntry(slotButton) then
+            return false
+        end
+        local fallbackOrder = 1000 + #CooldownCompanion:GetSpecCustomAuraBars() + 1
+        local id = RB.AddCustomBar
+            and RB.AddCustomBar(settings, entry, customBarsSpecID, fallbackOrder)
+            or EnsureCustomBarId(settings, entry)
+        if not RB.AddCustomBar then
+            customBars[#customBars + 1] = entry
+            EnsureCustomBarLayout(settings, nil, id, 1000 + #customBars)
+        end
+        ST._SelectConfigCustomBar(id)
+        ApplyCustomAuraBarPanelChanges({
+            updateAnchors = true,
+            refreshConfig = true,
+        })
+        return true
+    end
+
     local function CommitCustomBarText(widget, text)
         local lookupText, explicitType = StripExplicitCustomBarEntryTypeSuffix(text)
+        local equipmentSlot = ResolveCustomBarEquipmentSlotInput(lookupText)
+        if equipmentSlot and AddCustomBarFromEquipmentSlot(equipmentSlot) then
+            widget:SetText("")
+            return true
+        end
         local autocompleteEntry = ResolveAuraBarAutocompleteEntry and (
             ResolveAuraBarAutocompleteEntry(text)
             or (lookupText ~= text and ResolveAuraBarAutocompleteEntry(lookupText))
         )
+        if autocompleteEntry and autocompleteEntry.isEquipmentSlot
+            and AddCustomBarFromEquipmentSlot(autocompleteEntry.itemSlot) then
+            widget:SetText("")
+            return true
+        end
         if autocompleteEntry and AddCustomBarFromSpell(
             autocompleteEntry.id,
             GetAuraBarAutocompleteEntryName(autocompleteEntry),
@@ -1810,6 +1901,13 @@ local function BuildCustomBarsListPanel(container)
 
     local function onAuraBarSelect(entry)
         CS.HideAutocomplete()
+        if entry and entry.isEquipmentSlot then
+            if AddCustomBarFromEquipmentSlot(entry.itemSlot) then
+                addBox._cdcCustomBarAutocompleteCommitted = true
+                addBox:SetText("")
+            end
+            return
+        end
         if entry and AddCustomBarFromSpell(
             entry.id,
             GetAuraBarAutocompleteEntryName(entry),
@@ -1906,7 +2004,10 @@ local function BuildCustomBarsListPanel(container)
         local entry = item.entry
         index = item.index or index
         local customBarId = EnsureCustomBarId(settings, entry)
-        local spellName = entry.label
+        local isEquipmentSlotCustomBar = IsEquipmentSlotCustomBarConfig(entry)
+        local spellName = isEquipmentSlotCustomBar
+            and (RB.GetEquipmentSlotCustomBarDisplayName and RB.GetEquipmentSlotCustomBarDisplayName(entry) or entry.label)
+            or entry.label
             or (entry.spellID and GetAuraBarAutocompleteDisplayName(entry.spellID))
             or (entry.spellID and C_Spell.GetSpellName(entry.spellID))
             or ("Custom Bar " .. tostring(index))
@@ -1916,10 +2017,15 @@ local function BuildCustomBarsListPanel(container)
             rowText = (rowText or ("Custom Bar " .. tostring(index))) .. "  " .. typeIcons
         end
         local selected = customBarId == selectedId
-        local icon = entry.spellID and (GetAuraBarAutocompleteDisplayIcon(entry.spellID) or C_Spell.GetSpellTexture(entry.spellID)) or 134400
+        local icon = isEquipmentSlotCustomBar
+            and (RB.GetEquipmentSlotCustomBarIcon and RB.GetEquipmentSlotCustomBarIcon(entry) or 134400)
+            or (entry.spellID and (GetAuraBarAutocompleteDisplayIcon(entry.spellID) or C_Spell.GetSpellTexture(entry.spellID)) or 134400)
         local isSpellCustomBar = IsSpellCustomBarConfig(entry)
-        local resolvedRowAuraUnit = GetResolvedCustomAuraBarAuraUnit(entry, entry.spellID)
-        local showAuraStatusBadge = (not item.inactive) and ((not isSpellCustomBar) or entry.auraTracking == true)
+        local resolvedRowAuraUnit = (not isEquipmentSlotCustomBar)
+            and GetResolvedCustomAuraBarAuraUnit(entry, entry.spellID) or nil
+        local showAuraStatusBadge = (not item.inactive)
+            and (not isEquipmentSlotCustomBar)
+            and ((not isSpellCustomBar) or entry.auraTracking == true)
         local auraStatus = showAuraStatusBadge and ResolveCustomBarAuraTrackingStatus(entry, resolvedRowAuraUnit) or nil
         local rowRightPad = 4
         if entry.enabled == false then
@@ -2406,13 +2512,18 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     local layout = RB.GetSpecLayoutOrder and RB.GetSpecLayoutOrder(settings, layoutSpecID) or CooldownCompanion:GetSpecLayoutOrder()
     local thicknessField, thicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
     local isSpellCustomBar = IsSpellCustomBarConfig(cab)
+    local isEquipmentSlotCustomBar = IsEquipmentSlotCustomBarConfig(cab)
     local hasAuraDisplayControls = IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
     local trackingMode = GetCustomBarTrackingModeConfig(cab, isSpellCustomBar)
     local isStackDisplay = hasAuraDisplayControls and trackingMode ~= "active"
-    local resolvedAuraUnit = GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID)
+    local resolvedAuraUnit = (not isEquipmentSlotCustomBar)
+        and GetResolvedCustomAuraBarAuraUnit(cab, cab.spellID) or nil
     activeTab = activeTab or "appearance"
 
     if activeTab == "settings" or activeTab == "layout" or activeTab == "anchor" or activeTab == "alpha" then
+        activeTab = "appearance"
+    end
+    if (activeTab == "indicators" or activeTab == "soundalerts") and isEquipmentSlotCustomBar then
         activeTab = "appearance"
     end
 
@@ -2431,7 +2542,9 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
         return
     end
 
-    BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
+    if not isEquipmentSlotCustomBar then
+        BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUnit, infoButtons)
+    end
 
     if hasAuraDisplayControls then
         AddCustomBarSettingsHeading(container, "Aura Display Mode", infoButtons, {
@@ -2538,8 +2651,8 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 container:AddChild(cabHeightSlider)
             end
 
-            -- ---- Colors section (only when has spell ID) ----
-            if cab.spellID then
+            -- ---- Colors section ----
+            if cab.spellID or isEquipmentSlotCustomBar then
                 local colorHeading = AceGUI:Create("Heading")
                 colorHeading:SetText("Colors")
                 ColorHeading(colorHeading)
@@ -2552,11 +2665,13 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                 AddColorPicker(container, customBars[cabIdx], "barColor", "Bar Color", {0.5, 0.5, 1}, false,
                     cabApplyBars, function() CooldownCompanion:RecolorCustomAuraBar(customBars[cabIdx]) end)
 
-                if isSpellCustomBar and not isStackDisplay then
+                if (isSpellCustomBar or isEquipmentSlotCustomBar) and not isStackDisplay then
                     AddColorPicker(container, customBars[cabIdx], "barCooldownColor", "Bar Cooldown Color", {0.6, 0.13, 0.18, 1}, true,
                         cabApplyBars, cabApplyBars)
-                    AddColorPicker(container, customBars[cabIdx], "barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1}, true,
-                        cabApplyBars, cabApplyBars)
+                    if isSpellCustomBar then
+                        AddColorPicker(container, customBars[cabIdx], "barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1}, true,
+                            cabApplyBars, cabApplyBars)
+                    end
                 end
 
                 -- Overlay Color (overlay mode only)
@@ -2601,29 +2716,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         container:AddChild(durationTextCb)
                     end
 
-                    -- Show Stack Text
-                    local stackVal = cab.showStackText
-                    if stackVal == nil and not isActive then
-                        stackVal = cab.showText  -- backwards compat
-                    end
-
-                    local stackTextCb = AceGUI:Create("CheckBox")
-                    local stackTextLabel = "Show Stack Text"
-                    if isSpellCustomBar then
-                        stackTextLabel = isStackDisplay and "Show Aura Stack Text" or "Show Count Text (Charges/Uses)"
-                    end
-                    stackTextCb:SetLabel(stackTextLabel)
-                    stackTextCb:SetValue(stackVal == true)
-                    stackTextCb:SetFullWidth(true)
-                    stackTextCb:SetCallback("OnValueChanged", function(widget, event, val)
-                        customBars[cabIdx].showStackText = val or nil
-                        CooldownCompanion:ApplyResourceBars()
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                    container:AddChild(stackTextCb)
-
                     local showDuration = showDurationControls and cab.showDurationText == true
-                    local showStack = (stackVal == true)
                     local function BuildDurationTextAdvanced(panel)
                         local fontDrop = AceGUI:Create("Dropdown")
                         fontDrop:SetLabel("Duration Font")
@@ -2669,79 +2762,103 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                             build = BuildDurationTextAdvanced,
                         })
 
-                    local function BuildStackTextAdvanced(panel)
-                        if not isActive then
-                            local stackTextFormatDrop = AceGUI:Create("Dropdown")
-                            stackTextFormatDrop:SetLabel("Text Format")
-                            local stackTextFormatOptions = {
-                                current = "Current Value",
-                                current_max = "Current / Max",
-                            }
-                            local stackTextFormatOrder = { "current", "current_max" }
-                            stackTextFormatDrop:SetList(stackTextFormatOptions, stackTextFormatOrder)
-                            local stackTextFormatValue = cab.stackTextFormat or DEFAULT_CUSTOM_AURA_STACK_TEXT_FORMAT
-                            if stackTextFormatValue ~= "current" and stackTextFormatValue ~= "current_max" then
-                                stackTextFormatValue = DEFAULT_CUSTOM_AURA_STACK_TEXT_FORMAT
-                            end
-                            stackTextFormatDrop:SetValue(stackTextFormatValue)
-                            stackTextFormatDrop:SetFullWidth(true)
-                            stackTextFormatDrop:SetCallback("OnValueChanged", function(widget, event, val)
-                                if val == "current" or val == "current_max" then
-                                    customBars[cabIdx].stackTextFormat = val
-                                else
-                                    customBars[cabIdx].stackTextFormat = DEFAULT_CUSTOM_AURA_STACK_TEXT_FORMAT
-                                end
-                                CooldownCompanion:ApplyResourceBars()
-                            end)
-                            panel:AddChild(stackTextFormatDrop)
+                    if not isEquipmentSlotCustomBar then
+                        -- Show Stack Text
+                        local stackVal = cab.showStackText
+                        if stackVal == nil and not isActive then
+                            stackVal = cab.showText  -- backwards compat
                         end
 
-                        local fontDrop = AceGUI:Create("Dropdown")
-                        local stackFontLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font" or "Charge Font") or "Stack Font"
-                        fontDrop:SetLabel(stackFontLabel)
-                        CS.SetupFontDropdown(fontDrop)
-                        fontDrop:SetValue(cab.stackTextFont or DEFAULT_RESOURCE_TEXT_FONT)
-                        fontDrop:SetFullWidth(true)
-                        CS.SetFontDropdownCallback(fontDrop, function(widget, event, val)
-                            customBars[cabIdx].stackTextFont = val
+                        local stackTextCb = AceGUI:Create("CheckBox")
+                        local stackTextLabel = "Show Stack Text"
+                        if isSpellCustomBar then
+                            stackTextLabel = isStackDisplay and "Show Aura Stack Text" or "Show Count Text (Charges/Uses)"
+                        end
+                        stackTextCb:SetLabel(stackTextLabel)
+                        stackTextCb:SetValue(stackVal == true)
+                        stackTextCb:SetFullWidth(true)
+                        stackTextCb:SetCallback("OnValueChanged", function(widget, event, val)
+                            customBars[cabIdx].showStackText = val or nil
                             CooldownCompanion:ApplyResourceBars()
+                            CooldownCompanion:RefreshConfigPanel()
                         end)
-                        panel:AddChild(fontDrop)
+                        container:AddChild(stackTextCb)
 
-                        local sizeDrop = AceGUI:Create("Slider")
-                        local stackSizeLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font Size" or "Charge Font Size") or "Stack Font Size"
-                        sizeDrop:SetLabel(stackSizeLabel)
-                        sizeDrop:SetSliderValues(6, 24, 1)
-                        sizeDrop:SetValue(cab.stackTextFontSize or DEFAULT_RESOURCE_TEXT_SIZE)
-                        sizeDrop:SetFullWidth(true)
-                        sizeDrop:SetCallback("OnValueChanged", function(widget, event, val)
-                            customBars[cabIdx].stackTextFontSize = val
-                            CooldownCompanion:ApplyResourceBars()
-                        end)
-                        panel:AddChild(sizeDrop)
+                        local showStack = (stackVal == true)
+                        local function BuildStackTextAdvanced(panel)
+                            if not isActive then
+                                local stackTextFormatDrop = AceGUI:Create("Dropdown")
+                                stackTextFormatDrop:SetLabel("Text Format")
+                                local stackTextFormatOptions = {
+                                    current = "Current Value",
+                                    current_max = "Current / Max",
+                                }
+                                local stackTextFormatOrder = { "current", "current_max" }
+                                stackTextFormatDrop:SetList(stackTextFormatOptions, stackTextFormatOrder)
+                                local stackTextFormatValue = cab.stackTextFormat or DEFAULT_CUSTOM_AURA_STACK_TEXT_FORMAT
+                                if stackTextFormatValue ~= "current" and stackTextFormatValue ~= "current_max" then
+                                    stackTextFormatValue = DEFAULT_CUSTOM_AURA_STACK_TEXT_FORMAT
+                                end
+                                stackTextFormatDrop:SetValue(stackTextFormatValue)
+                                stackTextFormatDrop:SetFullWidth(true)
+                                stackTextFormatDrop:SetCallback("OnValueChanged", function(widget, event, val)
+                                    if val == "current" or val == "current_max" then
+                                        customBars[cabIdx].stackTextFormat = val
+                                    else
+                                        customBars[cabIdx].stackTextFormat = DEFAULT_CUSTOM_AURA_STACK_TEXT_FORMAT
+                                    end
+                                    CooldownCompanion:ApplyResourceBars()
+                                end)
+                                panel:AddChild(stackTextFormatDrop)
+                            end
 
-                        local outlineDrop = AceGUI:Create("Dropdown")
-                        local stackOutlineLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Outline" or "Charge Outline") or "Stack Outline"
-                        outlineDrop:SetLabel(stackOutlineLabel)
-                        CS.SetupFontOutlineDropdown(outlineDrop)
-                        outlineDrop:SetValue(cab.stackTextFontOutline or DEFAULT_RESOURCE_TEXT_OUTLINE)
-                        outlineDrop:SetFullWidth(true)
-                        CS.SetFontOutlineDropdownCallback(outlineDrop, function(widget, event, val)
-                            customBars[cabIdx].stackTextFontOutline = val
-                            CooldownCompanion:ApplyResourceBars()
-                        end)
-                        panel:AddChild(outlineDrop)
+                            local fontDrop = AceGUI:Create("Dropdown")
+                            local stackFontLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font" or "Charge Font") or "Stack Font"
+                            fontDrop:SetLabel(stackFontLabel)
+                            CS.SetupFontDropdown(fontDrop)
+                            fontDrop:SetValue(cab.stackTextFont or DEFAULT_RESOURCE_TEXT_FONT)
+                            fontDrop:SetFullWidth(true)
+                            CS.SetFontDropdownCallback(fontDrop, function(widget, event, val)
+                                customBars[cabIdx].stackTextFont = val
+                                CooldownCompanion:ApplyResourceBars()
+                            end)
+                            panel:AddChild(fontDrop)
 
-                        AddColorPicker(panel, customBars[cabIdx], "stackTextFontColor", "Stack Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
+                            local sizeDrop = AceGUI:Create("Slider")
+                            local stackSizeLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Font Size" or "Charge Font Size") or "Stack Font Size"
+                            sizeDrop:SetLabel(stackSizeLabel)
+                            sizeDrop:SetSliderValues(6, 24, 1)
+                            sizeDrop:SetValue(cab.stackTextFontSize or DEFAULT_RESOURCE_TEXT_SIZE)
+                            sizeDrop:SetFullWidth(true)
+                            sizeDrop:SetCallback("OnValueChanged", function(widget, event, val)
+                                customBars[cabIdx].stackTextFontSize = val
+                                CooldownCompanion:ApplyResourceBars()
+                            end)
+                            panel:AddChild(sizeDrop)
+
+                            local outlineDrop = AceGUI:Create("Dropdown")
+                            local stackOutlineLabel = isSpellCustomBar and (isStackDisplay and "Aura Stack Outline" or "Charge Outline") or "Stack Outline"
+                            outlineDrop:SetLabel(stackOutlineLabel)
+                            CS.SetupFontOutlineDropdown(outlineDrop)
+                            outlineDrop:SetValue(cab.stackTextFontOutline or DEFAULT_RESOURCE_TEXT_OUTLINE)
+                            outlineDrop:SetFullWidth(true)
+                            CS.SetFontOutlineDropdownCallback(outlineDrop, function(widget, event, val)
+                                customBars[cabIdx].stackTextFontOutline = val
+                                CooldownCompanion:ApplyResourceBars()
+                            end)
+                            panel:AddChild(outlineDrop)
+
+                            AddColorPicker(panel, customBars[cabIdx], "stackTextFontColor", "Stack Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
+                        end
+
+                        local stackAdvExpanded = AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack, {
+                            title = stackTextLabel .. " Advanced",
+                            build = BuildStackTextAdvanced,
+                        })
                     end
-
-                    local stackAdvExpanded = AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack, {
-                        title = stackTextLabel .. " Advanced",
-                        build = BuildStackTextAdvanced,
-                    })
                 end
 
-                if not isSpellCustomBar or cab.auraTracking == true then
+                if (not isEquipmentSlotCustomBar) and (not isSpellCustomBar or cab.auraTracking == true) then
                     BuildCustomBarVisibilityRulesSection(container, customBars, capturedIdx, cab, resolvedAuraUnit, capturedKey, infoButtons)
                 end
 

--- a/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/ConfigSettings/ResourceBarPanelsResource.lua
@@ -141,7 +141,15 @@ local function IsSpellCustomBarConfig(cab)
     return GetCustomBarEntryType and GetCustomBarEntryType(cab) == "spell"
 end
 
+local function IsEquipmentSlotCustomBarConfig(cab)
+    return RB.IsEquipmentSlotCustomBarConfig
+        and RB.IsEquipmentSlotCustomBarConfig(cab)
+end
+
 local function IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
+    if IsEquipmentSlotCustomBarConfig(cab) then
+        return false
+    end
     if isSpellCustomBar == nil then
         isSpellCustomBar = IsSpellCustomBarConfig(cab)
     end

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -64,6 +64,14 @@ function CooldownCompanion:RefreshEquipmentSlotEntries(reason, itemID)
             end
         end
     end
+    if self.IsBarsAndFramesRuntimeFeatureEnabled
+        and self:IsBarsAndFramesRuntimeFeatureEnabled("resourceBars")
+        and self.EvaluateResourceBars then
+        self:EvaluateResourceBars({ reason = reason or "equipment-slot-refresh" })
+        if self.UpdateAnchorStacking then
+            self:UpdateAnchorStacking()
+        end
+    end
     self:RefreshConfigPanel()
 end
 

--- a/Core/SoundAlerts.lua
+++ b/Core/SoundAlerts.lua
@@ -359,6 +359,11 @@ function CooldownCompanion:GetScopedValidSoundAlertEventsForButton(buttonData, s
 end
 
 function CooldownCompanion:GetScopedValidSoundAlertEventsForCustomBar(customBar)
+    if ST._RB
+        and ST._RB.IsEquipmentSlotCustomBarConfig
+        and ST._RB.IsEquipmentSlotCustomBarConfig(customBar) == true then
+        return nil
+    end
     if type(customBar) ~= "table" or not customBar.spellID then
         return nil
     end
@@ -409,6 +414,12 @@ end
 
 function CooldownCompanion:GetCustomBarSoundAlertConfig(customBar, createIfMissing)
     if type(customBar) ~= "table" then return nil end
+    if ST._RB
+        and ST._RB.IsEquipmentSlotCustomBarConfig
+        and ST._RB.IsEquipmentSlotCustomBarConfig(customBar) == true then
+        customBar.soundAlerts = nil
+        return nil
+    end
     local cfg = customBar.soundAlerts
     if type(cfg) ~= "table" then
         if not createIfMissing then return nil end

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -1849,8 +1849,9 @@ function CooldownCompanion:ApplyResourceBars(opts)
     -- Append enabled Custom Bars
     local customBars = GetSpecCustomAuraBars(settings)
     local customBarLoadDefaults = CooldownCompanion:GetLocalLoadConditionDefaults()
+    local isCustomBarRuntimeEligible = RB.IsCustomBarRuntimeEligible
     for i, cab in ipairs(customBars) do
-        if cab and cab.enabled and cab.spellID
+        if cab and cab.enabled and (isCustomBarRuntimeEligible and isCustomBarRuntimeEligible(cab) or cab.spellID)
             and CooldownCompanion:IsTalentConditionMet(cab)
             and CooldownCompanion:EvaluateLoadConditions(cab.loadConditions, customBarLoadDefaults) then
             table.insert(filtered, {
@@ -2552,9 +2553,15 @@ function CooldownCompanion:GetResourceBarRuntimeDebugInfo()
             barType = barInfo.barType,
             shown = barInfo.frame and barInfo.frame:IsShown() or false,
         }
+        if barInfo.cabConfig then
+            entry.entryType = barInfo.cabConfig.entryType
+        end
         if barInfo.cabConfig and barInfo.cabConfig.spellID then
             entry.spellID = tonumber(barInfo.cabConfig.spellID) or barInfo.cabConfig.spellID
             entry.hideWhenInactive = barInfo.cabConfig.hideWhenInactive == true
+        elseif barInfo.cabConfig and barInfo.cabConfig.entryType == "equipmentSlot" then
+            entry.itemSlot = barInfo.cabConfig.itemSlot
+            entry.itemSlotKind = barInfo.cabConfig.itemSlotKind
         end
         info[#info + 1] = entry
     end

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -31,6 +31,8 @@ end
 
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
+local IsEquipmentSlotCustomBarConfig = RB.IsEquipmentSlotCustomBarConfig
+local BuildEquipmentSlotCustomBarButtonData = RB.BuildEquipmentSlotCustomBarButtonData
 local GetResourceDisplayValue = RB.GetResourceDisplayValue
 local GetResourceSegmentedSmoothing = RB.GetResourceSegmentedSmoothing
 local NormalizeCustomAuraStackTextFormat = RB.NormalizeCustomAuraStackTextFormat
@@ -143,6 +145,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
     local function ResolveSpellCustomBarAuraState(barInfo)
         local cabConfig = barInfo and barInfo.cabConfig
+        if IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig) then
+            return nil
+        end
         local bar = barInfo and barInfo.frame
         local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, false)
         if not (buttonData and spellID and bar) then
@@ -504,10 +509,144 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         )
     end
 
+    local function EvaluateEquipmentSlotCustomBarCooldown(cabConfig, bar)
+        local result = {
+            state = ST.CooldownLogic.STATE_READY,
+            source = "equipment-slot-ready",
+            fetchOk = false,
+            itemID = nil,
+            itemCooldownStart = 0,
+            itemCooldownDuration = 0,
+            deferred = false,
+            isOnGCD = false,
+        }
+        local buttonData = BuildEquipmentSlotCustomBarButtonData and BuildEquipmentSlotCustomBarButtonData(cabConfig)
+        if not buttonData then
+            result.source = "equipment-slot-invalid"
+            return result
+        end
+
+        local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+        result.effectiveItem = effectiveItem
+        result.itemID = effectiveItem and effectiveItem.itemID or nil
+        if not (effectiveItem and effectiveItem.trackable and effectiveItem.itemID) then
+            result.source = "equipment-slot-" .. tostring(effectiveItem and effectiveItem.reason or "unavailable")
+            if bar then
+                bar._customCooldownItemID = nil
+                bar._customCooldownEquipmentSlotTrackable = false
+            end
+            return result
+        end
+
+        local startTime, duration, enableCooldownTimer = C_Item.GetItemCooldown(effectiveItem.itemID)
+        startTime = tonumber(startTime) or 0
+        duration = tonumber(duration) or 0
+        result.fetchOk = true
+        result.itemCooldownStart = startTime
+        result.itemCooldownDuration = duration
+        result.enableCooldownTimer = enableCooldownTimer
+        if bar then
+            bar._customCooldownItemID = effectiveItem.itemID
+            bar._customCooldownEquipmentSlotTrackable = true
+        end
+
+        if not enableCooldownTimer and startTime > 0 then
+            result.state = ST.CooldownLogic.STATE_COOLDOWN
+            result.source = "equipment-slot-deferred"
+            result.itemCooldownStart = 0
+            result.itemCooldownDuration = 0
+            result.deferred = true
+            return result
+        end
+
+        local itemGCDOnly = ST.CooldownLogic.IsItemGCDOnly(startTime, duration, CooldownCompanion._gcdInfo)
+        result.isOnGCD = itemGCDOnly == true
+        if duration > 0 and not itemGCDOnly then
+            result.state = ST.CooldownLogic.STATE_COOLDOWN
+            result.source = "equipment-slot-cooldown"
+        else
+            result.source = itemGCDOnly and "equipment-slot-gcd" or "equipment-slot-ready"
+            result.itemCooldownStart = 0
+            result.itemCooldownDuration = 0
+        end
+        return result
+    end
+
+    local function UpdateEquipmentSlotCustomCooldownBar(barInfo)
+        local cabConfig = barInfo and barInfo.cabConfig
+        local bar = barInfo and barInfo.frame
+        if not (cabConfig and bar) then return end
+
+        local cooldownResult = EvaluateEquipmentSlotCustomBarCooldown(cabConfig, bar)
+        local cooldownActive = cooldownResult
+            and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
+        local barColor = cabConfig.barColor or {0.5, 0.5, 1, 1}
+        local cooldownColor = cabConfig.barCooldownColor or {0.6, 0.13, 0.18, 1}
+        local fillColor = cooldownActive and cooldownColor or barColor
+
+        bar._auraActive = nil
+        bar._auraInstanceID = nil
+        bar._auraUnit = nil
+        bar._inPandemic = nil
+        if barInfo then
+            barInfo._sndInitialized = nil
+            barInfo._sndTransitionOptions = nil
+        end
+        ClearCustomAuraBarIndicatorState(barInfo, false)
+        ClearResourceAuraVisuals(bar)
+
+        SetStatusBarSmoothRange(bar, 0, 1)
+        bar:SetStatusBarColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] ~= nil and fillColor[4] or 1)
+        local now = GetTime()
+        if cooldownActive and cooldownResult.itemCooldownDuration and cooldownResult.itemCooldownDuration > 0 then
+            local elapsed = now - (cooldownResult.itemCooldownStart or 0)
+            local fraction = elapsed / cooldownResult.itemCooldownDuration
+            if fraction < 0 then fraction = 0 end
+            if fraction > 1 then fraction = 1 end
+            SetStatusBarSmoothValue(bar, fraction)
+        elseif cooldownActive then
+            SetStatusBarImmediateValue(bar, 0)
+        else
+            SetStatusBarImmediateValue(bar, 1)
+        end
+
+        if bar.thresholdOverlay then
+            SetStatusBarImmediateValue(bar.thresholdOverlay, 0)
+            bar.thresholdOverlay:Hide()
+        end
+
+        if bar.text and bar.text:IsShown() then
+            if cooldownActive and cooldownResult.itemCooldownDuration and cooldownResult.itemCooldownDuration > 0 then
+                local remaining = (cooldownResult.itemCooldownStart or 0)
+                    + cooldownResult.itemCooldownDuration
+                    - now
+                if remaining and remaining > 0 then
+                    bar.text:SetText(FormatTime(remaining, cabConfig))
+                else
+                    bar.text:SetText("")
+                end
+            else
+                bar.text:SetText("")
+            end
+        end
+        if bar.stackText and bar.stackText:IsShown() then
+            bar.stackText:SetText("")
+        end
+        if barInfo._maxStacksIndicator then
+            SetStatusBarImmediateValue(barInfo._maxStacksIndicator, 0)
+        end
+    end
+
     function RB.UpdateCustomCooldownBar(barInfo)
         local cabConfig = barInfo and barInfo.cabConfig
         local bar = barInfo and barInfo.frame
-        if not (cabConfig and cabConfig.spellID and bar) then return end
+        if not (cabConfig and bar) then return end
+        if IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig) then
+            UpdateEquipmentSlotCustomCooldownBar(barInfo)
+            return
+        end
+        if not cabConfig.spellID then return end
 
         local cooldownResult = EntryRuntime.EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
@@ -712,7 +851,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     end
 
     local function GetHiddenCustomAuraWakeUnit(cabConfig)
-        if not cabConfig or not cabConfig.spellID then
+        if not cabConfig
+            or not cabConfig.spellID
+            or (IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig)) then
             return nil
         end
         return EnsureCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
@@ -741,6 +882,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         local isTrackedSpellBar = barInfo.barType == "custom_cooldown"
+            and not (IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig))
             and cabConfig.auraTracking == true
         local isActiveAuraBar = barInfo.barType == "custom_continuous"
             and cabConfig.trackingMode == "active"
@@ -893,7 +1035,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     local function StyleCustomAuraBar(barInfo, cabConfig)
         local barColor = cabConfig.barColor or {0.5, 0.5, 1}
         local isSpellCustomBar = RB.IsSpellCustomBarConfig(cabConfig)
-        local thresholdEnabled = (not isSpellCustomBar) and IsCustomAuraMaxThresholdEnabled(cabConfig)
+        local isEquipmentSlotCustomBar = IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig)
+        local isCooldownCustomBar = isSpellCustomBar or isEquipmentSlotCustomBar
+        local thresholdEnabled = (not isCooldownCustomBar) and IsCustomAuraMaxThresholdEnabled(cabConfig)
         local thresholdColor = GetCustomAuraMaxThresholdColor(cabConfig)
 
         if barInfo.barType == "custom_continuous" or barInfo.barType == "custom_cooldown" then
@@ -907,14 +1051,16 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             end
 
             -- Determine visibility for both text elements
-            local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+            local spellAuraStackDisplay = (not isEquipmentSlotCustomBar) and RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
             local spellAuraStackActive = spellAuraStackDisplay and barInfo.barType ~= "custom_cooldown"
-            local isActive = isSpellCustomBar and not spellAuraStackActive
-                or ((not isSpellCustomBar) and cabConfig.trackingMode == "active")
+            local isActive = isCooldownCustomBar and not spellAuraStackActive
+                or ((not isCooldownCustomBar) and cabConfig.trackingMode == "active")
             local showDuration = cabConfig.showDurationText == true and not spellAuraStackActive
             local showStack = cabConfig.showStackText
             if isSpellCustomBar then
                 showStack = showStack == true
+            elseif isEquipmentSlotCustomBar then
+                showStack = false
             elseif showStack == nil then
                 -- Backwards compat: fall back to showText for stacks mode
                 if not isActive then
@@ -1074,20 +1220,22 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
         customBarId = customBarId or RB.EnsureCustomBarId(settings, cabConfig)
         local isSpellCustomBar = RB.IsSpellCustomBarConfig(cabConfig)
-        local spellAuraStackDisplay = RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
+        local isEquipmentSlotCustomBar = IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig)
+        local isCooldownCustomBar = isSpellCustomBar or isEquipmentSlotCustomBar
+        local spellAuraStackDisplay = isSpellCustomBar and RB.IsSpellCustomBarAuraStackDisplay(cabConfig)
         local spellAuraStackPresent = spellAuraStackDisplay and GetPreviewActive()
         if spellAuraStackDisplay and not spellAuraStackPresent and barInfo and barInfo.frame then
             local auraState = ResolveSpellCustomBarAuraState(barInfo)
             spellAuraStackPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         end
         local spellAuraStackActive = spellAuraStackDisplay and spellAuraStackPresent
-        local isActive = (isSpellCustomBar and not spellAuraStackActive)
-            or ((not isSpellCustomBar) and cabConfig.trackingMode == "active")
-        local mode = isSpellCustomBar
+        local isActive = (isCooldownCustomBar and not spellAuraStackActive)
+            or ((not isCooldownCustomBar) and cabConfig.trackingMode == "active")
+        local mode = isCooldownCustomBar
             and (spellAuraStackActive and (cabConfig.displayMode or "segmented") or "continuous")
             or (isActive and "continuous" or (cabConfig.displayMode or "segmented"))
         local maxStacks = isActive and 1 or (cabConfig.maxStacks or 1)
-        local targetBarType = (isSpellCustomBar and not spellAuraStackActive)
+        local targetBarType = (isCooldownCustomBar and not spellAuraStackActive)
             and "custom_cooldown"
             or ("custom_" .. mode)
         local customOrientation = isVerticalLayout and "vertical" or "horizontal"
@@ -1228,7 +1376,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         StyleCustomAuraBar(barInfo, cabConfig)
 
         if cabConfig.maxStacksGlowEnabled then
-            if isSpellCustomBar then
+            if isCooldownCustomBar then
                 ClearMaxStacksIndicator(barInfo)
             else
                 EnsureMaxStacksIndicator(barInfo)

--- a/OtherBars/ResourceBarHelpers.lua
+++ b/OtherBars/ResourceBarHelpers.lua
@@ -205,6 +205,8 @@ end
 
 local customBarContentFields = {
     "spellID",
+    "itemSlot",
+    "itemSlotKind",
     "trackingMode",
     "displayMode",
     "maxStacks",
@@ -302,7 +304,128 @@ local function IsConfiguredCustomBar(cab)
         )
 end
 
+local function ParseEquipmentSlotCustomBarStableKey(value)
+    if type(value) ~= "string" then
+        return nil
+    end
+    local slotKind, slotText = value:match("^equipmentSlot:([^:]+):([^:]+)$")
+    local itemSlot = tonumber(slotText)
+    if slotKind == CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET
+        and (itemSlot == CooldownCompanion.TRINKET_SLOT_1 or itemSlot == CooldownCompanion.TRINKET_SLOT_2) then
+        return itemSlot, slotKind
+    end
+    return nil
+end
+
+local function IsValidEquipmentSlotCustomBarIdentity(cab)
+    if type(cab) ~= "table" then
+        return false
+    end
+    local itemSlot = tonumber(cab.itemSlot)
+    return cab.itemSlotKind == CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET
+        and (itemSlot == CooldownCompanion.TRINKET_SLOT_1 or itemSlot == CooldownCompanion.TRINKET_SLOT_2)
+end
+
+local function ClearEquipmentSlotCustomBarInapplicableFields(cab)
+    cab.spellID = nil
+    cab.auraSpellID = nil
+    cab.auraTracking = nil
+    cab.auraUnit = nil
+    cab.auraUnitExplicit = nil
+    cab.trackingMode = nil
+    cab.displayMode = nil
+    cab.maxStacks = nil
+    cab.hasCharges = nil
+    cab.maxCharges = nil
+    cab.hideWhenInactive = nil
+    cab.hideWhileAuraActive = nil
+    cab.hideAuraActiveExceptPandemic = nil
+    cab.soundAlerts = nil
+    cab.showText = nil
+    cab.showStackText = nil
+    cab.stackTextFormat = nil
+    cab.stackTextFont = nil
+    cab.stackTextFontSize = nil
+    cab.stackTextFontOutline = nil
+    cab.stackTextFontColor = nil
+    cab.barChargeColor = nil
+    cab.thresholdColorEnabled = nil
+    cab.thresholdMaxColor = nil
+    cab.maxStacksGlowEnabled = nil
+    cab.maxStacksGlowStyle = nil
+    cab.maxStacksGlowColor = nil
+    cab.maxStacksGlowSize = nil
+    cab.maxStacksGlowSpeed = nil
+    cab.maxStacksGlowThickness = nil
+    cab.barAuraColor = nil
+    cab.barAuraEffect = nil
+    cab.barAuraEffectColor = nil
+    cab.barAuraEffectSize = nil
+    cab.barAuraEffectThickness = nil
+    cab.barAuraEffectSpeed = nil
+    cab.barAuraEffectLines = nil
+    cab.auraGlowCombatOnly = nil
+    cab.barAuraPulseEnabled = nil
+    cab.barAuraPulseSpeed = nil
+    cab.barAuraColorShiftEnabled = nil
+    cab.barAuraColorShiftSpeed = nil
+    cab.barAuraColorShiftColor = nil
+    cab.showPandemicGlow = nil
+    cab.barPandemicColor = nil
+    cab.pandemicBarEffect = nil
+    cab.pandemicBarEffectColor = nil
+    cab.pandemicBarEffectSize = nil
+    cab.pandemicBarEffectThickness = nil
+    cab.pandemicBarEffectSpeed = nil
+    cab.pandemicBarEffectLines = nil
+    cab.pandemicGlowCombatOnly = nil
+    cab.pandemicBarPulseEnabled = nil
+    cab.pandemicBarPulseSpeed = nil
+    cab.pandemicBarColorShiftEnabled = nil
+    cab.pandemicBarColorShiftSpeed = nil
+    cab.pandemicBarColorShiftColor = nil
+end
+
+local function NormalizeEquipmentSlotCustomBarConfig(cab)
+    if type(cab) ~= "table" then
+        return false
+    end
+
+    local stableSlot, stableKind = ParseEquipmentSlotCustomBarStableKey(cab.spellID)
+    if stableSlot then
+        cab.itemSlot = stableSlot
+        cab.itemSlotKind = stableKind
+    end
+
+    if cab.entryType == "equipmentSlot" or stableSlot then
+        local itemSlot = tonumber(cab.itemSlot)
+        cab.entryType = "equipmentSlot"
+        cab.itemSlot = itemSlot
+        cab.itemSlotKind = cab.itemSlotKind or CooldownCompanion.EQUIPMENT_SLOT_KIND_TRINKET
+        if not IsValidEquipmentSlotCustomBarIdentity(cab) then
+            return false
+        end
+        if not cab.label or cab.label == "" then
+            local buttonData = {
+                type = CooldownCompanion.EQUIPMENT_SLOT_TYPE,
+                itemSlot = itemSlot,
+                itemSlotKind = cab.itemSlotKind,
+            }
+            cab.label = CooldownCompanion.GetEquipmentSlotDisplayName
+                and CooldownCompanion.GetEquipmentSlotDisplayName(buttonData)
+                or ("Trinket Slot " .. (itemSlot == CooldownCompanion.TRINKET_SLOT_2 and "2" or "1"))
+        end
+        ClearEquipmentSlotCustomBarInapplicableFields(cab)
+        return true
+    end
+
+    return false
+end
+
 local function GetCustomBarEntryType(cab)
+    if NormalizeEquipmentSlotCustomBarConfig(cab) then
+        return "equipmentSlot"
+    end
     if type(cab) == "table" and cab.entryType == "spell" then
         return "spell"
     end
@@ -311,6 +434,64 @@ end
 
 local function IsSpellCustomBarConfig(cab)
     return GetCustomBarEntryType(cab) == "spell"
+end
+
+local function IsEquipmentSlotCustomBarConfig(cab)
+    return GetCustomBarEntryType(cab) == "equipmentSlot"
+end
+
+local function GetCustomBarSourceKind(cab)
+    return GetCustomBarEntryType(cab)
+end
+
+local function IsCustomBarRuntimeEligible(cab)
+    if type(cab) ~= "table" then
+        return false
+    end
+    if IsEquipmentSlotCustomBarConfig(cab) then
+        return true
+    end
+    return cab.spellID ~= nil
+end
+
+local function BuildEquipmentSlotCustomBarButtonData(cab)
+    if not IsEquipmentSlotCustomBarConfig(cab) then
+        return nil
+    end
+    local buttonData = {
+        type = CooldownCompanion.EQUIPMENT_SLOT_TYPE,
+        itemSlot = tonumber(cab.itemSlot),
+        itemSlotKind = cab.itemSlotKind,
+        name = cab.label,
+    }
+    if CooldownCompanion.IsEquipmentSlotEntry
+        and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        return buttonData
+    end
+    return nil
+end
+
+local function GetEquipmentSlotCustomBarDisplayName(cab)
+    local buttonData = BuildEquipmentSlotCustomBarButtonData(cab)
+    if not buttonData then
+        return nil
+    end
+    local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+        and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+    return (effectiveItem and effectiveItem.itemName)
+        or (CooldownCompanion.GetEquipmentSlotDisplayName
+            and CooldownCompanion.GetEquipmentSlotDisplayName(buttonData))
+        or cab.label
+end
+
+local function GetEquipmentSlotCustomBarIcon(cab)
+    local buttonData = BuildEquipmentSlotCustomBarButtonData(cab)
+    if not buttonData then
+        return nil
+    end
+    local effectiveItem = CooldownCompanion.ResolveEffectiveItem
+        and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+    return effectiveItem and effectiveItem.icon or 134400
 end
 
 local function GetCustomBarTrackingMode(cab, isSpellCustomBar)
@@ -332,6 +513,9 @@ end
 local function NormalizeCustomBarEntryType(cab)
     if type(cab) ~= "table" then
         return "aura"
+    end
+    if NormalizeEquipmentSlotCustomBarConfig(cab) then
+        return cab.entryType
     end
     cab.entryType = GetCustomBarEntryType(cab)
     return cab.entryType
@@ -1202,6 +1386,9 @@ local function HasExplicitCustomAuraBarAuraUnit(cabConfig)
 end
 
 local function GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
+    if IsEquipmentSlotCustomBarConfig(cabConfig) then
+        return nil
+    end
     local resolvedSpellID = spellID
     if resolvedSpellID == nil and type(cabConfig) == "table" then
         resolvedSpellID = cabConfig.spellID
@@ -1219,6 +1406,9 @@ local function GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
 end
 
 local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit, explicit)
+    if IsEquipmentSlotCustomBarConfig(cabConfig) then
+        return nil
+    end
     local resolvedSpellID = spellID
     if resolvedSpellID == nil and type(cabConfig) == "table" then
         resolvedSpellID = cabConfig.spellID
@@ -1246,6 +1436,9 @@ local function EnsureCustomAuraBarAuraUnit(cabConfig, spellID, unit, explicit)
 end
 
 local function RefreshCustomAuraBarAuraUnitForSpell(cabConfig, spellID)
+    if IsEquipmentSlotCustomBarConfig(cabConfig) then
+        return nil
+    end
     local resolvedSpellID = spellID
     if resolvedSpellID == nil and type(cabConfig) == "table" then
         resolvedSpellID = cabConfig.spellID
@@ -2096,6 +2289,14 @@ RB.EnsureCustomBarLayout = EnsureCustomBarLayout
 RB.IsConfiguredCustomBar = IsConfiguredCustomBar
 RB.GetCustomBarEntryType = GetCustomBarEntryType
 RB.IsSpellCustomBarConfig = IsSpellCustomBarConfig
+RB.IsEquipmentSlotCustomBarConfig = IsEquipmentSlotCustomBarConfig
+RB.GetCustomBarSourceKind = GetCustomBarSourceKind
+RB.IsCustomBarRuntimeEligible = IsCustomBarRuntimeEligible
+RB.ParseEquipmentSlotCustomBarStableKey = ParseEquipmentSlotCustomBarStableKey
+RB.NormalizeEquipmentSlotCustomBarConfig = NormalizeEquipmentSlotCustomBarConfig
+RB.BuildEquipmentSlotCustomBarButtonData = BuildEquipmentSlotCustomBarButtonData
+RB.GetEquipmentSlotCustomBarDisplayName = GetEquipmentSlotCustomBarDisplayName
+RB.GetEquipmentSlotCustomBarIcon = GetEquipmentSlotCustomBarIcon
 RB.GetCustomBarTrackingMode = GetCustomBarTrackingMode
 RB.IsSpellCustomBarAuraStackDisplay = IsSpellCustomBarAuraStackDisplay
 RB.IsValidCustomAuraUnit = IsValidCustomAuraUnit

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -18,6 +18,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
     local GetEffectiveAnchorGroupId = deps.GetEffectiveAnchorGroupId or RB.GetEffectiveAnchorGroupId
     local GetResourcePrimaryLength = deps.GetResourcePrimaryLength or RB.GetResourcePrimaryLength
     local GetResolvedCustomAuraBarAuraUnit = deps.GetResolvedCustomAuraBarAuraUnit or RB.GetResolvedCustomAuraBarAuraUnit
+    local IsEquipmentSlotCustomBarConfig = deps.IsEquipmentSlotCustomBarConfig or RB.IsEquipmentSlotCustomBarConfig
     local GetLastAppliedPrimaryLength = deps.GetLastAppliedPrimaryLength
     local UpdateMWMaxStacks = deps.UpdateMWMaxStacks
     local RefreshEventDrivenCustomAuraBarsForUnit = deps.RefreshEventDrivenCustomAuraBarsForUnit
@@ -42,6 +43,9 @@ function RB.CreateResourceBarLifecycleModule(deps)
 
     local function IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
         if not (barInfo and cabConfig) then return false end
+        if IsEquipmentSlotCustomBarConfig and IsEquipmentSlotCustomBarConfig(cabConfig) then
+            return false
+        end
         return barInfo.barType == "custom_continuous"
             or barInfo.barType == "custom_segmented"
             or barInfo.barType == "custom_overlay"
@@ -142,28 +146,29 @@ function RB.CreateResourceBarLifecycleModule(deps)
                         for _, barInfo in ipairs(resourceBarFrames) do
                             local bar = barInfo and barInfo.frame
                             local cabConfig = barInfo and barInfo.cabConfig
-                            local configUnit = cabConfig and GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
                             if IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
-                                and bar
-                                and (bar._auraUnit == unit or configUnit == unit) then
-                                if removedIDSet
-                                    and bar._auraInstanceID
-                                    and bar._auraUnit == unit
-                                    and removedIDSet[bar._auraInstanceID] then
-                                    ClearCustomBarAuraRuntime(bar, configUnit)
-                                    bar._auraEventRemoved = true
-                                end
-                                if updatedIDSet
-                                    and bar._auraInstanceID
-                                    and bar._auraUnit == unit
-                                    and updatedIDSet[bar._auraInstanceID] then
-                                    bar._inPandemic = false
-                                    bar._pandemicGraceStart = nil
-                                    bar._pandemicGraceSuppressed = true
-                                end
-                                if unit == "target" and bar._targetSwitchAt then
-                                    bar._targetSwitchDataReceived = true
-                                    targetSwitchDataReceived = true
+                                and bar then
+                                local configUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
+                                if bar._auraUnit == unit or configUnit == unit then
+                                    if removedIDSet
+                                        and bar._auraInstanceID
+                                        and bar._auraUnit == unit
+                                        and removedIDSet[bar._auraInstanceID] then
+                                        ClearCustomBarAuraRuntime(bar, configUnit)
+                                        bar._auraEventRemoved = true
+                                    end
+                                    if updatedIDSet
+                                        and bar._auraInstanceID
+                                        and bar._auraUnit == unit
+                                        and updatedIDSet[bar._auraInstanceID] then
+                                        bar._inPandemic = false
+                                        bar._pandemicGraceStart = nil
+                                        bar._pandemicGraceSuppressed = true
+                                    end
+                                    if unit == "target" and bar._targetSwitchAt then
+                                        bar._targetSwitchDataReceived = true
+                                        targetSwitchDataReceived = true
+                                    end
                                 end
                             end
                         end


### PR DESCRIPTION
## What Players Will Notice
- Trinket Slot 1 and Trinket Slot 2 can now be added as Custom Bars in Bars and Frames instead of only working in bar panels.
- Adding a trinket slot as a Custom Bar no longer routes the slot through spell/aura lookup, which prevents the `C_Spell.GetBaseSpell` error spam from malformed slot entries.
- Custom Bar rows for trinket slots show the equipped trinket name/icon when item data is available and update when the equipped trinket changes.

## Why This Changed
- The previous trinket-slot panel support allowed slot entries to exist, but Custom Bars still assumed entries were spells or auras. A saved slot key like `equipmentSlot:trinket:13` could be treated as a spell ID and reach spell-only APIs.
- Sound alerts for equipment-slot Custom Bars are intentionally deferred, so this PR keeps those controls and runtime paths disabled for trinket slots.

## What Changed
- Added a canonical equipment-slot Custom Bar model using `entryType="equipmentSlot"`, `itemSlot`, and `itemSlotKind`, with normalization for older malformed slot-shaped entries stored in `spellID`.
- Updated Custom Bar add/list/settings, layout preview, import/diagnostic fields, and tab availability so equipment-slot bars do not expose aura indicator or sound-alert controls.
- Added runtime handling that resolves the effective equipped trinket and reads cooldown state through `C_Item.GetItemCooldown`, while skipping spell cooldown, aura unit, and hidden aura wake paths.
- Refreshed resource bars when trinket equipment or item data changes so slot-based Custom Bars follow swaps and data loads.

## Validation
- `luac -p` on the touched Lua files passed.
- `git diff --check origin/main...HEAD` passed.
- `lua tests/custom-bar-equipment-slot.lua` passed locally as an ignored focused support harness.
- `lua tests/equipment-slot-trinkets.lua` passed.
- `lua tests/sound-alert-events.lua` passed.
- `lua tests/resource-settings-ui-shape.lua` passed.
- `lua tests/resource-settings-helpers.lua` passed.
- `lua tests/resource-settings-selection.lua` passed.
- Full local Lua test-folder execution was attempted, but it still includes unrelated existing failures in aura/pandemic tests plus a missing `Core/FuryWhirlwindPrediction.lua` fixture, so it was not used as a pass signal for this PR.
- In-game combat and restricted-content validation has not been performed yet; trinket-slot Custom Bars still need runtime testing in WoW before this should be considered ready.