### PR TITLE
Support EllesmereUI unit-frame anchoring

### DIFF
--- a/ConfigSettings/FrameAnchoringPanels.lua
+++ b/ConfigSettings/FrameAnchoringPanels.lua
@@ -24,10 +24,11 @@ local UNIT_FRAME_OPTIONS = {
     blizzard     = "Blizzard Default",
     uuf          = "UnhaltedUnitFrames",
     elvui        = "ElvUI",
+    ellesmere    = "EllesmereUI Unit Frames",
     msuf         = "Midnight Simple Unit Frames",
     custom       = "Custom",
 }
-local UNIT_FRAME_ORDER = { "", "blizzard", "uuf", "elvui", "msuf", "custom" }
+local UNIT_FRAME_ORDER = { "", "blizzard", "uuf", "elvui", "ellesmere", "msuf", "custom" }
 
 local function ValidateCustomUnitFrameName(frameName)
     if not frameName or frameName == "" then

--- a/Core/FrameAnchoring.lua
+++ b/Core/FrameAnchoring.lua
@@ -1,7 +1,7 @@
 --[[
     CooldownCompanion - FrameAnchoring
-    Anchors player and target unit frames (Blizzard, ElvUI, UnhaltedUnitFrames,
-    or custom) to icon groups.
+    Anchors player and target unit frames (Blizzard, ElvUI, EllesmereUI,
+    UnhaltedUnitFrames, Midnight Simple Unit Frames, or custom) to icon groups.
 
     Some unit frame addons (e.g., UnhaltedUnitFrames) use secure templates,
     making their frames protected during combat. All positioning (SetPoint/
@@ -56,10 +56,16 @@ end
 -- Constants
 ------------------------------------------------------------------------
 
-local FRAME_PAIRS = {
+local UNIT_FRAME_PROVIDERS = {
     blizzard = { player = "PlayerFrame",  target = "TargetFrame" },
     uuf      = { player = "UUF_Player",   target = "UUF_Target" },
     elvui    = { player = "ElvUF_Player",  target = "ElvUF_Target" },
+    ellesmere = {
+        families = {
+            { player = "EllesmereUIUnitFrames_Player",  target = "EllesmereUIUnitFrames_Target" },
+            { player = "EUIStandaloneUnitFrames_Player", target = "EUIStandaloneUnitFrames_Target" },
+        },
+    },
     msuf     = { player = "MSUF_player",  target = "MSUF_target" },
 }
 
@@ -179,8 +185,36 @@ local function InstallInheritedAlphaSetHook(frame)
     alphaSetHooksInstalled[frame] = true
 end
 
+local function ResolveUnitFrameFamily(family)
+    if not family then
+        return nil, nil
+    end
+    return _G[family.player], _G[family.target]
+end
+
+local function ResolveUnitFrameProvider(provider)
+    if not provider then
+        return nil, nil
+    end
+
+    local families = provider.families
+    if type(families) == "table" then
+        for _, family in ipairs(families) do
+            local playerFrame, targetFrame = ResolveUnitFrameFamily(family)
+            if playerFrame or targetFrame then
+                return playerFrame, targetFrame
+            end
+        end
+        return nil, nil
+    end
+
+    return ResolveUnitFrameFamily(provider)
+end
+
 --- Auto-detect which unit frame addon is active.
 local function AutoDetectUnitFrameAddon()
+    local ellesmerePlayerFrame, ellesmereTargetFrame = ResolveUnitFrameProvider(UNIT_FRAME_PROVIDERS.ellesmere)
+    if ellesmerePlayerFrame or ellesmereTargetFrame then return "ellesmere" end
     if _G["ElvUF_Player"] then return "elvui" end
     if _G["UUF_Player"] then return "uuf" end
     if _G["MSUF_player"] then return "msuf" end
@@ -219,10 +253,9 @@ local function GetUnitFrames(settings)
         playerFrame = _G["MSUF_player"] or (unitFrames and unitFrames.player)
         targetFrame = _G["MSUF_target"] or (unitFrames and unitFrames.target)
     else
-        local pair = FRAME_PAIRS[addon]
-        if pair then
-            playerFrame = _G[pair.player]
-            targetFrame = _G[pair.target]
+        local provider = UNIT_FRAME_PROVIDERS[addon]
+        if provider then
+            playerFrame, targetFrame = ResolveUnitFrameProvider(provider)
         end
     end
 

--- a/Core/FrameAnchoring.lua
+++ b/Core/FrameAnchoring.lua
@@ -192,29 +192,78 @@ local function ResolveUnitFrameFamily(family)
     return _G[family.player], _G[family.target]
 end
 
-local function ResolveUnitFrameProvider(provider)
+local function IsAutoDetectableUnitFrame(frame)
+    if not frame then
+        return false
+    end
+
+    if frame.GetAttribute then
+        local unit = frame:GetAttribute("unit")
+        if issecretvalue(unit) then
+            return false
+        end
+        if type(unit) == "string" and unit ~= "" then
+            return true
+        end
+    end
+
+    if frame.IsShown then
+        local shown = frame:IsShown()
+        if issecretvalue(shown) then
+            return false
+        end
+        return shown == true
+    end
+
+    return false
+end
+
+local function HasAutoDetectableUnitFrame(playerFrame, targetFrame)
+    return IsAutoDetectableUnitFrame(playerFrame) or IsAutoDetectableUnitFrame(targetFrame)
+end
+
+local function ResolveUnitFrameProvider(provider, options)
     if not provider then
         return nil, nil
     end
+    options = options or {}
 
     local families = provider.families
     if type(families) == "table" then
+        local fallbackPlayerFrame, fallbackTargetFrame
         for _, family in ipairs(families) do
             local playerFrame, targetFrame = ResolveUnitFrameFamily(family)
             if playerFrame or targetFrame then
-                return playerFrame, targetFrame
+                if not fallbackPlayerFrame and not fallbackTargetFrame then
+                    fallbackPlayerFrame, fallbackTargetFrame = playerFrame, targetFrame
+                end
+                if HasAutoDetectableUnitFrame(playerFrame, targetFrame) then
+                    return playerFrame, targetFrame
+                end
             end
+        end
+        if not options.requireAutoDetectable then
+            return fallbackPlayerFrame, fallbackTargetFrame
         end
         return nil, nil
     end
 
-    return ResolveUnitFrameFamily(provider)
+    local playerFrame, targetFrame = ResolveUnitFrameFamily(provider)
+    if options.requireAutoDetectable and not HasAutoDetectableUnitFrame(playerFrame, targetFrame) then
+        return nil, nil
+    end
+    return playerFrame, targetFrame
 end
 
 --- Auto-detect which unit frame addon is active.
 local function AutoDetectUnitFrameAddon()
-    local ellesmerePlayerFrame, ellesmereTargetFrame = ResolveUnitFrameProvider(UNIT_FRAME_PROVIDERS.ellesmere)
-    if ellesmerePlayerFrame or ellesmereTargetFrame then return "ellesmere" end
+    local ellesmerePlayerFrame, ellesmereTargetFrame = ResolveUnitFrameProvider(
+        UNIT_FRAME_PROVIDERS.ellesmere,
+        { requireAutoDetectable = true }
+    )
+    if ellesmerePlayerFrame or ellesmereTargetFrame then
+        return "ellesmere"
+    end
     if _G["ElvUF_Player"] then return "elvui" end
     if _G["UUF_Player"] then return "uuf" end
     if _G["MSUF_player"] then return "msuf" end
@@ -366,6 +415,10 @@ function CooldownCompanion:ApplyFrameAnchoring(opts)
     if not playerFrame and not targetFrame then
         self:RevertFrameAnchoring()
         return
+    end
+
+    if isApplied and (playerFrameRef ~= playerFrame or targetFrameRef ~= targetFrame) then
+        self:RevertFrameAnchoring()
     end
 
     if (playerFrame and WouldFrameDependOn(groupFrame, playerFrame))


### PR DESCRIPTION
## What Players Will Notice
- Frame Anchoring now includes a single `EllesmereUI Unit Frames` option for both the full EllesmereUI addon and the standalone EllesmereUI Unit Frames package.
- Auto-detect can choose the active Ellesmere player/target frames while avoiding disabled hidden placeholders, and switching between the integrated and standalone frame families restores the previous anchors cleanly.

## Why This Changed
- EllesmereUI exposes the same unit-frame feature through two different addon packages with different global frame names, so Cooldown Companion needed one user-facing option that recognizes both without making players pick the implementation detail.
- Ellesmere can also leave disabled frame placeholders around, so detection needs to prefer frames that look active instead of anchoring hidden placeholders.

## What Changed
- Added the `ellesmere` frame-anchoring provider and dropdown option, covering `EllesmereUIUnitFrames_Player/Target` and `EUIStandaloneUnitFrames_Player/Target` under one label.
- Reworked unit-frame provider resolution so Ellesmere auto-detect prefers the first active/detectable family, falls through to other frame addons when Ellesmere placeholders are disabled, and still supports explicit Ellesmere selection.
- Added safe active-frame checks using `unit` attributes first and `IsShown()` as a guarded fallback.
- Reverted saved anchor state before reapplying when the resolved player/target frame refs change, preventing stale anchors when moving between Ellesmere frame families.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Core\FrameAnchoring.lua ConfigSettings\FrameAnchoringPanels.lua tests\frame-anchoring-unit-frame-detection.lua`
- `lua tests\frame-anchoring-unit-frame-detection.lua`
- Checked the installed retail EllesmereUI and standalone EllesmereUI Unit Frames sources for the added frame globals and oUF spawn behavior.
- Verified WoW MCP `Frame` widget metadata for `GetAttribute` and `IsShown`.
- In-game validation with both Ellesmere distributions, including combat and restricted-content behavior, is still pending.
