### PR TITLE
Reduce cooldown refresh work during casts and target changes

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -13,6 +13,9 @@ local GetTime = GetTime
 local tonumber = tonumber
 local tostring = tostring
 local ipairs = ipairs
+local pairs = pairs
+local wipe = wipe
+local table_insert = table.insert
 local type = type
 local issecretvalue = issecretvalue
 local math_max = math.max
@@ -45,6 +48,8 @@ local GetConditionalVisualPreview = ST._GetConditionalVisualPreview
 local UpdateChargeTracking = ST._UpdateChargeTracking
 local UpdateDisplayCountTracking = ST._UpdateDisplayCountTracking
 local UpdateItemChargeTracking = ST._UpdateItemChargeTracking
+local UpdateIconTint = ST._UpdateIconTint
+local EvaluateDesaturation = ST._EvaluateDesaturation
 
 -- Imports from IconMode
 local ApplyIconCountTextStyle = ST._ApplyIconCountTextStyle
@@ -1773,4 +1778,232 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end
+end
+
+local function HasUnusableVisualStyle(style)
+    return style
+        and style.showUnusable == true
+        and (
+            ST.UnusableVisualUsesDimTint(style)
+            or ST.UnusableVisualUsesDesaturation(style)
+        )
+        or false
+end
+
+local function IsPowerSensitiveSpellButton(button, buttonData)
+    if not (button and buttonData and buttonData.type == "spell") then
+        return false
+    end
+    if buttonData.isPassive or buttonData.isPassiveCooldown then
+        return false
+    end
+
+    return button._isText == true
+        or buttonData.hideWhileUnusable == true
+        or HasUnusableVisualStyle(button.style)
+end
+
+function CooldownCompanion:InvalidatePowerSensitiveButtonIndex()
+    self._powerSensitiveButtonIndexDirty = true
+end
+
+local function RebuildPowerSensitiveButtonIndex(addon)
+    local buttons = addon._powerSensitiveButtons
+    if buttons then
+        wipe(buttons)
+    else
+        buttons = {}
+        addon._powerSensitiveButtons = buttons
+    end
+
+    local groupFrames = addon.groupFrames
+    if type(groupFrames) ~= "table" then
+        addon._powerSensitiveButtonIndexDirty = nil
+        return buttons
+    end
+
+    for _, frame in pairs(groupFrames) do
+        if frame and frame.IsShown and frame:IsShown() and frame.buttons then
+            for _, button in ipairs(frame.buttons) do
+                local buttonData = button and button.buttonData
+                if IsPowerSensitiveSpellButton(button, buttonData) then
+                    table_insert(buttons, button)
+                end
+            end
+        end
+    end
+
+    addon._powerSensitiveButtonIndexDirty = nil
+    return buttons
+end
+
+local function UpdatePowerUnusableTextState(button, buttonData)
+    if not button._isText then
+        button._isUnusable = false
+        button._isOutOfRange = false
+        return
+    end
+
+    local spellID = button._displaySpellId or buttonData.id
+    button._isUnusable = not C_Spell_IsSpellUsable(spellID)
+    button._isOutOfRange = button._spellOutOfRange or false
+end
+
+local function ApplyLightweightPowerVisibility(button, buttonData, conditionalPreview)
+    local auraOverrideActive = button._auraActive == true
+    local procOverlayActive = button._procOverlayActive == true
+    local auraOwnsPrimarySwipe = button._auraPrimarySwipeActive
+
+    EvaluateButtonVisibility(button, buttonData, auraOverrideActive, procOverlayActive, auraOwnsPrimarySwipe)
+    button._rawVisibilityHidden = button._visibilityHidden
+    button._rawVisibilityAlphaOverride = button._visibilityAlphaOverride
+    button._rawVisibilityReasonBits = button._visibilityReasonBits
+    button._rawVisibilityReasonMode = button._visibilityReasonMode
+
+    local group = button._groupId and CooldownCompanion.db and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
+    local isTriggerPanel = group and group.displayMode == "trigger"
+    local forceVisibleByUnlockPreview = group
+        and group.parentContainerId
+        and CooldownCompanion.IsContainerUnlockPreviewActive
+        and CooldownCompanion:IsContainerUnlockPreviewActive(group.parentContainerId)
+        and not isTriggerPanel
+    local forceVisibleByConfig = type(IsConfigButtonForceVisible) == "function"
+        and IsConfigButtonForceVisible(button)
+        or false
+    local forceVisibleByPreview = conditionalPreview ~= nil and not isTriggerPanel
+    local visibilityOverrideSource
+
+    if isTriggerPanel then
+        button._visibilityHidden = true
+        button._visibilityAlphaOverride = 0
+        visibilityOverrideSource = "trigger"
+    end
+    if forceVisibleByUnlockPreview or forceVisibleByPreview then
+        button._visibilityHidden = false
+        button._visibilityAlphaOverride = 1
+        visibilityOverrideSource = forceVisibleByUnlockPreview and "unlock-preview" or "conditional-preview"
+    elseif forceVisibleByConfig and not isTriggerPanel then
+        button._visibilityHidden = false
+        button._visibilityAlphaOverride = 1
+        visibilityOverrideSource = "config"
+    end
+
+    button._forceVisibleByConfig = ((forceVisibleByConfig or forceVisibleByUnlockPreview or forceVisibleByPreview) and not isTriggerPanel) or nil
+    if button._visibilityHidden == true then
+        button._visibilityFinalMode = "hidden"
+    elseif button._visibilityAlphaOverride ~= nil and button._visibilityAlphaOverride ~= 1 then
+        button._visibilityFinalMode = "dimmed"
+    else
+        button._visibilityFinalMode = "visible"
+    end
+    button._visibilityOverrideSource = visibilityOverrideSource
+    button._visibilityTriggerSuppressed = visibilityOverrideSource == "trigger" or nil
+    button._visibilityCompactLayout = group and group.compactLayout == true or nil
+
+    local visibilityChanged = button._visibilityHidden ~= button._prevVisibilityHidden
+    if visibilityChanged then
+        button._prevVisibilityHidden = button._visibilityHidden
+    end
+    local forceVisibleChanged = button._forceVisibleByConfig ~= button._prevForceVisibleByConfig
+    if forceVisibleChanged then
+        button._prevForceVisibleByConfig = button._forceVisibleByConfig
+    end
+    if visibilityChanged or forceVisibleChanged then
+        local groupFrame = button.GetParent and button:GetParent() or nil
+        if groupFrame then
+            groupFrame._layoutDirty = true
+        end
+    end
+
+    if button._visibilityHidden then
+        if button.cooldown then
+            button.cooldown:Hide()
+        end
+        HideIconFillForHiddenButton(button)
+        if group and group.compactLayout then
+            DispatchStandaloneTextureVisual(button)
+        else
+            if button.SetAlpha and button._lastVisAlpha ~= 0 then
+                button:SetAlpha(0)
+            end
+            button._lastVisAlpha = 0
+            DispatchStandaloneTextureVisual(button)
+        end
+        return false
+    end
+
+    local targetAlpha = button._visibilityAlphaOverride or 1
+    if button.SetAlpha and button._lastVisAlpha ~= targetAlpha then
+        button:SetAlpha(targetAlpha)
+    end
+    button._lastVisAlpha = targetAlpha
+    return true
+end
+
+local function RefreshPowerSensitiveButton(button, buttonData)
+    local style = button.style
+    local conditionalPreview = GetConditionalVisualPreview and GetConditionalVisualPreview(button)
+
+    ClearConditionalVisualPreviewFields(button)
+    ApplyConditionalVisualPreview(
+        button,
+        buttonData,
+        style,
+        conditionalPreview,
+        GetTime and GetTime() or 0,
+        UsesChargeBehavior(buttonData)
+    )
+
+    local isVisible = ApplyLightweightPowerVisibility(button, buttonData, conditionalPreview)
+    UpdatePowerUnusableTextState(button, buttonData)
+    if not isVisible then
+        return
+    end
+
+    if button._isText then
+        UpdateTextDisplay(button)
+    else
+        if type(EvaluateDesaturation) == "function" then
+            EvaluateDesaturation(button, buttonData, style)
+        end
+        if type(UpdateIconTint) == "function" then
+            UpdateIconTint(button, buttonData, style)
+        end
+        DispatchStandaloneTextureVisual(button)
+    end
+end
+
+function CooldownCompanion:RefreshPowerSensitiveButtonStates()
+    local groupFrames = self.groupFrames
+    if type(groupFrames) ~= "table" then
+        return false
+    end
+
+    local indexedButtons = self._powerSensitiveButtons
+    if self._powerSensitiveButtonIndexDirty or type(indexedButtons) ~= "table" then
+        indexedButtons = RebuildPowerSensitiveButtonIndex(self)
+    end
+
+    local updated = false
+    local foundStaleEntry = false
+    for _, button in ipairs(indexedButtons) do
+        local groupId = button and button._groupId
+        local frame = groupId and groupFrames[groupId] or nil
+        local buttonData = button and button.buttonData
+        if frame and frame.IsShown and frame:IsShown()
+                and button._pooled ~= true
+                and IsPowerSensitiveSpellButton(button, buttonData) then
+            RefreshPowerSensitiveButton(button, buttonData)
+            updated = true
+        else
+            foundStaleEntry = true
+        end
+    end
+
+    if foundStaleEntry then
+        self._powerSensitiveButtonIndexDirty = true
+    end
+
+    return updated
 end

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1790,7 +1790,7 @@ local function HasUnusableVisualStyle(style)
         or false
 end
 
-local function IsPowerSensitiveSpellButton(button, buttonData)
+local function IsPowerSensitiveSpellButton(addon, button, buttonData)
     if not (button and buttonData and buttonData.type == "spell") then
         return false
     end
@@ -1801,6 +1801,7 @@ local function IsPowerSensitiveSpellButton(button, buttonData)
     return button._isText == true
         or buttonData.hideWhileUnusable == true
         or HasUnusableVisualStyle(button.style)
+        or (addon.TriggerRowUsesCondition and addon:TriggerRowUsesCondition(buttonData, "usable"))
 end
 
 function CooldownCompanion:InvalidatePowerSensitiveButtonIndex()
@@ -1826,7 +1827,7 @@ local function RebuildPowerSensitiveButtonIndex(addon)
         if frame and frame.IsShown and frame:IsShown() and frame.buttons then
             for _, button in ipairs(frame.buttons) do
                 local buttonData = button and button.buttonData
-                if IsPowerSensitiveSpellButton(button, buttonData) then
+                if IsPowerSensitiveSpellButton(addon, button, buttonData) then
                     table_insert(buttons, button)
                 end
             end
@@ -1944,7 +1945,10 @@ end
 local function RefreshPowerSensitiveButton(button, buttonData)
     local style = button.style
     local conditionalPreview = GetConditionalVisualPreview and GetConditionalVisualPreview(button)
+    local wasHidden = button._visibilityHidden == true
 
+    local isVisible = ApplyLightweightPowerVisibility(button, buttonData, conditionalPreview)
+    UpdatePowerUnusableTextState(button, buttonData)
     ClearConditionalVisualPreviewFields(button)
     ApplyConditionalVisualPreview(
         button,
@@ -1954,10 +1958,11 @@ local function RefreshPowerSensitiveButton(button, buttonData)
         GetTime and GetTime() or 0,
         UsesChargeBehavior(buttonData)
     )
-
-    local isVisible = ApplyLightweightPowerVisibility(button, buttonData, conditionalPreview)
-    UpdatePowerUnusableTextState(button, buttonData)
     if not isVisible then
+        return
+    end
+    if wasHidden and button._visibilityHidden ~= true and button.UpdateCooldown then
+        button:UpdateCooldown()
         return
     end
 
@@ -1974,6 +1979,25 @@ local function RefreshPowerSensitiveButton(button, buttonData)
     end
 end
 
+local function AddPowerSensitiveTriggerFrame(addon, triggerFrames, frame, groupId)
+    local group = addon.db and addon.db.profile
+        and addon.db.profile.groups and addon.db.profile.groups[groupId] or nil
+    if group and group.displayMode == "trigger" then
+        triggerFrames[frame] = true
+    end
+end
+
+local function RefreshPowerSensitiveTriggerFrames(addon, triggerFrames)
+    if not addon.UpdateAuraTextureVisual then
+        return
+    end
+    for frame in pairs(triggerFrames) do
+        if frame.buttons and frame.buttons[1] then
+            addon:UpdateAuraTextureVisual(frame.buttons[1])
+        end
+    end
+end
+
 function CooldownCompanion:RefreshPowerSensitiveButtonStates()
     local groupFrames = self.groupFrames
     if type(groupFrames) ~= "table" then
@@ -1987,19 +2011,30 @@ function CooldownCompanion:RefreshPowerSensitiveButtonStates()
 
     local updated = false
     local foundStaleEntry = false
+    local triggerFrames = self._powerSensitiveTriggerFrames
+    if triggerFrames then
+        wipe(triggerFrames)
+    else
+        triggerFrames = {}
+        self._powerSensitiveTriggerFrames = triggerFrames
+    end
+
     for _, button in ipairs(indexedButtons) do
         local groupId = button and button._groupId
         local frame = groupId and groupFrames[groupId] or nil
         local buttonData = button and button.buttonData
         if frame and frame.IsShown and frame:IsShown()
                 and button._pooled ~= true
-                and IsPowerSensitiveSpellButton(button, buttonData) then
+                and IsPowerSensitiveSpellButton(self, button, buttonData) then
             RefreshPowerSensitiveButton(button, buttonData)
+            AddPowerSensitiveTriggerFrame(self, triggerFrames, frame, groupId)
             updated = true
         else
             foundStaleEntry = true
         end
     end
+
+    RefreshPowerSensitiveTriggerFrames(self, triggerFrames)
 
     if foundStaleEntry then
         self._powerSensitiveButtonIndexDirty = true

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -361,6 +361,12 @@ local function MatchesConditionalCastCountEvent(buttonData, spellID, baseSpellID
 end
 CooldownCompanion.MatchesConditionalCastCountEvent = MatchesConditionalCastCountEvent
 
+local function GetConditionalCastCountEventSpells(buttonData)
+    local family = GetConditionalCastCountFamily(buttonData)
+    return family and family.eventSpells or nil
+end
+CooldownCompanion.GetConditionalCastCountEventSpells = GetConditionalCastCountEventSpells
+
 local function GetConditionalCastCountSpellID(buttonData, currentSpellID)
     local family = GetConditionalCastCountFamily(buttonData)
     if not family or not currentSpellID then return nil end

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1151,6 +1151,9 @@ function CooldownCompanion:UpdateButtonIcon(button)
     -- Update cooldown secrecy when override spell changes (e.g. Command Demon → pet ability)
     if displayId ~= prevDisplayId and buttonData.type == "spell" then
         buttonData._cooldownSecrecy = C_Secrets.GetSpellCooldownSecrecy(displayId)
+        if CooldownCompanion.InvalidateCastButtonIndex then
+            CooldownCompanion:InvalidateCastButtonIndex()
+        end
     end
 
     -- Update bar name text when the display spell changes (e.g. transform)

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -16,6 +16,66 @@ local select = select
 local wipe = wipe
 local tostring = tostring
 local tonumber = tonumber
+local type = type
+local table_insert = table.insert
+
+function CooldownCompanion:InvalidateAuraButtonIndex()
+    self._auraButtonIndexDirty = true
+end
+
+local function RebuildAuraButtonIndex(addon)
+    local buttons = addon._auraButtons
+    if buttons then
+        wipe(buttons)
+    else
+        buttons = {}
+        addon._auraButtons = buttons
+    end
+
+    for _, frame in pairs(addon.groupFrames or {}) do
+        if frame and frame.buttons then
+            for _, button in ipairs(frame.buttons) do
+                local buttonData = button and button.buttonData
+                if buttonData and (buttonData.auraTracking or buttonData.isPassive) then
+                    table_insert(buttons, button)
+                end
+            end
+        end
+    end
+
+    addon._auraButtonIndexDirty = nil
+    return buttons
+end
+
+local function ForEachAuraButton(addon, callback)
+    if not callback then
+        return
+    end
+
+    local buttons = addon._auraButtons
+    if addon._auraButtonIndexDirty or type(buttons) ~= "table" then
+        buttons = RebuildAuraButtonIndex(addon)
+    end
+
+    local foundStaleEntry = false
+    for _, button in ipairs(buttons or {}) do
+        local groupId = button and button._groupId
+        local frame = groupId and addon.groupFrames and addon.groupFrames[groupId] or nil
+        local buttonData = button and button.buttonData
+        if frame and frame.buttons
+                and button._pooled ~= true
+                and buttonData
+                and (buttonData.auraTracking or buttonData.isPassive) then
+            callback(button, buttonData)
+        else
+            foundStaleEntry = true
+        end
+    end
+
+    if foundStaleEntry then
+        addon._auraButtonIndexDirty = true
+    end
+end
 
 -- Import cross-file variables (viewer system)
 local VIEWER_NAMES = ST._VIEWER_NAMES
@@ -489,7 +549,7 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
     local isTarget = (unit == "target")
     if removedIDs or updatedIDs or isTarget then
-        self:ForEachButton(function(button)
+        ForEachAuraButton(self, function(button)
             if button._auraInstanceID and button._auraUnit == unit then
                 if removedIDSet and removedIDSet[button._auraInstanceID] then
                     button._auraInstanceID = nil
@@ -526,17 +586,15 @@ end
 -- Clear aura state on buttons tracking a unit when that unit changes (target/focus switch).
 -- The viewer will re-evaluate on its next tick; this ensures stale data is cleared promptly.
 function CooldownCompanion:ClearAuraUnit(unitToken)
-    self:ForEachButton(function(button, bd)
-        if bd.auraTracking or bd.isPassive then
-            local configUnit = bd.auraUnit or "player"
-            local shouldClear = button._auraUnit == unitToken
-            if not shouldClear and configUnit == unitToken then
-                shouldClear = true
-            end
-            if shouldClear then
-                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, { useFalseState = true })
-                button._auraPrimarySwipeActive = nil
-            end
+    ForEachAuraButton(self, function(button, bd)
+        local configUnit = bd.auraUnit or "player"
+        local shouldClear = button._auraUnit == unitToken
+        if not shouldClear and configUnit == unitToken then
+            shouldClear = true
+        end
+        if shouldClear then
+            EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, { useFalseState = true })
+            button._auraPrimarySwipeActive = nil
         end
     end)
     self:MarkCooldownsDirty()
@@ -546,28 +604,26 @@ function CooldownCompanion:OnTargetChanged()
     if not UnitExists("target") then
         -- Deselected target: clear all target aura state immediately
         self:ClearAuraUnit("target")
+        self:QueueCooldownRefresh("target-event")
         return
     end
     -- New target: clear stale instance IDs so the viewer path doesn't
     -- read old auraInstanceIDs.  Keep _auraActive so the hold can
     -- maintain visual continuity while CDM refreshes.
     local now = GetTime()
-    self:ForEachButton(function(button, bd)
-        if bd.auraTracking or bd.isPassive then
-            local configUnit = bd.auraUnit or "player"
-            local isTarget = button._auraUnit == "target"
-                or configUnit == "target"
-            if isTarget then
-                EntryRuntime.StartTrackedAuraTargetSwitch(button, now, "target")
-            end
+    ForEachAuraButton(self, function(button, bd)
+        local configUnit = bd.auraUnit or "player"
+        local isTarget = button._auraUnit == "target"
+            or configUnit == "target"
+        if isTarget then
+            EntryRuntime.StartTrackedAuraTargetSwitch(button, now, "target")
         end
     end)
-    -- Synchronous probe: CDM viewer frames register their event handlers on
-    -- Blizzard frames created before addons load.  If UNIT_TARGET has already
-    -- been processed by the time PLAYER_TARGET_CHANGED fires, the CDM children
-    -- will have fresh auraInstanceID data.  Probing immediately lets the
-    -- primary path clear _targetSwitchAt in the same frame — zero hold.
-    self:UpdateAllCooldowns()
+    -- CDM viewer frames register their event handlers on Blizzard frames
+    -- created before addons load. Queue the target refresh to the frame
+    -- boundary so PLAYER_TARGET_CHANGED and UNIT_TARGET collapse to one walk
+    -- after the viewer has had a chance to process the same target switch.
+    self:QueueCooldownRefresh("target-event")
 end
 
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -100,6 +100,9 @@ function CooldownCompanion:QueueCooldownRefresh(source, eventName)
     self._queuedCooldownRefreshEvent = eventName
     if RefreshSourceSatisfiesDirty(source) then
         self._queuedCooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+    else
+        self._queuedCooldownRefreshSatisfiedSerial = nil
+        self._cooldownRefreshSatisfiedSerial = nil
     end
     self:EnsureCooldownRefreshQueueFrame()
 end
@@ -110,8 +113,9 @@ function CooldownCompanion:SatisfyQueuedCooldownRefresh(source)
         return false
     end
 
+    local satisfiedSerial = self._queuedCooldownRefreshSatisfiedSerial
     self:ResetCooldownRefreshState()
-    self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+    self._cooldownRefreshSatisfiedSerial = satisfiedSerial
     return true
 end
 
@@ -146,7 +150,7 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
 end
 
 function CooldownCompanion:ShouldRunTickerCooldownRefresh()
-    if self._cooldownsDirty or self._cooldownPeriodicRefreshActive then
+    if self._cooldownsDirty then
         return true
     end
 
@@ -172,13 +176,16 @@ function CooldownCompanion:TickCooldownRefresh()
     if self:CanSkipTickerCooldownRefresh() then
         return true
     end
-    if self._cooldownPeriodicRefreshActive and not self._cooldownsDirty then
+    local shouldRunFullRefresh = self:ShouldRunTickerCooldownRefresh()
+    if self._cooldownPeriodicRefreshActive
+            and not self._cooldownsDirty
+            and not shouldRunFullRefresh then
         if self.UpdateActiveCooldownButtons then
             self:UpdateActiveCooldownButtons()
             return false
         end
     end
-    if not self:ShouldRunTickerCooldownRefresh() then
+    if not shouldRunFullRefresh then
         return true
     end
     RunCooldownRefresh(self)

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -8,21 +8,28 @@
     - _queuedCooldownRefreshSource: pending queued refresh source; also the
       queue-pending flag checked by the ticker. Last writer wins; this is only
       a debug breadcrumb, not skip eligibility.
-    - _queuedCooldownRefreshCooldownEventSerial: dirty serial captured when a
-      queued cooldown-event request enters the queue.
+    - _queuedCooldownRefreshEvent: event name for the pending queued refresh;
+      kept separate so actionbar cooldown work can be satisfied by narrower
+      same-frame refreshes.
+    - _queuedCooldownRefreshSatisfiedSerial: dirty serial captured when a
+      queued refresh is expected to cover the pending dirty state.
     - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
-      cooldown-event refresh.
+      refresh that can safely satisfy the next ticker pass.
     - _cooldownImmediateRefreshThisFrame: latch allowing only the first
       immediate refresh in a frame to walk synchronously.
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
       frame and arm flag used to flush queued work on the next OnUpdate
       boundary. The frame must stay shown; hidden frames do not receive OnUpdate.
+    - _cooldownPeriodicRefreshActive: true when the last full cooldown pass
+      saw active timing/hold state that still needs 0.1s confirmation.
+    - _lastCooldownMaintenanceRefreshAt: GetTime() of the last full cooldown
+      pass. Idle ticker passes use it for low-frequency fallback polling.
 
     Invariants:
-    - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
+    - Only explicitly satisfying refresh sources write _cooldownRefreshSatisfiedSerial.
     - MarkCooldownsDirty is the only invalidator; stale satisfied serials are
       inert because they cannot match a later dirty serial.
-    - Queued cooldown-event requests satisfy the serial captured at queue time.
+    - Queued satisfying requests satisfy the serial captured at queue time.
       If another dirty mark lands before the flush, the later ticker walks
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
@@ -30,12 +37,28 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local type = type
+
+local IDLE_COOLDOWN_MAINTENANCE_INTERVAL = 1.0
+
+local function RefreshSourceSatisfiesDirty(source)
+    return source == "cooldown-event"
+        or source == "target-event"
+end
+
+local function GetRefreshTime()
+    return type(GetTime) == "function" and GetTime() or nil
+end
 
 local function CooldownRefreshQueueOnUpdate(frame)
     local addon = frame._cooldownCompanion
     if addon then
         addon:FlushQueuedCooldownRefresh()
     end
+end
+
+local function RunCooldownRefresh(addon)
+    addon:UpdateAllCooldowns()
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -61,23 +84,35 @@ end
 
 function CooldownCompanion:FlushQueuedCooldownRefresh()
     local queuedSource = self._queuedCooldownRefreshSource
-    local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
+    local satisfiedSerial = self._queuedCooldownRefreshSatisfiedSerial
     self:ResetCooldownRefreshState()
 
     if queuedSource then
-        self:UpdateAllCooldowns()
-        if cooldownEventSerial then
-            self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
+        RunCooldownRefresh(self)
+        if satisfiedSerial then
+            self._cooldownRefreshSatisfiedSerial = satisfiedSerial
         end
     end
 end
 
-function CooldownCompanion:QueueCooldownRefresh(source)
+function CooldownCompanion:QueueCooldownRefresh(source, eventName)
     self._queuedCooldownRefreshSource = source or "event"
-    if source == "cooldown-event" then
-        self._queuedCooldownRefreshCooldownEventSerial = self._cooldownDirtySerial or 0
+    self._queuedCooldownRefreshEvent = eventName
+    if RefreshSourceSatisfiesDirty(source) then
+        self._queuedCooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
     end
     self:EnsureCooldownRefreshQueueFrame()
+end
+
+function CooldownCompanion:SatisfyQueuedCooldownRefresh(source)
+    local queuedSource = self._queuedCooldownRefreshSource
+    if not queuedSource or (source and queuedSource ~= source) then
+        return false
+    end
+
+    self:ResetCooldownRefreshState()
+    self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+    return true
 end
 
 function CooldownCompanion:RunImmediateCooldownRefresh(source)
@@ -86,26 +121,47 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
         return
     end
 
-    local cooldownEventSerial
-    if source == "cooldown-event" then
-        cooldownEventSerial = self._cooldownDirtySerial or 0
+    local satisfiedSerial
+    if RefreshSourceSatisfiesDirty(source) then
+        satisfiedSerial = self._cooldownDirtySerial or 0
     end
 
     self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCooldownEventSerial = nil
+    self._queuedCooldownRefreshEvent = nil
+    self._queuedCooldownRefreshSatisfiedSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
-    self:UpdateAllCooldowns()
-    if cooldownEventSerial then
-        self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
+    RunCooldownRefresh(self)
+    if satisfiedSerial then
+        self._cooldownRefreshSatisfiedSerial = satisfiedSerial
     end
 end
 
 function CooldownCompanion:CanSkipTickerCooldownRefresh()
-    -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
-    -- target, and other dirty paths keep their normal ticker confirmation.
+    -- Only refresh sources that ran after the matching dirty mark can satisfy
+    -- the next ticker pass.  Aura and other viewer-sensitive paths keep their
+    -- normal ticker confirmation.
     return self._cooldownsDirty
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+end
+
+function CooldownCompanion:ShouldRunTickerCooldownRefresh()
+    if self._cooldownsDirty or self._cooldownPeriodicRefreshActive then
+        return true
+    end
+
+    local now = GetRefreshTime()
+    if not now then
+        return true
+    end
+
+    local lastRefreshAt = self._lastCooldownMaintenanceRefreshAt
+    if not lastRefreshAt then
+        return true
+    end
+
+    local interval = self._cooldownIdleMaintenanceInterval or IDLE_COOLDOWN_MAINTENANCE_INTERVAL
+    return now - lastRefreshAt >= interval
 end
 
 function CooldownCompanion:TickCooldownRefresh()
@@ -116,7 +172,16 @@ function CooldownCompanion:TickCooldownRefresh()
     if self:CanSkipTickerCooldownRefresh() then
         return true
     end
-    self:UpdateAllCooldowns()
+    if self._cooldownPeriodicRefreshActive and not self._cooldownsDirty then
+        if self.UpdateActiveCooldownButtons then
+            self:UpdateActiveCooldownButtons()
+            return false
+        end
+    end
+    if not self:ShouldRunTickerCooldownRefresh() then
+        return true
+    end
+    RunCooldownRefresh(self)
     return false
 end
 
@@ -126,6 +191,7 @@ function CooldownCompanion:ResetCooldownRefreshState()
     end
     self._cooldownRefreshQueueArmed = nil
     self._queuedCooldownRefreshSource = nil
-    self._queuedCooldownRefreshCooldownEventSerial = nil
+    self._queuedCooldownRefreshEvent = nil
+    self._queuedCooldownRefreshSatisfiedSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
 end

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -11,6 +11,7 @@ local ipairs = ipairs
 local tonumber = tonumber
 local select = select
 local wipe = wipe
+local table_insert = table.insert
 
 -- Some talent swaps briefly report pre-final spell charge state. Coalesce a
 -- delayed second pass so charge flags settle without duplicate refresh storms.
@@ -205,6 +206,7 @@ end
 
 function CooldownCompanion:UpdateRangeCheckRegistrations()
     local newSet = {}
+    local newButtonsBySpell = {}
     self:ForEachButton(function(button, bd)
         if bd.type == "spell"
             and not bd.isPassive
@@ -212,6 +214,12 @@ function CooldownCompanion:UpdateRangeCheckRegistrations()
             and ((button.style and button.style.showOutOfRange)
                 or (self.TriggerRowUsesCondition and self:TriggerRowUsesCondition(bd, "rangeActive"))) then
             newSet[bd.id] = true
+            local buttons = newButtonsBySpell[bd.id]
+            if not buttons then
+                buttons = {}
+                newButtonsBySpell[bd.id] = buttons
+            end
+            table_insert(buttons, button)
         end
     end)
     -- Enable newly needed range checks
@@ -227,22 +235,32 @@ function CooldownCompanion:UpdateRangeCheckRegistrations()
         end
     end
     self._rangeCheckSpells = newSet
+    self._rangeCheckButtonsBySpell = newButtonsBySpell
+    self._rangeCheckButtonIndexDirty = nil
+end
+
+function CooldownCompanion:InvalidateRangeCheckButtonIndex()
+    self._rangeCheckButtonIndexDirty = true
 end
 
 function CooldownCompanion:OnSpellRangeCheckUpdate(event, spellIdentifier, isInRange, checksRange)
+    if self._rangeCheckButtonIndexDirty or not self._rangeCheckButtonsBySpell then
+        self:UpdateRangeCheckRegistrations()
+    end
+
     local outOfRange = nil
     if checksRange then
         outOfRange = not isInRange
     end
     local changed = false
-    self:ForEachButton(function(button, bd)
-        if bd.type == "spell" and bd.id == spellIdentifier then
-            if button._spellOutOfRange ~= outOfRange then
-                button._spellOutOfRange = outOfRange
-                changed = true
-            end
+
+    local buttons = self._rangeCheckButtonsBySpell and self._rangeCheckButtonsBySpell[spellIdentifier]
+    for _, button in ipairs(buttons or {}) do
+        if button and button._pooled ~= true and button._spellOutOfRange ~= outOfRange then
+            button._spellOutOfRange = outOfRange
+            changed = true
         end
-    end)
+    end
     if changed then
         self:MarkCooldownsDirty()
     end

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -206,20 +206,22 @@ end
 
 function CooldownCompanion:UpdateRangeCheckRegistrations()
     local newSet = {}
+    local allButtonsBySpell = {}
     local newButtonsBySpell = {}
     self:ForEachButton(function(button, bd)
         if bd.type == "spell"
             and not bd.isPassive
-            and not bd.isPassiveCooldown
-            and ((button.style and button.style.showOutOfRange)
-                or (self.TriggerRowUsesCondition and self:TriggerRowUsesCondition(bd, "rangeActive"))) then
-            newSet[bd.id] = true
-            local buttons = newButtonsBySpell[bd.id]
+            and not bd.isPassiveCooldown then
+            local buttons = allButtonsBySpell[bd.id]
             if not buttons then
                 buttons = {}
-                newButtonsBySpell[bd.id] = buttons
+                allButtonsBySpell[bd.id] = buttons
             end
             table_insert(buttons, button)
+            if (button.style and button.style.showOutOfRange)
+                    or (self.TriggerRowUsesCondition and self:TriggerRowUsesCondition(bd, "rangeActive")) then
+                newSet[bd.id] = true
+            end
         end
     end)
     -- Enable newly needed range checks
@@ -233,6 +235,9 @@ function CooldownCompanion:UpdateRangeCheckRegistrations()
         if not newSet[spellId] then
             C_Spell.EnableSpellRangeCheck(spellId, false)
         end
+    end
+    for spellId in pairs(newSet) do
+        newButtonsBySpell[spellId] = allButtonsBySpell[spellId]
     end
     self._rangeCheckSpells = newSet
     self._rangeCheckButtonsBySpell = newButtonsBySpell

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -2365,6 +2365,9 @@ local function FinishGroupButtonRefresh(self, groupId, frame, group)
 
     -- Initial cooldown update
     frame:UpdateCooldowns()
+    if self.InvalidateCooldownRefreshIndexes then
+        self:InvalidateCooldownRefreshIndexes()
+    end
 
     -- Compact mode: apply reflow immediately so newly rebuilt buttons don't
     -- briefly appear before the next ticker-driven layout pass.

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -13,6 +13,7 @@ local wipe = wipe
 local select = select
 local next = next
 local type = type
+local table_insert = table.insert
 local UnitExists = UnitExists
 local UnitCanAttack = UnitCanAttack
 local InCombatLockdown = InCombatLockdown
@@ -45,6 +46,180 @@ local function RefreshKeyPressHighlightFrame(frame)
         else
             refreshButton(button)
         end
+    end
+end
+
+local function DurationObjectNeedsPeriodicRefresh(durationObj)
+    if not durationObj then
+        return false
+    end
+    if durationObj.HasSecretValues and durationObj:HasSecretValues() then
+        return true
+    end
+    if durationObj.GetRemainingDuration then
+        local remaining = durationObj:GetRemainingDuration()
+        return remaining and remaining > 0
+    end
+    return true
+end
+
+local function ItemCooldownNeedsPeriodicRefresh(button)
+    local startTime = button._itemCdStart
+    local duration = button._itemCdDuration
+    if not (startTime and duration and duration > 0) then
+        return false
+    end
+    if type(GetTime) ~= "function" then
+        return true
+    end
+    return GetTime() < startTime + duration
+end
+
+local function ReadyGlowWindowNeedsPeriodicRefresh(button, startField)
+    local startTime = button and button[startField]
+    if not startTime then
+        return false
+    end
+    local style = button.style
+    if not (style and style.readyGlowStyle and style.readyGlowStyle ~= "none") then
+        return false
+    end
+    local duration = style.readyGlowDuration or 0
+    if duration <= 0 then
+        return false
+    end
+    if type(GetTime) ~= "function" then
+        return true
+    end
+    return GetTime() - startTime <= duration
+end
+
+local function GetButtonPeriodicCooldownRefreshReason(button)
+    if not button then
+        return nil
+    end
+    if DurationObjectNeedsPeriodicRefresh(button._durationObj) then return "duration" end
+    if DurationObjectNeedsPeriodicRefresh(button._auraDurationObj) then return "aura-duration" end
+    if DurationObjectNeedsPeriodicRefresh(button._chargeDurationObj) then return "charge-duration" end
+    if ItemCooldownNeedsPeriodicRefresh(button) then return "item-cooldown" end
+    if button._cooldownDeferred == true then return "deferred-cooldown" end
+    if button._chargeRecharging == true then return "charge-recharging" end
+    if button._chargeCooldownVisualActive == true then return "charge-visual" end
+    if button._secondaryCdActive == true then return "secondary-cooldown" end
+    if button._desatCooldownActive == true then return "desat-cooldown" end
+    if button._auraActive == true then return "aura-active" end
+    if button._auraGraceStart ~= nil then return "aura-grace" end
+    if button._targetSwitchAt ~= nil then return "target-switch-hold" end
+    if ReadyGlowWindowNeedsPeriodicRefresh(button, "_readyGlowStartTime") then return "ready-glow-window" end
+    if ReadyGlowWindowNeedsPeriodicRefresh(button, "_readyGlowMaxChargesStartTime") then return "ready-glow-max-charges-window" end
+    if button._conditionalPreviewRemaining ~= nil then return "conditional-preview" end
+    return nil
+end
+
+local function RebuildCooldownPeriodicRefreshIndex(addon)
+    local activeButtons = addon._cooldownPeriodicRefreshButtons
+    if activeButtons then
+        wipe(activeButtons)
+    else
+        activeButtons = {}
+        addon._cooldownPeriodicRefreshButtons = activeButtons
+    end
+
+    local count = 0
+
+    for _, frame in pairs(addon.groupFrames or {}) do
+        if frame and frame.IsShown and frame:IsShown() and frame.buttons then
+            for _, button in ipairs(frame.buttons) do
+                local reason = GetButtonPeriodicCooldownRefreshReason(button)
+                if reason then
+                    count = count + 1
+                    activeButtons[count] = button
+                end
+            end
+        end
+    end
+
+    addon._cooldownPeriodicRefreshButtonsDirty = nil
+    addon._cooldownPeriodicRefreshActive = count > 0 or nil
+    return count
+end
+
+function CooldownCompanion:InvalidateCooldownRefreshIndexes()
+    self._cooldownPeriodicRefreshButtonsDirty = true
+    self._itemCooldownEventButtonsDirty = true
+    if self.InvalidatePowerSensitiveButtonIndex then
+        self:InvalidatePowerSensitiveButtonIndex()
+    end
+    if self.InvalidateCastButtonIndex then
+        self:InvalidateCastButtonIndex()
+    end
+    if self.InvalidateCastCountEventIndex then
+        self:InvalidateCastCountEventIndex()
+    end
+    if self.InvalidateRangeCheckButtonIndex then
+        self:InvalidateRangeCheckButtonIndex()
+    end
+    if self.InvalidateAuraButtonIndex then
+        self:InvalidateAuraButtonIndex()
+    end
+end
+
+local function RebuildItemCooldownEventButtonIndex(addon)
+    local buttons = addon._itemCooldownEventButtons
+    if buttons then
+        wipe(buttons)
+    else
+        buttons = {}
+        addon._itemCooldownEventButtons = buttons
+    end
+
+    local isEntryItemLike = addon.IsEntryItemLike
+    if type(isEntryItemLike) ~= "function" then
+        addon._itemCooldownEventButtonsDirty = nil
+        return buttons
+    end
+
+    for _, frame in pairs(addon.groupFrames or {}) do
+        if frame and frame.buttons then
+            for _, button in ipairs(frame.buttons) do
+                local buttonData = button and button.buttonData
+                if buttonData and isEntryItemLike(buttonData) and button.UpdateCooldown then
+                    table_insert(buttons, button)
+                end
+            end
+        end
+    end
+
+    addon._itemCooldownEventButtonsDirty = nil
+    return buttons
+end
+
+local function PrepareCooldownUpdatePass(addon)
+    addon._gcdInfo = C_Spell.GetSpellCooldown(61304)
+    -- GCD activity: isActive is NeverSecret (12.0.1 hotfix)
+    addon._gcdActive = addon._gcdInfo and addon._gcdInfo.isActive or false
+    -- Cache for GCD overlay display in CooldownUpdate (only when GCD is active)
+    addon._gcdDurationObj = addon._gcdActive and C_Spell.GetSpellCooldownDuration(61304) or nil
+
+    -- Assisted highlight target gate:
+    -- hard target has priority; if none exists, allow soft enemy fallback.
+    local hasHostileTarget = false
+    if UnitExists("target") then
+        hasHostileTarget = UnitCanAttack("player", "target") and true or false
+    elseif UnitExists("softenemy") then
+        hasHostileTarget = UnitCanAttack("player", "softenemy") and true or false
+    end
+    addon._assistedHighlightHasHostileTarget = hasHostileTarget
+
+    -- Cache CDM viewer CVar once per pass.
+    addon._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
+    addon._cooldownUpdatePassActive = true
+end
+
+local function FinishCooldownUpdatePass(addon)
+    addon._cooldownUpdatePassActive = nil
+    if type(GetTime) == "function" then
+        addon._lastCooldownMaintenanceRefreshAt = GetTime()
     end
 end
 
@@ -2283,6 +2458,9 @@ function CooldownCompanion:UnloadGroup(groupId)
     self._dormantFrames = self._dormantFrames or {}
     self._dormantFrames[groupId] = frame
     self.groupFrames[groupId] = nil
+    if self.InvalidateCooldownRefreshIndexes then
+        self:InvalidateCooldownRefreshIndexes()
+    end
     if self.RefreshCursorAnchorTicker then
         self:RefreshCursorAnchorTicker()
     end
@@ -2301,6 +2479,9 @@ function CooldownCompanion:RecoverDormantFrame(groupId)
 
     self._dormantFrames[groupId] = nil
     self.groupFrames[groupId] = frame
+    if self.InvalidateCooldownRefreshIndexes then
+        self:InvalidateCooldownRefreshIndexes()
+    end
 
     -- Restore button OnUpdate scripts
     if frame.buttons then
@@ -2346,29 +2527,107 @@ function CooldownCompanion:DiscardDormantFrame(groupId)
             self:ReleaseGroupButtonPools(frame)
         end
         self._dormantFrames[groupId] = nil
+        if self.InvalidateCooldownRefreshIndexes then
+            self:InvalidateCooldownRefreshIndexes()
+        end
     end
 end
 
-function CooldownCompanion:UpdateAllCooldowns()
-    self._gcdInfo = C_Spell.GetSpellCooldown(61304)
-    -- GCD activity: isActive is NeverSecret (12.0.1 hotfix)
-    self._gcdActive = self._gcdInfo and self._gcdInfo.isActive or false
-    -- Cache for GCD overlay display in CooldownUpdate (only when GCD is active)
-    self._gcdDurationObj = self._gcdActive and C_Spell.GetSpellCooldownDuration(61304) or nil
-
-    -- Assisted highlight target gate:
-    -- hard target has priority; if none exists, allow soft enemy fallback.
-    local hasHostileTarget = false
-    if UnitExists("target") then
-        hasHostileTarget = UnitCanAttack("player", "target") and true or false
-    elseif UnitExists("softenemy") then
-        hasHostileTarget = UnitCanAttack("player", "softenemy") and true or false
+function CooldownCompanion:UpdateCooldownButtonsForSpellEvent(spellID, baseSpellID)
+    if not self.CollectCooldownEventButtonsForSpell then
+        return false
     end
-    self._assistedHighlightHasHostileTarget = hasHostileTarget
 
-    -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
-    self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
-    self._cooldownUpdatePassActive = true
+    local buttons = self:CollectCooldownEventButtonsForSpell(spellID, baseSpellID)
+    if not buttons then
+        return false
+    end
+
+    PrepareCooldownUpdatePass(self)
+
+    local updated = false
+    for _, button in ipairs(buttons) do
+        local groupId = button and button._groupId
+        local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
+        if frame and frame.IsShown and frame:IsShown()
+                and button.UpdateCooldown
+                and button._pooled ~= true then
+            button:UpdateCooldown()
+            updated = true
+        end
+    end
+
+    RebuildCooldownPeriodicRefreshIndex(self)
+    FinishCooldownUpdatePass(self)
+
+    return updated
+end
+
+function CooldownCompanion:UpdateItemCooldownButtonsForEvent()
+    local isEntryItemLike = self.IsEntryItemLike
+    if type(isEntryItemLike) ~= "function" then
+        return false
+    end
+
+    local indexedButtons = self._itemCooldownEventButtons
+    if self._itemCooldownEventButtonsDirty or type(indexedButtons) ~= "table" then
+        indexedButtons = RebuildItemCooldownEventButtonIndex(self)
+    end
+    if #indexedButtons == 0 then
+        return false
+    end
+
+    local foundStaleEntry = false
+    local visibleButtons = self._itemCooldownEventVisibleButtons
+    if visibleButtons then
+        wipe(visibleButtons)
+    else
+        visibleButtons = {}
+        self._itemCooldownEventVisibleButtons = visibleButtons
+    end
+    for _, button in ipairs(indexedButtons) do
+        local groupId = button and button._groupId
+        local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
+        local buttonData = button and button.buttonData
+        if frame and button.UpdateCooldown
+                and button._pooled ~= true
+                and isEntryItemLike(buttonData) then
+            if frame.IsShown and frame:IsShown() then
+                table_insert(visibleButtons, button)
+            end
+        else
+            foundStaleEntry = true
+        end
+    end
+
+    if foundStaleEntry then
+        self._itemCooldownEventButtonsDirty = true
+    end
+
+    if #visibleButtons == 0 then
+        return false
+    end
+
+    PrepareCooldownUpdatePass(self)
+
+    local updated = false
+    for _, button in ipairs(visibleButtons) do
+        local groupId = button and button._groupId
+        local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
+        if frame then
+            button:UpdateCooldown()
+            updated = true
+        end
+    end
+
+    RebuildCooldownPeriodicRefreshIndex(self)
+    FinishCooldownUpdatePass(self)
+
+    return updated
+end
+
+function CooldownCompanion:UpdateAllCooldowns()
+    PrepareCooldownUpdatePass(self)
 
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
@@ -2376,7 +2635,52 @@ function CooldownCompanion:UpdateAllCooldowns()
         end
     end
 
-    self._cooldownUpdatePassActive = nil
+    RebuildCooldownPeriodicRefreshIndex(self)
+    FinishCooldownUpdatePass(self)
+end
+
+function CooldownCompanion:UpdateActiveCooldownButtons()
+    local periodicRefreshActive = false
+
+    PrepareCooldownUpdatePass(self)
+
+    if self._cooldownPeriodicRefreshButtonsDirty
+            or type(self._cooldownPeriodicRefreshButtons) ~= "table" then
+        RebuildCooldownPeriodicRefreshIndex(self)
+    end
+
+    local activeButtons = self._cooldownPeriodicRefreshButtons
+    local nextActiveButtons = self._cooldownPeriodicRefreshButtonsNext
+    if nextActiveButtons then
+        wipe(nextActiveButtons)
+    else
+        nextActiveButtons = {}
+    end
+    for _, button in ipairs(activeButtons or {}) do
+        local groupId = button and button._groupId
+        local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
+        if frame and frame.IsShown and frame:IsShown()
+                and button.UpdateCooldown
+                and button._pooled ~= true then
+            local reason = GetButtonPeriodicCooldownRefreshReason(button)
+            if reason then
+                button:UpdateCooldown()
+
+                reason = GetButtonPeriodicCooldownRefreshReason(button)
+                if reason then
+                    table_insert(nextActiveButtons, button)
+                    if not periodicRefreshActive then
+                        periodicRefreshActive = true
+                    end
+                end
+            end
+        end
+    end
+
+    FinishCooldownUpdatePass(self)
+    self._cooldownPeriodicRefreshButtonsNext = activeButtons
+    self._cooldownPeriodicRefreshButtons = nextActiveButtons
+    self._cooldownPeriodicRefreshActive = periodicRefreshActive or nil
 end
 
 function CooldownCompanion:UpdateAllGroupLayouts()

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -113,6 +113,7 @@ local function GetButtonPeriodicCooldownRefreshReason(button)
     if ReadyGlowWindowNeedsPeriodicRefresh(button, "_readyGlowStartTime") then return "ready-glow-window" end
     if ReadyGlowWindowNeedsPeriodicRefresh(button, "_readyGlowMaxChargesStartTime") then return "ready-glow-max-charges-window" end
     if button._conditionalPreviewRemaining ~= nil then return "conditional-preview" end
+    if button.style and button.style.showAssistedHighlight == true then return "assisted-highlight" end
     return nil
 end
 
@@ -142,6 +143,25 @@ local function RebuildCooldownPeriodicRefreshIndex(addon)
     addon._cooldownPeriodicRefreshButtonsDirty = nil
     addon._cooldownPeriodicRefreshActive = count > 0 or nil
     return count
+end
+
+local function AddTriggerFrameForButton(addon, triggerFrames, frame, groupId)
+    local group = addon.db and addon.db.profile
+        and addon.db.profile.groups and addon.db.profile.groups[groupId] or nil
+    if group and group.displayMode == "trigger" then
+        triggerFrames[frame] = true
+    end
+end
+
+local function RefreshTriggerFrames(addon, triggerFrames)
+    if not addon.UpdateAuraTextureVisual then
+        return
+    end
+    for frame in pairs(triggerFrames) do
+        if frame.buttons and frame.buttons[1] then
+            addon:UpdateAuraTextureVisual(frame.buttons[1])
+        end
+    end
 end
 
 function CooldownCompanion:InvalidateCooldownRefreshIndexes()
@@ -216,9 +236,9 @@ local function PrepareCooldownUpdatePass(addon)
     addon._cooldownUpdatePassActive = true
 end
 
-local function FinishCooldownUpdatePass(addon)
+local function FinishCooldownUpdatePass(addon, recordsMaintenanceRefresh)
     addon._cooldownUpdatePassActive = nil
-    if type(GetTime) == "function" then
+    if recordsMaintenanceRefresh and type(GetTime) == "function" then
         addon._lastCooldownMaintenanceRefreshAt = GetTime()
     end
 end
@@ -2382,6 +2402,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
                         if frame.UpdateCooldowns then
                             frame:UpdateCooldowns()
                         end
+                        if self.InvalidateCooldownRefreshIndexes then
+                            self:InvalidateCooldownRefreshIndexes()
+                        end
                         if group.compactLayout then
                             frame._layoutDirty = true
                             self:UpdateGroupLayout(groupId)
@@ -2533,34 +2556,56 @@ function CooldownCompanion:DiscardDormantFrame(groupId)
     end
 end
 
+local function UpdateCollectedCooldownButtons(addon, buttons)
+    if not buttons then
+        return false
+    end
+
+    PrepareCooldownUpdatePass(addon)
+
+    local updated = false
+    local triggerFrames = addon._cooldownEventTriggerFrames
+    if triggerFrames then
+        wipe(triggerFrames)
+    else
+        triggerFrames = {}
+        addon._cooldownEventTriggerFrames = triggerFrames
+    end
+
+    for _, button in ipairs(buttons) do
+        local groupId = button and button._groupId
+        local frame = groupId and addon.groupFrames and addon.groupFrames[groupId] or nil
+        if frame and frame.IsShown and frame:IsShown()
+                and button.UpdateCooldown
+                and button._pooled ~= true then
+            button:UpdateCooldown()
+            AddTriggerFrameForButton(addon, triggerFrames, frame, groupId)
+            updated = true
+        end
+    end
+
+    RefreshTriggerFrames(addon, triggerFrames)
+
+    RebuildCooldownPeriodicRefreshIndex(addon)
+    FinishCooldownUpdatePass(addon)
+
+    return updated
+end
+
 function CooldownCompanion:UpdateCooldownButtonsForSpellEvent(spellID, baseSpellID)
     if not self.CollectCooldownEventButtonsForSpell then
         return false
     end
 
-    local buttons = self:CollectCooldownEventButtonsForSpell(spellID, baseSpellID)
-    if not buttons then
+    return UpdateCollectedCooldownButtons(self, self:CollectCooldownEventButtonsForSpell(spellID, baseSpellID))
+end
+
+function CooldownCompanion:UpdateCooldownButtonsForActionbarEvent()
+    if not self.CollectCooldownEventButtonsForActionbar then
         return false
     end
 
-    PrepareCooldownUpdatePass(self)
-
-    local updated = false
-    for _, button in ipairs(buttons) do
-        local groupId = button and button._groupId
-        local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
-        if frame and frame.IsShown and frame:IsShown()
-                and button.UpdateCooldown
-                and button._pooled ~= true then
-            button:UpdateCooldown()
-            updated = true
-        end
-    end
-
-    RebuildCooldownPeriodicRefreshIndex(self)
-    FinishCooldownUpdatePass(self)
-
-    return updated
+    return UpdateCollectedCooldownButtons(self, self:CollectCooldownEventButtonsForActionbar())
 end
 
 function CooldownCompanion:UpdateItemCooldownButtonsForEvent()
@@ -2611,15 +2656,25 @@ function CooldownCompanion:UpdateItemCooldownButtonsForEvent()
     PrepareCooldownUpdatePass(self)
 
     local updated = false
+    local triggerFrames = self._cooldownEventTriggerFrames
+    if triggerFrames then
+        wipe(triggerFrames)
+    else
+        triggerFrames = {}
+        self._cooldownEventTriggerFrames = triggerFrames
+    end
+
     for _, button in ipairs(visibleButtons) do
         local groupId = button and button._groupId
         local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
         if frame then
             button:UpdateCooldown()
+            AddTriggerFrameForButton(self, triggerFrames, frame, groupId)
             updated = true
         end
     end
 
+    RefreshTriggerFrames(self, triggerFrames)
     RebuildCooldownPeriodicRefreshIndex(self)
     FinishCooldownUpdatePass(self)
 
@@ -2636,7 +2691,7 @@ function CooldownCompanion:UpdateAllCooldowns()
     end
 
     RebuildCooldownPeriodicRefreshIndex(self)
-    FinishCooldownUpdatePass(self)
+    FinishCooldownUpdatePass(self, true)
 end
 
 function CooldownCompanion:UpdateActiveCooldownButtons()
@@ -2656,27 +2711,33 @@ function CooldownCompanion:UpdateActiveCooldownButtons()
     else
         nextActiveButtons = {}
     end
+    local triggerFrames = self._cooldownEventTriggerFrames
+    if triggerFrames then
+        wipe(triggerFrames)
+    else
+        triggerFrames = {}
+        self._cooldownEventTriggerFrames = triggerFrames
+    end
     for _, button in ipairs(activeButtons or {}) do
         local groupId = button and button._groupId
         local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
         if frame and frame.IsShown and frame:IsShown()
                 and button.UpdateCooldown
                 and button._pooled ~= true then
+            button:UpdateCooldown()
+            AddTriggerFrameForButton(self, triggerFrames, frame, groupId)
+
             local reason = GetButtonPeriodicCooldownRefreshReason(button)
             if reason then
-                button:UpdateCooldown()
-
-                reason = GetButtonPeriodicCooldownRefreshReason(button)
-                if reason then
-                    table_insert(nextActiveButtons, button)
-                    if not periodicRefreshActive then
-                        periodicRefreshActive = true
-                    end
+                table_insert(nextActiveButtons, button)
+                if not periodicRefreshActive then
+                    periodicRefreshActive = true
                 end
             end
         end
     end
 
+    RefreshTriggerFrames(self, triggerFrames)
     FinishCooldownUpdatePass(self)
     self._cooldownPeriodicRefreshButtonsNext = activeButtons
     self._cooldownPeriodicRefreshButtons = nextActiveButtons

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -13,6 +13,9 @@ local pairs = pairs
 local wipe = wipe
 local ipairs = ipairs
 local select = select
+local table_insert = table.insert
+local type = type
+local GetTime = GetTime
 
 -- Import cross-file variables
 local defaults = ST._defaults
@@ -21,6 +24,9 @@ local minimapButton = ST._minimapButton
 
 -- LibSharedMedia for font/texture selection
 local LSM = LibStub("LibSharedMedia-3.0")
+
+local SatisfyQueuedActionbarCooldownRefresh
+local ACTIONBAR_COOLDOWN_FALLBACK_INTERVAL = 0.5
 
 -- Viewer frame list used by BuildViewerAuraMap, FindViewerChildForSpell, and OnEnable hooks.
 local VIEWER_NAMES = {
@@ -139,7 +145,7 @@ function CooldownCompanion:OnEnable()
         self._unitEventFrame = CreateFrame("Frame")
         self._unitEventFrame:SetScript("OnEvent", function(_, event, ...)
             if event == "UNIT_POWER_FREQUENT" then
-                self:MarkCooldownsDirty()
+                self:OnUnitPowerFrequent(event, ...)
             elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
                 self:OnSpellCast(event, ...)
             elseif event == "UNIT_AURA" then
@@ -211,16 +217,15 @@ function CooldownCompanion:OnEnable()
     self:RegisterEvent("PLAYER_TARGET_CHANGED", "OnTargetChanged")
 
     -- UNIT_TARGET requires RegisterUnitEvent (plain RegisterEvent does not
-    -- receive it).  Marks dirty so the next ticker pass reads fresh CDM viewer
-    -- data; catches pet/focus target changes that don't fire PLAYER_TARGET_CHANGED.
+    -- receive it). PLAYER_TARGET_CHANGED is the authoritative player-target
+    -- signal; this handler is kept for inherited unit-frame alpha resync
+    -- without forcing a duplicate cooldown walk.
     if not self._unitTargetFrame then
         self._unitTargetFrame = CreateFrame("Frame")
-        self._unitTargetFrame:SetScript("OnEvent", function(_, event, unitToken)
+        self._unitTargetFrame:SetScript("OnEvent", function()
             if ST._QueueInheritedUnitFrameAlphaResync then
                 ST._QueueInheritedUnitFrameAlphaResync()
             end
-            self:MarkCooldownsDirty()
-            self:UpdateAllCooldowns()
         end)
     end
     self._unitTargetFrame:RegisterUnitEvent("UNIT_TARGET", "player")
@@ -312,11 +317,114 @@ function CooldownCompanion:OnEnable()
     self:FinalizeContainerAnchorsToScreenOffsets()
 end
 
-function CooldownCompanion:OnCooldownStateChanged()
+function CooldownCompanion:OnCooldownStateChanged(event, spellID, baseSpellID, category, startRecoveryCategory)
+    if self:ShouldSkipActionbarCooldownEvent(event) then
+        return
+    end
+
+    if self:ShouldSkipStartRecoveryOnlyCooldownEvent(event, spellID, category, startRecoveryCategory) then
+        SatisfyQueuedActionbarCooldownRefresh(self)
+        return
+    end
+
+    if self.UpdateItemCooldownButtonsForEvent
+            and (
+                event == "BAG_UPDATE_COOLDOWN"
+                or (event == "ACTIONBAR_UPDATE_COOLDOWN" and not self:HasGCDSwipeRefreshConsumers())
+            ) then
+        self:UpdateItemCooldownButtonsForEvent()
+        return
+    end
+
     self:MarkCooldownsDirty()
+    if event == "SPELL_UPDATE_COOLDOWN"
+            and spellID
+            and (not category or category == 0)
+            and not self:HasGCDSwipeRefreshConsumers()
+            and self.UpdateCooldownButtonsForSpellEvent then
+        if self:UpdateCooldownButtonsForSpellEvent(spellID, baseSpellID) then
+            if not SatisfyQueuedActionbarCooldownRefresh(self) then
+                self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+            end
+        else
+            SatisfyQueuedActionbarCooldownRefresh(self)
+            self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+        end
+        return
+    end
+
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
-    self:RunImmediateCooldownRefresh("cooldown-event")
+    if event == "SPELL_UPDATE_COOLDOWN" and spellID then
+        self:RunImmediateCooldownRefresh("cooldown-event")
+    else
+        self:QueueCooldownRefresh("cooldown-event", event)
+    end
+end
+
+function CooldownCompanion:HasGCDSwipeRefreshConsumers()
+    local groups = self.db and self.db.profile and self.db.profile.groups
+    local groupFrames = self.groupFrames
+    if type(groups) ~= "table" or type(groupFrames) ~= "table" then
+        return true
+    end
+
+    for groupId, frame in pairs(groupFrames) do
+        if frame and frame.IsShown and frame:IsShown() then
+            local group = groups[groupId]
+            local style = group and group.style
+            if style and style.showGCDSwipe == true then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+function CooldownCompanion:ShouldSkipStartRecoveryOnlyCooldownEvent(event, spellID, category, startRecoveryCategory)
+    if event ~= "SPELL_UPDATE_COOLDOWN" or not spellID or not startRecoveryCategory then
+        return false
+    end
+    if category and category ~= 0 then
+        return false
+    end
+    return not self:HasGCDSwipeRefreshConsumers()
+end
+
+function CooldownCompanion:ShouldSkipActionbarCooldownEvent(event)
+    if event ~= "ACTIONBAR_UPDATE_COOLDOWN" then
+        return false
+    end
+    if self:HasGCDSwipeRefreshConsumers() then
+        return false
+    end
+
+    local gcdInfo = C_Spell.GetSpellCooldown(61304)
+    if gcdInfo and gcdInfo.isActive == true then
+        return true, "gcd-only-actionbar-event"
+    end
+
+    local now = type(GetTime) == "function" and GetTime() or nil
+    if not now then
+        return false
+    end
+
+    local lastFallbackAt = self._lastActionbarCooldownFallbackAt
+    local interval = self._actionbarCooldownFallbackInterval or ACTIONBAR_COOLDOWN_FALLBACK_INTERVAL
+    if lastFallbackAt and now - lastFallbackAt < interval then
+        return true, "actionbar-fallback-throttle"
+    end
+
+    self._lastActionbarCooldownFallbackAt = now
+    return false
+end
+
+function CooldownCompanion:OnUnitPowerFrequent(event, unitTarget, powerType)
+    if self.RefreshPowerSensitiveButtonStates then
+        self:RefreshPowerSensitiveButtonStates()
+    else
+        self:MarkCooldownsDirty()
+    end
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.
@@ -331,6 +439,258 @@ function CooldownCompanion:ForEachButton(callback)
             end
         end
     end
+end
+
+function CooldownCompanion:InvalidateCastButtonIndex()
+    self._castButtonIndexDirty = true
+end
+
+local function AddCastButtonIndexEntry(index, spellID, button)
+    if not spellID then
+        return
+    end
+
+    local buttons = index[spellID]
+    if not buttons then
+        buttons = {}
+        index[spellID] = buttons
+    end
+    table_insert(buttons, button)
+end
+
+local function RebuildCastButtonIndex(addon)
+    local index = {}
+    for _, frame in pairs(addon.groupFrames or {}) do
+        if frame and frame.buttons then
+            for _, button in ipairs(frame.buttons) do
+                local buttonData = button and button.buttonData
+                if buttonData and buttonData.type == "spell" and not buttonData.isPassive then
+                    AddCastButtonIndexEntry(index, buttonData.id, button)
+                    local overrideID = C_Spell
+                        and C_Spell.GetOverrideSpell
+                        and C_Spell.GetOverrideSpell(buttonData.id)
+                    if overrideID and overrideID ~= 0 and overrideID ~= buttonData.id then
+                        AddCastButtonIndexEntry(index, overrideID, button)
+                    end
+                    local baseID = C_Spell
+                        and C_Spell.GetBaseSpell
+                        and C_Spell.GetBaseSpell(buttonData.id)
+                    if baseID and baseID ~= 0 and baseID ~= buttonData.id then
+                        AddCastButtonIndexEntry(index, baseID, button)
+                    end
+                    if button._displaySpellId and button._displaySpellId ~= buttonData.id then
+                        AddCastButtonIndexEntry(index, button._displaySpellId, button)
+                    end
+                end
+            end
+        end
+    end
+    addon._castButtonIndex = index
+    addon._castButtonIndexDirty = nil
+    return index
+end
+
+local function RecordChargeSpentForCastButton(addon, button, buttonData, spellID)
+    if not (buttonData and buttonData.type == "spell" and not buttonData.isPassive) then
+        return false
+    end
+
+    local displaySpellID = button._displaySpellId or buttonData.id
+    if spellID ~= buttonData.id and spellID ~= displaySpellID then
+        return false
+    end
+
+    if addon.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
+        -- Track charge consumption for restricted-mode color heuristic.
+        -- _chargeRecharging at event time reflects the PRE-cast state:
+        --   false = casting from full charges -> reset to 1
+        --   true  = already recharging -> increment
+        EntryRuntime.RecordChargeSpent(button)
+        return true
+    end
+    return false
+end
+
+local function VisitIndexedCastButtons(addon, spellID, baseSpellID, callback)
+    local index = addon._castButtonIndex
+    if addon._castButtonIndexDirty or type(index) ~= "table" then
+        index = RebuildCastButtonIndex(addon)
+    end
+
+    local seen = addon._castButtonVisitSeen
+    if seen then
+        wipe(seen)
+    else
+        seen = {}
+        addon._castButtonVisitSeen = seen
+    end
+
+    local handled = false
+    local foundStaleEntry = false
+
+    local function visit(eventSpellID)
+        local buttons = eventSpellID and index[eventSpellID]
+        if not buttons then
+            return
+        end
+
+        for _, button in ipairs(buttons) do
+            if button and not seen[button] then
+                seen[button] = true
+                local groupId = button._groupId
+                local frame = groupId and addon.groupFrames and addon.groupFrames[groupId] or nil
+                local buttonData = button.buttonData
+                if frame and frame.buttons and buttonData and button._pooled ~= true then
+                    handled = callback(button, buttonData, frame, eventSpellID) or handled
+                else
+                    foundStaleEntry = true
+                end
+            end
+        end
+    end
+
+    visit(spellID)
+    if baseSpellID ~= spellID then
+        visit(baseSpellID)
+    end
+
+    if foundStaleEntry then
+        addon._castButtonIndexDirty = true
+    end
+    return handled
+end
+
+local function RecordIndexedCastButtons(addon, spellID)
+    if not spellID then
+        return false
+    end
+
+    return VisitIndexedCastButtons(addon, spellID, nil, function(button, buttonData)
+        return RecordChargeSpentForCastButton(addon, button, buttonData, spellID)
+    end)
+end
+
+function CooldownCompanion:CollectCooldownEventButtonsForSpell(spellID, baseSpellID)
+    if not spellID and not baseSpellID then
+        return nil
+    end
+
+    local collected = self._cooldownEventButtonsScratch
+    if collected then
+        wipe(collected)
+    else
+        collected = {}
+        self._cooldownEventButtonsScratch = collected
+    end
+
+    VisitIndexedCastButtons(self, spellID, baseSpellID, function(button, _, frame)
+        if frame and frame.IsShown and frame:IsShown() and button.UpdateCooldown then
+            table_insert(collected, button)
+            return true
+        end
+        return false
+    end)
+
+    return #collected > 0 and collected or nil
+end
+
+function SatisfyQueuedActionbarCooldownRefresh(addon)
+    local queuedEvent = addon._queuedCooldownRefreshEvent
+    if queuedEvent == "ACTIONBAR_UPDATE_COOLDOWN"
+            and addon.SatisfyQueuedCooldownRefresh then
+        addon:SatisfyQueuedCooldownRefresh("cooldown-event")
+        return true
+    end
+    return false
+end
+
+function CooldownCompanion:InvalidateCastCountEventIndex()
+    self._castCountEventIndexDirty = true
+end
+
+local function AddCastCountEventIndexEntry(index, eventSpellID, buttonData)
+    if not eventSpellID then
+        return
+    end
+
+    local entries = index[eventSpellID]
+    if not entries then
+        entries = {}
+        index[eventSpellID] = entries
+    end
+    table_insert(entries, buttonData)
+end
+
+local function RebuildCastCountEventIndex(addon)
+    local index = {}
+    local getEventSpells = addon.GetConditionalCastCountEventSpells
+    local groups = addon.db and addon.db.profile and addon.db.profile.groups
+    if getEventSpells and groups then
+        for _, group in pairs(groups) do
+            for _, buttonData in ipairs(group.buttons or {}) do
+                if buttonData.type == "spell" and not buttonData.hasCharges then
+                    local eventSpells = getEventSpells(buttonData)
+                    if eventSpells then
+                        for eventSpellID in pairs(eventSpells) do
+                            AddCastCountEventIndexEntry(index, eventSpellID, buttonData)
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    addon._castCountEventIndex = index
+    addon._castCountEventIndexDirty = nil
+    return index
+end
+
+local function MarkConditionalCastCountCandidates(addon, spellID, baseSpellID)
+    local matchesConditionalCastCountEvent = addon.MatchesConditionalCastCountEvent
+    if not matchesConditionalCastCountEvent then
+        return false
+    end
+
+    local index = addon._castCountEventIndex
+    if addon._castCountEventIndexDirty or type(index) ~= "table" then
+        index = RebuildCastCountEventIndex(addon)
+    end
+
+    local seen = addon._castCountEventSeen
+    if seen then
+        wipe(seen)
+    else
+        seen = {}
+        addon._castCountEventSeen = seen
+    end
+
+    local matched = false
+    local function markEntriesFor(eventSpellID)
+        local entries = eventSpellID and index[eventSpellID]
+        if not entries then
+            return
+        end
+
+        for _, buttonData in ipairs(entries) do
+            if not seen[buttonData] then
+                seen[buttonData] = true
+                if buttonData.type == "spell"
+                        and not buttonData.hasCharges
+                        and matchesConditionalCastCountEvent(buttonData, spellID, baseSpellID) then
+                    buttonData._castCountCandidate = true
+                    buttonData._castCountEventSpellID = spellID
+                    buttonData._castCountSelf = (buttonData.id == spellID) or nil
+                    matched = true
+                end
+            end
+        end
+    end
+
+    markEntriesFor(spellID)
+    if baseSpellID ~= spellID then
+        markEntriesFor(baseSpellID)
+    end
+    return matched
 end
 
 function CooldownCompanion:OnDisable()
@@ -375,22 +735,7 @@ end
 
 function CooldownCompanion:OnChargesChanged(event, spellID, baseSpellID)
     if event == "SPELL_UPDATE_USES" and spellID then
-        local matchesConditionalCastCountEvent = CooldownCompanion.MatchesConditionalCastCountEvent
-        local matchedCastCountButton = false
-        for _, group in pairs(self.db.profile.groups) do
-            for _, bd in ipairs(group.buttons) do
-                if bd.type == "spell"
-                        and not bd.hasCharges
-                        and matchesConditionalCastCountEvent
-                        and matchesConditionalCastCountEvent(bd, spellID, baseSpellID) then
-                    bd._castCountCandidate = true
-                    bd._castCountEventSpellID = spellID
-                    bd._castCountSelf = (bd.id == spellID) or nil
-                    matchedCastCountButton = true
-                end
-            end
-        end
-        if matchedCastCountButton then
+        if MarkConditionalCastCountCandidates(self, spellID, baseSpellID) then
             self._hasDisplayCountCandidates = true
         end
     end
@@ -413,25 +758,14 @@ end
 
 function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
     if unit == "player" then
-        self:ForEachButton(function(button, buttonData)
-            if buttonData.type == "spell"
-                and not buttonData.isPassive then
-                local displaySpellID = button._displaySpellId or buttonData.id
-                if spellID == buttonData.id or spellID == displaySpellID then
-                    if self.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
-                        -- Track charge consumption for restricted-mode color heuristic.
-                        -- _chargeRecharging at event time reflects the PRE-cast state:
-                        --   false = casting from full charges → reset to 1
-                        --   true  = already recharging → increment
-                        EntryRuntime.RecordChargeSpent(button)
-                    end
-                end
-            end
-        end)
+        local recordedCastState = RecordIndexedCastButtons(self, spellID)
+        local recordedCustomBarState = false
         if self.RecordCustomBarSpellCast then
-            self:RecordCustomBarSpellCast(spellID)
+            recordedCustomBarState = self:RecordCustomBarSpellCast(spellID) == true
         end
-        self:QueueCooldownRefresh("cast-event")
+        if recordedCastState or recordedCustomBarState then
+            self:QueueCooldownRefresh("cast-event")
+        end
     end
 end
 

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -15,7 +15,6 @@ local ipairs = ipairs
 local select = select
 local table_insert = table.insert
 local type = type
-local GetTime = GetTime
 
 -- Import cross-file variables
 local defaults = ST._defaults
@@ -26,7 +25,6 @@ local minimapButton = ST._minimapButton
 local LSM = LibStub("LibSharedMedia-3.0")
 
 local SatisfyQueuedActionbarCooldownRefresh
-local ACTIONBAR_COOLDOWN_FALLBACK_INTERVAL = 0.5
 
 -- Viewer frame list used by BuildViewerAuraMap, FindViewerChildForSpell, and OnEnable hooks.
 local VIEWER_NAMES = {
@@ -318,24 +316,27 @@ function CooldownCompanion:OnEnable()
 end
 
 function CooldownCompanion:OnCooldownStateChanged(event, spellID, baseSpellID, category, startRecoveryCategory)
-    if self:ShouldSkipActionbarCooldownEvent(event) then
-        return
-    end
-
     if self:ShouldSkipStartRecoveryOnlyCooldownEvent(event, spellID, category, startRecoveryCategory) then
         SatisfyQueuedActionbarCooldownRefresh(self)
         return
     end
 
-    if self.UpdateItemCooldownButtonsForEvent
-            and (
-                event == "BAG_UPDATE_COOLDOWN"
-                or (event == "ACTIONBAR_UPDATE_COOLDOWN" and not self:HasGCDSwipeRefreshConsumers())
-            ) then
+    if event == "BAG_UPDATE_COOLDOWN" and self.UpdateItemCooldownButtonsForEvent then
         self:UpdateItemCooldownButtonsForEvent()
         return
     end
 
+    if event == "ACTIONBAR_UPDATE_COOLDOWN" and not self:HasGCDSwipeRefreshConsumers() then
+        if self.UpdateItemCooldownButtonsForEvent then
+            self:UpdateItemCooldownButtonsForEvent()
+        end
+        if self.UpdateCooldownButtonsForActionbarEvent then
+            self:UpdateCooldownButtonsForActionbarEvent()
+        end
+        return
+    end
+
+    local hadPendingDirty = self._cooldownsDirty == true
     self:MarkCooldownsDirty()
     if event == "SPELL_UPDATE_COOLDOWN"
             and spellID
@@ -343,12 +344,15 @@ function CooldownCompanion:OnCooldownStateChanged(event, spellID, baseSpellID, c
             and not self:HasGCDSwipeRefreshConsumers()
             and self.UpdateCooldownButtonsForSpellEvent then
         if self:UpdateCooldownButtonsForSpellEvent(spellID, baseSpellID) then
-            if not SatisfyQueuedActionbarCooldownRefresh(self) then
-                self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+            if not hadPendingDirty then
+                if not SatisfyQueuedActionbarCooldownRefresh(self) then
+                    self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+                end
             end
         else
-            SatisfyQueuedActionbarCooldownRefresh(self)
-            self._cooldownRefreshSatisfiedSerial = self._cooldownDirtySerial or 0
+            if not hadPendingDirty then
+                SatisfyQueuedActionbarCooldownRefresh(self)
+            end
         end
         return
     end
@@ -376,46 +380,22 @@ function CooldownCompanion:HasGCDSwipeRefreshConsumers()
             if style and style.showGCDSwipe == true then
                 return true
             end
+            for _, button in ipairs(frame.buttons or {}) do
+                local buttonStyle = button and button.style
+                if button and button._pooled ~= true
+                        and buttonStyle and buttonStyle.showGCDSwipe == true then
+                    return true
+                end
+            end
         end
     end
     return false
 end
 
 function CooldownCompanion:ShouldSkipStartRecoveryOnlyCooldownEvent(event, spellID, category, startRecoveryCategory)
-    if event ~= "SPELL_UPDATE_COOLDOWN" or not spellID or not startRecoveryCategory then
-        return false
-    end
-    if category and category ~= 0 then
-        return false
-    end
-    return not self:HasGCDSwipeRefreshConsumers()
-end
-
-function CooldownCompanion:ShouldSkipActionbarCooldownEvent(event)
-    if event ~= "ACTIONBAR_UPDATE_COOLDOWN" then
-        return false
-    end
-    if self:HasGCDSwipeRefreshConsumers() then
-        return false
-    end
-
-    local gcdInfo = C_Spell.GetSpellCooldown(61304)
-    if gcdInfo and gcdInfo.isActive == true then
-        return true, "gcd-only-actionbar-event"
-    end
-
-    local now = type(GetTime) == "function" and GetTime() or nil
-    if not now then
-        return false
-    end
-
-    local lastFallbackAt = self._lastActionbarCooldownFallbackAt
-    local interval = self._actionbarCooldownFallbackInterval or ACTIONBAR_COOLDOWN_FALLBACK_INTERVAL
-    if lastFallbackAt and now - lastFallbackAt < interval then
-        return true, "actionbar-fallback-throttle"
-    end
-
-    self._lastActionbarCooldownFallbackAt = now
+    -- Conservatively keep these events on the normal spell refresh path. The
+    -- payload alone does not prove that a start-recovery category excludes a
+    -- real tracked spell cooldown, especially for no-category cooldowns.
     return false
 end
 
@@ -508,7 +488,9 @@ local function RecordChargeSpentForCastButton(addon, button, buttonData, spellID
         EntryRuntime.RecordChargeSpent(button)
         return true
     end
-    return false
+    return addon.HasCastCountText
+        and addon.HasCastCountText(buttonData)
+        or false
 end
 
 local function VisitIndexedCastButtons(addon, spellID, baseSpellID, callback)
@@ -591,6 +573,55 @@ function CooldownCompanion:CollectCooldownEventButtonsForSpell(spellID, baseSpel
         return false
     end)
 
+    return #collected > 0 and collected or nil
+end
+
+function CooldownCompanion:CollectCooldownEventButtonsForActionbar()
+    local index = self._castButtonIndex
+    if self._castButtonIndexDirty or type(index) ~= "table" then
+        index = RebuildCastButtonIndex(self)
+    end
+
+    local collected = self._cooldownEventActionbarButtonsScratch
+    if collected then
+        wipe(collected)
+    else
+        collected = {}
+        self._cooldownEventActionbarButtonsScratch = collected
+    end
+
+    local seen = self._cooldownEventActionbarButtonsSeen
+    if seen then
+        wipe(seen)
+    else
+        seen = {}
+        self._cooldownEventActionbarButtonsSeen = seen
+    end
+
+    local foundStaleEntry = false
+    for _, buttons in pairs(index) do
+        for _, button in ipairs(buttons) do
+            if button and not seen[button] then
+                seen[button] = true
+                local groupId = button._groupId
+                local frame = groupId and self.groupFrames and self.groupFrames[groupId] or nil
+                local buttonData = button.buttonData
+                if frame and frame.IsShown and frame:IsShown()
+                        and frame.buttons
+                        and buttonData
+                        and button.UpdateCooldown
+                        and button._pooled ~= true then
+                    table_insert(collected, button)
+                else
+                    foundStaleEntry = true
+                end
+            end
+        end
+    end
+
+    if foundStaleEntry then
+        self._castButtonIndexDirty = true
+    end
     return #collected > 0 and collected or nil
 end
 

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -704,8 +704,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
     end
 
     function CooldownCompanion:RecordCustomBarSpellCast(spellID)
-        if not spellID then return end
+        if not spellID then return false end
 
+        local recorded = false
         for _, barInfo in ipairs(resourceBarFrames) do
             local bar = barInfo and barInfo.frame
             local cabConfig = barInfo and barInfo.cabConfig
@@ -726,9 +727,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 if (maxCharges or 0) > 1
                     and (spellID == baseSpellID or spellID == runtimeSpellID) then
                     EntryRuntime.RecordChargeSpent(bar)
+                    recorded = true
                 end
             end
         end
+        return recorded
     end
 
     local function GetHiddenCustomAuraWakeUnit(cabConfig)


### PR DESCRIPTION
## What Players Will Notice
- Cooldown Companion should spend less time doing broad cooldown refresh work after common events like ability casts, actionbar cooldown updates, target changes, range changes, and power changes.
- Tracked cooldowns, trigger panels, unusable visuals, range state, cast-count displays, and target aura displays should continue updating accurately while those refreshes are narrowed.

## Why This Changed
- Ability use and target switching could fan out into full refresh passes even when only a small set of displayed buttons needed work.
- The goal was to reduce redundant CPU work without trading away tracker accuracy, especially around the paths players hit constantly in combat.

## What Changed
- Added cooldown refresh queue bookkeeping so same-frame cooldown work can be coalesced and ticker confirmation can be skipped only when a matching refresh safely satisfied the dirty state.
- Added targeted refresh paths for spell, actionbar, item, range, aura, cast-count, and power-sensitive button updates instead of walking every displayed cooldown for every event.
- Kept safety fallbacks for accuracy: full maintenance scans still run periodically, start-recovery cooldown events stay on the normal spell refresh path, and narrowed trigger/power/periodic refreshes refresh their aggregate trigger visuals when needed.
- Invalidated the new indexes when button frames are rebuilt, unloaded, recovered, or when display spell IDs change.

## Validation
- `luac -p` passed for all changed Lua files.
- Local Lua validation passed: `cooldown-refresh-queue`, `unit-aura-event-boundary`, `config-loader`, `pandemic-state-invariants`, `alpha-driver-idle`, `group-style-update-fast-path`, and `group-button-frame-pooling`.
- `git diff --check` passed; Git only reported LF-to-CRLF working-copy warnings.
- Ran an 8-cohort parallel static review/fix loop against `origin/main`; the final four-reviewer cohort returned `Findings: NO ACTIONABLE FINDINGS`.
- In-game validation has not been performed yet. Combat and restricted-content testing is still needed for ability casts, actionbar/item cooldown events, target aura switching, and power-driven unusable/trigger/text visuals.