### PR TITLE
Load configuration libraries only when settings open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ tests
 AGENTS.md
 STRATEGY.md
 CooldownCompanion/Libs
+CooldownCompanion_Config/Libs
 nul

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -8,54 +8,66 @@ move-folders:
   CooldownCompanion/CooldownCompanion_Config: CooldownCompanion_Config
 
 externals:
-  Libs/Ace3:
-    url: https://repos.wowace.com/wow/ace3/trunk
+  CooldownCompanion/Libs/Ace3/LibStub:
+    url: https://repos.wowace.com/wow/ace3/trunk/LibStub
     tag: latest
-  Libs/LibSharedMedia-3.0:
+  CooldownCompanion/Libs/Ace3/CallbackHandler-1.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/CallbackHandler-1.0
+    tag: latest
+  CooldownCompanion/Libs/Ace3/AceAddon-3.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/AceAddon-3.0
+    tag: latest
+  CooldownCompanion/Libs/Ace3/AceEvent-3.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/AceEvent-3.0
+    tag: latest
+  CooldownCompanion/Libs/Ace3/AceDB-3.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/AceDB-3.0
+    tag: latest
+  CooldownCompanion/Libs/Ace3/AceConsole-3.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/AceConsole-3.0
+    tag: latest
+  CooldownCompanion/Libs/LibSharedMedia-3.0:
     url: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
     tag: latest
-  Libs/LibDataBroker-1.1:
+  CooldownCompanion/Libs/LibDataBroker-1.1:
     url: https://github.com/tekkub/libdatabroker-1-1
-  Libs/LibDBIcon-1.0:
+  CooldownCompanion/Libs/LibDBIcon-1.0:
     url: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
     tag: latest
-  Libs/LibDeflate:
+  CooldownCompanion/Libs/LibCustomGlow:
+    url: https://github.com/Stanzilla/LibCustomGlow
+  CooldownCompanion_Config/Libs/Ace3/AceGUI-3.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/AceGUI-3.0
+    tag: latest
+  CooldownCompanion_Config/Libs/Ace3/AceSerializer-3.0:
+    url: https://repos.wowace.com/wow/ace3/trunk/AceSerializer-3.0
+    tag: latest
+  CooldownCompanion_Config/Libs/LibDeflate:
     url: https://github.com/SafeteeWoW/LibDeflate
     tag: 1.0.2-release
-  Libs/LibCustomGlow:
-    url: https://github.com/Stanzilla/LibCustomGlow
 
 ignore:
   - README.md
   - .github
-  - CooldownCompanion/Libs
-  # Ace3 non-runtime files
-  - Libs/Ace3/Ace3.lua
-  - Libs/Ace3/Ace3.toc
-  - Libs/Ace3/Bindings.xml
-  - Libs/Ace3/changelog.txt
-  - Libs/Ace3/CHANGES.txt
-  - Libs/Ace3/README.md
-  - Libs/Ace3/LICENSE.txt
   # LibDeflate non-runtime files
-  - Libs/LibDeflate/docs
-  - Libs/LibDeflate/examples
-  - Libs/LibDeflate/LibStub
-  - Libs/LibDeflate/LibDeflate.toc
-  - Libs/LibDeflate/README.md
-  - Libs/LibDeflate/LICENSE.txt
-  - Libs/LibDeflate/changelog.md
-  - "Libs/LibDeflate/libdeflate-*.rockspec"
+  - CooldownCompanion_Config/Libs/LibDeflate/docs
+  - CooldownCompanion_Config/Libs/LibDeflate/examples
+  - CooldownCompanion_Config/Libs/LibDeflate/LibStub
+  - CooldownCompanion_Config/Libs/LibDeflate/LibDeflate.toc
+  - CooldownCompanion_Config/Libs/LibDeflate/README.md
+  - CooldownCompanion_Config/Libs/LibDeflate/LICENSE.txt
+  - CooldownCompanion_Config/Libs/LibDeflate/changelog.md
+  - "CooldownCompanion_Config/Libs/LibDeflate/libdeflate-*.rockspec"
   # LibCustomGlow non-runtime files
-  - Libs/LibCustomGlow/.editorconfig
-  - Libs/LibCustomGlow/.luarc.json
-  - Libs/LibCustomGlow/.pkgmeta
-  - Libs/LibCustomGlow/cspell.json
-  - Libs/LibCustomGlow/LibStub
-  - Libs/LibCustomGlow/LibCustomGlow-1.0.toc
-  - Libs/LibCustomGlow/LibCustomGlow-1.0.xml
-  - Libs/LibCustomGlow/LICENSE
-  - Libs/LibCustomGlow/README.md
+  - CooldownCompanion/Libs/LibCustomGlow/.editorconfig
+  - CooldownCompanion/Libs/LibCustomGlow/.luarc.json
+  - CooldownCompanion/Libs/LibCustomGlow/.pkgmeta
+  - CooldownCompanion/Libs/LibCustomGlow/cspell.json
+  - CooldownCompanion/Libs/LibCustomGlow/LibStub
+  - CooldownCompanion/Libs/LibCustomGlow/LibCustomGlow-1.0.toc
+  - CooldownCompanion/Libs/LibCustomGlow/LibCustomGlow-1.0.xml
+  - CooldownCompanion/Libs/LibCustomGlow/LICENSE
+  - CooldownCompanion/Libs/LibCustomGlow/README.md
   # LibSharedMedia non-runtime files
-  - Libs/LibSharedMedia-3.0/CHANGES.txt
-  - Libs/LibSharedMedia-3.0/LibSharedMedia-3.0.toc
+  - CooldownCompanion/Libs/LibSharedMedia-3.0/CHANGES.txt
+  - CooldownCompanion/Libs/LibSharedMedia-3.0/LibSharedMedia-3.0.toc

--- a/CooldownCompanion/CooldownCompanion.toc
+++ b/CooldownCompanion/CooldownCompanion.toc
@@ -7,7 +7,7 @@
 ## X-Wago-ID: 4N2kWd6L
 ## SavedVariables: CooldownCompanionDB
 ## IconTexture: Interface\AddOns\CooldownCompanion\Media\cdcminimap.tga
-## OptionalDeps: Ace3, LibSharedMedia-3.0, LibDeflate, LibCustomGlow-1.0, LibDataBroker-1.1, LibDBIcon-1.0, Masque, IconBrowser
+## OptionalDeps: Ace3, LibSharedMedia-3.0, LibCustomGlow-1.0, LibDataBroker-1.1, LibDBIcon-1.0, Masque
 
 #@no-lib-strip@
 # Libraries - LibStub must be first
@@ -22,14 +22,6 @@ Libs\Ace3\AceAddon-3.0\AceAddon-3.0.xml
 Libs\Ace3\AceEvent-3.0\AceEvent-3.0.xml
 Libs\Ace3\AceDB-3.0\AceDB-3.0.xml
 Libs\Ace3\AceConsole-3.0\AceConsole-3.0.xml
-
-# Ace3 GUI Libraries
-Libs\Ace3\AceGUI-3.0\AceGUI-3.0.xml
-Libs\Ace3\AceConfig-3.0\AceConfig-3.0.xml
-Libs\Ace3\AceSerializer-3.0\AceSerializer-3.0.xml
-
-# Compression Library
-Libs\LibDeflate\lib.xml
 
 # Custom Glow Library
 Libs\LibCustomGlow\LibCustomGlow-1.0.lua

--- a/CooldownCompanion/Core/ConfigLoader.lua
+++ b/CooldownCompanion/Core/ConfigLoader.lua
@@ -11,6 +11,8 @@ local type = type
 local next = next
 
 local CONFIG_ADDON_NAME = ADDON_NAME .. "_Config"
+local SETTINGS_CATEGORY_NAME = "Cooldown Companion"
+local SETTINGS_LAUNCHER_TEXT = "Open Cooldown Companion"
 
 local function SetConfigPrimaryModeWrapper(mode, opts)
     if ST._SetConfigPrimaryModeImpl then
@@ -113,7 +115,6 @@ local function EnsureConfigOpen(addon)
     local configFrame = GetConfigFrameIfLoaded(addon)
     if configFrame and configFrame._miniFrame and configFrame._miniFrame:IsShown() then
         configFrame._miniFrame:Hide()
-        return true
     end
     if not configFrame or not configFrame.frame:IsShown() then
         if not addon._configToggleImpl then
@@ -157,6 +158,12 @@ function CooldownCompanion:RunConfigIntent(intent)
             return false
         end
         ST._SetConfigPrimaryMode(intent.mode or "buttons")
+        return true
+    elseif intent.action == "open" then
+        if not EnsureConfigOpen(self) then
+            self:Print(FormatConfigLoadFailure(entryPoint, "config panel unavailable"))
+            return false
+        end
         return true
     elseif intent.action == "debugimport" then
         if self._configOpenDiagnosticDecodePanelImpl then
@@ -262,50 +269,64 @@ local function RunProfileMigrationAndRefresh(addon, reason)
     end
 end
 
+local function CreateSettingsLauncherFrame(addon)
+    local frame = CreateFrame("Frame")
+    frame.name = SETTINGS_CATEGORY_NAME
+
+    local title = frame:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+    title:SetPoint("TOPLEFT", 16, -16)
+    title:SetText(SETTINGS_CATEGORY_NAME)
+
+    local description = frame:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+    description:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
+    description:SetJustifyH("LEFT")
+    description:SetText("Open the Cooldown Companion configuration panel.")
+    description:SetWidth(520)
+
+    local button = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+    button:SetPoint("TOPLEFT", description, "BOTTOMLEFT", 0, -16)
+    if button.SetTextToFit then
+        button:SetTextToFit(SETTINGS_LAUNCHER_TEXT)
+    else
+        button:SetText(SETTINGS_LAUNCHER_TEXT)
+        button:SetWidth(190)
+    end
+    button:SetHeight(24)
+    button:SetScript("OnClick", function()
+        addon:ToggleConfig({
+            action = "open",
+            entryPoint = "Blizzard Settings",
+            closeSettings = true,
+        })
+    end)
+
+    return frame
+end
+
+local function RegisterSettingsLauncher(addon)
+    if not (Settings and Settings.RegisterCanvasLayoutCategory and Settings.RegisterAddOnCategory) then
+        return
+    end
+
+    local frame = CreateSettingsLauncherFrame(addon)
+    local category = Settings.RegisterCanvasLayoutCategory(frame, SETTINGS_CATEGORY_NAME)
+    if category then
+        Settings.RegisterAddOnCategory(category)
+        if category.GetID then
+            addon._settingsCategoryID = category:GetID()
+        else
+            addon._settingsCategoryID = category.ID
+        end
+    end
+end
+
 function CooldownCompanion:SetupConfig()
     if self._configSetupDone then
         return
     end
     self._configSetupDone = true
 
-    local AceConfig = LibStub("AceConfig-3.0")
-    local AceConfigDialog = LibStub("AceConfigDialog-3.0")
-
-    local options = {
-        name = "Cooldown Companion",
-        type = "group",
-        args = {
-            openConfig = {
-                name = "Open Cooldown Companion",
-                desc = "Click to open the configuration panel",
-                type = "execute",
-                order = 1,
-                func = function()
-                    if InCombatLockdown and InCombatLockdown() then
-                        CooldownCompanion:ToggleConfig({
-                            action = "toggle",
-                            entryPoint = "Blizzard Settings",
-                            closeSettings = true,
-                        })
-                        return
-                    end
-                    if not CooldownCompanion:LoadConfigAddon("Blizzard Settings") then
-                        return
-                    end
-                    CloseBlizzardSettings()
-                    C_Timer.After(0.1, function()
-                        CooldownCompanion:ToggleConfig({
-                            action = "toggle",
-                            entryPoint = "Blizzard Settings",
-                        })
-                    end)
-                end,
-            },
-        },
-    }
-
-    AceConfig:RegisterOptionsTable(ADDON_NAME, options)
-    AceConfigDialog:AddToBlizOptions(ADDON_NAME, "Cooldown Companion")
+    RegisterSettingsLauncher(self)
 
     self.db.RegisterCallback(self, "OnProfileChanged", function(db, profileName)
         ResetLoadedConfigForProfileChange(CooldownCompanion)

--- a/CooldownCompanion_Config/CooldownCompanion_Config.toc
+++ b/CooldownCompanion_Config/CooldownCompanion_Config.toc
@@ -5,8 +5,15 @@
 ## Version: @project-version@
 ## RequiredDeps: CooldownCompanion
 ## IconTexture: Interface\AddOns\CooldownCompanion\Media\cdcminimap.tga
-## OptionalDeps: IconBrowser
+## OptionalDeps: Ace3, LibDeflate, IconBrowser
 ## LoadOnDemand: 1
+
+#@no-lib-strip@
+# Config UI and import/export libraries
+Libs\Ace3\AceGUI-3.0\AceGUI-3.0.xml
+Libs\Ace3\AceSerializer-3.0\AceSerializer-3.0.xml
+Libs\LibDeflate\lib.xml
+#@end-no-lib-strip@
 
 Bootstrap.lua
 Config\State.lua


### PR DESCRIPTION
## What Players Will Notice
- Existing cooldown panels continue to work on login and reload without opening the configuration UI.
- Opening Cooldown Companion from Blizzard Settings still works, now through a lightweight native launcher.
- Profile export/import keeps working from the packaged addon.

## Why This Changed
- The previous sibling config-addon split moved the configuration UI out of the main addon, but the main addon still loaded config-only libraries during normal startup.
- Moving those libraries behind the load-on-demand config addon keeps normal runtime closer to the already-configured player path.

## What Changed
- Removed AceGUI, AceConfig, AceSerializer, LibDeflate, and the config-only IconBrowser optional dependency from the main addon startup boundary.
- Added AceGUI, AceSerializer, and LibDeflate to `CooldownCompanion_Config` so the config addon owns the libraries used by the AceGUI UI and import/export codec.
- Replaced the main AceConfig/AceConfigDialog Blizzard Settings stub with a native Settings launcher that routes through the existing config intent path.
- Updated `.pkgmeta` so runtime embedded libraries package under `CooldownCompanion/Libs` and config-only libraries package under `CooldownCompanion_Config/Libs`.
- Kept local vendored library folders ignored for both addon folders.

## Validation
- `lua tests\config-loader.lua`
- `luac -p CooldownCompanion\Core\ConfigLoader.lua tests\config-loader.lua CooldownCompanion_Config\Config\ExportCodec.lua CooldownCompanion_Config\Config\Panel.lua CooldownCompanion_Config\Config\State.lua`
- `git diff --check`
- No-library TOC strip simulation for both addon TOCs.
- Verified local `CooldownCompanion/Libs` and `CooldownCompanion_Config/Libs` folders remain ignored and untracked.
- Packaged in-game validation reported: runtime panels work without opening config, runtime panels still work after reload, Blizzard Settings opens config, export/import works, and restricted content works.
- Combat-deferred launcher behavior is covered by the local config-loader harness; no separate live click-in-combat note was recorded beyond the restricted-content pass.
