### PR TITLE
Simplify cooldown refresh queue bookkeeping

### DIFF
--- a/CooldownCompanion/CooldownCompanion.toc
+++ b/CooldownCompanion/CooldownCompanion.toc
@@ -53,6 +53,7 @@ Core\ScopedSettings.lua
 Core\BarsAndFramesRuntime.lua
 Core\SoundAlerts.lua
 Core\StyleOverrides.lua
+Core\CooldownRefresh.lua
 Core\Lifecycle.lua
 Core\Aura.lua
 Core\EventHandlers.lua

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -14,8 +14,9 @@
       cooldown-event refresh.
     - _cooldownImmediateRefreshThisFrame: latch allowing only the first
       immediate refresh in a frame to walk synchronously.
-    - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: hidden frame and
-      arm flag used to flush queued work on the next OnUpdate boundary.
+    - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
+      frame and arm flag used to flush queued work on the next OnUpdate
+      boundary. The frame must stay shown; hidden frames do not receive OnUpdate.
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
@@ -59,16 +60,10 @@ function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
 end
 
 function CooldownCompanion:FlushQueuedCooldownRefresh()
-    if self._cooldownRefreshQueueFrame then
-        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
-    end
-    self._cooldownRefreshQueueArmed = nil
-    self._cooldownImmediateRefreshThisFrame = nil
-
     local queuedSource = self._queuedCooldownRefreshSource
     local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
-    self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCooldownEventSerial = nil
+    self:ResetCooldownRefreshState()
+
     if queuedSource then
         self:UpdateAllCooldowns()
         if cooldownEventSerial then
@@ -111,6 +106,18 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
     -- target, and other dirty paths keep their normal ticker confirmation.
     return self._cooldownsDirty
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+end
+
+function CooldownCompanion:TickCooldownRefresh()
+    if self._queuedCooldownRefreshSource then
+        self:FlushQueuedCooldownRefresh()
+        return false
+    end
+    if self:CanSkipTickerCooldownRefresh() then
+        return true
+    end
+    self:UpdateAllCooldowns()
+    return false
 end
 
 function CooldownCompanion:ResetCooldownRefreshState()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -2,31 +2,33 @@
     CooldownCompanion - Core/CooldownRefresh.lua: same-frame cooldown refresh
     coalescing and ticker-skip bookkeeping.
 
-    Current refresh state fields:
+    Refresh state fields:
     - _cooldownsDirty: true when the next ticker pass must confirm cooldown state.
     - _cooldownDirtySerial: monotonic dirty marker bumped by MarkCooldownsDirty.
-    - _lastCooldownRefreshSource/_lastCooldownRefreshSerial: last completed
-      refresh metadata used to let cooldown-event refreshes satisfy one ticker pass.
     - _queuedCooldownRefreshSource: pending queued refresh source; also the
-      queue-pending flag checked by the ticker.
-    - _queuedCooldownRefreshCanSkipTicker/_queuedCooldownRefreshSkipSerial:
-      queued preservation of cooldown-event skip eligibility.
+      queue-pending flag checked by the ticker. Last writer wins; this is only
+      a debug breadcrumb, not skip eligibility.
+    - _queuedCooldownRefreshCooldownEventSerial: dirty serial captured when a
+      queued cooldown-event request enters the queue.
+    - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
+      cooldown-event refresh.
     - _cooldownImmediateRefreshThisFrame: latch allowing only the first
       immediate refresh in a frame to walk synchronously.
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: hidden frame and
       arm flag used to flush queued work on the next OnUpdate boundary.
+
+    Invariants:
+    - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
+    - MarkCooldownsDirty is the only invalidator; stale satisfied serials are
+      inert because they cannot match a later dirty serial.
+    - Queued cooldown-event requests satisfy the serial captured at queue time.
+      If another dirty mark lands before the flush, the later ticker walks
+      instead of skipping. That is intentionally conservative: displays can only
+      be fresher, never staler.
 ]]
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
-
-local function MergeCooldownRefreshSource(currentSource, newSource)
-    newSource = newSource or "event"
-    if not currentSource or currentSource == newSource then
-        return newSource
-    end
-    return "event"
-end
 
 local function CooldownRefreshQueueOnUpdate(frame)
     local addon = frame._cooldownCompanion
@@ -42,12 +44,6 @@ end
 
 function CooldownCompanion:ClearCooldownsDirty()
     self._cooldownsDirty = false
-end
-
-function CooldownCompanion:RunCooldownRefresh(source)
-    self:UpdateAllCooldowns()
-    self._lastCooldownRefreshSerial = self._cooldownDirtySerial or 0
-    self._lastCooldownRefreshSource = source
 end
 
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
@@ -69,36 +65,23 @@ function CooldownCompanion:FlushQueuedCooldownRefresh()
     self._cooldownRefreshQueueArmed = nil
     self._cooldownImmediateRefreshThisFrame = nil
 
-    local source = self._queuedCooldownRefreshSource
-    local canSkipTicker = self._queuedCooldownRefreshCanSkipTicker
-    local skipSerial = self._queuedCooldownRefreshSkipSerial
+    local queuedSource = self._queuedCooldownRefreshSource
+    local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
     self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCanSkipTicker = nil
-    self._queuedCooldownRefreshSkipSerial = nil
-    if source then
-        self:RunCooldownRefresh(source)
-        -- Non-dirty queued work should not erase a satisfied cooldown-event
-        -- dirty serial, because that would re-enable the next ticker walk.
-        if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
-            self._lastCooldownRefreshSource = "cooldown-event"
-            self._lastCooldownRefreshSerial = skipSerial
+    self._queuedCooldownRefreshCooldownEventSerial = nil
+    if queuedSource then
+        self:UpdateAllCooldowns()
+        if cooldownEventSerial then
+            self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
         end
     end
 end
 
 function CooldownCompanion:QueueCooldownRefresh(source)
-    local dirtySerial = self._cooldownDirtySerial or 0
-    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
-        and self._queuedCooldownRefreshSkipSerial == dirtySerial
-    local lastRefreshCanSkipTicker = self._lastCooldownRefreshSource == "cooldown-event"
-        and self._lastCooldownRefreshSerial == dirtySerial
-    local canSkipTicker = source == "cooldown-event"
-        or queuedRefreshCanSkipTicker
-        or lastRefreshCanSkipTicker
-
-    self._queuedCooldownRefreshSource = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
-    self._queuedCooldownRefreshCanSkipTicker = canSkipTicker or nil
-    self._queuedCooldownRefreshSkipSerial = canSkipTicker and dirtySerial or nil
+    self._queuedCooldownRefreshSource = source or "event"
+    if source == "cooldown-event" then
+        self._queuedCooldownRefreshCooldownEventSerial = self._cooldownDirtySerial or 0
+    end
     self:EnsureCooldownRefreshQueueFrame()
 end
 
@@ -108,22 +91,18 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
         return
     end
 
-    local dirtySerial = self._cooldownDirtySerial or 0
-    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
-        and self._queuedCooldownRefreshSkipSerial == dirtySerial
-    local canSkipTicker = source == "cooldown-event" or queuedRefreshCanSkipTicker
-    local skipSerial = canSkipTicker and dirtySerial or nil
+    local cooldownEventSerial
+    if source == "cooldown-event" then
+        cooldownEventSerial = self._cooldownDirtySerial or 0
+    end
 
-    source = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
     self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCanSkipTicker = nil
-    self._queuedCooldownRefreshSkipSerial = nil
+    self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
-    self:RunCooldownRefresh(source)
-    if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
-        self._lastCooldownRefreshSource = "cooldown-event"
-        self._lastCooldownRefreshSerial = skipSerial
+    self:UpdateAllCooldowns()
+    if cooldownEventSerial then
+        self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
     end
 end
 
@@ -131,8 +110,7 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
     -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
     -- target, and other dirty paths keep their normal ticker confirmation.
     return self._cooldownsDirty
-        and self._lastCooldownRefreshSource == "cooldown-event"
-        and self._lastCooldownRefreshSerial == (self._cooldownDirtySerial or 0)
+        and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
 function CooldownCompanion:ResetCooldownRefreshState()
@@ -141,7 +119,6 @@ function CooldownCompanion:ResetCooldownRefreshState()
     end
     self._cooldownRefreshQueueArmed = nil
     self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCanSkipTicker = nil
-    self._queuedCooldownRefreshSkipSerial = nil
+    self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -1,0 +1,147 @@
+--[[
+    CooldownCompanion - Core/CooldownRefresh.lua: same-frame cooldown refresh
+    coalescing and ticker-skip bookkeeping.
+
+    Current refresh state fields:
+    - _cooldownsDirty: true when the next ticker pass must confirm cooldown state.
+    - _cooldownDirtySerial: monotonic dirty marker bumped by MarkCooldownsDirty.
+    - _lastCooldownRefreshSource/_lastCooldownRefreshSerial: last completed
+      refresh metadata used to let cooldown-event refreshes satisfy one ticker pass.
+    - _queuedCooldownRefreshSource: pending queued refresh source; also the
+      queue-pending flag checked by the ticker.
+    - _queuedCooldownRefreshCanSkipTicker/_queuedCooldownRefreshSkipSerial:
+      queued preservation of cooldown-event skip eligibility.
+    - _cooldownImmediateRefreshThisFrame: latch allowing only the first
+      immediate refresh in a frame to walk synchronously.
+    - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: hidden frame and
+      arm flag used to flush queued work on the next OnUpdate boundary.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local function MergeCooldownRefreshSource(currentSource, newSource)
+    newSource = newSource or "event"
+    if not currentSource or currentSource == newSource then
+        return newSource
+    end
+    return "event"
+end
+
+local function CooldownRefreshQueueOnUpdate(frame)
+    local addon = frame._cooldownCompanion
+    if addon then
+        addon:FlushQueuedCooldownRefresh()
+    end
+end
+
+function CooldownCompanion:MarkCooldownsDirty()
+    self._cooldownsDirty = true
+    self._cooldownDirtySerial = (self._cooldownDirtySerial or 0) + 1
+end
+
+function CooldownCompanion:ClearCooldownsDirty()
+    self._cooldownsDirty = false
+end
+
+function CooldownCompanion:RunCooldownRefresh(source)
+    self:UpdateAllCooldowns()
+    self._lastCooldownRefreshSerial = self._cooldownDirtySerial or 0
+    self._lastCooldownRefreshSource = source
+end
+
+function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
+    if not self._cooldownRefreshQueueFrame then
+        local frame = CreateFrame("Frame")
+        frame._cooldownCompanion = self
+        self._cooldownRefreshQueueFrame = frame
+    end
+    if not self._cooldownRefreshQueueArmed then
+        self._cooldownRefreshQueueArmed = true
+        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", CooldownRefreshQueueOnUpdate)
+    end
+end
+
+function CooldownCompanion:FlushQueuedCooldownRefresh()
+    if self._cooldownRefreshQueueFrame then
+        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
+    end
+    self._cooldownRefreshQueueArmed = nil
+    self._cooldownImmediateRefreshThisFrame = nil
+
+    local source = self._queuedCooldownRefreshSource
+    local canSkipTicker = self._queuedCooldownRefreshCanSkipTicker
+    local skipSerial = self._queuedCooldownRefreshSkipSerial
+    self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshCanSkipTicker = nil
+    self._queuedCooldownRefreshSkipSerial = nil
+    if source then
+        self:RunCooldownRefresh(source)
+        -- Non-dirty queued work should not erase a satisfied cooldown-event
+        -- dirty serial, because that would re-enable the next ticker walk.
+        if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
+            self._lastCooldownRefreshSource = "cooldown-event"
+            self._lastCooldownRefreshSerial = skipSerial
+        end
+    end
+end
+
+function CooldownCompanion:QueueCooldownRefresh(source)
+    local dirtySerial = self._cooldownDirtySerial or 0
+    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
+        and self._queuedCooldownRefreshSkipSerial == dirtySerial
+    local lastRefreshCanSkipTicker = self._lastCooldownRefreshSource == "cooldown-event"
+        and self._lastCooldownRefreshSerial == dirtySerial
+    local canSkipTicker = source == "cooldown-event"
+        or queuedRefreshCanSkipTicker
+        or lastRefreshCanSkipTicker
+
+    self._queuedCooldownRefreshSource = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
+    self._queuedCooldownRefreshCanSkipTicker = canSkipTicker or nil
+    self._queuedCooldownRefreshSkipSerial = canSkipTicker and dirtySerial or nil
+    self:EnsureCooldownRefreshQueueFrame()
+end
+
+function CooldownCompanion:RunImmediateCooldownRefresh(source)
+    if self._cooldownImmediateRefreshThisFrame then
+        self:QueueCooldownRefresh(source)
+        return
+    end
+
+    local dirtySerial = self._cooldownDirtySerial or 0
+    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
+        and self._queuedCooldownRefreshSkipSerial == dirtySerial
+    local canSkipTicker = source == "cooldown-event" or queuedRefreshCanSkipTicker
+    local skipSerial = canSkipTicker and dirtySerial or nil
+
+    source = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
+    self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshCanSkipTicker = nil
+    self._queuedCooldownRefreshSkipSerial = nil
+    self._cooldownImmediateRefreshThisFrame = true
+    self:EnsureCooldownRefreshQueueFrame()
+    self:RunCooldownRefresh(source)
+    if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
+        self._lastCooldownRefreshSource = "cooldown-event"
+        self._lastCooldownRefreshSerial = skipSerial
+    end
+end
+
+function CooldownCompanion:CanSkipTickerCooldownRefresh()
+    -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
+    -- target, and other dirty paths keep their normal ticker confirmation.
+    return self._cooldownsDirty
+        and self._lastCooldownRefreshSource == "cooldown-event"
+        and self._lastCooldownRefreshSerial == (self._cooldownDirtySerial or 0)
+end
+
+function CooldownCompanion:ResetCooldownRefreshState()
+    if self._cooldownRefreshQueueFrame then
+        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
+    end
+    self._cooldownRefreshQueueArmed = nil
+    self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshCanSkipTicker = nil
+    self._queuedCooldownRefreshSkipSerial = nil
+    self._cooldownImmediateRefreshThisFrame = nil
+end

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -104,11 +104,7 @@ function CooldownCompanion:EnsureRuntimeInitialized()
                 self.assistedSpellID = AssistedCombatManager.lastNextCastSpellID
             end
 
-            if self._queuedCooldownRefreshSource then
-                self:FlushQueuedCooldownRefresh()
-            elseif not self:CanSkipTickerCooldownRefresh() then
-                self:UpdateAllCooldowns()
-            end
+            self:TickCooldownRefresh()
             self:UpdateAllGroupLayouts()
             self:ClearCooldownsDirty()
         end)

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -107,7 +107,7 @@ function CooldownCompanion:EnsureRuntimeInitialized()
             if self._queuedCooldownRefreshSource then
                 self:FlushQueuedCooldownRefresh()
             elseif not self:CanSkipTickerCooldownRefresh() then
-                self:RunCooldownRefresh("ticker")
+                self:UpdateAllCooldowns()
             end
             self:UpdateAllGroupLayouts()
             self:ClearCooldownsDirty()

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -1,6 +1,6 @@
 --[[
-    CooldownCompanion - Core/Lifecycle.lua: OnInitialize, OnEnable, OnDisable, ForEachButton,
-    MarkCooldownsDirty, SlashCommand, simple event handlers, viewer frame constants
+    CooldownCompanion - Core/Lifecycle.lua: OnInitialize, OnEnable, OnDisable,
+    ForEachButton, SlashCommand, simple event handlers, viewer frame constants
 ]]
 
 local ADDON_NAME, ST = ...
@@ -21,21 +21,6 @@ local minimapButton = ST._minimapButton
 
 -- LibSharedMedia for font/texture selection
 local LSM = LibStub("LibSharedMedia-3.0")
-
-local function MergeCooldownRefreshSource(currentSource, newSource)
-    newSource = newSource or "event"
-    if not currentSource or currentSource == newSource then
-        return newSource
-    end
-    return "event"
-end
-
-local function CooldownRefreshQueueOnUpdate(frame)
-    local addon = frame._cooldownCompanion
-    if addon then
-        addon:FlushQueuedCooldownRefresh()
-    end
-end
 
 -- Viewer frame list used by BuildViewerAuraMap, FindViewerChildForSpell, and OnEnable hooks.
 local VIEWER_NAMES = {
@@ -331,106 +316,6 @@ function CooldownCompanion:OnEnable()
     self:FinalizeContainerAnchorsToScreenOffsets()
 end
 
-function CooldownCompanion:MarkCooldownsDirty()
-    self._cooldownsDirty = true
-    self._cooldownDirtySerial = (self._cooldownDirtySerial or 0) + 1
-end
-
-function CooldownCompanion:ClearCooldownsDirty()
-    self._cooldownsDirty = false
-end
-
-function CooldownCompanion:RunCooldownRefresh(source)
-    self:UpdateAllCooldowns()
-    self._lastCooldownRefreshSerial = self._cooldownDirtySerial or 0
-    self._lastCooldownRefreshSource = source
-end
-
-function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
-    if not self._cooldownRefreshQueueFrame then
-        local frame = CreateFrame("Frame")
-        frame._cooldownCompanion = self
-        self._cooldownRefreshQueueFrame = frame
-    end
-    if not self._cooldownRefreshQueueArmed then
-        self._cooldownRefreshQueueArmed = true
-        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", CooldownRefreshQueueOnUpdate)
-    end
-end
-
-function CooldownCompanion:FlushQueuedCooldownRefresh()
-    if self._cooldownRefreshQueueFrame then
-        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
-    end
-    self._cooldownRefreshQueueArmed = nil
-    self._cooldownImmediateRefreshThisFrame = nil
-
-    local source = self._queuedCooldownRefreshSource
-    local canSkipTicker = self._queuedCooldownRefreshCanSkipTicker
-    local skipSerial = self._queuedCooldownRefreshSkipSerial
-    self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCanSkipTicker = nil
-    self._queuedCooldownRefreshSkipSerial = nil
-    if source then
-        self:RunCooldownRefresh(source)
-        -- Non-dirty queued work should not erase a satisfied cooldown-event
-        -- dirty serial, because that would re-enable the next ticker walk.
-        if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
-            self._lastCooldownRefreshSource = "cooldown-event"
-            self._lastCooldownRefreshSerial = skipSerial
-        end
-    end
-end
-
-function CooldownCompanion:QueueCooldownRefresh(source)
-    local dirtySerial = self._cooldownDirtySerial or 0
-    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
-        and self._queuedCooldownRefreshSkipSerial == dirtySerial
-    local lastRefreshCanSkipTicker = self._lastCooldownRefreshSource == "cooldown-event"
-        and self._lastCooldownRefreshSerial == dirtySerial
-    local canSkipTicker = source == "cooldown-event"
-        or queuedRefreshCanSkipTicker
-        or lastRefreshCanSkipTicker
-
-    self._queuedCooldownRefreshSource = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
-    self._queuedCooldownRefreshCanSkipTicker = canSkipTicker or nil
-    self._queuedCooldownRefreshSkipSerial = canSkipTicker and dirtySerial or nil
-    self:EnsureCooldownRefreshQueueFrame()
-end
-
-function CooldownCompanion:RunImmediateCooldownRefresh(source)
-    if self._cooldownImmediateRefreshThisFrame then
-        self:QueueCooldownRefresh(source)
-        return
-    end
-
-    local dirtySerial = self._cooldownDirtySerial or 0
-    local queuedRefreshCanSkipTicker = self._queuedCooldownRefreshCanSkipTicker
-        and self._queuedCooldownRefreshSkipSerial == dirtySerial
-    local canSkipTicker = source == "cooldown-event" or queuedRefreshCanSkipTicker
-    local skipSerial = canSkipTicker and dirtySerial or nil
-
-    source = MergeCooldownRefreshSource(self._queuedCooldownRefreshSource, source)
-    self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCanSkipTicker = nil
-    self._queuedCooldownRefreshSkipSerial = nil
-    self._cooldownImmediateRefreshThisFrame = true
-    self:EnsureCooldownRefreshQueueFrame()
-    self:RunCooldownRefresh(source)
-    if canSkipTicker and skipSerial == (self._cooldownDirtySerial or 0) then
-        self._lastCooldownRefreshSource = "cooldown-event"
-        self._lastCooldownRefreshSerial = skipSerial
-    end
-end
-
-function CooldownCompanion:CanSkipTickerCooldownRefresh()
-    -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
-    -- target, and other dirty paths keep their normal ticker confirmation.
-    return self._cooldownsDirty
-        and self._lastCooldownRefreshSource == "cooldown-event"
-        and self._lastCooldownRefreshSerial == (self._cooldownDirtySerial or 0)
-end
-
 function CooldownCompanion:OnCooldownStateChanged()
     self:MarkCooldownsDirty()
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
@@ -465,14 +350,7 @@ function CooldownCompanion:OnDisable()
         self._alphaFrame = nil
     end
 
-    if self._cooldownRefreshQueueFrame then
-        self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
-    end
-    self._cooldownRefreshQueueArmed = nil
-    self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCanSkipTicker = nil
-    self._queuedCooldownRefreshSkipSerial = nil
-    self._cooldownImmediateRefreshThisFrame = nil
+    self:ResetCooldownRefreshState()
 
     -- Disable all range check registrations
     for spellId in pairs(self._rangeCheckSpells) do


### PR DESCRIPTION
## What Changed
- Moved cooldown refresh queue and ticker-skip bookkeeping out of `Core/Lifecycle.lua` into the new `Core/CooldownRefresh.lua` module.
- Replaced the old last-source / restoration-field state machine with a satisfied-serial model: cooldown-event refreshes record the dirty serial they covered, and later dirty marks naturally invalidate that skip eligibility.
- Kept the same same-frame coalescing shape: first immediate refresh runs synchronously, later same-frame refreshes queue for the next frame boundary, and ticker-time queued work flushes before ordinary skip/walk checks.
- Added a module-owned `TickCooldownRefresh()` helper so the live ticker no longer reads queue internals directly.

## Why This Changed
- The existing queue coalescing behavior was useful, but preserving cooldown-event ticker-skip eligibility required several interacting fields and restoration sites in `Lifecycle.lua`.
- This refactor keeps the intended behavior while making the invariants visible in one place and reducing the chance that a future event-handler change half-updates the queue state.
- One accepted conservative timing trade-off remains: if a queued cooldown-event request is dirtied again before its frame-boundary flush, the ticker may run one extra refresh walk instead of skipping. That can make displays fresher, never staler.

## Developer Impact
- Cooldown refresh queue ownership is now isolated from lifecycle/event registration code.
- The ticker path is easier to audit because the flush / skip / walk decision lives behind a named helper.
- The old bookkeeping names and restoration helpers were removed; a repository audit found no remaining references outside plan docs.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` on branch-touched Lua files
- Full local Lua harness sweep: `lua tests\*.lua`
- Focused local ignored harness: `lua tests\cooldown-refresh-queue.lua`
- Removed-symbol audit for the old queue fields/helpers outside `docs/plans/`
- Not yet validated in-game. Combat and restricted-content regression testing is still needed before this should be treated as runtime-proven.