### PR TITLE
Reduce non-player unit event work in cooldown updates

### DIFF
--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -126,8 +126,7 @@ function CooldownCompanion:OnEnable()
 
     -- Broader state changes can wait for the regular ticker pass.
     for _, evt in ipairs({
-        "UNIT_POWER_FREQUENT", "LOSS_OF_CONTROL_ADDED", "LOSS_OF_CONTROL_UPDATE",
-        "ITEM_COUNT_CHANGED",
+        "LOSS_OF_CONTROL_ADDED", "LOSS_OF_CONTROL_UPDATE", "ITEM_COUNT_CHANGED",
     }) do
         self:RegisterEvent(evt, "MarkCooldownsDirty")
     end
@@ -136,8 +135,22 @@ function CooldownCompanion:OnEnable()
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnPlayerEnteringWorld")
 
+    -- High-frequency player-only unit events. RegisterUnitEvent filters before
+    -- dispatch, avoiding global UNIT_* traffic through AceEvent.
+    if not self._playerUnitEventFrame then
+        self._playerUnitEventFrame = CreateFrame("Frame")
+        self._playerUnitEventFrame:SetScript("OnEvent", function(_, event, ...)
+            if event == "UNIT_POWER_FREQUENT" then
+                self:MarkCooldownsDirty()
+            elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
+                self:OnSpellCast(event, ...)
+            end
+        end)
+    end
+    self._playerUnitEventFrame:RegisterUnitEvent("UNIT_POWER_FREQUENT", "player")
+    self._playerUnitEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+
     -- Combat events
-    self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", "OnSpellCast")
     self:RegisterEvent("PLAYER_REGEN_DISABLED", "OnCombatStart")
     self:RegisterEvent("PLAYER_REGEN_ENABLED", "OnCombatEnd")
 
@@ -367,6 +380,11 @@ function CooldownCompanion:OnDisable()
     -- Unregister UNIT_TARGET frame (keep reference for reuse on re-enable)
     if self._unitTargetFrame then
         self._unitTargetFrame:UnregisterAllEvents()
+    end
+
+    -- Unregister player-only unit events (keep reference for reuse on re-enable)
+    if self._playerUnitEventFrame then
+        self._playerUnitEventFrame:UnregisterAllEvents()
     end
 
     -- Unregister EventRegistry callback (not managed by Ace3)


### PR DESCRIPTION
## What Players Will Notice
- No intended visual change: cooldown, resource, and spell-cast updates should continue to behave the same for the player.
- The addon now avoids routing high-frequency power and spell-cast events from non-player units through the main cooldown handlers.

## Why This Changed
- `UNIT_POWER_FREQUENT` can fire multiple times per frame while power changes quickly, and the previous global AceEvent registration marked cooldowns dirty for any unit.
- `UNIT_SPELLCAST_SUCCEEDED` already ignored non-player casts inside the handler, but still received the global event traffic first.

## What Changed
- Moved `UNIT_POWER_FREQUENT` and `UNIT_SPELLCAST_SUCCEEDED` onto a reusable dedicated frame registered with `Frame:RegisterUnitEvent(..., "player")`.
- Preserved the existing behavior by dispatching player power changes to `MarkCooldownsDirty()` and player spell casts through the existing `OnSpellCast()` handler.
- Added `OnDisable()` cleanup for the new player-only unit event frame.

## Validation
- Verified `Frame:RegisterUnitEvent(eventName [, units,...])`, `UNIT_POWER_FREQUENT: unitTarget, powerType`, and `UNIT_SPELLCAST_SUCCEEDED: unitTarget, castGUID, spellID, castBarID` with MCP-backed WoW API/wiki sources before editing.
- Ran `luac -p Core\Lifecycle.lua`.
- Ran `git diff --check origin/main...HEAD`.
- Reviewed the enable/disable path to confirm the dedicated frame unregisters cleanly.
- In-game combat and restricted-content verification is still pending; this needs a WoW runtime pass confirming player resource changes and player spell casts still refresh cooldown state without errors in combat/instances.