### PR TITLE
Reduce duplicate cooldown refreshes during event bursts

### DIFF
--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -22,6 +22,21 @@ local minimapButton = ST._minimapButton
 -- LibSharedMedia for font/texture selection
 local LSM = LibStub("LibSharedMedia-3.0")
 
+local function MergeCooldownRefreshSource(currentSource, newSource)
+    newSource = newSource or "event"
+    if not currentSource or currentSource == newSource then
+        return newSource
+    end
+    return "event"
+end
+
+local function CooldownRefreshQueueOnUpdate(frame)
+    local addon = frame._cooldownCompanion
+    if addon then
+        addon:FlushQueuedCooldownRefresh()
+    end
+end
+
 -- Viewer frame list used by BuildViewerAuraMap, FindViewerChildForSpell, and OnEnable hooks.
 local VIEWER_NAMES = {
     "EssentialCooldownViewer",
@@ -104,7 +119,9 @@ function CooldownCompanion:EnsureRuntimeInitialized()
                 self.assistedSpellID = AssistedCombatManager.lastNextCastSpellID
             end
 
-            if not self:CanSkipTickerCooldownRefresh() then
+            if self._queuedCooldownRefreshSource then
+                self:FlushQueuedCooldownRefresh()
+            elseif not self:CanSkipTickerCooldownRefresh() then
                 self:RunCooldownRefresh("ticker")
             end
             self:UpdateAllGroupLayouts()
@@ -329,6 +346,50 @@ function CooldownCompanion:RunCooldownRefresh(source)
     self._lastCooldownRefreshSource = source
 end
 
+function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
+    if not self._cooldownRefreshQueueFrame then
+        local frame = CreateFrame("Frame")
+        frame._cooldownCompanion = self
+        self._cooldownRefreshQueueFrame = frame
+    end
+    if not self._cooldownRefreshQueueArmed then
+        self._cooldownRefreshQueueArmed = true
+        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", CooldownRefreshQueueOnUpdate)
+    end
+end
+
+function CooldownCompanion:FlushQueuedCooldownRefresh()
+    if self._cooldownRefreshQueueFrame then
+        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
+    end
+    self._cooldownRefreshQueueArmed = nil
+    self._cooldownImmediateRefreshThisFrame = nil
+
+    local source = self._queuedCooldownRefreshSource
+    self._queuedCooldownRefreshSource = nil
+    if source then
+        self:RunCooldownRefresh(source)
+    end
+end
+
+function CooldownCompanion:QueueCooldownRefresh(source)
+    self._queuedCooldownRefreshSource = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
+    self:EnsureCooldownRefreshQueueFrame()
+end
+
+function CooldownCompanion:RunImmediateCooldownRefresh(source)
+    if self._cooldownImmediateRefreshThisFrame then
+        self:QueueCooldownRefresh(source)
+        return
+    end
+
+    source = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
+    self._queuedCooldownRefreshSource = nil
+    self._cooldownImmediateRefreshThisFrame = true
+    self:EnsureCooldownRefreshQueueFrame()
+    self:RunCooldownRefresh(source)
+end
+
 function CooldownCompanion:CanSkipTickerCooldownRefresh()
     -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
     -- target, and other dirty paths keep their normal ticker confirmation.
@@ -341,7 +402,7 @@ function CooldownCompanion:OnCooldownStateChanged()
     self:MarkCooldownsDirty()
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
-    self:RunCooldownRefresh("cooldown-event")
+    self:RunImmediateCooldownRefresh("cooldown-event")
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.
@@ -370,6 +431,13 @@ function CooldownCompanion:OnDisable()
         self._alphaFrame:SetScript("OnUpdate", nil)
         self._alphaFrame = nil
     end
+
+    if self._cooldownRefreshQueueFrame then
+        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
+    end
+    self._cooldownRefreshQueueArmed = nil
+    self._queuedCooldownRefreshSource = nil
+    self._cooldownImmediateRefreshThisFrame = nil
 
     -- Disable all range check registrations
     for spellId in pairs(self._rangeCheckSpells) do
@@ -420,18 +488,18 @@ function CooldownCompanion:OnChargesChanged(event, spellID, baseSpellID)
     if self._hasDisplayCountCandidates then
         self:RefreshChargeFlags("spell")
     end
-    self:UpdateAllCooldowns()
+    self:QueueCooldownRefresh("charges-event")
 end
 
 function CooldownCompanion:OnProcGlowShow(event, spellID)
     self.procOverlaySpells[spellID] = true
-    self:UpdateAllCooldowns()
+    self:QueueCooldownRefresh("proc-event")
 end
 
 function CooldownCompanion:OnProcGlowHide(event, spellID)
     self.procOverlaySpells[spellID] = nil
     self:MarkCooldownsDirty()
-    self:UpdateAllCooldowns()
+    self:QueueCooldownRefresh("proc-event")
 end
 
 function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
@@ -454,14 +522,14 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
         if self.RecordCustomBarSpellCast then
             self:RecordCustomBarSpellCast(spellID)
         end
-        self:UpdateAllCooldowns()
+        self:QueueCooldownRefresh("cast-event")
     end
 end
 
 
 function CooldownCompanion:OnCombatStart()
     self:BeginCombatForcedLock()
-    self:UpdateAllCooldowns()
+    self:QueueCooldownRefresh("combat-event")
     -- Close spellbook during combat to avoid Blizzard secret value errors
     if PlayerSpellsFrame and PlayerSpellsFrame:IsShown() then
         HideUIPanel(PlayerSpellsFrame)
@@ -480,7 +548,7 @@ end
 
 function CooldownCompanion:OnCombatEnd()
     local combatLockSnapshot = self:EndCombatForcedLock()
-    self:UpdateAllCooldowns()
+    self:QueueCooldownRefresh("combat-event")
     self:ApplyCdmAlpha()
     if self._pendingUnsupportedLegacyHide or self._unsupportedLegacyProfile then
         self._pendingUnsupportedLegacyHide = nil

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -404,11 +404,23 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
         return
     end
 
+    local dirtySerial = self._cooldownDirtySerial or 0
+    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
+        and self._queuedCooldownRefreshSkipSerial == dirtySerial
+    local canSkipTicker = source == "cooldown-event" or queuedRefreshCanSkipTicker
+    local skipSerial = canSkipTicker and dirtySerial or nil
+
     source = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
     self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshCanSkipTicker = nil
+    self._queuedCooldownRefreshSkipSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
     self:RunCooldownRefresh(source)
+    if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
+        self._lastCooldownRefreshSource = "cooldown-event"
+        self._lastCooldownRefreshSerial = skipSerial
+    end
 end
 
 function CooldownCompanion:CanSkipTickerCooldownRefresh()

--- a/Core/Lifecycle.lua
+++ b/Core/Lifecycle.lua
@@ -366,14 +366,35 @@ function CooldownCompanion:FlushQueuedCooldownRefresh()
     self._cooldownImmediateRefreshThisFrame = nil
 
     local source = self._queuedCooldownRefreshSource
+    local canSkipTicker = self._queuedCooldownRefreshCanSkipTicker
+    local skipSerial = self._queuedCooldownRefreshSkipSerial
     self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshCanSkipTicker = nil
+    self._queuedCooldownRefreshSkipSerial = nil
     if source then
         self:RunCooldownRefresh(source)
+        -- Non-dirty queued work should not erase a satisfied cooldown-event
+        -- dirty serial, because that would re-enable the next ticker walk.
+        if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
+            self._lastCooldownRefreshSource = "cooldown-event"
+            self._lastCooldownRefreshSerial = skipSerial
+        end
     end
 end
 
 function CooldownCompanion:QueueCooldownRefresh(source)
+    local dirtySerial = self._cooldownDirtySerial or 0
+    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
+        and self._queuedCooldownRefreshSkipSerial == dirtySerial
+    local lastRefreshCanSkipTicker = self._lastCooldownRefreshSource == "cooldown-event"
+        and self._lastCooldownRefreshSerial == dirtySerial
+    local canSkipTicker = source == "cooldown-event"
+        or queuedRefreshCanSkipTicker
+        or lastRefreshCanSkipTicker
+
     self._queuedCooldownRefreshSource = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
+    self._queuedCooldownRefreshCanSkipTicker = canSkipTicker or nil
+    self._queuedCooldownRefreshSkipSerial = canSkipTicker and dirtySerial or nil
     self:EnsureCooldownRefreshQueueFrame()
 end
 
@@ -437,6 +458,8 @@ function CooldownCompanion:OnDisable()
     end
     self._cooldownRefreshQueueArmed = nil
     self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshCanSkipTicker = nil
+    self._queuedCooldownRefreshSkipSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
 
     -- Disable all range check registrations


### PR DESCRIPTION
## What Players Will Notice
- Cooldown displays should remain just as responsive during casts, charge changes, proc glows, cooldown events, and combat transitions, while the addon avoids redundant full cooldown refresh walks when several of those events fire together.
- This is intended as a performance/responsiveness improvement with no player-facing cooldown behavior change.

## Why This Changed
- Bursty cooldown, cast, charge, proc, and combat events could each trigger their own full `UpdateAllCooldowns()` walk in the same frame.
- The existing ticker skip protected the next regular cooldown tick after direct cooldown-event refreshes, but it did not coalesce event handlers with each other.

## What Changed
- Added a small one-shot cooldown refresh queue in `Core/Lifecycle.lua` using a hidden frame `OnUpdate` callback to collapse same-frame event refresh requests.
- Kept the first cooldown-state event immediate so short cooldown windows still refresh without waiting for the 100ms ticker.
- Moved charge, proc glow, player spellcast, and combat start/end refreshes through the shared queue.
- Preserved cooldown-event ticker-skip eligibility when queued non-dirty refreshes are consumed before or after the immediate cooldown refresh, while still requiring ticker confirmation after genuinely new dirty state.

## Validation
- `luac -p Core\Lifecycle.lua`
- `git diff --check origin/main...HEAD`
- Ran a lightweight local Lua state-machine simulation covering:
  - cooldown event first, then queued non-dirty event
  - queued non-dirty event first, then immediate cooldown event
  - dirty non-cooldown event still blocking the cooldown-event ticker skip
- In-game combat and restricted-content validation has not been performed yet. Please verify charge spells, proc glow show/hide, cast-count text, GCD-only display, short cooldown responsiveness, and combat start/end behavior in-game before treating the branch as fully runtime-proven.