### PR TITLE
Reduce idle work from key press highlights

### DIFF
--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -116,15 +116,16 @@ local function ShouldEnrollKeyPressHighlightButton(button)
     end
 
     local style = button.style
+    if not (style and style.keyPressHighlightStyle and style.keyPressHighlightStyle ~= "none") then
+        return false
+    end
+
     local buttonData = button.buttonData
-    return style
-        and style.keyPressHighlightStyle
-        and style.keyPressHighlightStyle ~= "none"
-        and buttonData
-        and buttonData.type ~= "header"
-        and not buttonData.isPassive
-        and HasCachedBindingKeys(button)
-        or false
+    if not buttonData or buttonData.type == "header" or buttonData.isPassive then
+        return false
+    end
+
+    return HasCachedBindingKeys(button)
 end
 
 local function ShouldShowKeyPressHighlight(button, inCombat)
@@ -133,21 +134,20 @@ local function ShouldShowKeyPressHighlight(button, inCombat)
     end
 
     local style = button.style
-    local passedCombatCheck = true
     if style and style.keyPressHighlightCombatOnly then
         if inCombat == nil then
             inCombat = InCombatLockdown()
         end
-        passedCombatCheck = inCombat
+        if not inCombat then
+            return false, inCombat
+        end
     end
 
-    if passedCombatCheck then
-        local keyInfos = button._bindingKeyInfos
-        if keyInfos then
-            for _, info in ipairs(keyInfos) do
-                if IsBindingKeyPressed(info) then
-                    return true, inCombat
-                end
+    local keyInfos = button._bindingKeyInfos
+    if keyInfos then
+        for _, info in ipairs(keyInfos) do
+            if IsBindingKeyPressed(info) then
+                return true, inCombat
             end
         end
     end
@@ -219,20 +219,6 @@ RefreshKeyPressHighlightEnrollment = function(button)
         end
         StartKeyPressHighlightDriver()
     else
-        UnregisterKeyPressHighlightButton(button)
-    end
-end
-
-local function RefreshKeyPressHighlightFrame(frame)
-    if not (frame and frame.buttons) then return end
-    for _, button in ipairs(frame.buttons) do
-        RefreshKeyPressHighlightEnrollment(button)
-    end
-end
-
-local function UnregisterKeyPressHighlightFrame(frame)
-    if not (frame and frame.buttons) then return end
-    for _, button in ipairs(frame.buttons) do
         UnregisterKeyPressHighlightButton(button)
     end
 end
@@ -1733,8 +1719,6 @@ end
 -- Exports
 ST._RefreshKeyPressHighlightEnrollment = RefreshKeyPressHighlightEnrollment
 ST._UnregisterKeyPressHighlightButton = UnregisterKeyPressHighlightButton
-ST._RefreshKeyPressHighlightFrame = RefreshKeyPressHighlightFrame
-ST._UnregisterKeyPressHighlightFrame = UnregisterKeyPressHighlightFrame
 ST._UpdateIconModeVisuals = UpdateIconModeVisuals
 ST._UpdateIconModeGlows = UpdateIconModeGlows
 ST._ApplyIconCountTextStyle = ApplyCountTextStyle

--- a/ButtonFrame/IconMode.lua
+++ b/ButtonFrame/IconMode.lua
@@ -84,6 +84,159 @@ local BLIZZARD_AURA_SWIPE_TEX_LOW = {x = 0.15, y = 0.15}
 local BLIZZARD_AURA_SWIPE_TEX_HIGH = {x = 0.85, y = 0.85}
 local QUESTION_MARK_ICON = "Interface\\Icons\\INV_Misc_QuestionMark"
 
+local KPH_INTERVAL = 0.05
+local kphAccumulator = 0
+local kphButtons = {}
+local kphButtonIndexes = {}
+local kphUpdateFrame = CreateFrame("Frame")
+
+local RefreshKeyPressHighlightEnrollment
+local UnregisterKeyPressHighlightButton
+
+local function IsKeyPressHighlightGroupEligible(button)
+    local groupId = button and button._groupId
+    local groups = CooldownCompanion.db and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+    local group = groupId and groups and groups[groupId]
+    return group and group.displayMode ~= "bars" and group.displayMode ~= "text" or false
+end
+
+local function HasCachedBindingKeys(button)
+    local keyInfos = button and button._bindingKeyInfos
+    return keyInfos and #keyInfos > 0 or false
+end
+
+local function ShouldEnrollKeyPressHighlightButton(button)
+    if not (button and button.keyPressHighlight and IsKeyPressHighlightGroupEligible(button)) then
+        return false
+    end
+
+    if button._keyPressHighlightPreview then
+        return true
+    end
+
+    local style = button.style
+    local buttonData = button.buttonData
+    return style
+        and style.keyPressHighlightStyle
+        and style.keyPressHighlightStyle ~= "none"
+        and buttonData
+        and buttonData.type ~= "header"
+        and not buttonData.isPassive
+        and HasCachedBindingKeys(button)
+        or false
+end
+
+local function ShouldShowKeyPressHighlight(button, inCombat)
+    if button._keyPressHighlightPreview then
+        return true, inCombat
+    end
+
+    local style = button.style
+    local passedCombatCheck = true
+    if style and style.keyPressHighlightCombatOnly then
+        if inCombat == nil then
+            inCombat = InCombatLockdown()
+        end
+        passedCombatCheck = inCombat
+    end
+
+    if passedCombatCheck then
+        local keyInfos = button._bindingKeyInfos
+        if keyInfos then
+            for _, info in ipairs(keyInfos) do
+                if IsBindingKeyPressed(info) then
+                    return true, inCombat
+                end
+            end
+        end
+    end
+
+    return false, inCombat
+end
+
+local function StopKeyPressHighlightDriver()
+    kphAccumulator = 0
+    kphUpdateFrame:SetScript("OnUpdate", nil)
+end
+
+local function KeyPressHighlightOnUpdate(_, elapsed)
+    kphAccumulator = kphAccumulator + elapsed
+    if kphAccumulator < KPH_INTERVAL then return end
+    kphAccumulator = 0
+
+    local inCombat
+    local index = 1
+    while index <= #kphButtons do
+        local button = kphButtons[index]
+        if ShouldEnrollKeyPressHighlightButton(button) then
+            local showKPH
+            showKPH, inCombat = ShouldShowKeyPressHighlight(button, inCombat)
+            SetKeyPressHighlight(button, showKPH)
+            index = index + 1
+        else
+            UnregisterKeyPressHighlightButton(button)
+        end
+    end
+end
+
+local function StartKeyPressHighlightDriver()
+    if #kphButtons > 0 and not kphUpdateFrame:GetScript("OnUpdate") then
+        kphUpdateFrame:SetScript("OnUpdate", KeyPressHighlightOnUpdate)
+    end
+end
+
+UnregisterKeyPressHighlightButton = function(button)
+    if not button then return end
+
+    local index = kphButtonIndexes[button]
+    if index then
+        local lastIndex = #kphButtons
+        local lastButton = kphButtons[lastIndex]
+        kphButtons[index] = lastButton
+        kphButtons[lastIndex] = nil
+        kphButtonIndexes[button] = nil
+        if lastButton and lastButton ~= button then
+            kphButtonIndexes[lastButton] = index
+        end
+    end
+
+    if button.keyPressHighlight then
+        SetKeyPressHighlight(button, false)
+    end
+    button._keyPressHighlightActive = nil
+
+    if #kphButtons == 0 then
+        StopKeyPressHighlightDriver()
+    end
+end
+
+RefreshKeyPressHighlightEnrollment = function(button)
+    if ShouldEnrollKeyPressHighlightButton(button) then
+        if not kphButtonIndexes[button] then
+            kphButtons[#kphButtons + 1] = button
+            kphButtonIndexes[button] = #kphButtons
+        end
+        StartKeyPressHighlightDriver()
+    else
+        UnregisterKeyPressHighlightButton(button)
+    end
+end
+
+local function RefreshKeyPressHighlightFrame(frame)
+    if not (frame and frame.buttons) then return end
+    for _, button in ipairs(frame.buttons) do
+        RefreshKeyPressHighlightEnrollment(button)
+    end
+end
+
+local function UnregisterKeyPressHighlightFrame(frame)
+    if not (frame and frame.buttons) then return end
+    for _, button in ipairs(frame.buttons) do
+        UnregisterKeyPressHighlightButton(button)
+    end
+end
+
 local function SelectTextureValue(value, knownAvailable)
     if knownAvailable == true then
         return value, true
@@ -708,6 +861,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Store button data
     button.index = index
     button.style = style
+    button._groupId = parent.groupId
 
     -- Cache spell cooldown secrecy level (static per-spell: NeverSecret=0, ContextuallySecret=2)
     if buttonData.type == "spell" then
@@ -747,7 +901,6 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button._prevVisibilityHidden = false
     button._visibilityAlphaOverride = nil
     button._lastVisAlpha = 1
-    button._groupId = parent.groupId
 
     -- Set icon
     self:UpdateButtonIcon(button)
@@ -1484,6 +1637,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
             SetKeyPressHighlight(button, false)
         end
         button._keyPressHighlightActive = nil
+        RefreshKeyPressHighlightEnrollment(button)
     end
 
     -- Apply configurable strata ordering (LoC always on top)
@@ -1577,63 +1731,10 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
 end
 
 -- Exports
--- Throttled key press highlight updater (~20Hz).
--- Polls modifier + key state to light up buttons whose keybind is held.
--- Throttled from per-frame to 0.05s intervals — 50ms latency is imperceptible
--- for a "key held" indicator and avoids thousands of redundant API calls/sec
--- when many buttons are visible.
-local KPH_INTERVAL = 0.05
-local kphAccumulator = 0
-local kphUpdateFrame = CreateFrame("Frame")
-kphUpdateFrame:SetScript("OnUpdate", function(_, elapsed)
-    kphAccumulator = kphAccumulator + elapsed
-    if kphAccumulator < KPH_INTERVAL then return end
-    kphAccumulator = 0
-    local groupFrames = CooldownCompanion.groupFrames
-    if not groupFrames then return end
-    local groups = CooldownCompanion.db and CooldownCompanion.db.profile
-        and CooldownCompanion.db.profile.groups
-    if not groups then return end
-    local inCombat
-    for groupId, groupFrame in pairs(groupFrames) do
-        local group = groups[groupId]
-        if group and group.displayMode ~= "bars" and group.displayMode ~= "text"
-               and groupFrame.buttons then
-            for _, button in ipairs(groupFrame.buttons) do
-                if button.keyPressHighlight then
-                    local style = button.style
-                    local buttonData = button.buttonData
-                    local showKPH = false
-                    if button._keyPressHighlightPreview then
-                        showKPH = true
-                    elseif style and style.keyPressHighlightStyle
-                           and style.keyPressHighlightStyle ~= "none"
-                           and buttonData and buttonData.type ~= "header"
-                           and not buttonData.isPassive then
-                        local passedCombatCheck = true
-                        if style.keyPressHighlightCombatOnly then
-                            if inCombat == nil then inCombat = InCombatLockdown() end
-                            passedCombatCheck = inCombat
-                        end
-                        if passedCombatCheck then
-                            local keyInfos = button._bindingKeyInfos
-                            if keyInfos then
-                                for _, info in ipairs(keyInfos) do
-                                    if IsBindingKeyPressed(info) then
-                                        showKPH = true
-                                        break
-                                    end
-                                end
-                            end
-                        end
-                    end
-                    SetKeyPressHighlight(button, showKPH)
-                end
-            end
-        end
-    end
-end)
-
+ST._RefreshKeyPressHighlightEnrollment = RefreshKeyPressHighlightEnrollment
+ST._UnregisterKeyPressHighlightButton = UnregisterKeyPressHighlightButton
+ST._RefreshKeyPressHighlightFrame = RefreshKeyPressHighlightFrame
+ST._UnregisterKeyPressHighlightFrame = UnregisterKeyPressHighlightFrame
 ST._UpdateIconModeVisuals = UpdateIconModeVisuals
 ST._UpdateIconModeGlows = UpdateIconModeGlows
 ST._ApplyIconCountTextStyle = ApplyCountTextStyle

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -39,6 +39,19 @@ local activeTriggerPanelEffectPreviews = {}
 local activeConditionalGroupPreviews = {}
 local activeConditionalButtonPreviews = {}
 
+local function RefreshKeyPressHighlightEnrollment(button)
+    local refresh = ST._RefreshKeyPressHighlightEnrollment
+    if refresh then
+        refresh(button)
+    end
+end
+
+local function RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
+    if previewFlag == "_keyPressHighlightPreview" then
+        RefreshKeyPressHighlightEnrollment(button)
+    end
+end
+
 local function BumpButtonPreviewToken(tokenStore, groupId, buttonIndex)
     local groupTokens = tokenStore[groupId]
     if not groupTokens then
@@ -168,6 +181,7 @@ local function SetButtonPreview(self, groupId, buttonIndex, show, previewFlag, c
             button[previewFlag] = show or nil
             button[cacheFlag] = cacheValue
             if onToggle then onToggle(button, show) end
+            RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
             if updateCooldown and button.UpdateCooldown then
                 button:UpdateCooldown()
             end
@@ -190,6 +204,7 @@ local function SetGroupPreview(self, groupId, show, previewFlag, cacheFlag, cach
         button[previewFlag] = show or nil
         button[cacheFlag] = cacheValue
         if onToggle then onToggle(button, show) end
+        RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
         if updateCooldown and button.UpdateCooldown then
             button:UpdateCooldown()
         end
@@ -237,6 +252,7 @@ local function ClearAllPreviews(self, previewFlag, cacheFlag, cacheValue, groupT
             button[previewFlag] = nil
             button[cacheFlag] = cacheValue
             if onClear then onClear(button) end
+            RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
             if updateCooldown and button.UpdateCooldown then
                 button:UpdateCooldown()
             end
@@ -759,8 +775,8 @@ end
 
 --------------------------------------------------------------------------------
 -- Key Press Highlight Preview (no per-button methods, no UpdateCooldown)
--- KPH is rendered by the per-frame kphUpdateFrame OnUpdate handler, not by
--- UpdateCooldown — setting the flag and invalidating the cache is sufficient.
+-- KPH is rendered by the idle enrollment driver, not by UpdateCooldown.
+-- Setting the flag and invalidating the cache is sufficient.
 --------------------------------------------------------------------------------
 
 function CooldownCompanion:SetGroupKeyPressHighlightPreview(groupId, show)
@@ -977,6 +993,7 @@ local function ApplyPreviewFlagToButton(button, previewFlag)
         button._readyGlowActive = false
     elseif previewFlag == "_keyPressHighlightPreview" then
         button._keyPressHighlightActive = nil
+        RefreshKeyPressHighlightEnrollment(button)
     elseif previewFlag == "_textureProcPreview"
         or previewFlag == "_textureAuraPreview"
         or previewFlag == "_texturePandemicPreview"

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -46,9 +46,41 @@ local function RefreshKeyPressHighlightEnrollment(button)
     end
 end
 
+local function UnregisterKeyPressHighlightButton(button)
+    local unregister = ST._UnregisterKeyPressHighlightButton
+    if unregister then
+        unregister(button)
+    end
+end
+
 local function RefreshKeyPressHighlightPreview(button)
-    button._keyPressHighlightActive = nil
+    button._keyPressHighlightActive = false
     RefreshKeyPressHighlightEnrollment(button)
+end
+
+local function ClearDormantKeyPressHighlightPreviewFrame(frame)
+    if not (frame and frame.buttons) then return end
+    for _, button in ipairs(frame.buttons) do
+        if button._keyPressHighlightPreview or button._keyPressHighlightActive ~= nil then
+            button._keyPressHighlightPreview = nil
+            button._keyPressHighlightActive = false
+            UnregisterKeyPressHighlightButton(button)
+        end
+    end
+end
+
+local function ClearDormantKeyPressHighlightPreviews(self, groupId)
+    local dormantFrames = self and self._dormantFrames
+    if not dormantFrames then return end
+
+    if groupId then
+        ClearDormantKeyPressHighlightPreviewFrame(dormantFrames[groupId])
+        return
+    end
+
+    for _, frame in pairs(dormantFrames) do
+        ClearDormantKeyPressHighlightPreviewFrame(frame)
+    end
 end
 
 local function BumpButtonPreviewToken(tokenStore, groupId, buttonIndex)
@@ -775,7 +807,10 @@ end
 --------------------------------------------------------------------------------
 
 function CooldownCompanion:SetGroupKeyPressHighlightPreview(groupId, show)
-    SetGroupPreview(self, groupId, show, "_keyPressHighlightPreview", "_keyPressHighlightActive", nil, kphPreviewTokens, nil, RefreshKeyPressHighlightPreview, false)
+    SetGroupPreview(self, groupId, show, "_keyPressHighlightPreview", "_keyPressHighlightActive", false, kphPreviewTokens, nil, RefreshKeyPressHighlightPreview, false)
+    if not show then
+        ClearDormantKeyPressHighlightPreviews(self, groupId)
+    end
 end
 
 function CooldownCompanion:PlayGroupKeyPressHighlightPreview(groupId, durationSeconds)
@@ -783,7 +818,8 @@ function CooldownCompanion:PlayGroupKeyPressHighlightPreview(groupId, durationSe
 end
 
 function CooldownCompanion:ClearAllKeyPressHighlightPreviews()
-    ClearAllPreviews(self, "_keyPressHighlightPreview", "_keyPressHighlightActive", nil, kphPreviewTokens, nil, RefreshKeyPressHighlightPreview, false)
+    ClearAllPreviews(self, "_keyPressHighlightPreview", "_keyPressHighlightActive", false, kphPreviewTokens, nil, RefreshKeyPressHighlightPreview, false)
+    ClearDormantKeyPressHighlightPreviews(self)
 end
 
 --------------------------------------------------------------------------------

--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -46,10 +46,9 @@ local function RefreshKeyPressHighlightEnrollment(button)
     end
 end
 
-local function RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
-    if previewFlag == "_keyPressHighlightPreview" then
-        RefreshKeyPressHighlightEnrollment(button)
-    end
+local function RefreshKeyPressHighlightPreview(button)
+    button._keyPressHighlightActive = nil
+    RefreshKeyPressHighlightEnrollment(button)
 end
 
 local function BumpButtonPreviewToken(tokenStore, groupId, buttonIndex)
@@ -181,7 +180,6 @@ local function SetButtonPreview(self, groupId, buttonIndex, show, previewFlag, c
             button[previewFlag] = show or nil
             button[cacheFlag] = cacheValue
             if onToggle then onToggle(button, show) end
-            RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
             if updateCooldown and button.UpdateCooldown then
                 button:UpdateCooldown()
             end
@@ -204,7 +202,6 @@ local function SetGroupPreview(self, groupId, show, previewFlag, cacheFlag, cach
         button[previewFlag] = show or nil
         button[cacheFlag] = cacheValue
         if onToggle then onToggle(button, show) end
-        RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
         if updateCooldown and button.UpdateCooldown then
             button:UpdateCooldown()
         end
@@ -252,7 +249,6 @@ local function ClearAllPreviews(self, previewFlag, cacheFlag, cacheValue, groupT
             button[previewFlag] = nil
             button[cacheFlag] = cacheValue
             if onClear then onClear(button) end
-            RefreshKeyPressHighlightPreviewEnrollment(button, previewFlag)
             if updateCooldown and button.UpdateCooldown then
                 button:UpdateCooldown()
             end
@@ -776,11 +772,10 @@ end
 --------------------------------------------------------------------------------
 -- Key Press Highlight Preview (no per-button methods, no UpdateCooldown)
 -- KPH is rendered by the idle enrollment driver, not by UpdateCooldown.
--- Setting the flag and invalidating the cache is sufficient.
 --------------------------------------------------------------------------------
 
 function CooldownCompanion:SetGroupKeyPressHighlightPreview(groupId, show)
-    SetGroupPreview(self, groupId, show, "_keyPressHighlightPreview", "_keyPressHighlightActive", nil, kphPreviewTokens, nil, nil, false)
+    SetGroupPreview(self, groupId, show, "_keyPressHighlightPreview", "_keyPressHighlightActive", nil, kphPreviewTokens, nil, RefreshKeyPressHighlightPreview, false)
 end
 
 function CooldownCompanion:PlayGroupKeyPressHighlightPreview(groupId, durationSeconds)
@@ -788,7 +783,7 @@ function CooldownCompanion:PlayGroupKeyPressHighlightPreview(groupId, durationSe
 end
 
 function CooldownCompanion:ClearAllKeyPressHighlightPreviews()
-    ClearAllPreviews(self, "_keyPressHighlightPreview", "_keyPressHighlightActive", nil, kphPreviewTokens, nil, nil, false)
+    ClearAllPreviews(self, "_keyPressHighlightPreview", "_keyPressHighlightActive", nil, kphPreviewTokens, nil, RefreshKeyPressHighlightPreview, false)
 end
 
 --------------------------------------------------------------------------------
@@ -992,8 +987,7 @@ local function ApplyPreviewFlagToButton(button, previewFlag)
     elseif previewFlag == "_readyGlowPreview" then
         button._readyGlowActive = false
     elseif previewFlag == "_keyPressHighlightPreview" then
-        button._keyPressHighlightActive = nil
-        RefreshKeyPressHighlightEnrollment(button)
+        RefreshKeyPressHighlightPreview(button)
     elseif previewFlag == "_textureProcPreview"
         or previewFlag == "_textureAuraPreview"
         or previewFlag == "_texturePandemicPreview"

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -26,6 +26,13 @@ local SetFrameClickThrough = ST.SetFrameClickThrough
 local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
 local HideGlowStyles = ST._HideGlowStyles
 
+local function UnregisterKeyPressHighlightButton(button)
+    local unregister = ST._UnregisterKeyPressHighlightButton
+    if unregister then
+        unregister(button)
+    end
+end
+
 local CURSOR_ANCHOR_TARGET = CooldownCompanion:GetCursorAnchorTargetName()
 local DEFAULT_CURSOR_ANCHOR = CooldownCompanion:GetDefaultCursorPanelAnchor()
 local CURSOR_ANCHOR_POINT = DEFAULT_CURSOR_ANCHOR.point or "BOTTOMLEFT"
@@ -1852,6 +1859,7 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     -- Clear existing buttons (remove from Masque first if enabled)
     for _, button in ipairs(frame.buttons) do
+        UnregisterKeyPressHighlightButton(button)
         if CooldownCompanion.ReleaseAuraTextureVisual then
             CooldownCompanion:ReleaseAuraTextureVisual(button)
         end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -25,6 +25,34 @@ local function ClearButtonVisualState(button)
     end
 end
 
+local function UnregisterKeyPressHighlightFrame(frame)
+    local unregisterFrame = ST._UnregisterKeyPressHighlightFrame
+    if unregisterFrame then
+        unregisterFrame(frame)
+        return
+    end
+
+    local unregisterButton = ST._UnregisterKeyPressHighlightButton
+    if not (unregisterButton and frame and frame.buttons) then return end
+    for _, button in ipairs(frame.buttons) do
+        unregisterButton(button)
+    end
+end
+
+local function RefreshKeyPressHighlightFrame(frame)
+    local refreshFrame = ST._RefreshKeyPressHighlightFrame
+    if refreshFrame then
+        refreshFrame(frame)
+        return
+    end
+
+    local refreshButton = ST._RefreshKeyPressHighlightEnrollment
+    if not (refreshButton and frame and frame.buttons) then return end
+    for _, button in ipairs(frame.buttons) do
+        refreshButton(button)
+    end
+end
+
 local LOAD_CONDITION_DEFAULTS = {
     raid = false,
     dungeon = false,
@@ -2046,7 +2074,7 @@ function CooldownCompanion:RefreshAllGroups()
     if self._dormantFrames then
         for groupId, _ in pairs(self._dormantFrames) do
             if not self.db.profile.groups[groupId] then
-                self._dormantFrames[groupId] = nil
+                self:DiscardDormantFrame(groupId)
             end
         end
     end
@@ -2097,7 +2125,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     if self._dormantFrames then
         for groupId, _ in pairs(self._dormantFrames) do
             if not self.db.profile.groups[groupId] then
-                self._dormantFrames[groupId] = nil
+                self:DiscardDormantFrame(groupId)
             end
         end
     end
@@ -2201,6 +2229,7 @@ end
 function CooldownCompanion:UnloadGroup(groupId)
     local frame = self.groupFrames[groupId]
     if not frame then return end
+    UnregisterKeyPressHighlightFrame(frame)
 
     -- Save and clear button OnUpdate scripts, remove from Masque.
     -- Buttons stay attached to the frame for potential reuse.
@@ -2269,6 +2298,7 @@ function CooldownCompanion:RecoverDormantFrame(groupId)
             end
         end
     end
+    RefreshKeyPressHighlightFrame(frame)
 
     -- Recreate Masque group and re-add buttons
     local group = self.db.profile.groups[groupId]
@@ -2293,6 +2323,7 @@ end
 function CooldownCompanion:DiscardDormantFrame(groupId)
     if self._dormantFrames then
         local frame = self._dormantFrames[groupId]
+        UnregisterKeyPressHighlightFrame(frame)
         if frame and frame.buttons and self.ReleaseAuraTextureVisual then
             for _, button in ipairs(frame.buttons) do
                 self:ReleaseAuraTextureVisual(button)

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -26,12 +26,6 @@ local function ClearButtonVisualState(button)
 end
 
 local function UnregisterKeyPressHighlightFrame(frame)
-    local unregisterFrame = ST._UnregisterKeyPressHighlightFrame
-    if unregisterFrame then
-        unregisterFrame(frame)
-        return
-    end
-
     local unregisterButton = ST._UnregisterKeyPressHighlightButton
     if not (unregisterButton and frame and frame.buttons) then return end
     for _, button in ipairs(frame.buttons) do
@@ -40,12 +34,6 @@ local function UnregisterKeyPressHighlightFrame(frame)
 end
 
 local function RefreshKeyPressHighlightFrame(frame)
-    local refreshFrame = ST._RefreshKeyPressHighlightFrame
-    if refreshFrame then
-        refreshFrame(frame)
-        return
-    end
-
     local refreshButton = ST._RefreshKeyPressHighlightEnrollment
     if not (refreshButton and frame and frame.buttons) then return end
     for _, button in ipairs(frame.buttons) do

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -34,10 +34,17 @@ local function UnregisterKeyPressHighlightFrame(frame)
 end
 
 local function RefreshKeyPressHighlightFrame(frame)
+    local cacheButtonBindingKeys = ST._CacheButtonBindingKeys
     local refreshButton = ST._RefreshKeyPressHighlightEnrollment
-    if not (refreshButton and frame and frame.buttons) then return end
+    if not (frame and frame.buttons) then return end
+    if not (cacheButtonBindingKeys or refreshButton) then return end
+
     for _, button in ipairs(frame.buttons) do
-        refreshButton(button)
+        if cacheButtonBindingKeys then
+            cacheButtonBindingKeys(button, button.buttonData)
+        else
+            refreshButton(button)
+        end
     end
 end
 

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -35,6 +35,13 @@ local ACTION_BAR_BUTTONS = {
     {"MultiBar7Button",           "MULTIACTIONBAR7BUTTON",   12},
 }
 
+local function RefreshKeyPressHighlightEnrollment(button)
+    local refresh = ST._RefreshKeyPressHighlightEnrollment
+    if refresh then
+        refresh(button)
+    end
+end
+
 -- slot → {bindingAction, frameName} reverse lookup, rebuilt on events
 local slotToButtonInfo = {}
 
@@ -293,6 +300,7 @@ local function CacheButtonBindingKeys(button, buttonData)
     local infos = {}
     if not buttonData then
         button._bindingKeyInfos = infos
+        RefreshKeyPressHighlightEnrollment(button)
         return
     end
     local slots
@@ -321,6 +329,7 @@ local function CacheButtonBindingKeys(button, buttonData)
         end
     end
     button._bindingKeyInfos = infos
+    RefreshKeyPressHighlightEnrollment(button)
 end
 
 -- Rebuild the entire item→slot reverse lookup cache by scanning action button frames.

--- a/Core/Keybinds.lua
+++ b/Core/Keybinds.lua
@@ -298,31 +298,29 @@ end
 -- Stores result as button._bindingKeyInfos (array of parsed structs, or empty table).
 local function CacheButtonBindingKeys(button, buttonData)
     local infos = {}
-    if not buttonData then
-        button._bindingKeyInfos = infos
-        RefreshKeyPressHighlightEnrollment(button)
-        return
-    end
-    local slots
-    if buttonData.type == "spell" then
-        slots = GetSpellActionSlots(buttonData.id)
-    elseif buttonData.type == "item" or buttonData.type == "equipmentSlot" then
-        local itemID = button._resolvedItemId or buttonData.id
-        if itemID then
-            local slot = CooldownCompanion._itemSlotCache[itemID]
-            if slot then slots = {slot} end
+    if buttonData then
+        local slots
+        if buttonData.type == "spell" then
+            slots = GetSpellActionSlots(buttonData.id)
+        elseif buttonData.type == "item" or buttonData.type == "equipmentSlot" then
+            local itemID = button._resolvedItemId or buttonData.id
+            if itemID then
+                local slot = CooldownCompanion._itemSlotCache[itemID]
+                if slot then slots = {slot} end
+            end
         end
-    end
-    if slots then
-        local seen = {}
-        for _, slot in ipairs(slots) do
-            local rawKeys = GetRawBindingKeysForSlot(slot)
-            for _, rawKey in ipairs(rawKeys) do
-                if not seen[rawKey] then
-                    seen[rawKey] = true
-                    local parsed = ParseBindingKey(rawKey)
-                    if parsed then
-                        infos[#infos + 1] = parsed
+
+        if slots then
+            local seen = {}
+            for _, slot in ipairs(slots) do
+                local rawKeys = GetRawBindingKeysForSlot(slot)
+                for _, rawKey in ipairs(rawKeys) do
+                    if not seen[rawKey] then
+                        seen[rawKey] = true
+                        local parsed = ParseBindingKey(rawKey)
+                        if parsed then
+                            infos[#infos + 1] = parsed
+                        end
                     end
                 end
             end

--- a/tests/key-press-highlight-driver.lua
+++ b/tests/key-press-highlight-driver.lua
@@ -1,0 +1,101 @@
+local function ReadFile(path)
+    local file = assert(io.open(path, "rb"))
+    local text = file:read("*a")
+    file:close()
+    return text
+end
+
+local function Count(text, needle)
+    local found = 0
+    local index = 1
+    while true do
+        local startIndex = text:find(needle, index, true)
+        if not startIndex then
+            return found
+        end
+        found = found + 1
+        index = startIndex + #needle
+    end
+end
+
+local iconMode = ReadFile("ButtonFrame/IconMode.lua")
+local keybinds = ReadFile("Core/Keybinds.lua")
+local preview = ReadFile("ButtonFrame/Preview.lua")
+local groupFrame = ReadFile("Core/GroupFrame.lua")
+local groupOperations = ReadFile("Core/GroupOperations.lua")
+
+assert(iconMode:find("local kphButtons = {}", 1, true),
+    "KPH driver should track enrolled buttons directly")
+assert(iconMode:find("local kphButtonIndexes = {}", 1, true),
+    "KPH driver should keep O(1) enrollment lookups")
+assert(iconMode:find("local function KeyPressHighlightOnUpdate", 1, true),
+    "KPH driver should have a named OnUpdate handler")
+assert(iconMode:find("while index <= #kphButtons do", 1, true),
+    "KPH driver should iterate the enrolled button registry")
+assert(iconMode:find("kphUpdateFrame:SetScript(\"OnUpdate\", KeyPressHighlightOnUpdate)", 1, true),
+    "KPH driver should start only when enrollment is non-empty")
+assert(iconMode:find("kphUpdateFrame:SetScript(\"OnUpdate\", nil)", 1, true),
+    "KPH driver should stop when enrollment becomes empty")
+assert(iconMode:find("if #kphButtons == 0 then", 1, true),
+    "KPH unregister should check for an empty registry")
+assert(iconMode:find("StopKeyPressHighlightDriver()", 1, true),
+    "KPH unregister should stop the driver after the last button leaves")
+assert(not iconMode:find("kphUpdateFrame:SetScript(\"OnUpdate\", function", 1, true),
+    "KPH driver should not install a permanent anonymous module-load OnUpdate")
+assert(not iconMode:find("local groupFrames = CooldownCompanion.groupFrames", 1, true),
+    "KPH driver should not scan every visible group frame each tick")
+
+assert(iconMode:find("ST._RefreshKeyPressHighlightEnrollment = RefreshKeyPressHighlightEnrollment", 1, true),
+    "IconMode should export button enrollment refresh")
+assert(iconMode:find("ST._UnregisterKeyPressHighlightButton = UnregisterKeyPressHighlightButton", 1, true),
+    "IconMode should export button unregister")
+assert(not iconMode:find("ST._RefreshKeyPressHighlightFrame", 1, true),
+    "IconMode should keep KPH frame iteration out of the shared API surface")
+assert(not iconMode:find("ST._UnregisterKeyPressHighlightFrame", 1, true),
+    "IconMode should keep KPH frame unregister out of the shared API surface")
+
+assert(keybinds:find("local refresh = ST._RefreshKeyPressHighlightEnrollment", 1, true),
+    "Keybind changes should notify KPH enrollment")
+assert(keybinds:find("button._bindingKeyInfos = infos\n    RefreshKeyPressHighlightEnrollment(button)", 1, true),
+    "Binding-key cache writes should refresh KPH enrollment")
+assert(Count(keybinds, "button._bindingKeyInfos = infos") == 1,
+    "Binding-key cache should write binding infos through one path")
+
+assert(preview:find("local function RefreshKeyPressHighlightPreview(button)", 1, true),
+    "Preview state changes should use a KPH-specific callback")
+assert(preview:find("button._keyPressHighlightActive = false", 1, true),
+    "KPH preview refresh should invalidate the cache without suppressing the hide path")
+assert(not preview:find("RefreshKeyPressHighlightPreviewEnrollment", 1, true),
+    "Generic preview helpers should not special-case KPH")
+assert(Count(preview, "RefreshKeyPressHighlightPreview") >= 4,
+    "KPH preview start, clear, and config preview paths should refresh enrollment")
+assert(preview:find("local function ClearDormantKeyPressHighlightPreviews(self, groupId)", 1, true),
+    "KPH preview clear should reconcile dormant-frame preview flags")
+assert(preview:find("ClearDormantKeyPressHighlightPreviews(self, groupId)", 1, true),
+    "Group KPH preview clear should clear dormant-frame preview flags")
+assert(preview:find("ClearDormantKeyPressHighlightPreviews(self)", 1, true),
+    "Global KPH preview clear should clear dormant-frame preview flags")
+assert(Count(preview, "\"_keyPressHighlightActive\", false") >= 2,
+    "KPH preview clear paths should use false cache invalidation so off calls hide")
+
+assert(groupFrame:find("local unregister = ST._UnregisterKeyPressHighlightButton", 1, true),
+    "Button repopulation should reach the KPH unregister hook")
+assert(groupFrame:find("UnregisterKeyPressHighlightButton(button)", 1, true),
+    "Existing buttons should leave KPH enrollment before release")
+
+assert(groupOperations:find("local unregisterButton = ST._UnregisterKeyPressHighlightButton", 1, true),
+    "Group unload/discard should reach the KPH button unregister hook")
+assert(groupOperations:find("local cacheButtonBindingKeys = ST._CacheButtonBindingKeys", 1, true),
+    "Dormant-frame recovery should rebuild cached binding keys before KPH enrollment")
+assert(groupOperations:find("local refreshButton = ST._RefreshKeyPressHighlightEnrollment", 1, true),
+    "Dormant-frame recovery should reach the KPH button refresh hook")
+assert(groupOperations:find("cacheButtonBindingKeys(button, button.buttonData)", 1, true),
+    "Recovered dormant buttons should refresh binding cache before enrollment")
+assert(groupOperations:find("UnregisterKeyPressHighlightFrame(frame)", 1, true),
+    "Unloaded or discarded frames should unregister KPH buttons")
+assert(groupOperations:find("RefreshKeyPressHighlightFrame(frame)", 1, true),
+    "Recovered dormant frames should refresh KPH enrollment")
+assert(not groupOperations:find("if not self.db.profile.groups[groupId] then\n                self._dormantFrames[groupId] = nil", 1, true),
+    "Deleted dormant groups should be discarded through the unregister-aware path")
+
+print("key-press-highlight-driver ok")


### PR DESCRIPTION
## What Players Will Notice
- Key press highlights should look and respond the same, including previews, combat-only highlighting, normal gameplay, and restricted content.
- Cooldown Companion does less idle work when no eligible key press highlights are active.

## Why This Changed
- The previous key press highlight path kept a throttled `OnUpdate` installed and scanned every visible group frame to find buttons, even when no eligible highlight or preview button existed.
- This addresses the key press highlight driver optimization finding from the cooldown optimization review.

## What Changed
- Icon mode now owns a compact enrolled-button key press highlight registry and installs the driver only while at least one button is enrolled.
- Enrollment refreshes when buttons are created, styles change, bindings are recached, previews apply or clear, groups repopulate, and dormant frames unload, recover, or discard.
- Combat-only remains a display-time check, so enrollment and feature behavior are not gated by combat state.
- Added a source-invariant regression test covering the driver lifecycle and KPH enrollment boundaries.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p ButtonFrame\\IconMode.lua ButtonFrame\\Preview.lua Core\\GroupFrame.lua Core\\GroupOperations.lua Core\\Keybinds.lua tests\\key-press-highlight-driver.lua`
- `lua tests\\key-press-highlight-driver.lua`
- `Get-ChildItem -Path tests -Filter *.lua | Sort-Object Name | ForEach-Object { lua $_.FullName }`
- In-game normal, combat, and restricted-content validation passed.