### PR TITLE
Add Assistant Panels for rotation recommendations

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -606,7 +606,7 @@ end
 
 function CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
     if button.keybindText then
-        local text = self:GetDisplayedKeybindText(buttonData, button._resolvedItemId)
+        local text = self:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
         button.keybindText:SetText(text or "")
         button.keybindText:SetShown(button.style and button.style.showKeybindText and text ~= nil)
     end
@@ -865,6 +865,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
             CooldownCompanion:UpdateButtonIcon(button)
             button._forceBaseDisplaySpellId = nil
+            if buttonData._rotationAssistantVirtual == true and CooldownCompanion.RefreshResolvedItemKeybindState then
+                CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
+            end
             cooldownSpellId = forceBaseDisplayId and buttonData.id
                 or liveOverrideId
                 or button._displaySpellId

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -516,6 +516,79 @@ local function DispatchStandaloneTextureVisual(button)
     CooldownCompanion:UpdateAuraTextureVisual(button)
 end
 
+local function ClearCooldownWidget(widget)
+    if not widget then return end
+    if widget.SetCooldown then
+        widget:SetCooldown(0, 0)
+    end
+    if widget.Hide then
+        widget:Hide()
+    end
+end
+
+local function ClearRotationAssistantMissingState(button, buttonData, style)
+    button._durationObj = nil
+    button._auraDurationObj = nil
+    button._auraCooldownStart = nil
+    button._auraCooldownDuration = nil
+    button._auraPrimarySwipeActive = nil
+    button._cooldownDeferred = nil
+    button._cooldownState = COOLDOWN_STATE_READY
+    button._chargeState = nil
+    button._chargeCooldownVisualActive = nil
+    button._currentReadableCharges = nil
+    button._desatCooldownActive = false
+    button._spellOutOfRange = nil
+    button._isUnusable = false
+    button._isOutOfRange = false
+    button._procOverlayActive = false
+    button._auraActive = false
+    button._auraStackText = ""
+    button._visibilityHidden = false
+    button._visibilityAlphaOverride = nil
+    button._visibilityReasonBits = 0
+    button._visibilityReasonMode = "visible"
+
+    ClearCooldownWidget(button.cooldown)
+    ClearCooldownWidget(button.secondaryCooldown)
+    ClearCooldownWidget(button.auraBlizzardCooldown)
+    ClearCooldownWidget(button.locCooldown)
+    ClearCooldownWidget(button.iconGCDCooldown)
+    if ClearIconFillVisualState then
+        ClearIconFillVisualState(button)
+    end
+
+    if button.icon then
+        button.icon:SetDesaturated(false)
+        button.icon:SetVertexColor(1, 1, 1, 1)
+    end
+    if button.count then
+        button.count:SetText("")
+    end
+    if button.auraStackCount then
+        button.auraStackCount:SetText("")
+    end
+    if button.keybindText then
+        button.keybindText:SetText("")
+        button.keybindText:SetShown(false)
+    end
+    if button._cdTextRegion then
+        button._cdTextRegion:SetTextColor(0, 0, 0, 0)
+    end
+    if button._secondaryCdTextRegion then
+        button._secondaryCdTextRegion:SetTextColor(0, 0, 0, 0)
+    end
+    if button.SetAlpha and button._lastVisAlpha ~= 1 then
+        button:SetAlpha(1)
+        button._lastVisAlpha = 1
+    end
+
+    if UpdateIconModeGlows then
+        UpdateIconModeGlows(button, buttonData, style or {}, false)
+    end
+    DispatchStandaloneTextureVisual(button)
+end
+
 local function IsReadyGlowMaxChargeEligible(buttonData)
     return buttonData
         and buttonData.type == "spell"
@@ -711,6 +784,10 @@ end
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
+    if buttonData and buttonData._rotationAssistantVirtual == true and self.RefreshRotationAssistantButton then
+        self:RefreshRotationAssistantButton(button)
+        buttonData = button.buttonData
+    end
     local barAuraStackConfigured = button._isBar and CooldownCompanion:IsBarPanelAuraStackDisplay(buttonData)
     local barAuraStackDisplay = false
     local previousBarAuraStackValue = button._barAuraStackValue
@@ -726,6 +803,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
     local buttonDisplayMode = buttonGroup and (buttonGroup.displayMode or "icons") or "icons"
     ClearConditionalVisualPreviewFields(button)
+
+    if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
+        ClearRotationAssistantMissingState(button, buttonData, style)
+        return
+    end
 
     if UpdateResolvedItemState(button, buttonData) then
         CooldownCompanion:UpdateButtonIcon(button)
@@ -1536,7 +1618,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     ApplyChargeTextColor(button, buttonData, style, usesChargeBehavior)
 
     -- Per-button sound alerts (Blizzard-scoped events, CDM-valid only).
-    if buttonData.type == "spell" then
+    if buttonData.type == "spell" and buttonData._rotationAssistantVirtual ~= true then
         local soundCfg = buttonData.soundAlerts
         local hasSoundConfig = soundCfg and type(soundCfg.events) == "table" and next(soundCfg.events) ~= nil
         if hasSoundConfig then

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -121,7 +121,10 @@ local function ShouldEnrollKeyPressHighlightButton(button)
     end
 
     local buttonData = button.buttonData
-    if not buttonData or buttonData.type == "header" or buttonData.isPassive then
+    if not buttonData
+        or buttonData._rotationAssistantVirtual == true
+        or buttonData.type == "header"
+        or buttonData.isPassive then
         return false
     end
 
@@ -988,6 +991,17 @@ function CooldownCompanion:UpdateButtonIcon(button)
         return selectedAvailable
     end
 
+    if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
+        UseIcon(self:GetRotationAssistantFallbackIcon(), true)
+        button._displaySpellId = nil
+        if hasIcon then
+            button.icon:SetTexture(icon)
+        else
+            button.icon:SetTexture(QUESTION_MARK_ICON)
+        end
+        return
+    end
+
     if buttonData.type == "spell" then
         overrideId = C_Spell.GetOverrideSpell(buttonData.id)
         if overrideId == buttonData.id or overrideId == 0 then
@@ -1326,6 +1340,15 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
 
     -- Loss of control overlay
     UpdateLossOfControl(button)
+
+    if buttonData._rotationAssistantVirtual == true then
+        SetAssistedHighlight(button, false)
+        SetProcGlow(button, false)
+        SetAuraGlow(button, false, false)
+        SetReadyGlow(button, false)
+        SetKeyPressHighlight(button, false)
+        return
+    end
 
     -- Assisted highlight glow
     if button.assistedHighlight then

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -837,7 +837,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
         local xOff = style.keybindXOffset or -2
         local yOff = style.keybindYOffset or -2
         button.keybindText:SetPoint(anchor, xOff, yOff)
-        local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId)
+        local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
         button.keybindText:SetText(text or "")
         button.keybindText:SetShown(style.showKeybindText and text ~= nil)
     end
@@ -1588,7 +1588,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
         local xOff = style.keybindXOffset or -2
         local yOff = style.keybindYOffset or -2
         button.keybindText:SetPoint(anchor, xOff, yOff)
-        local text = CooldownCompanion:GetDisplayedKeybindText(button.buttonData, button._resolvedItemId)
+        local text = CooldownCompanion:GetDisplayedKeybindText(button.buttonData, button._resolvedItemId, button)
         button.keybindText:SetText(text or "")
         button.keybindText:SetShown(style.showKeybindText and text ~= nil)
     end

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -384,7 +384,7 @@ local function EvaluateTokenPresence(button, tokenName, timeRemaining, timeIsSec
     elseif tokenName == "aura" then
         return button._auraActive == true or auraIsSecret or (auraRemaining and auraRemaining > 0)
     elseif tokenName == "keybind" then
-        local kb = CooldownCompanion:GetKeybindText(button.buttonData, button._resolvedItemId)
+        local kb = CooldownCompanion:GetKeybindText(button.buttonData, button._resolvedItemId, button)
         return kb and kb ~= ""
     elseif tokenName == "pandemic" then
         return button._inPandemic == true
@@ -630,7 +630,7 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
                 end
 
             elseif token == "keybind" then
-                local kb = CooldownCompanion:GetKeybindText(buttonData, button._resolvedItemId)
+                local kb = CooldownCompanion:GetKeybindText(buttonData, button._resolvedItemId, button)
                 if kb and kb ~= "" then
                     parts[#parts + 1] = WrapColor(kb, colorOverride or baseColor)
                 end

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -183,6 +183,9 @@ local function SetTintIntent(target, active, reason, unusableActive, r, g, b, a)
 end
 
 local function IsUnusableVisualActive(button, buttonData)
+    if buttonData and buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
+        return false
+    end
     if buttonData.isPassive or buttonData.isPassiveCooldown then
         return false
     end
@@ -212,6 +215,10 @@ local function ResolveIconTintIntent(button, buttonData, style, target)
     end
 
     style = style or {}
+
+    if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
+        return SetTintIntent(target, false, nil, false, 1, 1, 1, 1)
+    end
 
     if buttonData.isPassive then
         local c

--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -103,6 +103,14 @@ end
 -- Called inside UpdateButtonCooldown after cooldown fetch and aura tracking are complete.
 -- Fast path: if no toggles are enabled, zero overhead.
 local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, procOverlayActive, auraOwnsPrimarySwipe)
+    if buttonData and buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
+        button._visibilityHidden = false
+        button._visibilityAlphaOverride = nil
+        button._visibilityReasonBits = 0
+        button._visibilityReasonMode = "visible"
+        return
+    end
+
     if auraOwnsPrimarySwipe == nil then
         auraOwnsPrimarySwipe = auraOverrideActive
     end
@@ -271,6 +279,12 @@ end
 -- returns secret start/duration that SetCooldown will reject after the 12.0.1 hotfix.
 local function UpdateLossOfControl(button)
     if not button.locCooldown then return end
+
+    local buttonData = button.buttonData
+    if buttonData and buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
+        button.locCooldown:SetCooldown(0, 0)
+        return
+    end
 
     if button.style.showLossOfControl and button.buttonData.type == "spell" and not button.buttonData.isPassive then
         local locDuration = C_Spell.GetSpellLossOfControlCooldownDuration(button.buttonData.id)

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -654,11 +654,25 @@ function CooldownCompanion:IsIconLikeDisplayMode(displayMode)
     return ST.IsIconLikeDisplayMode(displayMode)
 end
 
+function CooldownCompanion:GetPanelManualEntryRejectMessage(group)
+    if self:IsRotationAssistantGroup(group) then
+        return "Assistant Panels are populated automatically."
+    end
+    if group and group.displayMode == "textures" and group.buttons and #group.buttons >= 1 then
+        return "Texture Panels can only hold one entry. Remove the current entry first if you want to replace it."
+    end
+    return nil
+end
+
+function CooldownCompanion:CanPanelAcceptManualEntry(group)
+    return self:GetPanelManualEntryRejectMessage(group) == nil
+end
+
 function CooldownCompanion:GetRotationAssistantActionSpellID()
     local assistedCombat = C_AssistedCombat
     if assistedCombat and assistedCombat.GetActionSpell then
         local spellID = assistedCombat.GetActionSpell()
-        if type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID) then
+        if type(spellID) == "number" and not issecretvalue(spellID) and spellID > 0 then
             return spellID
         end
     end
@@ -674,6 +688,31 @@ function CooldownCompanion:GetRotationAssistantFallbackIcon()
         end
     end
     return ST.ROTATION_ASSISTANT_FALLBACK_ICON
+end
+
+function CooldownCompanion:GetRotationAssistantEntrySettings(group, create)
+    if not group then return nil end
+    local entry = group.rotationAssistantEntry
+    if type(entry) ~= "table" then
+        if create == false then
+            return nil
+        end
+        entry = {}
+        group.rotationAssistantEntry = entry
+    end
+    return entry
+end
+
+function CooldownCompanion:GetRotationAssistantConfigButtonData(group)
+    local entry = self:GetRotationAssistantEntrySettings(group, true)
+    if not entry then return nil end
+    entry.type = "spell"
+    entry.id = self:GetRotationAssistantActionSpellID()
+    entry.name = ST.ROTATION_ASSISTANT_NAME
+    entry.manualIcon = self:GetRotationAssistantFallbackIcon()
+    entry._rotationAssistantVirtual = true
+    entry._rotationAssistantMissing = true
+    return entry
 end
 
 function CooldownCompanion:GetRotationAssistantRecommendationSpellID()
@@ -697,7 +736,7 @@ function CooldownCompanion:GetRotationAssistantRecommendationSpellID()
     end
 
     local spellID = assistedCombat.GetNextCastSpell(false)
-    if type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID) then
+    if type(spellID) == "number" and not issecretvalue(spellID) and spellID > 0 then
         return spellID
     end
     return nil
@@ -705,6 +744,9 @@ end
 
 function CooldownCompanion:GetRotationAssistantButtonData(frame)
     if not frame then return nil end
+    local groups = self.db and self.db.profile and self.db.profile.groups
+    local group = frame._groupId and groups and groups[frame._groupId]
+    local entrySettings = self:GetRotationAssistantEntrySettings(group, false)
     local buttonData = frame._rotationAssistantButtonData
     if not buttonData then
         buttonData = {
@@ -716,6 +758,7 @@ function CooldownCompanion:GetRotationAssistantButtonData(frame)
         }
         frame._rotationAssistantButtonData = buttonData
     end
+    buttonData.loadConditions = entrySettings and entrySettings.loadConditions or nil
     return buttonData
 end
 

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -3,6 +3,12 @@
 ]]
 
 local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+ST.DISPLAY_MODE_ROTATION_ASSISTANT = "rotationAssistant"
+ST.ROTATION_ASSISTANT_NAME = "Assistant Panel"
+ST.ROTATION_ASSISTANT_ACTION_SPELL_ID = 1229376
+ST.ROTATION_ASSISTANT_FALLBACK_ICON = 6718291
 
 -- Default database structure
 local defaults = {
@@ -626,6 +632,155 @@ local defaults = {
 
 ST._defaults = defaults
 
+function ST.IsRotationAssistantDisplayMode(displayMode)
+    return displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
+end
+
+function ST.IsIconLikeDisplayMode(displayMode)
+    return displayMode == nil
+        or displayMode == "icons"
+        or displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
+end
+
+function CooldownCompanion:IsRotationAssistantGroup(group)
+    return group and ST.IsRotationAssistantDisplayMode(group.displayMode) or false
+end
+
+function CooldownCompanion:IsRotationAssistantButtonData(buttonData)
+    return buttonData and buttonData._rotationAssistantVirtual == true or false
+end
+
+function CooldownCompanion:IsIconLikeDisplayMode(displayMode)
+    return ST.IsIconLikeDisplayMode(displayMode)
+end
+
+function CooldownCompanion:GetRotationAssistantActionSpellID()
+    local assistedCombat = C_AssistedCombat
+    if assistedCombat and assistedCombat.GetActionSpell then
+        local spellID = assistedCombat.GetActionSpell()
+        if type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID) then
+            return spellID
+        end
+    end
+    return ST.ROTATION_ASSISTANT_ACTION_SPELL_ID
+end
+
+function CooldownCompanion:GetRotationAssistantFallbackIcon()
+    local spellID = self:GetRotationAssistantActionSpellID()
+    if spellID and C_Spell and C_Spell.GetSpellTexture then
+        local icon = C_Spell.GetSpellTexture(spellID)
+        if icon and not issecretvalue(icon) then
+            return icon
+        end
+    end
+    return ST.ROTATION_ASSISTANT_FALLBACK_ICON
+end
+
+function CooldownCompanion:GetRotationAssistantRecommendationSpellID()
+    local assistedCombat = C_AssistedCombat
+    if not (assistedCombat and assistedCombat.GetNextCastSpell) then
+        self._rotationAssistantAvailable = false
+        self._rotationAssistantUnavailableReason = "apiUnavailable"
+        return nil
+    end
+
+    if assistedCombat.IsAvailable then
+        local available, reason = assistedCombat.IsAvailable()
+        self._rotationAssistantAvailable = available == true
+        self._rotationAssistantUnavailableReason = reason
+        if available ~= true then
+            return nil
+        end
+    else
+        self._rotationAssistantAvailable = true
+        self._rotationAssistantUnavailableReason = nil
+    end
+
+    local spellID = assistedCombat.GetNextCastSpell(false)
+    if type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID) then
+        return spellID
+    end
+    return nil
+end
+
+function CooldownCompanion:GetRotationAssistantButtonData(frame)
+    if not frame then return nil end
+    local buttonData = frame._rotationAssistantButtonData
+    if not buttonData then
+        buttonData = {
+            type = "spell",
+            id = self:GetRotationAssistantActionSpellID(),
+            name = ST.ROTATION_ASSISTANT_NAME,
+            _rotationAssistantVirtual = true,
+            _rotationAssistantMissing = true,
+        }
+        frame._rotationAssistantButtonData = buttonData
+    end
+    return buttonData
+end
+
+function CooldownCompanion:ClearRotationAssistantButtonRuntime(button)
+    if not button then return end
+    button._displaySpellId = nil
+    button._liveOverrideSpellId = nil
+    button._lastSpellTexture = nil
+    button._spellTexBaseline = nil
+    button._baseNoCooldown = nil
+    button._baseNoCooldownSpellId = nil
+    button._noCooldown = nil
+    button._noCooldownSpellId = nil
+    button._resourceGateCost = nil
+    button._resourceGateCostSpellId = nil
+    button._baseResourceGateCost = nil
+    button._baseResourceGateCostSpellId = nil
+    button._spellOutOfRange = nil
+    button._auraActive = false
+    button._auraDurationObj = nil
+    button._auraCooldownStart = nil
+    button._auraCooldownDuration = nil
+    button._auraPrimarySwipeActive = nil
+    button._activeAuraSpellID = nil
+    button._activeAuraSpellIDFromFallback = nil
+    button._activeAuraIcon = nil
+    button._activeAuraIconAvailable = nil
+    button._procOverlayActive = false
+end
+
+function CooldownCompanion:RefreshRotationAssistantButton(button)
+    local buttonData = button and button.buttonData
+    if not self:IsRotationAssistantButtonData(buttonData) then
+        return false
+    end
+
+    local recommendedSpellID = self:GetRotationAssistantRecommendationSpellID()
+    local missing = recommendedSpellID == nil
+    local displaySpellID = recommendedSpellID or self:GetRotationAssistantActionSpellID()
+    local changed = buttonData.id ~= displaySpellID
+        or buttonData._rotationAssistantSpellID ~= recommendedSpellID
+        or buttonData._rotationAssistantMissing ~= missing
+
+    buttonData.id = displaySpellID
+    buttonData._rotationAssistantSpellID = recommendedSpellID
+    buttonData._rotationAssistantMissing = missing
+    buttonData.name = recommendedSpellID and C_Spell.GetSpellName(recommendedSpellID) or ST.ROTATION_ASSISTANT_NAME
+    button._rotationAssistantSpellID = recommendedSpellID
+
+    if changed then
+        self:ClearRotationAssistantButtonRuntime(button)
+        if self.UpdateButtonIcon then
+            self:UpdateButtonIcon(button)
+        end
+        if self.RefreshResolvedItemKeybindState then
+            self:RefreshResolvedItemKeybindState(button, buttonData)
+        end
+        if self.UpdateRangeCheckRegistrations then
+            self:UpdateRangeCheckRegistrations()
+        end
+    end
+
+    return changed
+end
+
 ------------------------------------------------------------------------
 -- OVERRIDE SECTIONS REGISTRY
 -- Maps section IDs to their labels, style keys, and applicable display modes.
@@ -636,7 +791,7 @@ ST.OVERRIDE_SECTIONS = {
     borderSettings = {
         label = "Border",
         keys = {"borderSize", "borderRenderMode", "borderColor"},
-        modes = {icons = true, bars = true},
+        modes = {icons = true, bars = true, rotationAssistant = true},
     },
     cooldownText = {
         label = "Cooldown Text",
@@ -656,7 +811,7 @@ ST.OVERRIDE_SECTIONS = {
     keybindText = {
         label = "Keybind Text",
         keys = {"showKeybindText", "keybindFont", "keybindFontSize", "keybindFontOutline", "keybindFontColor", "keybindAnchor", "keybindXOffset", "keybindYOffset"},
-        modes = {icons = true},
+        modes = {icons = true, rotationAssistant = true},
     },
     chargeText = {
         label = "Charge Text",
@@ -667,37 +822,37 @@ ST.OVERRIDE_SECTIONS = {
     desaturation = {
         label = "Desaturation",
         keys = {"desaturateOnCooldown"},
-        modes = {icons = true, bars = true},
+        modes = {icons = true, bars = true, rotationAssistant = true},
     },
     cooldownSwipe = {
         label = "Cooldown Swipe",
         keys = {"showCooldownSwipe", "showCooldownSwipeFill", "cooldownSwipeReverse", "showCooldownSwipeEdge", "cooldownSwipeAlpha", "cooldownSwipeEdgeColor"},
-        modes = {icons = true},
+        modes = {icons = true, rotationAssistant = true},
     },
     showGCDSwipe = {
         label = "Show GCD Swipe",
         keys = {"showGCDSwipe"},
-        modes = {icons = true, bars = true},
+        modes = {icons = true, bars = true, rotationAssistant = true},
     },
     showOutOfRange = {
         label = "Show Out of Range",
         keys = {"showOutOfRange"},
-        modes = {icons = true},
+        modes = {icons = true, rotationAssistant = true},
     },
     showTooltips = {
         label = "Show Tooltips",
         keys = {"showTooltips"},
-        modes = {icons = true, bars = true},
+        modes = {icons = true, bars = true, rotationAssistant = true},
     },
     lossOfControl = {
         label = "Loss of Control",
         keys = {"showLossOfControl"},
-        modes = {icons = true, bars = true},
+        modes = {icons = true, bars = true, rotationAssistant = true},
     },
     unusableDimming = {
         label = "Unusable Visual",
         keys = {"showUnusable", "unusableVisualMode", "iconUnusableTintColor"},
-        modes = {icons = true, bars = true},
+        modes = {icons = true, bars = true, rotationAssistant = true},
     },
     iconTint = {
         label = "Icon Tint",

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -679,8 +679,8 @@ function CooldownCompanion:GetRotationAssistantActionSpellID()
     return ST.ROTATION_ASSISTANT_ACTION_SPELL_ID
 end
 
-function CooldownCompanion:GetRotationAssistantFallbackIcon()
-    local spellID = self:GetRotationAssistantActionSpellID()
+function CooldownCompanion:GetRotationAssistantFallbackIcon(spellID)
+    spellID = spellID or self:GetRotationAssistantActionSpellID()
     if spellID and C_Spell and C_Spell.GetSpellTexture then
         local icon = C_Spell.GetSpellTexture(spellID)
         if icon and not issecretvalue(icon) then
@@ -745,7 +745,8 @@ end
 function CooldownCompanion:GetRotationAssistantButtonData(frame)
     if not frame then return nil end
     local groups = self.db and self.db.profile and self.db.profile.groups
-    local group = frame._groupId and groups and groups[frame._groupId]
+    local groupId = frame.groupId or frame._groupId
+    local group = groupId and groups and groups[groupId]
     local entrySettings = self:GetRotationAssistantEntrySettings(group, false)
     local buttonData = frame._rotationAssistantButtonData
     if not buttonData then
@@ -806,6 +807,11 @@ function CooldownCompanion:RefreshRotationAssistantButton(button)
     buttonData._rotationAssistantSpellID = recommendedSpellID
     buttonData._rotationAssistantMissing = missing
     buttonData.name = recommendedSpellID and C_Spell.GetSpellName(recommendedSpellID) or ST.ROTATION_ASSISTANT_NAME
+    if self.UpdateSpellChargeMetadata then
+        self:UpdateSpellChargeMetadata(buttonData, displaySpellID, {
+            clearInactiveMaxCharges = true,
+        })
+    end
     button._rotationAssistantSpellID = recommendedSpellID
 
     if changed then

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -203,10 +203,20 @@ function CooldownCompanion:OnSpellUpdateIcon()
     end)
 end
 
+local function GetRangeCheckSpellID(buttonData)
+    if not buttonData then
+        return nil
+    end
+    if buttonData._rotationAssistantVirtual == true then
+        return buttonData._rotationAssistantSpellID
+    end
+    return buttonData.id
+end
+
 function CooldownCompanion:UpdateRangeCheckRegistrations()
     local newSet = {}
     self:ForEachButton(function(button, bd)
-        local spellID = bd._rotationAssistantVirtual == true and bd._rotationAssistantSpellID or bd.id
+        local spellID = GetRangeCheckSpellID(bd)
         if spellID
             and bd.type == "spell"
             and not bd.isPassive
@@ -238,7 +248,7 @@ function CooldownCompanion:OnSpellRangeCheckUpdate(event, spellIdentifier, isInR
     end
     local changed = false
     self:ForEachButton(function(button, bd)
-        local spellID = bd._rotationAssistantVirtual == true and bd._rotationAssistantSpellID or bd.id
+        local spellID = GetRangeCheckSpellID(bd)
         if bd.type == "spell" and spellID == spellIdentifier then
             if button._spellOutOfRange ~= outOfRange then
                 button._spellOutOfRange = outOfRange

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -284,6 +284,99 @@ function CooldownCompanion:OnPetChanged()
     self:RefreshConfigPanel()
 end
 
+function CooldownCompanion:UpdateSpellChargeMetadata(buttonData, spellID, opts)
+    if not (buttonData and buttonData.type == "spell") then
+        return
+    end
+
+    local chargeInfo, chargeQueryID, maxCharges = ST.ResolveSpellChargeInfo(spellID or buttonData.id)
+    local hasRealCharges = buttonData.hasCharges and true or nil
+    local hadDisplayCountBehavior = (buttonData._hasDisplayCount == true or hasRealCharges == true)
+    local hadCastCountCandidate = (buttonData._castCountCandidate == true)
+    local castCountSelf = buttonData._castCountSelf
+    local castCountEventSpellID = buttonData._castCountEventSpellID
+    buttonData._castCountConfirmed = nil
+    buttonData._castCountSeeded = nil
+
+    if chargeInfo then
+        buttonData._castCountCandidate = nil
+        buttonData._castCountSelf = nil
+        buttonData._castCountEventSpellID = nil
+        buttonData._hasDisplayCount = nil
+        buttonData._displayCountFamily = nil
+        local mc = maxCharges or chargeInfo.maxCharges
+        if mc and mc > 1 then
+            hasRealCharges = true
+            if mc ~= buttonData.maxCharges then
+                buttonData.maxCharges = mc
+            end
+            -- Auto-enable charge text when first promoted to charge-based.
+            if buttonData.showChargeText == nil then
+                buttonData.showChargeText = true
+            end
+        else
+            hasRealCharges = nil
+            -- Reset stored maxCharges to reflect the current API value
+            -- (e.g. after Strafing Run buff fades, maxCharges returns from 2 to 1).
+            buttonData.maxCharges = mc
+        end
+    else
+        -- chargeInfo nil: check if spell has "use count" (brez shared
+        -- pool, etc.). GetSpellDisplayCount returns "" when inactive,
+        -- "N" when the pool is active.
+        hasRealCharges = nil
+        self._hasDisplayCountCandidates = true
+        local rawDisplayCount = C_Spell.GetSpellDisplayCount(chargeQueryID)
+        if not issecretvalue(rawDisplayCount) then
+            local displayCount = tonumber(rawDisplayCount)
+            if displayCount ~= nil then
+                buttonData._hasDisplayCount = true
+                buttonData._displayCountFamily = true
+                if displayCount > (buttonData.maxCharges or 0) then
+                    buttonData.maxCharges = displayCount
+                end
+            else
+                buttonData._hasDisplayCount = nil
+                if opts and opts.clearInactiveMaxCharges then
+                    buttonData._displayCountFamily = nil
+                end
+            end
+        elseif hadDisplayCountBehavior then
+            -- Preserve legacy display-count classification when the
+            -- API is secret during refresh (e.g. /reload into combat)
+            -- so the button does not temporarily fall out of the
+            -- count-bearing path until the value becomes readable.
+            buttonData._hasDisplayCount = true
+            buttonData._displayCountFamily = true
+        end
+        -- Auto-enable count text when a spell exposes a readable display count.
+        if buttonData._hasDisplayCount and buttonData.showChargeText == nil then
+            buttonData.showChargeText = true
+        end
+        if buttonData._hasDisplayCount then
+            buttonData._castCountCandidate = nil
+            buttonData._castCountSelf = nil
+            buttonData._castCountEventSpellID = nil
+        elseif hadCastCountCandidate then
+            buttonData._castCountCandidate = true
+            buttonData._castCountSelf = castCountSelf
+            buttonData._castCountEventSpellID = castCountEventSpellID
+        else
+            buttonData._castCountCandidate = nil
+            buttonData._castCountSelf = nil
+            buttonData._castCountEventSpellID = nil
+        end
+        if opts and opts.clearInactiveMaxCharges
+            and not buttonData._hasDisplayCount
+            and not buttonData._displayCountFamily
+        then
+            buttonData.maxCharges = nil
+        end
+    end
+
+    buttonData.hasCharges = hasRealCharges
+end
+
 -- Re-evaluate hasCharges on every spell button (talents can add/remove charges).
 -- Treat a spell as charge-based only when max charges is greater than 1.
 function CooldownCompanion:RefreshChargeFlags(typeFilter)
@@ -293,81 +386,7 @@ function CooldownCompanion:RefreshChargeFlags(typeFilter)
     for _, group in pairs(self.db.profile.groups) do
         for _, buttonData in ipairs(group.buttons) do
             if buttonData.type == "spell" and typeFilter ~= "item" then
-                local chargeInfo, chargeQueryID, maxCharges = ST.ResolveSpellChargeInfo(buttonData.id)
-                local hasRealCharges = buttonData.hasCharges and true or nil
-                local hadDisplayCountBehavior = (buttonData._hasDisplayCount == true or hasRealCharges == true)
-                local hadCastCountCandidate = (buttonData._castCountCandidate == true)
-                local castCountSelf = buttonData._castCountSelf
-                local castCountEventSpellID = buttonData._castCountEventSpellID
-                buttonData._castCountConfirmed = nil
-                buttonData._castCountSeeded = nil
-                if chargeInfo then
-                    buttonData._castCountCandidate = nil
-                    buttonData._castCountSelf = nil
-                    buttonData._castCountEventSpellID = nil
-                    buttonData._hasDisplayCount = nil
-                    buttonData._displayCountFamily = nil
-                    local mc = maxCharges or chargeInfo.maxCharges
-                    if mc and mc > 1 then
-                        hasRealCharges = true
-                        if mc ~= buttonData.maxCharges then
-                            buttonData.maxCharges = mc
-                        end
-                        -- Auto-enable charge text when first promoted to charge-based.
-                        if buttonData.showChargeText == nil then
-                            buttonData.showChargeText = true
-                        end
-                    else
-                        hasRealCharges = nil
-                        -- Reset stored maxCharges to reflect the current API value
-                        -- (e.g. after Strafing Run buff fades, maxCharges returns from 2 to 1).
-                        buttonData.maxCharges = mc
-                    end
-                else
-                    -- chargeInfo nil: check if spell has "use count" (brez shared
-                    -- pool, etc.). GetSpellDisplayCount returns "" when inactive,
-                    -- "N" when the pool is active.
-                    hasRealCharges = nil
-                    self._hasDisplayCountCandidates = true
-                    local rawDisplayCount = C_Spell.GetSpellDisplayCount(chargeQueryID)
-                    if not issecretvalue(rawDisplayCount) then
-                        local displayCount = tonumber(rawDisplayCount)
-                        if displayCount ~= nil then
-                            buttonData._hasDisplayCount = true
-                            buttonData._displayCountFamily = true
-                            if displayCount > (buttonData.maxCharges or 0) then
-                                buttonData.maxCharges = displayCount
-                            end
-                        else
-                            buttonData._hasDisplayCount = nil
-                        end
-                    elseif hadDisplayCountBehavior then
-                        -- Preserve legacy display-count classification when the
-                        -- API is secret during refresh (e.g. /reload into combat)
-                        -- so the button does not temporarily fall out of the
-                        -- count-bearing path until the value becomes readable.
-                        buttonData._hasDisplayCount = true
-                        buttonData._displayCountFamily = true
-                    end
-                    -- Auto-enable count text when a spell exposes a readable display count.
-                    if buttonData._hasDisplayCount and buttonData.showChargeText == nil then
-                        buttonData.showChargeText = true
-                    end
-                    if buttonData._hasDisplayCount then
-                        buttonData._castCountCandidate = nil
-                        buttonData._castCountSelf = nil
-                        buttonData._castCountEventSpellID = nil
-                    elseif hadCastCountCandidate then
-                        buttonData._castCountCandidate = true
-                        buttonData._castCountSelf = castCountSelf
-                        buttonData._castCountEventSpellID = castCountEventSpellID
-                    else
-                        buttonData._castCountCandidate = nil
-                        buttonData._castCountSelf = nil
-                        buttonData._castCountEventSpellID = nil
-                    end
-                end
-                buttonData.hasCharges = hasRealCharges
+                self:UpdateSpellChargeMetadata(buttonData, buttonData.id)
             elseif buttonData.type == "item" and typeFilter ~= "spell" then
                 -- Never clear hasCharges for items; unavailable charged items can
                 -- be indistinguishable from unowned items through count APIs.

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -206,12 +206,14 @@ end
 function CooldownCompanion:UpdateRangeCheckRegistrations()
     local newSet = {}
     self:ForEachButton(function(button, bd)
-        if bd.type == "spell"
+        local spellID = bd._rotationAssistantVirtual == true and bd._rotationAssistantSpellID or bd.id
+        if spellID
+            and bd.type == "spell"
             and not bd.isPassive
             and not bd.isPassiveCooldown
             and ((button.style and button.style.showOutOfRange)
                 or (self.TriggerRowUsesCondition and self:TriggerRowUsesCondition(bd, "rangeActive"))) then
-            newSet[bd.id] = true
+            newSet[spellID] = true
         end
     end)
     -- Enable newly needed range checks
@@ -236,7 +238,8 @@ function CooldownCompanion:OnSpellRangeCheckUpdate(event, spellIdentifier, isInR
     end
     local changed = false
     self:ForEachButton(function(button, bd)
-        if bd.type == "spell" and bd.id == spellIdentifier then
+        local spellID = bd._rotationAssistantVirtual == true and bd._rotationAssistantSpellID or bd.id
+        if bd.type == "spell" and spellID == spellIdentifier then
             if button._spellOutOfRange ~= outOfRange then
                 button._spellOutOfRange = outOfRange
                 changed = true

--- a/CooldownCompanion/Core/FrameAnchoring.lua
+++ b/CooldownCompanion/Core/FrameAnchoring.lua
@@ -400,7 +400,7 @@ function CooldownCompanion:ApplyFrameAnchoring(opts)
     end
 
     local group = self.db.profile.groups[groupId]
-    if not group or group.displayMode ~= "icons" then
+    if not group or not self:IsIconLikeDisplayMode(group.displayMode) then
         self:RevertFrameAnchoring()
         return
     end

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -608,6 +608,30 @@ local function GetButtonPoolKey(group, buttonData, style)
     return "icons"
 end
 
+local function GetRuntimeGroupButtonList(self, frame, group)
+    if self:IsRotationAssistantGroup(group) then
+        local buttonData = self:GetRotationAssistantButtonData(frame)
+        local list = frame._rotationAssistantButtonList
+        if not list then
+            list = {}
+            frame._rotationAssistantButtonList = list
+        end
+        list[1] = buttonData
+        for index = 2, #list do
+            list[index] = nil
+        end
+        return list
+    end
+    return group and group.buttons or {}
+end
+
+local function IsRuntimeButtonUsable(self, buttonData, group, opts)
+    if buttonData and buttonData._rotationAssistantVirtual == true then
+        return true
+    end
+    return self:IsButtonUsable(buttonData, group, opts)
+end
+
 local function GetExistingButtonPoolKey(button)
     if button and button._buttonPoolKey then
         return button._buttonPoolKey
@@ -920,6 +944,9 @@ local function PreparePooledButtonForUse(self, frame, group, button, index, butt
     button.index = index
     button.style = style
     button._groupId = frame.groupId
+    if buttonData._rotationAssistantVirtual == true and self.RefreshRotationAssistantButton then
+        self:RefreshRotationAssistantButton(button)
+    end
     ResolveReusableButtonEntryState(button, buttonData)
     RefreshButtonKeybindState(button, buttonData)
     if button.UpdateStyle then
@@ -2415,6 +2442,7 @@ local function GetStyleUpdateEntries(self, groupId, frame, group)
     local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
         and self:GetGroupButtonUsabilityOptions(groupId, group)
         or nil
+    local sourceButtons = GetRuntimeGroupButtonList(self, frame, group)
     local entries = frame._styleUpdateEntries
     if not entries then
         entries = {}
@@ -2423,8 +2451,8 @@ local function GetStyleUpdateEntries(self, groupId, frame, group)
 
     local previousCount = entries.count or 0
     local visibleIndex = 0
-    for sourceIndex, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
+    for sourceIndex, buttonData in ipairs(sourceButtons) do
+        if IsRuntimeButtonUsable(self, buttonData, group, buttonUsabilityOptions) then
             visibleIndex = visibleIndex + 1
             local button = frame.buttons and frame.buttons[visibleIndex]
             if not button then
@@ -2474,6 +2502,7 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     local isBarMode = group.displayMode == "bars"
     local style = group.style or {}
     local isTriggerMode = group.displayMode == "trigger"
+    local sourceButtons = GetRuntimeGroupButtonList(self, frame, group)
 
     -- Release existing buttons into bounded per-frame pools.
     for _, button in ipairs(frame.buttons) do
@@ -2486,8 +2515,8 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
     local headerHeight = ApplyTextGroupHeader(self, frame, group, style, isTextMode)
 
     -- Create new buttons (skip untalented spells)
-    for i, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
+    for i, buttonData in ipairs(sourceButtons) do
+        if IsRuntimeButtonUsable(self, buttonData, group, buttonUsabilityOptions) then
             local effectiveStyle = self:GetEffectiveStyle(style, buttonData)
             local poolKey = GetButtonPoolKey(group, buttonData, effectiveStyle)
             local button = AcquireButtonFromPool(frame, poolKey)
@@ -2510,6 +2539,8 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
             table_insert(frame.buttons, button)
             if reusedButton then
                 PreparePooledButtonForUse(self, frame, group, button, i, buttonData, effectiveStyle)
+            elseif buttonData._rotationAssistantVirtual == true and self.RefreshRotationAssistantButton then
+                self:RefreshRotationAssistantButton(button)
             end
 
             button:Show()
@@ -2548,7 +2579,9 @@ function CooldownCompanion:ResizeGroupFrame(groupId)
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")
     local buttonsPerRow = style.buttonsPerRow or 12
-    local numButtons = frame.visibleButtonCount or #group.buttons
+    local numButtons = frame.visibleButtonCount
+        or (self:IsRotationAssistantGroup(group) and 1)
+        or #group.buttons
     if group.parentContainerId and not group.compactLayout and frame.layoutButtonCount then
         numButtons = math_max(numButtons, frame.layoutButtonCount)
     end
@@ -2759,7 +2792,7 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     local isLocked, baseAlpha = GetContainerState(groupId)
 
     -- Update drag handle text and lock state
-    local hasButtons = #group.buttons > 0
+    local hasButtons = self:IsRotationAssistantGroup(group) or #group.buttons > 0
     local isTextureMode = group.displayMode == "textures" or group.displayMode == "trigger"
     local isCursorAnchored = IsCursorAnchor(group.anchor)
     local isCursorLayoutPreviewSelected = isCursorAnchored

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -627,6 +627,12 @@ end
 
 local function IsRuntimeButtonUsable(self, buttonData, group, opts)
     if buttonData and buttonData._rotationAssistantVirtual == true then
+        if opts and opts.checkLoadConditions == false then
+            return true
+        end
+        if not self:IsButtonLoadConditionMet(buttonData, group) then
+            return false
+        end
         return true
     end
     return self:IsButtonUsable(buttonData, group, opts)
@@ -1839,7 +1845,8 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     frame.coordLabel.text:SetTextColor(1, 1, 1, 1)
 
     local isCursorAnchored = IsCursorAnchor(group.anchor)
-    self:SetGroupDragControlsShown(frame, (not isLocked) and #group.buttons > 0 and not isTextureMode and not isCursorAnchored)
+    local hasDragEntry = self:IsRotationAssistantGroup(group) or #group.buttons > 0
+    self:SetGroupDragControlsShown(frame, (not isLocked) and hasDragEntry and not isTextureMode and not isCursorAnchored)
 
     -- Drag scripts (check lock state at drag time)
     frame:SetScript("OnDragStart", function(self)

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -627,13 +627,7 @@ end
 
 local function IsRuntimeButtonUsable(self, buttonData, group, opts)
     if buttonData and buttonData._rotationAssistantVirtual == true then
-        if opts and opts.checkLoadConditions == false then
-            return true
-        end
-        if not self:IsButtonLoadConditionMet(buttonData, group) then
-            return false
-        end
-        return true
+        return (opts and opts.checkLoadConditions == false) or self:IsButtonLoadConditionMet(buttonData, group)
     end
     return self:IsButtonUsable(buttonData, group, opts)
 end

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1486,13 +1486,9 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
     local group = self.db.profile.groups[groupId]
     if not group then return end
 
-    if ST.IsRotationAssistantDisplayMode(group.displayMode) then
-        self:Print("Assistant Panels are populated automatically.")
-        return nil
-    end
-
-    if group.displayMode == "textures" and #group.buttons >= 1 then
-        self:Print("Texture Panels can only hold one entry. Remove the current entry first if you want to replace it.")
+    local rejectMessage = self:GetPanelManualEntryRejectMessage(group)
+    if rejectMessage then
+        self:Print(rejectMessage)
         return nil
     end
 
@@ -1681,8 +1677,9 @@ function CooldownCompanion:AddEquipmentSlotToGroup(groupId, itemSlot, itemSlotKi
     local group = self.db.profile.groups[groupId]
     if not group then return end
 
-    if group.displayMode == "textures" and #group.buttons >= 1 then
-        self:Print("Texture Panels can only hold one entry. Remove the current entry first if you want to replace it.")
+    local rejectMessage = self:GetPanelManualEntryRejectMessage(group)
+    if rejectMessage then
+        self:Print(rejectMessage)
         return nil
     end
 
@@ -1851,7 +1848,10 @@ function CooldownCompanion:GetCharacterContainers(charKey)
             -- Skip empty containers (no panels with buttons)
             local hasButtons = false
             for _, group in pairs(db.groups) do
-                if group.parentContainerId == containerId and group.buttons and #group.buttons > 0 then
+                if group.parentContainerId == containerId and self:GroupHasUsableButtons(group, {
+                    checkLoadConditions = false,
+                    ignoreSpellAvailability = true,
+                }) then
                     hasButtons = true
                     break
                 end

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1039,6 +1039,9 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
     local db = self.db.profile
     local container = db.groupContainers[containerId]
     if not container then return nil end
+    displayMode = displayMode or "icons"
+    local isRotationAssistant = ST.IsRotationAssistantDisplayMode
+        and ST.IsRotationAssistantDisplayMode(displayMode)
 
     local groupId = db.nextGroupId
     db.nextGroupId = groupId + 1
@@ -1047,7 +1050,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
     local containerFrameName = "CooldownCompanionContainer" .. containerId
 
     db.groups[groupId] = {
-        name = "Panel " .. panelOrder,
+        name = isRotationAssistant and ST.ROTATION_ASSISTANT_NAME or ("Panel " .. panelOrder),
         parentContainerId = containerId,
         order = panelOrder,
         anchor = {
@@ -1059,7 +1062,7 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
         },
         buttons = {},
         style = CopyTable(db.globalStyle),
-        displayMode = displayMode or "icons",
+        displayMode = displayMode,
         masqueEnabled = false,
         compactLayout = false,
         maxVisibleButtons = 0,
@@ -1097,6 +1100,23 @@ function CooldownCompanion:CreatePanel(containerId, displayMode)
     if style.barAuraEffect == nil then style.barAuraEffect = "color" end
     if style.barAuraIndicatorEnabled == nil then
         style.barAuraIndicatorEnabled = (style.barAuraEffect or "none") ~= "none"
+    end
+    if isRotationAssistant then
+        style.orientation = "horizontal"
+        style.growthOrigin = "TOPLEFT"
+        style.buttonsPerRow = 1
+        style.maintainAspectRatio = true
+        style.showCooldownText = false
+        style.showChargeText = false
+        style.showAuraText = false
+        style.showAuraStackText = false
+        style.showAssistedHighlight = false
+        style.procGlowStyle = "none"
+        style.pandemicGlowStyle = "none"
+        style.readyGlowStyle = "none"
+        style.keyPressHighlightStyle = "none"
+        style.iconFillEnabled = false
+        style.auraUseBlizzardSwipe = false
     end
 
     if displayMode == "textures" then
@@ -1215,6 +1235,12 @@ function CooldownCompanion:ChangePanelDisplayMode(groupId, newMode)
     if not group then return end
 
     local oldMode = group.displayMode
+    if oldMode ~= newMode
+        and (ST.IsRotationAssistantDisplayMode(oldMode) or ST.IsRotationAssistantDisplayMode(newMode)) then
+        self:Print("Assistant Panels cannot be converted. Create a new Assistant Panel instead.")
+        return false
+    end
+
     if oldMode ~= newMode and (oldMode == "trigger" or newMode == "trigger") then
         self:Print("Trigger Panels cannot be converted. Create a new Trigger Panel instead.")
         return false
@@ -1459,6 +1485,11 @@ end
 function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPetSpell, isPassive, forceAura, cdmChildSlot)
     local group = self.db.profile.groups[groupId]
     if not group then return end
+
+    if ST.IsRotationAssistantDisplayMode(group.displayMode) then
+        self:Print("Assistant Panels are populated automatically.")
+        return nil
+    end
 
     if group.displayMode == "textures" and #group.buttons >= 1 then
         self:Print("Texture Panels can only hold one entry. Remove the current entry first if you want to replace it.")

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -688,7 +688,8 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
         return false
     end
 
-    if not (group.buttons and #group.buttons > 0) then
+    local isRotationAssistant = self:IsRotationAssistantGroup(group)
+    if not isRotationAssistant and not (group.buttons and #group.buttons > 0) then
         return false
     end
 
@@ -696,7 +697,7 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
     if groupFrame == nil and groupId then
         groupFrame = self.groupFrames and self.groupFrames[groupId] or nil
     end
-    if groupFrame and (not groupFrame.buttons or #groupFrame.buttons == 0) then
+    if groupFrame and not isRotationAssistant and (not groupFrame.buttons or #groupFrame.buttons == 0) then
         return false
     end
 
@@ -1084,7 +1085,11 @@ end
 function CooldownCompanion:GroupHasUsableButtons(group, opts)
     opts = opts or {}
     if self:IsRotationAssistantGroup(group) then
-        return true
+        if opts.checkLoadConditions == false then
+            return true
+        end
+        local entrySettings = self:GetRotationAssistantEntrySettings(group, false)
+        return self:IsButtonLoadConditionMet(entrySettings or {}, group)
     end
     if not (group and group.buttons and #group.buttons > 0) then
         return false
@@ -1772,6 +1777,12 @@ function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
     local frame = GetFrameForButtonSetComparison(self, groupId)
     if not frame or not frame.buttons then
         return false
+    end
+    if self:IsRotationAssistantGroup(group) then
+        local buttonData = self:GetRotationAssistantButtonData(frame)
+        return #frame.buttons ~= 1
+            or not frame.buttons[1]
+            or frame.buttons[1].buttonData ~= buttonData
     end
     if not group.buttons then
         return #frame.buttons > 0

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1083,6 +1083,9 @@ end
 
 function CooldownCompanion:GroupHasUsableButtons(group, opts)
     opts = opts or {}
+    if self:IsRotationAssistantGroup(group) then
+        return true
+    end
     if not (group and group.buttons and #group.buttons > 0) then
         return false
     end
@@ -1112,6 +1115,10 @@ function CooldownCompanion:GetGroupLayoutButtonUsabilityOptions(groupId, group)
 end
 
 function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)
+    if self:IsRotationAssistantGroup(group) then
+        return 1
+    end
+
     if not (group and group.buttons and #group.buttons > 0) then
         return 0
     end
@@ -1208,7 +1215,7 @@ function CooldownCompanion:IsGroupAvailableForAnchoring(groupId)
     elseif self.IsGroupCursorAnchored and self:IsGroupCursorAnchored(group) then
         return false
     end
-    if group.displayMode ~= "icons" then return false end
+    if self.IsIconLikeDisplayMode and not self:IsIconLikeDisplayMode(group.displayMode) then return false end
     local container = self:GetParentContainer(group)
     if container and container.isGlobal and not container.anchorEligible then return false end
     if container and not container.isGlobal and container.anchorEligible == false then return false end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1779,7 +1779,7 @@ function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
         return false
     end
     if self:IsRotationAssistantGroup(group) then
-        local buttonData = self:GetRotationAssistantButtonData(frame)
+        local buttonData = frame._rotationAssistantButtonData
         return #frame.buttons ~= 1
             or not frame.buttons[1]
             or frame.buttons[1].buttonData ~= buttonData

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -294,6 +294,28 @@ local function GetSpellActionSlots(spellID)
     return #slots > 0 and slots or nil
 end
 
+local function IsBindableSpellID(spellID)
+    return type(spellID) == "number" and not issecretvalue(spellID) and spellID > 0
+end
+
+local function GetRotationAssistantKeybindSpellID(buttonData, button)
+    if not buttonData or buttonData._rotationAssistantMissing == true then
+        return nil
+    end
+
+    local displayedSpellID = button and (button._liveOverrideSpellId or button._displaySpellId)
+    if IsBindableSpellID(displayedSpellID) then
+        return displayedSpellID
+    end
+
+    local recommendedSpellID = buttonData._rotationAssistantSpellID or buttonData.id
+    if IsBindableSpellID(recommendedSpellID) then
+        return recommendedSpellID
+    end
+
+    return nil
+end
+
 -- Resolve and cache parsed binding key info for a CC button.
 -- Stores result as button._bindingKeyInfos (array of parsed structs, or empty table).
 local function CacheButtonBindingKeys(button, buttonData)
@@ -301,9 +323,7 @@ local function CacheButtonBindingKeys(button, buttonData)
     if buttonData then
         local slots
         if buttonData._rotationAssistantVirtual == true then
-            if buttonData._rotationAssistantMissing ~= true then
-                slots = GetSpellActionSlots(buttonData._rotationAssistantSpellID or buttonData.id)
-            end
+            slots = GetSpellActionSlots(GetRotationAssistantKeybindSpellID(buttonData, button))
         elseif buttonData.type == "spell" then
             slots = GetSpellActionSlots(buttonData.id)
         elseif buttonData.type == "item" or buttonData.type == "equipmentSlot" then
@@ -430,14 +450,11 @@ function CooldownCompanion:RebuildAddonSlotBindings()
 end
 
 -- Return the formatted keybind text for a button, or nil if none found.
-function CooldownCompanion:GetKeybindText(buttonData, itemIDOverride)
+function CooldownCompanion:GetKeybindText(buttonData, itemIDOverride, displayButton)
     if not buttonData then return nil end
 
     if buttonData._rotationAssistantVirtual == true then
-        if buttonData._rotationAssistantMissing == true then
-            return nil
-        end
-        local slots = GetSpellActionSlots(buttonData._rotationAssistantSpellID or buttonData.id)
+        local slots = GetSpellActionSlots(GetRotationAssistantKeybindSpellID(buttonData, displayButton))
         if slots then
             for _, slot in ipairs(slots) do
                 local text = GetKeybindForSlot(slot)
@@ -472,11 +489,11 @@ end
 -- Return the icon-only display text for keybind overlays.
 -- This intentionally leaves GetKeybindText unchanged so text-mode {keybind}
 -- tokens continue reflecting the detected action bar bind only.
-function CooldownCompanion:GetDisplayedKeybindText(buttonData, itemIDOverride)
+function CooldownCompanion:GetDisplayedKeybindText(buttonData, itemIDOverride, displayButton)
     if not buttonData then return nil end
 
     if buttonData._rotationAssistantVirtual == true then
-        return self:GetKeybindText(buttonData, itemIDOverride)
+        return self:GetKeybindText(buttonData, itemIDOverride, displayButton)
     end
 
     local customText = buttonData.customKeybindText
@@ -484,7 +501,7 @@ function CooldownCompanion:GetDisplayedKeybindText(buttonData, itemIDOverride)
         return customText
     end
 
-    return self:GetKeybindText(buttonData, itemIDOverride)
+    return self:GetKeybindText(buttonData, itemIDOverride, displayButton)
 end
 
 function CooldownCompanion:RefreshKeybindState()
@@ -498,7 +515,7 @@ end
 function CooldownCompanion:OnKeybindsChanged()
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
-            local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId)
+            local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
             button.keybindText:SetText(text or "")
             button.keybindText:SetShown(button.style.showKeybindText and text ~= nil)
         end

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -300,7 +300,11 @@ local function CacheButtonBindingKeys(button, buttonData)
     local infos = {}
     if buttonData then
         local slots
-        if buttonData.type == "spell" then
+        if buttonData._rotationAssistantVirtual == true then
+            if buttonData._rotationAssistantMissing ~= true then
+                slots = GetSpellActionSlots(buttonData._rotationAssistantSpellID or buttonData.id)
+            end
+        elseif buttonData.type == "spell" then
             slots = GetSpellActionSlots(buttonData.id)
         elseif buttonData.type == "item" or buttonData.type == "equipmentSlot" then
             local itemID = button._resolvedItemId or buttonData.id
@@ -429,7 +433,20 @@ end
 function CooldownCompanion:GetKeybindText(buttonData, itemIDOverride)
     if not buttonData then return nil end
 
-    if buttonData.type == "spell" then
+    if buttonData._rotationAssistantVirtual == true then
+        if buttonData._rotationAssistantMissing == true then
+            return nil
+        end
+        local slots = GetSpellActionSlots(buttonData._rotationAssistantSpellID or buttonData.id)
+        if slots then
+            for _, slot in ipairs(slots) do
+                local text = GetKeybindForSlot(slot)
+                if text and text ~= "" then
+                    return text
+                end
+            end
+        end
+    elseif buttonData.type == "spell" then
         local slots = GetSpellActionSlots(buttonData.id)
         if slots then
             for _, slot in ipairs(slots) do
@@ -457,6 +474,10 @@ end
 -- tokens continue reflecting the detected action bar bind only.
 function CooldownCompanion:GetDisplayedKeybindText(buttonData, itemIDOverride)
     if not buttonData then return nil end
+
+    if buttonData._rotationAssistantVirtual == true then
+        return self:GetKeybindText(buttonData, itemIDOverride)
+    end
 
     local customText = buttonData.customKeybindText
     if customText and customText ~= "" then

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -918,7 +918,7 @@ local function SanitizeAnchorGroupID(groupId)
         return nil
     end
     local container = profile.groupContainers and profile.groupContainers[group.parentContainerId]
-    if group.displayMode ~= "icons" or (container and container.isGlobal) then
+    if not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) or (container and container.isGlobal) then
         return nil
     end
     if not CooldownCompanion:IsGroupVisibleToCurrentChar(numericGroupID) then

--- a/CooldownCompanion/OtherBars/CastBar.lua
+++ b/CooldownCompanion/OtherBars/CastBar.lua
@@ -1118,8 +1118,8 @@ function CooldownCompanion:ApplyCastBarSettings(opts)
             return
         end
 
-        -- Only anchor to icon-mode groups
-        if group.displayMode ~= "icons" then
+        -- Only anchor to icon-like groups
+        if not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) then
             self:RevertCastBar()
             return
         end

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -1822,7 +1822,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
         end
 
         local group = self.db.profile.groups[groupId]
-        if not group or group.displayMode ~= "icons" then
+        if not group or not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) then
             self:RevertResourceBars()
             return
         end

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -315,6 +315,7 @@ local PANEL_CREATION_MODES = {
     { mode = "text", label = "Text Panel" },
     { mode = "textures", label = "Texture Panel" },
     { mode = "trigger", label = "Trigger Panel" },
+    { mode = ST.DISPLAY_MODE_ROTATION_ASSISTANT, label = ST.ROTATION_ASSISTANT_NAME or "Assistant Panel" },
 }
 
 local function BuildContainerExportPayload(db, containerId, container)
@@ -406,7 +407,10 @@ local function BuildColumn1ContainerStats(db, containerIds)
             end
 
             stats.panelCount = stats.panelCount + 1
-            if group.buttons and #group.buttons > 0 then
+            if CooldownCompanion:GroupHasUsableButtons(group, {
+                checkLoadConditions = false,
+                ignoreSpellAvailability = true,
+            }) then
                 stats.hasButtons = true
 
                 local container = containers[containerId]
@@ -644,8 +648,16 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
                             containerId = containerId,
                             keepPanelMulti = true,
                         })
-                        CS.addingToPanelId = newPanelId
-                        CS.pendingEditBoxFocus = true
+                        local newPanel = CooldownCompanion.db.profile.groups[newPanelId]
+                        local acceptsManualEntries = not CooldownCompanion.CanPanelAcceptManualEntry
+                            or CooldownCompanion:CanPanelAcceptManualEntry(newPanel)
+                        if acceptsManualEntries then
+                            CS.addingToPanelId = newPanelId
+                            CS.pendingEditBoxFocus = true
+                        else
+                            CS.addingToPanelId = nil
+                            CS.pendingEditBoxFocus = false
+                        end
                         CooldownCompanion:RefreshConfigPanel()
                     end
                 end

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -348,8 +348,15 @@ local function FinalizeCreatedPanel(newPanelId, displayMode, opts)
     end
 
     SelectConfigPanel(newPanelId)
-    CS.addingToPanelId = newPanelId
-    CS.pendingEditBoxFocus = true
+    local acceptsManualEntries = not CooldownCompanion.CanPanelAcceptManualEntry
+        or CooldownCompanion:CanPanelAcceptManualEntry(group)
+    if acceptsManualEntries then
+        CS.addingToPanelId = newPanelId
+        CS.pendingEditBoxFocus = true
+    else
+        CS.addingToPanelId = nil
+        CS.pendingEditBoxFocus = false
+    end
     CooldownCompanion:RefreshConfigPanel()
 
     if opts and opts.notifyTutorial and NotifyTutorialAction then
@@ -927,8 +934,18 @@ local function IsAuraTrackingConfigReady(buttonData, cdmEnabled)
     return auraStatus.ready == true, auraStatus
 end
 
-local function CanTexturePanelAcceptEntry(group)
-    return not (group and group.displayMode == "textures" and group.buttons and #group.buttons >= 1)
+local function GetPanelManualEntryRejectMessage(group)
+    if CooldownCompanion.GetPanelManualEntryRejectMessage then
+        return CooldownCompanion:GetPanelManualEntryRejectMessage(group)
+    end
+    if group and group.displayMode == "textures" and group.buttons and #group.buttons >= 1 then
+        return "Texture Panels can only hold one entry. Remove the current entry first if you want to replace it."
+    end
+    return nil
+end
+
+local function CanPanelAcceptManualEntry(group)
+    return GetPanelManualEntryRejectMessage(group) == nil
 end
 
 IsTriggerPanelGroup = function(group)
@@ -1021,8 +1038,9 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     if not targetGroup then
         return false
     end
-    if not CanTexturePanelAcceptEntry(targetGroup) then
-        CooldownCompanion:Print("Texture Panels can only hold one entry.")
+    local rejectMessage = GetPanelManualEntryRejectMessage(targetGroup)
+    if rejectMessage then
+        CooldownCompanion:Print(rejectMessage)
         return false
     end
 
@@ -1046,7 +1064,7 @@ local function BuildEntryMoveDestinationSections(db, sourceGroupId)
     for groupId, group in pairs(db.groups or {}) do
         if groupId ~= sourceGroupId
             and CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
-            and CanTexturePanelAcceptEntry(group)
+            and CanPanelAcceptManualEntry(group)
         then
             local containerId = group.parentContainerId
             local container = containerId and containers[containerId]

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -348,8 +348,7 @@ local function FinalizeCreatedPanel(newPanelId, displayMode, opts)
     end
 
     SelectConfigPanel(newPanelId)
-    local acceptsManualEntries = not CooldownCompanion.CanPanelAcceptManualEntry
-        or CooldownCompanion:CanPanelAcceptManualEntry(group)
+    local acceptsManualEntries = CooldownCompanion:CanPanelAcceptManualEntry(group)
     if acceptsManualEntries then
         CS.addingToPanelId = newPanelId
         CS.pendingEditBoxFocus = true
@@ -934,20 +933,6 @@ local function IsAuraTrackingConfigReady(buttonData, cdmEnabled)
     return auraStatus.ready == true, auraStatus
 end
 
-local function GetPanelManualEntryRejectMessage(group)
-    if CooldownCompanion.GetPanelManualEntryRejectMessage then
-        return CooldownCompanion:GetPanelManualEntryRejectMessage(group)
-    end
-    if group and group.displayMode == "textures" and group.buttons and #group.buttons >= 1 then
-        return "Texture Panels can only hold one entry. Remove the current entry first if you want to replace it."
-    end
-    return nil
-end
-
-local function CanPanelAcceptManualEntry(group)
-    return GetPanelManualEntryRejectMessage(group) == nil
-end
-
 IsTriggerPanelGroup = function(group)
     return group and group.displayMode == "trigger"
 end
@@ -1038,7 +1023,7 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     if not targetGroup then
         return false
     end
-    local rejectMessage = GetPanelManualEntryRejectMessage(targetGroup)
+    local rejectMessage = CooldownCompanion:GetPanelManualEntryRejectMessage(targetGroup)
     if rejectMessage then
         CooldownCompanion:Print(rejectMessage)
         return false
@@ -1064,7 +1049,7 @@ local function BuildEntryMoveDestinationSections(db, sourceGroupId)
     for groupId, group in pairs(db.groups or {}) do
         if groupId ~= sourceGroupId
             and CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
-            and CanPanelAcceptManualEntry(group)
+            and CooldownCompanion:CanPanelAcceptManualEntry(group)
         then
             local containerId = group.parentContainerId
             local container = containerId and containers[containerId]
@@ -2561,15 +2546,10 @@ local function RefreshColumn2()
                 addBtn.icon:SetAtlas(isAdding and "common-icon-minus" or "common-icon-plus", false)
                 addBtn.icon:SetVertexColor(0.3, 0.8, 0.3)
                 local addBtnPanelId = panelId
-                local isRotationAssistantPanel = panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
-                local addBtnTextureFull = panel.displayMode == "textures" and btnCount >= 1
+                local addBtnRejectMessage = CooldownCompanion:GetPanelManualEntryRejectMessage(panel)
                 addBtn:SetScript("OnClick", function()
-                    if isRotationAssistantPanel then
-                        CooldownCompanion:Print("Assistant Panels are populated automatically.")
-                        return
-                    end
-                    if addBtnTextureFull then
-                        CooldownCompanion:Print("Texture Panels can only hold one entry.")
+                    if addBtnRejectMessage then
+                        CooldownCompanion:Print(addBtnRejectMessage)
                         return
                     end
                     if CS.addingToPanelId == addBtnPanelId then
@@ -2582,7 +2562,7 @@ local function RefreshColumn2()
                     end
                     CooldownCompanion:RefreshConfigPanel()
                 end)
-                addBtn:SetShown(not addBtnTextureFull and not isRotationAssistantPanel)
+                addBtn:SetShown(not addBtnRejectMessage)
 
                 panelContainer:AddChild(header)
                 table.insert(col2RenderedRows, { kind = "header", panelId = panelId, isCollapsed = isCollapsed, widget = header })

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -43,6 +43,7 @@ local SelectConfigPanel = ST._SelectConfigPanel
 local ToggleConfigPanelMultiSelect = ST._ToggleConfigPanelMultiSelect
 local SelectConfigButton = ST._SelectConfigButton
 local SelectConfigButtonPanel = ST._SelectConfigButtonPanel
+local SelectConfigRotationAssistantEntry = ST._SelectConfigRotationAssistantEntry
 
 local IsTriggerPanelGroup
 
@@ -84,6 +85,10 @@ local PANEL_TYPE_TOOLTIPS = {
     trigger = {
         title = "Trigger Panel",
         description = "Add spell or item entries, then set conditions on each one. The display appears only when every enabled entry meets its conditions.",
+    },
+    rotationAssistant = {
+        title = "Assistant Panel",
+        description = "Shows one locked recommendation icon from the in-game assistant.",
     },
 }
 
@@ -134,6 +139,13 @@ local function BuildPanelHeaderText(panel, panelId, buttonCount, countColor)
 
     return panelName .. " |cff" .. (countColor or "666666") .. "(" ..
         tostring(buttonCount or 0) .. ")|r"
+end
+
+local function GetConfigPanelButtonCount(panel)
+    if panel and panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+        return 1
+    end
+    return panel and panel.buttons and #panel.buttons or 0
 end
 
 local function EnsurePanelTypeTooltipTarget(header)
@@ -273,7 +285,13 @@ local function ConfigurePanelTypeBadge(header, displayMode, textWidth)
         modeBadge:SetDesaturated(false)
     end
     modeBadge:SetVertexColor(1, 1, 1, 1)
-    modeBadge:SetAtlas(GetPanelTypeBadgeAtlas(displayMode), false)
+    if displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+        modeBadge:SetTexture(CooldownCompanion:GetRotationAssistantFallbackIcon())
+        modeBadge:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+    else
+        modeBadge:SetAtlas(GetPanelTypeBadgeAtlas(displayMode), false)
+        modeBadge:SetTexCoord(0, 1, 0, 1)
+    end
     if displayMode == "trigger" then
         if modeBadge.SetDesaturated then
             modeBadge:SetDesaturated(true)
@@ -448,6 +466,16 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
                 CreatePanelInSelectedContainer("trigger")
             end
             UIDropDownMenu_AddButton(info, level)
+
+            info = UIDropDownMenu_CreateInfo()
+            info.text = "Assistant Panel"
+            info.notCheckable = true
+            AddPanelTypeMenuTooltip(info, "rotationAssistant")
+            info.func = function()
+                CloseDropDownMenus()
+                CreatePanelInSelectedContainer(ST.DISPLAY_MODE_ROTATION_ASSISTANT)
+            end
+            UIDropDownMenu_AddButton(info, level)
         end, "MENU")
         menu:SetFrameStrata("FULLSCREEN_DIALOG")
         ToggleDropDownMenu(1, nil, menu, "cursor", 0, 0)
@@ -525,6 +553,7 @@ local function RenderColumn2NoPanelsState(classColor)
         PANEL_TYPE_TOOLTIPS.text,
         PANEL_TYPE_TOOLTIPS.textures,
         PANEL_TYPE_TOOLTIPS.trigger,
+        PANEL_TYPE_TOOLTIPS.rotationAssistant,
     }
 
     for index, entry in ipairs(helpEntries) do
@@ -707,7 +736,9 @@ local function ConfigureInlineAddInstructions(inputBox, placeholderText)
 end
 
 local function BuildInlineAddControls(panelContainer, panelMeta, panel, panelId, btnCount)
-    if CS.addingToPanelId ~= panelId or (panel.displayMode == "textures" and btnCount >= 1) then
+    if panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
+        or CS.addingToPanelId ~= panelId
+        or (panel.displayMode == "textures" and btnCount >= 1) then
         return
     end
 
@@ -802,6 +833,27 @@ local function BuildInlineAddControls(panelContainer, panelMeta, panel, panelId,
 
     panelContainer:AddChild(addRow)
 
+end
+
+local function AddRotationAssistantLockedRow(panelContainer, panelId, opts)
+    local entry = AceGUI:Create("InteractiveLabel")
+    CleanRecycledEntry(entry)
+    entry:SetText(ST.ROTATION_ASSISTANT_NAME)
+    entry:SetFullWidth(true)
+    entry:SetFontObject(GameFontHighlight)
+    ApplyConfigRowIcon(entry, CooldownCompanion:GetRotationAssistantFallbackIcon())
+    entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+    if CS.selectedGroup == panelId and CS.selectedRotationAssistantEntry == true then
+        entry:SetColor(0.4, 0.7, 1.0)
+    end
+    entry:SetCallback("OnClick", function()
+        SelectConfigRotationAssistantEntry(panelId, {
+            containerId = opts and opts.containerId or CS.selectedContainer,
+        })
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    panelContainer:AddChild(entry)
+    return entry
 end
 
 local function EnsureRowBadge(frame, key, atlas, iconSize)
@@ -980,6 +1032,7 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     CooldownCompanion:RefreshGroupFrame(sourceGroupId)
     CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedButton = nil
+    CS.selectedRotationAssistantEntry = nil
     wipe(CS.selectedButtons)
     CooldownCompanion:RefreshConfigPanel()
     return true
@@ -1446,7 +1499,7 @@ local function RefreshColumn2()
             CS.col2Scroll:AddChild(panelContainer)
 
             -- Panel header (same badge pattern as normal Column 2 panel headers)
-            local buttonCount = panel.buttons and #panel.buttons or 0
+            local buttonCount = GetConfigPanelButtonCount(panel)
             local headerText = BuildPanelHeaderText(panel, nil, buttonCount, "888888")
 
             local header = AceGUI:Create("InteractiveLabel")
@@ -1478,7 +1531,9 @@ local function RefreshColumn2()
 
             if panel.enabled == false then
                 header:SetColor(0.5, 0.5, 0.5)
-            elseif CS.selectedGroup == panelGroupId and not CS.selectedButton then
+            elseif CS.selectedGroup == panelGroupId
+                and not CS.selectedButton
+                and not CS.selectedRotationAssistantEntry then
                 header:SetColor(0, 1, 0)
             end
             header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
@@ -1496,7 +1551,11 @@ local function RefreshColumn2()
             panelContainer:AddChild(headerSpacer)
 
             -- Button list (read-only)
-            if panel.buttons then
+            if panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+                AddRotationAssistantLockedRow(panelContainer, panelGroupId, {
+                    containerId = CS.browseContainerId,
+                })
+            elseif panel.buttons then
                 for buttonIndex, buttonData in ipairs(panel.buttons) do
                     local entry = AceGUI:Create("InteractiveLabel")
                     CleanRecycledEntry(entry)
@@ -1977,7 +2036,7 @@ local function RefreshColumn2()
             end
 
             -- Panel header
-                local btnCount = panel.buttons and #panel.buttons or 0
+                local btnCount = GetConfigPanelButtonCount(panel)
                 local headerText = BuildPanelHeaderText(panel, panelId, btnCount, "666666")
 
                 local header = AceGUI:Create("InteractiveLabel")
@@ -2126,7 +2185,9 @@ local function RefreshColumn2()
                     header:SetColor(0.4, 0.7, 1.0)
                 elseif panel.enabled == false then
                     header:SetColor(0.5, 0.5, 0.5)
-                elseif CS.selectedGroup == panelId and not CS.selectedButton then
+                elseif CS.selectedGroup == panelId
+                    and not CS.selectedButton
+                    and not CS.selectedRotationAssistantEntry then
                     header:SetColor(0, 1, 0)
                 end
 
@@ -2251,29 +2312,31 @@ local function RefreshColumn2()
                                 UIDropDownMenu_AddButton(info, level)
                             end
 
-                            local switchModes = {
-                                { mode = "icons", label = "Icons" },
-                                { mode = "bars", label = "Bars" },
-                                { mode = "text", label = "Text" },
-                                { mode = "textures", label = "Textures" },
-                            }
-                            for _, m in ipairs(switchModes) do
-                                if ctxPanel.displayMode ~= m.mode then
-                                    info = UIDropDownMenu_CreateInfo()
-                                    info.text = "Switch to " .. m.label
-                                    info.notCheckable = true
-                                    local targetMode = m.mode
-                                    info.func = function()
-                                        CloseDropDownMenus()
-                                        if CooldownCompanion:ChangePanelDisplayMode(ctxPanelId, targetMode) then
-                                            if targetMode == "textures" then
-                                                CS.pendingTexturePickerOpen = ctxPanelId
-                                                SelectConfigPanel(ctxPanelId)
+                            if ctxPanel.displayMode ~= ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+                                local switchModes = {
+                                    { mode = "icons", label = "Icons" },
+                                    { mode = "bars", label = "Bars" },
+                                    { mode = "text", label = "Text" },
+                                    { mode = "textures", label = "Textures" },
+                                }
+                                for _, m in ipairs(switchModes) do
+                                    if ctxPanel.displayMode ~= m.mode then
+                                        info = UIDropDownMenu_CreateInfo()
+                                        info.text = "Switch to " .. m.label
+                                        info.notCheckable = true
+                                        local targetMode = m.mode
+                                        info.func = function()
+                                            CloseDropDownMenus()
+                                            if CooldownCompanion:ChangePanelDisplayMode(ctxPanelId, targetMode) then
+                                                if targetMode == "textures" then
+                                                    CS.pendingTexturePickerOpen = ctxPanelId
+                                                    SelectConfigPanel(ctxPanelId)
+                                                end
+                                                CooldownCompanion:RefreshConfigPanel()
                                             end
-                                            CooldownCompanion:RefreshConfigPanel()
                                         end
+                                        UIDropDownMenu_AddButton(info, level)
                                     end
-                                    UIDropDownMenu_AddButton(info, level)
                                 end
                             end
 
@@ -2480,8 +2543,13 @@ local function RefreshColumn2()
                 addBtn.icon:SetAtlas(isAdding and "common-icon-minus" or "common-icon-plus", false)
                 addBtn.icon:SetVertexColor(0.3, 0.8, 0.3)
                 local addBtnPanelId = panelId
+                local isRotationAssistantPanel = panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
                 local addBtnTextureFull = panel.displayMode == "textures" and btnCount >= 1
                 addBtn:SetScript("OnClick", function()
+                    if isRotationAssistantPanel then
+                        CooldownCompanion:Print("Assistant Panels are populated automatically.")
+                        return
+                    end
                     if addBtnTextureFull then
                         CooldownCompanion:Print("Texture Panels can only hold one entry.")
                         return
@@ -2496,7 +2564,7 @@ local function RefreshColumn2()
                     end
                     CooldownCompanion:RefreshConfigPanel()
                 end)
-                addBtn:SetShown(not addBtnTextureFull)
+                addBtn:SetShown(not addBtnTextureFull and not isRotationAssistantPanel)
 
                 panelContainer:AddChild(header)
                 table.insert(col2RenderedRows, { kind = "header", panelId = panelId, isCollapsed = isCollapsed, widget = header })
@@ -2514,7 +2582,12 @@ local function RefreshColumn2()
             if not isCollapsed then
                 local panelButtons = panel.buttons or {}
 
-                for i, buttonData in ipairs(panelButtons) do
+                if panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+                    AddRotationAssistantLockedRow(panelContainer, panelId, {
+                        containerId = CS.selectedContainer,
+                    })
+                else
+                    for i, buttonData in ipairs(panelButtons) do
                     local entry = AceGUI:Create("InteractiveLabel")
                     CleanRecycledEntry(entry)
                     local usable = CooldownCompanion:IsButtonUsable(buttonData, panel)
@@ -2657,6 +2730,7 @@ local function RefreshColumn2()
                             if CS.selectedGroup ~= panelId then
                                 CS.selectedGroup = panelId
                                 CS.selectedButton = nil
+                                CS.selectedRotationAssistantEntry = nil
                                 wipe(CS.selectedButtons)
                             end
                             local cursorX, cursorY = GetScaledCursorPosition(CS.col2Scroll)
@@ -2825,7 +2899,8 @@ local function RefreshColumn2()
                         },
                         imageSize = entry.image and select(1, entry.image:GetSize()) or 32,
                     })
-                end -- button loop
+                    end -- button loop
+                end
 
                 BuildInlineAddControls(panelContainer, panelMeta, panel, panelId, btnCount)
             end -- not collapsed

--- a/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
+++ b/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
@@ -404,8 +404,10 @@ local function PerformCrossPanelMove(sourcePanelId, sourceIndex, targetPanelId, 
     local sourceGroup = db.groups[sourcePanelId]
     local targetGroup = db.groups[targetPanelId]
     if not sourceGroup or not targetGroup then return nil end
-    if targetGroup.displayMode == "textures" and #targetGroup.buttons >= 1 then
-        CooldownCompanion:Print("Texture Panels can only hold one entry.")
+    local rejectMessage = CooldownCompanion.GetPanelManualEntryRejectMessage
+        and CooldownCompanion:GetPanelManualEntryRejectMessage(targetGroup)
+    if rejectMessage then
+        CooldownCompanion:Print(rejectMessage)
         return nil
     end
     local buttonData = table.remove(sourceGroup.buttons, sourceIndex)
@@ -594,19 +596,26 @@ local function FinishButtonDrag(state)
             CooldownCompanion:RefreshGroupFrame(state.groupId)
         else
             local sourceGroup = CooldownCompanion.db.profile.groups[state.groupId]
-            local buttonData = sourceGroup and sourceGroup.buttons[state.sourceIndex]
-            if buttonData and ButtonHasOverrides(buttonData) then
-                ShowPopupAboveConfig("CDC_CROSS_PANEL_STRIP_OVERRIDES", buttonData.name or "this button", {
-                    sourcePanelId = state.groupId,
-                    sourceIndex = state.sourceIndex,
-                    targetPanelId = dt.targetPanelId,
-                    targetIndex = resolvedIndex,
-                })
-                return
+            local targetGroup = CooldownCompanion.db.profile.groups[dt.targetPanelId]
+            local rejectMessage = CooldownCompanion.GetPanelManualEntryRejectMessage
+                and CooldownCompanion:GetPanelManualEntryRejectMessage(targetGroup)
+            if rejectMessage then
+                CooldownCompanion:Print(rejectMessage)
+            else
+                local buttonData = sourceGroup and sourceGroup.buttons[state.sourceIndex]
+                if buttonData and ButtonHasOverrides(buttonData) then
+                    ShowPopupAboveConfig("CDC_CROSS_PANEL_STRIP_OVERRIDES", buttonData.name or "this button", {
+                        sourcePanelId = state.groupId,
+                        sourceIndex = state.sourceIndex,
+                        targetPanelId = dt.targetPanelId,
+                        targetIndex = resolvedIndex,
+                    })
+                    return
+                end
+                PerformCrossPanelMove(state.groupId, state.sourceIndex, dt.targetPanelId, resolvedIndex)
+                CooldownCompanion:RefreshGroupFrame(state.groupId)
+                CooldownCompanion:RefreshGroupFrame(dt.targetPanelId)
             end
-            PerformCrossPanelMove(state.groupId, state.sourceIndex, dt.targetPanelId, resolvedIndex)
-            CooldownCompanion:RefreshGroupFrame(state.groupId)
-            CooldownCompanion:RefreshGroupFrame(dt.targetPanelId)
         end
     else
         PerformButtonReorder(state.groupId, state.sourceIndex, state.dropIndex or state.sourceIndex)

--- a/CooldownCompanion_Config/Config/DragReorderPreview.lua
+++ b/CooldownCompanion_Config/Config/DragReorderPreview.lua
@@ -66,6 +66,8 @@ local function ApplyPreviewModeBadge(texture, displayMode)
         texture:SetTexture(134400)
     elseif displayMode == "trigger" then
         texture:SetTexture(134400)
+    elseif displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+        texture:SetTexture(CooldownCompanion:GetRotationAssistantFallbackIcon())
     else
         texture:SetAtlas("UI-QuestPoi-QuestNumber-SuperTracked", false)
     end

--- a/CooldownCompanion_Config/Config/DragReorderTargets.lua
+++ b/CooldownCompanion_Config/Config/DragReorderTargets.lua
@@ -135,6 +135,27 @@ local function FindPreviousPanelId(renderedRows, currentIndex)
     return nil
 end
 
+local function PanelAcceptsEntryDrop(panelId)
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    local group = panelId and db and db.groups and db.groups[panelId]
+    if not group then return false end
+    return not CooldownCompanion.GetPanelManualEntryRejectMessage
+        or CooldownCompanion:GetPanelManualEntryRejectMessage(group) == nil
+end
+
+local function BuildCol2EntryDropTarget(action, targetPanelId, targetIndex, anchorFrame, anchorAbove)
+    if not PanelAcceptsEntryDrop(targetPanelId) then
+        return nil
+    end
+    return {
+        action = action,
+        targetPanelId = targetPanelId,
+        targetIndex = targetIndex,
+        anchorFrame = anchorFrame,
+        anchorAbove = anchorAbove,
+    }
+end
+
 local function GetCol2DropTarget(cursorY, renderedRows)
     if not renderedRows or #renderedRows == 0 then return nil end
 
@@ -148,40 +169,16 @@ local function GetCol2DropTarget(cursorY, renderedRows)
 
                 if rowMeta.kind == "button" then
                     if cursorY > mid then
-                        return {
-                            action = "insert",
-                            targetPanelId = rowMeta.panelId,
-                            targetIndex = rowMeta.buttonIndex,
-                            anchorFrame = frame,
-                            anchorAbove = true,
-                        }
+                        return BuildCol2EntryDropTarget("insert", rowMeta.panelId, rowMeta.buttonIndex, frame, true)
                     else
-                        return {
-                            action = "insert",
-                            targetPanelId = rowMeta.panelId,
-                            targetIndex = rowMeta.buttonIndex + 1,
-                            anchorFrame = frame,
-                            anchorAbove = false,
-                        }
+                        return BuildCol2EntryDropTarget("insert", rowMeta.panelId, rowMeta.buttonIndex + 1, frame, false)
                     end
                 elseif rowMeta.kind == "header" then
                     if rowMeta.isCollapsed then
                         -- Drop onto collapsed header = append to that panel
-                        return {
-                            action = "append-to-collapsed",
-                            targetPanelId = rowMeta.panelId,
-                            targetIndex = nil, -- will resolve to #buttons+1
-                            anchorFrame = frame,
-                            anchorAbove = false,
-                        }
+                        return BuildCol2EntryDropTarget("append-to-collapsed", rowMeta.panelId, nil, frame, false)
                     else
-                        return {
-                            action = "insert",
-                            targetPanelId = rowMeta.panelId,
-                            targetIndex = 1,
-                            anchorFrame = frame,
-                            anchorAbove = true,
-                        }
+                        return BuildCol2EntryDropTarget("insert", rowMeta.panelId, 1, frame, true)
                     end
                 end
             end
@@ -201,50 +198,26 @@ local function GetCol2DropTarget(cursorY, renderedRows)
                 local gapMid = (prevBottom + nextTop) / 2
                 if nextMeta.kind == "header" and prevMeta.panelId ~= nextMeta.panelId then
                     if cursorY > gapMid then
-                        return {
-                            action = "append",
-                            targetPanelId = prevMeta.panelId,
-                            targetIndex = nil,
-                            anchorFrame = prevFrame,
-                            anchorAbove = false,
-                        }
+                        return BuildCol2EntryDropTarget("append", prevMeta.panelId, nil, prevFrame, false)
                     end
 
                     if nextMeta.isCollapsed then
-                        return {
-                            action = "append-to-collapsed",
-                            targetPanelId = nextMeta.panelId,
-                            targetIndex = nil,
-                            anchorFrame = nextFrame,
-                            anchorAbove = true,
-                        }
+                        return BuildCol2EntryDropTarget("append-to-collapsed", nextMeta.panelId, nil, nextFrame, true)
                     end
 
-                    return {
-                        action = "insert",
-                        targetPanelId = nextMeta.panelId,
-                        targetIndex = 1,
-                        anchorFrame = nextFrame,
-                        anchorAbove = true,
-                    }
+                    return BuildCol2EntryDropTarget("insert", nextMeta.panelId, 1, nextFrame, true)
                 end
 
                 if nextMeta.kind == "button" then
-                    return {
-                        action = "insert",
-                        targetPanelId = nextMeta.panelId,
-                        targetIndex = nextMeta.buttonIndex,
-                        anchorFrame = nextFrame,
-                        anchorAbove = true,
-                    }
+                    return BuildCol2EntryDropTarget("insert", nextMeta.panelId, nextMeta.buttonIndex, nextFrame, true)
                 elseif nextMeta.kind == "header" then
-                    return {
-                        action = nextMeta.isCollapsed and "append-to-collapsed" or "insert",
-                        targetPanelId = nextMeta.panelId,
-                        targetIndex = nextMeta.isCollapsed and nil or 1,
-                        anchorFrame = nextFrame,
-                        anchorAbove = true,
-                    }
+                    return BuildCol2EntryDropTarget(
+                        nextMeta.isCollapsed and "append-to-collapsed" or "insert",
+                        nextMeta.panelId,
+                        nextMeta.isCollapsed and nil or 1,
+                        nextFrame,
+                        true
+                    )
                 end
             end
         end
@@ -256,13 +229,7 @@ local function GetCol2DropTarget(cursorY, renderedRows)
         local panelId = lastRow.panelId
         local lastFrame = lastRow.widget and lastRow.widget.frame
         if lastFrame and lastFrame:IsShown() then
-            return {
-                action = "append",
-                targetPanelId = panelId,
-                targetIndex = nil,
-                anchorFrame = lastFrame,
-                anchorAbove = false,
-            }
+            return BuildCol2EntryDropTarget("append", panelId, nil, lastFrame, false)
         end
     end
     return nil

--- a/CooldownCompanion_Config/Config/DragReorderTargets.lua
+++ b/CooldownCompanion_Config/Config/DragReorderTargets.lua
@@ -135,16 +135,10 @@ local function FindPreviousPanelId(renderedRows, currentIndex)
     return nil
 end
 
-local function PanelAcceptsEntryDrop(panelId)
-    local db = CooldownCompanion.db and CooldownCompanion.db.profile
-    local group = panelId and db and db.groups and db.groups[panelId]
-    if not group then return false end
-    return not CooldownCompanion.GetPanelManualEntryRejectMessage
-        or CooldownCompanion:GetPanelManualEntryRejectMessage(group) == nil
-end
-
 local function BuildCol2EntryDropTarget(action, targetPanelId, targetIndex, anchorFrame, anchorAbove)
-    if not PanelAcceptsEntryDrop(targetPanelId) then
+    local groups = CooldownCompanion.db and CooldownCompanion.db.profile and CooldownCompanion.db.profile.groups
+    local group = targetPanelId and groups and groups[targetPanelId]
+    if not group or not CooldownCompanion:CanPanelAcceptManualEntry(group) then
         return nil
     end
     return {

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -2003,7 +2003,14 @@ local function CreateConfigPanel()
         if group.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
             and CS.selectedRotationAssistantEntry == true then
             if tab == "loadconditions" then
-                ST._BuildLoadConditionsTab(scroll)
+                local buttonData = CooldownCompanion:GetRotationAssistantConfigButtonData(group)
+                ST._BuildEntryLoadConditionsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
+            end
+            if CS.browseMode then
+                ST._DisableAllWidgets(scroll)
+                for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
+                    if btn.Disable then btn:Disable() end
+                end
             end
             return
         end

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -2000,6 +2000,14 @@ local function CreateConfigPanel()
         local group = CS.selectedGroup and CooldownCompanion.db.profile.groups[CS.selectedGroup]
         if not group then return end
 
+        if group.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
+            and CS.selectedRotationAssistantEntry == true then
+            if tab == "loadconditions" then
+                ST._BuildLoadConditionsTab(scroll)
+            end
+            return
+        end
+
         local buttonData = CS.selectedButton and group.buttons[CS.selectedButton]
         if not buttonData then return end
 

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -728,6 +728,9 @@ end
 -- Helper: Get icon for a group (from its first button)
 ------------------------------------------------------------------------
 local function GetGroupIcon(group)
+    if group and group.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+        return CooldownCompanion:GetRotationAssistantFallbackIcon()
+    end
     if group.buttons and group.buttons[1] then
         return GetButtonIcon(group.buttons[1])
     end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -202,6 +202,7 @@ ST._configState = {
     selectedContainer = nil,     -- containerId selected in Column 1
     selectedGroup = nil,         -- panelId (groupId) selected in Column 2 panel list
     selectedButton = nil,
+    selectedRotationAssistantEntry = nil,
     selectedButtons = {},
     selectedPanels = {},         -- multi-selected panel IDs (within a container)
     selectedGroups = {},         -- multi-selected container IDs
@@ -716,6 +717,7 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CS.selectedContainer = containerId
     CS.selectedGroup = panelId
     CS.selectedButton = buttonIndex
+    CS.selectedRotationAssistantEntry = nil
     CS.addingToPanelId = nil
     ClearConfigFinderText()
     RefreshAlphaDriverForConfigSelection()
@@ -2461,6 +2463,7 @@ end
 
 local function ClearSelectedButton()
     CS.selectedButton = nil
+    CS.selectedRotationAssistantEntry = nil
     wipe(CS.selectedButtons)
 end
 
@@ -2585,7 +2588,10 @@ local function SelectConfigPanel(panelId, opts)
         wipe(CS.selectedPanels)
     end
 
-    if opts and opts.toggle and CS.selectedGroup == panelId and not CS.selectedButton then
+    if opts and opts.toggle
+        and CS.selectedGroup == panelId
+        and not CS.selectedButton
+        and not CS.selectedRotationAssistantEntry then
         CS.selectedGroup = nil
     else
         CS.selectedGroup = panelId
@@ -2635,8 +2641,10 @@ local function SelectConfigButton(panelId, buttonIndex, opts)
             CS.selectedButtons[CS.selectedButton] = true
         end
         CS.selectedButton = nil
+        CS.selectedRotationAssistantEntry = nil
     else
         wipe(CS.selectedButtons)
+        CS.selectedRotationAssistantEntry = nil
         if opts and opts.force then
             CS.selectedButton = buttonIndex
         elseif not panelChanged and CS.selectedButton == buttonIndex then
@@ -2646,6 +2654,23 @@ local function SelectConfigButton(panelId, buttonIndex, opts)
         end
     end
 
+    CooldownCompanion:ClearAllConfigPreviews()
+    RefreshAlphaDriverForConfigSelection()
+end
+
+local function SelectConfigRotationAssistantEntry(panelId, opts)
+    if opts and opts.containerId ~= nil then
+        CS.selectedContainer = opts.containerId
+    end
+    if not (opts and opts.keepPanelMulti) then
+        wipe(CS.selectedPanels)
+    end
+
+    CS.selectedGroup = panelId
+    CS.selectedButton = nil
+    CS.selectedRotationAssistantEntry = true
+    wipe(CS.selectedButtons)
+    CS.buttonSettingsTab = "loadconditions"
     CooldownCompanion:ClearAllConfigPreviews()
     RefreshAlphaDriverForConfigSelection()
 end
@@ -2708,6 +2733,7 @@ local function SelectConfigCustomBar(customBarId, opts)
     end
     wipe(CS.selectedCustomBars)
     if opts and opts.clearButtonMulti then
+        CS.selectedRotationAssistantEntry = nil
         wipe(CS.selectedButtons)
     end
     return selectionChanged
@@ -2762,6 +2788,7 @@ local function SelectConfigResource(powerType, opts)
     wipe(CS.selectedCustomBars)
     SetConfigCustomBarSettingsTab("appearance")
     if opts and opts.clearButtonMulti then
+        CS.selectedRotationAssistantEntry = nil
         wipe(CS.selectedButtons)
     end
 
@@ -2812,6 +2839,7 @@ local function ResetConfigSelection(full)
     CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedFolder = nil
     CS.selectedButton = nil
+    CS.selectedRotationAssistantEntry = nil
     CS.selectedCustomBarId = nil
     CS.customBarSpecExpandedId = nil
     CS.customBarSettingsTab = "appearance"
@@ -3051,6 +3079,7 @@ ST._ToggleConfigContainerMultiSelect = ToggleConfigContainerMultiSelect
 ST._SelectConfigPanel = SelectConfigPanel
 ST._ToggleConfigPanelMultiSelect = ToggleConfigPanelMultiSelect
 ST._SelectConfigButton = SelectConfigButton
+ST._SelectConfigRotationAssistantEntry = SelectConfigRotationAssistantEntry
 ST._SelectConfigButtonPanel = SelectConfigButtonPanel
 ST._ClearConfigCustomBarPreviewState = ClearConfigCustomBarPreviewState
 ST._SetConfigCustomBarSettingsTab = SetConfigCustomBarSettingsTab

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -79,7 +79,17 @@ local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
 
+local function GroupUsesRotationAssistantEntry(group)
+    return group and group.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
+end
+
 local function BuildButtonSettingsTabs(group, buttonData)
+    if GroupUsesRotationAssistantEntry(group) then
+        return {
+            { value = "loadconditions", text = "Load Conditions" },
+        }
+    end
+
     local isEquipmentSlot = CooldownCompanion.IsEquipmentSlotEntry
         and CooldownCompanion.IsEquipmentSlotEntry(buttonData)
     if GroupUsesTriggerPanelEntries(group) then
@@ -2349,21 +2359,27 @@ local function RefreshButtonSettingsColumn()
 
     -- Check if a valid single button is selected
     local hasSelection = false
-    if CS.selectedGroup and CS.selectedButton then
-        local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
+    local group = CS.selectedGroup and CooldownCompanion.db.profile.groups[CS.selectedGroup]
+    local rotationAssistantSelection = group
+        and GroupUsesRotationAssistantEntry(group)
+        and CS.selectedRotationAssistantEntry == true
+    if rotationAssistantSelection then
+        hasSelection = true
+    elseif CS.selectedGroup and CS.selectedButton then
         if group and group.buttons[CS.selectedButton] then
             hasSelection = true
         end
     end
 
     if hasSelection then
-        local group = CooldownCompanion.db.profile.groups[CS.selectedGroup]
         local buttonData = group and group.buttons and group.buttons[CS.selectedButton]
         bsCol.bsTabGroup:SetTabs(BuildButtonSettingsTabs(group, buttonData))
         local isEquipmentSlot = CooldownCompanion.IsEquipmentSlotEntry
             and CooldownCompanion.IsEquipmentSlotEntry(buttonData)
 
-        if GroupUsesTriggerPanelEntries(group)
+        if rotationAssistantSelection then
+            CS.buttonSettingsTab = "loadconditions"
+        elseif GroupUsesTriggerPanelEntries(group)
             and CS.buttonSettingsTab ~= "settings"
             and CS.buttonSettingsTab ~= "loadconditions"
             and (CS.buttonSettingsTab ~= "soundalerts" or isEquipmentSlot) then
@@ -2381,7 +2397,7 @@ local function RefreshButtonSettingsColumn()
 
         if bsCol.bsPlaceholder then bsCol.bsPlaceholder:Hide() end
         bsCol.bsTabGroup.frame:Show()
-        bsCol.bsTabGroup:SelectTab(CS.buttonSettingsTab or "settings")
+        bsCol.bsTabGroup:SelectTab(CS.buttonSettingsTab or (rotationAssistantSelection and "loadconditions" or "settings"))
     else
         bsCol.bsTabGroup.frame:Hide()
         if bsCol.bsPlaceholder then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -79,12 +79,8 @@ local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
 
-local function GroupUsesRotationAssistantEntry(group)
-    return group and group.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT
-end
-
 local function BuildButtonSettingsTabs(group, buttonData)
-    if GroupUsesRotationAssistantEntry(group) then
+    if CooldownCompanion:IsRotationAssistantGroup(group) then
         return {
             { value = "loadconditions", text = "Load Conditions" },
         }
@@ -2361,7 +2357,7 @@ local function RefreshButtonSettingsColumn()
     local hasSelection = false
     local group = CS.selectedGroup and CooldownCompanion.db.profile.groups[CS.selectedGroup]
     local rotationAssistantSelection = group
-        and GroupUsesRotationAssistantEntry(group)
+        and CooldownCompanion:IsRotationAssistantGroup(group)
         and CS.selectedRotationAssistantEntry == true
     if rotationAssistantSelection then
         hasSelection = true

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -14,6 +14,19 @@ local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
 
+local function GetManualMoveRejectMessage(group, count)
+    if CooldownCompanion.GetPanelManualEntryRejectMessage then
+        local message = CooldownCompanion:GetPanelManualEntryRejectMessage(group)
+        if message then
+            return message
+        end
+    end
+    if group and group.displayMode == "textures" and (count or 0) > 1 then
+        return "Texture Panels can only hold one entry. Move one entry at a time."
+    end
+    return nil
+end
+
 function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, uniformType)
     for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
         btn:ClearAllPoints()
@@ -75,7 +88,9 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
             local containers = db.groupContainers or {}
             local folderGroups, looseGroups = {}, {}
             for id, groupInfo in pairs(db.groups) do
-                if id ~= sourceGroupId and CooldownCompanion:IsGroupVisibleToCurrentChar(id) then
+                if id ~= sourceGroupId
+                    and CooldownCompanion:IsGroupVisibleToCurrentChar(id)
+                    and not GetManualMoveRejectMessage(groupInfo, multiCount) then
                     local groupName = groupInfo.name or ("Group " .. id)
                     local cid = groupInfo.parentContainerId
                     local container = cid and containers[cid]
@@ -111,8 +126,14 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                     local info = UIDropDownMenu_CreateInfo()
                     info.text = groupEntry.name
                     info.func = function()
+                        local targetGroup = db.groups[groupEntry.id]
+                        local rejectMessage = GetManualMoveRejectMessage(targetGroup, multiCount)
+                        if rejectMessage then
+                            CooldownCompanion:Print(rejectMessage)
+                            return
+                        end
                         for _, idx in ipairs(indices) do
-                            table.insert(db.groups[groupEntry.id].buttons, db.groups[sourceGroupId].buttons[idx])
+                            table.insert(targetGroup.buttons, db.groups[sourceGroupId].buttons[idx])
                         end
                         table.sort(indices, function(a, b) return a > b end)
                         for _, idx in ipairs(indices) do
@@ -140,8 +161,14 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                     local info = UIDropDownMenu_CreateInfo()
                     info.text = groupEntry.name
                     info.func = function()
+                        local targetGroup = db.groups[groupEntry.id]
+                        local rejectMessage = GetManualMoveRejectMessage(targetGroup, multiCount)
+                        if rejectMessage then
+                            CooldownCompanion:Print(rejectMessage)
+                            return
+                        end
                         for _, idx in ipairs(indices) do
-                            table.insert(db.groups[groupEntry.id].buttons, db.groups[sourceGroupId].buttons[idx])
+                            table.insert(targetGroup.buttons, db.groups[sourceGroupId].buttons[idx])
                         end
                         table.sort(indices, function(a, b) return a > b end)
                         for _, idx in ipairs(indices) do

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -2864,7 +2864,13 @@ local function BuildAppearanceTab(container)
         end
 
         BuildBorderControls(container, style, refreshStyle)
-        BuildKeybindTextControls(container, style, refreshStyle)
+        BuildKeybindTextControls(container, style, refreshStyle, {
+            label = "Show Keybind Text",
+            tooltip = {
+                "Show Keybind Text",
+                {"Shows detected keybind text for the current recommendation.", 1, 1, 1, true},
+            },
+        })
         return
     end
 

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -2482,6 +2482,36 @@ local function BuildEffectsTab(container)
         return
     end
 
+    if displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+        AddIndicatorsHeading(container, "Timers")
+        BuildCooldownSwipeControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        BuildShowGCDSwipeControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+
+        AddIndicatorsHeading(container, "States")
+        BuildDesaturationControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        BuildShowOutOfRangeControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        BuildLossOfControlControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        BuildUnusableDimmingControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        BuildShowTooltipsControls(container, style, function()
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+        end)
+        return
+    end
+
     if displayMode == "textures" then
         BuildTextureEffectsTab(container, group)
         return
@@ -2766,6 +2796,76 @@ local function BuildAppearanceTab(container)
             BuildTriggerTextAppearanceTab(container, group)
             return
         end
+    end
+
+    if group.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
+        local heading = AceGUI:Create("Heading")
+        heading:SetText("Assistant Panel")
+        ColorHeading(heading)
+        heading:SetFullWidth(true)
+        container:AddChild(heading)
+
+        local squareCb = AceGUI:Create("CheckBox")
+        squareCb:SetLabel("Square Icons")
+        squareCb:SetValue(style.maintainAspectRatio ~= false)
+        squareCb:SetFullWidth(true)
+        squareCb:SetCallback("OnValueChanged", function(widget, event, value)
+            style.maintainAspectRatio = value ~= false
+            style.buttonsPerRow = 1
+            if not style.maintainAspectRatio then
+                local size = style.buttonSize or ST.BUTTON_SIZE
+                style.iconWidth = style.iconWidth or size
+                style.iconHeight = style.iconHeight or size
+            end
+            CooldownCompanion:UpdateGroupStyle(CS.selectedGroup)
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        container:AddChild(squareCb)
+
+        if style.maintainAspectRatio ~= false then
+            local sizeSlider = AceGUI:Create("Slider")
+            sizeSlider:SetLabel("Button Size")
+            sizeSlider:SetSliderValues(10, 150, 0.1)
+            sizeSlider:SetValue(style.buttonSize or ST.BUTTON_SIZE)
+            sizeSlider:SetFullWidth(true)
+            sizeSlider:SetCallback("OnValueChanged", function(widget, event, value)
+                style.buttonSize = value
+                style.buttonsPerRow = 1
+                refreshStyle()
+            end)
+            HookSliderEditBox(sizeSlider)
+            container:AddChild(sizeSlider)
+        else
+            local widthSlider = AceGUI:Create("Slider")
+            widthSlider:SetLabel("Icon Width")
+            widthSlider:SetSliderValues(10, 150, 0.1)
+            widthSlider:SetValue(style.iconWidth or style.buttonSize or ST.BUTTON_SIZE)
+            widthSlider:SetFullWidth(true)
+            widthSlider:SetCallback("OnValueChanged", function(widget, event, value)
+                style.iconWidth = value
+                style.buttonsPerRow = 1
+                refreshStyle()
+            end)
+            HookSliderEditBox(widthSlider)
+            container:AddChild(widthSlider)
+
+            local heightSlider = AceGUI:Create("Slider")
+            heightSlider:SetLabel("Icon Height")
+            heightSlider:SetSliderValues(10, 150, 0.1)
+            heightSlider:SetValue(style.iconHeight or style.buttonSize or ST.BUTTON_SIZE)
+            heightSlider:SetFullWidth(true)
+            heightSlider:SetCallback("OnValueChanged", function(widget, event, value)
+                style.iconHeight = value
+                style.buttonsPerRow = 1
+                refreshStyle()
+            end)
+            HookSliderEditBox(heightSlider)
+            container:AddChild(heightSlider)
+        end
+
+        BuildBorderControls(container, style, refreshStyle)
+        BuildKeybindTextControls(container, style, refreshStyle)
+        return
     end
 
     if group.displayMode == "textures" or group.displayMode == "trigger" then

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -534,6 +534,21 @@ local function GetConfiguredPreviewIconSize(group)
 end
 
 local function GetSavedPreviewButtons(group)
+    if CooldownCompanion:IsRotationAssistantGroup(group) then
+        return {
+            {
+                buttonData = {
+                    type = "spell",
+                    id = CooldownCompanion:GetRotationAssistantActionSpellID(),
+                    name = ST.ROTATION_ASSISTANT_NAME,
+                    manualIcon = CooldownCompanion:GetRotationAssistantFallbackIcon(),
+                    _rotationAssistantVirtual = true,
+                    _rotationAssistantMissing = true,
+                },
+            },
+        }
+    end
+
     local buttons = {}
     local fallbackButtons = {}
 

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -535,13 +535,14 @@ end
 
 local function GetSavedPreviewButtons(group)
     if CooldownCompanion:IsRotationAssistantGroup(group) then
+        local spellID = CooldownCompanion:GetRotationAssistantActionSpellID()
         return {
             {
                 buttonData = {
                     type = "spell",
-                    id = CooldownCompanion:GetRotationAssistantActionSpellID(),
+                    id = spellID,
                     name = ST.ROTATION_ASSISTANT_NAME,
-                    manualIcon = CooldownCompanion:GetRotationAssistantFallbackIcon(),
+                    manualIcon = CooldownCompanion:GetRotationAssistantFallbackIcon(spellID),
                     _rotationAssistantVirtual = true,
                     _rotationAssistantMissing = true,
                 },

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -563,8 +563,8 @@ local function GetSavedPreviewButtons(group)
 end
 
 local function BuildSourcePanelData(groupId, group, visibleButtons, frame)
-    if not group or group.displayMode ~= "icons" then
-        return nil, "The current attached anchor panel is not an icon-mode panel, so there is no icon row to mirror."
+    if not group or not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) then
+        return nil, "The current attached anchor panel is not an icon-like panel, so there is no icon row to mirror."
     end
 
     if #visibleButtons == 0 then
@@ -618,7 +618,7 @@ local function IsGroupConfigAvailableForPreview(groupId, checkLoadConditions)
     local group = CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[groupId]
     if not group then return false end
     if not group.parentContainerId then return false end
-    if group.displayMode ~= "icons" then return false end
+    if not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) then return false end
     if CooldownCompanion.DoesAnchorTargetReachCursorRoot
         and CooldownCompanion:DoesAnchorTargetReachCursorRoot("CooldownCompanionGroup" .. tostring(groupId)) then
         return false

--- a/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
+++ b/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
@@ -440,9 +440,11 @@ local function BuildAuraStackTextControls(container, styleTable, refreshCallback
     end
 end
 
-local function BuildKeybindTextControls(container, styleTable, refreshCallback)
+local function BuildKeybindTextControls(container, styleTable, refreshCallback, opts)
+    local label = opts and opts.label or KEYBIND_CUSTOM_LABEL
+    local tooltip = opts and opts.tooltip or KEYBIND_CUSTOM_TOOLTIP
     local kbCb = AceGUI:Create("CheckBox")
-    kbCb:SetLabel(KEYBIND_CUSTOM_LABEL)
+    kbCb:SetLabel(label)
     kbCb:SetValue(styleTable.showKeybindText or false)
     kbCb:SetFullWidth(true)
     kbCb:SetCallback("OnValueChanged", function(widget, event, val)
@@ -452,7 +454,7 @@ local function BuildKeybindTextControls(container, styleTable, refreshCallback)
     end)
     container:AddChild(kbCb)
 
-    CreateInfoButton(kbCb.frame, kbCb.checkbg, "LEFT", "RIGHT", kbCb.text:GetStringWidth() + 4, 0, KEYBIND_CUSTOM_TOOLTIP, kbCb)
+    CreateInfoButton(kbCb.frame, kbCb.checkbg, "LEFT", "RIGHT", kbCb.text:GetStringWidth() + 4, 0, tooltip, kbCb)
 
     if styleTable.showKeybindText then
         AddAnchorDropdown(container, styleTable, "keybindAnchor", "TOPRIGHT", refreshCallback)


### PR DESCRIPTION
## What Players Will Notice
- A new `Assistant Panel` type is available at the bottom of the panel creation menus.
- Assistant Panels show one locked icon that follows the in-game rotation assistant recommendation, with the spellbook assistant icon used in config and as the runtime fallback when no recommendation is available.
- The panel stays intentionally simple: no manual entries, sound alerts, overrides, or normal entry-editing tabs. Appearance is limited to icon sizing, border, and keybind text, with load conditions still available.
- The runtime icon participates in cooldown/duration swipe, GCD swipe, out-of-range, loss-of-control, unusable, tooltip, charge, and keybind behavior for the displayed recommendation while avoiding glow indicators.

## Why This Changed
- The built-in single-button rotation flow can add a GCD tax. This gives players a narrow display they can watch for the recommended next action while pressing their own existing keybinds.
- The configuration experience needed to make it clear that this is a special automatic panel, not a normal spell/item panel with editable entries.

## What Changed
- Added the `rotationAssistant` display mode, default `Assistant Panel` naming, fixed config icon/fallback texture, and runtime recommendation lookup through the assisted-combat APIs.
- Added a virtual Assistant Panel entry that is automatically populated, cannot accept manual entries, and can still use entry load conditions.
- Updated config Column 1/2/3 selection, panel creation, drag/drop rules, browse-mode display, and settings tabs so Assistant Panels expose only the intended controls.
- Updated runtime button handling so the recommendation can refresh icon, cooldown, range, keybind, visibility, charge metadata, and fallback state without persisted normal entries.
- Added review-driven fixes for Assistant Panel load-condition lookup and dynamic charge metadata when recommendations change.

## Validation
- `luac -p` over 28 Lua files.
- `lua tests/rotation-assistant-panel.lua`.
- `lua tests/soul-immolation-charge-override.lua`.
- `git diff --check origin/main...HEAD`.
- Ran a two-cohort parallel static review loop after simplification; fixed the load-condition and charge-metadata findings. A repeated suggestion to bind against the Single-Button Assistant action was intentionally declined because the accepted product behavior is for keybind text to follow the displayed recommendation.
- Assisted-combat API usage was checked during static review against local MCP/API source.
- In-game combat and restricted-content validation is still pending before merge.