### PR TITLE
Fix Death Strike adding as Coagulating Blood

### DIFF
--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -27,6 +27,7 @@ local FitHighlightFrame = ST._FitHighlightFrame
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local UsesChargeTextLane = CooldownCompanion.UsesChargeTextLane
 local HasItemFallbacks = CooldownCompanion.HasItemFallbacks
+local ResolveViewerChildForSpellDisplay = ST.ResolveViewerChildForSpellDisplay
 
 -- Imports from VisualState
 local ClearButtonVisualState = ST._ClearButtonVisualState
@@ -1014,24 +1015,8 @@ function CooldownCompanion:UpdateButtonIcon(button)
         -- For override spells (ability→buff mapping), viewerAuraFrames may point
         -- to a BuffIcon/BuffBar child whose spellID is the buff, not the ability.
         -- Scan for an Essential/Utility child that tracks the transforming spell.
-        local child
-        if buttonData.cdmChildSlot then
-            local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
-            child = allChildren and allChildren[buttonData.cdmChildSlot]
-        else
-            child = CooldownCompanion.viewerAuraFrames[buttonData.id]
-        end
+        local child = ResolveViewerChildForSpellDisplay(CooldownCompanion, buttonData)
         if child and child.cooldownInfo and not forceBaseDisplay then
-            -- For multi-slot buttons, keep the slot-specific buff viewer child —
-            -- FindCooldownViewerChild is not slot-aware and would lose differentiation.
-            if not buttonData.cdmChildSlot then
-                local parentName = child:GetParent() and child:GetParent():GetName()
-                if parentName == "BuffIconCooldownViewer" or parentName == "BuffBarCooldownViewer" then
-                    -- This is a buff viewer — look for a cooldown viewer instead for icon/name
-                    local cdChild = CooldownCompanion:FindCooldownViewerChild(buttonData.id)
-                    if cdChild then child = cdChild end
-                end
-            end
             -- Track the current override for display name and aura lookups
             if child.cooldownInfo.overrideSpellID then
                 displayId = child.cooldownInfo.overrideSpellID

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -22,6 +22,7 @@ local VIEWER_NAMES = ST._VIEWER_NAMES
 local COOLDOWN_VIEWER_NAMES = ST._COOLDOWN_VIEWER_NAMES
 local BUFF_VIEWER_SET = ST._BUFF_VIEWER_SET
 local cdmAlphaGuard = ST._cdmAlphaGuard
+local IsDistinctCDMAuraIdentity = ST.IsDistinctCDMAuraIdentity
 local pendingViewerAuraMapToken = 0
 local FindChildInViewers
 local TRACKED_AURA_CATEGORIES = {
@@ -183,6 +184,14 @@ local function HasBuffSuffixName(name)
     return type(name) == "string" and name:match("%s%([Bb]uff%)$") ~= nil
 end
 
+local function IsDistinctAuraIdentityForButton(buttonData, auraID)
+    return ST.IsPlainSpellEntry
+        and ST.IsPlainSpellEntry(buttonData)
+        and auraID
+        and IsDistinctCDMAuraIdentity
+        and IsDistinctCDMAuraIdentity(buttonData.id, auraID)
+end
+
 local function NormalizeResolvedAuraSpellID(baseId, auraSpellID)
     local numericAuraID = tonumber(auraSpellID)
     if not numericAuraID or numericAuraID == 0 then
@@ -341,7 +350,7 @@ local function BuildOrderedAuraCandidateIDs(buttonData)
         AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, baseId)
 
         local resolvedAuraId = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
-        if resolvedAuraId then
+        if resolvedAuraId and not IsDistinctAuraIdentityForButton(buttonData, resolvedAuraId) then
             AppendOrderedAuraCandidateID(candidateIDs, orderedCandidateSet, orderedCandidateIDs, resolvedAuraId)
         end
     end
@@ -583,7 +592,7 @@ function CooldownCompanion:ResolveAuraSpellID(buttonData)
     end
     if buttonData.type == "spell" then
         local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
-        if directAuraID then
+        if directAuraID and not IsDistinctAuraIdentityForButton(buttonData, directAuraID) then
             return directAuraID
         end
         -- Resolve through base spell so form-variant spells (e.g. Stampeding
@@ -591,7 +600,7 @@ function CooldownCompanion:ResolveAuraSpellID(buttonData)
         -- buff is always applied as the base spell regardless of form.
         local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
         local auraId = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
-        if auraId then
+        if auraId and not IsDistinctAuraIdentityForButton(buttonData, auraId) then
             return auraId
         end
         -- Many spells share the same ID for cast and buff; fall back to the base spell ID
@@ -615,13 +624,15 @@ function CooldownCompanion:InferConfirmedAuraSpellIDString(buttonData)
     end
 
     local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
-    if directAuraID then
+    if directAuraID and not IsDistinctAuraIdentityForButton(buttonData, directAuraID) then
         return tostring(directAuraID)
     end
 
     local baseId = C_Spell.GetBaseSpell(buttonData.id) or buttonData.id
     local resolvedAuraId = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
-    if resolvedAuraId and resolvedAuraId ~= buttonData.id then
+    if resolvedAuraId
+        and resolvedAuraId ~= buttonData.id
+        and not IsDistinctAuraIdentityForButton(buttonData, resolvedAuraId) then
         return tostring(resolvedAuraId)
     end
 
@@ -635,14 +646,22 @@ function CooldownCompanion:InferConfirmedAuraSpellIDString(buttonData)
             info.overrideTooltipSpellID,
         }) do
             local numericID = tonumber(spellID)
-            if numericID and numericID ~= 0 and numericID ~= buttonData.id and numericID ~= baseId then
+            if numericID
+                and numericID ~= 0
+                and numericID ~= buttonData.id
+                and numericID ~= baseId
+                and not IsDistinctAuraIdentityForButton(buttonData, numericID) then
                 distinctAuraIDs[numericID] = true
             end
         end
         if info.linkedSpellIDs then
             for _, linkedSpellID in ipairs(info.linkedSpellIDs) do
                 local numericID = tonumber(linkedSpellID)
-                if numericID and numericID ~= 0 and numericID ~= buttonData.id and numericID ~= baseId then
+                if numericID
+                    and numericID ~= 0
+                    and numericID ~= buttonData.id
+                    and numericID ~= baseId
+                    and not IsDistinctAuraIdentityForButton(buttonData, numericID) then
                     distinctAuraIDs[numericID] = true
                 end
             end
@@ -692,12 +711,12 @@ function CooldownCompanion:ResolveStandaloneAuraDefaultSpellID(buttonData)
     end
 
     local directAuraID = ResolveDirectBuffViewerSpellID(buttonData.id)
-    if directAuraID then
+    if directAuraID and not IsDistinctAuraIdentityForButton(buttonData, directAuraID) then
         return directAuraID
     end
 
     local resolvedAuraID = NormalizeResolvedAuraSpellID(baseId, C_UnitAuras.GetCooldownAuraBySpellID(baseId))
-    if resolvedAuraID then
+    if resolvedAuraID and not IsDistinctAuraIdentityForButton(buttonData, resolvedAuraID) then
         return resolvedAuraID
     end
 
@@ -711,7 +730,11 @@ function CooldownCompanion:ResolveStandaloneAuraDefaultSpellID(buttonData)
     local metadataCandidate
     for _, spellID in ipairs({info.spellID, info.overrideSpellID, info.overrideTooltipSpellID}) do
         local numericID = tonumber(spellID)
-        if numericID and numericID ~= 0 and numericID ~= buttonData.id and numericID ~= baseId then
+        if numericID
+            and numericID ~= 0
+            and numericID ~= buttonData.id
+            and numericID ~= baseId
+            and not IsDistinctAuraIdentityForButton(buttonData, numericID) then
             if metadataCandidate and metadataCandidate ~= numericID then
                 return nil
             end
@@ -721,7 +744,11 @@ function CooldownCompanion:ResolveStandaloneAuraDefaultSpellID(buttonData)
     if info.linkedSpellIDs then
         for _, linkedSpellID in ipairs(info.linkedSpellIDs) do
             local numericID = tonumber(linkedSpellID)
-            if numericID and numericID ~= 0 and numericID ~= buttonData.id and numericID ~= baseId then
+            if numericID
+                and numericID ~= 0
+                and numericID ~= buttonData.id
+                and numericID ~= baseId
+                and not IsDistinctAuraIdentityForButton(buttonData, numericID) then
                 if metadataCandidate and metadataCandidate ~= numericID then
                     return nil
                 end

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -8,6 +8,8 @@ local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local IsNoCooldownSpell = ST.IsNoCooldownSpell
 local HasPositiveResourceGateCost = ST.HasPositiveResourceGateCost
+local IsDistinctAuraViewerFrameForSpell = ST.IsDistinctAuraViewerFrameForSpell
+local ResolveCDMAuraSpellID = ST.ResolveCDMAuraSpellID
 
 local ipairs = ipairs
 local tonumber = tonumber
@@ -149,10 +151,50 @@ local function GetParsedAuraIDs(owner, buttonData)
     return owner._parsedAuraIDs, owner._parsedAuraIDsIncludeButtonID == true
 end
 
-local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUnit, now, allowDurationlessAuraInstance)
+local function ButtonExplicitlyTracksViewerAura(buttonData, viewerFrame)
+    if not (buttonData and buttonData.auraSpellID and viewerFrame) then
+        return false
+    end
+
+    local auraID = ResolveCDMAuraSpellID and ResolveCDMAuraSpellID(viewerFrame.cooldownInfo)
+    if not auraID then
+        return false
+    end
+
+    for id in tostring(buttonData.auraSpellID):gmatch("%d+") do
+        if tonumber(id) == auraID then
+            return true
+        end
+    end
+    return false
+end
+
+local function ResolveAllowedBuffViewerFrameForSpell(buttonData, spellID)
+    local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
+    if viewerFrame
+        and IsDistinctAuraViewerFrameForSpell
+        and IsDistinctAuraViewerFrameForSpell(buttonData, viewerFrame)
+        and not ButtonExplicitlyTracksViewerAura(buttonData, viewerFrame) then
+        return nil
+    end
+    return viewerFrame
+end
+
+local function ResolveAllowedButtonAuraViewerFrame(buttonData)
+    local viewerFrame = CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
+    if viewerFrame
+        and IsDistinctAuraViewerFrameForSpell
+        and IsDistinctAuraViewerFrameForSpell(buttonData, viewerFrame)
+        and not ButtonExplicitlyTracksViewerAura(buttonData, viewerFrame) then
+        return nil
+    end
+    return viewerFrame
+end
+
+local function ResolvePreferredAuraViewerFrame(buttonData, candidateIDs, configUnit, auraUnit, now, allowDurationlessAuraInstance)
     local firstTrackedFrame
     for _, spellID in ipairs(candidateIDs or {}) do
-        local viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
+        local viewerFrame = ResolveAllowedBuffViewerFrameForSpell(buttonData, spellID)
         if viewerFrame then
             if ViewerFrameHasActiveAuraProof(viewerFrame, configUnit, auraUnit, now, allowDurationlessAuraInstance) then
                 return viewerFrame, firstTrackedFrame
@@ -162,6 +204,7 @@ local function ResolvePreferredAuraViewerFrame(candidateIDs, configUnit, auraUni
     end
     return nil, firstTrackedFrame
 end
+
 local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, configUnit, auraUnit, now, allowDurationlessAuraInstance, useButtonAuraViewerFallback)
     local viewerFrame
     local cdmEnabled
@@ -208,6 +251,7 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
 
     if not viewerFrame and orderedStandaloneAuraIDs then
         local originalActiveFrame, firstOriginalFrame = ResolvePreferredAuraViewerFrame(
+            buttonData,
             standaloneOriginalAuraIDs,
             configUnit,
             auraUnit,
@@ -217,6 +261,7 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
         viewerFrame = originalActiveFrame
         if not viewerFrame then
             local fallbackActiveFrame, firstFallbackFrame = ResolvePreferredAuraViewerFrame(
+                buttonData,
                 standaloneFallbackAuraIDs,
                 configUnit,
                 auraUnit,
@@ -228,6 +273,7 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
     elseif not viewerFrame and buttonData.auraSpellID then
         local ids = GetParsedAuraIDs(owner, buttonData)
         local activeFrame, firstTrackedFrame = ResolvePreferredAuraViewerFrame(
+            buttonData,
             ids,
             configUnit,
             auraUnit,
@@ -238,20 +284,20 @@ local function ResolveTrackedAuraViewerFrame(owner, buttonData, auraSpellID, con
     end
 
     if not viewerFrame then
-        viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(auraSpellID)
+        viewerFrame = ResolveAllowedBuffViewerFrameForSpell(buttonData, auraSpellID)
         if not viewerFrame then
-            viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(buttonData.id)
-                or (owner._displaySpellId and CooldownCompanion:ResolveBuffViewerFrameForSpell(owner._displaySpellId))
+            viewerFrame = ResolveAllowedBuffViewerFrameForSpell(buttonData, buttonData.id)
+                or (owner._displaySpellId and ResolveAllowedBuffViewerFrameForSpell(buttonData, owner._displaySpellId))
             if not viewerFrame then
                 local baseId = C_Spell.GetBaseSpell(buttonData.id)
                 if baseId and baseId ~= buttonData.id and baseId ~= auraSpellID then
-                    viewerFrame = CooldownCompanion:ResolveBuffViewerFrameForSpell(baseId)
+                    viewerFrame = ResolveAllowedBuffViewerFrameForSpell(buttonData, baseId)
                 end
             end
         end
     end
     if not viewerFrame and useButtonAuraViewerFallback then
-        viewerFrame = CooldownCompanion:ResolveButtonAuraViewerFrame(buttonData)
+        viewerFrame = ResolveAllowedButtonAuraViewerFrame(buttonData)
     end
 
     return viewerFrame, cdmEnabled, orderedStandaloneAuraIDs

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -13,6 +13,7 @@ local InCombatLockdown = InCombatLockdown
 local math_floor = math.floor
 local table_sort = table.sort
 local table_remove = table.remove
+local IsDistinctAuraViewerFrameForSpell = ST.IsDistinctAuraViewerFrameForSpell
 local GROUP_SETTING_PRESET_MODES = {
     icons = true,
     bars = true,
@@ -1607,6 +1608,7 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
         if buttonType == "spell" then
             local newButton = group.buttons[buttonIndex]
             local viewerFrame
+            local foundViaAbilityBuffOverride = false
             local resolvedAuraId = C_UnitAuras.GetCooldownAuraBySpellID(id)
             viewerFrame = (resolvedAuraId and resolvedAuraId ~= 0
                     and self.viewerAuraFrames[resolvedAuraId])
@@ -1623,7 +1625,10 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
                 if overrideBuffs then
                     for buffId in overrideBuffs:gmatch("%d+") do
                         viewerFrame = self.viewerAuraFrames[tonumber(buffId)]
-                        if viewerFrame then break end
+                        if viewerFrame then
+                            foundViaAbilityBuffOverride = true
+                            break
+                        end
                     end
                 end
             end
@@ -1632,6 +1637,13 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
                 local parent = viewerFrame:GetParent()
                 local parentName = parent and parent:GetName()
                 hasViewerFrame = parentName == "BuffIconCooldownViewer" or parentName == "BuffBarCooldownViewer"
+            end
+            if hasViewerFrame
+                and not foundViaAbilityBuffOverride
+                and IsDistinctAuraViewerFrameForSpell(newButton, viewerFrame) then
+                newButton.auraTracking = false
+                newButton.auraIndicatorEnabled = false
+                hasViewerFrame = false
             end
             if hasViewerFrame then
                 newButton.auraTracking = true

--- a/CooldownCompanion/Core/SpellQueries.lua
+++ b/CooldownCompanion/Core/SpellQueries.lua
@@ -42,11 +42,18 @@ function ST.IsDistinctCDMAuraIdentity(spellID, auraID)
     end
 
     local auraBase = C_Spell.GetBaseSpell(auraID)
-    if auraBase ~= nil and not IsConcreteSpellID(auraBase) then
-        return false
-    end
-    if auraBase == spellID then
-        return false
+    if auraBase ~= nil then
+        if issecretvalue and issecretvalue(auraBase) then
+            return false
+        end
+        if auraBase ~= 0 then
+            if not IsConcreteSpellID(auraBase) then
+                return false
+            end
+            if auraBase == spellID then
+                return false
+            end
+        end
     end
 
     local spellName = C_Spell.GetSpellName(spellID)

--- a/CooldownCompanion/Core/SpellQueries.lua
+++ b/CooldownCompanion/Core/SpellQueries.lua
@@ -10,6 +10,103 @@ local tonumber = tonumber
 local issecretvalue = issecretvalue
 local Enum = Enum
 
+local function IsConcreteSpellID(spellID)
+    return type(spellID) == "number"
+        and spellID > 0
+        and not (issecretvalue and issecretvalue(spellID))
+end
+ST.IsConcreteSpellID = IsConcreteSpellID
+
+function ST.ResolveCDMAuraSpellID(cooldownInfo)
+    if type(cooldownInfo) ~= "table" then
+        return nil
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
+        return cooldownInfo.overrideTooltipSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideSpellID) then
+        return cooldownInfo.overrideSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.spellID) then
+        return cooldownInfo.spellID
+    end
+    return nil
+end
+
+function ST.IsDistinctCDMAuraIdentity(spellID, auraID)
+    if not IsConcreteSpellID(spellID) or not IsConcreteSpellID(auraID) then
+        return false
+    end
+    if auraID == spellID then
+        return false
+    end
+
+    local auraBase = C_Spell.GetBaseSpell(auraID)
+    if auraBase ~= nil and not IsConcreteSpellID(auraBase) then
+        return false
+    end
+    if auraBase == spellID then
+        return false
+    end
+
+    local spellName = C_Spell.GetSpellName(spellID)
+    local auraName = C_Spell.GetSpellName(auraID)
+    if type(spellName) ~= "string"
+        or type(auraName) ~= "string"
+        or (issecretvalue and (issecretvalue(spellName) or issecretvalue(auraName))) then
+        return false
+    end
+
+    return spellName ~= auraName
+end
+
+function ST.IsCDMBuffViewerChild(frame)
+    if not (frame and frame.GetParent) then
+        return false
+    end
+    local parent = frame:GetParent()
+    local parentName = parent and parent.GetName and parent:GetName()
+    local buffViewerSet = ST._BUFF_VIEWER_SET
+    return buffViewerSet and buffViewerSet[parentName] == true
+end
+
+function ST.IsPlainSpellEntry(buttonData)
+    return buttonData
+        and buttonData.type == "spell"
+        and buttonData.addedAs ~= "aura"
+        and not buttonData.isPassive
+        and not buttonData.cdmChildSlot
+end
+
+function ST.IsDistinctAuraViewerFrameForSpell(buttonData, frame)
+    if not (ST.IsPlainSpellEntry(buttonData) and ST.IsCDMBuffViewerChild(frame)) then
+        return false
+    end
+
+    local auraID = ST.ResolveCDMAuraSpellID(frame.cooldownInfo)
+    return auraID and ST.IsDistinctCDMAuraIdentity(buttonData.id, auraID) or false
+end
+
+function ST.ResolveViewerChildForSpellDisplay(addon, buttonData)
+    if not (addon and buttonData and buttonData.type == "spell") then
+        return nil
+    end
+
+    local child
+    if buttonData.cdmChildSlot then
+        local allChildren = addon.viewerAuraAllChildren and addon.viewerAuraAllChildren[buttonData.id]
+        child = allChildren and allChildren[buttonData.cdmChildSlot]
+    else
+        child = addon.viewerAuraFrames and addon.viewerAuraFrames[buttonData.id]
+    end
+
+    if child and ST.IsDistinctAuraViewerFrameForSpell(buttonData, child) then
+        return addon.FindCooldownViewerChild and addon:FindCooldownViewerChild(buttonData.id) or nil
+    end
+
+    return child
+end
+
 --------------------------------------------------------------------------------
 -- Spell Resolution
 --------------------------------------------------------------------------------

--- a/CooldownCompanion_Config/Config/AutoImport.lua
+++ b/CooldownCompanion_Config/Config/AutoImport.lua
@@ -16,6 +16,8 @@ local IsSpellInCDMCooldown = ST._IsSpellInCDMCooldown
 local IsNeverTrackableSpell = ST._IsNeverTrackableSpell
 local ShouldSuppressSpellbookEntry = ST._ShouldSuppressSpellbookEntry
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
+local ResolveCDMAuraSpellID = ST.ResolveCDMAuraSpellID
+local IsDistinctCDMAuraIdentity = ST.IsDistinctCDMAuraIdentity
 
 local ICON_FALLBACK = 134400
 local ACTION_BAR_COUNT = 6
@@ -35,22 +37,6 @@ local SOURCE_GROUP_ORDER_GENERAL = 4000
 
 local function IsConcreteSpellID(spellID)
     return type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID)
-end
-
-local function ResolveCDMAuraSpellID(cooldownInfo)
-    if type(cooldownInfo) ~= "table" then
-        return nil
-    end
-    if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
-        return cooldownInfo.overrideTooltipSpellID
-    end
-    if IsConcreteSpellID(cooldownInfo.overrideSpellID) then
-        return cooldownInfo.overrideSpellID
-    end
-    if IsConcreteSpellID(cooldownInfo.spellID) then
-        return cooldownInfo.spellID
-    end
-    return nil
 end
 
 local function CooldownInfoReferencesSpellID(cooldownInfo, spellID)
@@ -281,7 +267,11 @@ local function BuildActionBarPreview(selectedBars)
                                 -- Omit known non-trackable spells from preview.
                             else
                                 local cdmAuraSpellID, ambiguousCDMAuras, hasTrackedCDMAura = ResolveTrackedCDMAuraSpellIDForSpell(spellID)
-                                local isBuffOnlyCDMSpell = hasTrackedCDMAura and not IsSpellInCDMCooldown(spellID)
+                                local isDistinctCDMAura = cdmAuraSpellID
+                                    and IsDistinctCDMAuraIdentity(spellID, cdmAuraSpellID)
+                                local isBuffOnlyCDMSpell = hasTrackedCDMAura
+                                    and not IsSpellInCDMCooldown(spellID)
+                                    and not isDistinctCDMAura
                                 local isAura = IsPassiveOrProc(spellID) or isBuffOnlyCDMSpell
                                 if ambiguousCDMAuras then
                                     AddSkipped(result, sourceLabel, "Choose a specific CDM aura.", spellName)

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -29,6 +29,7 @@ local TryReceiveCursorDrop = ST._TryReceiveCursorDrop
 local OnAutocompleteSelect = ST._OnAutocompleteSelect
 local SearchAutocomplete = ST._SearchAutocomplete
 local OpenAutoAddFlow = ST._OpenAutoAddFlow
+local ResolveViewerChildForSpellDisplay = ST.ResolveViewerChildForSpellDisplay
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
@@ -993,13 +994,7 @@ local function ResolveColumn2TooltipSpellId(buttonData)
         return nil
     end
 
-    local child
-    if buttonData.cdmChildSlot then
-        local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
-        child = allChildren and allChildren[buttonData.cdmChildSlot]
-    else
-        child = CooldownCompanion.viewerAuraFrames[buttonData.id]
-    end
+    local child = ResolveViewerChildForSpellDisplay(CooldownCompanion, buttonData)
 
     if child and child.cooldownInfo then
         if child.cooldownInfo.overrideTooltipSpellID then

--- a/CooldownCompanion_Config/Config/SpellItemAdd.lua
+++ b/CooldownCompanion_Config/Config/SpellItemAdd.lua
@@ -75,6 +75,37 @@ local function CDMAuraChildrenShareResolvedSpellID(children)
     return resolvedID ~= nil
 end
 
+local function CooldownInfoReferencesSpellID(cooldownInfo, spellID)
+    if type(cooldownInfo) ~= "table" or not IsConcreteSpellID(spellID) then
+        return false
+    end
+    if cooldownInfo.spellID == spellID
+        or cooldownInfo.overrideSpellID == spellID
+        or cooldownInfo.overrideTooltipSpellID == spellID then
+        return true
+    end
+    if cooldownInfo.linkedSpellIDs then
+        for _, linkedSpellID in ipairs(cooldownInfo.linkedSpellIDs) do
+            if linkedSpellID == spellID then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+local function AddCDMAuraIDForReferencedSpell(cdmAuraIDsByBase, spellID, auraID)
+    if not (IsConcreteSpellID(spellID) and auraID) then
+        return
+    end
+    local byBase = cdmAuraIDsByBase[spellID]
+    if not byBase then
+        byBase = {}
+        cdmAuraIDsByBase[spellID] = byBase
+    end
+    byBase[auraID] = true
+end
+
 local function TrackedCDMAuraIdentitiesAreDistinct(spellID)
     local found = false
     for _, cat in ipairs({Enum.CooldownViewerCategory.TrackedBuff, Enum.CooldownViewerCategory.TrackedBar}) do
@@ -82,7 +113,7 @@ local function TrackedCDMAuraIdentitiesAreDistinct(spellID)
         if ids then
             for _, cdID in ipairs(ids) do
                 local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
-                if info and info.spellID == spellID then
+                if CooldownInfoReferencesSpellID(info, spellID) then
                     found = true
                     local auraID = ResolveCDMAuraSpellID(info)
                     if not (auraID and IsDistinctCDMAuraIdentity(spellID, auraID)) then
@@ -633,15 +664,17 @@ local function BuildAutocompleteCache()
         if ids then
             for _, cdID in ipairs(ids) do
                 local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
-                if info and IsConcreteSpellID(info.spellID) then
+                if info then
                     local auraID = ResolveCDMAuraSpellID(info)
                     if auraID then
-                        local byBase = cdmAuraIDsByBase[info.spellID]
-                        if not byBase then
-                            byBase = {}
-                            cdmAuraIDsByBase[info.spellID] = byBase
+                        AddCDMAuraIDForReferencedSpell(cdmAuraIDsByBase, info.spellID, auraID)
+                        AddCDMAuraIDForReferencedSpell(cdmAuraIDsByBase, info.overrideSpellID, auraID)
+                        AddCDMAuraIDForReferencedSpell(cdmAuraIDsByBase, info.overrideTooltipSpellID, auraID)
+                        if info.linkedSpellIDs then
+                            for _, linkedSpellID in ipairs(info.linkedSpellIDs) do
+                                AddCDMAuraIDForReferencedSpell(cdmAuraIDsByBase, linkedSpellID, auraID)
+                            end
                         end
-                        byBase[auraID] = true
                     end
                 end
             end

--- a/CooldownCompanion_Config/Config/SpellItemAdd.lua
+++ b/CooldownCompanion_Config/Config/SpellItemAdd.lua
@@ -19,6 +19,9 @@ local CDM_VIEWER_NAMES = ST._CDM_VIEWER_NAMES
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local SelectConfigPanel = ST._SelectConfigPanel
 local SelectConfigButton = ST._SelectConfigButton
+local IsConcreteSpellID = ST.IsConcreteSpellID
+local ResolveCDMAuraSpellID = ST.ResolveCDMAuraSpellID
+local IsDistinctCDMAuraIdentity = ST.IsDistinctCDMAuraIdentity
 
 -- After a successful add, set selection state to the new button so the
 -- next RefreshConfigPanel shows its settings in Column 3.
@@ -58,26 +61,6 @@ local function IsTriggerPanelTarget(groupId)
     return group and group.displayMode == "trigger"
 end
 
-local function IsConcreteSpellID(spellID)
-    return type(spellID) == "number" and spellID > 0 and not issecretvalue(spellID)
-end
-
-local function ResolveCDMAuraSpellID(cooldownInfo)
-    if type(cooldownInfo) ~= "table" then
-        return nil
-    end
-    if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
-        return cooldownInfo.overrideTooltipSpellID
-    end
-    if IsConcreteSpellID(cooldownInfo.overrideSpellID) then
-        return cooldownInfo.overrideSpellID
-    end
-    if IsConcreteSpellID(cooldownInfo.spellID) then
-        return cooldownInfo.spellID
-    end
-    return nil
-end
-
 local function CDMAuraChildrenShareResolvedSpellID(children)
     local resolvedID
     for _, child in ipairs(children or {}) do
@@ -90,6 +73,26 @@ local function CDMAuraChildrenShareResolvedSpellID(children)
         end
     end
     return resolvedID ~= nil
+end
+
+local function TrackedCDMAuraIdentitiesAreDistinct(spellID)
+    local found = false
+    for _, cat in ipairs({Enum.CooldownViewerCategory.TrackedBuff, Enum.CooldownViewerCategory.TrackedBar}) do
+        local ids = C_CooldownViewer.GetCooldownViewerCategorySet(cat, true)
+        if ids then
+            for _, cdID in ipairs(ids) do
+                local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cdID)
+                if info and info.spellID == spellID then
+                    found = true
+                    local auraID = ResolveCDMAuraSpellID(info)
+                    if not (auraID and IsDistinctCDMAuraIdentity(spellID, auraID)) then
+                        return false
+                    end
+                end
+            end
+        end
+    end
+    return found
 end
 
 -- File-local state
@@ -369,7 +372,8 @@ local function TryAdd(input)
         if spellFound and not passiveOrProc then
             if IsSpellInCDMBuffBar(id)
                 and not IsSpellInCDMCooldown(id)
-                and not IsPassiveCooldownSpell(id) then
+                and not IsPassiveCooldownSpell(id)
+                and not TrackedCDMAuraIdentitiesAreDistinct(id) then
                 return TryAddSpell(tostring(id), nil, true)
             end
             local forceAura = nil
@@ -467,7 +471,8 @@ local function TryAdd(input)
             else
                 if IsSpellInCDMBuffBar(spellId)
                     and not IsSpellInCDMCooldown(spellId)
-                    and not IsPassiveCooldownSpell(spellId) then
+                    and not IsPassiveCooldownSpell(spellId)
+                    and not TrackedCDMAuraIdentitiesAreDistinct(spellId) then
                     return TryAddSpell(tostring(spellId), nil, true)
                 end
                 local idx, notified = CooldownCompanion:AddButtonToGroup(CS.selectedGroup, "spell", spellId, spellName)
@@ -621,6 +626,7 @@ local function BuildAutocompleteCache()
     end
 
     local cdmDistinctAuraBaseSet = {}
+    local cdmAllAuraIDsDistinctByBase = {}
     local cdmAuraIDsByBase = {}
     for _, cat in ipairs({Enum.CooldownViewerCategory.TrackedBuff, Enum.CooldownViewerCategory.TrackedBar}) do
         local ids = C_CooldownViewer.GetCooldownViewerCategorySet(cat, true)
@@ -642,13 +648,18 @@ local function BuildAutocompleteCache()
         end
     end
     for baseID, auraIDs in pairs(cdmAuraIDsByBase) do
-        local firstID
+        local sawAuraID = false
+        local allDistinct = true
         for auraID in pairs(auraIDs) do
-            if firstID and firstID ~= auraID then
+            sawAuraID = true
+            if IsDistinctCDMAuraIdentity(baseID, auraID) then
                 cdmDistinctAuraBaseSet[baseID] = true
-                break
+            else
+                allDistinct = false
             end
-            firstID = auraID
+        end
+        if sawAuraID and allDistinct then
+            cdmAllAuraIDsDistinctByBase[baseID] = true
         end
     end
 
@@ -671,6 +682,9 @@ local function BuildAutocompleteCache()
                 then
                     local isAura = IsPassiveOrProc(id)
                     local isBuffOnlyCDMSpell = not passiveCooldown and cdmBuffSet[id] and not cdmCooldownSet[id]
+                    if isBuffOnlyCDMSpell and cdmAllAuraIDsDistinctByBase[id] then
+                        isBuffOnlyCDMSpell = false
+                    end
                     if ShouldSuppressSpellbookEntry(id, lineIdx, isAura) then
                         -- Omit filtered entries to reduce autocomplete noise.
                     elseif not seen[id] then

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -6,6 +6,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local ResolveViewerChildForSpellDisplay = ST.ResolveViewerChildForSpellDisplay
 
 local AceGUI = LibStub("AceGUI-3.0")
 local LSM = LibStub("LibSharedMedia-3.0")
@@ -481,13 +482,7 @@ local function GetConfigEntryDisplayName(buttonData, opts)
     if isEquipmentSlot then
         entryName = entryName or ("Unknown " .. tostring(buttonData.type))
     elseif buttonData.type == "spell" then
-        local child
-        if buttonData.cdmChildSlot then
-            local allChildren = CooldownCompanion.viewerAuraAllChildren[buttonData.id]
-            child = allChildren and allChildren[buttonData.cdmChildSlot]
-        else
-            child = CooldownCompanion.viewerAuraFrames[buttonData.id]
-        end
+        local child = ResolveViewerChildForSpellDisplay(CooldownCompanion, buttonData)
 
         if not buttonData.customName then
             local displayId = GetCooldownInfoDisplaySpellID(child and child.cooldownInfo)

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -28,6 +28,7 @@ local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
 local UsesChargeBehavior = CooldownCompanion.UsesChargeBehavior
 local NormalizeItemFallbacks = CooldownCompanion.NormalizeItemFallbacks
 local UpdateItemChargeMetadata = CooldownCompanion.UpdateItemChargeMetadata
+local IsDistinctAuraViewerFrameForSpell = ST.IsDistinctAuraViewerFrameForSpell
 
 -- Imports from SectionBuilders.lua (used by BuildOverridesTab)
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -756,9 +757,14 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
     local useCollapse = options.useCollapse == true
     local showHeading = options.showHeading ~= false
     local isIconGroup = group and (group.displayMode or "icons") == "icons"
+    local hasDistinctAuraViewerFrame = hasViewerFrame
+        and IsDistinctAuraViewerFrameForSpell(buttonData, viewerFrame)
 
     -- Auto-enable aura tracking for viewer-backed spells.
-    if hasViewerFrame and buttonData.auraTracking == nil then
+    if hasDistinctAuraViewerFrame and buttonData.auraTracking == nil then
+        buttonData.auraTracking = false
+        buttonData.auraIndicatorEnabled = false
+    elseif hasViewerFrame and buttonData.auraTracking == nil then
         buttonData.auraTracking = true
         local overrideBuffs = CooldownCompanion.ABILITY_BUFF_OVERRIDES[buttonData.id]
         if overrideBuffs and not isAuraEntry and not buttonData.auraSpellID then


### PR DESCRIPTION
## What Players Will Notice
- Blood Death Knights can add Death Strike as a normal spell entry again.
- Death Strike should no longer automatically attach itself to Coagulating Blood aura tracking or rename/display as Coagulating Blood after the entry is selected and reselected.
- Coagulating Blood remains available as its own CDM aura entry when players intentionally add or track that aura.

## Why This Changed
- Blizzard's Cooldown Manager can expose Death Strike through a distinct Coagulating Blood aura identity. Cooldown Companion was treating that aura viewer identity as if it were the Death Strike spell itself, which made Death Strike behave like an aura entry instead of a normal ability.

## What Changed
- Added shared CDM identity helpers so the addon can tell when a CDM buff/bar viewer child represents a distinct aura rather than the spell being added.
- Updated direct add, autocomplete, action-bar import, config row display, tooltip display, icon display, aura resolution, and runtime viewer lookup paths to keep plain spell entries separate from distinct CDM aura identities.
- Preserved explicit aura behavior so Coagulating Blood and other intentionally selected aura entries can still be tracked normally.

## Validation
- `luac -p` passed for all 10 changed Lua files.
- `git diff --check origin/main...HEAD` passed.
- Focused Lua harness passed for Death Strike display/aura resolution with Coagulating Blood mocked as a distinct CDM aura.
- Focused `EntryRuntime.EvaluateTrackedAuraState` harness passed: stale plain Death Strike rejects the Coagulating Blood viewer frame, while explicit `auraSpellID = "463730"` still resolves to that aura.
- Five-reviewer static review passes were run during the fix loop; the last remaining note was limited to old/manual aura-tracking config status and was accepted as out of scope for this PR.
- Live in-game Blood DK validation has not been performed yet; combat/restricted-content behavior still needs a real in-game check before release.