### PR TITLE
Show inactive button overrides instead of blank tabs

### DIFF
--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -830,9 +830,17 @@ ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS = {
     barActiveAura = true,
 }
 
+ST.NO_COOLDOWN_DENIED_OVERRIDE_SECTIONS = {
+    desaturation = true,
+    readyGlow = true,
+}
+
 function ST.CanButtonUseOverrideSection(buttonData, sectionId)
     if buttonData and buttonData.type == "equipmentSlot" then
-        return not ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId]
+        if ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId] then
+            return false, "entryType"
+        end
+        return true
     end
     return true
 end

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -758,6 +758,13 @@ ST.OVERRIDE_SECTIONS = {
     barIcon = {
         label = "Bar Icon",
         keys = {"showBarIcon", "barIconReverse", "barIconOffset", "barIconSizeOverride", "barIconSize"},
+        defaults = {
+            showBarIcon = true,
+            barIconReverse = false,
+            barIconOffset = 0,
+            barIconSizeOverride = false,
+            barIconSize = 20,
+        },
         modes = {bars = true},
     },
     barColor = {

--- a/CooldownCompanion/Core/StyleOverrides.lua
+++ b/CooldownCompanion/Core/StyleOverrides.lua
@@ -82,6 +82,9 @@ function CooldownCompanion:PromoteSection(buttonData, groupStyle, sectionId)
     -- Copy current group values into overrides
     for _, key in ipairs(section.keys) do
         local val = groupStyle[key]
+        if val == nil and section.defaults then
+            val = section.defaults[key]
+        end
         if key == "unusableVisualMode" then
             val = ST.GetUnusableVisualMode(groupStyle)
         end

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua
@@ -10,8 +10,7 @@ local CreateRevertButton = ST._CreateRevertButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
-local IsNoCooldownSpellID = ST.IsNoCooldownSpell
-local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
+local CanButtonUseConfigOverrideSection = ST._CanButtonUseConfigOverrideSection
 
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
 local BuildAuraTextControls = ST._BuildAuraTextControls
@@ -48,13 +47,34 @@ local BuildTextBackgroundControls = ST._BuildTextBackgroundControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 
-local function CanButtonUseOverrideSection(buttonData, sectionId)
-    if ST.CanButtonUseOverrideSection then
-        return ST.CanButtonUseOverrideSection(buttonData, sectionId)
+local function GetHiddenOverrideReasonText(reason)
+    if reason == "noCooldown" then
+        return "Saved for this button, but inactive because this spell does not have a real cooldown."
+    elseif reason == "entryType" then
+        return "Saved for this button, but inactive because this entry type cannot use it."
+    elseif reason == "displayMode" then
+        return "Saved for this button, but inactive in the current display mode."
     end
-    return not (buttonData and buttonData.type == "equipmentSlot"
-        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS
-        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId])
+    return "Saved for this button, but inactive for this entry right now."
+end
+
+local function AddHiddenOverrideSection(scroll, buttonData, hiddenSection, infoButtons)
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(hiddenSection.sectionDef.label .. " (inactive)")
+    if heading.label then
+        heading.label:SetTextColor(0.55, 0.55, 0.55)
+    end
+    heading:SetFullWidth(true)
+    scroll:AddChild(heading)
+
+    local revertBtn = CreateRevertButton(heading, buttonData, hiddenSection.sectionId)
+    table.insert(infoButtons, revertBtn)
+
+    local reasonLabel = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(reasonLabel)
+    reasonLabel:SetText("|cff888888" .. GetHiddenOverrideReasonText(hiddenSection.reason) .. "|r")
+    reasonLabel:SetFullWidth(true)
+    scroll:AddChild(reasonLabel)
 end
 
 local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex)
@@ -246,6 +266,69 @@ local function BuildSingleBarColorControl(key, label, defaultColor)
     end
 end
 
+local function BuildBarIconControls(container, styleTable, onChange)
+    local showIconCb = AceGUI:Create("CheckBox")
+    showIconCb:SetLabel("Show Icon")
+    showIconCb:SetValue(styleTable.showBarIcon ~= false)
+    showIconCb:SetFullWidth(true)
+    showIconCb:SetCallback("OnValueChanged", function(_, _, val)
+        styleTable.showBarIcon = val
+        onChange()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(showIconCb)
+
+    if styleTable.showBarIcon == false then
+        return
+    end
+
+    local flipIconCheck = AceGUI:Create("CheckBox")
+    flipIconCheck:SetLabel("Flip Icon Side")
+    flipIconCheck:SetValue(styleTable.barIconReverse or false)
+    flipIconCheck:SetFullWidth(true)
+    flipIconCheck:SetCallback("OnValueChanged", function(_, _, val)
+        styleTable.barIconReverse = val == true
+        CooldownCompanion:RefreshGroupFrame(CS.selectedGroup)
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(flipIconCheck)
+
+    local iconOffsetSlider = AceGUI:Create("Slider")
+    iconOffsetSlider:SetLabel("Icon Offset")
+    iconOffsetSlider:SetSliderValues(-5, 50, 0.1)
+    iconOffsetSlider:SetValue(styleTable.barIconOffset or 0)
+    iconOffsetSlider:SetFullWidth(true)
+    iconOffsetSlider:SetCallback("OnValueChanged", function(_, _, val)
+        styleTable.barIconOffset = val
+        onChange()
+    end)
+    container:AddChild(iconOffsetSlider)
+
+    local customIconSizeCb = AceGUI:Create("CheckBox")
+    customIconSizeCb:SetLabel("Custom Icon Size")
+    customIconSizeCb:SetValue(styleTable.barIconSizeOverride or false)
+    customIconSizeCb:SetFullWidth(true)
+    customIconSizeCb:SetCallback("OnValueChanged", function(_, _, val)
+        styleTable.barIconSizeOverride = val
+        onChange()
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    container:AddChild(customIconSizeCb)
+
+    if styleTable.barIconSizeOverride then
+        local iconSizeSlider = AceGUI:Create("Slider")
+        iconSizeSlider:SetLabel("Icon Size")
+        iconSizeSlider:SetSliderValues(5, 100, 0.1)
+        iconSizeSlider:SetValue(styleTable.barIconSize or 20)
+        iconSizeSlider:SetFullWidth(true)
+        iconSizeSlider:SetCallback("OnValueChanged", function(_, _, val)
+            styleTable.barIconSize = val
+            onChange()
+        end)
+        container:AddChild(iconSizeSlider)
+    end
+end
+
 function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
     local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
     if not group then return end
@@ -285,7 +368,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         "borderSettings", "cooldownText", "auraText", "auraStackText",
         "iconFillTimer", "cooldownSwipe", "auraDurationSwipe", "showGCDSwipe", "keybindText", "chargeText", "desaturation", "showOutOfRange", "showTooltips",
         "lossOfControl", "unusableDimming", "iconTint", "assistedHighlight", "procGlow", "auraIndicator", "pandemicGlow", "readyGlow", "keyPressHighlight",
-        "barColor", "barCooldownColor", "barChargeColor", "barBgColor", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
+        "barIcon", "barColor", "barCooldownColor", "barChargeColor", "barBgColor", "barNameText", "barReadyText", "pandemicBar", "barActiveAura",
         "textFont", "textColors", "textBackground",
     }
 
@@ -320,6 +403,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         end,
         readyGlow = BuildReadyGlowControls,
         keyPressHighlight = BuildKeyPressHighlightControls,
+        barIcon = BuildBarIconControls,
         barColor = BuildSingleBarColorControl("barColor", "Bar Color", {0.2, 0.6, 1.0, 1.0}),
         barCooldownColor = BuildSingleBarColorControl("barCooldownColor", "Bar Cooldown Color", {0.6, 0.6, 0.6, 1.0}),
         barChargeColor = BuildSingleBarColorControl("barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1.0}),
@@ -353,17 +437,14 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
         textBackground = BuildTextBackgroundControls,
     }
 
-    local isNoCooldownSpell = false
-    if buttonData.type == "spell" and not buttonData.isPassive and not UsesChargeBehavior(buttonData) then
-        isNoCooldownSpell = IsNoCooldownSpellID(buttonData.id)
-    end
-
+    local visibleOverrideSections = 0
+    local hiddenOverrideSections = {}
     for _, sectionId in ipairs(sectionOrder) do
-        if buttonData.overrideSections[sectionId]
-            and CanButtonUseOverrideSection(buttonData, sectionId)
-            and not (isNoCooldownSpell and (sectionId == "readyGlow" or sectionId == "desaturation")) then
+        if buttonData.overrideSections[sectionId] then
             local sectionDef = ST.OVERRIDE_SECTIONS[sectionId]
-            if sectionDef and sectionDef.modes[displayMode] then
+            local sectionAllowed, sectionUnavailableReason = CanButtonUseConfigOverrideSection(buttonData, sectionId)
+            if sectionDef and sectionAllowed and sectionDef.modes[displayMode] then
+                visibleOverrideSections = visibleOverrideSections + 1
                 local heading = AceGUI:Create("Heading")
                 heading:SetText(sectionDef.label)
                 ColorHeading(heading)
@@ -566,7 +647,25 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
 
                     end
                 end
+            elseif sectionDef then
+                table.insert(hiddenOverrideSections, {
+                    sectionId = sectionId,
+                    sectionDef = sectionDef,
+                    reason = sectionAllowed and "displayMode" or sectionUnavailableReason,
+                })
             end
         end
+    end
+
+    if visibleOverrideSections == 0 and displayMode ~= "text" then
+        local noVisibleOverridesLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(noVisibleOverridesLabel)
+        noVisibleOverridesLabel:SetText("|cff888888No appearance overrides are currently available for this entry.\n\nSome saved overrides may be hidden because they do not apply to this entry type or spell cooldown behavior.|r")
+        noVisibleOverridesLabel:SetFullWidth(true)
+        scroll:AddChild(noVisibleOverridesLabel)
+    end
+
+    for _, hiddenSection in ipairs(hiddenOverrideSections) do
+        AddHiddenOverrideSection(scroll, buttonData, hiddenSection, infoButtons)
     end
 end

--- a/CooldownCompanion_Config/ConfigSettings/Helpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/Helpers.lua
@@ -249,6 +249,32 @@ local function GroupSupportsPerButtonOverrides(group)
     return group and (group.displayMode or "icons") ~= "textures"
 end
 
+local function GetSelectedRuntimeButton(buttonData)
+    local groupId = CS.selectedGroup
+    local buttonIndex = CS.selectedButton
+    if not (buttonData and groupId and buttonIndex) then
+        return nil
+    end
+
+    local profile = CooldownCompanion.db and CooldownCompanion.db.profile
+    local group = profile and profile.groups and profile.groups[groupId]
+    if not (group and group.buttons and group.buttons[buttonIndex] == buttonData) then
+        return nil
+    end
+
+    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
+    if not (frame and frame.buttons) then
+        return nil
+    end
+
+    for _, button in ipairs(frame.buttons) do
+        if button and button.buttonData == buttonData then
+            return button
+        end
+    end
+    return nil
+end
+
 local function CanButtonUseConfigOverrideSection(buttonData, sectionId)
     if ST.CanButtonUseOverrideSection then
         local allowed, reason = ST.CanButtonUseOverrideSection(buttonData, sectionId)
@@ -273,7 +299,17 @@ local function CanButtonUseConfigOverrideSection(buttonData, sectionId)
         return true
     end
 
-    if IsNoCooldownSpellID and IsNoCooldownSpellID(buttonData.id) == true then
+    local cooldownSpellId = buttonData.id
+    local button = GetSelectedRuntimeButton(buttonData)
+    if button then
+        local displaySpellId = button._displaySpellId or buttonData.id
+        if button._noCooldown ~= nil and button._noCooldownSpellId == displaySpellId then
+            return not button._noCooldown, button._noCooldown and "noCooldown" or nil
+        end
+        cooldownSpellId = displaySpellId
+    end
+
+    if IsNoCooldownSpellID and IsNoCooldownSpellID(cooldownSpellId) == true then
         return false, "noCooldown"
     end
 

--- a/CooldownCompanion_Config/ConfigSettings/Helpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/Helpers.lua
@@ -4,6 +4,8 @@ local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 local ShowPopupAboveConfig = CS.ShowPopupAboveConfig
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
+local IsNoCooldownSpellID = ST.IsNoCooldownSpell
+local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 
 -- Helper: tint AceGUI Heading labels with player class color
 local function ColorHeading(heading)
@@ -247,13 +249,35 @@ local function GroupSupportsPerButtonOverrides(group)
     return group and (group.displayMode or "icons") ~= "textures"
 end
 
-local function CanButtonUseOverrideSection(buttonData, sectionId)
+local function CanButtonUseConfigOverrideSection(buttonData, sectionId)
     if ST.CanButtonUseOverrideSection then
-        return ST.CanButtonUseOverrideSection(buttonData, sectionId)
-    end
-    return not (buttonData and buttonData.type == "equipmentSlot"
+        local allowed, reason = ST.CanButtonUseOverrideSection(buttonData, sectionId)
+        if not allowed then
+            return false, reason
+        end
+    elseif buttonData and buttonData.type == "equipmentSlot"
         and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS
-        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId])
+        and ST.EQUIPMENT_SLOT_DENIED_OVERRIDE_SECTIONS[sectionId] then
+        return false, "entryType"
+    end
+
+    if not (ST.NO_COOLDOWN_DENIED_OVERRIDE_SECTIONS
+        and ST.NO_COOLDOWN_DENIED_OVERRIDE_SECTIONS[sectionId]
+        and buttonData
+        and buttonData.type == "spell"
+        and not buttonData.isPassive) then
+        return true
+    end
+
+    if UsesChargeBehavior and UsesChargeBehavior(buttonData) then
+        return true
+    end
+
+    if IsNoCooldownSpellID and IsNoCooldownSpellID(buttonData.id) == true then
+        return false, "noCooldown"
+    end
+
+    return true
 end
 
 local function CreatePromoteButton(headingWidget, sectionId, buttonData, groupStyle)
@@ -279,7 +303,7 @@ local function CreatePromoteButton(headingWidget, sectionId, buttonData, groupSt
     if CS.selectedButtons then
         for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
     end
-    local sectionAllowed = CanButtonUseOverrideSection(buttonData, sectionId)
+    local sectionAllowed, sectionUnavailableReason = CanButtonUseConfigOverrideSection(buttonData, sectionId)
     local canPromote = CS.selectedButton ~= nil and multiCount < 2
         and buttonData ~= nil
         and sectionAllowed
@@ -300,6 +324,8 @@ local function CreatePromoteButton(headingWidget, sectionId, buttonData, groupSt
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if canPromote then
             GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        elseif buttonData and sectionUnavailableReason == "noCooldown" then
+            GameTooltip:AddLine("This override is not available for spells without a real cooldown", 0.5, 0.5, 0.5)
         elseif buttonData and not sectionAllowed then
             GameTooltip:AddLine("This override is not available for equipment slots", 0.5, 0.5, 0.5)
         else
@@ -379,7 +405,7 @@ local function CreateCheckboxPromoteButton(cbWidget, anchorAfterFrame, sectionId
     if CS.selectedButtons then
         for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
     end
-    local sectionAllowed = CanButtonUseOverrideSection(btnData, sectionId)
+    local sectionAllowed, sectionUnavailableReason = CanButtonUseConfigOverrideSection(btnData, sectionId)
     local canPromote = CS.selectedButton ~= nil and multiCount < 2
         and btnData ~= nil
         and sectionAllowed
@@ -400,6 +426,8 @@ local function CreateCheckboxPromoteButton(cbWidget, anchorAfterFrame, sectionId
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if canPromote then
             GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        elseif btnData and sectionUnavailableReason == "noCooldown" then
+            GameTooltip:AddLine("This override is not available for spells without a real cooldown", 0.5, 0.5, 0.5)
         elseif btnData and not sectionAllowed then
             GameTooltip:AddLine("This override is not available for equipment slots", 0.5, 0.5, 0.5)
         else
@@ -448,7 +476,7 @@ local function CreateColorPickerPromoteButton(colorPickerWidget, sectionId, grou
     if CS.selectedButtons then
         for _ in pairs(CS.selectedButtons) do multiCount = multiCount + 1 end
     end
-    local sectionAllowed = CanButtonUseOverrideSection(btnData, sectionId)
+    local sectionAllowed, sectionUnavailableReason = CanButtonUseConfigOverrideSection(btnData, sectionId)
     local canPromote = CS.selectedButton ~= nil and multiCount < 2
         and btnData ~= nil
         and sectionAllowed
@@ -469,6 +497,8 @@ local function CreateColorPickerPromoteButton(colorPickerWidget, sectionId, grou
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
         if canPromote then
             GameTooltip:AddLine("Override " .. sectionLabel .. " for this button")
+        elseif btnData and sectionUnavailableReason == "noCooldown" then
+            GameTooltip:AddLine("This override is not available for spells without a real cooldown", 0.5, 0.5, 0.5)
         elseif btnData and not sectionAllowed then
             GameTooltip:AddLine("This override is not available for equipment slots", 0.5, 0.5, 0.5)
         else
@@ -1257,6 +1287,7 @@ ST._CreatePromoteButton = CreatePromoteButton
 ST._CreateRevertButton = CreateRevertButton
 ST._CreateCheckboxPromoteButton = CreateCheckboxPromoteButton
 ST._CreateColorPickerPromoteButton = CreateColorPickerPromoteButton
+ST._CanButtonUseConfigOverrideSection = CanButtonUseConfigOverrideSection
 ST._CreateInfoButton = CreateInfoButton
 ST._BuildCompactModeControls = BuildCompactModeControls
 ST._BuildGroupSettingPresetControls = BuildGroupSettingPresetControls


### PR DESCRIPTION
## What Players Will Notice
- The per-button Appearance Overrides tab no longer opens as an empty panel when the selected button only has saved overrides that are inactive for that entry type or spell cooldown behavior.
- Saved inactive overrides now show as inactive rows with Revert buttons, so players can see and remove old per-button settings instead of hunting for hidden state.
- Bar-mode buttons can now edit per-button Bar Icon overrides, and promoted Bar Icon overrides keep the current flip, offset, and size behavior even if the group defaults change later.

## Why This Changed
- Some appearance overrides, such as Ready Glow and Desaturation, do not apply to spells without a real cooldown. The config UI was filtering those sections out, but when every saved section was filtered the Overrides tab looked broken and offered no way to revert the saved settings.
- Bar Icon was already registered as an override section, but the Overrides tab did not expose controls for it, and promotion did not freeze default-backed values like icon side or offset.

## What Changed
- Added config-side override eligibility reasons so unsupported sections can be disabled or shown as inactive without deleting saved override data.
- Kept no-cooldown gating config-only and aligned it with the selected runtime button's displayed spell classification when that runtime state is available.
- Added inactive saved override rows with Revert buttons in the per-button Overrides tab.
- Added Bar Icon controls to the Overrides tab and default-copy support for override sections so nil-backed Bar Icon defaults are preserved during promotion.

## Validation
- Ran a post-simplification parallel review/fix loop; the final four-reviewer cohort returned no actionable findings.
- `luac -p` over all 168 addon/config Lua files passed.
- `git diff --check` passed, with only LF-to-CRLF working-copy warnings.
- `lua tests/config-loader.lua` passed.
- 12 local Lua harnesses passed.
- `tests/assisted-rotation-entry.lua` still fails because it expects `ST.ASSISTED_ROTATION_TYPE`, which is absent from the current source; this appears to be an existing stale local harness mismatch rather than this branch.
- In-game validation has not been performed yet. Before merge, please verify inactive saved no-cooldown overrides, equipment-slot inactive overrides, replacement/displayed spell cases, Bar Icon promote/edit/revert behavior, and combat/restricted-content behavior.