### PR TITLE
Reduce aura-event work to player and target units

### DIFF
--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -514,11 +514,12 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
         end)
     end
 
-    -- Update immediately — CDM viewer frames registered their event handlers
-    -- before our addon loaded, so by the time this handler fires the CDM has
-    -- already refreshed its children with fresh auraInstanceID data.
+    -- Refresh immediately on the first aura event this frame. CDM viewer
+    -- frames registered their event handlers before our addon loaded, so by
+    -- the time this handler fires the CDM has already refreshed its children
+    -- with fresh auraInstanceID data. Bursts later in the same frame coalesce.
     if unit == "target" or unit == "player" then
-        self:UpdateAllCooldowns()
+        self:RunImmediateCooldownRefresh("aura-event")
     end
 end
 

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -152,20 +152,23 @@ function CooldownCompanion:OnEnable()
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnPlayerEnteringWorld")
 
-    -- High-frequency player-only unit events. RegisterUnitEvent filters before
-    -- dispatch, avoiding global UNIT_* traffic through AceEvent.
-    if not self._playerUnitEventFrame then
-        self._playerUnitEventFrame = CreateFrame("Frame")
-        self._playerUnitEventFrame:SetScript("OnEvent", function(_, event, ...)
+    -- High-frequency unit events. RegisterUnitEvent filters before dispatch,
+    -- avoiding global UNIT_* traffic through AceEvent.
+    if not self._unitEventFrame then
+        self._unitEventFrame = CreateFrame("Frame")
+        self._unitEventFrame:SetScript("OnEvent", function(_, event, ...)
             if event == "UNIT_POWER_FREQUENT" then
                 self:MarkCooldownsDirty()
             elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
                 self:OnSpellCast(event, ...)
+            elseif event == "UNIT_AURA" then
+                self:OnUnitAura(event, ...)
             end
         end)
     end
-    self._playerUnitEventFrame:RegisterUnitEvent("UNIT_POWER_FREQUENT", "player")
-    self._playerUnitEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+    self._unitEventFrame:RegisterUnitEvent("UNIT_POWER_FREQUENT", "player")
+    self._unitEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+    self._unitEventFrame:RegisterUnitEvent("UNIT_AURA", "player", "target")
 
     -- Combat events
     self:RegisterEvent("PLAYER_REGEN_DISABLED", "OnCombatStart")
@@ -222,9 +225,6 @@ function CooldownCompanion:OnEnable()
     -- the vehicle state check to avoid duplicate AceEvent registrations.
     self:RegisterEvent("UNIT_ENTERED_VEHICLE", "OnVehicleUIChanged")
     self:RegisterEvent("UNIT_EXITED_VEHICLE", "OnVehicleUIChanged")
-
-    -- Aura (buff/debuff) changes — drives aura tracking overlay
-    self:RegisterEvent("UNIT_AURA", "OnUnitAura")
 
     -- Target change — marks dirty so ticker reads fresh viewer data next pass
     self:RegisterEvent("PLAYER_TARGET_CHANGED", "OnTargetChanged")
@@ -485,9 +485,9 @@ function CooldownCompanion:OnDisable()
         self._unitTargetFrame:UnregisterAllEvents()
     end
 
-    -- Unregister player-only unit events (keep reference for reuse on re-enable)
-    if self._playerUnitEventFrame then
-        self._playerUnitEventFrame:UnregisterAllEvents()
+    -- Unregister filtered unit events (keep reference for reuse on re-enable)
+    if self._unitEventFrame then
+        self._unitEventFrame:UnregisterAllEvents()
     end
 
     -- Unregister EventRegistry callback (not managed by Ace3)


### PR DESCRIPTION
## What Players Will Notice
- Aura tracking should behave the same for player and target buffs/debuffs.
- In group, raid, battleground, or other busy content, Cooldown Companion now avoids work from unrelated units' aura churn that it never displays.

## Why This Changed
- The main addon was registered for global `UNIT_AURA` traffic through AceEvent even though addon aura tracking only supports `player` and `target` units.
- Unrelated aura churn could mark cooldowns dirty, weaken the cooldown-event ticker skip optimization, and trigger unnecessary per-event walks in the main addon.

## What Changed
- Moved the main addon `UNIT_AURA` listener onto the existing unit-event frame with `RegisterUnitEvent("UNIT_AURA", "player", "target")`.
- Removed the old global AceEvent `UNIT_AURA` registration so player/target events are not double-processed.
- Routed player/target aura refreshes through `RunImmediateCooldownRefresh("aura-event")`, preserving first-in-frame synchronous behavior while coalescing same-frame aura bursts.
- Renamed the reused unit-event frame from `_playerUnitEventFrame` to `_unitEventFrame` so the lifecycle name matches the broader player/target registration.

## Dirty-Consumer Audit
- All `_cooldownsDirty` / `MarkCooldownsDirty` consumers were reviewed. Producers (`EventHandlers`, `GroupOperations`, `Aura`, Lifecycle event handlers) are unaffected.
- The ticker-skip machinery (`Lifecycle.lua:122-128`, `426-432`) only benefits from losing dirty marks from non-player/target units: the skip can engage more often, while still requiring a same-serial cooldown-event refresh.
- The bar-mode aura-expiry guards (`BarMode.lua:1391`, `1409`) skip expiry detection while dirty, so fewer spurious dirty marks means expiry detection is suppressed less often. Genuine player/target aura events and target switches still mark dirty before those guards need to hold.
- No consumer depends on dirty marks from units other than player/target.

## Validation
- MCP checked current WoW API data: `Frame:RegisterUnitEvent` exists and is not deprecated; `UNIT_AURA` payload is `unitTarget, updateInfo`.
- `luac -p CooldownCompanion\Core\Lifecycle.lua CooldownCompanion\Core\Aura.lua`
- `git diff --check origin/main...HEAD`
- `lua tests\unit-aura-event-boundary.lua`
- Full local ignored harness sweep: `Get-ChildItem -Path tests -Filter *.lua | Sort-Object Name | ForEach-Object { lua $_.FullName }`
- Review follow-up found no required code changes. The remaining design nuance is the shared per-frame immediate refresh slot: an aura event and cooldown event in the same frame may queue the second refresh by one frame. This is expected to be sub-perceptual but still needs live validation.
- In-game combat and restricted-content validation has not been performed yet. This PR should stay draft until player/target aura tracking, target-switch behavior, and same-frame aura/cooldown competition are verified in-game.

## Post-Deploy Monitoring & Validation
- Watch for Lua errors mentioning `OnUnitAura`, `RunImmediateCooldownRefresh`, `RegisterUnitEvent`, or `UNIT_AURA`.
- Healthy signal: player and target aura overlays, pandemic windows, stack counts, and target-switch holds behave as before while unrelated unit aura churn does not affect the main addon.
- Failure signal: visible aura flicker, stuck target-switch holds, delayed cooldown swipe/text on aura-applying abilities, or combat/restricted-content Lua errors.
- Rollback trigger: any reproducible combat or restricted-content error, or any visible regression in target aura hold termination. Mitigation is to revert this branch while preserving the prior global listener/direct-refresh behavior.
- Validation owner/window: maintainer in-game pass before marking the PR ready for review; include target-switch plus ability-spam coverage because that is the sensitive same-frame edge.