### PR TITLE
Idle the alpha fade driver when no alpha work is active

### DIFF
--- a/ButtonFrame/Preview.lua
+++ b/ButtonFrame/Preview.lua
@@ -1139,4 +1139,7 @@ function CooldownCompanion:ClearAllConfigPreviews()
     if ST._RefreshAdvancedSettingsPreviewButtons then
         ST._RefreshAdvancedSettingsPreviewButtons()
     end
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
+    end
 end

--- a/Config/State.lua
+++ b/Config/State.lua
@@ -702,6 +702,8 @@ local function BuildConfigFinderResults()
     return results
 end
 
+local RefreshAlphaDriverForConfigSelection
+
 local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CooldownCompanion:ClearAllConfigPreviews()
     wipe(CS.selectedGroups)
@@ -716,6 +718,7 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CS.selectedButton = buttonIndex
     CS.addingToPanelId = nil
     ClearConfigFinderText()
+    RefreshAlphaDriverForConfigSelection()
     CooldownCompanion:RefreshConfigPanel()
 end
 
@@ -2461,18 +2464,28 @@ local function ClearSelectedButton()
     wipe(CS.selectedButtons)
 end
 
+function RefreshAlphaDriverForConfigSelection()
+    if CooldownCompanion.RefreshAlphaUpdateDriver then
+        CooldownCompanion:RefreshAlphaUpdateDriver()
+    end
+end
+
 local function ClearConfigButtonSelection()
     ClearSelectedButton()
 end
 
-local function ClearConfigPanelSelection()
+local function ClearConfigPanelSelection(opts)
     CS.selectedGroup = nil
     ClearSelectedButton()
+    if not (opts and opts.deferAlphaRefresh) then
+        RefreshAlphaDriverForConfigSelection()
+    end
 end
 
 local function ClearConfigContainerSelection()
     CS.selectedContainer = nil
-    ClearConfigPanelSelection()
+    ClearConfigPanelSelection({ deferAlphaRefresh = true })
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function ClearConfigPanelMultiSelection(opts)
@@ -2480,10 +2493,12 @@ local function ClearConfigPanelMultiSelection(opts)
     if opts and opts.selectContainerId ~= nil then
         CS.selectedContainer = opts.selectContainerId
     end
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function ClearConfigContainerMultiSelection()
     wipe(CS.selectedGroups)
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function ClearConfigResourceSelection()
@@ -2501,6 +2516,7 @@ local function ClearConfigPrimarySelection()
     wipe(CS.selectedGroups)
     wipe(CS.selectedCustomBars)
     ClearConfigResourceSelection()
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function SelectConfigFolder(folderId)
@@ -2511,6 +2527,7 @@ local function SelectConfigFolder(folderId)
     ClearSelectedButton()
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function SelectConfigContainer(containerId, opts)
@@ -2536,6 +2553,7 @@ local function SelectConfigContainer(containerId, opts)
     if opts and opts.clearFinder then
         ClearConfigFinderText()
     end
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function ToggleConfigContainerMultiSelect(containerId)
@@ -2555,6 +2573,7 @@ local function ToggleConfigContainerMultiSelect(containerId)
     ClearSelectedButton()
     wipe(CS.selectedPanels)
     wipe(CS.selectedCustomBars)
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function SelectConfigPanel(panelId, opts)
@@ -2573,6 +2592,7 @@ local function SelectConfigPanel(panelId, opts)
     end
 
     ClearSelectedButton()
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function ToggleConfigPanelMultiSelect(panelId)
@@ -2589,6 +2609,7 @@ local function ToggleConfigPanelMultiSelect(panelId)
     CS.selectedGroup = nil
     ClearSelectedButton()
     CS.addingToPanelId = nil
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function SelectConfigButton(panelId, buttonIndex, opts)
@@ -2626,6 +2647,7 @@ local function SelectConfigButton(panelId, buttonIndex, opts)
     end
 
     CooldownCompanion:ClearAllConfigPreviews()
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function SelectConfigButtonPanel(panelId, opts)
@@ -2633,9 +2655,11 @@ local function SelectConfigButtonPanel(panelId, opts)
         CooldownCompanion:ClearAllConfigPreviews()
         CS.selectedGroup = panelId
         ClearSelectedButton()
+        RefreshAlphaDriverForConfigSelection()
     end
     if opts and opts.clearPanelMulti then
         wipe(CS.selectedPanels)
+        RefreshAlphaDriverForConfigSelection()
     end
 end
 
@@ -2806,6 +2830,7 @@ local function ResetConfigSelection(full)
         CS.browseCharKey = nil
         CS.browseContainerId = nil
     end
+    RefreshAlphaDriverForConfigSelection()
 end
 
 local function SetConfigPrimaryMode(mode, opts)

--- a/ConfigSettings/Helpers.lua
+++ b/ConfigSettings/Helpers.lua
@@ -1304,6 +1304,15 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
     local tabInfoBtns = opts.infoButtons or CS.tabInfoButtons
     local controlsDisabled = opts.disabled == true
 
+    local function ApplyAlphaSettingChange(refreshPanel)
+        if CooldownCompanion.RefreshAlphaUpdateDriver then
+            CooldownCompanion:RefreshAlphaUpdateDriver()
+        end
+        if refreshPanel and refreshFn then
+            refreshFn()
+        end
+    end
+
     local alphaHeading = AceGUI:Create("Heading")
     alphaHeading:SetText("Alpha")
     ColorHeading(alphaHeading)
@@ -1340,6 +1349,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         if opts.onBaselineChanged then
             opts.onBaselineChanged(val)
         end
+        ApplyAlphaSettingChange(false)
     end)
     container:AddChild(baseAlphaSlider)
 
@@ -1376,7 +1386,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
                 if controlsDisabled then return end
                 config[visibleKey] = (newVal == true)
                 config[hiddenKey] = (newVal == nil)
-                refreshFn()
+                ApplyAlphaSettingChange(true)
             end)
             return cb
         end
@@ -1401,6 +1411,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
             travelCb:SetCallback("OnValueChanged", function(widget, event, val)
                 if controlsDisabled then return end
                 config.treatTravelFormAsMounted = val
+                ApplyAlphaSettingChange(false)
             end)
             container:AddChild(travelCb)
         end
@@ -1414,7 +1425,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         targetCb:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.forceAlphaTargetExists = val
-            refreshFn()
+            ApplyAlphaSettingChange(true)
         end)
         container:AddChild(targetCb)
 
@@ -1428,7 +1439,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
             enemyOnlyCb:SetCallback("OnValueChanged", function(widget, event, val)
                 if controlsDisabled then return end
                 config.forceAlphaTargetEnemyOnly = val
-                refreshFn()
+                ApplyAlphaSettingChange(true)
             end)
             container:AddChild(enemyOnlyCb)
             ApplyCheckboxIndent(enemyOnlyCb, 20)
@@ -1443,7 +1454,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         focusCb:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.forceAlphaFocusExists = val
-            refreshFn()
+            ApplyAlphaSettingChange(true)
         end)
         container:AddChild(focusCb)
 
@@ -1456,7 +1467,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         mouseoverCb:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.forceAlphaMouseover = val
-            refreshFn()
+            ApplyAlphaSettingChange(true)
         end)
         container:AddChild(mouseoverCb)
 
@@ -1473,7 +1484,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeCb:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.customFade = val or nil
-            refreshFn()
+            ApplyAlphaSettingChange(true)
         end)
         container:AddChild(fadeCb)
 
@@ -1487,6 +1498,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeDelaySlider:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.fadeDelay = val
+            ApplyAlphaSettingChange(false)
         end)
         container:AddChild(fadeDelaySlider)
 
@@ -1499,6 +1511,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeInSlider:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.fadeInDuration = val
+            ApplyAlphaSettingChange(false)
         end)
         container:AddChild(fadeInSlider)
 
@@ -1511,6 +1524,7 @@ local function BuildAlphaControls(container, config, refreshFn, collapseKey, opt
         fadeOutSlider:SetCallback("OnValueChanged", function(widget, event, val)
             if controlsDisabled then return end
             config.fadeOutDuration = val
+            ApplyAlphaSettingChange(false)
         end)
         container:AddChild(fadeOutSlider)
         end -- config.customFade

--- a/Core/AlphaFade.lua
+++ b/Core/AlphaFade.lua
@@ -26,6 +26,78 @@ local function FrameAlphaDiffers(frame, alpha)
     return frame:GetAlpha() ~= alpha
 end
 
+local function HasLiveAlphaFrames(frames)
+    if type(frames) ~= "table" then
+        return false
+    end
+    for i = 1, #frames do
+        if frames[i] then
+            return true
+        end
+    end
+    return false
+end
+
+local function AlphaFrameListsEqual(left, right)
+    if left == right then
+        return true
+    end
+    if type(left) ~= "table" or type(right) ~= "table" then
+        return false
+    end
+    if #left ~= #right then
+        return false
+    end
+    for i = 1, #left do
+        if left[i] ~= right[i] then
+            return false
+        end
+    end
+    return true
+end
+
+local function RestoreAlphaFrames(frames)
+    if type(frames) ~= "table" then
+        return
+    end
+    for i = 1, #frames do
+        local frame = frames[i]
+        if frame and frame.SetAlpha then
+            frame:SetAlpha(1)
+        end
+    end
+end
+
+local function AlphaStateNeedsCleanup(self, stateKey)
+    local state = self.alphaState and self.alphaState[stateKey]
+    return state and state.currentAlpha and state.currentAlpha ~= 1 or false
+end
+
+local function ConfigNeedsAlphaUpdate(self, config, stateKey)
+    if ST.HasActiveAlphaSettings and ST.HasActiveAlphaSettings(config) then
+        return true
+    end
+    return AlphaStateNeedsCleanup(self, stateKey)
+end
+
+local function GroupNeedsAlphaUpdate(self, group, groupId, frame)
+    if self.ShouldInheritPanelAnchorAlpha and self:ShouldInheritPanelAnchorAlpha(groupId) then
+        return false
+    end
+    if frame and frame._inheritsExternalAnchorAlpha then
+        return false
+    end
+    if ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(groupId) then
+        return true
+    end
+    return ConfigNeedsAlphaUpdate(self, group, groupId)
+end
+
+local function FrameIsAlphaWorkTarget(frame, isDependencyTarget)
+    return frame
+        and ((frame.IsShown and frame:IsShown()) or isDependencyTarget)
+end
+
 -- Alpha fade system: per-group runtime state
 -- self.alphaState[groupId] = {
 --     currentAlpha   - current interpolated alpha
@@ -364,108 +436,195 @@ function CooldownCompanion:RegisterModuleAlpha(moduleId, config, frames)
     if not self._moduleAlphaTargets then
         self._moduleAlphaTargets = {}
     end
-    self._moduleAlphaTargets[moduleId] = { config = config, frames = frames }
+    local hasActiveSettings = ST.HasActiveAlphaSettings and ST.HasActiveAlphaSettings(config) or false
+    local entry = self._moduleAlphaTargets[moduleId]
+    if entry and entry.config == config and AlphaFrameListsEqual(entry.frames, frames) then
+        if entry.hasActiveSettings ~= hasActiveSettings then
+            entry.hasActiveSettings = hasActiveSettings
+            self:RefreshAlphaUpdateDriver()
+            return
+        end
+        local alphaFrame = self._alphaFrame
+        if alphaFrame and not alphaFrame:GetScript("OnUpdate")
+            and HasLiveAlphaFrames(frames)
+            and ConfigNeedsAlphaUpdate(self, config, moduleId) then
+            self:RefreshAlphaUpdateDriver()
+        end
+        return
+    end
+    self._moduleAlphaTargets[moduleId] = { config = config, frames = frames, hasActiveSettings = hasActiveSettings }
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
+    end
 end
 
 function CooldownCompanion:UnregisterModuleAlpha(moduleId, preserveState)
+    local entry = self._moduleAlphaTargets and self._moduleAlphaTargets[moduleId] or nil
+    local frames = entry and entry.frames or nil
+    if not preserveState then
+        RestoreAlphaFrames(frames)
+    end
     if self._moduleAlphaTargets then
         self._moduleAlphaTargets[moduleId] = nil
     end
-    if not preserveState and self.alphaState then
+    if self.alphaState and ((not preserveState) or not HasLiveAlphaFrames(frames)) then
         self.alphaState[moduleId] = nil
+    end
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
     end
 end
 
-function CooldownCompanion:InitAlphaUpdateFrame()
-    if self._alphaFrame then return end
-
-    local alphaFrame = CreateFrame("Frame")
-    self._alphaFrame = alphaFrame
-    local accumulator = 0
-    local UPDATE_INTERVAL = 1 / 30 -- ~30Hz for smooth fading
-
-    local function ConfigNeedsAlphaUpdate(config, stateKey)
-        if (config.baselineAlpha or 1) < 1 then return true end
-        if config.forceAlphaInCombat or config.forceAlphaOutOfCombat
-            or config.forceAlphaRegularMounted or config.forceAlphaDragonriding
-            or config.forceAlphaTargetExists or config.forceAlphaFocusExists
-            or config.forceAlphaMouseover then
-            return true
-        end
-        if config.forceHideInCombat or config.forceHideOutOfCombat
-            or config.forceHideRegularMounted or config.forceHideDragonriding then
-            return true
-        end
-        -- Check for stale alpha state that needs cleanup
-        local state = self.alphaState[stateKey]
-        if state and state.currentAlpha and state.currentAlpha ~= 1 then
-            return true
-        end
+function CooldownCompanion:EvaluateAlphaDriverNeedsWork()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
         return false
     end
 
-    local function GroupNeedsAlphaUpdate(group, groupId, frame)
-        if self:ShouldInheritPanelAnchorAlpha(groupId) then
-            return false
+    local groups = profile.groups or {}
+    local groupFrames = self.groupFrames or {}
+    local dormantFrames = self._dormantFrames
+    local previousEvaluating = self._evaluatingAlphaDriverNeedsWork
+    self._evaluatingAlphaDriverNeedsWork = true
+    local panelAlphaAnchorTargets = self.GetPanelAlphaDependencyTargets
+        and self:GetPanelAlphaDependencyTargets(groups)
+        or nil
+    self._evaluatingAlphaDriverNeedsWork = previousEvaluating
+
+    for groupId, group in pairs(groups) do
+        local frame = groupFrames[groupId] or (dormantFrames and dormantFrames[groupId])
+        if FrameIsAlphaWorkTarget(frame, panelAlphaAnchorTargets and panelAlphaAnchorTargets[groupId]) then
+            if GroupNeedsAlphaUpdate(self, group, groupId, frame) then
+                return true
+            end
         end
-        if frame and frame._inheritsExternalAnchorAlpha then
-            return false
-        end
-        if ST.IsGroupConfigSelected(groupId) then return true end
-        return ConfigNeedsAlphaUpdate(group, groupId)
     end
 
-    alphaFrame:SetScript("OnUpdate", function(_, dt)
-        accumulator = accumulator + (dt or 0)
-        if accumulator < UPDATE_INTERVAL then return end
-        accumulator = 0
-
-        local now = GetTime()
-        local inCombat = InCombatLockdown()
-        local hasTarget = UnitExists("target")
-        local hasEnemyTarget = hasTarget and UnitCanAttack("player", "target") and true or false
-        local hasFocus = UnitExists("focus")
-        local mounted = IsMounted()
-        local regularMounted, dragonridingMounted = self:ResolveMountedAlphaStates(mounted)
-
-        local inTravelForm = false
-        if self._playerClassID == 11 then -- Druid
-            local fi = GetShapeshiftForm()
-            if fi and fi > 0 then
-                local _, _, _, spellID = GetShapeshiftFormInfo(fi)
-                if spellID == 783 or spellID == 210053 then
-                    inTravelForm = spellID
-                end
+    if self._moduleAlphaTargets then
+        for moduleId, entry in pairs(self._moduleAlphaTargets) do
+            if entry and HasLiveAlphaFrames(entry.frames)
+                and ConfigNeedsAlphaUpdate(self, entry.config, moduleId) then
+                return true
             end
         end
+    end
 
-        local containers = self.db.profile.groupContainers or {}
-        local groups = self.db.profile.groups or {}
-        local panelAlphaAnchorTargets = self:GetPanelAlphaDependencyTargets(groups)
-        for groupId, group in pairs(groups) do
-            local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
-            if frame
-                and (frame:IsShown() or (panelAlphaAnchorTargets and panelAlphaAnchorTargets[groupId])) then
-                if GroupNeedsAlphaUpdate(group, groupId, frame) then
-                    local locked = true
-                    if group.parentContainerId then
-                        local c = containers[group.parentContainerId]
-                        if c then locked = c.locked ~= false end
-                    else
-                        locked = group.locked
-                    end
-                    self:UpdateGroupAlpha(groupId, group, locked, frame, now, inCombat, hasTarget, hasEnemyTarget, hasFocus, regularMounted, dragonridingMounted, inTravelForm)
-                end
+    return false
+end
+
+function CooldownCompanion:AlphaUpdateOnUpdate(dt)
+    local updateInterval = self._alphaUpdateInterval or (1 / 30)
+    self._alphaUpdateAccumulator = (self._alphaUpdateAccumulator or 0) + (dt or 0)
+    if self._alphaUpdateAccumulator < updateInterval then return end
+    self._alphaUpdateAccumulator = 0
+
+    local now = GetTime()
+    local inCombat = InCombatLockdown()
+    local hasTarget = UnitExists("target")
+    local hasEnemyTarget = hasTarget and UnitCanAttack("player", "target") and true or false
+    local hasFocus = UnitExists("focus")
+    local mounted = IsMounted()
+    local regularMounted, dragonridingMounted = self:ResolveMountedAlphaStates(mounted)
+
+    local inTravelForm = false
+    if self._playerClassID == 11 then -- Druid
+        local fi = GetShapeshiftForm()
+        if fi and fi > 0 then
+            local _, _, _, spellID = GetShapeshiftFormInfo(fi)
+            if spellID == 783 or spellID == 210053 then
+                inTravelForm = spellID
             end
         end
+    end
 
-        -- Process registered module alpha targets (resource bars, custom aura bars, texture panels)
-        if self._moduleAlphaTargets then
-            for moduleId, entry in pairs(self._moduleAlphaTargets) do
-                if ConfigNeedsAlphaUpdate(entry.config, moduleId) then
-                    self:UpdateModuleAlpha(moduleId, entry.config, entry.frames, now, inCombat, hasTarget, hasEnemyTarget, hasFocus, regularMounted, dragonridingMounted, inTravelForm)
+    local containers = self.db.profile.groupContainers or {}
+    local groups = self.db.profile.groups or {}
+    local panelAlphaAnchorTargets = self:GetPanelAlphaDependencyTargets(groups)
+    local needsPostPassRefresh = false
+    local processedAlphaWork = false
+    for groupId, group in pairs(groups) do
+        local frame = self.groupFrames[groupId] or (self._dormantFrames and self._dormantFrames[groupId])
+        if FrameIsAlphaWorkTarget(frame, panelAlphaAnchorTargets and panelAlphaAnchorTargets[groupId]) then
+            if GroupNeedsAlphaUpdate(self, group, groupId, frame) then
+                processedAlphaWork = true
+                if not (ST.HasActiveAlphaSettings and ST.HasActiveAlphaSettings(group))
+                    and AlphaStateNeedsCleanup(self, groupId) then
+                    needsPostPassRefresh = true
                 end
+                local locked = true
+                if group.parentContainerId then
+                    local c = containers[group.parentContainerId]
+                    if c then locked = c.locked ~= false end
+                else
+                    locked = group.locked
+                end
+                self:UpdateGroupAlpha(groupId, group, locked, frame, now, inCombat, hasTarget, hasEnemyTarget, hasFocus, regularMounted, dragonridingMounted, inTravelForm)
             end
         end
-    end)
+    end
+
+    -- Process registered module alpha targets (resource bars, custom aura bars, texture panels)
+    if self._moduleAlphaTargets then
+        for moduleId, entry in pairs(self._moduleAlphaTargets) do
+            if entry and HasLiveAlphaFrames(entry.frames)
+                and ConfigNeedsAlphaUpdate(self, entry.config, moduleId) then
+                processedAlphaWork = true
+                if not (ST.HasActiveAlphaSettings and ST.HasActiveAlphaSettings(entry.config))
+                    and AlphaStateNeedsCleanup(self, moduleId) then
+                    needsPostPassRefresh = true
+                end
+                self:UpdateModuleAlpha(moduleId, entry.config, entry.frames, now, inCombat, hasTarget, hasEnemyTarget, hasFocus, regularMounted, dragonridingMounted, inTravelForm)
+            end
+        end
+    end
+    if needsPostPassRefresh or not processedAlphaWork then
+        self:RefreshAlphaUpdateDriver()
+    end
+end
+
+function CooldownCompanion:RefreshAlphaUpdateDriver()
+    if not self._alphaFrame then
+        if self._initializingAlphaUpdateFrame then
+            return false
+        end
+        if self.InitAlphaUpdateFrame then
+            self:InitAlphaUpdateFrame()
+        end
+    end
+
+    local alphaFrame = self._alphaFrame
+    if not alphaFrame then
+        return false
+    end
+
+    local needsWork = self:EvaluateAlphaDriverNeedsWork()
+    local handler = self._alphaUpdateHandler
+    if needsWork then
+        if not alphaFrame:GetScript("OnUpdate") then
+            alphaFrame:SetScript("OnUpdate", handler)
+        end
+    else
+        if alphaFrame:GetScript("OnUpdate") then
+            alphaFrame:SetScript("OnUpdate", nil)
+        end
+        self._alphaUpdateAccumulator = 0
+    end
+    return needsWork
+end
+
+function CooldownCompanion:InitAlphaUpdateFrame()
+    if self._alphaFrame then
+        self:RefreshAlphaUpdateDriver()
+        return
+    end
+
+    self._initializingAlphaUpdateFrame = true
+    self._alphaFrame = CreateFrame("Frame")
+    self._alphaUpdateAccumulator = 0
+    self._alphaUpdateInterval = 1 / 30 -- ~30Hz for smooth fading
+    self._alphaUpdateHandler = function(_, dt)
+        self:AlphaUpdateOnUpdate(dt)
+    end
+    self._initializingAlphaUpdateFrame = nil
+    self:RefreshAlphaUpdateDriver()
 end

--- a/Core/AnchorPolicy.lua
+++ b/Core/AnchorPolicy.lua
@@ -367,21 +367,6 @@ local function SanitizeScopedExternalAnchors(profile, targetIsCursorRoot)
     end)
 end
 
-local function HasActiveAlphaSettings(group)
-    return (group.baselineAlpha or 1) < 1
-        or group.forceAlphaInCombat == true
-        or group.forceAlphaOutOfCombat == true
-        or group.forceAlphaRegularMounted == true
-        or group.forceAlphaDragonriding == true
-        or group.forceAlphaTargetExists == true
-        or group.forceAlphaFocusExists == true
-        or group.forceAlphaMouseover == true
-        or group.forceHideInCombat == true
-        or group.forceHideOutOfCombat == true
-        or group.forceHideRegularMounted == true
-        or group.forceHideDragonriding == true
-end
-
 local function AddDependent(dependents, name)
     dependents[#dependents + 1] = {
         name = name,
@@ -511,6 +496,9 @@ function CooldownCompanion:RebuildPanelAlphaDependencyTargets(groups)
     local targets = BuildPanelAlphaDependencyTargets(sourceGroups)
     self._panelAlphaDependencyTargets = targets
     self._panelAlphaDependencyGroups = sourceGroups
+    if self.RefreshAlphaUpdateDriver and not self._evaluatingAlphaDriverNeedsWork then
+        self:RefreshAlphaUpdateDriver()
+    end
     return targets
 end
 
@@ -795,7 +783,8 @@ function CooldownCompanion:NormalizePanelAlphaInheritance(profile)
         if type(group) == "table"
             and group.inheritPanelAlpha == nil
             and (self:IsPanelAnchoredToPanel(group) or IsPanelAnchoredToExternalFrame(group))
-            and HasActiveAlphaSettings(group) then
+            and ST.HasActiveAlphaSettings
+            and ST.HasActiveAlphaSettings(group) then
             group.inheritPanelAlpha = false
         end
     end

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -2311,6 +2311,9 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     if self.RefreshCursorAnchorTicker then
         self:RefreshCursorAnchorTicker()
     end
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
+    end
 end
 
 function CooldownCompanion:WouldCreateCircularAnchor(sourceId, targetId, targetKind, sourceKind)

--- a/Core/GroupFrame.lua
+++ b/Core/GroupFrame.lua
@@ -1535,6 +1535,9 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     end
 
     self:RefreshCursorAnchorTicker()
+    if self.RefreshAlphaUpdateDriver and not self._creatingAllGroupFrames then
+        self:RefreshAlphaUpdateDriver()
+    end
 
     return frame
 end

--- a/Core/GroupOperations.lua
+++ b/Core/GroupOperations.lua
@@ -1885,13 +1885,19 @@ function CooldownCompanion:RefreshAllGroupsForSpellAvailability()
 end
 
 function CooldownCompanion:CreateAllGroupFrames()
+    local previousCreatingAllGroupFrames = self._creatingAllGroupFrames
+    self._creatingAllGroupFrames = true
     for groupId, _ in pairs(self.db.profile.groups) do
         if self:IsGroupVisibleToCurrentChar(groupId) then
             self:CreateGroupFrame(groupId)
         end
     end
+    self._creatingAllGroupFrames = previousCreatingAllGroupFrames
     self:FinalizePanelAnchors()
     self:FinalizeNonPanelGroupAnchors()
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
+    end
 end
 
 function CooldownCompanion:RefreshConfigSelectedGroupFrames()
@@ -1900,6 +1906,9 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
     end
     if InCombatLockdown() then
         self._pendingFullRefresh = true
+        if self.RefreshAlphaUpdateDriver then
+            self:RefreshAlphaUpdateDriver()
+        end
         return
     end
     if not (ST.IsGroupConfigSelected and self.db and self.db.profile and self.db.profile.groups) then
@@ -2032,6 +2041,9 @@ function CooldownCompanion:RefreshAllGroups()
     -- are all blocked. Per-tick cooldown updates continue independently.
     if InCombatLockdown() then
         self._pendingFullRefresh = true
+        if self.RefreshAlphaUpdateDriver then
+            self:RefreshAlphaUpdateDriver()
+        end
         return
     end
     -- Clean up stale container frames (e.g. after profile switch)
@@ -2097,6 +2109,9 @@ function CooldownCompanion:RefreshAllGroups()
     end
     if self.RefreshCursorAnchorTicker then
         self:RefreshCursorAnchorTicker()
+    end
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
     end
 end
 
@@ -2213,6 +2228,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     if self.RefreshCursorAnchorTicker then
         self:RefreshCursorAnchorTicker()
     end
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
+    end
 end
 
 -- Fully unload a group: save/clear button OnUpdate scripts, remove from
@@ -2270,6 +2288,9 @@ function CooldownCompanion:UnloadGroup(groupId)
     self.groupFrames[groupId] = nil
     if self.RefreshCursorAnchorTicker then
         self:RefreshCursorAnchorTicker()
+    end
+    if self.RefreshAlphaUpdateDriver then
+        self:RefreshAlphaUpdateDriver()
     end
 end
 

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -573,6 +573,22 @@ end
 -- Config Selection Helpers
 --------------------------------------------------------------------------------
 
+function ST.HasActiveAlphaSettings(config)
+    return type(config) == "table"
+        and ((config.baselineAlpha or 1) < 1
+            or config.forceAlphaInCombat == true
+            or config.forceAlphaOutOfCombat == true
+            or config.forceAlphaRegularMounted == true
+            or config.forceAlphaDragonriding == true
+            or config.forceAlphaTargetExists == true
+            or config.forceAlphaFocusExists == true
+            or config.forceAlphaMouseover == true
+            or config.forceHideInCombat == true
+            or config.forceHideOutOfCombat == true
+            or config.forceHideRegularMounted == true
+            or config.forceHideDragonriding == true)
+end
+
 -- Returns true when a group/panel frame should be at full alpha because it
 -- (or its parent container) is selected in the Config panel, or because it is
 -- part of an active cursor Layout preview.


### PR DESCRIPTION
## What Players Will Notice
- Profiles without active alpha fading or force-visible/force-hidden alpha rules now stop the global alpha fade driver instead of running hidden 30 Hz work in the background.
- Existing alpha behavior should stay the same when alpha settings, config previews, resource bars, texture panels, or inherited panel alpha need updates.

## Why This Changed
- The alpha fade frame was initialized for every runtime session and kept an OnUpdate script installed even when no group or module had alpha work to perform.
- Default-alpha profiles still paid repeated combat, target, focus, mount, and shapeshift checks that could not affect visible output.

## What Changed
- Added a lifecycle gate that installs the alpha OnUpdate only when active alpha settings, config-selected previews, module alpha targets, hidden dependency targets, or stale cleanup need it.
- Centralized the active-alpha settings predicate and reused it from runtime alpha evaluation and panel-anchor normalization.
- Refreshed the driver from alpha-setting callbacks, config preview and selection changes, group refresh/create/unload paths, panel dependency rebuilds, and module register/unregister paths so the driver wakes and idles at owner boundaries.
- Preserved inherited-alpha ownership so panel/frame alpha sync paths continue to own inherited alpha while the global driver skips those frames.

## Validation
- `lua tests\alpha-driver-idle.lua` (local-only ignored harness)
- `luac -p Core\AlphaFade.lua Core\AnchorPolicy.lua Core\Utils.lua ConfigSettings\Helpers.lua ConfigSettings\GroupTabs.lua ConfigSettings\ResourceBarPanelsResource.lua Config\Panel.lua Config\State.lua Core\GroupOperations.lua Core\GroupManagement.lua Core\GroupFrame.lua Core\AuraTexturesDisplay.lua OtherBars\ResourceBar.lua ButtonFrame\Preview.lua`
- `git diff --check origin/main...HEAD`
- In-game combat/restricted-content validation has not been performed yet and is still required before treating the runtime behavior as fully proven.