### PR TITLE
Fix timerless aura swipes and unavailable spell entries

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1016,12 +1016,18 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if auraOverrideActive then
             if auraState.durationObj then
                 button._auraDurationObj = auraState.durationObj
-                if auraPrimarySwipeAllowed then
+                if auraHasTimer and auraPrimarySwipeAllowed then
                     button._durationObj = auraState.durationObj
                     button.cooldown:SetCooldownFromDurationObject(auraState.durationObj)
+                elseif auraPrimarySwipeAllowed then
+                    button.cooldown:SetCooldown(0, 0)
+                    button.cooldown:Hide()
                 end
             elseif auraState.auraCooldownStart and auraState.auraCooldownDuration and auraPrimarySwipeAllowed then
                 button.cooldown:SetCooldown(auraState.auraCooldownStart, auraState.auraCooldownDuration)
+            elseif auraPrimarySwipeAllowed then
+                button.cooldown:SetCooldown(0, 0)
+                button.cooldown:Hide()
             end
             fetchOk = true
         end

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1208,8 +1208,10 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
             and button._chargeCooldownVisualActive ~= true
             and button._cooldownState ~= COOLDOWN_STATE_COOLDOWN
 
+        local timedAuraPrimarySwipeActive = button._auraPrimarySwipeActive == true
+            and button._auraHasTimer ~= false
         local cooldownVisualActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
-            or button._auraPrimarySwipeActive == true
+            or timedAuraPrimarySwipeActive
             or button._conditionalAuraDurationTextPreview == true
             or button._conditionalPreviewDomain == "cooldown"
             or button._chargeCooldownVisualActive == true

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -72,10 +72,6 @@ local LOCAL_LOAD_CONDITION_DEFAULTS = {
     vehicleUI = false,
 }
 
-local IGNORE_SPELL_AVAILABILITY_OPTIONS = {
-    ignoreSpellAvailability = true,
-}
-
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -1100,23 +1096,6 @@ function CooldownCompanion:GroupHasUsableButtons(group, opts)
         end
     end
     return false
-end
-
-function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
-    if group
-        and group.parentContainerId
-        and ST.IsGroupConfigSelected
-        and ST.IsGroupConfigSelected(groupId) then
-        return IGNORE_SPELL_AVAILABILITY_OPTIONS
-    end
-    return nil
-end
-
-function CooldownCompanion:GetGroupLayoutButtonUsabilityOptions(groupId, group)
-    if group and group.parentContainerId and not group.compactLayout then
-        return IGNORE_SPELL_AVAILABILITY_OPTIONS
-    end
-    return nil
 end
 
 function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)


### PR DESCRIPTION
## What Players Will Notice
- Timerless active auras such as Sweeping Strikes keep their static active-aura icon instead of briefly showing a cooldown swipe while active.
- Unknown, unlearned, or otherwise unavailable spell entries no longer linger in the live display or reserve attached-bar layout space just because their config panel is selected.

## Why This Changed
- Timerless aura overrides could still mark the primary cooldown swipe as active, making no-duration aura tracking briefly look like timed cooldown tracking.
- Config selection could bypass normal spell availability while building runtime button sets, so unavailable spell entries behaved like hidden-but-loaded buttons.

## What Changed
- Active aura cooldown handling now only drives the primary swipe when the aura has timer data, and clears/hides the cooldown widget for timerless aura overrides.
- Icon mode treats aura-owned primary swipe state as a cooldown visual only when the aura is not explicitly timerless.
- Runtime button usability and layout counting now use normal spell availability checks even when a panel is selected in config.
- This rolls up #380 and #381 from `dev-branch` into `main`.

## Validation
- `git fetch origin main`
- Merge base for this comparison: `cf62c03be81240070173f90fcd98b599671dc9c9`
- `git diff --check origin/main...HEAD`
- `luac -p CooldownCompanion\ButtonFrame\CooldownUpdate.lua CooldownCompanion\ButtonFrame\IconMode.lua CooldownCompanion\Core\GroupOperations.lua`
- `lua tests\durationless-aura-cooldown-swipe.lua`
- `lua tests\pandemic-state-invariants.lua`
- `lua tests\pandemic-visual-state.lua`
- `lua tests\spell-availability-runtime-pruning.lua`
- `lua tests\group-button-frame-pooling.lua`
- `lua tests\group-style-update-fast-path.lua`
- A prior post-fix in-game visual check was reported for the durationless aura fix in #380; no fresh in-game, combat, or restricted-content validation was performed for this aggregate PR.