### PR TITLE
Keep durationless active auras from showing cooldown swipes

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1016,12 +1016,18 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if auraOverrideActive then
             if auraState.durationObj then
                 button._auraDurationObj = auraState.durationObj
-                if auraPrimarySwipeAllowed then
+                if auraHasTimer and auraPrimarySwipeAllowed then
                     button._durationObj = auraState.durationObj
                     button.cooldown:SetCooldownFromDurationObject(auraState.durationObj)
+                elseif auraPrimarySwipeAllowed then
+                    button.cooldown:SetCooldown(0, 0)
+                    button.cooldown:Hide()
                 end
             elseif auraState.auraCooldownStart and auraState.auraCooldownDuration and auraPrimarySwipeAllowed then
                 button.cooldown:SetCooldown(auraState.auraCooldownStart, auraState.auraCooldownDuration)
+            elseif auraPrimarySwipeAllowed then
+                button.cooldown:SetCooldown(0, 0)
+                button.cooldown:Hide()
             end
             fetchOk = true
         end

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1208,8 +1208,10 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
             and button._chargeCooldownVisualActive ~= true
             and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
 
+        local timedAuraPrimarySwipeActive = button._auraPrimarySwipeActive == true
+            and button._auraHasTimer ~= false
         local cooldownVisualActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
-            or button._auraPrimarySwipeActive == true
+            or timedAuraPrimarySwipeActive
             or button._conditionalAuraDurationTextPreview == true
             or button._conditionalPreviewDomain == "cooldown"
             or button._chargeCooldownVisualActive == true


### PR DESCRIPTION
## What Players Will Notice
- Tracked active auras with no visible duration, such as Sweeping Strikes, keep their static dimmed active-aura icon instead of briefly showing a cooldown swipe while active.

## Why This Changed
- A recent runtime/config split regression let timerless aura tracking briefly behave like timed cooldown tracking, which could leave the primary cooldown swipe visible for stack-style buffs with no visible duration.

## What Changed
- Active aura tracking now only drives the primary cooldown swipe when the aura actually has a timer.
- Timerless active auras still keep their aura visual state, but the primary cooldown widget is cleared and hidden instead of showing swipe progress.
- Icon mode now treats aura-owned primary swipe state as a cooldown visual only when the aura is not explicitly timerless.

## Validation
- `git diff --check origin/dev-branch...HEAD`
- `luac -p CooldownCompanion\ButtonFrame\CooldownUpdate.lua CooldownCompanion\ButtonFrame\IconMode.lua tests\durationless-aura-cooldown-swipe.lua`
- `lua tests\durationless-aura-cooldown-swipe.lua`
- `lua tests\pandemic-state-invariants.lua`
- `lua tests\pandemic-visual-state.lua`
- `parallel-review-recommendations`: five fresh static reviewers, all with no actionable findings.
- User performed a post-fix in-game visual check and reported it looked good. Codex did not independently run DevBridge, combat, or restricted-content validation.