### PR TITLE
Reduce duplicate form-change refresh work

### DIFF
--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -17,6 +17,8 @@
       covered by the pending broad flush.
     - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
       cooldown-event refresh.
+    - _spellAvailabilityRefreshSatisfiedSerial: dirty serial covered by an
+      executed spell-availability broad refresh.
     - _targetRefreshTransitionSerial: monotonic target-state marker bumped by
       PLAYER_TARGET_CHANGED.
     - _targetRefreshSatisfiedTransitionSerial/_targetRefreshSatisfiedDirtySerial:
@@ -44,6 +46,9 @@
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
+    - Spell-availability satisfaction only covers the dirty serial created by
+      the direct spell-availability broad pass, and only while the active
+      cooldown eligibility snapshot remains valid.
     - MarkCooldownsDirty is the only invalidator; stale satisfied serials are
       inert because they cannot match a later dirty serial.
     - Queued cooldown-event requests satisfy the serial captured at queue time.
@@ -627,6 +632,7 @@ end
 function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._cooldownRefreshEligibilityKnown = nil
     self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
+    self._spellAvailabilityRefreshSatisfiedSerial = nil
     self._activeActionbarCooldownFallbackRequired = nil
     self._activeCooldownPeriodicMaintenanceRequired = nil
     self._activeTargetCooldownMaintenanceRequired = nil
@@ -946,6 +952,22 @@ function CooldownCompanion:CanSkipCooldownEventTickerRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
+function CooldownCompanion:RecordSpellAvailabilityCooldownRefreshSatisfied(dirtySerial)
+    if not self._cooldownRefreshEligibilityKnown then return end
+    if dirtySerial == nil then
+        if not self._cooldownsDirty then return end
+        dirtySerial = self._cooldownDirtySerial or 0
+    end
+    self._spellAvailabilityRefreshSatisfiedSerial = dirtySerial
+end
+
+function CooldownCompanion:CanSkipSpellAvailabilityTickerCooldownRefresh()
+    if self._queuedCooldownRefreshSource then return false end
+    if not self._cooldownRefreshEligibilityKnown then return false end
+    return self._cooldownsDirty
+        and self._spellAvailabilityRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+end
+
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
     if not self._cooldownRefreshEligibilityKnown then return false end
@@ -1063,6 +1085,7 @@ end
 
 function CooldownCompanion:CanSkipTickerCooldownRefresh()
     return self:CanSkipCooldownEventTickerRefresh()
+        or self:CanSkipSpellAvailabilityTickerCooldownRefresh()
         or self:CanSkipTargetTickerCooldownRefresh()
 end
 
@@ -1274,14 +1297,16 @@ function CooldownCompanion:OnPowerEventCooldownRefresh()
     return true
 end
 
-function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
+function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied, spellAvailabilitySatisfied)
     if not self._actionbarCooldownPulsePending then
         return false
     end
     if self._queuedCooldownRefreshSource then
         return false
     end
-    if self._cooldownsDirty and not (cooldownEventSatisfied or targetRefreshSatisfied) then
+    local broadRefreshSatisfied = cooldownEventSatisfied == true
+    local dirtyRefreshSatisfied = broadRefreshSatisfied or spellAvailabilitySatisfied or targetRefreshSatisfied
+    if self._cooldownsDirty and not dirtyRefreshSatisfied then
         return false
     end
     if not self._cooldownRefreshEligibilityKnown then
@@ -1290,7 +1315,7 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._activeActionbarCooldownFallbackRequired then
         return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
+    if self._activeCooldownPeriodicMaintenanceRequired and not broadRefreshSatisfied then
         if not self:HasOnlySkippableVisualMaintenance() then
             return false
         end
@@ -1314,14 +1339,16 @@ function CooldownCompanion:TickCooldownRefresh()
     end
 
     local cooldownEventSatisfied = self:CanSkipCooldownEventTickerRefresh()
+    local spellAvailabilitySatisfied = self:CanSkipSpellAvailabilityTickerCooldownRefresh()
     local targetRefreshSatisfied = self:CanSkipTargetTickerCooldownRefresh()
-    local tickerRefreshSatisfied = cooldownEventSatisfied or targetRefreshSatisfied
+    local tickerRefreshSatisfied = cooldownEventSatisfied or spellAvailabilitySatisfied or targetRefreshSatisfied
+    local broadRefreshSatisfied = cooldownEventSatisfied == true
     local actionbarFallbackRequired = false
     if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
-        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
+        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied, spellAvailabilitySatisfied)
         if canSkipActionbarPulse then
             if self._activeChargeCooldownVisualMaintenanceRequired
-                and not cooldownEventSatisfied
+                and not broadRefreshSatisfied
                 and not self:RunChargeCooldownVisualMaintenance() then
                 self:UpdateAllCooldowns()
                 self:RecordTargetPendingTickerRefreshSatisfied()
@@ -1329,7 +1356,7 @@ function CooldownCompanion:TickCooldownRefresh()
                 return false
             end
             if self._activeSafeTextWidgetMaintenanceRequired
-                and not cooldownEventSatisfied
+                and not broadRefreshSatisfied
                 and not self:RunSafeTextWidgetMaintenance() then
                 self:UpdateAllCooldowns()
                 self:RecordTargetPendingTickerRefreshSatisfied()

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -51,12 +51,38 @@ local function QueueTalentChargeRefresh(addon)
     end)
 end
 
+local function RefreshSpellAvailabilitySettlingState(addon)
+    addon:CachePlayerState()
+    addon:CacheCurrentSpec()
+    addon._currentHeroSpecId = C_ClassTalents.GetActiveHeroTalentSpec()
+    addon:RebuildTalentNodeCache()
+
+    local chargeFlagsChanged = addon:RefreshChargeFlags("spell") == true
+    local groupSurfaceChanged
+    if addon.AnyGroupSurfaceNeedsSpellAvailabilityRefresh then
+        groupSurfaceChanged = addon:AnyGroupSurfaceNeedsSpellAvailabilityRefresh()
+    else
+        groupSurfaceChanged = addon:AnyGroupButtonSetNeedsRebuild()
+    end
+    if not chargeFlagsChanged and not groupSurfaceChanged then
+        addon._lastSpellAvailabilitySettlingDecision = "skipped-clean"
+        return
+    end
+
+    addon._lastSpellAvailabilitySettlingDecision = chargeFlagsChanged
+        and (groupSurfaceChanged and "refreshed-charge-and-surface" or "refreshed-charge")
+        or "refreshed-surface"
+    addon:RefreshAllGroupsForSpellAvailability()
+    addon:RefreshKeybindState()
+    addon:RefreshConfigPanel()
+end
+
 local function QueueSpellAvailabilitySettlingRefresh(addon)
     pendingSpellAvailabilityRefreshToken = pendingSpellAvailabilityRefreshToken + 1
     local token = pendingSpellAvailabilityRefreshToken
     C_Timer.After(0.2, function()
         if pendingSpellAvailabilityRefreshToken ~= token then return end
-        addon:RefreshSpellAvailabilityState({ skipSettlingRefresh = true })
+        RefreshSpellAvailabilitySettlingState(addon)
     end)
 end
 
@@ -394,23 +420,101 @@ function CooldownCompanion:UpdateSpellChargeMetadata(buttonData, spellID, opts)
     buttonData.hasCharges = hasRealCharges
 end
 
+local function CaptureChargeFlagState(buttonData)
+    return buttonData.hasCharges,
+        buttonData.maxCharges,
+        buttonData.showChargeText,
+        buttonData._hasDisplayCount,
+        buttonData._displayCountFamily,
+        buttonData._castCountCandidate,
+        buttonData._castCountSelf,
+        buttonData._castCountEventSpellID,
+        buttonData._castCountConfirmed,
+        buttonData._castCountSeeded
+end
+
+local function ChargeFlagStateChanged(
+    buttonData,
+    hasCharges,
+    maxCharges,
+    showChargeText,
+    hasDisplayCount,
+    displayCountFamily,
+    castCountCandidate,
+    castCountSelf,
+    castCountEventSpellID,
+    castCountConfirmed,
+    castCountSeeded
+)
+    return buttonData.hasCharges ~= hasCharges
+        or buttonData.maxCharges ~= maxCharges
+        or buttonData.showChargeText ~= showChargeText
+        or buttonData._hasDisplayCount ~= hasDisplayCount
+        or buttonData._displayCountFamily ~= displayCountFamily
+        or buttonData._castCountCandidate ~= castCountCandidate
+        or buttonData._castCountSelf ~= castCountSelf
+        or buttonData._castCountEventSpellID ~= castCountEventSpellID
+        or buttonData._castCountConfirmed ~= castCountConfirmed
+        or buttonData._castCountSeeded ~= castCountSeeded
+end
+
 -- Re-evaluate hasCharges on every spell button (talents can add/remove charges).
 -- Treat a spell as charge-based only when max charges is greater than 1.
 function CooldownCompanion:RefreshChargeFlags(typeFilter)
+    local changed = false
     if typeFilter ~= "item" then
         self._hasDisplayCountCandidates = false
     end
     for _, group in pairs(self.db.profile.groups) do
         for _, buttonData in ipairs(group.buttons) do
             if buttonData.type == "spell" and typeFilter ~= "item" then
+                local hasCharges, maxCharges, showChargeText, hasDisplayCount,
+                    displayCountFamily, castCountCandidate, castCountSelf,
+                    castCountEventSpellID, castCountConfirmed,
+                    castCountSeeded = CaptureChargeFlagState(buttonData)
                 self:UpdateSpellChargeMetadata(buttonData, buttonData.id)
+                if ChargeFlagStateChanged(
+                    buttonData,
+                    hasCharges,
+                    maxCharges,
+                    showChargeText,
+                    hasDisplayCount,
+                    displayCountFamily,
+                    castCountCandidate,
+                    castCountSelf,
+                    castCountEventSpellID,
+                    castCountConfirmed,
+                    castCountSeeded
+                ) then
+                    changed = true
+                end
             elseif buttonData.type == "item" and typeFilter ~= "spell" then
                 -- Never clear hasCharges for items; unavailable charged items can
                 -- be indistinguishable from unowned items through count APIs.
+                local hasCharges, maxCharges, showChargeText, hasDisplayCount,
+                    displayCountFamily, castCountCandidate, castCountSelf,
+                    castCountEventSpellID, castCountConfirmed,
+                    castCountSeeded = CaptureChargeFlagState(buttonData)
                 self.UpdateItemChargeMetadata(buttonData, buttonData.id)
+                if ChargeFlagStateChanged(
+                    buttonData,
+                    hasCharges,
+                    maxCharges,
+                    showChargeText,
+                    hasDisplayCount,
+                    displayCountFamily,
+                    castCountCandidate,
+                    castCountSelf,
+                    castCountEventSpellID,
+                    castCountConfirmed,
+                    castCountSeeded
+                ) then
+                    changed = true
+                end
             end
         end
     end
+    return changed
 end
 
 function CooldownCompanion:CacheCurrentSpec()

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1836,6 +1836,62 @@ function CooldownCompanion:AnyGroupButtonSetNeedsRebuild()
     return false
 end
 
+function CooldownCompanion:GroupSurfaceNeedsSpellAvailabilityRefresh(groupId, group)
+    local frame = self.groupFrames and self.groupFrames[groupId] or nil
+    local dormantFrame = self._dormantFrames and self._dormantFrames[groupId] or nil
+    if not self:IsGroupVisibleToCurrentChar(groupId) then
+        return frame ~= nil or dormantFrame ~= nil
+    end
+
+    local active = self:IsGroupActive(groupId, {
+        group = group,
+        checkCharVisibility = true,
+        checkLoadConditions = true,
+        requireButtons = true,
+    })
+
+    if not active then
+        return frame ~= nil or dormantFrame ~= nil
+    end
+    if not frame then
+        return true
+    end
+    if type(frame.IsShown) == "function" and not frame:IsShown() then
+        return true
+    end
+
+    return self:GroupButtonSetNeedsRebuild(groupId, group)
+end
+
+function CooldownCompanion:AnyGroupSurfaceNeedsSpellAvailabilityRefresh()
+    if not self.db or not self.db.profile or not self.db.profile.groups then
+        return false
+    end
+
+    if self.groupFrames then
+        for groupId, _ in pairs(self.groupFrames) do
+            if not self.db.profile.groups[groupId] then
+                return true
+            end
+        end
+    end
+    if self._dormantFrames then
+        for groupId, _ in pairs(self._dormantFrames) do
+            if not self.db.profile.groups[groupId] then
+                return true
+            end
+        end
+    end
+
+    for groupId, group in pairs(self.db.profile.groups) do
+        if self:GroupSurfaceNeedsSpellAvailabilityRefresh(groupId, group) then
+            return true
+        end
+    end
+
+    return false
+end
+
 function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
     local function resetFrameButtons(frame)
         if not frame or not frame.buttons then return end
@@ -1896,7 +1952,11 @@ function CooldownCompanion:RefreshAllGroupsForSpellAvailability()
         self:RefreshAllGroupsVisibilityOnly()
     end
 
+    local spellAvailabilityDirtySerial = self._cooldownsDirty and (self._cooldownDirtySerial or 0) or nil
     self:UpdateAllCooldowns()
+    if self.RecordSpellAvailabilityCooldownRefreshSatisfied then
+        self:RecordSpellAvailabilityCooldownRefreshSatisfied(spellAvailabilityDirtySerial)
+    end
 end
 
 function CooldownCompanion:CreateAllGroupFrames()


### PR DESCRIPTION
## What Players Will Notice
- Shapeshift/form and spell-availability updates should keep tracked displays accurate while doing less duplicate cooldown refresh work after the initial update.
- Normal tracked ability presses and combat/restricted-content use should continue to behave the same, with no intended display accuracy tradeoff.

## Why This Changed
- Form/spell-availability changes can require a broad refresh to keep spell identity, icons, charge metadata, and group visibility correct.
- The delayed settling pass was still capable of repeating broad cooldown work even when the earlier pass had already covered the same dirty state.

## What Changed
- Spell-availability refreshes now record when their direct broad cooldown pass satisfied the current dirty serial, allowing the next matching ticker confirmation to skip duplicate work.
- Delayed spell-availability settling now rechecks charge metadata and active group surface/frame state before deciding whether a second group refresh is necessary.
- Actionbar pulse maintenance remains conservative: spell-availability satisfaction can skip its own duplicate ticker, but it does not mask later actionbar pulse maintenance.

## Validation
- Ran `lua tests\spell-availability-delayed-settling.lua`.
- Ran `lua tests\spell-availability-settling.lua`.
- Ran `lua tests\actionbar-cooldown-policy.lua`.
- Ran `lua tests\target-switch-dedupe.lua`.
- Ran `lua tests\power-event-refresh-policy.lua`.
- Ran `lua .local-tools\cdc-profiler\self-check.lua`.
- Ran `luac -p` on the changed shipped Lua files, focused local tests, and profiler files.
- Ran `git diff --check`; only existing LF-to-CRLF working-copy warnings were reported.
- Ran five-agent static review against `perf-refresh-pivot`; all five reviewers reported no actionable findings.
- In-game profiler validation covered shapeshift/form, normal tracked ability/actionbar, and combat/restricted-content smoke captures; captures were complete/non-truncated and no Lua errors were observed by the user.
