### PR TITLE
Keep pandemic glow stable through aura updates

### DIFF
--- a/ButtonFrame/BarMode.lua
+++ b/ButtonFrame/BarMode.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local EntryRuntime = ST.EntryRuntime
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
@@ -1872,8 +1873,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._barAuraVisualSettings = nil
     ClearBarAuraStackVisual(button)
     button._inPandemic = nil
-    button._pandemicGraceStart = nil
-    button._pandemicGraceSuppressed = nil
+    EntryRuntime.ClearAuraPandemicRuntimeState(button)
     button._viewerAuraVisualsActive = nil
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil

--- a/ButtonFrame/CooldownUpdate.lua
+++ b/ButtonFrame/CooldownUpdate.lua
@@ -115,7 +115,7 @@ local function ClearConditionalVisualPreviewFields(button)
         local buttonData = button.buttonData
         if not (buttonData and buttonData.auraTracking) then
             button._inPandemic = false
-            button._pandemicGraceStart = nil
+            EntryRuntime.ClearAuraPandemicRuntimeState(button)
         end
     end
     button._conditionalPreviewKind = nil
@@ -1028,6 +1028,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             now = now,
             enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic),
             previewActive = button._pandemicPreview == true,
+            clearWhenDisabled = true,
+            auraState = auraState,
         })
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local EntryRuntime = ST.EntryRuntime
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
@@ -1314,8 +1315,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 
     button._auraInstanceID = nil
     button._inPandemic = nil
-    button._pandemicGraceStart = nil
-    button._pandemicGraceSuppressed = nil
+    EntryRuntime.ClearAuraPandemicRuntimeState(button)
     button._viewerAuraVisualsActive = nil
     button._auraDisplayName = nil
     button._auraNameOverrideActive = nil

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -7,6 +7,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 
 -- Imports from Glows
 local SetBarAuraEffect = ST._SetBarAuraEffect
@@ -300,7 +301,7 @@ local function ClearConditionalVisualPreviewDerivedFields(button)
     end
     if button._conditionalPandemicPreview then
         button._inPandemic = false
-        button._pandemicGraceStart = nil
+        EntryRuntime.ClearAuraPandemicRuntimeState(button)
     end
     button._conditionalPreviewKind = nil
     button._conditionalPreviewStartTime = nil

--- a/Core/Aura.lua
+++ b/Core/Aura.lua
@@ -494,17 +494,15 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
                 if removedIDSet and removedIDSet[button._auraInstanceID] then
                     button._auraInstanceID = nil
                     button._inPandemic = false
+                    EntryRuntime.ClearAuraPandemicRuntimeState(button)
                     button._auraEventRemoved = true
                 end
-                -- Aura reapplication (pandemic refresh) arrives as an update, not a
-                -- removal + add.  Clear pandemic state and suppress the grace hold so
-                -- the next evaluation clears pandemic immediately instead of holding 0.3s.
+                -- Updates are dirty signals, not proof of refresh. Let the shared
+                -- resolver compare fresh semantic range and readable aura timing.
                 if updatedIDSet
                     and button._auraInstanceID
                     and updatedIDSet[button._auraInstanceID] then
-                    button._inPandemic = false
-                    button._pandemicGraceStart = nil
-                    button._pandemicGraceSuppressed = true
+                    EntryRuntime.MarkAuraPandemicStateDirty(button, unit, button._auraInstanceID)
                 end
             end
             -- Signal that the server has delivered target aura data, so the hold

--- a/Core/EntryRuntime.lua
+++ b/Core/EntryRuntime.lua
@@ -353,6 +353,245 @@ local function AuraDataMatchesTrackedSpell(owner, buttonData, auraSpellID, auraD
 end
 EntryRuntime.AuraDataMatchesTrackedSpell = AuraDataMatchesTrackedSpell
 
+local function GetReadableAuraTiming(auraData)
+    local auraDataSecret = issecretvalue(auraData)
+    if auraDataSecret or auraData == nil then
+        return nil, nil, false
+    end
+
+    local expirationTime = auraData.expirationTime
+    local duration = auraData.duration
+    local expirationSecret = issecretvalue(expirationTime)
+    local durationSecret = issecretvalue(duration)
+    if expirationSecret or durationSecret then
+        return nil, nil, false
+    end
+    if expirationTime == nil or duration == nil then
+        return nil, nil, false
+    end
+
+    return expirationTime, duration, true
+end
+
+local function ClearAcceptedPandemicRange(owner)
+    if not owner then return end
+
+    owner._pandemicLatchUnit = nil
+    owner._pandemicLatchAuraInstanceID = nil
+    owner._pandemicLatchStart = nil
+    owner._pandemicLatchEnd = nil
+    owner._pandemicLatchAuraExpirationTime = nil
+    owner._pandemicLatchAuraDuration = nil
+end
+
+local function ClearAuraPandemicRuntimeState(owner)
+    if not owner then return end
+
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    owner._pandemicDirtyUnit = nil
+    owner._pandemicDirtyAuraInstanceID = nil
+    ClearAcceptedPandemicRange(owner)
+    owner._pandemicSuppressedUnit = nil
+    owner._pandemicSuppressedAuraInstanceID = nil
+    owner._pandemicSuppressedStart = nil
+    owner._pandemicSuppressedEnd = nil
+end
+EntryRuntime.ClearAuraPandemicRuntimeState = ClearAuraPandemicRuntimeState
+
+local function ClearAuraPandemicDirtyState(owner)
+    if not owner then return end
+
+    owner._pandemicDirtyUnit = nil
+    owner._pandemicDirtyAuraInstanceID = nil
+end
+
+function EntryRuntime.MarkAuraPandemicStateDirty(owner, unit, auraInstanceID)
+    if not owner then return end
+
+    owner._pandemicDirtyUnit = unit
+    owner._pandemicDirtyAuraInstanceID = auraInstanceID
+end
+
+local function GetReadablePandemicRange(viewerFrame)
+    if not viewerFrame then
+        return nil, nil, false
+    end
+
+    local startTime = viewerFrame.pandemicStartTime
+    local endTime = viewerFrame.pandemicEndTime
+    local startSecret = issecretvalue(startTime)
+    local endSecret = issecretvalue(endTime)
+    if startSecret or endSecret then
+        return nil, nil, false
+    end
+    if startTime == nil or endTime == nil then
+        return nil, nil, false
+    end
+
+    return startTime, endTime, true
+end
+
+local function GetPandemicAuraIdentity(owner, options)
+    local auraState = options and options.auraState
+    local auraUnit = options and options.auraUnit
+    if auraUnit == nil and auraState then
+        auraUnit = auraState.auraUnit
+    end
+    if auraUnit == nil and owner then
+        auraUnit = owner._auraUnit
+    end
+
+    local auraInstanceID = options and options.auraInstanceID
+    if auraInstanceID == nil and auraState then
+        auraInstanceID = auraState.auraInstanceID
+    end
+    if auraInstanceID == nil and owner then
+        auraInstanceID = owner._auraInstanceID
+    end
+
+    return auraUnit, auraInstanceID
+end
+
+local function GetPandemicAuraTiming(options)
+    local auraState = options and options.auraState
+    local auraData = options and options.auraData
+    local auraDataSecret = issecretvalue(auraData)
+    if auraDataSecret then
+        auraData = nil
+    elseif auraData == nil and auraState then
+        auraData = auraState.auraData
+    end
+
+    local expirationTime = options and options.auraExpirationTime
+    local expirationSecret = issecretvalue(expirationTime)
+    if expirationSecret then
+        expirationTime = nil
+    elseif expirationTime == nil and auraState then
+        expirationTime = auraState.auraExpirationTime
+    end
+    local duration = options and options.auraDuration
+    local durationSecret = issecretvalue(duration)
+    if durationSecret then
+        duration = nil
+    elseif duration == nil and auraState then
+        duration = auraState.auraDuration
+    end
+
+    expirationSecret = issecretvalue(expirationTime)
+    durationSecret = issecretvalue(duration)
+    if not expirationSecret and not durationSecret and expirationTime ~= nil and duration ~= nil then
+        return expirationTime, duration, true
+    end
+
+    return GetReadableAuraTiming(auraData)
+end
+
+local function CanLatchPandemicRange(auraUnit, auraInstanceID)
+    return auraUnit ~= nil and auraInstanceID ~= nil
+end
+
+local function AcceptedPandemicRangeMatches(owner, auraUnit, auraInstanceID, startTime, endTime)
+    return owner._pandemicLatchUnit == auraUnit
+        and owner._pandemicLatchAuraInstanceID == auraInstanceID
+        and owner._pandemicLatchStart == startTime
+        and owner._pandemicLatchEnd == endTime
+end
+
+local function ClearSuppressedPandemicRange(owner)
+    if not owner then return end
+
+    owner._pandemicSuppressedUnit = nil
+    owner._pandemicSuppressedAuraInstanceID = nil
+    owner._pandemicSuppressedStart = nil
+    owner._pandemicSuppressedEnd = nil
+end
+
+local function IsCurrentPandemicRangeSuppressed(owner, auraUnit, auraInstanceID, startTime, endTime, hasReadableRange)
+    if not CanLatchPandemicRange(auraUnit, auraInstanceID) then
+        return false
+    end
+
+    if owner._pandemicSuppressedUnit == nil then
+        return false
+    end
+
+    if owner._pandemicSuppressedUnit ~= auraUnit
+        or owner._pandemicSuppressedAuraInstanceID ~= auraInstanceID then
+        ClearSuppressedPandemicRange(owner)
+        return false
+    end
+
+    if hasReadableRange
+        and (owner._pandemicSuppressedStart ~= startTime
+            or owner._pandemicSuppressedEnd ~= endTime) then
+        ClearSuppressedPandemicRange(owner)
+        return false
+    end
+
+    return true
+end
+
+local function RecordAcceptedPandemicRange(owner, auraUnit, auraInstanceID, startTime, endTime, options)
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    ClearAuraPandemicDirtyState(owner)
+    ClearSuppressedPandemicRange(owner)
+
+    if not CanLatchPandemicRange(auraUnit, auraInstanceID) then
+        ClearAcceptedPandemicRange(owner)
+        return
+    end
+
+    local expirationTime, duration, timingReadable = GetPandemicAuraTiming(options)
+    owner._pandemicLatchUnit = auraUnit
+    owner._pandemicLatchAuraInstanceID = auraInstanceID
+    owner._pandemicLatchStart = startTime
+    owner._pandemicLatchEnd = endTime
+    owner._pandemicLatchAuraExpirationTime = timingReadable and expirationTime or nil
+    owner._pandemicLatchAuraDuration = timingReadable and duration or nil
+end
+
+local function RecordSuppressedPandemicRange(owner, auraUnit, auraInstanceID, startTime, endTime)
+    owner._pandemicGraceStart = nil
+    owner._pandemicGraceSuppressed = nil
+    ClearAuraPandemicDirtyState(owner)
+    ClearAcceptedPandemicRange(owner)
+
+    if CanLatchPandemicRange(auraUnit, auraInstanceID) then
+        owner._pandemicSuppressedUnit = auraUnit
+        owner._pandemicSuppressedAuraInstanceID = auraInstanceID
+        owner._pandemicSuppressedStart = startTime
+        owner._pandemicSuppressedEnd = endTime
+    else
+        ClearSuppressedPandemicRange(owner)
+    end
+end
+
+local function UpdatedAuraTimingProvesStaleRange(owner, auraUnit, auraInstanceID, startTime, endTime, options)
+    if not CanLatchPandemicRange(auraUnit, auraInstanceID) then
+        return false
+    end
+    if owner._pandemicDirtyUnit ~= auraUnit
+        or owner._pandemicDirtyAuraInstanceID ~= auraInstanceID then
+        return false
+    end
+    if not AcceptedPandemicRangeMatches(owner, auraUnit, auraInstanceID, startTime, endTime) then
+        return false
+    end
+
+    local expirationTime, duration, timingReadable = GetPandemicAuraTiming(options)
+    if not timingReadable then
+        return false
+    end
+    if owner._pandemicLatchAuraExpirationTime == nil or owner._pandemicLatchAuraDuration == nil then
+        return false
+    end
+
+    return expirationTime ~= owner._pandemicLatchAuraExpirationTime
+        or duration ~= owner._pandemicLatchAuraDuration
+end
+
 function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
     if not owner then return end
     options = options or {}
@@ -376,8 +615,7 @@ function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
         owner._targetSwitchDataReceived = nil
     end
     owner._inPandemic = inactiveValue
-    owner._pandemicGraceStart = nil
-    owner._pandemicGraceSuppressed = nil
+    ClearAuraPandemicRuntimeState(owner)
     if options.clearCustomAuraStacks then
         owner._customAuraStackValue = nil
         owner._customAuraApplicationsValue = nil
@@ -388,8 +626,7 @@ function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
     if not owner then return end
     owner._auraInstanceID = nil
     owner._inPandemic = false
-    owner._pandemicGraceStart = nil
-    owner._pandemicGraceSuppressed = nil
+    ClearAuraPandemicRuntimeState(owner)
     owner._targetSwitchAt = now
     owner._targetSwitchDataReceived = nil
     owner._auraUnit = unit or "target"
@@ -405,9 +642,53 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
 
     if not (options.enabled and viewerFrame) then
         if options.clearWhenDisabled then
-            owner._pandemicGraceStart = nil
-            owner._pandemicGraceSuppressed = nil
+            ClearAuraPandemicRuntimeState(owner)
         end
+        return false
+    end
+
+    local now = options.now or GetTime()
+    local auraUnit, auraInstanceID = GetPandemicAuraIdentity(owner, options)
+    local pandemicStartTime, pandemicEndTime, hasReadableRange = GetReadablePandemicRange(viewerFrame)
+    if hasReadableRange and viewerFrame.IsInPandemicTime then
+        local semanticResult = viewerFrame:IsInPandemicTime(now)
+        if not issecretvalue(semanticResult) then
+            if semanticResult == true then
+                if IsCurrentPandemicRangeSuppressed(
+                    owner,
+                    auraUnit,
+                    auraInstanceID,
+                    pandemicStartTime,
+                    pandemicEndTime,
+                    true
+                ) then
+                    owner._pandemicGraceStart = nil
+                    return false
+                end
+
+                if UpdatedAuraTimingProvesStaleRange(
+                    owner,
+                    auraUnit,
+                    auraInstanceID,
+                    pandemicStartTime,
+                    pandemicEndTime,
+                    options
+                ) then
+                    RecordSuppressedPandemicRange(owner, auraUnit, auraInstanceID, pandemicStartTime, pandemicEndTime)
+                    return false
+                end
+
+                RecordAcceptedPandemicRange(owner, auraUnit, auraInstanceID, pandemicStartTime, pandemicEndTime, options)
+                return true
+            elseif semanticResult == false then
+                ClearAuraPandemicRuntimeState(owner)
+                return false
+            end
+        end
+    end
+
+    if IsCurrentPandemicRangeSuppressed(owner, auraUnit, auraInstanceID, pandemicStartTime, pandemicEndTime, hasReadableRange) then
+        owner._pandemicGraceStart = nil
         return false
     end
 
@@ -419,7 +700,6 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
         owner._pandemicGraceStart = nil
         return true
     elseif owner._inPandemic then
-        local now = options.now or GetTime()
         if not owner._pandemicGraceStart then
             owner._pandemicGraceStart = now
         end
@@ -694,6 +974,7 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         end
     end
 
+    local auraExpirationTime, auraDuration, auraTimingReadable = GetReadableAuraTiming(auraPresent and auraData or nil)
     local state = {
         ready = ready == true,
         auraPresent = auraPresent == true,
@@ -709,6 +990,8 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
         durationObj = auraPresent and durationObj or nil,
         auraCooldownStart = auraPresent and auraCooldownStart or nil,
         auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
+        auraExpirationTime = auraTimingReadable and auraExpirationTime or nil,
+        auraDuration = auraTimingReadable and auraDuration or nil,
         auraHasTimer = auraPresent and auraHasTimer == true or false,
         auraGraceHeld = auraGraceHeld == true,
         activeAuraSpellID = activeAuraSpellID,

--- a/OtherBars/ResourceBar.lua
+++ b/OtherBars/ResourceBar.lua
@@ -290,8 +290,7 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
 
     if not auraActive then
         bar._inPandemic = nil
-        bar._pandemicGraceStart = nil
-        bar._pandemicGraceSuppressed = nil
+        EntryRuntime.ClearAuraPandemicRuntimeState(bar)
         ResetCustomAuraBarIndicatorVisuals(bar, cabConfig)
         return
     end

--- a/OtherBars/ResourceBarCustomBars.lua
+++ b/OtherBars/ResourceBarCustomBars.lua
@@ -264,6 +264,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             enabled = configUnit == "target" and auraPresent,
             previewActive = pandemicPreview == true,
             clearWhenDisabled = true,
+            auraState = auraState,
+            auraUnit = auraUnit,
+            auraInstanceID = instId,
         })
 
         if isActive and bar then
@@ -554,6 +557,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             enabled = configUnit == "target" and auraPresent,
             previewActive = pandemicPreview == true,
             clearWhenDisabled = true,
+            auraState = auraState,
         })
 
         if auraState

--- a/OtherBars/ResourceBarLifecycle.lua
+++ b/OtherBars/ResourceBarLifecycle.lua
@@ -157,9 +157,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
                                     and bar._auraInstanceID
                                     and bar._auraUnit == unit
                                     and updatedIDSet[bar._auraInstanceID] then
-                                    bar._inPandemic = false
-                                    bar._pandemicGraceStart = nil
-                                    bar._pandemicGraceSuppressed = true
+                                    EntryRuntime.MarkAuraPandemicStateDirty(bar, unit, bar._auraInstanceID)
                                 end
                                 if unit == "target" and bar._targetSwitchAt then
                                     bar._targetSwitchDataReceived = true


### PR DESCRIPTION
## What Players Will Notice
- Pandemic glow should stay stable while a tracked aura remains in its pandemic refresh window, instead of briefly blinking during same-aura update timing.
- Button panels and resource-attached custom aura bars now use the same pandemic-state behavior.

## Why This Changed
- Same-instance aura updates were treated too much like proof that the pandemic state should clear. That could create a one-frame gap where Blizzard's Cooldown Viewer still knew the aura was in its pandemic range, but Cooldown Companion had already dropped its local pandemic state.
- The fix treats pandemic as an accepted range for the current aura instance, so transient update ordering does not erase a still-valid glow.

## What Changed
- Centralized semantic pandemic range latching in `Core/EntryRuntime.lua`.
- Changed `UNIT_AURA` update handling so same-instance updates mark pandemic state dirty instead of clearing it immediately.
- The shared resolver now clears pandemic only when the aura disappears, leaves pandemic, changes identity, or readable duration/expiration timing proves the previously accepted range is stale.
- Added shared pandemic runtime cleanup for button panels, previews, icon/bar lanes, resource bars, and custom aura bars.
- Passed evaluated aura state into resource custom bar pandemic resolution so custom bars follow the same rules as panels.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p Core\EntryRuntime.lua Core\Aura.lua OtherBars\ResourceBarLifecycle.lua ButtonFrame\CooldownUpdate.lua ButtonFrame\Preview.lua ButtonFrame\BarMode.lua ButtonFrame\IconMode.lua OtherBars\ResourceBar.lua OtherBars\ResourceBarCustomBars.lua`
- `lua tests\pandemic-state-invariants.lua`
- `lua tests\aura-instance-membership.lua`
- `lua tests\pandemic-visual-state.lua`
- Code review pass found no actionable issues.
- Still pending before ready-for-review: live in-game validation of the reported multi-aura flicker path, including combat and restricted-content coverage.