### PR TITLE
Show charges for talented Soul Immolation

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -280,17 +280,7 @@ function CooldownCompanion:RefreshChargeFlags(typeFilter)
     for _, group in pairs(self.db.profile.groups) do
         for _, buttonData in ipairs(group.buttons) do
             if buttonData.type == "spell" and typeFilter ~= "item" then
-                local chargeInfo = C_Spell.GetSpellCharges(buttonData.id)
-                -- Base spell may lack charges when the override has them
-                -- (e.g. Primal Strike base → Stormstrike with 2 charges).
-                local chargeQueryID = buttonData.id
-                if not chargeInfo then
-                    local overrideID = C_Spell.GetOverrideSpell(buttonData.id)
-                    if overrideID and overrideID ~= 0 and overrideID ~= buttonData.id then
-                        chargeInfo = C_Spell.GetSpellCharges(overrideID)
-                        chargeQueryID = overrideID
-                    end
-                end
+                local chargeInfo, chargeQueryID, maxCharges = ST.ResolveSpellChargeInfo(buttonData.id)
                 local hasRealCharges = buttonData.hasCharges and true or nil
                 local hadDisplayCountBehavior = (buttonData._hasDisplayCount == true or hasRealCharges == true)
                 local hadCastCountCandidate = (buttonData._castCountCandidate == true)
@@ -304,8 +294,8 @@ function CooldownCompanion:RefreshChargeFlags(typeFilter)
                     buttonData._castCountEventSpellID = nil
                     buttonData._hasDisplayCount = nil
                     buttonData._displayCountFamily = nil
-                    local mc = chargeInfo.maxCharges
-                    if mc > 1 then
+                    local mc = maxCharges or chargeInfo.maxCharges
+                    if mc and mc > 1 then
                         hasRealCharges = true
                         if mc ~= buttonData.maxCharges then
                             buttonData.maxCharges = mc

--- a/Core/GroupManagement.lua
+++ b/Core/GroupManagement.lua
@@ -1501,20 +1501,10 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
     -- Auto-detect charges for castable and passive-cooldown spells.
     -- Treat as charge-based only when max charges is greater than 1.
     if buttonType == "spell" and not isPassive then
-        local chargeInfo = C_Spell.GetSpellCharges(id)
-        -- Base spell may not have charges when the override form does
-        -- (e.g. Primal Strike → Stormstrike). Try the current override.
-        local chargeQueryID = id
-        if not chargeInfo then
-            local overrideID = C_Spell.GetOverrideSpell(id)
-            if overrideID and overrideID ~= 0 and overrideID ~= id then
-                chargeInfo = C_Spell.GetSpellCharges(overrideID)
-                chargeQueryID = overrideID
-            end
-        end
+        local chargeInfo, chargeQueryID, maxCharges = ST.ResolveSpellChargeInfo(id)
         if chargeInfo then
-            local mc = chargeInfo.maxCharges
-            if mc > 1 then
+            local mc = maxCharges or chargeInfo.maxCharges
+            if mc and mc > 1 then
                 group.buttons[buttonIndex].hasCharges = true
                 group.buttons[buttonIndex]._hasDisplayCount = nil
                 group.buttons[buttonIndex]._displayCountFamily = nil

--- a/Core/SpellQueries.lua
+++ b/Core/SpellQueries.lua
@@ -133,6 +133,43 @@ function ST.HasChargeCooldownInfo(spellId)
     return false
 end
 
+local function GetReadableMaxCharges(chargeInfo)
+    local maxCharges = chargeInfo and chargeInfo.maxCharges
+    if maxCharges and not (issecretvalue and issecretvalue(maxCharges)) then
+        return tonumber(maxCharges)
+    end
+    return nil
+end
+
+function ST.ResolveSpellChargeInfo(spellId)
+    if not spellId then return nil, spellId, nil end
+
+    local chargeInfo = C_Spell.GetSpellCharges(spellId)
+    local chargeQueryID = spellId
+    local maxCharges = GetReadableMaxCharges(chargeInfo)
+
+    if not maxCharges or maxCharges <= 1 then
+        local overrideID = C_Spell.GetOverrideSpell(spellId)
+        if overrideID and overrideID ~= 0 and overrideID ~= spellId then
+            local overrideInfo = C_Spell.GetSpellCharges(overrideID)
+            local overrideMaxCharges = GetReadableMaxCharges(overrideInfo)
+            if not chargeInfo then
+                chargeQueryID = overrideID
+            end
+            if not chargeInfo and overrideInfo then
+                chargeInfo = overrideInfo
+                maxCharges = overrideMaxCharges
+            elseif overrideInfo and (overrideMaxCharges or 0) > (maxCharges or 0) then
+                chargeInfo = overrideInfo
+                chargeQueryID = overrideID
+                maxCharges = overrideMaxCharges
+            end
+        end
+    end
+
+    return chargeInfo, chargeQueryID, maxCharges
+end
+
 local function IsPositiveReadableNumber(value)
     if issecretvalue and issecretvalue(value) then
         return false


### PR DESCRIPTION
## What Players Will Notice
- Soul Immolation now displays as a charge-based spell when the Devourer Demon Hunter talent gives it 2 charges.

## Why This Changed
- Soul Immolation is an active override of Immolation Aura. The base Immolation Aura spell can report valid charge info with only 1 max charge, while the active Soul Immolation override reports 2 max charges.
- Cooldown Companion stopped after the base spell's 1-charge response, so it never promoted the button into charge behavior.

## What Changed
- Added a shared spell-charge resolver that compares the stored spell and its active override before deciding charge behavior.
- Updated both add-time button setup and talent/charge refresh paths to use that shared resolver.
- Preserved the active-override query path for display-count fallback when no real charge info exists.

## Validation
- Confirmed the live API shape from in-game output: `258920 -> 1241937`, base max charges `1`, override max charges `2`.
- Ran `lua tests\soul-immolation-charge-override.lua`.
- Ran all local `tests/*.lua` harnesses.
- Ran `luac -p Core\SpellQueries.lua Core\EventHandlers.lua Core\GroupManagement.lua tests\soul-immolation-charge-override.lua`.
- Ran `git diff --check`.
- In-game reload/button behavior and combat/restricted-content validation are still pending.