### PR TITLE
Reduce target and aura refresh work

### DIFF
--- a/CooldownCompanion/CooldownCompanion.toc
+++ b/CooldownCompanion/CooldownCompanion.toc
@@ -54,6 +54,7 @@ Core\BarsAndFramesRuntime.lua
 Core\SoundAlerts.lua
 Core\StyleOverrides.lua
 Core\CooldownRefresh.lua
+Core\RefreshScope.lua
 Core\Lifecycle.lua
 Core\Aura.lua
 Core\EventHandlers.lua

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -519,7 +519,12 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- the time this handler fires the CDM has already refreshed its children
     -- with fresh auraInstanceID data. Bursts later in the same frame coalesce.
     if unit == "target" or unit == "player" then
-        self:RunImmediateCooldownRefresh("aura-event")
+        self:RunImmediateCooldownRefresh({
+            kind = "unit-aura",
+            source = "aura-event",
+            event = event,
+            unit = unit,
+        })
     end
 end
 
@@ -567,7 +572,12 @@ function CooldownCompanion:OnTargetChanged()
     -- been processed by the time PLAYER_TARGET_CHANGED fires, the CDM children
     -- will have fresh auraInstanceID data.  Probing immediately lets the
     -- primary path clear _targetSwitchAt in the same frame — zero hold.
-    self:UpdateAllCooldowns()
+    self:UpdateAllCooldowns({
+        kind = "target-changed",
+        source = "target-event",
+        event = "PLAYER_TARGET_CHANGED",
+        unit = "target",
+    })
 end
 
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -8,6 +8,8 @@
     - _queuedCooldownRefreshSource: pending queued refresh source; also the
       queue-pending flag checked by the ticker. Last writer wins; this is only
       a debug breadcrumb, not skip eligibility.
+    - _queuedCooldownRefreshReason: structured pending reason passed to the
+      eventual refresh walk. Ambiguous combinations escalate to full refresh.
     - _queuedCooldownRefreshCooldownEventSerial: dirty serial captured when a
       queued cooldown-event request enters the queue.
     - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
@@ -61,11 +63,12 @@ end
 
 function CooldownCompanion:FlushQueuedCooldownRefresh()
     local queuedSource = self._queuedCooldownRefreshSource
+    local queuedReason = self._queuedCooldownRefreshReason
     local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
     self:ResetCooldownRefreshState()
 
     if queuedSource then
-        self:UpdateAllCooldowns()
+        self:UpdateAllCooldowns(queuedReason)
         if cooldownEventSerial then
             self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
         end
@@ -73,7 +76,11 @@ function CooldownCompanion:FlushQueuedCooldownRefresh()
 end
 
 function CooldownCompanion:QueueCooldownRefresh(source)
-    self._queuedCooldownRefreshSource = source or "event"
+    local reason = self:NormalizeCooldownRefreshReason(source, "queued-refresh")
+    self._queuedCooldownRefreshReason = self:CombineCooldownRefreshReasons(self._queuedCooldownRefreshReason, reason)
+    self._queuedCooldownRefreshSource = self:GetCooldownRefreshReasonSource(self._queuedCooldownRefreshReason or source)
+
+    source = self:GetCooldownRefreshReasonSource(source)
     if source == "cooldown-event" then
         self._queuedCooldownRefreshCooldownEventSerial = self._cooldownDirtySerial or 0
     end
@@ -86,16 +93,23 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
         return
     end
 
-    local cooldownEventSerial
-    if source == "cooldown-event" then
+    local reason = self:NormalizeCooldownRefreshReason(source, "immediate-refresh")
+    if self._queuedCooldownRefreshSource then
+        reason = self:CombineCooldownRefreshReasons(self._queuedCooldownRefreshReason, reason)
+    end
+
+    local refreshSource = self:GetCooldownRefreshReasonSource(source)
+    local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
+    if refreshSource == "cooldown-event" then
         cooldownEventSerial = self._cooldownDirtySerial or 0
     end
 
     self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshReason = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
-    self:UpdateAllCooldowns()
+    self:UpdateAllCooldowns(reason)
     if cooldownEventSerial then
         self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
     end
@@ -110,7 +124,11 @@ end
 
 function CooldownCompanion:TickCooldownRefresh()
     if self._queuedCooldownRefreshSource then
+        local queuedReasonScoped = self:IsScopedCooldownRefreshReason(self._queuedCooldownRefreshReason)
         self:FlushQueuedCooldownRefresh()
+        if queuedReasonScoped and self._cooldownsDirty and not self:CanSkipTickerCooldownRefresh() then
+            self:UpdateAllCooldowns()
+        end
         return false
     end
     if self:CanSkipTickerCooldownRefresh() then
@@ -126,6 +144,7 @@ function CooldownCompanion:ResetCooldownRefreshState()
     end
     self._cooldownRefreshQueueArmed = nil
     self._queuedCooldownRefreshSource = nil
+    self._queuedCooldownRefreshReason = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
 end

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -1948,10 +1948,8 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     end)
 
     -- Update functions
-    frame.UpdateCooldowns = function(self)
-        for _, button in ipairs(self.buttons) do
-            button:UpdateCooldown()
-        end
+    frame.UpdateCooldowns = function(self, refreshReason, collectStats)
+        return CooldownCompanion:UpdateGroupFrameCooldownButtons(self, refreshReason, collectStats)
     end
     
     frame.Refresh = function(self)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2367,7 +2367,11 @@ function CooldownCompanion:DiscardDormantFrame(groupId)
     end
 end
 
-function CooldownCompanion:UpdateAllCooldowns()
+function CooldownCompanion:UpdateAllCooldowns(refreshReason)
+    if refreshReason ~= nil and self.NormalizeCooldownRefreshReason then
+        refreshReason = self:NormalizeCooldownRefreshReason(refreshReason, "update-all")
+    end
+
     self._gcdInfo = C_Spell.GetSpellCooldown(61304)
     -- GCD activity: isActive is NeverSecret (12.0.1 hotfix)
     self._gcdActive = self._gcdInfo and self._gcdInfo.isActive or false
@@ -2387,14 +2391,40 @@ function CooldownCompanion:UpdateAllCooldowns()
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
     self._cooldownUpdatePassActive = true
+    local scoped = self.IsScopedCooldownRefreshReason
+        and self:IsScopedCooldownRefreshReason(refreshReason)
+    local collectStats = scoped or self._collectCooldownRefreshStats == true
+    local stats
+    if collectStats then
+        stats = {
+            reason = refreshReason,
+            updatedGroupCount = 0,
+            skippedGroupCount = 0,
+            updatedButtonCount = 0,
+            skippedButtonCount = 0,
+        }
+    end
 
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
-            frame:UpdateCooldowns()
+            local updatedButtons, skippedButtons = frame:UpdateCooldowns(refreshReason, collectStats)
+            if stats then
+                updatedButtons = updatedButtons or 0
+                skippedButtons = skippedButtons or 0
+                if updatedButtons > 0 then
+                    stats.updatedGroupCount = stats.updatedGroupCount + 1
+                else
+                    stats.skippedGroupCount = stats.skippedGroupCount + 1
+                end
+                stats.updatedButtonCount = stats.updatedButtonCount + updatedButtons
+                stats.skippedButtonCount = stats.skippedButtonCount + skippedButtons
+            end
         end
     end
 
     self._cooldownUpdatePassActive = nil
+    self._lastCooldownRefreshStats = stats
+    return stats
 end
 
 function CooldownCompanion:UpdateAllGroupLayouts()

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -220,7 +220,12 @@ function CooldownCompanion:OnEnable()
                 ST._QueueInheritedUnitFrameAlphaResync()
             end
             self:MarkCooldownsDirty()
-            self:UpdateAllCooldowns()
+            self:UpdateAllCooldowns({
+                kind = "unit-target",
+                source = "target-event",
+                event = event,
+                unit = "target",
+            })
         end)
     end
     self._unitTargetFrame:RegisterUnitEvent("UNIT_TARGET", "player")

--- a/CooldownCompanion/Core/RefreshScope.lua
+++ b/CooldownCompanion/Core/RefreshScope.lua
@@ -1,0 +1,242 @@
+--[[
+    CooldownCompanion - Core/RefreshScope.lua: structured refresh reasons and
+    conservative target/aura scoped refresh predicates.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local SCOPED_REASON_KINDS = {
+    ["target-changed"] = true,
+    ["unit-target"] = true,
+    ["unit-aura"] = true,
+}
+
+local function CopyReason(reason)
+    if type(reason) ~= "table" then
+        return nil
+    end
+    local copy = {}
+    for key, value in pairs(reason) do
+        copy[key] = value
+    end
+    return copy
+end
+
+local function FullReason(source, fallbackOrigin, fallbackReason)
+    return {
+        kind = "full",
+        source = source or "event",
+        origin = fallbackOrigin,
+        broad = true,
+        fallbackReason = fallbackReason,
+    }
+end
+
+function CooldownCompanion:NormalizeCooldownRefreshReason(reasonOrSource, fallbackOrigin)
+    if type(reasonOrSource) ~= "table" then
+        return FullReason(reasonOrSource, fallbackOrigin, "string-or-empty-source")
+    end
+
+    local kind = reasonOrSource.kind
+    if not SCOPED_REASON_KINDS[kind] then
+        local reason = CopyReason(reasonOrSource) or {}
+        reason.kind = kind or "full"
+        reason.source = reason.source or "event"
+        reason.origin = reason.origin or fallbackOrigin
+        reason.broad = true
+        reason.fallbackReason = reason.fallbackReason or "unsupported-kind"
+        return reason
+    end
+
+    local unit = reasonOrSource.unit
+    if kind == "unit-aura" and unit ~= "player" and unit ~= "target" then
+        return FullReason(reasonOrSource.source, fallbackOrigin, "unsupported-aura-unit")
+    end
+    if (kind == "target-changed" or kind == "unit-target") and unit ~= nil and unit ~= "target" then
+        return FullReason(reasonOrSource.source, fallbackOrigin, "unsupported-target-unit")
+    end
+
+    local reason = CopyReason(reasonOrSource) or {}
+    reason.source = reason.source or "event"
+    reason.origin = reason.origin or fallbackOrigin
+    reason.unit = unit or "target"
+    reason.broad = false
+    return reason
+end
+
+function CooldownCompanion:GetCooldownRefreshReasonSource(reason)
+    if type(reason) == "table" then
+        return reason.source or reason.kind or "event"
+    end
+    return reason or "event"
+end
+
+function CooldownCompanion:IsScopedCooldownRefreshReason(reason)
+    return type(reason) == "table"
+        and reason.broad ~= true
+        and SCOPED_REASON_KINDS[reason.kind] == true
+end
+
+function CooldownCompanion:CombineCooldownRefreshReasons(existingReason, nextReason)
+    if not existingReason then
+        return nextReason
+    end
+    if not nextReason then
+        return existingReason
+    end
+
+    local existing = self:NormalizeCooldownRefreshReason(existingReason, "combine-existing")
+    local nextValue = self:NormalizeCooldownRefreshReason(nextReason, "combine-next")
+
+    if not self:IsScopedCooldownRefreshReason(existing) or not self:IsScopedCooldownRefreshReason(nextValue) then
+        return FullReason(nextValue.source or existing.source, "combine", "mixed-full-or-unsupported")
+    end
+
+    if existing.kind == nextValue.kind and existing.unit == nextValue.unit then
+        return nextValue
+    end
+
+    if (existing.kind == "target-changed" or existing.kind == "unit-target")
+        and (nextValue.kind == "target-changed" or nextValue.kind == "unit-target") then
+        return nextValue
+    end
+
+    return FullReason(nextValue.source or existing.source, "combine", "mixed-scoped-reasons")
+end
+
+local function ButtonHasAuraDependency(button, buttonData, unit)
+    if not (buttonData and (buttonData.auraTracking == true or buttonData.isPassive == true)) then
+        return false
+    end
+    local configUnit = buttonData.auraUnit or "player"
+    return (button and button._auraUnit == unit) or configUnit == unit
+end
+
+local function TextSegmentsUseToken(segments, tokenName)
+    if type(segments) ~= "table" then
+        return false
+    end
+    for _, segment in ipairs(segments) do
+        if segment.type == "token" and segment.value == tokenName then
+            return true
+        end
+        if segment.type == "cond_start" and segment.value == tokenName then
+            return true
+        end
+        if TextSegmentsUseToken(segment.children, tokenName) then
+            return true
+        end
+    end
+    return false
+end
+
+local function ButtonUsesAssistedTargetGate(button, buttonData)
+    if not (button and button.assistedHighlight and buttonData and buttonData.type == "spell") then
+        return false
+    end
+    local style = button.style
+    return style
+        and style.showAssistedHighlight == true
+        and style.assistedHighlightHostileTargetOnly ~= false
+end
+
+local function ButtonUsesUnusableTargetGate(button, buttonData)
+    if buttonData.isPassive == true or buttonData.isPassiveCooldown == true then
+        return false
+    end
+    local style = button and button.style
+    if buttonData.hideWhileUnusable == true then
+        return true
+    end
+    if not (style and style.showUnusable == true) then
+        return false
+    end
+    if ST.GetUnusableVisualMode then
+        return ST.GetUnusableVisualMode(style) ~= ST.UNUSABLE_VISUAL_MODE_NONE
+    end
+    return true
+end
+
+local function ButtonUsesTargetRangeOrUsability(addon, button, buttonData)
+    if not buttonData then
+        return false
+    end
+
+    local style = button and button.style
+    local isSpell = buttonData.type == "spell"
+        and buttonData.isPassive ~= true
+        and buttonData.isPassiveCooldown ~= true
+    local isItemLike = addon.IsEntryItemLike and addon.IsEntryItemLike(buttonData)
+    if not (isSpell or isItemLike or buttonData.type == "equipitem") then
+        return false
+    end
+
+    if style and style.showOutOfRange == true then
+        return true
+    end
+    if ButtonUsesAssistedTargetGate(button, buttonData) then
+        return true
+    end
+    if ButtonUsesUnusableTargetGate(button, buttonData) then
+        return true
+    end
+    if button and button._isText and (
+        TextSegmentsUseToken(button._textSegments, "oor")
+        or TextSegmentsUseToken(button._textSegments, "unusable")
+    ) then
+        return true
+    end
+    if addon.TriggerRowUsesCondition then
+        return addon:TriggerRowUsesCondition(buttonData, "rangeActive")
+            or addon:TriggerRowUsesCondition(buttonData, "usable")
+    end
+    return false
+end
+
+function CooldownCompanion:ButtonMatchesCooldownRefreshReason(button, buttonData, reason)
+    if not self:IsScopedCooldownRefreshReason(reason) then
+        return true
+    end
+    if not buttonData then
+        return false
+    end
+    if buttonData._rotationAssistantVirtual == true then
+        return true
+    end
+
+    if reason.kind == "unit-aura" then
+        return ButtonHasAuraDependency(button, buttonData, reason.unit)
+    end
+
+    if reason.kind == "target-changed" or reason.kind == "unit-target" then
+        return ButtonHasAuraDependency(button, buttonData, "target")
+            or ButtonUsesTargetRangeOrUsability(self, button, buttonData)
+    end
+
+    return true
+end
+
+function CooldownCompanion:UpdateGroupFrameCooldownButtons(frame, refreshReason, collectStats)
+    local scoped = self:IsScopedCooldownRefreshReason(refreshReason)
+    local canFilter = scoped and self.ButtonMatchesCooldownRefreshReason
+    if not canFilter and not collectStats then
+        for _, button in ipairs(frame.buttons) do
+            button:UpdateCooldown()
+        end
+        return nil, nil
+    end
+
+    local updatedCount = 0
+    local skippedCount = 0
+    for _, button in ipairs(frame.buttons) do
+        if not canFilter
+            or self:ButtonMatchesCooldownRefreshReason(button, button.buttonData, refreshReason) then
+            button:UpdateCooldown()
+            updatedCount = updatedCount + 1
+        else
+            skippedCount = skippedCount + 1
+        end
+    end
+    return updatedCount, skippedCount
+end


### PR DESCRIPTION
## What Players Will Notice
- Target switching and target/player aura updates should do less unnecessary display-refresh work, especially on profiles with several active panels.
- Displays should remain accurate while target/aura-driven refreshes skip buttons that are not relevant to that event.

## Why This Changed
- Profiling showed target switches and aura updates were contributing to CPU bursts because they refreshed every active cooldown button even when only target- or aura-dependent entries could change.
- The previous refresh path was intentionally accurate but too broad for event-specific updates.

## What Changed
- Added structured cooldown refresh reasons so target-change, unit-target, and unit-aura events can carry their cause through the refresh queue.
- Added conservative scoped-refresh matching for target aura dependencies, player aura dependencies, target range/usability gates, assisted rotation target gates, unusable visibility/tint gates, and rotation assistant virtual entries.
- Updated group refreshes to skip irrelevant buttons for scoped target/aura reasons while falling back to full active-surface refreshes when causes are ambiguous or mixed with broad cooldown work.
- Preserved full refresh behavior for cooldown-event and ticker paths; those remain the next optimization target rather than part of this PR.

## Validation
- `lua tests/refresh-scope.lua`
- `lua tests/cooldown-refresh-queue.lua`
- `lua tests/unit-aura-event-boundary.lua`
- `lua .local-tools/cdc-profiler/self-check.lua`
- `luac -p CooldownCompanion/Core/RefreshScope.lua CooldownCompanion/Core/CooldownRefresh.lua CooldownCompanion/Core/GroupOperations.lua CooldownCompanion/Core/GroupFrame.lua CooldownCompanion/Core/Aura.lua CooldownCompanion/Core/Lifecycle.lua .local-tools/cdc-profiler/CooldownCompanion_Profiler/CooldownCompanionAdapter.lua .local-tools/cdc-profiler/self-check.lua`
- `git diff --check origin/perf-main...HEAD`
- In-game profiler validation:
  - `target-switch-clean-01`: target refreshes stayed scoped with no target-event full fallback.
  - `target-aura-expire-clean-01`: target/player aura refreshes stayed scoped.
  - `combat-target-switch-clean-01`: combat target refreshes stayed scoped with no target-event full fallback.
  - `combat-target-aura-expire-clean-01`: combat target/player aura refreshes stayed scoped.
  - `restricted-combat-smoke-01`: no Lua errors, displays looked correct, no profiler warnings, and target refreshes stayed scoped in restricted content.