### PR TITLE
Reduce actionbar refresh work during ability bursts

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1450,6 +1450,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button._actionSlotCooldownCandidate = true
             end
             if slotProbe.shown ~= nil then
+                button._actionSlotCooldownFallback = true
                 button._mainCDShown = slotProbe.realShown == true
             elseif not auraOwnsPrimarySwipe then
                 -- No action bar slot found; use the ignoreGCD-backed real cooldown state.

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -569,7 +569,7 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     local build = self._cooldownRefreshEligibilityBuild
     if not build or not button then return end
 
-    if button._actionSlotCooldownFallback == true or button._actionSlotCooldownCandidate == true then
+    if button._actionSlotCooldownFallback == true then
         build.actionbarFallbackRequired = true
     end
 


### PR DESCRIPTION
## What Players Will Notice
- Pressing tracked abilities should cause fewer unnecessary full cooldown refreshes from actionbar cooldown pulses, reducing CPU spikes while preserving conservative fallback behavior when action-slot cooldown data is actually used.

## Why This Changed
- Profiler captures showed ability presses could treat action-slot cooldown candidates as if they required broad actionbar fallback work, causing extra full cooldown walks even when the addon had not actually fallen back to action-slot cooldown data.

## What Changed
- Candidate-only action-slot cooldown probes no longer mark actionbar fallback as required.
- The actual restricted action-slot cooldown fallback path now marks itself explicitly, so conservative broad refresh behavior remains available when the addon consumes that fallback data.
- This keeps the branch focused on ability-burst/actionbar fallback policy and leaves unrelated periodic charge visual maintenance noise for the next performance lane.

## Validation
- `lua tests/actionbar-cooldown-policy.lua`
- `luac -p CooldownCompanion/Core/CooldownRefresh.lua CooldownCompanion/ButtonFrame/CooldownUpdate.lua tests/actionbar-cooldown-policy.lua`
- `git diff --check`
- Five-agent static review against `perf-refresh-pivot`: no actionable findings.
- In-game profiler validation for a simple tracked ability press showed actionbar fallback broad refreshes drop from 12 to 0, `UpdateAllCooldowns` drop from 15 to 3, and button updates drop from 405 to 81.
- A later charged ability profile showed remaining `charge-cooldown-visual` periodic maintenance noise, which is intentionally out of scope for this branch and belongs to the next lane.
- Combat/restricted-content behavior was not separately re-run by this publish step; validate in game before final merge if that has not already been covered by the profiling round.