### PR TITLE
Fix Surging Totem cooldown tracking while the totem is active

### DIFF
--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1653,8 +1653,15 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
                 and baseNoCooldown == true
                 and baseResourceGateCost == true))
 
+    local allowActionSlotRealFallback = not hasCharges
+        and (noCooldown ~= true
+            or (cooldownSpellID ~= spellID and baseNoCooldown ~= true))
+    local allowActionSlotReadyFallback = allowActionSlotRealFallback
+        and cooldownSpellID ~= spellID
+
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
-        allowActionSlotRealFallback = not hasCharges and cooldownSpellID == spellID and noCooldown ~= true,
+        allowActionSlotRealFallback = allowActionSlotRealFallback,
+        allowActionSlotReadyFallback = allowActionSlotReadyFallback,
         suppressCooldownSurface = resourceGatedNoCooldown == true,
     })
     result.baseSpellID = spellID

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1283,7 +1283,9 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
     end
 
     local needsRealCooldownFallback = result.state ~= COOLDOWN_STATE_COOLDOWN
-        and (result.isOnGCD == true or result.normalCooldownShown == true)
+        and (result.isOnGCD == true
+            or result.normalCooldownShown == true
+            or options.allowActionSlotReadyFallback == true)
 
     if needsRealCooldownFallback
         and options.allowActionSlotRealFallback then
@@ -1309,11 +1311,14 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
                 and baseNoCooldown == true
                 and baseResourceGateCost == true))
     local allowActionSlotRealFallback = buttonData.hasCharges ~= true
-        and cooldownSpellId == buttonData.id
-        and noCooldown ~= true
+        and (noCooldown ~= true
+            or (cooldownSpellId ~= buttonData.id and baseNoCooldown ~= true))
+    local allowActionSlotReadyFallback = allowActionSlotRealFallback
+        and cooldownSpellId ~= buttonData.id
 
     return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
         allowActionSlotRealFallback = allowActionSlotRealFallback,
+        allowActionSlotReadyFallback = allowActionSlotReadyFallback,
         suppressCooldownSurface = resourceGatedNoCooldown == true,
     })
 end


### PR DESCRIPTION
## What Players Will Notice
- Enhancement Shamans should no longer see Surging Totem as ready while its real cooldown is still running after the totem has been used.
- While Surging Totem is active, the display can follow the temporary move-totem replacement spell, then return to the base Surging Totem cooldown view once the replacement is gone.
- Spell Custom Bars using Surging Totem get the same cooldown fallback behavior as normal cooldown buttons.

## Why This Changed
- Enhancement Surging Totem is replaced by a same-name move-totem spell while the totem is active. That replacement can report as ready through the spell cooldown surface even though the base Surging Totem action slot still has the real cooldown.
- The previous fallback only probed the action slot for same-spell cooldown evaluations, so the replacement spell could make the entry look available too early.

## What Changed
- Broadened the shared spell cooldown lane so replacement spells can opt into action-slot real-cooldown fallback even when the replacement cooldown surface is ready.
- Applied the replacement-aware fallback to both normal spell buttons and Spell Custom Bars.
- Kept the fallback guarded by existing charge and resource-gated no-cooldown checks, and still requires the action-slot ignore-GCD cooldown object to prove a real cooldown before promoting the entry to cooldown.

## Validation
- Ran `lua tests\surging-totem-override-cooldown.lua` with local coverage for both normal buttons and Spell Custom Bars.
- Ran `luac -p CooldownCompanion\Core\EntryRuntime.lua`.
- Ran full Lua parse over `CooldownCompanion` and `CooldownCompanion_Config`.
- Ran `git diff --check`.
- Ran a final `parallel-review-recommendations` pass with five reviewers; all reported no actionable static findings.
- In-game/DevBridge validation of the final patch is still pending. The remaining live checks are Enhancement Surging Totem `444995 -> 1221348` while active, return to the base cooldown display afterward, and a Restoration Shaman spot-check for the non-replacement path.