### PR TITLE
Keep duplicated profiles from loading other characters' groups

### DIFF
--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -394,8 +394,10 @@ StaticPopupDialogs["CDC_DUPLICATE_PROFILE"] = {
                 return
             end
             local db = CooldownCompanion.db
+            CooldownCompanion._suppressOwnershipRestamp = true
             db:SetProfile(newName)
             db:CopyProfile(data.source)
+            CooldownCompanion._suppressOwnershipRestamp = nil
             ResetConfigSelection(true)
             CooldownCompanion:RefreshConfigPanel()
             CooldownCompanion:RefreshAllGroups()


### PR DESCRIPTION
## What Players Will Notice
- Duplicating a profile now keeps character-only groups assigned to their original characters instead of immediately loading every copied character's groups on the current character.

## Why This Changed
- Profile duplication copies the source profile data, but the profile-copy callback was restamping every character-owned group, container, and folder to the current character. That made the duplicate profile behave differently from the source profile as soon as it was created.

## What Changed
- The duplicate profile popup now suppresses ownership restamping while `CopyProfile` runs, matching the existing rename flow and preserving the copied profile's ownership structure.

## Validation
- Ran `lua tests/config-loader.lua` with a local ignored regression case that failed before the fix and passes after.
- Ran `luac -p CooldownCompanion_Config/Config/Popups.lua tests/config-loader.lua`.
- Ran `git diff --check origin/main...HEAD`.
- In-game combat and restricted-content validation is still pending.