### PR TITLE
Reduce unnecessary cooldown refresh work

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1450,6 +1450,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button._actionSlotCooldownCandidate = true
             end
             if slotProbe.shown ~= nil then
+                button._actionSlotCooldownFallback = true
                 button._mainCDShown = slotProbe.realShown == true
             elseif not auraOwnsPrimarySwipe then
                 -- No action bar slot found; use the ignoreGCD-backed real cooldown state.

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -78,6 +78,12 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
+local function RecordCooldownRefreshEligibility(addon, button, buttonData, displayMode)
+    if addon.RecordButtonCooldownRefreshEligibility then
+        addon:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
+    end
+end
+
 function CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot()
     local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
     return isEnabled and isEnabled() == true
@@ -808,9 +814,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
         ClearRotationAssistantMissingState(button, buttonData, style)
-        if self.RecordButtonCooldownRefreshEligibility then
-            self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
-        end
+        RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
         return
     end
 
@@ -1448,6 +1452,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- this path and the isActive fallback.
             local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
                 or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+            if slotProbe.sawAnySlot then
+                button._actionSlotCooldownCandidate = true
+            end
             if slotProbe.shown ~= nil then
                 button._mainCDShown = slotProbe.realShown == true
             elseif not auraOwnsPrimarySwipe then
@@ -1777,6 +1784,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
+            RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
             return  -- Skip all visual updates
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -1797,6 +1805,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
+            RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
             return  -- Skip visual updates for hidden buttons
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -1864,9 +1873,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end
-    if self.RecordButtonCooldownRefreshEligibility then
-        self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
-    end
+    RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -78,12 +78,6 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
-local function RecordCooldownRefreshEligibility(addon, button, buttonData, displayMode)
-    if addon.RecordButtonCooldownRefreshEligibility then
-        addon:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
-    end
-end
-
 function CooldownCompanion:ShouldRefreshButtonVisualStateSnapshot()
     local isEnabled = ST._AreButtonVisualStateSnapshotsEnabled
     return isEnabled and isEnabled() == true
@@ -814,7 +808,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
         ClearRotationAssistantMissingState(button, buttonData, style)
-        RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
+        self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
         return
     end
 
@@ -1784,7 +1778,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
-            RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
+            self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
             return  -- Skip all visual updates
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -1805,7 +1799,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
-            RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
+            self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
             return  -- Skip visual updates for hidden buttons
         else
             local targetAlpha = button._visibilityAlphaOverride or 1
@@ -1873,7 +1867,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
     end
-    RecordCooldownRefreshEligibility(self, button, buttonData, buttonDisplayMode)
+    self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -803,9 +803,14 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
     local buttonDisplayMode = buttonGroup and (buttonGroup.displayMode or "icons") or "icons"
     ClearConditionalVisualPreviewFields(button)
+    button._actionSlotCooldownCandidate = nil
+    button._actionSlotCooldownFallback = nil
 
     if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
         ClearRotationAssistantMissingState(button, buttonData, style)
+        if self.RecordButtonCooldownRefreshEligibility then
+            self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
+        end
         return
     end
 
@@ -1238,6 +1243,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 spellCooldownDuration = spellCooldownResult.durationObj
                 spellRealCooldownShown = spellCooldownResult.realCooldownShown == true
                 isOnGCD = spellCooldownResult.isOnGCD or false
+                local slotProbe = spellCooldownResult.slotProbe
+                button._actionSlotCooldownCandidate = slotProbe and slotProbe.sawAnySlot == true or nil
+                button._actionSlotCooldownFallback = (spellCooldownResult.source == "action-slot-real-fallback"
+                    or spellCooldownResult.source == "action-slot-real-no-spell-info") or nil
                 button._cooldownState = spellCooldownResult.state or COOLDOWN_STATE_READY
                 local renderDurationObj = spellCooldownResult.renderDurationObj
                 button._cooldownDeferred = spellCooldownResult.deferred or nil
@@ -1854,6 +1863,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
         DispatchStandaloneTextureVisual(button)
+    end
+    if self.RecordButtonCooldownRefreshEligibility then
+        self:RecordButtonCooldownRefreshEligibility(button, buttonData, buttonDisplayMode)
     end
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1348,6 +1348,20 @@ function CooldownCompanion:ApplySafeIconTextWidgetMaintenance(button, buttonData
     return true
 end
 
+function CooldownCompanion:ApplyPowerIconUsabilityVisualMaintenance(button, buttonData)
+    if not (button and buttonData and button.icon) then
+        return false
+    end
+    if button._isBar or button._isText then
+        return false
+    end
+
+    local style = button.style or {}
+    ApplyIconDesaturationIntent(button, buttonData, style)
+    UpdateIconTint(button, buttonData, style)
+    return true
+end
+
 -- Update icon-mode glow effects: loss of control, assisted highlight, proc glow, aura glow.
 local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
     local inCombat = InCombatLockdown()

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1196,6 +1196,84 @@ local function ApplyIconDesaturationIntent(button, buttonData, style)
     end
 end
 
+local function ApplyIconCooldownTextWidgetStyle(button, buttonData, style)
+    if button._secondaryCdTextRegion and button._cdTextRegion then
+        local wantAuraPos = button._auraPrimarySwipeActive == true or button._conditionalAuraDurationTextPreview == true
+        if button._cdTextAtAuraPos ~= wantAuraPos then
+            button._cdTextAtAuraPos = wantAuraPos
+            button._cdTextRegion:ClearAllPoints()
+            if wantAuraPos then
+                local auraAnchor = style.auraTextAnchor or "TOPLEFT"
+                local auraXOff = style.auraTextXOffset or 2
+                local auraYOff = style.auraTextYOffset or -2
+                button._cdTextRegion:SetPoint(auraAnchor, button.overlayFrame, auraAnchor, auraXOff, auraYOff)
+            else
+                local cdAnchor = style.cooldownTextAnchor or "CENTER"
+                local cdXOff = style.cooldownTextXOffset or 0
+                local cdYOff = style.cooldownTextYOffset or 0
+                button._cdTextRegion:SetPoint(cdAnchor, button.overlayFrame, cdAnchor, cdXOff, cdYOff)
+            end
+        end
+    end
+
+    -- Color is reapplied because WoW's CooldownFrame may reset it while ticking.
+    if button._cdTextRegion then
+        local showText, fontColor, wantFont, wantSize, wantOutline
+        local auraTextPreview = button._conditionalAuraDurationTextPreview == true
+        local auraTextActive = button._auraPrimarySwipeActive == true or auraTextPreview
+        if auraTextActive then
+            showText = style.showAuraText ~= false
+            fontColor = style.auraTextFontColor or DEFAULT_AURA_TEXT_COLOR
+            wantFont = CooldownCompanion:FetchFont(style.auraTextFont or "Friz Quadrata TT")
+            wantSize = style.auraTextFontSize or 12
+            wantOutline = ST.GetEffectiveFontOutline(style.auraTextFontOutline or "OUTLINE")
+        elseif buttonData.isPassive then
+            button._cdTextRegion:SetTextColor(0, 0, 0, 0)
+        else
+            showText = style.showCooldownText
+            if showText and button._hideCooldownChargesActive then
+                showText = false
+            end
+            fontColor = style.cooldownFontColor or DEFAULT_WHITE
+            wantFont = CooldownCompanion:FetchFont(style.cooldownFont or "Friz Quadrata TT")
+            wantSize = style.cooldownFontSize or 12
+            wantOutline = ST.GetEffectiveFontOutline(style.cooldownFontOutline or "OUTLINE")
+        end
+        if showText then
+            local cc = fontColor
+            button._cdTextRegion:SetTextColor(cc[1], cc[2], cc[3], cc[4])
+            local mode = auraTextActive and "aura" or "cd"
+            if button._cdTextMode ~= mode then
+                button._cdTextMode = mode
+                button._cdTextRegion:SetFont(wantFont, wantSize, wantOutline)
+            end
+        else
+            button._cdTextRegion:SetTextColor(0, 0, 0, 0)
+        end
+
+        local wantHide = not showText
+        if button._cdTextHidden ~= wantHide then
+            button._cdTextHidden = wantHide
+            button.cooldown:SetHideCountdownNumbers(wantHide)
+        end
+    end
+
+    if button._secondaryCdTextRegion then
+        local showSecondary = button._auraPrimarySwipeActive and button._secondaryCdActive and style.showCooldownText
+        if showSecondary then
+            local cc = style.cooldownFontColor or DEFAULT_WHITE
+            button._secondaryCdTextRegion:SetTextColor(cc[1], cc[2], cc[3], cc[4])
+        else
+            button._secondaryCdTextRegion:SetTextColor(0, 0, 0, 0)
+        end
+        local wantHideSecondary = not showSecondary
+        if button._secondaryCdTextHidden ~= wantHideSecondary then
+            button._secondaryCdTextHidden = wantHideSecondary
+            button.secondaryCooldown:SetHideCountdownNumbers(wantHideSecondary)
+        end
+    end
+end
+
 -- Update icon-mode visuals: GCD suppression, cooldown text, desaturation, and vertex color.
 local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
     -- GCD suppression (isOnGCD is NeverSecret, always readable)
@@ -1247,91 +1325,27 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
     UpdateIconFill(button, buttonData, style)
     UpdateBlizzardAuraSwipe(button, style)
 
-    -- When separate text positions: move primary text to aura anchor during aura, cooldown anchor otherwise
-    if button._secondaryCdTextRegion and button._cdTextRegion then
-        local wantAuraPos = button._auraPrimarySwipeActive == true or button._conditionalAuraDurationTextPreview == true
-        if button._cdTextAtAuraPos ~= wantAuraPos then
-            button._cdTextAtAuraPos = wantAuraPos
-            button._cdTextRegion:ClearAllPoints()
-            if wantAuraPos then
-                local auraAnchor = style.auraTextAnchor or "TOPLEFT"
-                local auraXOff = style.auraTextXOffset or 2
-                local auraYOff = style.auraTextYOffset or -2
-                button._cdTextRegion:SetPoint(auraAnchor, button.overlayFrame, auraAnchor, auraXOff, auraYOff)
-            else
-                local cdAnchor = style.cooldownTextAnchor or "CENTER"
-                local cdXOff = style.cooldownTextXOffset or 0
-                local cdYOff = style.cooldownTextYOffset or 0
-                button._cdTextRegion:SetPoint(cdAnchor, button.overlayFrame, cdAnchor, cdXOff, cdYOff)
-            end
-        end
-    end
-
-    -- Cooldown/aura text: pick font + visibility based on current state.
-    -- Color is reapplied each tick because WoW's CooldownFrame may reset it.
-    if button._cdTextRegion then
-        local showText, fontColor, wantFont, wantSize, wantOutline
-        local auraTextPreview = button._conditionalAuraDurationTextPreview == true
-        local auraTextActive = button._auraPrimarySwipeActive == true or auraTextPreview
-        if auraTextActive then
-            showText = style.showAuraText ~= false
-            fontColor = style.auraTextFontColor or DEFAULT_AURA_TEXT_COLOR
-            wantFont = CooldownCompanion:FetchFont(style.auraTextFont or "Friz Quadrata TT")
-            wantSize = style.auraTextFontSize or 12
-            wantOutline = ST.GetEffectiveFontOutline(style.auraTextFontOutline or "OUTLINE")
-        elseif buttonData.isPassive then
-            -- Inactive passive aura: no text (cooldown frame hidden)
-            button._cdTextRegion:SetTextColor(0, 0, 0, 0)
-        else
-            showText = style.showCooldownText
-            if showText and button._hideCooldownChargesActive then
-                showText = false
-            end
-            fontColor = style.cooldownFontColor or DEFAULT_WHITE
-            wantFont = CooldownCompanion:FetchFont(style.cooldownFont or "Friz Quadrata TT")
-            wantSize = style.cooldownFontSize or 12
-            wantOutline = ST.GetEffectiveFontOutline(style.cooldownFontOutline or "OUTLINE")
-        end
-        if showText then
-            local cc = fontColor
-            button._cdTextRegion:SetTextColor(cc[1], cc[2], cc[3], cc[4])
-            -- Only call SetFont when mode changes to avoid per-tick overhead
-            local mode = auraTextActive and "aura" or "cd"
-            if button._cdTextMode ~= mode then
-                button._cdTextMode = mode
-                button._cdTextRegion:SetFont(wantFont, wantSize, wantOutline)
-            end
-        else
-            button._cdTextRegion:SetTextColor(0, 0, 0, 0)
-        end
-        -- Properly hide/show countdown numbers via API (alpha=0 alone is unreliable
-        -- because WoW's CooldownFrame animation resets text color each tick)
-        local wantHide = not showText
-        if button._cdTextHidden ~= wantHide then
-            button._cdTextHidden = wantHide
-            button.cooldown:SetHideCountdownNumbers(wantHide)
-        end
-    end
-
-    -- Secondary cooldown text: visible only when aura owns primary text and a real cooldown is running.
-    if button._secondaryCdTextRegion then
-        local showSecondary = button._auraPrimarySwipeActive and button._secondaryCdActive and style.showCooldownText
-        if showSecondary then
-            local cc = style.cooldownFontColor or DEFAULT_WHITE
-            button._secondaryCdTextRegion:SetTextColor(cc[1], cc[2], cc[3], cc[4])
-        else
-            button._secondaryCdTextRegion:SetTextColor(0, 0, 0, 0)
-        end
-        local wantHideSecondary = not showSecondary
-        if button._secondaryCdTextHidden ~= wantHideSecondary then
-            button._secondaryCdTextHidden = wantHideSecondary
-            button.secondaryCooldown:SetHideCountdownNumbers(wantHideSecondary)
-        end
-    end
+    ApplyIconCooldownTextWidgetStyle(button, buttonData, style)
 
     ApplyIconDesaturationIntent(button, buttonData, style)
 
     UpdateIconTint(button, buttonData, style)
+end
+
+function CooldownCompanion:ApplySafeIconTextWidgetMaintenance(button, buttonData)
+    if not (button and buttonData and button._cdTextRegion and button.cooldown) then
+        return false
+    end
+    if button._isBar or button._isText then
+        return false
+    end
+    local style = button.style or {}
+    UpdateIconFill(button, buttonData, style)
+    UpdateBlizzardAuraSwipe(button, style)
+    ApplyIconCooldownTextWidgetStyle(button, buttonData, style)
+    ApplyIconDesaturationIntent(button, buttonData, style)
+    UpdateIconTint(button, buttonData, style)
+    return true
 end
 
 -- Update icon-mode glow effects: loss of control, assisted highlight, proc glow, aura glow.

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -518,7 +518,9 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- frames registered their event handlers before our addon loaded, so by
     -- the time this handler fires the CDM has already refreshed its children
     -- with fresh auraInstanceID data. Bursts later in the same frame coalesce.
-    if unit == "target" or unit == "player" then
+    if unit == "target" then
+        self:RunImmediateCooldownRefresh("target-aura-event")
+    elseif unit == "player" then
         self:RunImmediateCooldownRefresh("aura-event")
     end
 end
@@ -544,10 +546,13 @@ end
 
 function CooldownCompanion:OnTargetChanged()
     if not UnitExists("target") then
+        local transitionSerial = self:BeginTargetCooldownRefreshTransition("target-clear")
         -- Deselected target: clear all target aura state immediately
         self:ClearAuraUnit("target")
+        self:MarkTargetCooldownRefreshPending(transitionSerial)
         return
     end
+    local transitionSerial = self:BeginTargetCooldownRefreshTransition("target-exists")
     -- New target: clear stale instance IDs so the viewer path doesn't
     -- read old auraInstanceIDs.  Keep _auraActive so the hold can
     -- maintain visual continuity while CDM refreshes.
@@ -568,6 +573,9 @@ function CooldownCompanion:OnTargetChanged()
     -- will have fresh auraInstanceID data.  Probing immediately lets the
     -- primary path clear _targetSwitchAt in the same frame — zero hold.
     self:UpdateAllCooldowns()
+    self:RecordTargetCooldownRefreshSatisfied("target-event", transitionSerial, nil, {
+        allowCleanTickerSkip = true,
+    })
 end
 
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -37,6 +37,10 @@
     - _cooldownRefreshEligibilityKnown: true after a broad pass has rebuilt
       cached active-surface eligibility for actionbar fallback and periodic
       maintenance. Unknown eligibility falls back to broad work.
+    - _activePowerCooldownRefreshMode: active-surface contract for
+      UNIT_POWER_FREQUENT. Unknown or broad-required keeps the existing dirty
+      ticker path; simple icon usability visuals can run focused maintenance;
+      none skips because no loaded display consumes power-only visual state.
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
@@ -62,6 +66,21 @@ local TARGET_REFRESH_SOURCES = {
     ["target-aura-event"] = true,
     ["unit-target-event"] = true,
     ["target-ticker"] = true,
+}
+local POWER_REFRESH_MODE_NONE = "none"
+local POWER_REFRESH_MODE_FOCUSED = "simple-usability-visual"
+local POWER_REFRESH_MODE_BROAD = "broad-required"
+local POWER_REFRESH_MODE_UNKNOWN = "unknown"
+local POWER_REFRESH_MODE_PRECEDENCE = {
+    [POWER_REFRESH_MODE_NONE] = 0,
+    [POWER_REFRESH_MODE_FOCUSED] = 1,
+    [POWER_REFRESH_MODE_BROAD] = 2,
+    [POWER_REFRESH_MODE_UNKNOWN] = 2,
+}
+local POWER_TEXT_TOKENS = {
+    unusable = true,
+    usable = true,
+    isUsable = true,
 }
 
 local function IsTargetRefreshSource(source)
@@ -154,6 +173,8 @@ local function ClearReasonTracking(build)
     ClearTable(build.safeTextWidgetMaintenanceSeen)
     ClearTable(build.unprovenIconTextMaintenanceReasons)
     ClearTable(build.unprovenIconTextMaintenanceSeen)
+    ClearTable(build.powerRefreshReasons)
+    ClearTable(build.powerRefreshSeen)
 end
 
 local function EnsureReasonTracking(build)
@@ -163,6 +184,8 @@ local function EnsureReasonTracking(build)
     build.safeTextWidgetMaintenanceSeen = build.safeTextWidgetMaintenanceSeen or {}
     build.unprovenIconTextMaintenanceReasons = build.unprovenIconTextMaintenanceReasons or {}
     build.unprovenIconTextMaintenanceSeen = build.unprovenIconTextMaintenanceSeen or {}
+    build.powerRefreshReasons = build.powerRefreshReasons or {}
+    build.powerRefreshSeen = build.powerRefreshSeen or {}
 end
 
 local function CopyReasonList(list)
@@ -172,6 +195,24 @@ local function CopyReasonList(list)
         copy[i] = list[i]
     end
     return copy
+end
+
+local function RecordPowerRefreshMode(build, mode, reason)
+    if not build or mode == POWER_REFRESH_MODE_NONE then
+        return
+    end
+
+    EnsureReasonTracking(build)
+    local currentMode = build.powerRefreshMode or POWER_REFRESH_MODE_NONE
+    if (POWER_REFRESH_MODE_PRECEDENCE[mode] or 0) > (POWER_REFRESH_MODE_PRECEDENCE[currentMode] or 0)
+        or (currentMode == POWER_REFRESH_MODE_UNKNOWN and mode == POWER_REFRESH_MODE_BROAD) then
+        build.powerRefreshMode = mode
+    end
+    AddUniqueReason(build.powerRefreshReasons, build.powerRefreshSeen, reason or mode)
+end
+
+local function PowerModeRequiresBroad(mode)
+    return mode == POWER_REFRESH_MODE_BROAD or mode == POWER_REFRESH_MODE_UNKNOWN
 end
 
 local function IsSafeTextWidgetMaintenanceOnly(button, buttonData)
@@ -324,6 +365,140 @@ local function IsTriggerRuntime(button, displayMode)
         or buttonData and type(buttonData.triggerConditions) == "table"
 end
 
+local function GetButtonDisplayMode(button)
+    if not button then
+        return nil
+    end
+
+    local groupId = button._groupId or button.groupID
+    local group = groupId
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[groupId]
+        or nil
+    return group and group.displayMode
+end
+
+local function IsPowerSensitiveSpellEntry(buttonData)
+    return buttonData
+        and buttonData.type == "spell"
+        and buttonData.isPassive ~= true
+        and buttonData.isPassiveCooldown ~= true
+end
+
+local function StyleUsesUnusableIconVisual(style)
+    if not (style and style.showUnusable == true) then
+        return false
+    end
+
+    local hasVisualContract = false
+    if type(ST.UnusableVisualUsesDimTint) == "function" then
+        hasVisualContract = ST.UnusableVisualUsesDimTint(style) or hasVisualContract
+    else
+        hasVisualContract = true
+    end
+    if type(ST.UnusableVisualUsesDesaturation) == "function" then
+        hasVisualContract = ST.UnusableVisualUsesDesaturation(style) or hasVisualContract
+    else
+        hasVisualContract = true
+    end
+
+    return hasVisualContract
+end
+
+local function HasUnusableTextureContract(button, style)
+    if button and (button._conditionalUnusablePreview == true or button._textureUnusablePreview == true) then
+        return true
+    end
+    if not style then
+        return false
+    end
+    if style.textureIndicators
+        and style.textureIndicators.unusable
+        and style.textureIndicators.unusable.enabled == true then
+        return true
+    end
+    return style.unusableTexture ~= nil
+        or style.unusableTextureID ~= nil
+        or style.unusableTextureId ~= nil
+        or style.unusableAtlas ~= nil
+        or style.showUnusableTexture == true
+        or style.useUnusableTexture == true
+end
+
+local function TextSegmentsRequirePowerRefresh(button)
+    if not (button and button._textSegments) then
+        return false
+    end
+
+    for _, segment in ipairs(button._textSegments) do
+        if segment then
+            if POWER_TEXT_TOKENS[segment.token]
+                or POWER_TEXT_TOKENS[segment.type]
+                or POWER_TEXT_TOKENS[segment.kind]
+                or POWER_TEXT_TOKENS[segment.value] then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local function IsFocusedPowerIconDisplayMode(displayMode)
+    return displayMode == nil or displayMode == "icons"
+end
+
+local function ClassifyPowerCooldownRefresh(button, buttonData, displayMode)
+    if not button then
+        return POWER_REFRESH_MODE_UNKNOWN, "missing-button"
+    end
+    if not buttonData then
+        return POWER_REFRESH_MODE_UNKNOWN, "missing-button-data"
+    end
+    displayMode = displayMode or GetButtonDisplayMode(button)
+
+    if buttonData._rotationAssistantVirtual == true then
+        return POWER_REFRESH_MODE_BROAD, "rotation-assistant"
+    end
+    if IsTriggerRuntime(button, displayMode) then
+        return POWER_REFRESH_MODE_BROAD, "trigger-runtime"
+    end
+    if button._resourceGateCost == true or button._baseResourceGateCost == true then
+        return POWER_REFRESH_MODE_BROAD, "resource-gated-cooldown-surface"
+    end
+
+    if not IsPowerSensitiveSpellEntry(buttonData) then
+        return POWER_REFRESH_MODE_NONE
+    end
+
+    local style = button.style or {}
+    if buttonData.hideWhileUnusable == true then
+        return POWER_REFRESH_MODE_BROAD, "visibility-usability"
+    end
+    if button._isText == true then
+        if TextSegmentsRequirePowerRefresh(button) or style.showUnusable == true then
+            return POWER_REFRESH_MODE_BROAD, "text-usability"
+        end
+        return POWER_REFRESH_MODE_NONE
+    end
+    if HasUnusableTextureContract(button, style) then
+        return POWER_REFRESH_MODE_BROAD, "texture-usability"
+    end
+    if not StyleUsesUnusableIconVisual(style) then
+        return POWER_REFRESH_MODE_NONE
+    end
+    if not IsFocusedPowerIconDisplayMode(displayMode) or button._isBar == true then
+        return POWER_REFRESH_MODE_BROAD, "non-icon-usability-visual"
+    end
+    if not CanRunSafeTextWidgetVisualMaintenance(button) then
+        return POWER_REFRESH_MODE_NONE, "hidden-simple-usability-visual"
+    end
+
+    return POWER_REFRESH_MODE_FOCUSED, "simple-usability-visual"
+end
+
 local function CooldownRefreshQueueOnUpdate(frame)
     local addon = frame._cooldownCompanion
     if addon then
@@ -345,6 +520,11 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._activeSafeTextWidgetMaintenanceReasons = nil
     self._activeUnprovenIconTextMaintenanceReasons = nil
     self._lastSafeTextWidgetMaintenanceCount = nil
+    self._activePowerCooldownRefreshMode = nil
+    self._activePowerCooldownRefreshReasons = nil
+    self._lastPowerIconVisualMaintenanceCount = nil
+    self._lastPowerIconVisualMaintenanceEligibleCount = nil
+    self._lastPowerEventCooldownRefreshDecision = nil
 end
 
 function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
@@ -360,6 +540,7 @@ function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
         build.safeTextWidgetMaintenanceRequired = nil
         build.unprovenIconTextMaintenanceRequired = nil
         build.otherPeriodicMaintenanceRequired = nil
+        build.powerRefreshMode = nil
         ClearReasonTracking(build)
     end
     EnsureReasonTracking(build)
@@ -425,6 +606,9 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     if IsTriggerRuntime(button, displayMode) then
         RecordPeriodicMaintenance(build, false, "trigger-runtime")
     end
+
+    local powerMode, powerReason = ClassifyPowerCooldownRefresh(button, buttonData, displayMode)
+    RecordPowerRefreshMode(build, powerMode, powerReason)
 end
 
 function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
@@ -447,6 +631,8 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
     self._activeCooldownPeriodicMaintenanceReasons = CopyReasonList(build.periodicMaintenanceReasons)
     self._activeSafeTextWidgetMaintenanceReasons = CopyReasonList(build.safeTextWidgetMaintenanceReasons)
     self._activeUnprovenIconTextMaintenanceReasons = CopyReasonList(build.unprovenIconTextMaintenanceReasons)
+    self._activePowerCooldownRefreshMode = build.powerRefreshMode or POWER_REFRESH_MODE_NONE
+    self._activePowerCooldownRefreshReasons = CopyReasonList(build.powerRefreshReasons)
 end
 
 function CooldownCompanion:HasOnlySafeTextWidgetMaintenance()
@@ -473,6 +659,23 @@ function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
         safeTextWidgetMaintenanceReasons = self._activeSafeTextWidgetMaintenanceReasons,
         unprovenIconTextMaintenanceReasons = self._activeUnprovenIconTextMaintenanceReasons,
         lastSafeTextWidgetMaintenanceCount = self._lastSafeTextWidgetMaintenanceCount,
+        powerRefreshMode = self._activePowerCooldownRefreshMode,
+        powerRefreshReasons = self._activePowerCooldownRefreshReasons,
+        lastPowerIconVisualMaintenanceCount = self._lastPowerIconVisualMaintenanceCount,
+        lastPowerIconVisualMaintenanceEligibleCount = self._lastPowerIconVisualMaintenanceEligibleCount,
+        lastPowerEventCooldownRefreshDecision = self._lastPowerEventCooldownRefreshDecision,
+    }
+end
+
+function CooldownCompanion:GetPowerCooldownEligibilityInfo()
+    return {
+        known = self._cooldownRefreshEligibilityKnown == true,
+        invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
+        powerRefreshMode = self._activePowerCooldownRefreshMode,
+        powerRefreshReasons = self._activePowerCooldownRefreshReasons,
+        lastPowerIconVisualMaintenanceCount = self._lastPowerIconVisualMaintenanceCount,
+        lastPowerIconVisualMaintenanceEligibleCount = self._lastPowerIconVisualMaintenanceEligibleCount,
+        lastPowerEventCooldownRefreshDecision = self._lastPowerEventCooldownRefreshDecision,
     }
 end
 
@@ -739,6 +942,68 @@ function CooldownCompanion:RunSafeTextWidgetMaintenance()
     end
 
     self._lastSafeTextWidgetMaintenanceCount = updated
+    return true
+end
+
+function CooldownCompanion:RunPowerIconVisualMaintenance()
+    if type(self.ApplyPowerIconUsabilityVisualMaintenance) ~= "function" then
+        return false
+    end
+
+    local updated = 0
+    local eligible = 0
+    if type(self.groupFrames) == "table" then
+        for _, frame in pairs(self.groupFrames) do
+            if frame and frame.IsShown and frame:IsShown() and type(frame.buttons) == "table" then
+                for _, button in ipairs(frame.buttons) do
+                    local buttonData = button and button.buttonData
+                    local mode = ClassifyPowerCooldownRefresh(button, buttonData, GetButtonDisplayMode(button))
+                    if PowerModeRequiresBroad(mode) then
+                        return false
+                    end
+                    if mode == POWER_REFRESH_MODE_FOCUSED then
+                        eligible = eligible + 1
+                        if CanRunSafeTextWidgetVisualMaintenance(button) then
+                            if self:ApplyPowerIconUsabilityVisualMaintenance(button, buttonData) == false then
+                                return false
+                            end
+                            updated = updated + 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    self._lastPowerIconVisualMaintenanceCount = updated
+    self._lastPowerIconVisualMaintenanceEligibleCount = eligible
+    return true
+end
+
+function CooldownCompanion:OnPowerEventCooldownRefresh()
+    if not self._cooldownRefreshEligibilityKnown then
+        self._lastPowerEventCooldownRefreshDecision = "broad-unknown-eligibility"
+        self:MarkCooldownsDirty()
+        return true
+    end
+
+    local mode = self._activePowerCooldownRefreshMode or POWER_REFRESH_MODE_NONE
+    if mode == POWER_REFRESH_MODE_NONE then
+        self._lastPowerEventCooldownRefreshDecision = "skipped-none"
+        return false
+    end
+    if mode == POWER_REFRESH_MODE_FOCUSED then
+        if self:RunPowerIconVisualMaintenance() then
+            self._lastPowerEventCooldownRefreshDecision = "focused-simple-usability-visual"
+            return false
+        end
+        self._lastPowerEventCooldownRefreshDecision = "broad-focused-fallback"
+        self:MarkCooldownsDirty()
+        return true
+    end
+
+    self._lastPowerEventCooldownRefreshDecision = "broad-required"
+    self:MarkCooldownsDirty()
     return true
 end
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -36,6 +36,10 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic or {}
+local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN or "cooldown"
+local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING or "missing"
+local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO or "zero"
 
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
@@ -85,6 +89,44 @@ local function HasActiveIconCooldownText(button, buttonData)
         or button._auraCooldownStart ~= nil
         or button._chargeCooldownVisualActive == true
         or button._secondaryCdActive == true
+end
+
+local function HasCooldownDrivenVisualMaintenance(button, buttonData)
+    if not (button and buttonData) then return false end
+
+    local style = button.style or {}
+    local cooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        or button._desatCooldownActive == true
+    local chargeState = button._chargeState
+    local chargeMissingOrZero = chargeState == CHARGE_STATE_ZERO
+        or chargeState == CHARGE_STATE_MISSING
+    local chargeTransitionActive = chargeMissingOrZero
+        or button._chargeRecharging == true
+        or button._chargeCooldownVisualActive == true
+        or button._hideCooldownChargesActive ~= nil
+
+    if cooldownActive
+        and (style.desaturateOnCooldown
+            or style.iconCooldownTintEnabled
+            or buttonData.hideWhileOnCooldown
+            or buttonData.hideWhileNotOnCooldown) then
+        return true
+    end
+
+    if chargeTransitionActive
+        and (buttonData.hideWhileOnCooldown
+            or buttonData.hideWhileNotOnCooldown
+            or buttonData.hideCooldownWithCharges) then
+        return true
+    end
+
+    if chargeState == CHARGE_STATE_ZERO
+        and (buttonData.hideWhileZeroCharges
+            or buttonData.desaturateWhileZeroCharges) then
+        return true
+    end
+
+    return false
 end
 
 local function IsTriggerRuntime(button, displayMode)
@@ -140,6 +182,9 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     end
 
     if HasActiveIconCooldownText(button, buttonData) then
+        build.periodicMaintenanceRequired = true
+    end
+    if HasCooldownDrivenVisualMaintenance(button, buttonData) then
         build.periodicMaintenanceRequired = true
     end
     if button._isText == true then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -17,6 +17,12 @@
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
       frame and arm flag used to flush queued work on the next OnUpdate
       boundary. The frame must stay shown; hidden frames do not receive OnUpdate.
+    - _actionbarCooldownPulsePending: true when a raw ACTIONBAR_UPDATE_COOLDOWN
+      pulse has arrived and the next ticker must decide whether it is safe to
+      skip the clean broad pass.
+    - _cooldownRefreshEligibilityKnown: true after a broad pass has rebuilt
+      cached active-surface eligibility for actionbar fallback and periodic
+      maintenance. Unknown eligibility falls back to broad work.
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
@@ -31,11 +37,134 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
+local function AddReason(reasons, seen, reason)
+    if not reason or seen[reason] then return end
+    seen[reason] = true
+    reasons[#reasons + 1] = reason
+end
+
+local function HasSoundAlerts(buttonData)
+    local cfg = buttonData and buttonData.soundAlerts
+    return cfg and type(cfg.events) == "table" and next(cfg.events) ~= nil
+end
+
+local function HasTimedReadyGlow(button)
+    if not button then return false end
+    local style = button.style
+    local duration = style and (style.readyGlowDuration or 0) or 0
+    if duration <= 0 then
+        return false
+    end
+
+    local now = GetTime()
+    local function WindowNeedsRefresh(startTime)
+        if startTime == nil then return false end
+        return (now - startTime) <= duration or button._readyGlowActive == true
+    end
+
+    return WindowNeedsRefresh(button._readyGlowStartTime)
+        or WindowNeedsRefresh(button._readyGlowMaxChargesStartTime)
+end
+
+local function IsTriggerRuntime(button, displayMode)
+    if not button then return false end
+    if displayMode == "trigger" then return true end
+
+    local group = button._groupId
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[button._groupId]
+        or nil
+    local buttonData = button.buttonData
+    return (not displayMode
+            and group
+            and CooldownCompanion.IsTriggerPanelGroup
+            and CooldownCompanion:IsTriggerPanelGroup(group))
+        or buttonData and type(buttonData.triggerConditions) == "table"
+end
+
 local function CooldownRefreshQueueOnUpdate(frame)
     local addon = frame._cooldownCompanion
     if addon then
         addon:FlushQueuedCooldownRefresh()
     end
+end
+
+function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
+    self._cooldownRefreshEligibilityKnown = nil
+    self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
+    self._activeActionbarCooldownFallbackRequired = nil
+    self._activeCooldownPeriodicMaintenanceRequired = nil
+    self._activeActionbarCooldownFallbackReasons = nil
+    self._activeCooldownPeriodicMaintenanceReasons = nil
+end
+
+function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
+    self._cooldownRefreshEligibilityBuild = {
+        actionbarFallbackReasons = {},
+        actionbarFallbackSeen = {},
+        periodicMaintenanceReasons = {},
+        periodicMaintenanceSeen = {},
+    }
+end
+
+function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
+    local build = self._cooldownRefreshEligibilityBuild
+    if not build or not button then return end
+
+    if button._actionSlotCooldownFallback == true then
+        AddReason(build.actionbarFallbackReasons, build.actionbarFallbackSeen, "action-slot-fallback")
+    end
+
+    if button._isText == true then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "text-mode")
+    end
+    if button._cooldownDeferred == true then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "deferred-cooldown")
+    end
+    if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "pending-aura-hold")
+    end
+    if HasTimedReadyGlow(button) then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "ready-glow-window")
+    end
+    if HasSoundAlerts(buttonData) then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "sound-alert")
+    end
+    if buttonData and buttonData._rotationAssistantVirtual == true then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "rotation-assistant")
+    end
+    if IsTriggerRuntime(button, displayMode) then
+        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "trigger-runtime")
+    end
+end
+
+function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
+    local build = self._cooldownRefreshEligibilityBuild
+    self._cooldownRefreshEligibilityBuild = nil
+    if not build then
+        self:InvalidateCooldownRefreshEligibility("missing-build")
+        return
+    end
+
+    self._cooldownRefreshEligibilityKnown = true
+    self._cooldownRefreshEligibilityInvalidationReason = nil
+    self._activeActionbarCooldownFallbackRequired = #build.actionbarFallbackReasons > 0 or nil
+    self._activeCooldownPeriodicMaintenanceRequired = #build.periodicMaintenanceReasons > 0 or nil
+    self._activeActionbarCooldownFallbackReasons = #build.actionbarFallbackReasons > 0 and build.actionbarFallbackReasons or nil
+    self._activeCooldownPeriodicMaintenanceReasons = #build.periodicMaintenanceReasons > 0 and build.periodicMaintenanceReasons or nil
+end
+
+function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
+    return {
+        known = self._cooldownRefreshEligibilityKnown == true,
+        invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
+        actionbarFallbackRequired = self._activeActionbarCooldownFallbackRequired == true,
+        actionbarFallbackReasons = self._activeActionbarCooldownFallbackReasons,
+        periodicMaintenanceRequired = self._activeCooldownPeriodicMaintenanceRequired == true,
+        periodicMaintenanceReasons = self._activeCooldownPeriodicMaintenanceReasons,
+    }
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -108,15 +237,80 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
+function CooldownCompanion:RecordActionbarCooldownPulse(event)
+    self._actionbarCooldownPulsePending = true
+    self._actionbarCooldownPulseEvent = event or "ACTIONBAR_UPDATE_COOLDOWN"
+    self._actionbarCooldownPulseCount = (self._actionbarCooldownPulseCount or 0) + 1
+end
+
+function CooldownCompanion:ClearActionbarCooldownPulse()
+    self._actionbarCooldownPulsePending = nil
+    self._actionbarCooldownPulseEvent = nil
+    self._actionbarCooldownPulseCount = nil
+end
+
+function CooldownCompanion:GetActionbarCooldownPulseDecision()
+    if not self._actionbarCooldownPulsePending then
+        return false, "no-actionbar-pulse"
+    end
+    if self._queuedCooldownRefreshSource then
+        return false, "queued-refresh"
+    end
+    if self._cooldownsDirty then
+        return false, "dirty"
+    end
+    if not self._cooldownRefreshEligibilityKnown then
+        return false, self._cooldownRefreshEligibilityInvalidationReason or "eligibility-unknown"
+    end
+    if self._activeActionbarCooldownFallbackRequired then
+        return false, "actionbar-fallback-required"
+    end
+    if self._activeCooldownPeriodicMaintenanceRequired then
+        return false, "periodic-maintenance-required"
+    end
+    return true, "pulse-only"
+end
+
+function CooldownCompanion:GetActionbarCooldownFallbackReason(decision)
+    local eligibility = self:GetActionbarCooldownEligibilityInfo()
+    return {
+        kind = "actionbar-cooldown",
+        source = "actionbar-cooldown-event",
+        event = self._actionbarCooldownPulseEvent or "ACTIONBAR_UPDATE_COOLDOWN",
+        origin = "ticker",
+        broad = true,
+        actionbarPulseDecision = decision,
+        actionbarPulseCount = self._actionbarCooldownPulseCount,
+        actionbarFallbackRequired = eligibility.actionbarFallbackRequired,
+        actionbarFallbackReasons = eligibility.actionbarFallbackReasons,
+        periodicMaintenanceRequired = eligibility.periodicMaintenanceRequired,
+        periodicMaintenanceReasons = eligibility.periodicMaintenanceReasons,
+        eligibilityKnown = eligibility.known,
+    }
+end
+
 function CooldownCompanion:TickCooldownRefresh()
     if self._queuedCooldownRefreshSource then
         self:FlushQueuedCooldownRefresh()
         return false
     end
     if self:CanSkipTickerCooldownRefresh() then
+        self:ClearActionbarCooldownPulse()
         return true
     end
-    self:UpdateAllCooldowns()
+
+    local actionbarOnlyReason
+    if self._actionbarCooldownPulsePending and not self._cooldownsDirty then
+        local canSkipActionbarPulse, decision = self:GetActionbarCooldownPulseDecision()
+        if canSkipActionbarPulse then
+            self:ClearActionbarCooldownPulse()
+            return true
+        end
+        actionbarOnlyReason = self:GetActionbarCooldownFallbackReason(decision)
+    end
+
+    self:UpdateAllCooldowns(actionbarOnlyReason)
+    self:ClearActionbarCooldownPulse()
     return false
 end
 
@@ -128,4 +322,5 @@ function CooldownCompanion:ResetCooldownRefreshState()
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
+    self:ClearActionbarCooldownPulse()
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -67,6 +67,20 @@ local function IsTargetRefreshSource(source)
     return TARGET_REFRESH_SOURCES[source] == true
 end
 
+local function CaptureTargetRefreshState()
+    if type(UnitExists) ~= "function" or not UnitExists("target") then
+        return false, nil, true
+    end
+    if type(UnitGUID) ~= "function" then
+        return true, nil, false
+    end
+    local guid = UnitGUID("target")
+    if not guid then
+        return true, nil, false
+    end
+    return true, guid, true
+end
+
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
     return cfg and type(cfg.events) == "table" and next(cfg.events) ~= nil
@@ -264,6 +278,8 @@ function CooldownCompanion:BeginTargetCooldownRefreshTransition(reason)
     self._targetRefreshSatisfiedTransitionSerial = nil
     self._targetRefreshSatisfiedDirtySerial = nil
     self._targetRefreshSatisfiedSource = nil
+    self._targetRefreshSatisfiedTargetExists = nil
+    self._targetRefreshSatisfiedTargetGUID = nil
     self._targetRefreshCleanTickerSkipTransitionSerial = nil
     self._targetRefreshPendingTransitionSerial = nil
     return self._targetRefreshTransitionSerial
@@ -286,6 +302,17 @@ function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transiti
         return
     end
 
+    local targetExists, targetGUID, targetStateKnown = CaptureTargetRefreshState()
+    if not targetStateKnown then
+        self._targetRefreshSatisfiedTransitionSerial = nil
+        self._targetRefreshSatisfiedDirtySerial = nil
+        self._targetRefreshSatisfiedSource = nil
+        self._targetRefreshSatisfiedTargetExists = nil
+        self._targetRefreshSatisfiedTargetGUID = nil
+        self._targetRefreshCleanTickerSkipTransitionSerial = nil
+        return
+    end
+
     if dirtySerial == nil and self._cooldownsDirty then
         dirtySerial = self._cooldownDirtySerial or 0
     end
@@ -293,6 +320,8 @@ function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transiti
     self._targetRefreshSatisfiedTransitionSerial = transitionSerial
     self._targetRefreshSatisfiedDirtySerial = dirtySerial
     self._targetRefreshSatisfiedSource = source
+    self._targetRefreshSatisfiedTargetExists = targetExists
+    self._targetRefreshSatisfiedTargetGUID = targetGUID
 
     if transitionSerial and self._targetRefreshPendingTransitionSerial == transitionSerial then
         self._targetRefreshPendingTransitionSerial = nil
@@ -302,12 +331,29 @@ function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transiti
     end
 end
 
+function CooldownCompanion:IsTargetCooldownRefreshStateSatisfied()
+    if self._targetRefreshSatisfiedTargetExists == nil then
+        return false
+    end
+    local targetExists, targetGUID, targetStateKnown = CaptureTargetRefreshState()
+    if not targetStateKnown or targetExists ~= self._targetRefreshSatisfiedTargetExists then
+        return false
+    end
+    if not targetExists then
+        return true
+    end
+    return targetGUID == self._targetRefreshSatisfiedTargetGUID
+end
+
 function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
     if not IsTargetRefreshSource(source) then return false end
     if self._queuedCooldownRefreshSource then return false end
 
     local transitionSerial = self._targetRefreshTransitionSerial
     if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+        return false
+    end
+    if not self:IsTargetCooldownRefreshStateSatisfied() then
         return false
     end
 
@@ -324,14 +370,24 @@ end
 
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
-    if self._cooldownsDirty then
-        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    if self._activeCooldownPeriodicMaintenanceRequired then return false end
+    if not self:IsTargetCooldownRefreshStateSatisfied() then
+        return false
     end
 
     local transitionSerial = self._targetRefreshTransitionSerial
-    return transitionSerial ~= nil
-        and self._targetRefreshSatisfiedTransitionSerial == transitionSerial
-        and self._targetRefreshCleanTickerSkipTransitionSerial == transitionSerial
+    if self._cooldownsDirty then
+        if self._targetRefreshSatisfiedTransitionSerial
+            and self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+            return false
+        end
+        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    end
+
+    if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+        return false
+    end
+    return self._targetRefreshCleanTickerSkipTransitionSerial == transitionSerial
 end
 
 function CooldownCompanion:ConsumeTargetTickerCooldownRefreshSkip()
@@ -373,6 +429,8 @@ function CooldownCompanion:FlushQueuedCooldownRefresh()
         end
         if targetSource then
             self:RecordTargetCooldownRefreshSatisfied(targetSource, targetTransitionSerial, targetDirtySerial)
+        else
+            self:RecordTargetPendingTickerRefreshSatisfied()
         end
     end
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -216,6 +216,15 @@ local function SafeTextWidgetTimingStillActive(button)
     return not sawTimingSource
 end
 
+local function CanRunSafeTextWidgetVisualMaintenance(button)
+    if not button then return false end
+    if button._visibilityHidden == true then return false end
+    if type(button.IsShown) == "function" and not button:IsShown() then
+        return false
+    end
+    return true
+end
+
 local function RecordIconCooldownTextMaintenance(build, button, buttonData)
     if not HasActiveIconCooldownText(button, buttonData) then
         return
@@ -715,12 +724,14 @@ function CooldownCompanion:RunSafeTextWidgetMaintenance()
         for _, frame in pairs(self.groupFrames) do
             if frame and frame.IsShown and frame:IsShown() and type(frame.buttons) == "table" then
                 for _, button in ipairs(frame.buttons) do
-                    if IsSafeTextWidgetMaintenanceOnly(button, button.buttonData)
-                        and SafeTextWidgetTimingStillActive(button)
-                        and self:ApplySafeIconTextWidgetMaintenance(button, button.buttonData) ~= false then
-                        updated = updated + 1
-                    elseif IsSafeTextWidgetMaintenanceOnly(button, button.buttonData) then
-                        return false
+                    if IsSafeTextWidgetMaintenanceOnly(button, button.buttonData) then
+                        if not SafeTextWidgetTimingStillActive(button) then
+                            return false
+                        end
+                        if CanRunSafeTextWidgetVisualMaintenance(button)
+                            and self:ApplySafeIconTextWidgetMaintenance(button, button.buttonData) ~= false then
+                            updated = updated + 1
+                        end
                     end
                 end
             end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -135,9 +135,7 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     local build = self._cooldownRefreshEligibilityBuild
     if not build or not button then return end
 
-    if button._actionSlotCooldownFallback == true then
-        build.actionbarFallbackRequired = true
-    elseif button._actionSlotCooldownCandidate == true then
+    if button._actionSlotCooldownFallback == true or button._actionSlotCooldownCandidate == true then
         build.actionbarFallbackRequired = true
     end
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -171,6 +171,8 @@ local function ClearReasonTracking(build)
     ClearTable(build.periodicMaintenanceSeen)
     ClearTable(build.safeTextWidgetMaintenanceReasons)
     ClearTable(build.safeTextWidgetMaintenanceSeen)
+    ClearTable(build.chargeCooldownVisualMaintenanceReasons)
+    ClearTable(build.chargeCooldownVisualMaintenanceSeen)
     ClearTable(build.unprovenIconTextMaintenanceReasons)
     ClearTable(build.unprovenIconTextMaintenanceSeen)
     ClearTable(build.powerRefreshReasons)
@@ -182,6 +184,8 @@ local function EnsureReasonTracking(build)
     build.periodicMaintenanceSeen = build.periodicMaintenanceSeen or {}
     build.safeTextWidgetMaintenanceReasons = build.safeTextWidgetMaintenanceReasons or {}
     build.safeTextWidgetMaintenanceSeen = build.safeTextWidgetMaintenanceSeen or {}
+    build.chargeCooldownVisualMaintenanceReasons = build.chargeCooldownVisualMaintenanceReasons or {}
+    build.chargeCooldownVisualMaintenanceSeen = build.chargeCooldownVisualMaintenanceSeen or {}
     build.unprovenIconTextMaintenanceReasons = build.unprovenIconTextMaintenanceReasons or {}
     build.unprovenIconTextMaintenanceSeen = build.unprovenIconTextMaintenanceSeen or {}
     build.powerRefreshReasons = build.powerRefreshReasons or {}
@@ -215,15 +219,20 @@ local function PowerModeRequiresBroad(mode)
     return mode == POWER_REFRESH_MODE_BROAD or mode == POWER_REFRESH_MODE_UNKNOWN
 end
 
+local function HasSafeTextWidgetTiming(button)
+    if not button then return false end
+    return (button._durationObj ~= nil and button._durationObj ~= button._chargeDurationObj)
+        or button._auraDurationObj ~= nil
+        or button._auraCooldownStart ~= nil
+end
+
 local function IsSafeTextWidgetMaintenanceOnly(button, buttonData)
     if not buttonData then return false end
     if not HasActiveIconCooldownText(button, buttonData) then return false end
-    if button._chargeCooldownVisualActive == true or button._secondaryCdActive == true then
+    if button._secondaryCdActive == true then
         return false
     end
-    return button._durationObj ~= nil
-        or button._auraDurationObj ~= nil
-        or button._auraCooldownStart ~= nil
+    return HasSafeTextWidgetTiming(button)
 end
 
 local function SafeTextWidgetTimingStillActive(button)
@@ -234,7 +243,7 @@ local function SafeTextWidgetTimingStillActive(button)
     end
 
     local sawTimingSource = false
-    if button._durationObj ~= nil then
+    if button._durationObj ~= nil and button._durationObj ~= button._chargeDurationObj then
         sawTimingSource = true
         if durationObjectShowsCooldown(button._durationObj) then
             return true
@@ -257,6 +266,17 @@ local function SafeTextWidgetTimingStillActive(button)
     return not sawTimingSource
 end
 
+local function ChargeCooldownVisualTimingStillActive(button)
+    if not button or button._chargeCooldownVisualActive ~= true or button._chargeDurationObj == nil then
+        return false
+    end
+    local durationObjectShowsCooldown = EntryRuntime.DurationObjectShowsCooldown
+    if type(durationObjectShowsCooldown) ~= "function" then
+        return false
+    end
+    return durationObjectShowsCooldown(button._chargeDurationObj) == true
+end
+
 local function CanRunSafeTextWidgetVisualMaintenance(button)
     if not button then return false end
     if button._visibilityHidden == true then return false end
@@ -264,6 +284,74 @@ local function CanRunSafeTextWidgetVisualMaintenance(button)
         return false
     end
     return true
+end
+
+local function HasIconChargeCooldownVisualTail(button, buttonData)
+    if not buttonData then return false end
+    if not button then return false end
+    if button._isBar or button._isText then return false end
+    if buttonData.isPassive then return false end
+    if button._hideCooldownChargesActive == true then return false end
+    if button._chargeCooldownVisualActive ~= true then return false end
+    if button._chargeDurationObj == nil then return false end
+    if button._secondaryCdActive == true then return false end
+    return true
+end
+
+local function IsChargeCooldownVisualMaintenanceOnly(button, buttonData)
+    return HasIconChargeCooldownVisualTail(button, buttonData)
+end
+
+local StyleUsesUnusableIconVisual
+local HasUnusableTextureContract
+
+local function HasChargeBroadVisualContract(button, buttonData)
+    if not buttonData then return false end
+
+    local style = button and button.style or nil
+    return buttonData.hideWhileOnCooldown
+        or buttonData.hideWhileNotOnCooldown
+        or buttonData.hideCooldownWithCharges
+        or buttonData.hideWhileZeroCharges
+        or buttonData.desaturateWhileZeroCharges
+        or buttonData.hideWhileUnusable
+        or (HasUnusableTextureContract and HasUnusableTextureContract(button, style))
+end
+
+local function StyleUsesReadyTextureIndicator(style)
+    local indicators = style and style.textureIndicators
+    local ready = indicators and indicators.ready
+    return ready and ready.enabled == true
+end
+
+local function ChargeCooldownVisualNeedsSafeIconMaintenance(button, buttonData)
+    return IsChargeCooldownVisualMaintenanceOnly(button, buttonData)
+        and HasActiveIconCooldownText(button, buttonData)
+        and not IsSafeTextWidgetMaintenanceOnly(button, buttonData)
+end
+
+local function ChargeCooldownVisualNeedsFocusedRefresh(button, buttonData)
+    if not IsChargeCooldownVisualMaintenanceOnly(button, buttonData) then return false end
+    if HasChargeBroadVisualContract(button, buttonData) then return false end
+
+    local style = button.style or {}
+    return style.desaturateOnCooldown == true
+        or style.iconCooldownTintEnabled == true
+        or (StyleUsesUnusableIconVisual and StyleUsesUnusableIconVisual(style))
+        or (style.readyGlowDuration or 0) > 0
+        or style.readyGlowOnlyAtMaxCharges == true
+        or style.iconFillEnabled == true
+        or StyleUsesReadyTextureIndicator(style)
+end
+
+local function FocusedChargeRefreshBroadFallbackReason(button)
+    if not button then return "missing-button-fallback" end
+    if button._actionSlotCooldownFallback == true then return "actionbar-fallback" end
+    if button._secondaryCdActive == true then return "secondary-cooldown-fallback" end
+    if button._cooldownDeferred == true then return "deferred-cooldown-fallback" end
+    if not ChargeCooldownVisualTimingStillActive(button) then return "settle-fallback" end
+    if HasTimedReadyGlow(button) then return "ready-glow-fallback" end
+    return nil
 end
 
 local function RecordIconCooldownTextMaintenance(build, button, buttonData)
@@ -277,8 +365,9 @@ local function RecordIconCooldownTextMaintenance(build, button, buttonData)
     end
 
     local safeTextWidget = false
+    local chargeVisualMaintenance = false
     local unproven = false
-    if button._durationObj ~= nil then
+    if button._durationObj ~= nil and button._durationObj ~= button._chargeDurationObj then
         safeTextWidget = true
         AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "duration-object")
     end
@@ -291,21 +380,34 @@ local function RecordIconCooldownTextMaintenance(build, button, buttonData)
         AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "aura-cooldown-start")
     end
     if button._chargeCooldownVisualActive == true then
-        unproven = true
-        AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "charge-cooldown-visual")
+        if IsChargeCooldownVisualMaintenanceOnly(button, buttonData) then
+            chargeVisualMaintenance = true
+            AddUniqueReason(
+                build.chargeCooldownVisualMaintenanceReasons,
+                build.chargeCooldownVisualMaintenanceSeen,
+                "active-charge-duration-object"
+            )
+        else
+            unproven = true
+            AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "charge-cooldown-visual")
+        end
     end
     if button._secondaryCdActive == true then
         unproven = true
         AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "secondary-cooldown-text")
     end
-    if not safeTextWidget and not unproven then
+    if not safeTextWidget and not chargeVisualMaintenance and not unproven then
         unproven = true
         AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "unknown-icon-text")
     end
 
     if safeTextWidget and not unproven then
         RecordPeriodicMaintenance(build, false, "safe-text-widget", true)
-    else
+    end
+    if chargeVisualMaintenance and not unproven then
+        RecordPeriodicMaintenance(build, false, "charge-cooldown-visual-active-tail", false, false, true)
+    end
+    if unproven or (not safeTextWidget and not chargeVisualMaintenance) then
         RecordPeriodicMaintenance(build, false, "unproven-icon-text", false, true)
     end
 end
@@ -331,10 +433,7 @@ local function HasCooldownDrivenVisualMaintenance(button, buttonData)
         return true
     end
 
-    if chargeTransitionActive
-        and (buttonData.hideWhileOnCooldown
-            or buttonData.hideWhileNotOnCooldown
-            or buttonData.hideCooldownWithCharges) then
+    if chargeTransitionActive and HasChargeBroadVisualContract(button, buttonData) then
         return true
     end
 
@@ -344,7 +443,26 @@ local function HasCooldownDrivenVisualMaintenance(button, buttonData)
         return true
     end
 
-    return false
+    return ChargeCooldownVisualNeedsFocusedRefresh(button, buttonData)
+end
+
+local function HasChargeDrivenVisualMaintenance(button, buttonData)
+    if not (button and buttonData) then return false end
+
+    local chargeState = button._chargeState
+    local chargeMissingOrZero = chargeState == CHARGE_STATE_ZERO
+        or chargeState == CHARGE_STATE_MISSING
+    local chargeTransitionActive = chargeMissingOrZero
+        or button._chargeRecharging == true
+        or button._chargeCooldownVisualActive == true
+
+    if chargeTransitionActive and HasChargeBroadVisualContract(button, buttonData) then
+        return true
+    end
+
+    return chargeState == CHARGE_STATE_ZERO
+        and (buttonData.hideWhileZeroCharges
+            or buttonData.desaturateWhileZeroCharges)
 end
 
 local function IsTriggerRuntime(button, displayMode)
@@ -387,7 +505,7 @@ local function IsPowerSensitiveSpellEntry(buttonData)
         and buttonData.isPassiveCooldown ~= true
 end
 
-local function StyleUsesUnusableIconVisual(style)
+StyleUsesUnusableIconVisual = function(style)
     if not (style and style.showUnusable == true) then
         return false
     end
@@ -407,7 +525,7 @@ local function StyleUsesUnusableIconVisual(style)
     return hasVisualContract
 end
 
-local function HasUnusableTextureContract(button, style)
+HasUnusableTextureContract = function(button, style)
     if button and (button._conditionalUnusablePreview == true or button._textureUnusablePreview == true) then
         return true
     end
@@ -514,12 +632,19 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._activeTargetCooldownMaintenanceRequired = nil
     self._activeNonTargetCooldownMaintenanceRequired = nil
     self._activeSafeTextWidgetMaintenanceRequired = nil
+    self._activeChargeCooldownVisualMaintenanceRequired = nil
     self._activeUnprovenIconTextMaintenanceRequired = nil
     self._activeOtherPeriodicMaintenanceRequired = nil
     self._activeCooldownPeriodicMaintenanceReasons = nil
     self._activeSafeTextWidgetMaintenanceReasons = nil
+    self._activeChargeCooldownVisualMaintenanceReasons = nil
     self._activeUnprovenIconTextMaintenanceReasons = nil
     self._lastSafeTextWidgetMaintenanceCount = nil
+    self._lastChargeCooldownVisualMaintenanceCount = nil
+    self._lastChargeCooldownVisualMaintenanceEligibleCount = nil
+    self._lastChargeCooldownVisualMaintenanceDecision = nil
+    self._lastChargeCooldownVisualMaintenanceFocusedCount = nil
+    self._lastChargeCooldownVisualMaintenanceSafeCount = nil
     self._activePowerCooldownRefreshMode = nil
     self._activePowerCooldownRefreshReasons = nil
     self._lastPowerIconVisualMaintenanceCount = nil
@@ -538,6 +663,7 @@ function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
         build.targetMaintenanceRequired = nil
         build.nonTargetMaintenanceRequired = nil
         build.safeTextWidgetMaintenanceRequired = nil
+        build.chargeCooldownVisualMaintenanceRequired = nil
         build.unprovenIconTextMaintenanceRequired = nil
         build.otherPeriodicMaintenanceRequired = nil
         build.powerRefreshMode = nil
@@ -547,12 +673,14 @@ function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
     self._cooldownRefreshEligibilityBuild = build
 end
 
-RecordPeriodicMaintenance = function(build, targetMaintenance, reason, safeTextWidget, unprovenIconText)
+RecordPeriodicMaintenance = function(build, targetMaintenance, reason, safeTextWidget, unprovenIconText, chargeCooldownVisual)
     EnsureReasonTracking(build)
     build.periodicMaintenanceRequired = true
     AddUniqueReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, reason or "unknown")
     if safeTextWidget then
         build.safeTextWidgetMaintenanceRequired = true
+    elseif chargeCooldownVisual then
+        build.chargeCooldownVisualMaintenanceRequired = true
     elseif unprovenIconText then
         build.unprovenIconTextMaintenanceRequired = true
     else
@@ -575,9 +703,17 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
 
     RecordIconCooldownTextMaintenance(build, button, buttonData)
     if HasCooldownDrivenVisualMaintenance(button, buttonData) then
-        if IsSafeTextWidgetMaintenanceOnly(button, buttonData) then
+        if not HasChargeDrivenVisualMaintenance(button, buttonData)
+            and IsSafeTextWidgetMaintenanceOnly(button, buttonData) then
             AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "icon-visual-presentation")
             RecordPeriodicMaintenance(build, false, "safe-icon-visual-presentation", true)
+        elseif ChargeCooldownVisualNeedsFocusedRefresh(button, buttonData) then
+            AddUniqueReason(
+                build.chargeCooldownVisualMaintenanceReasons,
+                build.chargeCooldownVisualMaintenanceSeen,
+                "focused-charge-presentation"
+            )
+            RecordPeriodicMaintenance(build, false, "focused-charge-presentation", false, false, true)
         else
             RecordPeriodicMaintenance(build, false, "cooldown-driven-visual")
         end
@@ -626,10 +762,12 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
     self._activeTargetCooldownMaintenanceRequired = build.targetMaintenanceRequired == true or nil
     self._activeNonTargetCooldownMaintenanceRequired = build.nonTargetMaintenanceRequired == true or nil
     self._activeSafeTextWidgetMaintenanceRequired = build.safeTextWidgetMaintenanceRequired == true or nil
+    self._activeChargeCooldownVisualMaintenanceRequired = build.chargeCooldownVisualMaintenanceRequired == true or nil
     self._activeUnprovenIconTextMaintenanceRequired = build.unprovenIconTextMaintenanceRequired == true or nil
     self._activeOtherPeriodicMaintenanceRequired = build.otherPeriodicMaintenanceRequired == true or nil
     self._activeCooldownPeriodicMaintenanceReasons = CopyReasonList(build.periodicMaintenanceReasons)
     self._activeSafeTextWidgetMaintenanceReasons = CopyReasonList(build.safeTextWidgetMaintenanceReasons)
+    self._activeChargeCooldownVisualMaintenanceReasons = CopyReasonList(build.chargeCooldownVisualMaintenanceReasons)
     self._activeUnprovenIconTextMaintenanceReasons = CopyReasonList(build.unprovenIconTextMaintenanceReasons)
     self._activePowerCooldownRefreshMode = build.powerRefreshMode or POWER_REFRESH_MODE_NONE
     self._activePowerCooldownRefreshReasons = CopyReasonList(build.powerRefreshReasons)
@@ -637,6 +775,15 @@ end
 
 function CooldownCompanion:HasOnlySafeTextWidgetMaintenance()
     return self._activeSafeTextWidgetMaintenanceRequired == true
+        and not self._activeChargeCooldownVisualMaintenanceRequired
+        and not self._activeUnprovenIconTextMaintenanceRequired
+        and not self._activeOtherPeriodicMaintenanceRequired
+        and not self._activeTargetCooldownMaintenanceRequired
+end
+
+function CooldownCompanion:HasOnlySkippableVisualMaintenance()
+    return (self._activeSafeTextWidgetMaintenanceRequired == true
+            or self._activeChargeCooldownVisualMaintenanceRequired == true)
         and not self._activeUnprovenIconTextMaintenanceRequired
         and not self._activeOtherPeriodicMaintenanceRequired
         and not self._activeTargetCooldownMaintenanceRequired
@@ -644,6 +791,7 @@ end
 
 function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
     local safeTextOnly = self:HasOnlySafeTextWidgetMaintenance()
+    local skippableVisualOnly = self:HasOnlySkippableVisualMaintenance()
     return {
         known = self._cooldownRefreshEligibilityKnown == true,
         invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
@@ -653,12 +801,21 @@ function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
         nonTargetMaintenanceRequired = self._activeNonTargetCooldownMaintenanceRequired == true,
         safeTextWidgetMaintenanceRequired = self._activeSafeTextWidgetMaintenanceRequired == true,
         safeTextWidgetMaintenanceOnly = safeTextOnly == true,
+        chargeCooldownVisualMaintenanceRequired = self._activeChargeCooldownVisualMaintenanceRequired == true,
+        chargeCooldownVisualMaintenanceOnly = self._activeChargeCooldownVisualMaintenanceRequired == true
+            and not self._activeSafeTextWidgetMaintenanceRequired
+            and skippableVisualOnly == true,
+        skippableVisualMaintenanceOnly = skippableVisualOnly == true,
         unprovenIconTextMaintenanceRequired = self._activeUnprovenIconTextMaintenanceRequired == true,
         otherPeriodicMaintenanceRequired = self._activeOtherPeriodicMaintenanceRequired == true,
         periodicMaintenanceReasons = self._activeCooldownPeriodicMaintenanceReasons,
         safeTextWidgetMaintenanceReasons = self._activeSafeTextWidgetMaintenanceReasons,
+        chargeCooldownVisualMaintenanceReasons = self._activeChargeCooldownVisualMaintenanceReasons,
         unprovenIconTextMaintenanceReasons = self._activeUnprovenIconTextMaintenanceReasons,
         lastSafeTextWidgetMaintenanceCount = self._lastSafeTextWidgetMaintenanceCount,
+        lastChargeCooldownVisualMaintenanceCount = self._lastChargeCooldownVisualMaintenanceCount,
+        lastChargeCooldownVisualMaintenanceEligibleCount = self._lastChargeCooldownVisualMaintenanceEligibleCount,
+        lastChargeCooldownVisualMaintenanceDecision = self._lastChargeCooldownVisualMaintenanceDecision,
         powerRefreshMode = self._activePowerCooldownRefreshMode,
         powerRefreshReasons = self._activePowerCooldownRefreshReasons,
         lastPowerIconVisualMaintenanceCount = self._lastPowerIconVisualMaintenanceCount,
@@ -945,6 +1102,116 @@ function CooldownCompanion:RunSafeTextWidgetMaintenance()
     return true
 end
 
+function CooldownCompanion:CanSkipChargeCooldownVisualMaintenance()
+    local eligible = 0
+    local active = 0
+    if type(self.groupFrames) == "table" then
+        for _, frame in pairs(self.groupFrames) do
+            if frame and frame.IsShown and frame:IsShown() and type(frame.buttons) == "table" then
+                for _, button in ipairs(frame.buttons) do
+                    local buttonData = button and button.buttonData
+                    if IsChargeCooldownVisualMaintenanceOnly(button, buttonData) then
+                        eligible = eligible + 1
+                        local needsFocusedRefresh = ChargeCooldownVisualNeedsFocusedRefresh(button, buttonData)
+                        if not ChargeCooldownVisualTimingStillActive(button) then
+                            self._lastChargeCooldownVisualMaintenanceCount = active
+                            self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+                            self._lastChargeCooldownVisualMaintenanceDecision = "settle-fallback"
+                            return false
+                        end
+                        if needsFocusedRefresh and type(self.UpdateButtonCooldown) ~= "function" then
+                            self._lastChargeCooldownVisualMaintenanceCount = active
+                            self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+                            self._lastChargeCooldownVisualMaintenanceDecision = "focused-refresh-unavailable"
+                            return false
+                        end
+                        if not needsFocusedRefresh
+                            and ChargeCooldownVisualNeedsSafeIconMaintenance(button, buttonData)
+                            and type(self.ApplySafeIconTextWidgetMaintenance) ~= "function" then
+                            self._lastChargeCooldownVisualMaintenanceCount = active
+                            self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+                            self._lastChargeCooldownVisualMaintenanceDecision = "safe-icon-maintenance-unavailable"
+                            return false
+                        end
+                        active = active + 1
+                    end
+                end
+            end
+        end
+    end
+
+    self._lastChargeCooldownVisualMaintenanceCount = active
+    self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+    self._lastChargeCooldownVisualMaintenanceDecision = "active-duration-object-tail"
+    return true
+end
+
+function CooldownCompanion:RunChargeCooldownVisualMaintenance()
+    if type(self.UpdateButtonCooldown) ~= "function" then
+        return self:CanSkipChargeCooldownVisualMaintenance()
+    end
+
+    local eligible = 0
+    local active = 0
+    local focused = 0
+    local safe = 0
+    if type(self.groupFrames) == "table" then
+        for _, frame in pairs(self.groupFrames) do
+            if frame and frame.IsShown and frame:IsShown() and type(frame.buttons) == "table" then
+                for _, button in ipairs(frame.buttons) do
+                    local buttonData = button and button.buttonData
+                    if IsChargeCooldownVisualMaintenanceOnly(button, buttonData) then
+                        eligible = eligible + 1
+                        if not ChargeCooldownVisualTimingStillActive(button) then
+                            self._lastChargeCooldownVisualMaintenanceCount = active
+                            self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+                            self._lastChargeCooldownVisualMaintenanceDecision = "settle-fallback"
+                            self._lastChargeCooldownVisualMaintenanceFocusedCount = focused
+                            return false
+                        end
+                        active = active + 1
+                        if ChargeCooldownVisualNeedsFocusedRefresh(button, buttonData) then
+                            self:UpdateButtonCooldown(button)
+                            focused = focused + 1
+                            local fallbackReason = FocusedChargeRefreshBroadFallbackReason(button)
+                            if fallbackReason then
+                                self._lastChargeCooldownVisualMaintenanceCount = active
+                                self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+                                self._lastChargeCooldownVisualMaintenanceDecision = fallbackReason
+                                self._lastChargeCooldownVisualMaintenanceFocusedCount = focused
+                                self._lastChargeCooldownVisualMaintenanceSafeCount = safe
+                                return false
+                            end
+                        elseif ChargeCooldownVisualNeedsSafeIconMaintenance(button, buttonData)
+                            and CanRunSafeTextWidgetVisualMaintenance(button) then
+                            if type(self.ApplySafeIconTextWidgetMaintenance) ~= "function"
+                                or self:ApplySafeIconTextWidgetMaintenance(button, buttonData) == false then
+                                self._lastChargeCooldownVisualMaintenanceCount = active
+                                self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+                                self._lastChargeCooldownVisualMaintenanceDecision = "safe-icon-maintenance-fallback"
+                                self._lastChargeCooldownVisualMaintenanceFocusedCount = focused
+                                self._lastChargeCooldownVisualMaintenanceSafeCount = safe
+                                return false
+                            end
+                            safe = safe + 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    self._lastChargeCooldownVisualMaintenanceCount = active
+    self._lastChargeCooldownVisualMaintenanceEligibleCount = eligible
+    self._lastChargeCooldownVisualMaintenanceDecision = focused > 0
+        and "focused-charge-visual-refresh"
+        or safe > 0 and "safe-charge-icon-maintenance"
+        or "active-duration-object-tail"
+    self._lastChargeCooldownVisualMaintenanceFocusedCount = focused
+    self._lastChargeCooldownVisualMaintenanceSafeCount = safe
+    return true
+end
+
 function CooldownCompanion:RunPowerIconVisualMaintenance()
     if type(self.ApplyPowerIconUsabilityVisualMaintenance) ~= "function" then
         return false
@@ -1024,8 +1291,18 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
         return false
     end
     if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
-        return self:HasOnlySafeTextWidgetMaintenance()
-            and type(self.ApplySafeIconTextWidgetMaintenance) == "function"
+        if not self:HasOnlySkippableVisualMaintenance() then
+            return false
+        end
+        if self._activeSafeTextWidgetMaintenanceRequired
+            and type(self.ApplySafeIconTextWidgetMaintenance) ~= "function" then
+            return false
+        end
+        if self._activeChargeCooldownVisualMaintenanceRequired
+            and not self:CanSkipChargeCooldownVisualMaintenance() then
+            return false
+        end
+        return true
     end
     return true
 end
@@ -1043,6 +1320,14 @@ function CooldownCompanion:TickCooldownRefresh()
     if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
         local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
         if canSkipActionbarPulse then
+            if self._activeChargeCooldownVisualMaintenanceRequired
+                and not cooldownEventSatisfied
+                and not self:RunChargeCooldownVisualMaintenance() then
+                self:UpdateAllCooldowns()
+                self:RecordTargetPendingTickerRefreshSatisfied()
+                self:ClearActionbarCooldownPulse()
+                return false
+            end
             if self._activeSafeTextWidgetMaintenanceRequired
                 and not cooldownEventSatisfied
                 and not self:RunSafeTextWidgetMaintenance() then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -366,6 +366,9 @@ end
 function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
     if not IsTargetRefreshSource(source) then return false end
     if self._queuedCooldownRefreshSource then return false end
+    if source == "unit-target-event" and self._activeTargetCooldownMaintenanceRequired then
+        return false
+    end
 
     local transitionSerial = self._targetRefreshTransitionSerial
     if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -103,7 +103,6 @@ local function HasCooldownDrivenVisualMaintenance(button, buttonData)
     local chargeTransitionActive = chargeMissingOrZero
         or button._chargeRecharging == true
         or button._chargeCooldownVisualActive == true
-        or button._hideCooldownChargesActive ~= nil
 
     if cooldownActive
         and (style.desaturateOnCooldown

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -569,7 +569,7 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     local build = self._cooldownRefreshEligibilityBuild
     if not build or not button then return end
 
-    if button._actionSlotCooldownFallback == true or button._actionSlotCooldownCandidate == true then
+    if button._actionSlotCooldownFallback == true then
         build.actionbarFallbackRequired = true
     end
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -198,6 +198,8 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
     self._activeActionbarCooldownFallbackRequired = nil
     self._activeCooldownPeriodicMaintenanceRequired = nil
+    self._activeTargetCooldownMaintenanceRequired = nil
+    self._activeNonTargetCooldownMaintenanceRequired = nil
 end
 
 function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
@@ -208,8 +210,19 @@ function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
     else
         build.actionbarFallbackRequired = nil
         build.periodicMaintenanceRequired = nil
+        build.targetMaintenanceRequired = nil
+        build.nonTargetMaintenanceRequired = nil
     end
     self._cooldownRefreshEligibilityBuild = build
+end
+
+local function RecordPeriodicMaintenance(build, targetMaintenance)
+    build.periodicMaintenanceRequired = true
+    if targetMaintenance then
+        build.targetMaintenanceRequired = true
+    else
+        build.nonTargetMaintenanceRequired = true
+    end
 end
 
 function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
@@ -221,31 +234,34 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     end
 
     if HasActiveIconCooldownText(button, buttonData) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if HasCooldownDrivenVisualMaintenance(button, buttonData) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if button._isText == true then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if button._cooldownDeferred == true then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
-    if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
-        build.periodicMaintenanceRequired = true
+    if button._auraGraceStart ~= nil then
+        RecordPeriodicMaintenance(build)
+    end
+    if button._targetSwitchAt ~= nil then
+        RecordPeriodicMaintenance(build, true)
     end
     if HasTimedReadyGlow(button) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if HasSoundAlerts(buttonData) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if buttonData and buttonData._rotationAssistantVirtual == true then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
     if IsTriggerRuntime(button, displayMode) then
-        build.periodicMaintenanceRequired = true
+        RecordPeriodicMaintenance(build)
     end
 end
 
@@ -261,6 +277,8 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
     self._cooldownRefreshEligibilityInvalidationReason = nil
     self._activeActionbarCooldownFallbackRequired = build.actionbarFallbackRequired == true or nil
     self._activeCooldownPeriodicMaintenanceRequired = build.periodicMaintenanceRequired == true or nil
+    self._activeTargetCooldownMaintenanceRequired = build.targetMaintenanceRequired == true or nil
+    self._activeNonTargetCooldownMaintenanceRequired = build.nonTargetMaintenanceRequired == true or nil
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -370,7 +388,7 @@ end
 
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
-    if self._activeCooldownPeriodicMaintenanceRequired then return false end
+    if self._activeNonTargetCooldownMaintenanceRequired then return false end
     if not self:IsTargetCooldownRefreshStateSatisfied() then
         return false
     end
@@ -494,7 +512,7 @@ function CooldownCompanion:ClearActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = nil
 end
 
-function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
+function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
     if not self._actionbarCooldownPulsePending then
         return false
     end
@@ -510,7 +528,11 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._activeActionbarCooldownFallbackRequired then
         return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
+    if self._activeCooldownPeriodicMaintenanceRequired
+        and not cooldownEventSatisfied
+        and not (targetRefreshSatisfied
+            and self._activeTargetCooldownMaintenanceRequired
+            and not self._activeNonTargetCooldownMaintenanceRequired) then
         return false
     end
     return true
@@ -527,7 +549,7 @@ function CooldownCompanion:TickCooldownRefresh()
     local tickerRefreshSatisfied = cooldownEventSatisfied or targetRefreshSatisfied
     local actionbarFallbackRequired = false
     if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
-        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
+        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
         if canSkipActionbarPulse then
             self:ClearActionbarCooldownPulse()
             if targetRefreshSatisfied then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -366,7 +366,9 @@ end
 function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
     if not IsTargetRefreshSource(source) then return false end
     if self._queuedCooldownRefreshSource then return false end
-    if source == "unit-target-event" and self._activeTargetCooldownMaintenanceRequired then
+    if source == "unit-target-event"
+        and (not self._cooldownRefreshEligibilityKnown
+            or self._activeTargetCooldownMaintenanceRequired) then
         return false
     end
 
@@ -391,6 +393,8 @@ end
 
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
+    if not self._cooldownRefreshEligibilityKnown then return false end
+    if self._activeTargetCooldownMaintenanceRequired then return false end
     if self._activeNonTargetCooldownMaintenanceRequired then return false end
     if not self:IsTargetCooldownRefreshStateSatisfied() then
         return false

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -53,6 +53,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic or {}
+local EntryRuntime = ST.EntryRuntime or {}
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN or "cooldown"
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING or "missing"
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO or "zero"
@@ -131,6 +132,134 @@ local function HasActiveIconCooldownText(button, buttonData)
         or button._secondaryCdActive == true
 end
 
+local RecordPeriodicMaintenance
+
+local function ClearTable(tbl)
+    if not tbl then return end
+    for key in pairs(tbl) do
+        tbl[key] = nil
+    end
+end
+
+local function AddUniqueReason(list, seen, reason)
+    if not reason or seen[reason] then return end
+    seen[reason] = true
+    list[#list + 1] = reason
+end
+
+local function ClearReasonTracking(build)
+    ClearTable(build.periodicMaintenanceReasons)
+    ClearTable(build.periodicMaintenanceSeen)
+    ClearTable(build.safeTextWidgetMaintenanceReasons)
+    ClearTable(build.safeTextWidgetMaintenanceSeen)
+    ClearTable(build.unprovenIconTextMaintenanceReasons)
+    ClearTable(build.unprovenIconTextMaintenanceSeen)
+end
+
+local function EnsureReasonTracking(build)
+    build.periodicMaintenanceReasons = build.periodicMaintenanceReasons or {}
+    build.periodicMaintenanceSeen = build.periodicMaintenanceSeen or {}
+    build.safeTextWidgetMaintenanceReasons = build.safeTextWidgetMaintenanceReasons or {}
+    build.safeTextWidgetMaintenanceSeen = build.safeTextWidgetMaintenanceSeen or {}
+    build.unprovenIconTextMaintenanceReasons = build.unprovenIconTextMaintenanceReasons or {}
+    build.unprovenIconTextMaintenanceSeen = build.unprovenIconTextMaintenanceSeen or {}
+end
+
+local function CopyReasonList(list)
+    if not list or #list == 0 then return nil end
+    local copy = {}
+    for i = 1, #list do
+        copy[i] = list[i]
+    end
+    return copy
+end
+
+local function IsSafeTextWidgetMaintenanceOnly(button, buttonData)
+    if not buttonData then return false end
+    if not HasActiveIconCooldownText(button, buttonData) then return false end
+    if button._chargeCooldownVisualActive == true or button._secondaryCdActive == true then
+        return false
+    end
+    return button._durationObj ~= nil
+        or button._auraDurationObj ~= nil
+        or button._auraCooldownStart ~= nil
+end
+
+local function SafeTextWidgetTimingStillActive(button)
+    if not button then return false end
+    local durationObjectShowsCooldown = EntryRuntime.DurationObjectShowsCooldown
+    if type(durationObjectShowsCooldown) ~= "function" then
+        return true
+    end
+
+    local sawTimingSource = false
+    if button._durationObj ~= nil then
+        sawTimingSource = true
+        if durationObjectShowsCooldown(button._durationObj) then
+            return true
+        end
+    end
+    if button._auraDurationObj ~= nil then
+        sawTimingSource = true
+        if durationObjectShowsCooldown(button._auraDurationObj) then
+            return true
+        end
+    end
+    if button._auraCooldownStart ~= nil then
+        sawTimingSource = true
+        local duration = button._auraCooldownDuration or 0
+        if duration > 0 and type(GetTime) == "function" and (GetTime() - button._auraCooldownStart) < duration then
+            return true
+        end
+    end
+
+    return not sawTimingSource
+end
+
+local function RecordIconCooldownTextMaintenance(build, button, buttonData)
+    if not HasActiveIconCooldownText(button, buttonData) then
+        return
+    end
+    if not buttonData then
+        AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "missing-button-data")
+        RecordPeriodicMaintenance(build, false, "unproven-icon-text", false, true)
+        return
+    end
+
+    local safeTextWidget = false
+    local unproven = false
+    if button._durationObj ~= nil then
+        safeTextWidget = true
+        AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "duration-object")
+    end
+    if button._auraDurationObj ~= nil then
+        safeTextWidget = true
+        AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "aura-duration-object")
+    end
+    if button._auraCooldownStart ~= nil then
+        safeTextWidget = true
+        AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "aura-cooldown-start")
+    end
+    if button._chargeCooldownVisualActive == true then
+        unproven = true
+        AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "charge-cooldown-visual")
+    end
+    if button._secondaryCdActive == true then
+        unproven = true
+        AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "secondary-cooldown-text")
+    end
+    if not safeTextWidget and not unproven then
+        unproven = true
+        AddUniqueReason(build.unprovenIconTextMaintenanceReasons, build.unprovenIconTextMaintenanceSeen, "unknown-icon-text")
+    end
+
+    if safeTextWidget and not unproven then
+        RecordPeriodicMaintenance(build, false, "safe-text-widget", true)
+    else
+        RecordPeriodicMaintenance(build, false, "unproven-icon-text", false, true)
+    end
+end
+
 local function HasCooldownDrivenVisualMaintenance(button, buttonData)
     if not (button and buttonData) then return false end
 
@@ -200,6 +329,13 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._activeCooldownPeriodicMaintenanceRequired = nil
     self._activeTargetCooldownMaintenanceRequired = nil
     self._activeNonTargetCooldownMaintenanceRequired = nil
+    self._activeSafeTextWidgetMaintenanceRequired = nil
+    self._activeUnprovenIconTextMaintenanceRequired = nil
+    self._activeOtherPeriodicMaintenanceRequired = nil
+    self._activeCooldownPeriodicMaintenanceReasons = nil
+    self._activeSafeTextWidgetMaintenanceReasons = nil
+    self._activeUnprovenIconTextMaintenanceReasons = nil
+    self._lastSafeTextWidgetMaintenanceCount = nil
 end
 
 function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
@@ -212,12 +348,26 @@ function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
         build.periodicMaintenanceRequired = nil
         build.targetMaintenanceRequired = nil
         build.nonTargetMaintenanceRequired = nil
+        build.safeTextWidgetMaintenanceRequired = nil
+        build.unprovenIconTextMaintenanceRequired = nil
+        build.otherPeriodicMaintenanceRequired = nil
+        ClearReasonTracking(build)
     end
+    EnsureReasonTracking(build)
     self._cooldownRefreshEligibilityBuild = build
 end
 
-local function RecordPeriodicMaintenance(build, targetMaintenance)
+RecordPeriodicMaintenance = function(build, targetMaintenance, reason, safeTextWidget, unprovenIconText)
+    EnsureReasonTracking(build)
     build.periodicMaintenanceRequired = true
+    AddUniqueReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, reason or "unknown")
+    if safeTextWidget then
+        build.safeTextWidgetMaintenanceRequired = true
+    elseif unprovenIconText then
+        build.unprovenIconTextMaintenanceRequired = true
+    else
+        build.otherPeriodicMaintenanceRequired = true
+    end
     if targetMaintenance then
         build.targetMaintenanceRequired = true
     else
@@ -233,35 +383,38 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
         build.actionbarFallbackRequired = true
     end
 
-    if HasActiveIconCooldownText(button, buttonData) then
-        RecordPeriodicMaintenance(build)
-    end
+    RecordIconCooldownTextMaintenance(build, button, buttonData)
     if HasCooldownDrivenVisualMaintenance(button, buttonData) then
-        RecordPeriodicMaintenance(build)
+        if IsSafeTextWidgetMaintenanceOnly(button, buttonData) then
+            AddUniqueReason(build.safeTextWidgetMaintenanceReasons, build.safeTextWidgetMaintenanceSeen, "icon-visual-presentation")
+            RecordPeriodicMaintenance(build, false, "safe-icon-visual-presentation", true)
+        else
+            RecordPeriodicMaintenance(build, false, "cooldown-driven-visual")
+        end
     end
     if button._isText == true then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "text-mode")
     end
     if button._cooldownDeferred == true then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "deferred-cooldown")
     end
     if button._auraGraceStart ~= nil then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "pending-aura-hold")
     end
     if button._targetSwitchAt ~= nil then
-        RecordPeriodicMaintenance(build, true)
+        RecordPeriodicMaintenance(build, true, "pending-aura-hold")
     end
     if HasTimedReadyGlow(button) then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "ready-glow-window")
     end
     if HasSoundAlerts(buttonData) then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "sound-alert")
     end
     if buttonData and buttonData._rotationAssistantVirtual == true then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "rotation-assistant")
     end
     if IsTriggerRuntime(button, displayMode) then
-        RecordPeriodicMaintenance(build)
+        RecordPeriodicMaintenance(build, false, "trigger-runtime")
     end
 end
 
@@ -279,6 +432,39 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
     self._activeCooldownPeriodicMaintenanceRequired = build.periodicMaintenanceRequired == true or nil
     self._activeTargetCooldownMaintenanceRequired = build.targetMaintenanceRequired == true or nil
     self._activeNonTargetCooldownMaintenanceRequired = build.nonTargetMaintenanceRequired == true or nil
+    self._activeSafeTextWidgetMaintenanceRequired = build.safeTextWidgetMaintenanceRequired == true or nil
+    self._activeUnprovenIconTextMaintenanceRequired = build.unprovenIconTextMaintenanceRequired == true or nil
+    self._activeOtherPeriodicMaintenanceRequired = build.otherPeriodicMaintenanceRequired == true or nil
+    self._activeCooldownPeriodicMaintenanceReasons = CopyReasonList(build.periodicMaintenanceReasons)
+    self._activeSafeTextWidgetMaintenanceReasons = CopyReasonList(build.safeTextWidgetMaintenanceReasons)
+    self._activeUnprovenIconTextMaintenanceReasons = CopyReasonList(build.unprovenIconTextMaintenanceReasons)
+end
+
+function CooldownCompanion:HasOnlySafeTextWidgetMaintenance()
+    return self._activeSafeTextWidgetMaintenanceRequired == true
+        and not self._activeUnprovenIconTextMaintenanceRequired
+        and not self._activeOtherPeriodicMaintenanceRequired
+        and not self._activeTargetCooldownMaintenanceRequired
+end
+
+function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
+    local safeTextOnly = self:HasOnlySafeTextWidgetMaintenance()
+    return {
+        known = self._cooldownRefreshEligibilityKnown == true,
+        invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
+        actionbarFallbackRequired = self._activeActionbarCooldownFallbackRequired == true,
+        periodicMaintenanceRequired = self._activeCooldownPeriodicMaintenanceRequired == true,
+        targetMaintenanceRequired = self._activeTargetCooldownMaintenanceRequired == true,
+        nonTargetMaintenanceRequired = self._activeNonTargetCooldownMaintenanceRequired == true,
+        safeTextWidgetMaintenanceRequired = self._activeSafeTextWidgetMaintenanceRequired == true,
+        safeTextWidgetMaintenanceOnly = safeTextOnly == true,
+        unprovenIconTextMaintenanceRequired = self._activeUnprovenIconTextMaintenanceRequired == true,
+        otherPeriodicMaintenanceRequired = self._activeOtherPeriodicMaintenanceRequired == true,
+        periodicMaintenanceReasons = self._activeCooldownPeriodicMaintenanceReasons,
+        safeTextWidgetMaintenanceReasons = self._activeSafeTextWidgetMaintenanceReasons,
+        unprovenIconTextMaintenanceReasons = self._activeUnprovenIconTextMaintenanceReasons,
+        lastSafeTextWidgetMaintenanceCount = self._lastSafeTextWidgetMaintenanceCount,
+    }
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -519,6 +705,32 @@ function CooldownCompanion:ClearActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = nil
 end
 
+function CooldownCompanion:RunSafeTextWidgetMaintenance()
+    if type(self.ApplySafeIconTextWidgetMaintenance) ~= "function" then
+        return false
+    end
+
+    local updated = 0
+    if type(self.groupFrames) == "table" then
+        for _, frame in pairs(self.groupFrames) do
+            if frame and frame.IsShown and frame:IsShown() and type(frame.buttons) == "table" then
+                for _, button in ipairs(frame.buttons) do
+                    if IsSafeTextWidgetMaintenanceOnly(button, button.buttonData)
+                        and SafeTextWidgetTimingStillActive(button)
+                        and self:ApplySafeIconTextWidgetMaintenance(button, button.buttonData) ~= false then
+                        updated = updated + 1
+                    elseif IsSafeTextWidgetMaintenanceOnly(button, button.buttonData) then
+                        return false
+                    end
+                end
+            end
+        end
+    end
+
+    self._lastSafeTextWidgetMaintenanceCount = updated
+    return true
+end
+
 function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
     if not self._actionbarCooldownPulsePending then
         return false
@@ -536,7 +748,8 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
         return false
     end
     if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
-        return false
+        return self:HasOnlySafeTextWidgetMaintenance()
+            and type(self.ApplySafeIconTextWidgetMaintenance) == "function"
     end
     return true
 end
@@ -554,6 +767,14 @@ function CooldownCompanion:TickCooldownRefresh()
     if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
         local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
         if canSkipActionbarPulse then
+            if self._activeSafeTextWidgetMaintenanceRequired
+                and not cooldownEventSatisfied
+                and not self:RunSafeTextWidgetMaintenance() then
+                self:UpdateAllCooldowns()
+                self:RecordTargetPendingTickerRefreshSatisfied()
+                self:ClearActionbarCooldownPulse()
+                return false
+            end
             self:ClearActionbarCooldownPulse()
             if targetRefreshSatisfied then
                 self:ConsumeTargetTickerCooldownRefreshSkip()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -17,6 +17,8 @@
       covered by the pending broad flush.
     - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
       cooldown-event refresh.
+    - _spellAvailabilityRefreshSatisfiedSerial: dirty serial covered by an
+      executed spell-availability broad refresh.
     - _targetRefreshTransitionSerial: monotonic target-state marker bumped by
       PLAYER_TARGET_CHANGED.
     - _targetRefreshSatisfiedTransitionSerial/_targetRefreshSatisfiedDirtySerial:
@@ -44,6 +46,9 @@
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
+    - Spell-availability satisfaction only covers the dirty serial created by
+      the direct spell-availability broad pass, and only while the active
+      cooldown eligibility snapshot remains valid.
     - MarkCooldownsDirty is the only invalidator; stale satisfied serials are
       inert because they cannot match a later dirty serial.
     - Queued cooldown-event requests satisfy the serial captured at queue time.
@@ -627,6 +632,7 @@ end
 function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._cooldownRefreshEligibilityKnown = nil
     self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
+    self._spellAvailabilityRefreshSatisfiedSerial = nil
     self._activeActionbarCooldownFallbackRequired = nil
     self._activeCooldownPeriodicMaintenanceRequired = nil
     self._activeTargetCooldownMaintenanceRequired = nil
@@ -946,6 +952,22 @@ function CooldownCompanion:CanSkipCooldownEventTickerRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
+function CooldownCompanion:RecordSpellAvailabilityCooldownRefreshSatisfied(dirtySerial)
+    if not self._cooldownRefreshEligibilityKnown then return end
+    if dirtySerial == nil then
+        if not self._cooldownsDirty then return end
+        dirtySerial = self._cooldownDirtySerial or 0
+    end
+    self._spellAvailabilityRefreshSatisfiedSerial = dirtySerial
+end
+
+function CooldownCompanion:CanSkipSpellAvailabilityTickerCooldownRefresh()
+    if self._queuedCooldownRefreshSource then return false end
+    if not self._cooldownRefreshEligibilityKnown then return false end
+    return self._cooldownsDirty
+        and self._spellAvailabilityRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+end
+
 function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
     if self._queuedCooldownRefreshSource then return false end
     if not self._cooldownRefreshEligibilityKnown then return false end
@@ -1063,6 +1085,7 @@ end
 
 function CooldownCompanion:CanSkipTickerCooldownRefresh()
     return self:CanSkipCooldownEventTickerRefresh()
+        or self:CanSkipSpellAvailabilityTickerCooldownRefresh()
         or self:CanSkipTargetTickerCooldownRefresh()
 end
 
@@ -1274,14 +1297,16 @@ function CooldownCompanion:OnPowerEventCooldownRefresh()
     return true
 end
 
-function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
+function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied, spellAvailabilitySatisfied)
     if not self._actionbarCooldownPulsePending then
         return false
     end
     if self._queuedCooldownRefreshSource then
         return false
     end
-    if self._cooldownsDirty and not (cooldownEventSatisfied or targetRefreshSatisfied) then
+    local broadRefreshSatisfied = cooldownEventSatisfied == true
+    local dirtyRefreshSatisfied = broadRefreshSatisfied or spellAvailabilitySatisfied or targetRefreshSatisfied
+    if self._cooldownsDirty and not dirtyRefreshSatisfied then
         return false
     end
     if not self._cooldownRefreshEligibilityKnown then
@@ -1290,7 +1315,7 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._activeActionbarCooldownFallbackRequired then
         return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
+    if self._activeCooldownPeriodicMaintenanceRequired and not broadRefreshSatisfied then
         if not self:HasOnlySkippableVisualMaintenance() then
             return false
         end
@@ -1314,14 +1339,16 @@ function CooldownCompanion:TickCooldownRefresh()
     end
 
     local cooldownEventSatisfied = self:CanSkipCooldownEventTickerRefresh()
+    local spellAvailabilitySatisfied = self:CanSkipSpellAvailabilityTickerCooldownRefresh()
     local targetRefreshSatisfied = self:CanSkipTargetTickerCooldownRefresh()
-    local tickerRefreshSatisfied = cooldownEventSatisfied or targetRefreshSatisfied
+    local tickerRefreshSatisfied = cooldownEventSatisfied or spellAvailabilitySatisfied or targetRefreshSatisfied
+    local broadRefreshSatisfied = cooldownEventSatisfied == true
     local actionbarFallbackRequired = false
     if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
-        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied)
+        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied, targetRefreshSatisfied, spellAvailabilitySatisfied)
         if canSkipActionbarPulse then
             if self._activeChargeCooldownVisualMaintenanceRequired
-                and not cooldownEventSatisfied
+                and not broadRefreshSatisfied
                 and not self:RunChargeCooldownVisualMaintenance() then
                 self:UpdateAllCooldowns()
                 self:RecordTargetPendingTickerRefreshSatisfied()
@@ -1329,7 +1356,7 @@ function CooldownCompanion:TickCooldownRefresh()
                 return false
             end
             if self._activeSafeTextWidgetMaintenanceRequired
-                and not cooldownEventSatisfied
+                and not broadRefreshSatisfied
                 and not self:RunSafeTextWidgetMaintenance() then
                 self:UpdateAllCooldowns()
                 self:RecordTargetPendingTickerRefreshSatisfied()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -526,7 +526,7 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._queuedCooldownRefreshSource then
         return false
     end
-    if self._cooldownsDirty and not cooldownEventSatisfied then
+    if self._cooldownsDirty and not (cooldownEventSatisfied or targetRefreshSatisfied) then
         return false
     end
     if not self._cooldownRefreshEligibilityKnown then
@@ -535,11 +535,7 @@ function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisf
     if self._activeActionbarCooldownFallbackRequired then
         return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired
-        and not cooldownEventSatisfied
-        and not (targetRefreshSatisfied
-            and self._activeTargetCooldownMaintenanceRequired
-            and not self._activeNonTargetCooldownMaintenanceRequired) then
+    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
         return false
     end
     return true

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -37,15 +37,14 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
-local function AddReason(reasons, seen, reason)
-    if not reason or seen[reason] then return end
-    seen[reason] = true
-    reasons[#reasons + 1] = reason
-end
-
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
     return cfg and type(cfg.events) == "table" and next(cfg.events) ~= nil
+end
+
+local function ReadyGlowWindowNeedsRefresh(startTime, now, duration, active)
+    if startTime == nil then return false end
+    return (now - startTime) <= duration or active == true
 end
 
 local function HasTimedReadyGlow(button)
@@ -57,13 +56,35 @@ local function HasTimedReadyGlow(button)
     end
 
     local now = GetTime()
-    local function WindowNeedsRefresh(startTime)
-        if startTime == nil then return false end
-        return (now - startTime) <= duration or button._readyGlowActive == true
+    return ReadyGlowWindowNeedsRefresh(button._readyGlowStartTime, now, duration, button._readyGlowActive)
+        or ReadyGlowWindowNeedsRefresh(button._readyGlowMaxChargesStartTime, now, duration, button._readyGlowActive)
+end
+
+local function HasActiveIconCooldownText(button, buttonData)
+    if not (button and button._cdTextRegion) then return false end
+    if button._isBar or button._isText then return false end
+
+    local style = button.style or {}
+    local auraTextActive = button._auraPrimarySwipeActive == true
+        or button._conditionalAuraDurationTextPreview == true
+    if auraTextActive then
+        if style.showAuraText == false then
+            return false
+        end
+    else
+        if style.showCooldownText == false or button._hideCooldownChargesActive then
+            return false
+        end
+        if buttonData and buttonData.isPassive then
+            return false
+        end
     end
 
-    return WindowNeedsRefresh(button._readyGlowStartTime)
-        or WindowNeedsRefresh(button._readyGlowMaxChargesStartTime)
+    return button._durationObj ~= nil
+        or button._auraDurationObj ~= nil
+        or button._auraCooldownStart ~= nil
+        or button._chargeCooldownVisualActive == true
+        or button._secondaryCdActive == true
 end
 
 local function IsTriggerRuntime(button, displayMode)
@@ -96,17 +117,18 @@ function CooldownCompanion:InvalidateCooldownRefreshEligibility(reason)
     self._cooldownRefreshEligibilityInvalidationReason = reason or "unknown"
     self._activeActionbarCooldownFallbackRequired = nil
     self._activeCooldownPeriodicMaintenanceRequired = nil
-    self._activeActionbarCooldownFallbackReasons = nil
-    self._activeCooldownPeriodicMaintenanceReasons = nil
 end
 
 function CooldownCompanion:BeginCooldownRefreshEligibilityBuild()
-    self._cooldownRefreshEligibilityBuild = {
-        actionbarFallbackReasons = {},
-        actionbarFallbackSeen = {},
-        periodicMaintenanceReasons = {},
-        periodicMaintenanceSeen = {},
-    }
+    local build = self._cooldownRefreshEligibilityBuildCache
+    if not build then
+        build = {}
+        self._cooldownRefreshEligibilityBuildCache = build
+    else
+        build.actionbarFallbackRequired = nil
+        build.periodicMaintenanceRequired = nil
+    end
+    self._cooldownRefreshEligibilityBuild = build
 end
 
 function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, buttonData, displayMode)
@@ -114,29 +136,34 @@ function CooldownCompanion:RecordButtonCooldownRefreshEligibility(button, button
     if not build or not button then return end
 
     if button._actionSlotCooldownFallback == true then
-        AddReason(build.actionbarFallbackReasons, build.actionbarFallbackSeen, "action-slot-fallback")
+        build.actionbarFallbackRequired = true
+    elseif button._actionSlotCooldownCandidate == true then
+        build.actionbarFallbackRequired = true
     end
 
+    if HasActiveIconCooldownText(button, buttonData) then
+        build.periodicMaintenanceRequired = true
+    end
     if button._isText == true then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "text-mode")
+        build.periodicMaintenanceRequired = true
     end
     if button._cooldownDeferred == true then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "deferred-cooldown")
+        build.periodicMaintenanceRequired = true
     end
     if button._auraGraceStart ~= nil or button._targetSwitchAt ~= nil then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "pending-aura-hold")
+        build.periodicMaintenanceRequired = true
     end
     if HasTimedReadyGlow(button) then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "ready-glow-window")
+        build.periodicMaintenanceRequired = true
     end
     if HasSoundAlerts(buttonData) then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "sound-alert")
+        build.periodicMaintenanceRequired = true
     end
     if buttonData and buttonData._rotationAssistantVirtual == true then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "rotation-assistant")
+        build.periodicMaintenanceRequired = true
     end
     if IsTriggerRuntime(button, displayMode) then
-        AddReason(build.periodicMaintenanceReasons, build.periodicMaintenanceSeen, "trigger-runtime")
+        build.periodicMaintenanceRequired = true
     end
 end
 
@@ -150,21 +177,8 @@ function CooldownCompanion:FinishCooldownRefreshEligibilityBuild()
 
     self._cooldownRefreshEligibilityKnown = true
     self._cooldownRefreshEligibilityInvalidationReason = nil
-    self._activeActionbarCooldownFallbackRequired = #build.actionbarFallbackReasons > 0 or nil
-    self._activeCooldownPeriodicMaintenanceRequired = #build.periodicMaintenanceReasons > 0 or nil
-    self._activeActionbarCooldownFallbackReasons = #build.actionbarFallbackReasons > 0 and build.actionbarFallbackReasons or nil
-    self._activeCooldownPeriodicMaintenanceReasons = #build.periodicMaintenanceReasons > 0 and build.periodicMaintenanceReasons or nil
-end
-
-function CooldownCompanion:GetActionbarCooldownEligibilityInfo()
-    return {
-        known = self._cooldownRefreshEligibilityKnown == true,
-        invalidationReason = self._cooldownRefreshEligibilityInvalidationReason,
-        actionbarFallbackRequired = self._activeActionbarCooldownFallbackRequired == true,
-        actionbarFallbackReasons = self._activeActionbarCooldownFallbackReasons,
-        periodicMaintenanceRequired = self._activeCooldownPeriodicMaintenanceRequired == true,
-        periodicMaintenanceReasons = self._activeCooldownPeriodicMaintenanceReasons,
-    }
+    self._activeActionbarCooldownFallbackRequired = build.actionbarFallbackRequired == true or nil
+    self._activeCooldownPeriodicMaintenanceRequired = build.periodicMaintenanceRequired == true or nil
 end
 
 function CooldownCompanion:MarkCooldownsDirty()
@@ -191,7 +205,7 @@ end
 function CooldownCompanion:FlushQueuedCooldownRefresh()
     local queuedSource = self._queuedCooldownRefreshSource
     local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
-    self:ResetCooldownRefreshState()
+    self:ResetCooldownRefreshState(queuedSource == nil)
 
     if queuedSource then
         self:UpdateAllCooldowns()
@@ -237,56 +251,34 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
-function CooldownCompanion:RecordActionbarCooldownPulse(event)
+function CooldownCompanion:RecordActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = true
-    self._actionbarCooldownPulseEvent = event or "ACTIONBAR_UPDATE_COOLDOWN"
-    self._actionbarCooldownPulseCount = (self._actionbarCooldownPulseCount or 0) + 1
 end
 
 function CooldownCompanion:ClearActionbarCooldownPulse()
     self._actionbarCooldownPulsePending = nil
-    self._actionbarCooldownPulseEvent = nil
-    self._actionbarCooldownPulseCount = nil
 end
 
-function CooldownCompanion:GetActionbarCooldownPulseDecision()
+function CooldownCompanion:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
     if not self._actionbarCooldownPulsePending then
-        return false, "no-actionbar-pulse"
+        return false
     end
     if self._queuedCooldownRefreshSource then
-        return false, "queued-refresh"
+        return false
     end
-    if self._cooldownsDirty then
-        return false, "dirty"
+    if self._cooldownsDirty and not cooldownEventSatisfied then
+        return false
     end
     if not self._cooldownRefreshEligibilityKnown then
-        return false, self._cooldownRefreshEligibilityInvalidationReason or "eligibility-unknown"
+        return false
     end
     if self._activeActionbarCooldownFallbackRequired then
-        return false, "actionbar-fallback-required"
+        return false
     end
-    if self._activeCooldownPeriodicMaintenanceRequired then
-        return false, "periodic-maintenance-required"
+    if self._activeCooldownPeriodicMaintenanceRequired and not cooldownEventSatisfied then
+        return false
     end
-    return true, "pulse-only"
-end
-
-function CooldownCompanion:GetActionbarCooldownFallbackReason(decision)
-    local eligibility = self:GetActionbarCooldownEligibilityInfo()
-    return {
-        kind = "actionbar-cooldown",
-        source = "actionbar-cooldown-event",
-        event = self._actionbarCooldownPulseEvent or "ACTIONBAR_UPDATE_COOLDOWN",
-        origin = "ticker",
-        broad = true,
-        actionbarPulseDecision = decision,
-        actionbarPulseCount = self._actionbarCooldownPulseCount,
-        actionbarFallbackRequired = eligibility.actionbarFallbackRequired,
-        actionbarFallbackReasons = eligibility.actionbarFallbackReasons,
-        periodicMaintenanceRequired = eligibility.periodicMaintenanceRequired,
-        periodicMaintenanceReasons = eligibility.periodicMaintenanceReasons,
-        eligibilityKnown = eligibility.known,
-    }
+    return true
 end
 
 function CooldownCompanion:TickCooldownRefresh()
@@ -294,27 +286,29 @@ function CooldownCompanion:TickCooldownRefresh()
         self:FlushQueuedCooldownRefresh()
         return false
     end
-    if self:CanSkipTickerCooldownRefresh() then
-        self:ClearActionbarCooldownPulse()
-        return true
-    end
 
-    local actionbarOnlyReason
-    if self._actionbarCooldownPulsePending and not self._cooldownsDirty then
-        local canSkipActionbarPulse, decision = self:GetActionbarCooldownPulseDecision()
+    local cooldownEventSatisfied = self:CanSkipTickerCooldownRefresh()
+    local actionbarFallbackRequired = false
+    if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or cooldownEventSatisfied) then
+        local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
         if canSkipActionbarPulse then
             self:ClearActionbarCooldownPulse()
             return true
         end
-        actionbarOnlyReason = self:GetActionbarCooldownFallbackReason(decision)
+        actionbarFallbackRequired = true
     end
 
-    self:UpdateAllCooldowns(actionbarOnlyReason)
+    if cooldownEventSatisfied and not actionbarFallbackRequired then
+        self:ClearActionbarCooldownPulse()
+        return true
+    end
+
+    self:UpdateAllCooldowns()
     self:ClearActionbarCooldownPulse()
     return false
 end
 
-function CooldownCompanion:ResetCooldownRefreshState()
+function CooldownCompanion:ResetCooldownRefreshState(preserveActionbarPulse)
     if self._cooldownRefreshQueueFrame then
         self._cooldownRefreshQueueFrame:SetScript("OnUpdate", nil)
     end
@@ -322,5 +316,7 @@ function CooldownCompanion:ResetCooldownRefreshState()
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
-    self:ClearActionbarCooldownPulse()
+    if not preserveActionbarPulse then
+        self:ClearActionbarCooldownPulse()
+    end
 end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -10,8 +10,22 @@
       a debug breadcrumb, not skip eligibility.
     - _queuedCooldownRefreshCooldownEventSerial: dirty serial captured when a
       queued cooldown-event request enters the queue.
+    - _queuedCooldownRefreshTargetDirtySerial/_queuedCooldownRefreshTargetTransitionSerial:
+      target-family state captured when a queued target request enters the
+      queue.
+    - _queuedCooldownRefreshTargetSource: first queued target-family source
+      covered by the pending broad flush.
     - _cooldownRefreshSatisfiedSerial: dirty serial covered by an executed
       cooldown-event refresh.
+    - _targetRefreshTransitionSerial: monotonic target-state marker bumped by
+      PLAYER_TARGET_CHANGED.
+    - _targetRefreshSatisfiedTransitionSerial/_targetRefreshSatisfiedDirtySerial:
+      target-family broad work that covered the current transition and, when
+      dirty, the serial it covered.
+    - _targetRefreshCleanTickerSkipTransitionSerial: one-shot clean ticker
+      confirmation covered by the target-exists synchronous probe.
+    - _targetRefreshPendingTransitionSerial: target-clear dirty confirmation
+      waiting for its first broad pass.
     - _cooldownImmediateRefreshThisFrame: latch allowing only the first
       immediate refresh in a frame to walk synchronously.
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
@@ -32,6 +46,8 @@
       If another dirty mark lands before the flush, the later ticker walks
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
+    - Target-family duplicate skips require either the same target transition or
+      the exact dirty serial already covered by a target-family broad pass.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -40,6 +56,16 @@ local CooldownLogic = ST.CooldownLogic or {}
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN or "cooldown"
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING or "missing"
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO or "zero"
+local TARGET_REFRESH_SOURCES = {
+    ["target-event"] = true,
+    ["target-aura-event"] = true,
+    ["unit-target-event"] = true,
+    ["target-ticker"] = true,
+}
+
+local function IsTargetRefreshSource(source)
+    return TARGET_REFRESH_SOURCES[source] == true
+end
 
 local function HasSoundAlerts(buttonData)
     local cfg = buttonData and buttonData.soundAlerts
@@ -232,6 +258,94 @@ function CooldownCompanion:ClearCooldownsDirty()
     self._cooldownsDirty = false
 end
 
+function CooldownCompanion:BeginTargetCooldownRefreshTransition(reason)
+    self._targetRefreshTransitionSerial = (self._targetRefreshTransitionSerial or 0) + 1
+    self._targetRefreshTransitionReason = reason or "target"
+    self._targetRefreshSatisfiedTransitionSerial = nil
+    self._targetRefreshSatisfiedDirtySerial = nil
+    self._targetRefreshSatisfiedSource = nil
+    self._targetRefreshCleanTickerSkipTransitionSerial = nil
+    self._targetRefreshPendingTransitionSerial = nil
+    return self._targetRefreshTransitionSerial
+end
+
+function CooldownCompanion:MarkTargetCooldownRefreshPending(transitionSerial)
+    transitionSerial = transitionSerial or self._targetRefreshTransitionSerial
+    if transitionSerial then
+        self._targetRefreshPendingTransitionSerial = transitionSerial
+    end
+end
+
+function CooldownCompanion:RecordTargetCooldownRefreshSatisfied(source, transitionSerial, dirtySerial, options)
+    if not IsTargetRefreshSource(source) then return end
+
+    transitionSerial = transitionSerial or self._targetRefreshTransitionSerial
+    if transitionSerial
+        and self._targetRefreshTransitionSerial
+        and transitionSerial ~= self._targetRefreshTransitionSerial then
+        return
+    end
+
+    if dirtySerial == nil and self._cooldownsDirty then
+        dirtySerial = self._cooldownDirtySerial or 0
+    end
+
+    self._targetRefreshSatisfiedTransitionSerial = transitionSerial
+    self._targetRefreshSatisfiedDirtySerial = dirtySerial
+    self._targetRefreshSatisfiedSource = source
+
+    if transitionSerial and self._targetRefreshPendingTransitionSerial == transitionSerial then
+        self._targetRefreshPendingTransitionSerial = nil
+    end
+    if options and options.allowCleanTickerSkip and transitionSerial and dirtySerial == nil then
+        self._targetRefreshCleanTickerSkipTransitionSerial = transitionSerial
+    end
+end
+
+function CooldownCompanion:CanSkipTargetRefreshDuplicate(source)
+    if not IsTargetRefreshSource(source) then return false end
+    if self._queuedCooldownRefreshSource then return false end
+
+    local transitionSerial = self._targetRefreshTransitionSerial
+    if not transitionSerial or self._targetRefreshSatisfiedTransitionSerial ~= transitionSerial then
+        return false
+    end
+
+    if self._cooldownsDirty then
+        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    end
+    return true
+end
+
+function CooldownCompanion:CanSkipCooldownEventTickerRefresh()
+    return self._cooldownsDirty
+        and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+end
+
+function CooldownCompanion:CanSkipTargetTickerCooldownRefresh()
+    if self._queuedCooldownRefreshSource then return false end
+    if self._cooldownsDirty then
+        return self._targetRefreshSatisfiedDirtySerial == (self._cooldownDirtySerial or 0)
+    end
+
+    local transitionSerial = self._targetRefreshTransitionSerial
+    return transitionSerial ~= nil
+        and self._targetRefreshSatisfiedTransitionSerial == transitionSerial
+        and self._targetRefreshCleanTickerSkipTransitionSerial == transitionSerial
+end
+
+function CooldownCompanion:ConsumeTargetTickerCooldownRefreshSkip()
+    self._targetRefreshCleanTickerSkipTransitionSerial = nil
+end
+
+function CooldownCompanion:RecordTargetPendingTickerRefreshSatisfied()
+    local transitionSerial = self._targetRefreshPendingTransitionSerial
+    if transitionSerial and transitionSerial == self._targetRefreshTransitionSerial then
+        self:RecordTargetCooldownRefreshSatisfied("target-ticker", transitionSerial)
+    end
+    self._targetRefreshCleanTickerSkipTransitionSerial = nil
+end
+
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
     if not self._cooldownRefreshQueueFrame then
         local frame = CreateFrame("Frame")
@@ -247,12 +361,18 @@ end
 function CooldownCompanion:FlushQueuedCooldownRefresh()
     local queuedSource = self._queuedCooldownRefreshSource
     local cooldownEventSerial = self._queuedCooldownRefreshCooldownEventSerial
+    local targetSource = self._queuedCooldownRefreshTargetSource
+    local targetDirtySerial = self._queuedCooldownRefreshTargetDirtySerial
+    local targetTransitionSerial = self._queuedCooldownRefreshTargetTransitionSerial
     self:ResetCooldownRefreshState(queuedSource == nil)
 
     if queuedSource then
         self:UpdateAllCooldowns()
         if cooldownEventSerial then
             self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
+        end
+        if targetSource then
+            self:RecordTargetCooldownRefreshSatisfied(targetSource, targetTransitionSerial, targetDirtySerial)
         end
     end
 end
@@ -261,6 +381,11 @@ function CooldownCompanion:QueueCooldownRefresh(source)
     self._queuedCooldownRefreshSource = source or "event"
     if source == "cooldown-event" then
         self._queuedCooldownRefreshCooldownEventSerial = self._cooldownDirtySerial or 0
+    end
+    if IsTargetRefreshSource(source) then
+        self._queuedCooldownRefreshTargetSource = source
+        self._queuedCooldownRefreshTargetDirtySerial = self._cooldownsDirty and (self._cooldownDirtySerial or 0) or nil
+        self._queuedCooldownRefreshTargetTransitionSerial = self._targetRefreshTransitionSerial
     end
     self:EnsureCooldownRefreshQueueFrame()
 end
@@ -275,22 +400,32 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
     if source == "cooldown-event" then
         cooldownEventSerial = self._cooldownDirtySerial or 0
     end
+    local targetDirtySerial
+    local targetTransitionSerial
+    if IsTargetRefreshSource(source) then
+        targetDirtySerial = self._cooldownsDirty and (self._cooldownDirtySerial or 0) or nil
+        targetTransitionSerial = self._targetRefreshTransitionSerial
+    end
 
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
+    self._queuedCooldownRefreshTargetSource = nil
+    self._queuedCooldownRefreshTargetDirtySerial = nil
+    self._queuedCooldownRefreshTargetTransitionSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
     self:UpdateAllCooldowns()
     if cooldownEventSerial then
         self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
     end
+    if IsTargetRefreshSource(source) then
+        self:RecordTargetCooldownRefreshSatisfied(source, targetTransitionSerial, targetDirtySerial)
+    end
 end
 
 function CooldownCompanion:CanSkipTickerCooldownRefresh()
-    -- Only cooldown-event refreshes can satisfy the next ticker pass. Aura,
-    -- target, and other dirty paths keep their normal ticker confirmation.
-    return self._cooldownsDirty
-        and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
+    return self:CanSkipCooldownEventTickerRefresh()
+        or self:CanSkipTargetTickerCooldownRefresh()
 end
 
 function CooldownCompanion:RecordActionbarCooldownPulse()
@@ -329,23 +464,32 @@ function CooldownCompanion:TickCooldownRefresh()
         return false
     end
 
-    local cooldownEventSatisfied = self:CanSkipTickerCooldownRefresh()
+    local cooldownEventSatisfied = self:CanSkipCooldownEventTickerRefresh()
+    local targetRefreshSatisfied = self:CanSkipTargetTickerCooldownRefresh()
+    local tickerRefreshSatisfied = cooldownEventSatisfied or targetRefreshSatisfied
     local actionbarFallbackRequired = false
-    if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or cooldownEventSatisfied) then
+    if self._actionbarCooldownPulsePending and (not self._cooldownsDirty or tickerRefreshSatisfied) then
         local canSkipActionbarPulse = self:GetActionbarCooldownPulseDecision(cooldownEventSatisfied)
         if canSkipActionbarPulse then
             self:ClearActionbarCooldownPulse()
+            if targetRefreshSatisfied then
+                self:ConsumeTargetTickerCooldownRefreshSkip()
+            end
             return true
         end
         actionbarFallbackRequired = true
     end
 
-    if cooldownEventSatisfied and not actionbarFallbackRequired then
+    if tickerRefreshSatisfied and not actionbarFallbackRequired then
         self:ClearActionbarCooldownPulse()
+        if targetRefreshSatisfied then
+            self:ConsumeTargetTickerCooldownRefreshSkip()
+        end
         return true
     end
 
     self:UpdateAllCooldowns()
+    self:RecordTargetPendingTickerRefreshSatisfied()
     self:ClearActionbarCooldownPulse()
     return false
 end
@@ -357,6 +501,9 @@ function CooldownCompanion:ResetCooldownRefreshState(preserveActionbarPulse)
     self._cooldownRefreshQueueArmed = nil
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
+    self._queuedCooldownRefreshTargetSource = nil
+    self._queuedCooldownRefreshTargetDirtySerial = nil
+    self._queuedCooldownRefreshTargetTransitionSerial = nil
     self._cooldownImmediateRefreshThisFrame = nil
     if not preserveActionbarPulse then
         self:ClearActionbarCooldownPulse()

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1242,8 +1242,10 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     if needsRealCooldownFallback
         and options.allowActionSlotRealFallback then
         local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
-        if slotProbe.realShown == true and slotProbe.realDurationObj then
+        if slotProbe.sawAnySlot then
             result.slotProbe = slotProbe
+        end
+        if slotProbe.realShown == true and slotProbe.realDurationObj then
             result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
             result.realCooldownShown = true
             result.durationObj = slotProbe.durationObj or result.durationObj

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -22,6 +22,23 @@ local pendingSpellAvailabilityRefreshToken = 0
 -- Same token pattern as QueueTalentChargeRefresh.
 local pendingSlotChangeToken = 0
 local pendingSlotChangedSlots = {}
+local actionbarSlotSignatures = {}
+
+local function GetActionbarSlotSignature(slot)
+    if type(slot) ~= "number" then return nil end
+    if not C_ActionBar.HasAction(slot) then return "empty" end
+    local actionType, id, subType = GetActionInfo(slot)
+    return tostring(actionType) .. "\001" .. tostring(id) .. "\001" .. tostring(subType)
+end
+
+local function ActionbarSlotContentChanged(slot)
+    local signature = GetActionbarSlotSignature(slot)
+    if actionbarSlotSignatures[slot] == signature then
+        return false
+    end
+    actionbarSlotSignatures[slot] = signature
+    return true
+end
 
 local function QueueTalentChargeRefresh(addon)
     pendingTalentChargeRefreshToken = pendingTalentChargeRefreshToken + 1
@@ -592,17 +609,25 @@ function CooldownCompanion:OnActionBarSlotChanged(_, slot)
     local token = pendingSlotChangeToken
     C_Timer.After(0, function()
         if pendingSlotChangeToken ~= token then return end
+        local slotContentChanged = pendingSlotChangedSlots._fullRebuild == true
         self:RebuildSlotMapping()
         if pendingSlotChangedSlots._fullRebuild then
+            wipe(actionbarSlotSignatures)
             self:RebuildItemSlotCache()
         else
             for s in pairs(pendingSlotChangedSlots) do
+                if ActionbarSlotContentChanged(s) then
+                    slotContentChanged = true
+                end
                 self:UpdateItemSlotCache(s)
             end
         end
         wipe(pendingSlotChangedSlots)
         self:RebuildAddonSlotBindings()
         self:OnKeybindsChanged()
+        if slotContentChanged and self.InvalidateCooldownRefreshEligibility then
+            self:InvalidateCooldownRefreshEligibility("actionbar-slot-changed")
+        end
     end)
 end
 

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -51,12 +51,38 @@ local function QueueTalentChargeRefresh(addon)
     end)
 end
 
+local function RefreshSpellAvailabilitySettlingState(addon)
+    addon:CachePlayerState()
+    addon:CacheCurrentSpec()
+    addon._currentHeroSpecId = C_ClassTalents.GetActiveHeroTalentSpec()
+    addon:RebuildTalentNodeCache()
+
+    local chargeFlagsChanged = addon:RefreshChargeFlags("spell") == true
+    local groupSurfaceChanged
+    if addon.AnyGroupSurfaceNeedsSpellAvailabilityRefresh then
+        groupSurfaceChanged = addon:AnyGroupSurfaceNeedsSpellAvailabilityRefresh()
+    else
+        groupSurfaceChanged = addon:AnyGroupButtonSetNeedsRebuild()
+    end
+    if not chargeFlagsChanged and not groupSurfaceChanged then
+        addon._lastSpellAvailabilitySettlingDecision = "skipped-clean"
+        return
+    end
+
+    addon._lastSpellAvailabilitySettlingDecision = chargeFlagsChanged
+        and (groupSurfaceChanged and "refreshed-charge-and-surface" or "refreshed-charge")
+        or "refreshed-surface"
+    addon:RefreshAllGroupsForSpellAvailability()
+    addon:RefreshKeybindState()
+    addon:RefreshConfigPanel()
+end
+
 local function QueueSpellAvailabilitySettlingRefresh(addon)
     pendingSpellAvailabilityRefreshToken = pendingSpellAvailabilityRefreshToken + 1
     local token = pendingSpellAvailabilityRefreshToken
     C_Timer.After(0.2, function()
         if pendingSpellAvailabilityRefreshToken ~= token then return end
-        addon:RefreshSpellAvailabilityState({ skipSettlingRefresh = true })
+        RefreshSpellAvailabilitySettlingState(addon)
     end)
 end
 
@@ -394,23 +420,101 @@ function CooldownCompanion:UpdateSpellChargeMetadata(buttonData, spellID, opts)
     buttonData.hasCharges = hasRealCharges
 end
 
+local function CaptureChargeFlagState(buttonData)
+    return buttonData.hasCharges,
+        buttonData.maxCharges,
+        buttonData.showChargeText,
+        buttonData._hasDisplayCount,
+        buttonData._displayCountFamily,
+        buttonData._castCountCandidate,
+        buttonData._castCountSelf,
+        buttonData._castCountEventSpellID,
+        buttonData._castCountConfirmed,
+        buttonData._castCountSeeded
+end
+
+local function ChargeFlagStateChanged(
+    buttonData,
+    hasCharges,
+    maxCharges,
+    showChargeText,
+    hasDisplayCount,
+    displayCountFamily,
+    castCountCandidate,
+    castCountSelf,
+    castCountEventSpellID,
+    castCountConfirmed,
+    castCountSeeded
+)
+    return buttonData.hasCharges ~= hasCharges
+        or buttonData.maxCharges ~= maxCharges
+        or buttonData.showChargeText ~= showChargeText
+        or buttonData._hasDisplayCount ~= hasDisplayCount
+        or buttonData._displayCountFamily ~= displayCountFamily
+        or buttonData._castCountCandidate ~= castCountCandidate
+        or buttonData._castCountSelf ~= castCountSelf
+        or buttonData._castCountEventSpellID ~= castCountEventSpellID
+        or buttonData._castCountConfirmed ~= castCountConfirmed
+        or buttonData._castCountSeeded ~= castCountSeeded
+end
+
 -- Re-evaluate hasCharges on every spell button (talents can add/remove charges).
 -- Treat a spell as charge-based only when max charges is greater than 1.
 function CooldownCompanion:RefreshChargeFlags(typeFilter)
+    local changed = false
     if typeFilter ~= "item" then
         self._hasDisplayCountCandidates = false
     end
     for _, group in pairs(self.db.profile.groups) do
         for _, buttonData in ipairs(group.buttons) do
             if buttonData.type == "spell" and typeFilter ~= "item" then
+                local hasCharges, maxCharges, showChargeText, hasDisplayCount,
+                    displayCountFamily, castCountCandidate, castCountSelf,
+                    castCountEventSpellID, castCountConfirmed,
+                    castCountSeeded = CaptureChargeFlagState(buttonData)
                 self:UpdateSpellChargeMetadata(buttonData, buttonData.id)
+                if ChargeFlagStateChanged(
+                    buttonData,
+                    hasCharges,
+                    maxCharges,
+                    showChargeText,
+                    hasDisplayCount,
+                    displayCountFamily,
+                    castCountCandidate,
+                    castCountSelf,
+                    castCountEventSpellID,
+                    castCountConfirmed,
+                    castCountSeeded
+                ) then
+                    changed = true
+                end
             elseif buttonData.type == "item" and typeFilter ~= "spell" then
                 -- Never clear hasCharges for items; unavailable charged items can
                 -- be indistinguishable from unowned items through count APIs.
+                local hasCharges, maxCharges, showChargeText, hasDisplayCount,
+                    displayCountFamily, castCountCandidate, castCountSelf,
+                    castCountEventSpellID, castCountConfirmed,
+                    castCountSeeded = CaptureChargeFlagState(buttonData)
                 self.UpdateItemChargeMetadata(buttonData, buttonData.id)
+                if ChargeFlagStateChanged(
+                    buttonData,
+                    hasCharges,
+                    maxCharges,
+                    showChargeText,
+                    hasDisplayCount,
+                    displayCountFamily,
+                    castCountCandidate,
+                    castCountSelf,
+                    castCountEventSpellID,
+                    castCountConfirmed,
+                    castCountSeeded
+                ) then
+                    changed = true
+                end
             end
         end
     end
+    return changed
 end
 
 function CooldownCompanion:CacheCurrentSpec()

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -608,6 +608,9 @@ end
 
 function CooldownCompanion:OnActionBarLayoutChanged()
     self:RefreshKeybindState()
+    if self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("actionbar-layout-changed")
+    end
     -- UPDATE_OVERRIDE_ACTIONBAR / UPDATE_VEHICLE_ACTIONBAR also route here for
     -- keybind rebuilds; piggyback vehicle UI state check to avoid duplicate
     -- AceEvent registrations (AceEvent allows only one handler per event).

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -2555,6 +2555,9 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     ApplyActiveButtonLayout(self, groupId, frame, group, buttonSizingOptions, headerHeight)
     FinishGroupButtonRefresh(self, groupId, frame, group)
+    if self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("group-buttons-populated")
+    end
     -- _hasBeenSized is now true if the compact resize ran (set by
     -- ResizeGroupFrame), or still false if all buttons were visible and no
     -- compact resize was needed.  When compactLayout is off, it stays false

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -3144,6 +3144,9 @@ function CooldownCompanion:UpdateGroupStyle(groupId)
     local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
     ApplyActiveButtonLayout(self, groupId, frame, group, buttonSizingOptions, headerHeight)
     FinishGroupButtonRefresh(self, groupId, frame, group)
+    if self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("group-style-updated")
+    end
 end
 
 function CooldownCompanion:UpdateGroupClickthrough(groupId)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2387,6 +2387,9 @@ function CooldownCompanion:UpdateAllCooldowns()
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
     self._cooldownUpdatePassActive = true
+    if self.BeginCooldownRefreshEligibilityBuild then
+        self:BeginCooldownRefreshEligibilityBuild()
+    end
 
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
@@ -2394,6 +2397,9 @@ function CooldownCompanion:UpdateAllCooldowns()
         end
     end
 
+    if self.FinishCooldownRefreshEligibilityBuild then
+        self:FinishCooldownRefreshEligibilityBuild()
+    end
     self._cooldownUpdatePassActive = nil
 end
 

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1836,6 +1836,62 @@ function CooldownCompanion:AnyGroupButtonSetNeedsRebuild()
     return false
 end
 
+function CooldownCompanion:GroupSurfaceNeedsSpellAvailabilityRefresh(groupId, group)
+    local frame = self.groupFrames and self.groupFrames[groupId] or nil
+    local dormantFrame = self._dormantFrames and self._dormantFrames[groupId] or nil
+    if not self:IsGroupVisibleToCurrentChar(groupId) then
+        return frame ~= nil or dormantFrame ~= nil
+    end
+
+    local active = self:IsGroupActive(groupId, {
+        group = group,
+        checkCharVisibility = true,
+        checkLoadConditions = true,
+        requireButtons = true,
+    })
+
+    if not active then
+        return frame ~= nil or dormantFrame ~= nil
+    end
+    if not frame then
+        return true
+    end
+    if type(frame.IsShown) == "function" and not frame:IsShown() then
+        return true
+    end
+
+    return self:GroupButtonSetNeedsRebuild(groupId, group)
+end
+
+function CooldownCompanion:AnyGroupSurfaceNeedsSpellAvailabilityRefresh()
+    if not self.db or not self.db.profile or not self.db.profile.groups then
+        return false
+    end
+
+    if self.groupFrames then
+        for groupId, _ in pairs(self.groupFrames) do
+            if not self.db.profile.groups[groupId] then
+                return true
+            end
+        end
+    end
+    if self._dormantFrames then
+        for groupId, _ in pairs(self._dormantFrames) do
+            if not self.db.profile.groups[groupId] then
+                return true
+            end
+        end
+    end
+
+    for groupId, group in pairs(self.db.profile.groups) do
+        if self:GroupSurfaceNeedsSpellAvailabilityRefresh(groupId, group) then
+            return true
+        end
+    end
+
+    return false
+end
+
 function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
     local function resetFrameButtons(frame)
         if not frame or not frame.buttons then return end
@@ -1896,7 +1952,11 @@ function CooldownCompanion:RefreshAllGroupsForSpellAvailability()
         self:RefreshAllGroupsVisibilityOnly()
     end
 
+    local spellAvailabilityDirtySerial = self._cooldownsDirty and (self._cooldownDirtySerial or 0) or nil
     self:UpdateAllCooldowns()
+    if self.RecordSpellAvailabilityCooldownRefreshSatisfied then
+        self:RecordSpellAvailabilityCooldownRefreshSatisfied(spellAvailabilityDirtySerial)
+    end
 end
 
 function CooldownCompanion:CreateAllGroupFrames()

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2138,12 +2138,14 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
         self:ClearUnsupportedProfileRuntime()
         return
     end
+    local cooldownEligibilityChanged = false
 
     -- Fully unload frames for groups not in the current profile
     for groupId, _ in pairs(self.groupFrames) do
         if not self.db.profile.groups[groupId] then
             self:UnloadGroup(groupId)
             self:DiscardDormantFrame(groupId)
+            cooldownEligibilityChanged = true
         end
     end
     -- Also discard dormant frames for deleted groups
@@ -2151,6 +2153,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
         for groupId, _ in pairs(self._dormantFrames) do
             if not self.db.profile.groups[groupId] then
                 self:DiscardDormantFrame(groupId)
+                cooldownEligibilityChanged = true
             end
         end
     end
@@ -2158,6 +2161,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     for groupId, group in pairs(self.db.profile.groups) do
         if not self:IsGroupVisibleToCurrentChar(groupId) then
             self:UnloadGroup(groupId)
+            cooldownEligibilityChanged = true
         else
             local active = self:IsGroupActive(groupId, {
                 group = group,
@@ -2168,23 +2172,32 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
 
             if not active then
                 self:UnloadGroup(groupId)
+                cooldownEligibilityChanged = true
             else
                 local frame = self.groupFrames[groupId]
                 if frame and self:GroupButtonSetNeedsRebuild(groupId, group) then
                     self:RefreshGroupFrame(groupId)
+                    cooldownEligibilityChanged = true
                     frame = self.groupFrames[groupId]
                 elseif not frame then
                     if self:GroupButtonSetNeedsRebuild(groupId, group) then
                         self:DiscardDormantFrame(groupId)
+                        cooldownEligibilityChanged = true
                     end
                     -- Recover dormant frame with buttons intact (no repopulation needed)
                     frame = self:RecoverDormantFrame(groupId)
+                    if frame then
+                        cooldownEligibilityChanged = true
+                    end
                 end
                 if not frame then
                     if InCombatLockdown() then
                         self._pendingVisibilityRefresh = true
                     else
                         frame = self:CreateGroupFrame(groupId)
+                        if frame then
+                            cooldownEligibilityChanged = true
+                        end
                     end
                 end
 
@@ -2225,6 +2238,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
                         if frame.UpdateCooldowns then
                             frame:UpdateCooldowns()
                         end
+                        cooldownEligibilityChanged = true
                         if group.compactLayout then
                             frame._layoutDirty = true
                             self:UpdateGroupLayout(groupId)
@@ -2245,6 +2259,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     end
     if self.RefreshAlphaUpdateDriver then
         self:RefreshAlphaUpdateDriver()
+    end
+    if cooldownEligibilityChanged and self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility("visibility-only-refresh")
     end
 end
 

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -512,7 +512,7 @@ function CooldownCompanion:RefreshKeybindState()
 end
 
 -- Refresh keybind text and binding key caches on all buttons.
-function CooldownCompanion:OnKeybindsChanged(invalidationReason)
+function CooldownCompanion:OnKeybindsChanged()
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
             local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
@@ -522,9 +522,6 @@ function CooldownCompanion:OnKeybindsChanged(invalidationReason)
         -- Rebuild key press highlight binding cache
         CacheButtonBindingKeys(button, buttonData)
     end)
-    if invalidationReason and self.InvalidateCooldownRefreshEligibility then
-        self:InvalidateCooldownRefreshEligibility(invalidationReason)
-    end
 end
 
 -- Exports for key press highlight

--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -512,7 +512,7 @@ function CooldownCompanion:RefreshKeybindState()
 end
 
 -- Refresh keybind text and binding key caches on all buttons.
-function CooldownCompanion:OnKeybindsChanged()
+function CooldownCompanion:OnKeybindsChanged(invalidationReason)
     self:ForEachButton(function(button, buttonData)
         if button.keybindText then
             local text = CooldownCompanion:GetDisplayedKeybindText(buttonData, button._resolvedItemId, button)
@@ -522,6 +522,9 @@ function CooldownCompanion:OnKeybindsChanged()
         -- Rebuild key press highlight binding cache
         CacheButtonBindingKeys(button, buttonData)
     end)
+    if invalidationReason and self.InvalidateCooldownRefreshEligibility then
+        self:InvalidateCooldownRefreshEligibility(invalidationReason)
+    end
 end
 
 -- Exports for key press highlight

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -140,7 +140,7 @@ function CooldownCompanion:OnEnable()
         self._unitEventFrame = CreateFrame("Frame")
         self._unitEventFrame:SetScript("OnEvent", function(_, event, ...)
             if event == "UNIT_POWER_FREQUENT" then
-                self:MarkCooldownsDirty()
+                self:OnPowerEventCooldownRefresh()
             elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
                 self:OnSpellCast(event, ...)
             elseif event == "UNIT_AURA" then

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -321,7 +321,7 @@ function CooldownCompanion:OnCooldownStateChanged()
 end
 
 function CooldownCompanion:OnActionBarCooldownChanged(event)
-    self:RecordActionbarCooldownPulse(event or "ACTIONBAR_UPDATE_COOLDOWN")
+    self:RecordActionbarCooldownPulse()
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -208,20 +208,25 @@ function CooldownCompanion:OnEnable()
     self:RegisterEvent("UNIT_ENTERED_VEHICLE", "OnVehicleUIChanged")
     self:RegisterEvent("UNIT_EXITED_VEHICLE", "OnVehicleUIChanged")
 
-    -- Target change — marks dirty so ticker reads fresh viewer data next pass
+    -- Target change — probes or clears target aura state through OnTargetChanged.
     self:RegisterEvent("PLAYER_TARGET_CHANGED", "OnTargetChanged")
 
     -- UNIT_TARGET requires RegisterUnitEvent (plain RegisterEvent does not
-    -- receive it).  Marks dirty so the next ticker pass reads fresh CDM viewer
-    -- data; catches pet/focus target changes that don't fire PLAYER_TARGET_CHANGED.
+    -- receive it).  It stays a conservative broad fallback unless the current
+    -- target transition was already covered by PLAYER_TARGET_CHANGED or target
+    -- aura work.
     if not self._unitTargetFrame then
         self._unitTargetFrame = CreateFrame("Frame")
         self._unitTargetFrame:SetScript("OnEvent", function(_, event, unitToken)
             if ST._QueueInheritedUnitFrameAlphaResync then
                 ST._QueueInheritedUnitFrameAlphaResync()
             end
+            if self:CanSkipTargetRefreshDuplicate("unit-target-event") then
+                return
+            end
             self:MarkCooldownsDirty()
             self:UpdateAllCooldowns()
+            self:RecordTargetCooldownRefreshSatisfied("unit-target-event")
         end)
     end
     self._unitTargetFrame:RegisterUnitEvent("UNIT_TARGET", "player")

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -117,10 +117,11 @@ function CooldownCompanion:OnEnable()
     -- Cooldown events can expose very short ready windows, so refresh them
     -- immediately instead of waiting for the ticker.
     for _, evt in ipairs({
-        "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN", "ACTIONBAR_UPDATE_COOLDOWN",
+        "SPELL_UPDATE_COOLDOWN", "BAG_UPDATE_COOLDOWN",
     }) do
         self:RegisterEvent(evt, "OnCooldownStateChanged")
     end
+    self:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN", "OnActionBarCooldownChanged")
 
     -- Broader state changes can wait for the regular ticker pass.
     for _, evt in ipairs({
@@ -317,6 +318,10 @@ function CooldownCompanion:OnCooldownStateChanged()
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
     self:RunImmediateCooldownRefresh("cooldown-event")
+end
+
+function CooldownCompanion:OnActionBarCooldownChanged(event)
+    self:RecordActionbarCooldownPulse(event or "ACTIONBAR_UPDATE_COOLDOWN")
 end
 
 -- Iterate every button across all groups, calling callback(button, buttonData) for each.


### PR DESCRIPTION
## What Players Will Notice
- Cooldown Companion should do less repeated refresh work during idle/actionbar pulses, target changes, power updates, ability bursts, periodic cooldown maintenance, and form/spell-availability changes.
- Tracked displays should continue to stay accurate, while the addon avoids many duplicate broad cooldown walks when recent work already covered the active displays.

## Why This Changed
- The previous refresh model leaned heavily on broad correctness refreshes for many chatty game events. That kept displays accurate, but profiler captures showed repeated group/button scans even when little or nothing changed.
- This branch keeps conservative broad refreshes where they protect correctness, but adds bounded satisfaction and eligibility checks where profiler data showed duplicate work.

## What Changed
- Added cooldown refresh bookkeeping for actionbar cooldown pulses, target transitions, queued refreshes, cooldown-event satisfaction, spell-availability settling, and clean ticker decisions.
- Added active-surface eligibility tracking so idle/actionbar pulses, safe icon text maintenance, charge cooldown visual tails, and simple power usability visuals can use cheaper focused maintenance or skip paths when safe.
- Reduced duplicate broad refreshes around target switching, power events, action-slot cooldown candidates, periodic visual maintenance, and spell-availability/form settling.
- Updated icon, aura, lifecycle, event, group, and cooldown-refresh paths to preserve correctness signals while avoiding unnecessary full active-surface walks.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` on all changed shipped Lua files.
- In-game profiler acceptance sweep on `perf-refresh-pivot` after the merged lanes: five non-truncated sessions covering idle, one target switch, gameplay/action button work, combat/restricted-style smoke, and the button/form spike scenario.
- Final acceptance highlights: idle had `0` `UpdateAllCooldowns()` calls and `0` button cooldown updates; actionbar fallback refreshes were `0` across all five sessions; target/combat/action windows remained bounded to expected cooldown, aura, power, or spell-availability work.
- Restored event-pressure CPU counters were still marked ambiguous by the local profiler, so validation relied on chronological spans, function counters, and in-game profiler rollups rather than those event-counter rows.