### PR TITLE
Reduce cooldown refresh work during target and actionbar updates

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1917,6 +1917,7 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._noCooldownSpellId = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil
+    button._actionSlotCooldownFallback = nil
     button._resourceGateCost = nil
     button._resourceGateCostSpellId = nil
     button._baseResourceGateCost = nil

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1238,6 +1238,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
+                button._actionSlotCooldownFallback = spellCooldownResult.slotProbe ~= nil or nil
+                if spellCooldownResult.slotProbe then
+                    button._actionSlotCooldownCandidate = true
+                end
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
                 local renderDurationObj = spellCooldownResult.renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
@@ -1264,6 +1268,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 end
                 fetchOk = true
             elseif not fetchOk or auraOverrideActive then
+                button._actionSlotCooldownFallback = nil
                 button.cooldown:SetCooldown(0, 0)
             end
         elseif IsEntryItemLike(buttonData) then

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -611,8 +611,9 @@ function CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
         button.keybindText:SetShown(button.style and button.style.showKeybindText and text ~= nil)
     end
     if CacheButtonBindingKeys then
-        CacheButtonBindingKeys(button, buttonData)
+        return CacheButtonBindingKeys(button, buttonData)
     end
+    return false
 end
 
 local function GetLiveOverrideSpellID(buttonData)

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1439,6 +1439,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._noCooldownSpellId = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil
+    button._actionSlotCooldownFallback = nil
     button._resourceGateCost = nil
     button._resourceGateCostSpellId = nil
     button._baseResourceGateCost = nil

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -1251,6 +1251,7 @@ function CooldownCompanion:QueueBuildViewerAuraMap()
     C_Timer.After(0, function()
         if pendingViewerAuraMapToken ~= token then return end
         self:BuildViewerAuraMap()
+        self:QueueCooldownRefresh("viewer-map-event")
         self:RefreshConfigPanel()
     end)
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -28,6 +28,8 @@
       If another dirty mark lands before the flush, the later ticker walks
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
+    - Clean ticker passes do not perform a full cooldown walk. They only run the
+      scoped periodic path when active buttons have semantic polling needs.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -134,8 +136,18 @@ function CooldownCompanion:TickCooldownRefresh()
     if self:CanSkipTickerCooldownRefresh() then
         return true
     end
-    self:UpdateAllCooldowns()
-    return false
+    if self._cooldownsDirty then
+        self:UpdateAllCooldowns()
+        return false
+    end
+    if self:HasPeriodicCooldownRefreshCandidates() then
+        self:UpdateAllCooldowns({
+            kind = "periodic",
+            source = "ticker",
+        })
+        return false
+    end
+    return true
 end
 
 function CooldownCompanion:ResetCooldownRefreshState()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -130,6 +130,11 @@ function CooldownCompanion:TickCooldownRefresh()
         self:FlushQueuedCooldownRefresh()
         if queuedReasonScoped and self._cooldownsDirty and not self:CanSkipTickerCooldownRefresh() then
             self:UpdateAllCooldowns()
+        elseif not self._cooldownsDirty and self:HasPeriodicCooldownRefreshCandidates() then
+            self:UpdateAllCooldowns({
+                kind = "periodic",
+                source = "ticker",
+            })
         end
         return false
     end

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -773,6 +773,8 @@ function CooldownCompanion:ClearRotationAssistantButtonRuntime(button)
     button._baseNoCooldownSpellId = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil
+    button._actionSlotCooldownCandidate = nil
+    button._actionSlotCooldownFallback = nil
     button._resourceGateCost = nil
     button._resourceGateCostSpellId = nil
     button._baseResourceGateCost = nil

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -603,11 +603,13 @@ function CooldownCompanion:OnActionBarSlotChanged(_, slot)
         wipe(pendingSlotChangedSlots)
         self:RebuildAddonSlotBindings()
         self:OnKeybindsChanged()
+        self:QueueCooldownRefresh("actionbar-layout-event")
     end)
 end
 
 function CooldownCompanion:OnActionBarLayoutChanged()
     self:RefreshKeybindState()
+    self:QueueCooldownRefresh("actionbar-layout-event")
     -- UPDATE_OVERRIDE_ACTIONBAR / UPDATE_VEHICLE_ACTIONBAR also route here for
     -- keybind rebuilds; piggyback vehicle UI state check to avoid duplicate
     -- AceEvent registrations (AceEvent allows only one handler per event).

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -602,14 +602,18 @@ function CooldownCompanion:OnActionBarSlotChanged(_, slot)
         end
         wipe(pendingSlotChangedSlots)
         self:RebuildAddonSlotBindings()
-        self:OnKeybindsChanged()
-        self:QueueCooldownRefresh("actionbar-layout-event")
+        local actionSlotCooldownCandidateChanged = self:OnKeybindsChanged()
+        if actionSlotCooldownCandidateChanged then
+            self:QueueCooldownRefresh("actionbar-layout-event")
+        end
     end)
 end
 
 function CooldownCompanion:OnActionBarLayoutChanged()
-    self:RefreshKeybindState()
-    self:QueueCooldownRefresh("actionbar-layout-event")
+    local actionSlotCooldownCandidateChanged = self:RefreshKeybindState()
+    if actionSlotCooldownCandidateChanged then
+        self:QueueCooldownRefresh("actionbar-layout-event")
+    end
     -- UPDATE_OVERRIDE_ACTIONBAR / UPDATE_VEHICLE_ACTIONBAR also route here for
     -- keybind rebuilds; piggyback vehicle UI state check to avoid duplicate
     -- AceEvent registrations (AceEvent allows only one handler per event).

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -729,6 +729,8 @@ local function ClearReusableButtonRuntime(button)
     button._noCooldownSpellId = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil
+    button._actionSlotCooldownCandidate = nil
+    button._actionSlotCooldownFallback = nil
     button._resourceGateCost = nil
     button._resourceGateCostSpellId = nil
     button._baseResourceGateCost = nil
@@ -2540,6 +2542,9 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
                 PreparePooledButtonForUse(self, frame, group, button, i, buttonData, effectiveStyle)
             elseif buttonData._rotationAssistantVirtual == true and self.RefreshRotationAssistantButton then
                 self:RefreshRotationAssistantButton(button)
+            end
+            if not reusedButton then
+                RefreshButtonKeybindState(button, buttonData)
             end
 
             button:Show()

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -36,14 +36,14 @@ end
 
 local function RefreshButtonKeybindState(button, buttonData)
     if CooldownCompanion.RefreshResolvedItemKeybindState then
-        CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
-        return
+        return CooldownCompanion:RefreshResolvedItemKeybindState(button, buttonData)
     end
 
     local cache = ST._CacheButtonBindingKeys
     if cache then
-        cache(button, buttonData)
+        return cache(button, buttonData)
     end
+    return false
 end
 
 local function ClearButtonVisualState(button)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2380,13 +2380,9 @@ function CooldownCompanion:UpdateAllCooldowns(refreshReason)
 
     -- Assisted highlight target gate:
     -- hard target has priority; if none exists, allow soft enemy fallback.
-    local hasHostileTarget = false
-    if UnitExists("target") then
-        hasHostileTarget = UnitCanAttack("player", "target") and true or false
-    elseif UnitExists("softenemy") then
-        hasHostileTarget = UnitCanAttack("player", "softenemy") and true or false
+    if self.RefreshAssistedHighlightHostileTargetState then
+        self:RefreshAssistedHighlightHostileTargetState()
     end
-    self._assistedHighlightHasHostileTarget = hasHostileTarget
 
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1846,6 +1846,8 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._noCooldownSpellId = nil
                 button._baseNoCooldown = nil
                 button._baseNoCooldownSpellId = nil
+                button._actionSlotCooldownCandidate = nil
+                button._actionSlotCooldownFallback = nil
                 button._resourceGateCost = nil
                 button._resourceGateCostSpellId = nil
                 button._baseResourceGateCost = nil

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -349,6 +349,10 @@ local function CacheButtonBindingKeys(button, buttonData)
                 end
             end
         end
+
+        if buttonData.type == "spell" or buttonData._rotationAssistantVirtual == true then
+            button._actionSlotCooldownCandidate = slots ~= nil or nil
+        end
     end
     button._bindingKeyInfos = infos
     RefreshKeyPressHighlightEnrollment(button)

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -320,6 +320,7 @@ end
 -- Stores result as button._bindingKeyInfos (array of parsed structs, or empty table).
 local function CacheButtonBindingKeys(button, buttonData)
     local infos = {}
+    local actionSlotCooldownCandidateChanged = false
     if buttonData then
         local slots
         if buttonData._rotationAssistantVirtual == true then
@@ -351,11 +352,17 @@ local function CacheButtonBindingKeys(button, buttonData)
         end
 
         if buttonData.type == "spell" or buttonData._rotationAssistantVirtual == true then
-            button._actionSlotCooldownCandidate = slots ~= nil or nil
+            local actionSlotCooldownCandidate = slots ~= nil or nil
+            actionSlotCooldownCandidateChanged = button._actionSlotCooldownCandidate ~= actionSlotCooldownCandidate
+            button._actionSlotCooldownCandidate = actionSlotCooldownCandidate
+        elseif button._actionSlotCooldownCandidate ~= nil then
+            actionSlotCooldownCandidateChanged = true
+            button._actionSlotCooldownCandidate = nil
         end
     end
     button._bindingKeyInfos = infos
     RefreshKeyPressHighlightEnrollment(button)
+    return actionSlotCooldownCandidateChanged
 end
 
 -- Rebuild the entire item→slot reverse lookup cache by scanning action button frames.
@@ -512,11 +519,12 @@ function CooldownCompanion:RefreshKeybindState()
     self:RebuildSlotMapping()
     self:RebuildItemSlotCache()
     self:RebuildAddonSlotBindings()
-    self:OnKeybindsChanged()
+    return self:OnKeybindsChanged()
 end
 
 -- Refresh keybind text and binding key caches on all buttons.
 function CooldownCompanion:OnKeybindsChanged()
+    local actionSlotCooldownCandidateChanged = false
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
             local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
@@ -524,8 +532,11 @@ function CooldownCompanion:OnKeybindsChanged()
             button.keybindText:SetShown(button.style.showKeybindText and text ~= nil)
         end
         -- Rebuild key press highlight binding cache
-        CacheButtonBindingKeys(button, buttonData)
+        if CacheButtonBindingKeys(button, buttonData) then
+            actionSlotCooldownCandidateChanged = true
+        end
     end)
+    return actionSlotCooldownCandidateChanged
 end
 
 -- Exports for key press highlight

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -121,6 +121,7 @@ function CooldownCompanion:OnEnable()
     }) do
         self:RegisterEvent(evt, "OnCooldownStateChanged")
     end
+    self:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN", "OnActionBarCooldownChanged")
     self:RegisterEvent("SPELL_UPDATE_USABLE", "OnSpellUsabilityChanged")
 
     -- Broader state changes can wait for the regular ticker pass.
@@ -329,6 +330,13 @@ function CooldownCompanion:OnSpellUsabilityChanged()
     self:QueueCooldownRefresh({
         kind = "spell-usability",
         source = "spell-usability-event",
+    })
+end
+
+function CooldownCompanion:OnActionBarCooldownChanged()
+    self:QueueCooldownRefresh({
+        kind = "actionbar-cooldown",
+        source = "actionbar-cooldown-event",
     })
 end
 

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -121,6 +121,7 @@ function CooldownCompanion:OnEnable()
     }) do
         self:RegisterEvent(evt, "OnCooldownStateChanged")
     end
+    self:RegisterEvent("SPELL_UPDATE_USABLE", "OnSpellUsabilityChanged")
 
     -- Broader state changes can wait for the regular ticker pass.
     for _, evt in ipairs({
@@ -317,15 +318,18 @@ function CooldownCompanion:OnEnable()
     self:FinalizeContainerAnchorsToScreenOffsets()
 end
 
-function CooldownCompanion:OnCooldownStateChanged(event)
-    if event == "ACTIONBAR_UPDATE_COOLDOWN" then
-        return
-    end
-
+function CooldownCompanion:OnCooldownStateChanged()
     self:MarkCooldownsDirty()
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
     self:RunImmediateCooldownRefresh("cooldown-event")
+end
+
+function CooldownCompanion:OnSpellUsabilityChanged()
+    self:QueueCooldownRefresh({
+        kind = "spell-usability",
+        source = "spell-usability-event",
+    })
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -117,7 +117,7 @@ function CooldownCompanion:OnEnable()
     -- Cooldown events can expose very short ready windows, so refresh them
     -- immediately instead of waiting for the ticker.
     for _, evt in ipairs({
-        "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN", "ACTIONBAR_UPDATE_COOLDOWN",
+        "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN",
     }) do
         self:RegisterEvent(evt, "OnCooldownStateChanged")
     end
@@ -317,7 +317,11 @@ function CooldownCompanion:OnEnable()
     self:FinalizeContainerAnchorsToScreenOffsets()
 end
 
-function CooldownCompanion:OnCooldownStateChanged()
+function CooldownCompanion:OnCooldownStateChanged(event)
+    if event == "ACTIONBAR_UPDATE_COOLDOWN" then
+        return
+    end
+
     self:MarkCooldownsDirty()
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.

--- a/CooldownCompanion/Core/RefreshScope.lua
+++ b/CooldownCompanion/Core/RefreshScope.lua
@@ -5,8 +5,11 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic or {}
+local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL or "full"
 
 local SCOPED_REASON_KINDS = {
+    ["periodic"] = true,
     ["target-changed"] = true,
     ["unit-target"] = true,
     ["unit-aura"] = true,
@@ -46,6 +49,14 @@ function CooldownCompanion:NormalizeCooldownRefreshReason(reasonOrSource, fallba
         reason.origin = reason.origin or fallbackOrigin
         reason.broad = true
         reason.fallbackReason = reason.fallbackReason or "unsupported-kind"
+        return reason
+    end
+
+    if kind == "periodic" then
+        local reason = CopyReason(reasonOrSource) or {}
+        reason.source = reason.source or "ticker"
+        reason.origin = reason.origin or fallbackOrigin
+        reason.broad = false
         return reason
     end
 
@@ -194,12 +205,110 @@ local function ButtonUsesTargetRangeOrUsability(addon, button, buttonData)
     return false
 end
 
+local function ButtonUsesReadyGlowDuration(button)
+    local style = button and button.style
+    if not style then
+        return false, nil, 0
+    end
+    local duration = style.readyGlowDuration or 0
+    if duration <= 0 then
+        return false, nil, 0
+    end
+    if not style.readyGlowStyle or style.readyGlowStyle == "none" then
+        return false, nil, 0
+    end
+    return true, style, duration
+end
+
+local function ReadyGlowStartWithinWindow(startTime, duration)
+    if startTime == nil then
+        return false
+    end
+    local now = type(GetTime) == "function" and GetTime() or nil
+    if not now then
+        return true
+    end
+    return now - startTime <= duration + 0.2
+end
+
+local function ButtonUsesMaxChargeReadyGlow(buttonData, style)
+    return style
+        and style.readyGlowOnlyAtMaxCharges == true
+        and buttonData
+        and buttonData.type == "spell"
+        and buttonData.hasCharges == true
+        and not buttonData._hasDisplayCount
+end
+
+local function ButtonNeedsReadyGlowPeriodicRefresh(button, buttonData)
+    local enabled, style, duration = ButtonUsesReadyGlowDuration(button)
+    if not enabled then
+        return false
+    end
+    if ButtonUsesMaxChargeReadyGlow(buttonData, style) then
+        if ReadyGlowStartWithinWindow(button._readyGlowMaxChargesStartTime, duration) then
+            return true
+        end
+        if button._readyGlowActive == true then
+            return true
+        end
+        return button._chargeState ~= nil and button._chargeState ~= CHARGE_STATE_FULL
+    end
+    return ReadyGlowStartWithinWindow(button._readyGlowStartTime, duration)
+        or button._readyGlowActive == true
+        or button._desatCooldownActive == true
+end
+
+local function ButtonNeedsPeriodicCooldownRefresh(button, buttonData)
+    if not buttonData then
+        return false
+    end
+    if buttonData._rotationAssistantVirtual == true then
+        return true
+    end
+    if not button then
+        return false
+    end
+    if button._isText == true then
+        return true
+    end
+    if button._cooldownDeferred == true then
+        return true
+    end
+    if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
+        return true
+    end
+    if ButtonNeedsReadyGlowPeriodicRefresh(button, buttonData) then
+        return true
+    end
+    return false
+end
+
+function CooldownCompanion:HasPeriodicCooldownRefreshCandidates()
+    if not self.groupFrames then
+        return false
+    end
+    for _, frame in pairs(self.groupFrames) do
+        if frame and frame.buttons and frame:IsShown() then
+            for _, button in ipairs(frame.buttons) do
+                if ButtonNeedsPeriodicCooldownRefresh(button, button.buttonData) then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
 function CooldownCompanion:ButtonMatchesCooldownRefreshReason(button, buttonData, reason)
     if not self:IsScopedCooldownRefreshReason(reason) then
         return true
     end
     if not buttonData then
         return false
+    end
+    if reason.kind == "periodic" then
+        return ButtonNeedsPeriodicCooldownRefresh(button, buttonData)
     end
     if buttonData._rotationAssistantVirtual == true then
         return true

--- a/CooldownCompanion/Core/RefreshScope.lua
+++ b/CooldownCompanion/Core/RefreshScope.lua
@@ -14,6 +14,7 @@ local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO or "zero"
 local SCOPED_REASON_KINDS = {
     ["periodic"] = true,
     ["spell-usability"] = true,
+    ["actionbar-cooldown"] = true,
     ["target-changed"] = true,
     ["unit-target"] = true,
     ["unit-aura"] = true,
@@ -65,6 +66,15 @@ function CooldownCompanion:NormalizeCooldownRefreshReason(reasonOrSource, fallba
     end
 
     if kind == "spell-usability" then
+        local reason = CopyReason(reasonOrSource) or {}
+        reason.source = reason.source or "event"
+        reason.origin = reason.origin or fallbackOrigin
+        reason.unit = nil
+        reason.broad = false
+        return reason
+    end
+
+    if kind == "actionbar-cooldown" then
         local reason = CopyReason(reasonOrSource) or {}
         reason.source = reason.source or "event"
         reason.origin = reason.origin or fallbackOrigin
@@ -236,6 +246,33 @@ local function ButtonUsesTargetRangeOrUsability(addon, button, buttonData)
     return false
 end
 
+local function ButtonUsesActionbarCooldown(addon, button, buttonData)
+    if not buttonData then
+        return false
+    end
+
+    local isItemLike = addon.IsEntryItemLike and addon.IsEntryItemLike(buttonData)
+    if isItemLike or buttonData.type == "equipitem" then
+        return true
+    end
+
+    if buttonData.type ~= "spell"
+        or buttonData.isPassive == true
+        or buttonData.isPassiveCooldown == true
+        or buttonData.hasCharges == true then
+        return false
+    end
+
+    if buttonData._cooldownSecrecy ~= nil and buttonData._cooldownSecrecy ~= 0 then
+        return true
+    end
+
+    return button
+        and button._noCooldown ~= true
+        and (button._actionSlotCooldownCandidate == true
+            or button._actionSlotCooldownFallback == true)
+end
+
 local function ButtonUsesSpellUsability(addon, button, buttonData)
     if not (buttonData and buttonData.type == "spell")
         or buttonData.isPassive == true
@@ -366,6 +403,9 @@ local function ButtonHasCooldownDrivenIconFeature(button, buttonData, style)
         return true
     end
     if buttonData.hideWhileOnCooldown == true or buttonData.hideWhileNotOnCooldown == true then
+        return true
+    end
+    if buttonData.hideWhileZeroCharges == true then
         return true
     end
     local soundAlerts = buttonData.soundAlerts
@@ -529,6 +569,10 @@ local function ButtonNeedsTriggerConditionPeriodicRefresh(addon, button, buttonD
         and (button._desatCooldownActive == true or button._cooldownState == COOLDOWN_STATE_COOLDOWN) then
         return true
     end
+    if addon:TriggerRowUsesCondition(buttonData, "auraActive")
+        and button._auraActive == true then
+        return true
+    end
     if addon:TriggerRowUsesCondition(buttonData, "chargesRecharging")
         and button._chargeRecharging == true then
         return true
@@ -684,6 +728,9 @@ function CooldownCompanion:ButtonMatchesCooldownRefreshReason(button, buttonData
     end
     if reason.kind == "spell-usability" then
         return ButtonUsesSpellUsability(self, button, buttonData)
+    end
+    if reason.kind == "actionbar-cooldown" then
+        return ButtonUsesActionbarCooldown(self, button, buttonData)
     end
     if buttonData._rotationAssistantVirtual == true then
         return true

--- a/CooldownCompanion/Core/RefreshScope.lua
+++ b/CooldownCompanion/Core/RefreshScope.lua
@@ -6,10 +6,14 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic or {}
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN or "cooldown"
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL or "full"
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING or "missing"
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO or "zero"
 
 local SCOPED_REASON_KINDS = {
     ["periodic"] = true,
+    ["spell-usability"] = true,
     ["target-changed"] = true,
     ["unit-target"] = true,
     ["unit-aura"] = true,
@@ -56,6 +60,15 @@ function CooldownCompanion:NormalizeCooldownRefreshReason(reasonOrSource, fallba
         local reason = CopyReason(reasonOrSource) or {}
         reason.source = reason.source or "ticker"
         reason.origin = reason.origin or fallbackOrigin
+        reason.broad = false
+        return reason
+    end
+
+    if kind == "spell-usability" then
+        local reason = CopyReason(reasonOrSource) or {}
+        reason.source = reason.source or "event"
+        reason.origin = reason.origin or fallbackOrigin
+        reason.unit = nil
         reason.broad = false
         return reason
     end
@@ -152,6 +165,21 @@ local function ButtonUsesAssistedTargetGate(button, buttonData)
         and style.assistedHighlightHostileTargetOnly ~= false
 end
 
+local function ButtonUsesAssistedHighlight(button, buttonData)
+    if not (button and button.assistedHighlight and buttonData and buttonData.type == "spell") then
+        return false
+    end
+    local style = button.style
+    return style and style.showAssistedHighlight == true
+end
+
+local function ButtonUsesTextureUnusableIndicator(button)
+    local style = button and button.style
+    local indicators = style and style.textureIndicators
+    local unusable = indicators and indicators.unusable
+    return type(unusable) == "table" and unusable.enabled == true
+end
+
 local function ButtonUsesUnusableTargetGate(button, buttonData)
     if buttonData.isPassive == true or buttonData.isPassiveCooldown == true then
         return false
@@ -192,6 +220,9 @@ local function ButtonUsesTargetRangeOrUsability(addon, button, buttonData)
     if ButtonUsesUnusableTargetGate(button, buttonData) then
         return true
     end
+    if ButtonUsesTextureUnusableIndicator(button) then
+        return true
+    end
     if button and button._isText and (
         TextSegmentsUseToken(button._textSegments, "oor")
         or TextSegmentsUseToken(button._textSegments, "unusable")
@@ -203,6 +234,26 @@ local function ButtonUsesTargetRangeOrUsability(addon, button, buttonData)
             or addon:TriggerRowUsesCondition(buttonData, "usable")
     end
     return false
+end
+
+local function ButtonUsesSpellUsability(addon, button, buttonData)
+    if not (buttonData and buttonData.type == "spell")
+        or buttonData.isPassive == true
+        or buttonData.isPassiveCooldown == true then
+        return false
+    end
+    if ButtonUsesUnusableTargetGate(button, buttonData) then
+        return true
+    end
+    if ButtonUsesTextureUnusableIndicator(button) then
+        return true
+    end
+    if button and button._isText and TextSegmentsUseToken(button._textSegments, "unusable") then
+        return true
+    end
+    return addon
+        and addon.TriggerRowUsesCondition
+        and addon:TriggerRowUsesCondition(buttonData, "usable")
 end
 
 local function ButtonUsesReadyGlowDuration(button)
@@ -259,39 +310,360 @@ local function ButtonNeedsReadyGlowPeriodicRefresh(button, buttonData)
         or button._desatCooldownActive == true
 end
 
-local function ButtonNeedsPeriodicCooldownRefresh(button, buttonData)
-    if not buttonData then
+local function ButtonNeedsIconCooldownTextPeriodicRefresh(button)
+    if not (button and button._cdTextRegion and not button._isText and not button._isBar) then
         return false
     end
-    if buttonData._rotationAssistantVirtual == true then
-        return true
-    end
-    if not button then
+    local style = button.style
+    if not style then
         return false
     end
-    if button._isText == true then
+    if button._auraPrimarySwipeActive == true or button._conditionalAuraDurationTextPreview == true then
+        return style.showAuraText ~= false
+    end
+    if button._secondaryCdTextRegion and button._secondaryCdActive == true then
+        return style.showCooldownText == true
+    end
+    return button._desatCooldownActive == true
+        and style.showCooldownText == true
+        and button._hideCooldownChargesActive ~= true
+end
+
+local function ButtonNeedsBarPeriodicRefresh(button)
+    if not (button and button._isBar == true) then
+        return false
+    end
+    if button._desatCooldownActive == true or button._cooldownState == COOLDOWN_STATE_COOLDOWN then
         return true
     end
-    if button._cooldownDeferred == true then
+    if button._chargeState == CHARGE_STATE_ZERO or button._chargeState == CHARGE_STATE_MISSING then
         return true
     end
-    if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
+    return button._auraActive == true
+        and (button._durationObj ~= nil or button._viewerBar ~= nil or button._conditionalPreviewRemaining ~= nil)
+end
+
+local function TextureIndicatorEnabled(style, sectionKey)
+    local indicators = style and style.textureIndicators
+    local section = indicators and indicators[sectionKey]
+    return type(section) == "table" and section.enabled == true
+end
+
+local function ButtonHasCooldownDrivenIconFeature(button, buttonData, style)
+    if style.showCooldownSwipe ~= false
+        and (style.showCooldownSwipeFill ~= false or style.showCooldownSwipeEdge ~= false) then
         return true
     end
-    if ButtonNeedsReadyGlowPeriodicRefresh(button, buttonData) then
+    if style.desaturateOnCooldown == true or buttonData.desaturateWhileZeroCharges == true then
+        return true
+    end
+    if style.iconFillEnabled == true then
+        return true
+    end
+    if TextureIndicatorEnabled(style, "cooldown")
+        or TextureIndicatorEnabled(style, "ready")
+        or TextureIndicatorEnabled(style, "unusable") then
+        return true
+    end
+    if buttonData.hideWhileOnCooldown == true or buttonData.hideWhileNotOnCooldown == true then
+        return true
+    end
+    local soundAlerts = buttonData.soundAlerts
+    if soundAlerts and type(soundAlerts.events) == "table" and next(soundAlerts.events) ~= nil then
+        return true
+    end
+    if style.readyGlowStyle and style.readyGlowStyle ~= "none" then
         return true
     end
     return false
+end
+
+local function ButtonNeedsIconCooldownStatePeriodicRefresh(button, buttonData)
+    if not (button and buttonData and not button._isText and not button._isBar) then
+        return false
+    end
+    local style = button.style
+    if not style then
+        return false
+    end
+    if button._desatCooldownActive ~= true
+        and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
+        and button._chargeState ~= CHARGE_STATE_ZERO
+        and button._chargeState ~= CHARGE_STATE_MISSING then
+        return false
+    end
+    return ButtonHasCooldownDrivenIconFeature(button, buttonData, style)
+end
+
+local function ButtonUsesActiveAuraIcon(buttonData)
+    return buttonData
+        and (buttonData.auraShowAuraIcon == true
+            or buttonData.addedAs == "aura"
+            or buttonData.isPassive == true)
+end
+
+local function ButtonNeedsAuraIconVisualPeriodicRefresh(button, buttonData)
+    if not (button and buttonData and not button._isText and not button._isBar) then
+        return false
+    end
+    return buttonData.type == "spell"
+        and buttonData.auraTracking == true
+        and ButtonUsesActiveAuraIcon(buttonData)
+        and button._auraSpellID ~= nil
+end
+
+local function ButtonNeedsAuraPandemicPeriodicRefresh(button, buttonData)
+    if not (button and buttonData and not button._isText and not button._isBar) then
+        return false
+    end
+    if buttonData.type ~= "spell"
+        or buttonData.auraTracking ~= true
+        or button._auraSpellID == nil
+        or button._auraActive ~= true then
+        return false
+    end
+    local style = button.style
+    if not style then
+        return false
+    end
+    return style.showPandemicGlow ~= false
+        or buttonData.hideAuraActiveExceptPandemic == true
+end
+
+local function GetLiveOverrideSpellID(buttonData)
+    if not (C_Spell and C_Spell.GetOverrideSpell and buttonData and buttonData.id) then
+        return nil
+    end
+    local overrideID = C_Spell.GetOverrideSpell(buttonData.id)
+    if overrideID and overrideID ~= 0 and overrideID ~= buttonData.id then
+        return overrideID
+    end
+    return nil
+end
+
+local function GetSpellTexture(buttonData)
+    if not (C_Spell and C_Spell.GetSpellTexture and buttonData and buttonData.id) then
+        return nil
+    end
+    return C_Spell.GetSpellTexture(buttonData.id)
+end
+
+local function ButtonCanPollSpellVisuals(button, buttonData)
+    return button
+        and buttonData
+        and buttonData.type == "spell"
+        and buttonData.isPassive ~= true
+        and buttonData.isPassiveCooldown ~= true
+        and not buttonData.cdmChildSlot
+end
+
+local function ButtonNeedsSpellVisualPeriodicRefresh(button, buttonData)
+    if not ButtonCanPollSpellVisuals(button, buttonData) then
+        return false
+    end
+
+    local liveOverrideID = GetLiveOverrideSpellID(buttonData)
+    local spellTexture = GetSpellTexture(buttonData)
+    local previousOverrideID = button._periodicLiveOverrideSpellId
+    if previousOverrideID == nil then
+        previousOverrideID = button._liveOverrideSpellId
+    end
+    local previousTexture = button._periodicSpellTexture
+    if previousTexture == nil then
+        previousTexture = button._lastSpellTexture
+    end
+
+    if previousOverrideID ~= liveOverrideID
+        or (spellTexture ~= nil and spellTexture ~= previousTexture)
+        or (previousTexture ~= nil and spellTexture == nil) then
+        button._spellVisualRefreshPending = true
+        return true
+    end
+
+    return button._spellVisualRefreshPending == true
+end
+
+local function ButtonNeedsAssistedHighlightPeriodicRefresh(addon, button, buttonData)
+    if not ButtonUsesAssistedHighlight(button, buttonData) then
+        return false
+    end
+    return button._periodicAssistedSpellID ~= addon.assistedSpellID
+        or button._periodicAssistedHighlightHasHostileTarget ~= addon._assistedHighlightHasHostileTarget
+end
+
+local function ButtonNeedsItemRangeOrUsabilityPeriodicRefresh(addon, button, buttonData)
+    if not (buttonData and button) then
+        return false
+    end
+    local isItemLike = addon.IsEntryItemLike and addon.IsEntryItemLike(buttonData)
+    if not (isItemLike or buttonData.type == "equipitem") then
+        return false
+    end
+    return ButtonUsesTargetRangeOrUsability(addon, button, buttonData)
+end
+
+local function ButtonNeedsItemFallbackPeriodicRefresh(addon, buttonData)
+    if not (addon and addon.HasItemFallbacks and buttonData) then
+        return false
+    end
+    return (buttonData.type == "item" or buttonData.type == "equipitem")
+        and addon.HasItemFallbacks(buttonData) == true
+end
+
+local function CountTextIsActive(button)
+    if not (button and button.count and button.count.GetText) then
+        return false
+    end
+    local countText = button.count:GetText()
+    if type(issecretvalue) == "function" and issecretvalue(countText) then
+        return true
+    end
+    return countText ~= nil and countText ~= ""
+end
+
+local function ButtonNeedsTriggerConditionPeriodicRefresh(addon, button, buttonData)
+    if not (addon and addon.TriggerRowUsesCondition and button and buttonData) then
+        return false
+    end
+    if addon:TriggerRowUsesCondition(buttonData, "cooldownActive")
+        and (button._desatCooldownActive == true or button._cooldownState == COOLDOWN_STATE_COOLDOWN) then
+        return true
+    end
+    if addon:TriggerRowUsesCondition(buttonData, "chargesRecharging")
+        and button._chargeRecharging == true then
+        return true
+    end
+    if addon:TriggerRowUsesCondition(buttonData, "chargeState")
+        and button._chargeState ~= nil
+        and button._chargeState ~= CHARGE_STATE_FULL then
+        return true
+    end
+    if addon:TriggerRowUsesCondition(buttonData, "countTextActive")
+        and CountTextIsActive(button) then
+        return true
+    end
+    if addon:TriggerRowUsesCondition(buttonData, "countState")
+        and button._currentReadableCharges ~= nil then
+        return true
+    end
+    return false
+end
+
+local PERIODIC_REFRESH_CONTRACTS = {
+    {
+        tag = "assistant-runtime",
+        matches = function(addon, button, buttonData)
+            return buttonData._rotationAssistantVirtual == true
+                or ButtonNeedsAssistedHighlightPeriodicRefresh(addon, button, buttonData)
+        end,
+    },
+    {
+        tag = "text-runtime",
+        matches = function(_, button)
+            return button and button._isText == true
+        end,
+    },
+    {
+        tag = "cooldown-state",
+        matches = function(_, button, buttonData)
+            return button
+                and (button._cooldownDeferred == true
+                    or ButtonNeedsReadyGlowPeriodicRefresh(button, buttonData)
+                    or ButtonNeedsIconCooldownTextPeriodicRefresh(button)
+                    or ButtonNeedsIconCooldownStatePeriodicRefresh(button, buttonData)
+                    or ButtonNeedsBarPeriodicRefresh(button))
+        end,
+    },
+    {
+        tag = "aura-runtime",
+        matches = function(_, button, buttonData)
+            return button
+                and (button._auraGraceStart ~= nil
+                    or button._targetSwitchAt ~= nil
+                    or ButtonNeedsAuraIconVisualPeriodicRefresh(button, buttonData)
+                    or ButtonNeedsAuraPandemicPeriodicRefresh(button, buttonData))
+        end,
+    },
+    {
+        tag = "spell-visual",
+        matches = function(_, button, buttonData)
+            return button
+                and (button._iconDirty == true
+                    or ButtonNeedsSpellVisualPeriodicRefresh(button, buttonData))
+        end,
+    },
+    {
+        tag = "item-runtime",
+        matches = function(addon, button, buttonData)
+            return ButtonNeedsItemRangeOrUsabilityPeriodicRefresh(addon, button, buttonData)
+                or ButtonNeedsItemFallbackPeriodicRefresh(addon, buttonData)
+        end,
+    },
+    {
+        tag = "trigger-runtime",
+        matches = ButtonNeedsTriggerConditionPeriodicRefresh,
+    },
+}
+
+local function GetPeriodicRefreshContractTag(addon, button, buttonData)
+    if not buttonData then
+        return nil
+    end
+    for _, contract in ipairs(PERIODIC_REFRESH_CONTRACTS) do
+        if contract.matches(addon, button, buttonData) then
+            return contract.tag
+        end
+    end
+    return nil
+end
+
+local function CaptureButtonRefreshPollingState(addon, button, buttonData)
+    if not button then
+        return
+    end
+    if ButtonUsesAssistedHighlight(button, buttonData) then
+        button._periodicAssistedSpellID = addon.assistedSpellID
+        button._periodicAssistedHighlightHasHostileTarget = addon._assistedHighlightHasHostileTarget
+    end
+    if ButtonCanPollSpellVisuals(button, buttonData) then
+        button._periodicLiveOverrideSpellId = GetLiveOverrideSpellID(buttonData)
+        button._periodicSpellTexture = GetSpellTexture(buttonData)
+        button._spellVisualRefreshPending = nil
+    end
+end
+
+local function ButtonNeedsPeriodicCooldownRefresh(addon, button, buttonData)
+    return GetPeriodicRefreshContractTag(addon, button, buttonData) ~= nil
+end
+
+function CooldownCompanion:GetPeriodicCooldownRefreshContract(button, buttonData)
+    return GetPeriodicRefreshContractTag(self, button, buttonData)
+end
+
+function CooldownCompanion:RefreshAssistedHighlightHostileTargetState()
+    local hasHostileTarget = false
+    if type(UnitExists) == "function" and type(UnitCanAttack) == "function" then
+        if UnitExists("target") then
+            hasHostileTarget = UnitCanAttack("player", "target") and true or false
+        elseif UnitExists("softenemy") then
+            hasHostileTarget = UnitCanAttack("player", "softenemy") and true or false
+        end
+    end
+    self._assistedHighlightHasHostileTarget = hasHostileTarget
+    return hasHostileTarget
 end
 
 function CooldownCompanion:HasPeriodicCooldownRefreshCandidates()
     if not self.groupFrames then
         return false
     end
+    if self.RefreshAssistedHighlightHostileTargetState then
+        self:RefreshAssistedHighlightHostileTargetState()
+    end
     for _, frame in pairs(self.groupFrames) do
         if frame and frame.buttons and frame:IsShown() then
             for _, button in ipairs(frame.buttons) do
-                if ButtonNeedsPeriodicCooldownRefresh(button, button.buttonData) then
+                if ButtonNeedsPeriodicCooldownRefresh(self, button, button.buttonData) then
                     return true
                 end
             end
@@ -308,7 +680,10 @@ function CooldownCompanion:ButtonMatchesCooldownRefreshReason(button, buttonData
         return false
     end
     if reason.kind == "periodic" then
-        return ButtonNeedsPeriodicCooldownRefresh(button, buttonData)
+        return ButtonNeedsPeriodicCooldownRefresh(self, button, buttonData)
+    end
+    if reason.kind == "spell-usability" then
+        return ButtonUsesSpellUsability(self, button, buttonData)
     end
     if buttonData._rotationAssistantVirtual == true then
         return true
@@ -326,12 +701,39 @@ function CooldownCompanion:ButtonMatchesCooldownRefreshReason(button, buttonData
     return true
 end
 
+local function IsTriggerRefreshFrame(addon, frame)
+    if not (addon and frame) then
+        return false
+    end
+    if frame.displayMode == "trigger" then
+        return true
+    end
+
+    local groupId = frame.groupId
+    local profile = addon.db and addon.db.profile
+    local group = profile and profile.groups and groupId and profile.groups[groupId]
+    return group and group.displayMode == "trigger"
+end
+
+local function TriggerFrameMatchesCooldownRefreshReason(addon, frame, refreshReason)
+    for _, button in ipairs(frame.buttons) do
+        if addon:ButtonMatchesCooldownRefreshReason(button, button.buttonData, refreshReason) then
+            return true
+        end
+    end
+    return false
+end
+
 function CooldownCompanion:UpdateGroupFrameCooldownButtons(frame, refreshReason, collectStats)
     local scoped = self:IsScopedCooldownRefreshReason(refreshReason)
     local canFilter = scoped and self.ButtonMatchesCooldownRefreshReason
+    local forceWholeFrame = canFilter
+        and IsTriggerRefreshFrame(self, frame)
+        and TriggerFrameMatchesCooldownRefreshReason(self, frame, refreshReason)
     if not canFilter and not collectStats then
         for _, button in ipairs(frame.buttons) do
             button:UpdateCooldown()
+            CaptureButtonRefreshPollingState(self, button, button.buttonData)
         end
         return nil, nil
     end
@@ -339,9 +741,11 @@ function CooldownCompanion:UpdateGroupFrameCooldownButtons(frame, refreshReason,
     local updatedCount = 0
     local skippedCount = 0
     for _, button in ipairs(frame.buttons) do
-        if not canFilter
+        if forceWholeFrame
+            or not canFilter
             or self:ButtonMatchesCooldownRefreshReason(button, button.buttonData, refreshReason) then
             button:UpdateCooldown()
+            CaptureButtonRefreshPollingState(self, button, button.buttonData)
             updatedCount = updatedCount + 1
         else
             skippedCount = skippedCount + 1


### PR DESCRIPTION
## What Players Will Notice
- Cooldown Companion should feel lighter during common gameplay moments like target switches, ability presses, aura changes, and actionbar cooldown pulses.
- Tracked displays should remain accurate, but the addon now avoids broad cooldown walks when only a narrower set of active displays can be affected.

## Why This Changed
- Profiler captures showed that target switches and button presses were causing more cooldown refresh work than necessary.
- Some paths were refreshing every active display even when only target-aware, aura-aware, spell usability, or actionbar-backed entries could change.

## What Changed
- Added structured cooldown refresh reasons and scoped refresh matching so target, aura, spell usability, actionbar cooldown, and periodic maintenance paths can update only relevant active buttons.
- Changed clean ticker behavior so it no longer performs full cooldown walks unless active displays have semantic periodic work to do.
- Kept conservative full refresh fallbacks for unsupported or mixed reasons, dirty confirmation paths, and actionbar/layout candidate changes where correctness needs a broad confirmation.
- Seeded actionbar cooldown candidate state for freshly-created runtime buttons and only queued actionbar-layout cooldown confirmation when a visible spell button's action-slot cooldown candidate state actually changed.

## Validation
- Static checks: `lua tests\refresh-scope.lua`, `lua tests\cooldown-refresh-queue.lua`, `lua tests\actionbar-cooldown-pulse.lua`, `lua tests\unit-aura-event-boundary.lua`, `lua .local-tools\cdc-profiler\self-check.lua`.
- Syntax/hygiene: `luac -p` on touched addon, test, and profiler Lua files; `git diff --check` against the merge base.
- Review: parallel review loop completed with a final four-reviewer cohort reporting no actionable findings; a final manual review of the follow-up gating commit found no actionable issues.
- In-game profiling/smoke: user confirmed behavior looked good; latest profiler flush confirmed repeated `actionbar-layout-event` full cooldown passes dropped to `0` after the gating fix.
- Still pending before final release merge: dedicated combat/restricted-content validation, plus the known separate next optimization target where scoped `ACTIONBAR_UPDATE_COOLDOWN` still wakes actionbar-backed candidates frequently.