### PR TITLE
Reduce actionbar cooldown refresh work

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -78,6 +78,12 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
+local function RecordCooldownRefreshEligibility(addon, button, buttonData, displayMode)
+    if addon.RecordButtonCooldownRefreshEligibility then
+        addon:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
+    end
+end
+
 function CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot()
     local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
     return isEnabled and isEnabled() == true
@@ -808,9 +814,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
         ClearRotationAssistantMissingState(button, buttonData, style)
-        if self.RecordButtonCooldownRefreshEligibility then
-            self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
-        end
+        RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
         return
     end
 
@@ -1448,6 +1452,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- this path and the isActive fallback.
             local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
                 or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+            if slotProbe.sawAnySlot then
+                button._actionSlotCooldownCandidate = true
+            end
             if slotProbe.shown ~= nil then
                 button._mainCDShown = slotProbe.realShown == true
             elseif not auraOwnsPrimarySwipe then
@@ -1777,6 +1784,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
+            RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
             return  -- Skip all visual updates
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -1797,6 +1805,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
+            RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
             return  -- Skip visual updates for hidden buttons
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -1864,9 +1873,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end
-    if self.RecordButtonCooldownRefreshEligibility then
-        self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
-    end
+    RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -803,9 +803,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
     local buttonDisplayMode = buttonGroup and (buttonGroup.displayMode or "icons") or "icons"
     ClearConditionalVisualPreviewFields(button)
+    button._actionSlotCooldownCandidate = nil
+    button._actionSlotCooldownFallback = nil
 
     if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
         ClearRotationAssistantMissingState(button, buttonData, style)
+        if self.RecordButtonCooldownRefreshEligibility then
+            self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
+        end
         return
     end
 
@@ -1238,6 +1243,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
+                local slotProbe = spellCooldownResult.slotProbe
+                button._actionSlotCooldownCandidate = slotProbe and slotProbe.sawAnySlot == true or nil
+                button._actionSlotCooldownFallback = (spellCooldownResult.source == "action-slot-real-fallback"
+                    or spellCooldownResult.source == "action-slot-real-no-spell-info") or nil
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
                 local renderDurationObj = spellCooldownResult.renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
@@ -1854,6 +1863,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
+    end
+    if self.RecordButtonCooldownRefreshEligibility then
+        self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
     end
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -17,6 +17,12 @@
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
       frame and arm flag used to flush queued work on the next OnUpdate
       boundary. The frame must stay shown; hidden frames do not receive OnUpdate.
+    - _actionbarCooldownPulsePending: true when a raw ACTIONBAR_UPDATE_COOLDOWN
+      pulse has arrived and the next ticker must decide whether it is safe to
+      skip the clean broad pass.
+    - _cooldownRefreshEligibilityKnown: true after a broad pass has rebuilt
+      cached active-surface eligibility for actionbar fallback and periodic
+      maintenance. Unknown eligibility falls back to broad work.
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
@@ -31,11 +37,134 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
+local function AddReason(reasons, seen, reason)
+    if not reason or seen[reason] then return end
+    seen[reason] = true
+    reasons[#reasons + 1] = reason
+end
+
+local function HasSoundAlerts(buttonData)
+    local cfg = buttonData and buttonData.soundAlerts
+    return cfg and type(cfg.events) == "table" and next(cfg.events) ~= nil
+end
+
+local function HasTimedReadyGlow(button)
+    if not button then return false end
+    local style = button.style
+    local duration = style and (style.readyGlowDuration or 0) or 0
+    if duration <= 0 then
+        return false
+    end
+
+    local now = GetTime()
+    local function WindowNeedsRefresh(startTime)
+        if startTime == nil then return false end
+        return (now - startTime) <= duration or button._readyGlowActive == true
+    end
+
+    return WindowNeedsRefresh(button._readyGlowStartTime)
+        or WindowNeedsRefresh(button._readyGlowMaxChargesStartTime)
+end
+
+local function IsTriggerRuntime(button, displayMode)
+    if not button then return false end
+    if displayMode == "trigger" then return true end
+
+    local group = button._groupId
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[button._groupId]
+        or nil
+    local buttonData = button.buttonData
+    return (not displayMode
+            and group
+            and CooldownCompanion.IsTriggerPanelGroup
+            and CooldownCompanion:IsTriggerPanelGroup(group))
+        or buttonData and type(buttonData.triggerConditions) == "table"
+end
+
 local function CooldownRefreshQueueOnUpdate(frame)
     local addon = frame._cooldownCompanion
     if addon then
         addon:FlushQueuedCooldownRefresh()
     end
+end
+
+function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
+    self._cooldownRefreshEligibilityKnown = nil
+    self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
+    self._activeActionbarCooldownFallbackRequired = nil
+    self._activeCooldownPeriodicMaintenanceRequired = nil
+    self._activeActionbarCooldownFallbackReasons = nil
+    self._activeCooldownPeriodicMaintenanceReasons = nil
+end
+
+function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
+    self._cooldownRefreshEligibilityBuild = {
+        actionbarFallbackReasons = {},
+        actionbarFallbackSeen = {},
+        periodicMaintenanceReasons = {},
+        periodicMaintenanceSeen = {},
+    }
+end
+
+function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
+    local build = self._cooldownRefreshEligibilityBuild
+    if not build or not button then return end
+
+    if button._actionSlotCooldownFallback == true then
+        AddReason(build.actionbarFallbackReasons, build.actionbarFallbackSeen, "action-slot-fallback")
+    end
+
+    if button._isText == true then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "text-mode")
+    end
+    if button._cooldownDeferred == true then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "deferred-cooldown")
+    end
+    if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "pending-aura-hold")
+    end
+    if HasTimedReadyGlow(button) then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "ready-glow-window")
+    end
+    if HasSoundAlerts(buttonData) then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "sound-alert")
+    end
+    if buttonData and buttonData._rotationAssistantVirtual == true then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "rotation-assistant")
+    end
+    if IsTriggerRuntime(button, displayMode) then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "trigger-runtime")
+    end
+end
+
+function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
+    local build = self._cooldownRefreshEligibilityBuild
+    self._cooldownRefreshEligibilityBuild = nil
+    if not build then
+        self:InvalidateCooldownRefreshEligibility("missing-build")
+        return
+    end
+
+    self._cooldownRefreshEligibilityKnown = true
+    self._cooldownRefreshEligibilityInvalidationReason = nil
+    self._activeActionbarCooldownFallbackRequired = #build.actionbarFallbackReasons > 0 or nil
+    self._activeCooldownPeriodicMaintenanceRequired = #build.periodicMaintenanceReasons > 0 or nil
+    self._activeActionbarCooldownFallbackReasons = #build.actionbarFallbackReasons > 0 and build.actionbarFallbackReasons or nil
+    self._activeCooldownPeriodicMaintenanceReasons = #build.periodicMaintenanceReasons > 0 and build.periodicMaintenanceReasons or nil
+end
+
+function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
+    return {
+        known = self._cooldownRefreshEligibilityKnown == true,
+        invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
+        actionbarFallbackRequired = self._activeActionbarCooldownFallbackRequired == true,
+        actionbarFallbackReasons = self._activeActionbarCooldownFallbackReasons,
+        periodicMaintenanceRequired = self._activeCooldownPeriodicMaintenanceRequired == true,
+        periodicMaintenanceReasons = self._activeCooldownPeriodicMaintenanceReasons,
+    }
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -108,15 +237,80 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
+function CooldownCompanion:RecordActionbarCooldownPulse(event)
+    self._actionbarCooldownPulsePending = true
+    self._actionbarCooldownPulseEvent = event or "ACTIONBAR_UPDATE_COOLDOWN"
+    self._actionbarCooldownPulseCount = (self._actionbarCooldownPulseCount or 0) + 1
+end
+
+function CooldownCompanion:ClearActionbarCooldownPulse()
+    self._actionbarCooldownPulsePending = nil
+    self._actionbarCooldownPulseEvent = nil
+    self._actionbarCooldownPulseCount = nil
+end
+
+function CooldownCompanion:GetActionbarCooldownPulseDecision()
+    if not self._actionbarCooldownPulsePending then
+        return false, "no-actionbar-pulse"
+    end
+    if self._queuedCooldownRefreshSource then
+        return false, "queued-refresh"
+    end
+    if self._cooldownsDirty then
+        return false, "dirty"
+    end
+    if not self._cooldownRefreshEligibilityKnown then
+        return false, self._cooldownRefreshEligibilityInvalidationReason or "eligibility-unknown"
+    end
+    if self._activeActionbarCooldownFallbackRequired then
+        return false, "actionbar-fallback-required"
+    end
+    if self._activeCooldownPeriodicMaintenanceRequired then
+        return false, "periodic-maintenance-required"
+    end
+    return true, "pulse-only"
+end
+
+function CooldownCompanion:GetActionbarCooldownFallbackReason(decision)
+    local eligibility = self:GetActionbarCooldownEligibilityInfo()
+    return {
+        kind = "actionbar-cooldown",
+        source = "actionbar-cooldown-event",
+        event = self._actionbarCooldownPulseEvent or "ACTIONBAR_UPDATE_COOLDOWN",
+        origin = "ticker",
+        broad = true,
+        actionbarPulseDecision = decision,
+        actionbarPulseCount = self._actionbarCooldownPulseCount,
+        actionbarFallbackRequired = eligibility.actionbarFallbackRequired,
+        actionbarFallbackReasons = eligibility.actionbarFallbackReasons,
+        periodicMaintenanceRequired = eligibility.periodicMaintenanceRequired,
+        periodicMaintenanceReasons = eligibility.periodicMaintenanceReasons,
+        eligibilityKnown = eligibility.known,
+    }
+end
+
 function CooldownCompanion:TickCooldownRefresh()
     if self._queuedCooldownRefreshSource then
         self:FlushQueuedCooldownRefresh()
         return false
     end
     if self:CanSkipTickerCooldownRefresh() then
+        self:ClearActionbarCooldownPulse()
         return true
     end
-    self:UpdateAllCooldowns()
+
+    local actionbarOnlyReason
+    if self._actionbarCooldownPulsePending and not self._cooldownsDirty then
+        local canSkipActionbarPulse, decision = self:GetActionbarCooldownPulseDecision()
+        if canSkipActionbarPulse then
+            self:ClearActionbarCooldownPulse()
+            return true
+        end
+        actionbarOnlyReason = self:GetActionbarCooldownFallbackReason(decision)
+    end
+
+    self:UpdateAllCooldowns(actionbarOnlyReason)
+    self:ClearActionbarCooldownPulse()
     return false
 end
 
@@ -128,4 +322,5 @@ function CooldownCompanion:ResetCooldownRefreshState()
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
+    self:ClearActionbarCooldownPulse()
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -37,15 +37,14 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
-local function AddReason(reasons, seen, reason)
-    if not reason or seen[reason] then return end
-    seen[reason] = true
-    reasons[#reasons + 1] = reason
-end
-
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
     return cfg and type(cfg.events) == "table" and next(cfg.events) ~= nil
+end
+
+local function ReadyGlowWindowNeedsRefresh(startTime, now, duration, active)
+    if startTime == nil then return false end
+    return (now - startTime) <= duration or active == true
 end
 
 local function HasTimedReadyGlow(button)
@@ -57,13 +56,35 @@ local function HasTimedReadyGlow(button)
     end
 
     local now = GetTime()
-    local function WindowNeedsRefresh(startTime)
-        if startTime == nil then return false end
-        return (now - startTime) <= duration or button._readyGlowActive == true
+    return ReadyGlowWindowNeedsRefresh(button._readyGlowStartTime, now, duration, button._readyGlowActive)
+        or ReadyGlowWindowNeedsRefresh(button._readyGlowMaxChargesStartTime, now, duration, button._readyGlowActive)
+end
+
+local function HasActiveIconCooldownText(button, buttonData)
+    if not (button and button._cdTextRegion) then return false end
+    if button._isBar or button._isText then return false end
+
+    local style = button.style or {}
+    local auraTextActive = button._auraPrimarySwipeActive == true
+        or button._conditionalAuraDurationTextPreview == true
+    if auraTextActive then
+        if style.showAuraText == false then
+            return false
+        end
+    else
+        if style.showCooldownText == false or button._hideCooldownChargesActive then
+            return false
+        end
+        if buttonData and buttonData.isPassive then
+            return false
+        end
     end
 
-    return WindowNeedsRefresh(button._readyGlowStartTime)
-        or WindowNeedsRefresh(button._readyGlowMaxChargesStartTime)
+    return button._durationObj ~= nil
+        or button._auraDurationObj ~= nil
+        or button._auraCooldownStart ~= nil
+        or button._chargeCooldownVisualActive == true
+        or button._secondaryCdActive == true
 end
 
 local function IsTriggerRuntime(button, displayMode)
@@ -96,17 +117,18 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
     self._activeActionbarCooldownFallbackRequired = nil
     self._activeCooldownPeriodicMaintenanceRequired = nil
-    self._activeActionbarCooldownFallbackReasons = nil
-    self._activeCooldownPeriodicMaintenanceReasons = nil
 end
 
 function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
-    self._cooldownRefreshEligibilityBuild = {
-        actionbarFallbackReasons = {},
-        actionbarFallbackSeen = {},
-        periodicMaintenanceReasons = {},
-        periodicMaintenanceSeen = {},
-    }
+    local build = self._cooldownRefreshEligibilityBuildCache
+    if not build then
+        build = {}
+        self._cooldownRefreshEligibilityBuildCache = build
+    else
+        build.actionbarFallbackRequired = nil
+        build.periodicMaintenanceRequired = nil
+    end
+    self._cooldownRefreshEligibilityBuild = build
 end
 
 function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
@@ -114,29 +136,34 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     if not build or not button then return end
 
     if button._actionSlotCooldownFallback == true then
-        AddReason(build.actionbarFallbackReasons, build.actionbarFallbackSeen, "action-slot-fallback")
+        build.actionbarFallbackRequired = true
+    elseif button._actionSlotCooldownCandidate == true then
+        build.actionbarFallbackRequired = true
     end
 
+    if HasActiveIconCooldownText(button, buttonData) then
+        build.periodicMaintenanceRequired = true
+    end
     if button._isText == true then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "text-mode")
+        build.periodicMaintenanceRequired = true
     end
     if button._cooldownDeferred == true then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "deferred-cooldown")
+        build.periodicMaintenanceRequired = true
     end
     if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "pending-aura-hold")
+        build.periodicMaintenanceRequired = true
     end
     if HasTimedReadyGlow(button) then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "ready-glow-window")
+        build.periodicMaintenanceRequired = true
     end
     if HasSoundAlerts(buttonData) then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "sound-alert")
+        build.periodicMaintenanceRequired = true
     end
     if buttonData and buttonData._rotationAssistantVirtual == true then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "rotation-assistant")
+        build.periodicMaintenanceRequired = true
     end
     if IsTriggerRuntime(button, displayMode) then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "trigger-runtime")
+        build.periodicMaintenanceRequired = true
     end
 end
 
@@ -150,21 +177,8 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
 
     self._cooldownRefreshEligibilityKnown = true
     self._cooldownRefreshEligibilityInvalidationReason = nil
-    self._activeActionbarCooldownFallbackRequired = #build.actionbarFallbackReasons > 0 or nil
-    self._activeCooldownPeriodicMaintenanceRequired = #build.periodicMaintenanceReasons > 0 or nil
-    self._activeActionbarCooldownFallbackReasons = #build.actionbarFallbackReasons > 0 and build.actionbarFallbackReasons or nil
-    self._activeCooldownPeriodicMaintenanceReasons = #build.periodicMaintenanceReasons > 0 and build.periodicMaintenanceReasons or nil
-end
-
-function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
-    return {
-        known = self._cooldownRefreshEligibilityKnown == true,
-        invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
-        actionbarFallbackRequired = self._activeActionbarCooldownFallbackRequired == true,
-        actionbarFallbackReasons = self._activeActionbarCooldownFallbackReasons,
-        periodicMaintenanceRequired = self._activeCooldownPeriodicMaintenanceRequired == true,
-        periodicMaintenanceReasons = self._activeCooldownPeriodicMaintenanceReasons,
-    }
+    self._activeActionbarCooldownFallbackRequired = build.actionbarFallbackRequired == true or nil
+    self._activeCooldownPeriodicMaintenanceRequired = build.periodicMaintenanceRequired == true or nil
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -191,7 +205,7 @@ end
 function CooldownCompanion:FlushQueuedCooldownRefresh()
     local queuedSource = self._queuedCooldownRefreshSource
     local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
-    self:ResetCooldownRefreshState()
+    self:ResetCooldownRefreshState(queuedSource == nil)
 
     if queuedSource then
         self:UpdateAllCooldowns()
@@ -237,56 +251,34 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
-function CooldownCompanion:RecordActionbarCooldownPulse(event)
+function CooldownCompanion:RecordActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = true
-    self._actionbarCooldownPulseEvent = event or "ACTIONBAR_UPDATE_COOLDOWN"
-    self._actionbarCooldownPulseCount = (self._actionbarCooldownPulseCount or 0) + 1
 end
 
 function CooldownCompanion:ClearActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = nil
-    self._actionbarCooldownPulseEvent = nil
-    self._actionbarCooldownPulseCount = nil
 end
 
-function CooldownCompanion:GetActionbarCooldownPulseDecision()
+function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
     if not self._actionbarCooldownPulsePending then
-        return false, "no-actionbar-pulse"
+        return false
     end
     if self._queuedCooldownRefreshSource then
-        return false, "queued-refresh"
+        return false
     end
-    if self._cooldownsDirty then
-        return false, "dirty"
+    if self._cooldownsDirty and not cooldownEventSatisfied then
+        return false
     end
     if not self._cooldownRefreshEligibilityKnown then
-        return false, self._cooldownRefreshEligibilityInvalidationReason or "eligibility-unknown"
+        return false
     end
     if self._activeActionbarCooldownFallbackRequired then
-        return false, "actionbar-fallback-required"
+        return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired then
-        return false, "periodic-maintenance-required"
+    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
+        return false
     end
-    return true, "pulse-only"
-end
-
-function CooldownCompanion:GetActionbarCooldownFallbackReason(decision)
-    local eligibility = self:GetActionbarCooldownEligibilityInfo()
-    return {
-        kind = "actionbar-cooldown",
-        source = "actionbar-cooldown-event",
-        event = self._actionbarCooldownPulseEvent or "ACTIONBAR_UPDATE_COOLDOWN",
-        origin = "ticker",
-        broad = true,
-        actionbarPulseDecision = decision,
-        actionbarPulseCount = self._actionbarCooldownPulseCount,
-        actionbarFallbackRequired = eligibility.actionbarFallbackRequired,
-        actionbarFallbackReasons = eligibility.actionbarFallbackReasons,
-        periodicMaintenanceRequired = eligibility.periodicMaintenanceRequired,
-        periodicMaintenanceReasons = eligibility.periodicMaintenanceReasons,
-        eligibilityKnown = eligibility.known,
-    }
+    return true
 end
 
 function CooldownCompanion:TickCooldownRefresh()
@@ -294,27 +286,29 @@ function CooldownCompanion:TickCooldownRefresh()
         self:FlushQueuedCooldownRefresh()
         return false
     end
-    if self:CanSkipTickerCooldownRefresh() then
-        self:ClearActionbarCooldownPulse()
-        return true
-    end
 
-    local actionbarOnlyReason
-    if self._actionbarCooldownPulsePending and not self._cooldownsDirty then
-        local canSkipActionbarPulse, decision = self:GetActionbarCooldownPulseDecision()
+    local cooldownEventSatisfied = self:CanSkipTickerCooldownRefresh()
+    local actionbarFallbackRequired = false
+    if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or cooldownEventSatisfied) then
+        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
         if canSkipActionbarPulse then
             self:ClearActionbarCooldownPulse()
             return true
         end
-        actionbarOnlyReason = self:GetActionbarCooldownFallbackReason(decision)
+        actionbarFallbackRequired = true
     end
 
-    self:UpdateAllCooldowns(actionbarOnlyReason)
+    if cooldownEventSatisfied and not actionbarFallbackRequired then
+        self:ClearActionbarCooldownPulse()
+        return true
+    end
+
+    self:UpdateAllCooldowns()
     self:ClearActionbarCooldownPulse()
     return false
 end
 
-function CooldownCompanion:ResetCooldownRefreshState()
+function CooldownCompanion:ResetCooldownRefreshState(preserveActionbarPulse)
     if self._cooldownRefreshQueueFrame then
         self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
     end
@@ -322,5 +316,7 @@ function CooldownCompanion:ResetCooldownRefreshState()
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
-    self:ClearActionbarCooldownPulse()
+    if not preserveActionbarPulse then
+        self:ClearActionbarCooldownPulse()
+    end
 end

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1242,8 +1242,10 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     if needsRealCooldownFallback
         and options.allowActionSlotRealFallback then
         local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
-        if slotProbe.realShown == true and slotProbe.realDurationObj then
+        if slotProbe.sawAnySlot then
             result.slotProbe = slotProbe
+        end
+        if slotProbe.realShown == true and slotProbe.realDurationObj then
             result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
             result.realCooldownShown = true
             result.durationObj = slotProbe.durationObj or result.durationObj

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -22,6 +22,23 @@ local pendingSpellAvailabilityRefreshToken = 0
 -- Same token pattern as QueueTalentChargeRefresh.
 local pendingSlotChangeToken = 0
 local pendingSlotChangedSlots = {}
+local actionbarSlotSignatures = {}
+
+local function GetActionbarSlotSignature(slot)
+    if type(slot) ~= "number" then return nil end
+    if not C_ActionBar.HasAction(slot) then return "empty" end
+    local actionType, id, subType = GetActionInfo(slot)
+    return tostring(actionType) .. "\001" .. tostring(id) .. "\001" .. tostring(subType)
+end
+
+local function ActionbarSlotContentChanged(slot)
+    local signature = GetActionbarSlotSignature(slot)
+    if actionbarSlotSignatures[slot] == signature then
+        return false
+    end
+    actionbarSlotSignatures[slot] = signature
+    return true
+end
 
 local function QueueTalentChargeRefresh(addon)
     pendingTalentChargeRefreshToken = pendingTalentChargeRefreshToken + 1
@@ -592,17 +609,25 @@ function CooldownCompanion:OnActionBarSlotChanged(_, slot)
     local token = pendingSlotChangeToken
     C_Timer.After(0, function()
         if pendingSlotChangeToken ~= token then return end
+        local slotContentChanged = pendingSlotChangedSlots._fullRebuild == true
         self:RebuildSlotMapping()
         if pendingSlotChangedSlots._fullRebuild then
+            wipe(actionbarSlotSignatures)
             self:RebuildItemSlotCache()
         else
             for s in pairs(pendingSlotChangedSlots) do
+                if ActionbarSlotContentChanged(s) then
+                    slotContentChanged = true
+                end
                 self:UpdateItemSlotCache(s)
             end
         end
         wipe(pendingSlotChangedSlots)
         self:RebuildAddonSlotBindings()
         self:OnKeybindsChanged()
+        if slotContentChanged and self.InvalidateCooldownRefreshEligibility then
+            self:InvalidateCooldownRefreshEligibility("actionbar-slot-changed")
+        end
     end)
 end
 

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -608,6 +608,9 @@ end
 
 function CooldownCompanion:OnActionBarLayoutChanged()
     self:RefreshKeybindState()
+    if self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("actionbar-layout-changed")
+    end
     -- UPDATE_OVERRIDE_ACTIONBAR / UPDATE_VEHICLE_ACTIONBAR also route here for
     -- keybind rebuilds; piggyback vehicle UI state check to avoid duplicate
     -- AceEvent registrations (AceEvent allows only one handler per event).

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -2555,6 +2555,9 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     ApplyActiveButtonLayout(self, groupId, frame, group, buttonSizingOptions, headerHeight)
     FinishGroupButtonRefresh(self, groupId, frame, group)
+    if self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("group-buttons-populated")
+    end
     -- _hasBeenSized is now true if the compact resize ran (set by
     -- ResizeGroupFrame), or still false if all buttons were visible and no
     -- compact resize was needed.  When compactLayout is off, it stays false

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -3144,6 +3144,9 @@ function CooldownCompanion:UpdateGroupStyle(groupId)
     local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
     ApplyActiveButtonLayout(self, groupId, frame, group, buttonSizingOptions, headerHeight)
     FinishGroupButtonRefresh(self, groupId, frame, group)
+    if self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("group-style-updated")
+    end
 end
 
 function CooldownCompanion:UpdateGroupClickthrough(groupId)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2387,6 +2387,9 @@ function CooldownCompanion:UpdateAllCooldowns()
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
     self._cooldownUpdatePassActive = true
+    if self.BeginCooldownRefreshEligibilityBuild then
+        self:BeginCooldownRefreshEligibilityBuild()
+    end
 
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
@@ -2394,6 +2397,9 @@ function CooldownCompanion:UpdateAllCooldowns()
         end
     end
 
+    if self.FinishCooldownRefreshEligibilityBuild then
+        self:FinishCooldownRefreshEligibilityBuild()
+    end
     self._cooldownUpdatePassActive = nil
 end
 

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2138,12 +2138,14 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
         self:ClearUnsupportedProfileRuntime()
         return
     end
+    local cooldownEligibilityChanged = false
 
     -- Fully unload frames for groups not in the current profile
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
             self:UnloadGroup(groupId)
             self:DiscardDormantFrame(groupId)
+            cooldownEligibilityChanged = true
         end
     end
     -- Also discard dormant frames for deleted groups
@@ -2151,6 +2153,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
         for groupId, _ in pairs(self._dormantFrames) do
             if not self.db.profile.groups[groupId] then
                 self:DiscardDormantFrame(groupId)
+                cooldownEligibilityChanged = true
             end
         end
     end
@@ -2158,6 +2161,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     for groupId, group in pairs(self.db.profile.groups) do
         if not self:IsGroupVisibleToCurrentChar(groupId) then
             self:UnloadGroup(groupId)
+            cooldownEligibilityChanged = true
         else
             local active = self:IsGroupActive(groupId, {
                 group = group,
@@ -2168,23 +2172,32 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
 
             if not active then
                 self:UnloadGroup(groupId)
+                cooldownEligibilityChanged = true
             else
                 local frame = self.groupFrames[groupId]
                 if frame and self:GroupButtonSetNeedsRebuild(groupId, group) then
                     self:RefreshGroupFrame(groupId)
+                    cooldownEligibilityChanged = true
                     frame = self.groupFrames[groupId]
                 elseif not frame then
                     if self:GroupButtonSetNeedsRebuild(groupId, group) then
                         self:DiscardDormantFrame(groupId)
+                        cooldownEligibilityChanged = true
                     end
                     -- Recover dormant frame with buttons intact (no repopulation needed)
                     frame = self:RecoverDormantFrame(groupId)
+                    if frame then
+                        cooldownEligibilityChanged = true
+                    end
                 end
                 if not frame then
                     if InCombatLockdown() then
                         self._pendingVisibilityRefresh = true
                     else
                         frame = self:CreateGroupFrame(groupId)
+                        if frame then
+                            cooldownEligibilityChanged = true
+                        end
                     end
                 end
 
@@ -2225,6 +2238,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
                         if frame.UpdateCooldowns then
                             frame:UpdateCooldowns()
                         end
+                        cooldownEligibilityChanged = true
                         if group.compactLayout then
                             frame._layoutDirty = true
                             self:UpdateGroupLayout(groupId)
@@ -2245,6 +2259,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     end
     if self.RefreshAlphaUpdateDriver then
         self:RefreshAlphaUpdateDriver()
+    end
+    if cooldownEligibilityChanged and self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("visibility-only-refresh")
     end
 end
 

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -512,7 +512,7 @@ function CooldownCompanion:RefreshKeybindState()
 end
 
 -- Refresh keybind text and binding key caches on all buttons.
-function CooldownCompanion:OnKeybindsChanged(invalidationReason)
+function CooldownCompanion:OnKeybindsChanged()
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
             local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
@@ -522,9 +522,6 @@ function CooldownCompanion:OnKeybindsChanged(invalidationReason)
         -- Rebuild key press highlight binding cache
         CacheButtonBindingKeys(button, buttonData)
     end)
-    if invalidationReason and self.InvalidateCooldownRefreshEligibility then
-        self:InvalidateCooldownRefreshEligibility(invalidationReason)
-    end
 end
 
 -- Exports for key press highlight

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -512,7 +512,7 @@ function CooldownCompanion:RefreshKeybindState()
 end
 
 -- Refresh keybind text and binding key caches on all buttons.
-function CooldownCompanion:OnKeybindsChanged()
+function CooldownCompanion:OnKeybindsChanged(invalidationReason)
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
             local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
@@ -522,6 +522,9 @@ function CooldownCompanion:OnKeybindsChanged()
         -- Rebuild key press highlight binding cache
         CacheButtonBindingKeys(button, buttonData)
     end)
+    if invalidationReason and self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility(invalidationReason)
+    end
 end
 
 -- Exports for key press highlight

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -321,7 +321,7 @@ function CooldownCompanion:OnCooldownStateChanged()
 end
 
 function CooldownCompanion:OnActionBarCooldownChanged(event)
-    self:RecordActionbarCooldownPulse(event or "ACTIONBAR_UPDATE_COOLDOWN")
+    self:RecordActionbarCooldownPulse()
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -117,10 +117,11 @@ function CooldownCompanion:OnEnable()
     -- Cooldown events can expose very short ready windows, so refresh them
     -- immediately instead of waiting for the ticker.
     for _, evt in ipairs({
-        "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN", "ACTIONBAR_UPDATE_COOLDOWN",
+        "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN",
     }) do
         self:RegisterEvent(evt, "OnCooldownStateChanged")
     end
+    self:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN", "OnActionBarCooldownChanged")
 
     -- Broader state changes can wait for the regular ticker pass.
     for _, evt in ipairs({
@@ -317,6 +318,10 @@ function CooldownCompanion:OnCooldownStateChanged()
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
     self:RunImmediateCooldownRefresh("cooldown-event")
+end
+
+function CooldownCompanion:OnActionBarCooldownChanged(event)
+    self:RecordActionbarCooldownPulse(event or "ACTIONBAR_UPDATE_COOLDOWN")
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.


### PR DESCRIPTION
## What Players Will Notice
- Cooldown Companion should do less background work from raw actionbar cooldown pulses, especially during idle moments, target/button activity, and combat where the game fires frequent `ACTIONBAR_UPDATE_COOLDOWN` events.
- Cooldown displays still fall back to broad refreshes when active displays need them, so accuracy remains the priority.

## Why This Changed
- Profiling showed many actionbar cooldown pulses were causing broad cooldown refresh work even when no active display needed an actionbar-driven update.
- The old behavior was safe but too blunt: every pulse was treated like semantic cooldown state, which created duplicate work around button presses and other normal gameplay events.

## What Changed
- Split raw `ACTIONBAR_UPDATE_COOLDOWN` handling away from semantic cooldown events like spell and bag cooldown updates.
- Added a small broad-main eligibility cache that lets actionbar-only pulses skip the ticker refresh only when the active surface is known safe.
- Kept broad refresh fallback for unknown eligibility, changed active surfaces, action-slot cooldown candidates/fallbacks, active cooldown text, text mode, ready glow windows, deferred cooldowns, sound alerts, trigger runtime, Rotation Assistant, and pending aura holds.
- Invalidated the eligibility cache when group buttons, styles, visibility/load state, actionbar layout, or actionbar slot contents can change what the active surface needs.
- Preserved profiler-side attribution in local tooling while keeping shipped runtime state boolean-only and broad-refresh shaped.

## Validation
- `lua tests\\actionbar-cooldown-policy.lua`
- `lua tests\\rotation-assistant-panel.lua`
- `lua .local-tools\\cdc-profiler\\self-check.lua`
- `luac -p` on touched addon/profiler/test Lua files
- `git diff --check` passed with CRLF warnings only
- Parallel review loop ended clean after correctness and maintainability re-checks.
- Manual in-game profiling/smoke passes earlier on this branch covered idle, tracked ability, tracked item/trinket, combat, and restricted-content scenarios with no reported Lua errors and expected display behavior. The final post-review cleanup was validated locally and by static review, not by a fresh in-game pass.
