### PR TITLE
Hide unavailable spells from selected config panels

### DIFF
--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -72,10 +72,6 @@ local LOCAL_LOAD_CONDITION_DEFAULTS = {
     vehicleUI = false,
 }
 
-local IGNORE_SPELL_AVAILABILITY_OPTIONS = {
-    ignoreSpellAvailability = true,
-}
-
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -1100,23 +1096,6 @@ function CooldownCompanion:GroupHasUsableButtons(group, opts)
         end
     end
     return false
-end
-
-function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
-    if group
-        and group.parentContainerId
-        and ST.IsGroupConfigSelected
-        and ST.IsGroupConfigSelected(groupId) then
-        return IGNORE_SPELL_AVAILABILITY_OPTIONS
-    end
-    return nil
-end
-
-function CooldownCompanion:GetGroupLayoutButtonUsabilityOptions(groupId, group)
-    if group and group.parentContainerId and not group.compactLayout then
-        return IGNORE_SPELL_AVAILABILITY_OPTIONS
-    end
-    return nil
 end
 
 function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)


### PR DESCRIPTION
## What Players Will Notice
- Unknown, unlearned, or otherwise unavailable spells no longer keep appearing in the live runtime display just because their panel is selected in config.
- Attached bars no longer reserve layout space for those unavailable spell entries after the runtime button set is rebuilt.

## Why This Changed
- Config selection was allowed to bypass spell availability while deciding which buttons belonged in a live panel. That made unavailable spell entries behave like visible-but-hidden buttons instead of being fully unloaded.

## What Changed
- Removed the config-selected spell-availability bypass from runtime button usability and layout counting.
- Runtime panel population now uses the normal spell availability checks even while the config UI is selecting the panel.
- Config preview can still force already-loaded buttons visible for editing, but it no longer makes unavailable spells part of the runtime button set.

## Validation
- `lua tests\spell-availability-runtime-pruning.lua`
- `lua tests\group-button-frame-pooling.lua`
- `lua tests\group-style-update-fast-path.lua`
- `luac -p CooldownCompanion\Core\GroupOperations.lua`
- `git diff --check origin/dev-branch...HEAD`
- In-game, combat, and restricted-content validation has not been performed yet.