### PR TITLE
Reduce target-switch cooldown refresh work

### DIFF
--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -518,7 +518,9 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- frames registered their event handlers before our addon loaded, so by
     -- the time this handler fires the CDM has already refreshed its children
     -- with fresh auraInstanceID data. Bursts later in the same frame coalesce.
-    if unit == "target" or unit == "player" then
+    if unit == "target" then
+        self:RunImmediateCooldownRefresh("target-aura-event")
+    elseif unit == "player" then
         self:RunImmediateCooldownRefresh("aura-event")
     end
 end
@@ -544,10 +546,13 @@ end
 
 function CooldownCompanion:OnTargetChanged()
     if not UnitExists("target") then
+        local transitionSerial = self:BeginTargetCooldownRefreshTransition("target-clear")
         -- Deselected target: clear all target aura state immediately
         self:ClearAuraUnit("target")
+        self:MarkTargetCooldownRefreshPending(transitionSerial)
         return
     end
+    local transitionSerial = self:BeginTargetCooldownRefreshTransition("target-exists")
     -- New target: clear stale instance IDs so the viewer path doesn't
     -- read old auraInstanceIDs.  Keep _auraActive so the hold can
     -- maintain visual continuity while CDM refreshes.
@@ -568,6 +573,9 @@ function CooldownCompanion:OnTargetChanged()
     -- will have fresh auraInstanceID data.  Probing immediately lets the
     -- primary path clear _targetSwitchAt in the same frame — zero hold.
     self:UpdateAllCooldowns()
+    self:RecordTargetCooldownRefreshSatisfied("target-event", transitionSerial, nil, {
+        allowCleanTickerSkip = true,
+    })
 end
 
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -67,6 +67,20 @@ local function IsTargetRefreshSource(source)
     return TARGET_REFRESH_SOURCES[source] == true
 end
 
+local function CaptureTargetRefreshState()
+    if type(UnitExists) ~= "function" or not UnitExists("target") then
+        return false, nil, true
+    end
+    if type(UnitGUID) ~= "function" then
+        return true, nil, false
+    end
+    local guid = UnitGUID("target")
+    if not guid then
+        return true, nil, false
+    end
+    return true, guid, true
+end
+
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
     return cfg and type(cfg.events) == "table" and next(cfg.events) ~= nil
@@ -264,6 +278,8 @@ function CooldownCompanion:BeginTargetCooldownRefreshTransition(reason)
     self._targetRefreshSatisfiedTransitionSerial = nil
     self._targetRefreshSatisfiedDirtySerial = nil
     self._targetRefreshSatisfiedSource = nil
+    self._targetRefreshSatisfiedTargetExists = nil
+    self._targetRefreshSatisfiedTargetGUID = nil
     self._targetRefreshCleanTickerSkipTransitionSerial = nil
     self._targetRefreshPendingTransitionSerial = nil
     return self._targetRefreshTransitionSerial
@@ -286,6 +302,17 @@ function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transiti
         return
     end
 
+    local targetExists, targetGUID, targetStateKnown = CaptureTargetRefreshState()
+    if not targetStateKnown then
+        self._targetRefreshSatisfiedTransitionSerial = nil
+        self._targetRefreshSatisfiedDirtySerial = nil
+        self._targetRefreshSatisfiedSource = nil
+        self._targetRefreshSatisfiedTargetExists = nil
+        self._targetRefreshSatisfiedTargetGUID = nil
+        self._targetRefreshCleanTickerSkipTransitionSerial = nil
+        return
+    end
+
     if dirtySerial == nil and self._cooldownsDirty then
         dirtySerial = self._cooldownDirtySerial or 0
     end
@@ -293,6 +320,8 @@ function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transiti
     self._targetRefreshSatisfiedTransitionSerial = transitionSerial
     self._targetRefreshSatisfiedDirtySerial = dirtySerial
     self._targetRefreshSatisfiedSource = source
+    self._targetRefreshSatisfiedTargetExists = targetExists
+    self._targetRefreshSatisfiedTargetGUID = targetGUID
 
     if transitionSerial and self._targetRefreshPendingTransitionSerial == transitionSerial then
         self._targetRefreshPendingTransitionSerial = nil
@@ -302,12 +331,29 @@ function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transiti
     end
 end
 
+function CooldownCompanion:IsTargetCooldownRefreshStateSatisfied()
+    if self._targetRefreshSatisfiedTargetExists == nil then
+        return false
+    end
+    local targetExists, targetGUID, targetStateKnown = CaptureTargetRefreshState()
+    if not targetStateKnown or targetExists ~= self._targetRefreshSatisfiedTargetExists then
+        return false
+    end
+    if not targetExists then
+        return true
+    end
+    return targetGUID == self._targetRefreshSatisfiedTargetGUID
+end
+
 function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
     if not IsTargetRefreshSource(source) then return false end
     if self._queuedCooldownRefreshSource then return false end
 
     local transitionSerial = self._targetRefreshTransitionSerial
     if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+        return false
+    end
+    if not self:IsTargetCooldownRefreshStateSatisfied() then
         return false
     end
 
@@ -324,14 +370,24 @@ end
 
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
-    if self._cooldownsDirty then
-        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    if self._activeCooldownPeriodicMaintenanceRequired then return false end
+    if not self:IsTargetCooldownRefreshStateSatisfied() then
+        return false
     end
 
     local transitionSerial = self._targetRefreshTransitionSerial
-    return transitionSerial ~= nil
-        and self._targetRefreshSatisfiedTransitionSerial == transitionSerial
-        and self._targetRefreshCleanTickerSkipTransitionSerial == transitionSerial
+    if self._cooldownsDirty then
+        if self._targetRefreshSatisfiedTransitionSerial
+            and self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+            return false
+        end
+        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    end
+
+    if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+        return false
+    end
+    return self._targetRefreshCleanTickerSkipTransitionSerial == transitionSerial
 end
 
 function CooldownCompanion:ConsumeTargetTickerCooldownRefreshSkip()
@@ -373,6 +429,8 @@ function CooldownCompanion:FlushQueuedCooldownRefresh()
         end
         if targetSource then
             self:RecordTargetCooldownRefreshSatisfied(targetSource, targetTransitionSerial, targetDirtySerial)
+        else
+            self:RecordTargetPendingTickerRefreshSatisfied()
         end
     end
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -366,6 +366,9 @@ end
 function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
     if not IsTargetRefreshSource(source) then return false end
     if self._queuedCooldownRefreshSource then return false end
+    if source == "unit-target-event" and self._activeTargetCooldownMaintenanceRequired then
+        return false
+    end
 
     local transitionSerial = self._targetRefreshTransitionSerial
     if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -198,6 +198,8 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
     self._activeActionbarCooldownFallbackRequired = nil
     self._activeCooldownPeriodicMaintenanceRequired = nil
+    self._activeTargetCooldownMaintenanceRequired = nil
+    self._activeNonTargetCooldownMaintenanceRequired = nil
 end
 
 function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
@@ -208,8 +210,19 @@ function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
     else
         build.actionbarFallbackRequired = nil
         build.periodicMaintenanceRequired = nil
+        build.targetMaintenanceRequired = nil
+        build.nonTargetMaintenanceRequired = nil
     end
     self._cooldownRefreshEligibilityBuild = build
+end
+
+local function RecordPeriodicMaintenance(build, targetMaintenance)
+    build.periodicMaintenanceRequired = true
+    if targetMaintenance then
+        build.targetMaintenanceRequired = true
+    else
+        build.nonTargetMaintenanceRequired = true
+    end
 end
 
 function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
@@ -221,31 +234,34 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     end
 
     if HasActiveIconCooldownText(button, buttonData) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if HasCooldownDrivenVisualMaintenance(button, buttonData) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if button._isText == true then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if button._cooldownDeferred == true then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
-    if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
-        build.periodicMaintenanceRequired = true
+    if button._auraGraceStart ~= nil then
+        RecordPeriodicMaintenance(build)
+    end
+    if button._targetSwitchAt ~= nil then
+        RecordPeriodicMaintenance(build, true)
     end
     if HasTimedReadyGlow(button) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if HasSoundAlerts(buttonData) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if buttonData and buttonData._rotationAssistantVirtual == true then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if IsTriggerRuntime(button, displayMode) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
 end
 
@@ -261,6 +277,8 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
     self._cooldownRefreshEligibilityInvalidationReason = nil
     self._activeActionbarCooldownFallbackRequired = build.actionbarFallbackRequired == true or nil
     self._activeCooldownPeriodicMaintenanceRequired = build.periodicMaintenanceRequired == true or nil
+    self._activeTargetCooldownMaintenanceRequired = build.targetMaintenanceRequired == true or nil
+    self._activeNonTargetCooldownMaintenanceRequired = build.nonTargetMaintenanceRequired == true or nil
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -370,7 +388,7 @@ end
 
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
-    if self._activeCooldownPeriodicMaintenanceRequired then return false end
+    if self._activeNonTargetCooldownMaintenanceRequired then return false end
     if not self:IsTargetCooldownRefreshStateSatisfied() then
         return false
     end
@@ -494,7 +512,7 @@ function CooldownCompanion:ClearActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = nil
 end
 
-function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
+function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
     if not self._actionbarCooldownPulsePending then
         return false
     end
@@ -510,7 +528,11 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._activeActionbarCooldownFallbackRequired then
         return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
+    if self._activeCooldownPeriodicMaintenanceRequired
+        and not cooldownEventSatisfied
+        and not (targetRefreshSatisfied
+            and self._activeTargetCooldownMaintenanceRequired
+            and not self._activeNonTargetCooldownMaintenanceRequired) then
         return false
     end
     return true
@@ -527,7 +549,7 @@ function CooldownCompanion:TickCooldownRefresh()
     local tickerRefreshSatisfied = cooldownEventSatisfied or targetRefreshSatisfied
     local actionbarFallbackRequired = false
     if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
-        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
+        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
         if canSkipActionbarPulse then
             self:ClearActionbarCooldownPulse()
             if targetRefreshSatisfied then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -366,7 +366,9 @@ end
 function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
     if not IsTargetRefreshSource(source) then return false end
     if self._queuedCooldownRefreshSource then return false end
-    if source == "unit-target-event" and self._activeTargetCooldownMaintenanceRequired then
+    if source == "unit-target-event"
+        and (not self._cooldownRefreshEligibilityKnown
+            or self._activeTargetCooldownMaintenanceRequired) then
         return false
     end
 
@@ -391,6 +393,8 @@ end
 
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
+    if not self._cooldownRefreshEligibilityKnown then return false end
+    if self._activeTargetCooldownMaintenanceRequired then return false end
     if self._activeNonTargetCooldownMaintenanceRequired then return false end
     if not self:IsTargetCooldownRefreshStateSatisfied() then
         return false

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -526,7 +526,7 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._queuedCooldownRefreshSource then
         return false
     end
-    if self._cooldownsDirty and not cooldownEventSatisfied then
+    if self._cooldownsDirty and not (cooldownEventSatisfied or targetRefreshSatisfied) then
         return false
     end
     if not self._cooldownRefreshEligibilityKnown then
@@ -535,11 +535,7 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._activeActionbarCooldownFallbackRequired then
         return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired
-        and not cooldownEventSatisfied
-        and not (targetRefreshSatisfied
-            and self._activeTargetCooldownMaintenanceRequired
-            and not self._activeNonTargetCooldownMaintenanceRequired) then
+    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
         return false
     end
     return true

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -10,8 +10,22 @@
       a debug breadcrumb, not skip eligibility.
     - _queuedCooldownRefreshCooldownEventSerial: dirty serial captured when a
       queued cooldown-event request enters the queue.
+    - _queuedCooldownRefreshTargetDirtySerial/_queuedCooldownRefreshTargetTransitionSerial:
+      target-family state captured when a queued target request enters the
+      queue.
+    - _queuedCooldownRefreshTargetSource: first queued target-family source
+      covered by the pending broad flush.
     - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
       cooldown-event refresh.
+    - _targetRefreshTransitionSerial: monotonic target-state marker bumped by
+      PLAYER_TARGET_CHANGED.
+    - _targetRefreshSatisfiedTransitionSerial/_targetRefreshSatisfiedDirtySerial:
+      target-family broad work that covered the current transition and, when
+      dirty, the serial it covered.
+    - _targetRefreshCleanTickerSkipTransitionSerial: one-shot clean ticker
+      confirmation covered by the target-exists synchronous probe.
+    - _targetRefreshPendingTransitionSerial: target-clear dirty confirmation
+      waiting for its first broad pass.
     - _cooldownImmediateRefreshThisFrame: latch allowing only the first
       immediate refresh in a frame to walk synchronously.
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
@@ -32,6 +46,8 @@
       If another dirty mark lands before the flush, the later ticker walks
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
+    - Target-family duplicate skips require either the same target transition or
+      the exact dirty serial already covered by a target-family broad pass.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -40,6 +56,16 @@ local CooldownLogic = ST.CooldownLogic or {}
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN or "cooldown"
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING or "missing"
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO or "zero"
+local TARGET_REFRESH_SOURCES = {
+    ["target-event"] = true,
+    ["target-aura-event"] = true,
+    ["unit-target-event"] = true,
+    ["target-ticker"] = true,
+}
+
+local function IsTargetRefreshSource(source)
+    return TARGET_REFRESH_SOURCES[source] == true
+end
 
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
@@ -232,6 +258,94 @@ function CooldownCompanion:ClearCooldownsDirty()
     self._cooldownsDirty = false
 end
 
+function CooldownCompanion:BeginTargetCooldownRefreshTransition(reason)
+    self._targetRefreshTransitionSerial = (self._targetRefreshTransitionSerial or 0) + 1
+    self._targetRefreshTransitionReason = reason or "target"
+    self._targetRefreshSatisfiedTransitionSerial = nil
+    self._targetRefreshSatisfiedDirtySerial = nil
+    self._targetRefreshSatisfiedSource = nil
+    self._targetRefreshCleanTickerSkipTransitionSerial = nil
+    self._targetRefreshPendingTransitionSerial = nil
+    return self._targetRefreshTransitionSerial
+end
+
+function CooldownCompanion:MarkTargetCooldownRefreshPending(transitionSerial)
+    transitionSerial = transitionSerial or self._targetRefreshTransitionSerial
+    if transitionSerial then
+        self._targetRefreshPendingTransitionSerial = transitionSerial
+    end
+end
+
+function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transitionSerial, dirtySerial, options)
+    if not IsTargetRefreshSource(source) then return end
+
+    transitionSerial = transitionSerial or self._targetRefreshTransitionSerial
+    if transitionSerial
+        and self._targetRefreshTransitionSerial
+        and transitionSerial ~= self._targetRefreshTransitionSerial then
+        return
+    end
+
+    if dirtySerial == nil and self._cooldownsDirty then
+        dirtySerial = self._cooldownDirtySerial or 0
+    end
+
+    self._targetRefreshSatisfiedTransitionSerial = transitionSerial
+    self._targetRefreshSatisfiedDirtySerial = dirtySerial
+    self._targetRefreshSatisfiedSource = source
+
+    if transitionSerial and self._targetRefreshPendingTransitionSerial == transitionSerial then
+        self._targetRefreshPendingTransitionSerial = nil
+    end
+    if options and options.allowCleanTickerSkip and transitionSerial and dirtySerial == nil then
+        self._targetRefreshCleanTickerSkipTransitionSerial = transitionSerial
+    end
+end
+
+function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
+    if not IsTargetRefreshSource(source) then return false end
+    if self._queuedCooldownRefreshSource then return false end
+
+    local transitionSerial = self._targetRefreshTransitionSerial
+    if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+        return false
+    end
+
+    if self._cooldownsDirty then
+        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    end
+    return true
+end
+
+function CooldownCompanion:CanSkipCooldownEventTickerRefresh()
+    return self._cooldownsDirty
+        and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+end
+
+function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
+    if self._queuedCooldownRefreshSource then return false end
+    if self._cooldownsDirty then
+        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    end
+
+    local transitionSerial = self._targetRefreshTransitionSerial
+    return transitionSerial ~= nil
+        and self._targetRefreshSatisfiedTransitionSerial == transitionSerial
+        and self._targetRefreshCleanTickerSkipTransitionSerial == transitionSerial
+end
+
+function CooldownCompanion:ConsumeTargetTickerCooldownRefreshSkip()
+    self._targetRefreshCleanTickerSkipTransitionSerial = nil
+end
+
+function CooldownCompanion:RecordTargetPendingTickerRefreshSatisfied()
+    local transitionSerial = self._targetRefreshPendingTransitionSerial
+    if transitionSerial and transitionSerial == self._targetRefreshTransitionSerial then
+        self:RecordTargetCooldownRefreshSatisfied("target-ticker", transitionSerial)
+    end
+    self._targetRefreshCleanTickerSkipTransitionSerial = nil
+end
+
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
     if not self._cooldownRefreshQueueFrame then
         local frame = CreateFrame("Frame")
@@ -247,12 +361,18 @@ end
 function CooldownCompanion:FlushQueuedCooldownRefresh()
     local queuedSource = self._queuedCooldownRefreshSource
     local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
+    local targetSource = self._queuedCooldownRefreshTargetSource
+    local targetDirtySerial = self._queuedCooldownRefreshTargetDirtySerial
+    local targetTransitionSerial = self._queuedCooldownRefreshTargetTransitionSerial
     self:ResetCooldownRefreshState(queuedSource == nil)
 
     if queuedSource then
         self:UpdateAllCooldowns()
         if cooldownEventSerial then
             self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
+        end
+        if targetSource then
+            self:RecordTargetCooldownRefreshSatisfied(targetSource, targetTransitionSerial, targetDirtySerial)
         end
     end
 end
@@ -261,6 +381,11 @@ function CooldownCompanion:QueueCooldownRefresh(source)
     self._queuedCooldownRefreshSource = source or "event"
     if source == "cooldown-event" then
         self._queuedCooldownRefreshCooldownEventSerial = self._cooldownDirtySerial or 0
+    end
+    if IsTargetRefreshSource(source) then
+        self._queuedCooldownRefreshTargetSource = source
+        self._queuedCooldownRefreshTargetDirtySerial = self._cooldownsDirty and (self._cooldownDirtySerial or 0) or nil
+        self._queuedCooldownRefreshTargetTransitionSerial = self._targetRefreshTransitionSerial
     end
     self:EnsureCooldownRefreshQueueFrame()
 end
@@ -275,22 +400,32 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
     if source == "cooldown-event" then
         cooldownEventSerial = self._cooldownDirtySerial or 0
     end
+    local targetDirtySerial
+    local targetTransitionSerial
+    if IsTargetRefreshSource(source) then
+        targetDirtySerial = self._cooldownsDirty and (self._cooldownDirtySerial or 0) or nil
+        targetTransitionSerial = self._targetRefreshTransitionSerial
+    end
 
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
+    self._queuedCooldownRefreshTargetSource = nil
+    self._queuedCooldownRefreshTargetDirtySerial = nil
+    self._queuedCooldownRefreshTargetTransitionSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
     self:UpdateAllCooldowns()
     if cooldownEventSerial then
         self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
     end
+    if IsTargetRefreshSource(source) then
+        self:RecordTargetCooldownRefreshSatisfied(source, targetTransitionSerial, targetDirtySerial)
+    end
 end
 
 function CooldownCompanion:CanSkipTickerCooldownRefresh()
-    -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
-    -- target, and other dirty paths keep their normal ticker confirmation.
-    return self._cooldownsDirty
-        and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+    return self:CanSkipCooldownEventTickerRefresh()
+        or self:CanSkipTargetTickerCooldownRefresh()
 end
 
 function CooldownCompanion:RecordActionbarCooldownPulse()
@@ -329,23 +464,32 @@ function CooldownCompanion:TickCooldownRefresh()
         return false
     end
 
-    local cooldownEventSatisfied = self:CanSkipTickerCooldownRefresh()
+    local cooldownEventSatisfied = self:CanSkipCooldownEventTickerRefresh()
+    local targetRefreshSatisfied = self:CanSkipTargetTickerCooldownRefresh()
+    local tickerRefreshSatisfied = cooldownEventSatisfied or targetRefreshSatisfied
     local actionbarFallbackRequired = false
-    if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or cooldownEventSatisfied) then
+    if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
         local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
         if canSkipActionbarPulse then
             self:ClearActionbarCooldownPulse()
+            if targetRefreshSatisfied then
+                self:ConsumeTargetTickerCooldownRefreshSkip()
+            end
             return true
         end
         actionbarFallbackRequired = true
     end
 
-    if cooldownEventSatisfied and not actionbarFallbackRequired then
+    if tickerRefreshSatisfied and not actionbarFallbackRequired then
         self:ClearActionbarCooldownPulse()
+        if targetRefreshSatisfied then
+            self:ConsumeTargetTickerCooldownRefreshSkip()
+        end
         return true
     end
 
     self:UpdateAllCooldowns()
+    self:RecordTargetPendingTickerRefreshSatisfied()
     self:ClearActionbarCooldownPulse()
     return false
 end
@@ -357,6 +501,9 @@ function CooldownCompanion:ResetCooldownRefreshState(preserveActionbarPulse)
     self._cooldownRefreshQueueArmed = nil
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
+    self._queuedCooldownRefreshTargetSource = nil
+    self._queuedCooldownRefreshTargetDirtySerial = nil
+    self._queuedCooldownRefreshTargetTransitionSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
     if not preserveActionbarPulse then
         self:ClearActionbarCooldownPulse()

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -208,20 +208,25 @@ function CooldownCompanion:OnEnable()
     self:RegisterEvent("UNIT_ENTERED_VEHICLE", "OnVehicleUIChanged")
     self:RegisterEvent("UNIT_EXITED_VEHICLE", "OnVehicleUIChanged")
 
-    -- Target change — marks dirty so ticker reads fresh viewer data next pass
+    -- Target change — probes or clears target aura state through OnTargetChanged.
     self:RegisterEvent("PLAYER_TARGET_CHANGED", "OnTargetChanged")
 
     -- UNIT_TARGET requires RegisterUnitEvent (plain RegisterEvent does not
-    -- receive it).  Marks dirty so the next ticker pass reads fresh CDM viewer
-    -- data; catches pet/focus target changes that don't fire PLAYER_TARGET_CHANGED.
+    -- receive it).  It stays a conservative broad fallback unless the current
+    -- target transition was already covered by PLAYER_TARGET_CHANGED or target
+    -- aura work.
     if not self._unitTargetFrame then
         self._unitTargetFrame = CreateFrame("Frame")
         self._unitTargetFrame:SetScript("OnEvent", function(_, event, unitToken)
             if ST._QueueInheritedUnitFrameAlphaResync then
                 ST._QueueInheritedUnitFrameAlphaResync()
             end
+            if self:CanSkipTargetRefreshDuplicate("unit-target-event") then
+                return
+            end
             self:MarkCooldownsDirty()
             self:UpdateAllCooldowns()
+            self:RecordTargetCooldownRefreshSatisfied("unit-target-event")
         end)
     end
     self._unitTargetFrame:RegisterUnitEvent("UNIT_TARGET", "player")


### PR DESCRIPTION
## What Players Will Notice
- Cooldown Companion does less duplicate cooldown display work during target switches, which should reduce the CPU bursts that were showing up around target selection while keeping tracked target/aura displays accurate.
- Repeated actionbar cooldown pulses that follow a covered target refresh now stay cheap instead of forcing extra broad display walks.

## Why This Changed
- Profiling showed that target-switch windows could combine `PLAYER_TARGET_CHANGED`, `UNIT_TARGET`, target aura refreshes, and actionbar cooldown pulses into redundant broad cooldown refreshes.
- The broad refresh model is intentionally retained for correctness, but this branch teaches the scheduler when target-related broad work has already covered the current target transition.

## What Changed
- Added target refresh transition bookkeeping so target-event, target-aura, unit-target, queued, immediate, and ticker paths can identify when the current target state has already been refreshed.
- Split periodic cooldown maintenance into target and non-target requirements so target-only duplicate checks do not incorrectly skip unrelated periodic display work.
- Updated actionbar pulse handling so a pulse can skip only when the relevant dirty work was already satisfied by a cooldown-event or target refresh, while still falling back conservatively for unknown eligibility, queued work, fallback-required buttons, or active non-target periodic maintenance.
- Adjusted target event handling so target aura events run as target-specific refreshes, target clears mark pending target work, and `UNIT_TARGET` avoids duplicate broad refreshes only after the target transition is safely covered.

## Validation
- `luac -p CooldownCompanion/Core/CooldownRefresh.lua CooldownCompanion/Core/Aura.lua CooldownCompanion/Core/Lifecycle.lua tests/actionbar-cooldown-policy.lua tests/target-switch-dedupe.lua .local-tools/cdc-profiler/CooldownCompanion_Profiler/CooldownCompanionAdapter.lua .local-tools/cdc-profiler/self-check.lua`
- `git diff --check origin/perf-refresh-pivot...HEAD`
- `lua tests\actionbar-cooldown-policy.lua`
- `lua tests\target-switch-dedupe.lua`
- `lua .local-tools\cdc-profiler\self-check.lua`
- In-game profiler validation after the final cleanup: one single-target-switch capture produced 187 spans, 1 `UpdateAllCooldowns`, 26 button updates, 13 actionbar pulse skips, 0 actionbar fallback broad refreshes, and no Lua errors in the flushed DevBridge snapshot.
- Earlier target-switch profiling in this branch also covered target A-to-B / target-clear style validation. Combat or restricted-content validation was not repeated after the final one-line cleanup.
