### PR TITLE
Add unified eligibility controls for load conditions

### DIFF
--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -96,6 +96,17 @@ local function RefreshPanelAlphaDependencyTargets(self)
     end
 end
 
+local function NormalizeCopiedEntityForContainerScope(self, entity, container)
+    if type(entity) ~= "table" or not container or container.isGlobal == true then
+        return
+    end
+    if self.NormalizeEligibilityForCharacterScope then
+        self:NormalizeEligibilityForCharacterScope(entity, {
+            ownerCharKey = container.createdBy or (self.db and self.db.keys and self.db.keys.char),
+        })
+    end
+end
+
 function CooldownCompanion:NormalizeContainerAnchor(anchor, resolveAddonFrames)
     local normalized = type(anchor) == "table" and anchor or {}
     local point = normalized.point or "CENTER"
@@ -967,6 +978,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
     newContainer.specOrders = nil
     newContainer.createdBy = self.db.keys.char
     newContainer.isGlobal = false
+    NormalizeCopiedEntityForContainerScope(self, newContainer, newContainer)
 
     -- If source was global, clear folderId on the copy
     if sourceContainer.isGlobal and newContainer.folderId then
@@ -1001,6 +1013,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
                 x = group.anchor and group.anchor.x or 0,
                 y = group.anchor and group.anchor.y or 0,
             }
+            NormalizeCopiedEntityForContainerScope(self, newPanel, newContainer)
 
             db.groups[newGroupId] = newPanel
             groupIdMap[groupId] = newGroupId
@@ -1165,6 +1178,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
     local db = self.db.profile
     local sourcePanel = db.groups[groupId]
     if not sourcePanel or sourcePanel.parentContainerId ~= containerId then return nil end
+    local container = db.groupContainers[containerId]
 
     local newGroupId = db.nextGroupId
     db.nextGroupId = newGroupId + 1
@@ -1173,6 +1187,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
     newPanel.name = sourcePanel.name .. " (Copy)"
     newPanel.order = self:GetPanelCount(containerId) + 1
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, groupId, containerId, containerId)
+    NormalizeCopiedEntityForContainerScope(self, newPanel, container)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
@@ -1364,6 +1379,7 @@ function CooldownCompanion:DuplicateGroup(id)
     newGroup.order = newGroupId
     newGroup.createdBy = self.db.keys.char
     newGroup.isGlobal = false
+    NormalizeCopiedEntityForContainerScope(self, newGroup, newGroup)
     if sourceGroup.isGlobal and newGroup.folderId then
         newGroup.folderId = nil
     end
@@ -1967,7 +1983,8 @@ function CooldownCompanion:CopyPanelToContainer(sourceGroupId, targetContainerId
     local db = self.db.profile
     local sourcePanel = db.groups[sourceGroupId]
     if not sourcePanel then return nil end
-    if not db.groupContainers[targetContainerId] then return nil end
+    local targetContainer = db.groupContainers[targetContainerId]
+    if not targetContainer then return nil end
 
     local newGroupId = db.nextGroupId
     db.nextGroupId = newGroupId + 1
@@ -1985,6 +2002,7 @@ function CooldownCompanion:CopyPanelToContainer(sourceGroupId, targetContainerId
         y = 0,
     }
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, sourceGroupId, sourcePanel.parentContainerId, targetContainerId)
+    NormalizeCopiedEntityForContainerScope(self, newPanel, targetContainer)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
@@ -2000,6 +2018,7 @@ function CooldownCompanion:CopyPanelAsNewGroup(sourceGroupId, sourceName)
 
     -- Create a new container
     local containerId = self:CreateContainer(sourceName or "Copied Group")
+    local container = db.groupContainers[containerId]
 
     -- Create container frame
     if self.CreateContainerFrame then
@@ -2024,6 +2043,7 @@ function CooldownCompanion:CopyPanelAsNewGroup(sourceGroupId, sourceName)
         y = 0,
     }
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, sourceGroupId, sourcePanel.parentContainerId, containerId)
+    NormalizeCopiedEntityForContainerScope(self, newPanel, container)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1466,6 +1466,9 @@ function CooldownCompanion:ToggleFolderGlobal(folderId)
             end
         end
     end
+    if newSection == "char" and self.NormalizeFolderEligibilityForCharacterScope then
+        self:NormalizeFolderEligibilityForCharacterScope(folderId)
+    end
     self:RefreshAllGroups()
 end
 
@@ -1478,6 +1481,9 @@ function CooldownCompanion:ToggleGroupGlobal(containerId)
     container.isGlobal = newGlobal
     if not newGlobal then
         container.createdBy = self.db.keys.char
+        if self.NormalizeContainerEligibilityForCharacterScope then
+            self:NormalizeContainerEligibilityForCharacterScope(containerId)
+        end
     end
 
     self:RefreshAllGroups()

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1850,6 +1850,67 @@ function CooldownCompanion:EnumerateBrowseCharacters()
     return result
 end
 
+--- Return sorted active-profile character choices for Load Conditions.
+--- Includes the current character, AceDB profile keys that point at the active
+--- profile, and owners referenced by entities in the active profile.
+function CooldownCompanion:EnumerateActiveProfileCharacters()
+    local db = self.db
+    local profile = db and db.profile
+    local currentChar = db and db.keys and db.keys.char
+    local currentProfile = db and db.keys and db.keys.profile
+    if db and db.GetCurrentProfile then
+        currentProfile = db:GetCurrentProfile() or currentProfile
+    end
+
+    local seen = {}
+    local result = {}
+
+    local function AddCharKey(charKey)
+        if type(charKey) ~= "string" or charKey == "" or seen[charKey] then
+            return
+        end
+        seen[charKey] = true
+        local info = db and db.global and db.global.characterInfo and db.global.characterInfo[charKey]
+        result[#result + 1] = {
+            charKey = charKey,
+            classFilename = info and info.classFilename or nil,
+            classID = info and info.classID or nil,
+        }
+    end
+
+    AddCharKey(currentChar)
+
+    local profileKeys = db and db.sv and db.sv.profileKeys
+    if type(profileKeys) == "table" and type(currentProfile) == "string" then
+        for charKey, profileKey in pairs(profileKeys) do
+            if profileKey == currentProfile then
+                AddCharKey(charKey)
+            end
+        end
+    end
+
+    if type(profile) == "table" then
+        for _, group in pairs(profile.groups or {}) do
+            if type(group) == "table" and not group.isGlobal then
+                AddCharKey(group.createdBy)
+            end
+        end
+        for _, container in pairs(profile.groupContainers or {}) do
+            if type(container) == "table" and not container.isGlobal then
+                AddCharKey(container.createdBy)
+            end
+        end
+        for _, folder in pairs(profile.folders or {}) do
+            if type(folder) == "table" and folder.section == "char" then
+                AddCharKey(folder.createdBy)
+            end
+        end
+    end
+
+    table_sort(result, function(a, b) return a.charKey < b.charKey end)
+    return result
+end
+
 --- Return sorted array of { containerId, container } for a given character key.
 function CooldownCompanion:GetCharacterContainers(charKey)
     local db = self.db.profile

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -113,18 +113,24 @@ local function NormalizeTruthyMap(map, normalizer, failClosed)
 
     local normalized = {}
     local sawEntry = false
+    local invalidEnabledEntry = false
     for key, enabled in pairs(map) do
         sawEntry = true
         if enabled == true then
             local normalizedKey = normalizer(key)
             if normalizedKey ~= nil then
                 normalized[normalizedKey] = true
+            else
+                invalidEnabledEntry = true
             end
         end
     end
 
     if next(normalized) then
         return normalized, false, true
+    end
+    if invalidEnabledEntry and failClosed then
+        return {}, true, true
     end
     if sawEntry and failClosed then
         return {}, false, true
@@ -152,11 +158,40 @@ local function IntersectTruthyMaps(left, right)
 end
 
 local function AddEffectiveSource(sources, map, inherited, normalizer)
-    local normalized, _, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
+    local normalized, malformed, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
     if hasRestriction then
         sources[#sources + 1] = {
             values = normalized or {},
             inherited = inherited and true or false,
+            malformed = malformed and true or false,
+        }
+    end
+end
+
+local function AddCombinedEffectiveSource(sources, inherited, normalizer, ...)
+    local values
+    local hasRestriction = false
+    local malformed = false
+
+    for index = 1, select("#", ...) do
+        local normalized, sourceMalformed, sourceHasRestriction = NormalizeTruthyMap(select(index, ...), normalizer, true)
+        if sourceMalformed then
+            malformed = true
+        end
+        if sourceHasRestriction then
+            hasRestriction = true
+            values = values or {}
+            for key in pairs(normalized or {}) do
+                values[key] = true
+            end
+        end
+    end
+
+    if hasRestriction then
+        sources[#sources + 1] = {
+            values = values,
+            inherited = inherited and true or false,
+            malformed = malformed,
         }
     end
 end
@@ -169,10 +204,15 @@ local function ResolveEffectiveSources(sources)
     for _, source in ipairs(sources or {}) do
         hasRestriction = true
         if source.inherited then inherited = true end
-        if effective == nil then
+        if source.malformed then
+            effective = {}
+        elseif effective == nil then
             effective = CopyTruthyMap(source.values) or {}
         else
-            effective = IntersectTruthyMaps(effective, source.values)
+            local intersection = IntersectTruthyMaps(effective, source.values)
+            if next(intersection) then
+                effective = intersection
+            end
         end
     end
 
@@ -194,7 +234,10 @@ local function MergeEligibilityAllowlist(state, key, map, normalizer)
     if state[key] == nil then
         state[key] = CopyTruthyMap(normalized) or {}
     else
-        state[key] = IntersectTruthyMaps(state[key], normalized)
+        local intersection = IntersectTruthyMaps(state[key], normalized)
+        if next(intersection) then
+            state[key] = intersection
+        end
     end
     return true
 end
@@ -861,47 +904,47 @@ function CooldownCompanion:GetEffectiveSpecs(group)
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
-            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
-            AddEffectiveSource(
+            AddCombinedEffectiveSource(
                 sources,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
                 true,
-                NormalizeSpecKey
+                NormalizeSpecKey,
+                folder and folder.specs,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist
             )
         end
-        AddEffectiveSource(sources, container.specs, true, NormalizeSpecKey)
-        AddEffectiveSource(
+        AddCombinedEffectiveSource(
             sources,
-            container.loadConditions and container.loadConditions.specAllowlist,
             true,
-            NormalizeSpecKey
+            NormalizeSpecKey,
+            container.specs,
+            container.loadConditions and container.loadConditions.specAllowlist
         )
-        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
-        AddEffectiveSource(
+        AddCombinedEffectiveSource(
             sources,
-            group.loadConditions and group.loadConditions.specAllowlist,
             false,
-            NormalizeSpecKey
+            NormalizeSpecKey,
+            group.specs,
+            group.loadConditions and group.loadConditions.specAllowlist
         )
     else
         local folderId = group.folderId
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
-            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
-            AddEffectiveSource(
+            AddCombinedEffectiveSource(
                 sources,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
                 true,
-                NormalizeSpecKey
+                NormalizeSpecKey,
+                folder and folder.specs,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist
             )
         end
-        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
-        AddEffectiveSource(
+        AddCombinedEffectiveSource(
             sources,
-            group.loadConditions and group.loadConditions.specAllowlist,
             false,
-            NormalizeSpecKey
+            NormalizeSpecKey,
+            group.specs,
+            group.loadConditions and group.loadConditions.specAllowlist
         )
     end
 
@@ -1335,6 +1378,190 @@ function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
     if not next(group.heroTalents) then
         group.heroTalents = nil
     end
+end
+
+local function ClearEmptyCoreLoadConditions(entity)
+    if type(entity) ~= "table" or type(entity.loadConditions) ~= "table" then return end
+    if not next(entity.loadConditions) then
+        entity.loadConditions = nil
+    end
+end
+
+local function GetClassKeyFromClassID(classID)
+    if not (classID and GetClassInfo) then return nil end
+    local _, classFilename = GetClassInfo(classID)
+    return NormalizeClassKey(classFilename)
+end
+
+local function GetCurrentScopeClassKey(addon)
+    local classFilename = addon and addon._playerClassFilename
+    if not classFilename and UnitClass then
+        classFilename = select(2, UnitClass("player"))
+    end
+    return NormalizeClassKey(classFilename)
+end
+
+local function GetSpecClassKey(specId)
+    if not (C_SpecializationInfo and C_SpecializationInfo.GetClassIDFromSpecID) then
+        return nil
+    end
+    return GetClassKeyFromClassID(C_SpecializationInfo.GetClassIDFromSpecID(tonumber(specId)))
+end
+
+local function SpecBelongsToClass(specId, classKey)
+    if not classKey then return true end
+    local specClassKey = GetSpecClassKey(specId)
+    return specClassKey == classKey
+end
+
+local function GetCharacterClassKey(addon, charKey)
+    local info = charKey
+        and addon
+        and addon.db
+        and addon.db.global
+        and addon.db.global.characterInfo
+        and addon.db.global.characterInfo[charKey]
+    if type(info) ~= "table" then
+        return nil
+    end
+    return NormalizeClassKey(info.classFilename)
+        or GetClassKeyFromClassID(info.classID)
+end
+
+local function PruneSpecMapToClass(addon, entity, map, classKey)
+    if type(map) ~= "table" or not classKey then return false end
+    local changed = false
+    for key in pairs(map) do
+        local specId = NormalizeSpecKey(key)
+        if specId and SpecBelongsToClass(specId, classKey) then
+            if key ~= specId then
+                map[specId] = true
+                map[key] = nil
+                changed = true
+            end
+        else
+            map[key] = nil
+            if specId then
+                map[specId] = nil
+                if addon and addon.CleanHeroTalentsForSpec then
+                    addon:CleanHeroTalentsForSpec(entity, specId)
+                end
+            end
+            changed = true
+        end
+    end
+    return changed
+end
+
+local function CharacterKeyMatchesClass(addon, charKey, classKey, ownerCharKey)
+    if not classKey then return true end
+    if charKey and ownerCharKey and charKey == ownerCharKey then
+        return true
+    end
+    local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
+    if charKey and currentCharKey and charKey == currentCharKey then
+        return true
+    end
+    return GetCharacterClassKey(addon, charKey) == classKey
+end
+
+local function PruneCharacterMapToClass(addon, map, classKey, ownerCharKey)
+    if type(map) ~= "table" or not classKey then return false end
+    local changed = false
+    for key in pairs(map) do
+        local charKey = NormalizeCharacterKey(key)
+        if not (charKey and CharacterKeyMatchesClass(addon, charKey, classKey, ownerCharKey)) then
+            map[key] = nil
+            if charKey then
+                map[charKey] = nil
+            end
+            changed = true
+        end
+    end
+    return changed
+end
+
+local function WithOwnerCharKey(opts, ownerCharKey)
+    if opts and opts.ownerCharKey then return opts end
+    local scopedOpts = opts and CopyTable(opts) or {}
+    scopedOpts.ownerCharKey = ownerCharKey
+    return scopedOpts
+end
+
+function CooldownCompanion:NormalizeEligibilityForCharacterScope(entity, opts)
+    if type(entity) ~= "table" then return false end
+    opts = opts or {}
+    local ownerCharKey = opts.ownerCharKey
+        or entity.createdBy
+        or (self.db and self.db.keys and self.db.keys.char)
+    local classKey = NormalizeClassKey(opts.scopeClassKey)
+        or GetCharacterClassKey(self, ownerCharKey)
+        or GetCurrentScopeClassKey(self)
+    local changed = false
+
+    if PruneSpecMapToClass(self, entity, entity.specs, classKey) then
+        changed = true
+        if type(entity.specs) == "table" and not next(entity.specs) then
+            entity.specs = nil
+        end
+    end
+
+    local loadConditions = entity.loadConditions
+    if type(loadConditions) == "table" then
+        if loadConditions.classAllowlist ~= nil then
+            loadConditions.classAllowlist = nil
+            changed = true
+        end
+        if PruneSpecMapToClass(self, entity, loadConditions.specAllowlist, classKey) then
+            changed = true
+            if type(loadConditions.specAllowlist) == "table" and not next(loadConditions.specAllowlist) then
+                loadConditions.specAllowlist = nil
+            end
+        end
+        if PruneCharacterMapToClass(self, loadConditions.characterAllowlist, classKey, ownerCharKey) then
+            changed = true
+            if type(loadConditions.characterAllowlist) == "table"
+                and not next(loadConditions.characterAllowlist)
+            then
+                loadConditions.characterAllowlist = nil
+            end
+        end
+        ClearEmptyCoreLoadConditions(entity)
+    end
+
+    return changed
+end
+
+function CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(containerId, opts)
+    local db = self.db and self.db.profile
+    if not (db and db.groupContainers) then return false end
+    local container = db.groupContainers[containerId]
+    if not container then return false end
+    opts = WithOwnerCharKey(opts, container.createdBy or (self.db and self.db.keys and self.db.keys.char))
+
+    local changed = self:NormalizeEligibilityForCharacterScope(container, opts)
+    for _, group in pairs(db.groups or {}) do
+        if type(group) == "table" and group.parentContainerId == containerId then
+            changed = self:NormalizeEligibilityForCharacterScope(group, opts) or changed
+        end
+    end
+    return changed
+end
+
+function CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(folderId, opts)
+    local db = self.db and self.db.profile
+    if not (db and db.folders) then return false end
+    local folder = db.folders[folderId]
+    if not folder then return false end
+    opts = WithOwnerCharKey(opts, folder.createdBy or (self.db and self.db.keys and self.db.keys.char))
+
+    local changed = self:NormalizeEligibilityForCharacterScope(folder, opts)
+    for containerId, container in pairs(db.groupContainers or {}) do
+        if type(container) == "table" and container.folderId == folderId then
+            changed = self:NormalizeContainerEligibilityForCharacterScope(containerId, opts) or changed
+        end
+    end
+    return changed
 end
 
 function CooldownCompanion:IsGroupAvailableForAnchoring(groupId)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -78,6 +78,8 @@ local LOAD_CONDITION_ALLOWLIST_KEYS = {
     characterAllowlist = true,
 }
 
+local CLASS_SCAN_LIMIT = 30
+
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -209,10 +211,7 @@ local function ResolveEffectiveSources(sources)
         elseif effective == nil then
             effective = CopyTruthyMap(source.values) or {}
         else
-            local intersection = IntersectTruthyMaps(effective, source.values)
-            if next(intersection) then
-                effective = intersection
-            end
+            effective = IntersectTruthyMaps(effective, source.values)
         end
     end
 
@@ -234,10 +233,7 @@ local function MergeEligibilityAllowlist(state, key, map, normalizer)
     if state[key] == nil then
         state[key] = CopyTruthyMap(normalized) or {}
     else
-        local intersection = IntersectTruthyMaps(state[key], normalized)
-        if next(intersection) then
-            state[key] = intersection
-        end
+        state[key] = IntersectTruthyMaps(state[key], normalized)
     end
     return true
 end
@@ -1393,6 +1389,17 @@ local function GetClassKeyFromClassID(classID)
     return NormalizeClassKey(classFilename)
 end
 
+local function GetClassIDFromClassKey(classKey)
+    classKey = NormalizeClassKey(classKey)
+    if not (classKey and GetClassInfo) then return nil end
+    for classID = 1, CLASS_SCAN_LIMIT do
+        if GetClassKeyFromClassID(classID) == classKey then
+            return classID
+        end
+    end
+    return nil
+end
+
 local function GetCurrentScopeClassKey(addon)
     local classFilename = addon and addon._playerClassFilename
     if not classFilename and UnitClass then
@@ -1412,6 +1419,43 @@ local function SpecBelongsToClass(specId, classKey)
     if not classKey then return true end
     local specClassKey = GetSpecClassKey(specId)
     return specClassKey == classKey
+end
+
+local function HeroTalentBelongsToClass(subTreeID, classKey)
+    subTreeID = tonumber(subTreeID)
+    if not classKey then return true end
+    if not (subTreeID
+        and C_ClassTalents
+        and C_ClassTalents.GetHeroTalentSpecsForClassSpec
+        and C_SpecializationInfo
+        and C_SpecializationInfo.GetNumSpecializationsForClassID
+        and C_SpecializationInfo.GetSpecializationInfo)
+    then
+        return false
+    end
+
+    local classID = GetClassIDFromClassKey(classKey)
+    if not classID then return false end
+
+    local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
+    for specIndex = 1, numSpecs do
+        local specId = C_SpecializationInfo.GetSpecializationInfo(
+            specIndex,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
+        local subTreeIDs = specId and C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+        for _, availableSubTreeID in ipairs(subTreeIDs or {}) do
+            if tonumber(availableSubTreeID) == subTreeID then
+                return true
+            end
+        end
+    end
+    return false
 end
 
 local function GetCharacterClassKey(addon, charKey)
@@ -1481,6 +1525,31 @@ local function PruneCharacterMapToClass(addon, map, classKey, ownerCharKey)
     return changed
 end
 
+local function PruneHeroTalentMapToClass(entity, classKey)
+    if type(entity) ~= "table" or type(entity.heroTalents) ~= "table" or not classKey then return false end
+    local changed = false
+    for subTreeID in pairs(entity.heroTalents) do
+        local normalizedSubTreeID = tonumber(subTreeID)
+        if normalizedSubTreeID and HeroTalentBelongsToClass(normalizedSubTreeID, classKey) then
+            if subTreeID ~= normalizedSubTreeID then
+                entity.heroTalents[normalizedSubTreeID] = true
+                entity.heroTalents[subTreeID] = nil
+                changed = true
+            end
+        else
+            entity.heroTalents[subTreeID] = nil
+            if normalizedSubTreeID then
+                entity.heroTalents[normalizedSubTreeID] = nil
+            end
+            changed = true
+        end
+    end
+    if not next(entity.heroTalents) then
+        entity.heroTalents = nil
+    end
+    return changed
+end
+
 local function WithOwnerCharKey(opts, ownerCharKey)
     if opts and opts.ownerCharKey then return opts end
     local scopedOpts = opts and CopyTable(opts) or {}
@@ -1505,6 +1574,7 @@ function CooldownCompanion:NormalizeEligibilityForCharacterScope(entity, opts)
             entity.specs = nil
         end
     end
+    changed = PruneHeroTalentMapToClass(entity, classKey) or changed
 
     local loadConditions = entity.loadConditions
     if type(loadConditions) == "table" then

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -218,6 +218,22 @@ local function ResolveEffectiveSources(sources)
     return effective, inherited, hasRestriction
 end
 
+local function AddEntityEffectiveSpecSource(sources, entity, inherited)
+    AddCombinedEffectiveSource(
+        sources,
+        inherited,
+        NormalizeSpecKey,
+        entity and entity.specs,
+        entity and entity.loadConditions and entity.loadConditions.specAllowlist
+    )
+end
+
+local function AddFolderEffectiveSpecSource(sources, profile, folderId)
+    local folders = profile and profile.folders
+    local folder = folderId and folders and folders[folderId]
+    AddEntityEffectiveSpecSource(sources, folder, true)
+end
+
 local function MergeEligibilityAllowlist(state, key, map, normalizer)
     local normalized, malformed, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
     if malformed then
@@ -865,6 +881,10 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
         return false
     end
 
+    if self.IsGroupEligibilityMet and not self:IsGroupEligibilityMet(group) then
+        return false
+    end
+
     local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
     if hasSpecFilter then
         if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
@@ -893,55 +913,33 @@ function CooldownCompanion:GetEffectiveSpecs(group)
     if not group then return nil, false end
 
     local sources = {}
+    local profile = self.db and self.db.profile
 
     local container = self:GetParentContainer(group)
     if container then
-        local folderId = container.folderId
-        if folderId then
-            local folders = self.db and self.db.profile and self.db.profile.folders
-            local folder = folders and folders[folderId]
-            AddCombinedEffectiveSource(
-                sources,
-                true,
-                NormalizeSpecKey,
-                folder and folder.specs,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist
-            )
-        end
-        AddCombinedEffectiveSource(
-            sources,
-            true,
-            NormalizeSpecKey,
-            container.specs,
-            container.loadConditions and container.loadConditions.specAllowlist
-        )
-        AddCombinedEffectiveSource(
-            sources,
-            false,
-            NormalizeSpecKey,
-            group.specs,
-            group.loadConditions and group.loadConditions.specAllowlist
-        )
+        AddFolderEffectiveSpecSource(sources, profile, container.folderId)
+        AddEntityEffectiveSpecSource(sources, container, true)
+        AddEntityEffectiveSpecSource(sources, group, false)
     else
-        local folderId = group.folderId
-        if folderId then
-            local folders = self.db and self.db.profile and self.db.profile.folders
-            local folder = folders and folders[folderId]
-            AddCombinedEffectiveSource(
-                sources,
-                true,
-                NormalizeSpecKey,
-                folder and folder.specs,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist
-            )
-        end
-        AddCombinedEffectiveSource(
-            sources,
-            false,
-            NormalizeSpecKey,
-            group.specs,
-            group.loadConditions and group.loadConditions.specAllowlist
-        )
+        AddFolderEffectiveSpecSource(sources, profile, group.folderId)
+        AddEntityEffectiveSpecSource(sources, group, false)
+    end
+
+    return ResolveEffectiveSources(sources)
+end
+
+function CooldownCompanion:GetInheritedEffectiveSpecs(group)
+    if not group then return nil, false end
+
+    local sources = {}
+    local profile = self.db and self.db.profile
+
+    local container = self:GetParentContainer(group)
+    if container then
+        AddFolderEffectiveSpecSource(sources, profile, container.folderId)
+        AddEntityEffectiveSpecSource(sources, container, true)
+    else
+        AddFolderEffectiveSpecSource(sources, profile, group.folderId)
     end
 
     return ResolveEffectiveSources(sources)
@@ -2103,12 +2101,15 @@ function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
     return sources
 end
 
-function CooldownCompanion:EvaluateLoadConditionSources(sources)
+function CooldownCompanion:EvaluateLoadConditionSources(sources, opts)
+    opts = opts or {}
     local eligibility
     local identity
 
     for _, source in ipairs(sources or {}) do
-        if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
+        if opts.eligibilityOnly ~= true
+            and not self:EvaluateLoadConditions(source.loadConditions, source.defaults)
+        then
             return false, source.label
         end
         local loadConditions = source.loadConditions
@@ -2137,8 +2138,20 @@ function CooldownCompanion:IsGroupLoadConditionMet(group)
     return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForGroup(group))
 end
 
+function CooldownCompanion:IsGroupEligibilityMet(group)
+    return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForGroup(group), {
+        eligibilityOnly = true,
+    })
+end
+
 function CooldownCompanion:IsButtonLoadConditionMet(buttonData, group)
     return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForEntry(buttonData, group))
+end
+
+function CooldownCompanion:IsCustomBarLoadConditionMet(customBar)
+    local sources = {}
+    AddLoadConditionSource(sources, "Custom Bar", customBar, LOCAL_LOAD_CONDITION_DEFAULTS, true)
+    return self:EvaluateLoadConditionSources(sources)
 end
 
 

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -72,6 +72,12 @@ local LOCAL_LOAD_CONDITION_DEFAULTS = {
     vehicleUI = false,
 }
 
+local LOAD_CONDITION_ALLOWLIST_KEYS = {
+    classAllowlist = true,
+    specAllowlist = true,
+    characterAllowlist = true,
+}
+
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -83,6 +89,121 @@ local function GetFrameName(frame)
         return "CooldownCompanionGroup" .. frame.groupId
     end
     return frame.name
+end
+
+local function NormalizeClassKey(key)
+    if type(key) ~= "string" or key == "" then return nil end
+    return string.upper(key)
+end
+
+local function NormalizeSpecKey(key)
+    local specId = tonumber(key)
+    if not specId then return nil end
+    return specId
+end
+
+local function NormalizeCharacterKey(key)
+    if type(key) ~= "string" or key == "" then return nil end
+    return key
+end
+
+local function NormalizeTruthyMap(map, normalizer, failClosed)
+    if map == nil then return nil, false, false end
+    if type(map) ~= "table" then return nil, true, true end
+
+    local normalized = {}
+    local sawEntry = false
+    for key, enabled in pairs(map) do
+        sawEntry = true
+        if enabled == true then
+            local normalizedKey = normalizer(key)
+            if normalizedKey ~= nil then
+                normalized[normalizedKey] = true
+            end
+        end
+    end
+
+    if next(normalized) then
+        return normalized, false, true
+    end
+    if sawEntry and failClosed then
+        return {}, false, true
+    end
+    return nil, false, false
+end
+
+local function CopyTruthyMap(map)
+    if not map then return nil end
+    local copy = {}
+    for key in pairs(map) do
+        copy[key] = true
+    end
+    return copy
+end
+
+local function IntersectTruthyMaps(left, right)
+    local intersection = {}
+    for key in pairs(left or {}) do
+        if right and right[key] then
+            intersection[key] = true
+        end
+    end
+    return intersection
+end
+
+local function AddEffectiveSource(sources, map, inherited, normalizer)
+    local normalized, _, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
+    if hasRestriction then
+        sources[#sources + 1] = {
+            values = normalized or {},
+            inherited = inherited and true or false,
+        }
+    end
+end
+
+local function ResolveEffectiveSources(sources)
+    local effective
+    local inherited = false
+    local hasRestriction = false
+
+    for _, source in ipairs(sources or {}) do
+        hasRestriction = true
+        if source.inherited then inherited = true end
+        if effective == nil then
+            effective = CopyTruthyMap(source.values) or {}
+        else
+            effective = IntersectTruthyMaps(effective, source.values)
+        end
+    end
+
+    return effective, inherited, hasRestriction
+end
+
+local function MergeEligibilityAllowlist(state, key, map, normalizer)
+    local normalized, malformed, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
+    if malformed then
+        state[key .. "Restricted"] = true
+        state[key .. "NoMatch"] = true
+        state[key] = {}
+        return false
+    end
+    if not hasRestriction then return true end
+
+    local restrictedKey = key .. "Restricted"
+    state[restrictedKey] = true
+    if state[key] == nil then
+        state[key] = CopyTruthyMap(normalized) or {}
+    else
+        state[key] = IntersectTruthyMaps(state[key], normalized)
+    end
+    return true
+end
+
+local function AllowlistMatches(state, key, currentValue)
+    if not state[key .. "Restricted"] then return true end
+    if state[key .. "NoMatch"] then return false end
+    if currentValue == nil then return false end
+    return state[key] and state[key][currentValue] == true
 end
 
 local function GetCurrentAnchorTargetName(frame)
@@ -705,8 +826,8 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
         return false
     end
 
-    local effectiveSpecs = self:GetEffectiveSpecs(group)
-    if effectiveSpecs and next(effectiveSpecs) then
+    local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
+    if hasSpecFilter then
         if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
             return false
         end
@@ -732,61 +853,57 @@ end
 function CooldownCompanion:GetEffectiveSpecs(group)
     if not group then return nil, false end
 
-    -- Panel: container specs (includes stamped folder specs) → panel's own
+    local sources = {}
+
     local container = self:GetParentContainer(group)
     if container then
-        if container.specs and next(container.specs) then
-            return container.specs, true
+        local folderId = container.folderId
+        if folderId then
+            local folders = self.db and self.db.profile and self.db.profile.folders
+            local folder = folders and folders[folderId]
+            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
         end
-        -- Fall through to panel's own
-        return group.specs, false
+        AddEffectiveSource(sources, container.specs, true, NormalizeSpecKey)
+        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
+    else
+        local folderId = group.folderId
+        if folderId then
+            local folders = self.db and self.db.profile and self.db.profile.folders
+            local folder = folders and folders[folderId]
+            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
+        end
+        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
     end
 
-    -- Non-panel group: check folder cascade
-    local folderId = group.folderId
-    if folderId then
-        local folders = self.db and self.db.profile and self.db.profile.folders
-        local folder = folders and folders[folderId]
-        if folder and folder.specs and next(folder.specs) then
-            return folder.specs, true
-        end
-    end
-    return group.specs, false
+    return ResolveEffectiveSources(sources)
 end
 
 function CooldownCompanion:GetEffectiveHeroTalents(group)
     if not group then return nil, false end
 
-    -- Panel cascade: folder → container → panel's own heroTalents
+    local sources = {}
+
     local container = self:GetParentContainer(group)
     if container then
-        -- Check folder first
         local folderId = container.folderId
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
-            if folder and folder.heroTalents and next(folder.heroTalents) then
-                return folder.heroTalents, true
-            end
+            AddEffectiveSource(sources, folder and folder.heroTalents, true, NormalizeSpecKey)
         end
-        -- Then container's own heroTalents
-        if container.heroTalents and next(container.heroTalents) then
-            return container.heroTalents, true
+        AddEffectiveSource(sources, container.heroTalents, true, NormalizeSpecKey)
+        AddEffectiveSource(sources, group.heroTalents, false, NormalizeSpecKey)
+    else
+        local folderId = group.folderId
+        if folderId then
+            local folders = self.db and self.db.profile and self.db.profile.folders
+            local folder = folders and folders[folderId]
+            AddEffectiveSource(sources, folder and folder.heroTalents, true, NormalizeSpecKey)
         end
-        -- Fall through to panel's own
-        return group.heroTalents, false
+        AddEffectiveSource(sources, group.heroTalents, false, NormalizeSpecKey)
     end
 
-    -- Non-panel container: check folder cascade
-    local folderId = group.folderId
-    if folderId then
-        local folders = self.db and self.db.profile and self.db.profile.folders
-        local folder = folders and folders[folderId]
-        if folder and folder.heroTalents and next(folder.heroTalents) then
-            return folder.heroTalents, true
-        end
-    end
-    return group.heroTalents, false
+    return ResolveEffectiveSources(sources)
 end
 
 local function CopyTalentCondition(cond)
@@ -1071,8 +1188,8 @@ function CooldownCompanion:SetFolderHeroTalent(folderId, subTreeID, enabled)
 end
 
 function CooldownCompanion:IsHeroTalentAllowed(group)
-    local effectiveHeroTalents = self:GetEffectiveHeroTalents(group)
-    if not (effectiveHeroTalents and next(effectiveHeroTalents)) then return true end
+    local effectiveHeroTalents, _, hasHeroTalentFilter = self:GetEffectiveHeroTalents(group)
+    if not hasHeroTalentFilter then return true end
     local heroSpecId = self._currentHeroSpecId
     if not heroSpecId then return true end  -- low level, no hero talent selected
     return effectiveHeroTalents[heroSpecId] == true
@@ -1154,8 +1271,8 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
     end
 
     -- Spec and hero talent filtering (GetEffectiveSpecs already delegates to container)
-    local effectiveSpecs = self:GetEffectiveSpecs(group)
-    if effectiveSpecs and next(effectiveSpecs) then
+    local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
+    if hasSpecFilter then
         if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
             return false
         end
@@ -1521,8 +1638,11 @@ function CooldownCompanion:HasLocalLoadConditions(entity)
     if not (type(entity) == "table" and type(entity.loadConditions) == "table") then
         return false
     end
-    for _, value in pairs(entity.loadConditions) do
+    for key, value in pairs(entity.loadConditions) do
         if value == true then
+            return true
+        end
+        if LOAD_CONDITION_ALLOWLIST_KEYS[key] and type(value) == "table" and next(value) then
             return true
         end
     end
@@ -1573,18 +1693,39 @@ function CooldownCompanion:EvaluateLoadConditions(loadConditions, defaults)
     return true
 end
 
+function CooldownCompanion:GetCurrentEligibilityIdentity()
+    local classFilename = self._playerClassFilename
+    if not classFilename and UnitClass then
+        classFilename = select(2, UnitClass("player"))
+    end
+    return {
+        classFilename = NormalizeClassKey(classFilename),
+        specId = self._currentSpecId,
+        charKey = self.db and self.db.keys and self.db.keys.char or nil,
+    }
+end
+
 function CooldownCompanion:CheckLoadConditions(group)
     return self:EvaluateLoadConditions(group and group.loadConditions)
 end
 
-local function AddLoadConditionSource(sources, label, entity, defaults)
+local function AddLoadConditionSource(sources, label, entity, defaults, allowClassEligibility)
     if type(entity) == "table" and type(entity.loadConditions) == "table" then
         sources[#sources + 1] = {
             label = label,
             loadConditions = entity.loadConditions,
             defaults = defaults,
+            allowClassEligibility = allowClassEligibility == true,
         }
     end
+end
+
+local function IsFolderGlobalScope(folder)
+    return type(folder) == "table" and folder.section == "global"
+end
+
+local function IsContainerGlobalScope(container)
+    return type(container) == "table" and container.isGlobal == true
 end
 
 function CooldownCompanion:GetInheritedLoadConditionSources(group)
@@ -1595,34 +1736,58 @@ function CooldownCompanion:GetInheritedLoadConditionSources(group)
     local container = self:GetParentContainer(group)
     if container then
         local folder = container.folderId and db.folders and db.folders[container.folderId]
-        AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS)
-        AddLoadConditionSource(sources, "Group", container, LOAD_CONDITION_DEFAULTS)
+        AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS, IsFolderGlobalScope(folder))
+        AddLoadConditionSource(sources, "Group", container, LOAD_CONDITION_DEFAULTS, IsContainerGlobalScope(container))
         return sources
     end
 
     local folder = group.folderId and db.folders and db.folders[group.folderId]
-    AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS)
+    AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS, IsFolderGlobalScope(folder))
     return sources
 end
 
 function CooldownCompanion:GetLoadConditionSourcesForGroup(group)
     local sources = self:GetInheritedLoadConditionSources(group)
     if group then
-        AddLoadConditionSource(sources, group.parentContainerId and "Panel" or "Group", group, LOAD_CONDITION_DEFAULTS)
+        local container = self:GetParentContainer(group)
+        local allowClassEligibility
+        if container then
+            allowClassEligibility = IsContainerGlobalScope(container)
+        else
+            allowClassEligibility = group.isGlobal == true
+        end
+        AddLoadConditionSource(sources, group.parentContainerId and "Panel" or "Group", group, LOAD_CONDITION_DEFAULTS, allowClassEligibility)
     end
     return sources
 end
 
 function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
     local sources = self:GetLoadConditionSourcesForGroup(group)
-    AddLoadConditionSource(sources, "Entry", buttonData, LOCAL_LOAD_CONDITION_DEFAULTS)
+    AddLoadConditionSource(sources, "Entry", buttonData, LOCAL_LOAD_CONDITION_DEFAULTS, false)
     return sources
 end
 
 function CooldownCompanion:EvaluateLoadConditionSources(sources)
+    local eligibility = {}
+    local identity = self:GetCurrentEligibilityIdentity()
+
     for _, source in ipairs(sources or {}) do
         if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
             return false, source.label
+        end
+        local loadConditions = source.loadConditions
+        if type(loadConditions) == "table" then
+            if source.allowClassEligibility then
+                MergeEligibilityAllowlist(eligibility, "class", loadConditions.classAllowlist, NormalizeClassKey)
+            end
+            MergeEligibilityAllowlist(eligibility, "spec", loadConditions.specAllowlist, NormalizeSpecKey)
+            MergeEligibilityAllowlist(eligibility, "character", loadConditions.characterAllowlist, NormalizeCharacterKey)
+            if not AllowlistMatches(eligibility, "class", identity.classFilename)
+                or not AllowlistMatches(eligibility, "spec", identity.specId)
+                or not AllowlistMatches(eligibility, "character", identity.charKey)
+            then
+                return false, source.label
+            end
         end
     end
     return true, nil

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1720,6 +1720,15 @@ local function AddLoadConditionSource(sources, label, entity, defaults, allowCla
     end
 end
 
+local function HasEligibilityAllowlist(loadConditions, allowClassEligibility)
+    if type(loadConditions) ~= "table" then return false end
+    if allowClassEligibility and loadConditions.classAllowlist ~= nil then
+        return true
+    end
+    return loadConditions.specAllowlist ~= nil
+        or loadConditions.characterAllowlist ~= nil
+end
+
 local function IsFolderGlobalScope(folder)
     return type(folder) == "table" and folder.section == "global"
 end
@@ -1768,15 +1777,19 @@ function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
 end
 
 function CooldownCompanion:EvaluateLoadConditionSources(sources)
-    local eligibility = {}
-    local identity = self:GetCurrentEligibilityIdentity()
+    local eligibility
+    local identity
 
     for _, source in ipairs(sources or {}) do
         if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
             return false, source.label
         end
         local loadConditions = source.loadConditions
-        if type(loadConditions) == "table" then
+        if HasEligibilityAllowlist(loadConditions, source.allowClassEligibility) then
+            if not eligibility then
+                eligibility = {}
+                identity = self:GetCurrentEligibilityIdentity()
+            end
             if source.allowClassEligibility then
                 MergeEligibilityAllowlist(eligibility, "class", loadConditions.classAllowlist, NormalizeClassKey)
             end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -862,17 +862,47 @@ function CooldownCompanion:GetEffectiveSpecs(group)
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
             AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
+            AddEffectiveSource(
+                sources,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
+                true,
+                NormalizeSpecKey
+            )
         end
         AddEffectiveSource(sources, container.specs, true, NormalizeSpecKey)
+        AddEffectiveSource(
+            sources,
+            container.loadConditions and container.loadConditions.specAllowlist,
+            true,
+            NormalizeSpecKey
+        )
         AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
+        AddEffectiveSource(
+            sources,
+            group.loadConditions and group.loadConditions.specAllowlist,
+            false,
+            NormalizeSpecKey
+        )
     else
         local folderId = group.folderId
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
             AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
+            AddEffectiveSource(
+                sources,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
+                true,
+                NormalizeSpecKey
+            )
         end
         AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
+        AddEffectiveSource(
+            sources,
+            group.loadConditions and group.loadConditions.specAllowlist,
+            false,
+            NormalizeSpecKey
+        )
     end
 
     return ResolveEffectiveSources(sources)
@@ -1260,16 +1290,6 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if group.enabled == false then return false end
     end
 
-    local buttonUsabilityOptions = opts.buttonUsabilityOptions
-        or (self.GetGroupButtonUsabilityOptions and self:GetGroupButtonUsabilityOptions(groupId, group))
-
-    if opts.requireButtons and not self:GroupHasUsableButtons(group, {
-        checkLoadConditions = opts.checkLoadConditions,
-        ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
-    }) then
-        return false
-    end
-
     -- Spec and hero talent filtering (GetEffectiveSpecs already delegates to container)
     local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
     if hasSpecFilter then
@@ -1290,6 +1310,16 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if not self:IsGroupLoadConditionMet(group) then
             return false
         end
+    end
+
+    local buttonUsabilityOptions = opts.buttonUsabilityOptions
+        or (self.GetGroupButtonUsabilityOptions and self:GetGroupButtonUsabilityOptions(groupId, group))
+
+    if opts.requireButtons and not self:GroupHasUsableButtons(group, {
+        checkLoadConditions = opts.checkLoadConditions,
+        ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
+    }) then
+        return false
     end
 
     return true

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -284,12 +284,14 @@ function CooldownCompanion:OnEnable()
     self:RegisterEvent("PET_BAR_UPDATE", "OnActionBarLayoutChanged")
 
     -- Cache player identity for class/race-specific checks.
-    self._playerClassID = select(3, UnitClass("player"))
+    local _, classFilename, classID = UnitClass("player")
+    self._playerClassFilename = classFilename
+    self._playerClassID = classID
     self._isDracthyr = (select(2, UnitRace("player")) == "Dracthyr")
 
     -- Store class info in global scope for cross-character browse mode
     self.db.global.characterInfo[self.db.keys.char] = {
-        classFilename = select(2, UnitClass("player")),
+        classFilename = classFilename,
         classID = self._playerClassID,
     }
 

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -1848,11 +1848,10 @@ function CooldownCompanion:ApplyResourceBars(opts)
 
     -- Append enabled Custom Bars
     local customBars = GetSpecCustomAuraBars(settings)
-    local customBarLoadDefaults = CooldownCompanion:GetLocalLoadConditionDefaults()
     for i, cab in ipairs(customBars) do
         if cab and cab.enabled and cab.spellID
             and CooldownCompanion:IsTalentConditionMet(cab)
-            and CooldownCompanion:EvaluateLoadConditions(cab.loadConditions, customBarLoadDefaults) then
+            and CooldownCompanion:IsCustomBarLoadConditionMet(cab) then
             table.insert(filtered, {
                 kind = "custom",
                 customBarIndex = i,

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -469,7 +469,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             info.notCheckable = true
             info.func = function()
                 CloseDropDownMenus()
-                if container.isGlobal and container.specs and ContainersHaveForeignSpecs({ container }, false) then
+                if container.isGlobal and ContainersHaveForeignSpecs({ container }, false) then
                     ShowPopupAboveConfig("CDC_UNGLOBAL_GROUP", container.name, { containerId = containerId })
                     return
                 end

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -47,6 +47,21 @@ local SelectConfigPanel = ST._SelectConfigPanel
 
 local GenerateGroupName
 
+local function OpenContainerLoadConditions(containerId)
+    CS.specExpandedGroupId = nil
+    CS.specExpandedFolderId = nil
+    SelectConfigContainer(containerId)
+    CS.selectedContainerTab = "loadconditions"
+    CooldownCompanion:RefreshConfigPanel()
+end
+
+local function OpenFolderLoadConditions(folderId)
+    CS.specExpandedGroupId = nil
+    CS.specExpandedFolderId = nil
+    SelectConfigFolder(folderId)
+    CooldownCompanion:RefreshConfigPanel()
+end
+
 local function TrimGroupName(name)
     if name == nil then return "" end
     return tostring(name):match("^%s*(.-)%s*$") or ""
@@ -560,13 +575,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             info.notCheckable = true
             info.func = function()
                 CloseDropDownMenus()
-                if CS.specExpandedGroupId == containerId then
-                    CS.specExpandedGroupId = nil
-                else
-                    CS.specExpandedGroupId = containerId
-                    CS.specExpandedFolderId = nil
-                end
-                CooldownCompanion:RefreshConfigPanel()
+                OpenContainerLoadConditions(containerId)
             end
             UIDropDownMenu_AddButton(info, level)
 
@@ -766,13 +775,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
         info.notCheckable = true
         info.func = function()
             CloseDropDownMenus()
-            if CS.specExpandedFolderId == folderId then
-                CS.specExpandedFolderId = nil
-            else
-                CS.specExpandedFolderId = folderId
-                CS.specExpandedGroupId = nil
-            end
-            CooldownCompanion:RefreshConfigPanel()
+            OpenFolderLoadConditions(folderId)
         end
         UIDropDownMenu_AddButton(info, level)
 
@@ -1299,13 +1302,7 @@ local function RefreshColumn1(preserveDrag)
                     return
                 end
                 if IsShiftKeyDown() then
-                    if CS.specExpandedGroupId == containerId then
-                        CS.specExpandedGroupId = nil
-                    else
-                        CS.specExpandedGroupId = containerId
-                        CS.specExpandedFolderId = nil
-                    end
-                    CooldownCompanion:RefreshConfigPanel()
+                    OpenContainerLoadConditions(containerId)
                     return
                 elseif IsControlKeyDown() then
                     -- Ctrl+click: toggle multi-select (container IDs)
@@ -1650,13 +1647,7 @@ local function RefreshColumn1(preserveDrag)
                     return
                 end
                 if IsShiftKeyDown() then
-                    if CS.specExpandedFolderId == folderId then
-                        CS.specExpandedFolderId = nil
-                    else
-                        CS.specExpandedFolderId = folderId
-                        CS.specExpandedGroupId = nil
-                    end
-                    CooldownCompanion:RefreshConfigPanel()
+                    OpenFolderLoadConditions(folderId)
                     return
                 end
                 SelectConfigFolder(folderId)

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -48,6 +48,13 @@ local SelectConfigRotationAssistantEntry = ST._SelectConfigRotationAssistantEntr
 
 local IsTriggerPanelGroup
 
+local function OpenPanelLoadConditions(panelId, containerId)
+    SelectConfigPanel(panelId, { containerId = containerId })
+    CS.selectedTab = "loadconditions"
+    CS.panelSettingsTab = "loadconditions"
+    CooldownCompanion:RefreshConfigPanel()
+end
+
 local function HideAllBarWidgets(col2)
     if col2._barsStylingScroll then col2._barsStylingScroll.frame:Hide() end
     if col2._resourceStylingTabGroup then col2._resourceStylingTabGroup.frame:Hide() end
@@ -2240,6 +2247,11 @@ local function RefreshColumn2()
                             return
                         end
 
+                        if IsShiftKeyDown() then
+                            OpenPanelLoadConditions(panelId, CS.selectedContainer)
+                            return
+                        end
+
                         SelectConfigPanel(panelId, { toggle = true })
                         CooldownCompanion:RefreshConfigPanel()
                         return
@@ -2287,6 +2299,15 @@ local function RefreshColumn2()
                                 ctxPanel.enabled = not (ctxPanel.enabled ~= false)
                                 CooldownCompanion:RefreshGroupFrame(ctxPanelId)
                                 CooldownCompanion:RefreshConfigPanel()
+                            end
+                            UIDropDownMenu_AddButton(info, level)
+
+                            info = UIDropDownMenu_CreateInfo()
+                            info.text = "Load Conditions"
+                            info.notCheckable = true
+                            info.func = function()
+                                CloseDropDownMenus()
+                                OpenPanelLoadConditions(ctxPanelId, ctxContainerId)
                             end
                             UIDropDownMenu_AddButton(info, level)
 

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -34,6 +34,7 @@ local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
 local GroupsHaveForeignSpecs = ST._GroupsHaveForeignSpecs
+local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
@@ -2111,21 +2112,31 @@ local function RefreshColumn2()
                     sb:Hide()
                 end
 
-                local containerSpecs = container.specs
+                local containerSpecs = BuildEligibilityBadgeMap(
+                    container.specs,
+                    container.loadConditions and container.loadConditions.specAllowlist
+                )
                 local containerHeroTalents = container.heroTalents
                 local folderSpecs, folderHeroTalents
                 if container.folderId and profile.folders then
                     local folder = profile.folders[container.folderId]
                     if folder then
-                        folderSpecs = folder.specs
+                        folderSpecs = BuildEligibilityBadgeMap(
+                            folder.specs,
+                            folder.loadConditions and folder.loadConditions.specAllowlist
+                        )
                         folderHeroTalents = folder.heroTalents
                     end
                 end
 
                 local specBadgeIdx = 0
+                local panelSpecs = BuildEligibilityBadgeMap(
+                    panel.specs,
+                    panel.loadConditions and panel.loadConditions.specAllowlist
+                )
 
-                if panel.specs then
-                    for specId in pairs(panel.specs) do
+                if panelSpecs then
+                    for specId in pairs(panelSpecs) do
                         if not (containerSpecs and containerSpecs[specId])
                            and not (folderSpecs and folderSpecs[specId]) then
                             local _, _, _, specIcon = GetSpecializationInfoForSpecID(specId)

--- a/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
+++ b/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
@@ -81,6 +81,9 @@ local function ApplyCol1Drop(state)
                 else
                     container.isGlobal = false
                     container.createdBy = CooldownCompanion.db.keys.char
+                    if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
+                        CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(sourceContainerId)
+                    end
                 end
             end
 
@@ -177,6 +180,9 @@ local function ApplyCol1Drop(state)
                     else
                         c.isGlobal = false
                         c.createdBy = CooldownCompanion.db.keys.char
+                        if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
+                            CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(cid)
+                        end
                     end
                 end
             end
@@ -317,6 +323,9 @@ local function ApplyCol1Drop(state)
                         container.createdBy = CooldownCompanion.db.keys.char
                     end
                 end
+            end
+            if section == "char" and CooldownCompanion.NormalizeFolderEligibilityForCharacterScope then
+                CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(sourceFolderId)
             end
         end
 
@@ -515,7 +524,7 @@ local function FinishCol1FolderAwareDrag(state)
         local sourceContainer = CooldownCompanion.db.profile.groupContainers[state.sourceGroupId]
         if targetSection and targetSection ~= state.sourceSection
            and state.sourceSection == "global"
-           and sourceContainer and sourceContainer.specs
+           and sourceContainer
            and GroupsHaveForeignSpecs({ sourceContainer }, false) then
             ShowPopupAboveConfig("CDC_DRAG_UNGLOBAL_GROUP", sourceContainer.name, {
                 dragState = state,

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -17,11 +17,55 @@ local UNSUPPORTED_COMPACT_FORMATS = {
     compact2 = true,
 }
 
+local LOAD_CONDITION_ALLOWLIST_KEYS = {
+    classAllowlist = "class",
+    specAllowlist = "spec",
+    characterAllowlist = "character",
+}
+
 local function CopyValue(value)
     if type(value) == "table" then
         return CopyTable(value)
     end
     return value
+end
+
+local function NormalizeAllowlistKey(kind, key)
+    if kind == "class" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return string.upper(key)
+    elseif kind == "spec" then
+        return tonumber(key)
+    elseif kind == "character" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return key
+    end
+    return nil
+end
+
+local function CopyAllowlistMap(map, kind)
+    if type(map) ~= "table" then return nil end
+    local copy = {}
+    for key, enabled in pairs(map) do
+        if enabled == true then
+            local normalizedKey = NormalizeAllowlistKey(kind, key)
+            if normalizedKey ~= nil then
+                copy[normalizedKey] = true
+            end
+        end
+    end
+    return next(copy) and copy or nil
+end
+
+local function NormalizeLoadConditionAllowlists(loadConditions)
+    if type(loadConditions) ~= "table" then return loadConditions end
+    local normalized = CopyTable(loadConditions)
+    for key, kind in pairs(LOAD_CONDITION_ALLOWLIST_KEYS or {}) do
+        if normalized[key] ~= nil then
+            normalized[key] = CopyAllowlistMap(normalized[key], kind)
+        end
+    end
+    return normalized
 end
 
 local LOAD_CONDITIONS_DEFAULTS = {
@@ -423,7 +467,8 @@ local function CompactLoadConditions(loadConditions, formatVersion, localScope)
     if type(loadConditions) ~= "table" then
         return nil
     end
-    local compact = CompactTableAgainstDefaults(loadConditions, GetLoadConditionsDefaults(formatVersion, localScope))
+    local normalized = NormalizeLoadConditionAllowlists(loadConditions)
+    local compact = CompactTableAgainstDefaults(normalized, GetLoadConditionsDefaults(formatVersion, localScope))
     if localScope then
         return compact
     end
@@ -439,6 +484,11 @@ local function RehydrateLoadConditions(loadConditions, formatVersion, localScope
         for key, value in pairs(loadConditions) do
             if value == true then
                 localOnly[key] = true
+            elseif LOAD_CONDITION_ALLOWLIST_KEYS[key] then
+                local allowlist = CopyAllowlistMap(value, LOAD_CONDITION_ALLOWLIST_KEYS[key])
+                if allowlist then
+                    localOnly[key] = allowlist
+                end
             end
         end
         return next(localOnly) and localOnly or nil

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -11,6 +11,7 @@ local LibDeflate = LibStub("LibDeflate")
 
 local COMPRESSION_CONFIG = { level = 9 }
 local COMPACT_FORMAT_KEY = "_cdcExportFormat"
+local STRIPPED_CHARACTER_ELIGIBILITY_KEY = "_cdcCharacterEligibilityStripped"
 local CURRENT_COMPACT_FORMAT_VALUE = "compact3"
 local UNSUPPORTED_COMPACT_FORMATS = {
     compact1 = true,
@@ -20,7 +21,6 @@ local UNSUPPORTED_COMPACT_FORMATS = {
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
     classAllowlist = "class",
     specAllowlist = "spec",
-    characterAllowlist = "character",
 }
 
 local function CopyValue(value)
@@ -57,9 +57,94 @@ local function CopyAllowlistMap(map, kind)
     return next(copy) and copy or nil
 end
 
+local function StripCharacterEligibilityFromLoadConditions(loadConditions)
+    if type(loadConditions) ~= "table" then return 0 end
+    if loadConditions.characterAllowlist == nil then return 0 end
+    loadConditions.characterAllowlist = nil
+    return 1
+end
+
+local function StripCharacterEligibilityFromEntity(entity)
+    if type(entity) ~= "table" then return 0 end
+    local stripped = StripCharacterEligibilityFromLoadConditions(entity.loadConditions)
+    if type(entity.buttons) == "table" then
+        for _, button in ipairs(entity.buttons) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(button)
+        end
+    end
+    if type(entity.loadConditions) == "table" and not next(entity.loadConditions) then
+        entity.loadConditions = nil
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromContainerEntry(entry)
+    if type(entry) ~= "table" then return 0 end
+    local stripped = StripCharacterEligibilityFromEntity(entry.container)
+    if type(entry.panels) == "table" then
+        for _, panel in ipairs(entry.panels) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(panel)
+        end
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromProfile(profile)
+    if type(profile) ~= "table" then return 0 end
+    local stripped = 0
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(group)
+        end
+    end
+    if type(profile.groupContainers) == "table" then
+        for _, container in pairs(profile.groupContainers) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(container)
+        end
+    end
+    if type(profile.folders) == "table" then
+        for _, folder in pairs(profile.folders) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(folder)
+        end
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromPayload(payload)
+    if type(payload) ~= "table" then return 0 end
+    local stripped = 0
+    stripped = stripped + StripCharacterEligibilityFromProfile(payload)
+    stripped = stripped + StripCharacterEligibilityFromProfile(payload.profile)
+    stripped = stripped + StripCharacterEligibilityFromEntity(payload.group)
+    stripped = stripped + StripCharacterEligibilityFromEntity(payload.container)
+    stripped = stripped + StripCharacterEligibilityFromEntity(payload.folder)
+    if type(payload.groups) == "table" then
+        for _, group in ipairs(payload.groups) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(group)
+        end
+    end
+    if type(payload.panels) == "table" then
+        for _, panel in ipairs(payload.panels) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(panel)
+        end
+    end
+    if type(payload.containers) == "table" then
+        for _, entry in ipairs(payload.containers) do
+            stripped = stripped + StripCharacterEligibilityFromContainerEntry(entry)
+        end
+    end
+    if type(payload.bars) == "table" then
+        for _, bar in ipairs(payload.bars) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(bar)
+        end
+    end
+    return stripped
+end
+
 local function NormalizeLoadConditionAllowlists(loadConditions)
     if type(loadConditions) ~= "table" then return loadConditions end
     local normalized = CopyTable(loadConditions)
+    normalized.characterAllowlist = nil
     for key, kind in pairs(LOAD_CONDITION_ALLOWLIST_KEYS or {}) do
         if normalized[key] ~= nil then
             normalized[key] = CopyAllowlistMap(normalized[key], kind)
@@ -479,6 +564,7 @@ local function RehydrateLoadConditions(loadConditions, formatVersion, localScope
     if type(loadConditions) ~= "table" then
         return nil
     end
+    loadConditions.characterAllowlist = nil
     if localScope then
         local localOnly = {}
         for key, value in pairs(loadConditions) do
@@ -1126,6 +1212,8 @@ local function EncodeSharedPayload(payload, exportKind)
     local exportData = CopyTable(payload)
     local formatVersion = CURRENT_COMPACT_FORMAT_VALUE
 
+    StripCharacterEligibilityFromPayload(exportData)
+
     if CooldownCompanion.StampExportPayloadCheckpoint then
         CooldownCompanion:StampExportPayloadCheckpoint(exportData, exportKind)
     end
@@ -1181,9 +1269,18 @@ local function DecodeSharedPayload(text)
         data = NormalizeTextureLibraryPayload(data)
     end
 
+    local strippedCharacterEligibility = StripCharacterEligibilityFromPayload(data)
+    if strippedCharacterEligibility > 0 then
+        data[STRIPPED_CHARACTER_ELIGIBILITY_KEY] = strippedCharacterEligibility
+    end
+
     return true, data
 end
 
+ST._StripCharacterEligibilityFromLoadConditions = StripCharacterEligibilityFromLoadConditions
+ST._StripCharacterEligibilityFromEntity = StripCharacterEligibilityFromEntity
+ST._StripCharacterEligibilityFromProfile = StripCharacterEligibilityFromProfile
+ST._StripCharacterEligibilityFromPayload = StripCharacterEligibilityFromPayload
 ST._EncodeSharedPayload = EncodeSharedPayload
 ST._DecodeSharedPayload = DecodeSharedPayload
 ST._PrepareSharedImportText = PrepareSharedImportText

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -141,6 +141,14 @@ local function StripCharacterEligibilityFromPayload(payload)
     return stripped
 end
 
+local function StripAndTagCharacterEligibility(payload)
+    local stripped = StripCharacterEligibilityFromPayload(payload)
+    if stripped > 0 then
+        payload[STRIPPED_CHARACTER_ELIGIBILITY_KEY] = stripped
+    end
+    return stripped
+end
+
 local function NormalizeLoadConditionAllowlists(loadConditions)
     if type(loadConditions) ~= "table" then return loadConditions end
     local normalized = CopyTable(loadConditions)
@@ -1212,7 +1220,7 @@ local function EncodeSharedPayload(payload, exportKind)
     local exportData = CopyTable(payload)
     local formatVersion = CURRENT_COMPACT_FORMAT_VALUE
 
-    StripCharacterEligibilityFromPayload(exportData)
+    StripAndTagCharacterEligibility(exportData)
 
     if CooldownCompanion.StampExportPayloadCheckpoint then
         CooldownCompanion:StampExportPayloadCheckpoint(exportData, exportKind)
@@ -1269,10 +1277,7 @@ local function DecodeSharedPayload(text)
         data = NormalizeTextureLibraryPayload(data)
     end
 
-    local strippedCharacterEligibility = StripCharacterEligibilityFromPayload(data)
-    if strippedCharacterEligibility > 0 then
-        data[STRIPPED_CHARACTER_ELIGIBILITY_KEY] = strippedCharacterEligibility
-    end
+    StripAndTagCharacterEligibility(data)
 
     return true, data
 end

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -89,6 +89,37 @@ local function StripCharacterEligibilityFromContainerEntry(entry)
     return stripped
 end
 
+local function StripCharacterEligibilityFromCustomBarTree(value, seen)
+    if type(value) ~= "table" then return 0 end
+    seen = seen or {}
+    if seen[value] then return 0 end
+    seen[value] = true
+
+    local stripped = StripCharacterEligibilityFromEntity(value)
+    for _, child in pairs(value) do
+        stripped = stripped + StripCharacterEligibilityFromCustomBarTree(child, seen)
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromResourceBarSettings(settings)
+    if type(settings) ~= "table" then return 0 end
+    return StripCharacterEligibilityFromCustomBarTree(settings.customBars)
+        + StripCharacterEligibilityFromCustomBarTree(settings.customAuraBars)
+end
+
+local function StripCharacterEligibilityFromResourceBarStores(profile)
+    if type(profile) ~= "table" then return 0 end
+    local stripped = StripCharacterEligibilityFromResourceBarSettings(profile.resourceBars)
+        + StripCharacterEligibilityFromResourceBarSettings(profile.legacyResourceBarsSeed)
+    if type(profile.resourceBarsByChar) == "table" then
+        for _, settings in pairs(profile.resourceBarsByChar) do
+            stripped = stripped + StripCharacterEligibilityFromResourceBarSettings(settings)
+        end
+    end
+    return stripped
+end
+
 local function StripCharacterEligibilityFromProfile(profile)
     if type(profile) ~= "table" then return 0 end
     local stripped = 0
@@ -107,6 +138,7 @@ local function StripCharacterEligibilityFromProfile(profile)
             stripped = stripped + StripCharacterEligibilityFromEntity(folder)
         end
     end
+    stripped = stripped + StripCharacterEligibilityFromResourceBarStores(profile)
     return stripped
 end
 

--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -268,6 +268,13 @@ local function ReviewUsesSelectedPieces(review)
     return IsProfileReviewKind(review) and review.mode == "selected"
 end
 
+local function AddCharacterEligibilityNotice(lines, data)
+    local stripped = type(data) == "table" and tonumber(data._cdcCharacterEligibilityStripped) or 0
+    if stripped and stripped > 0 then
+        AddLine(lines, "Character eligibility is local and will not be imported.")
+    end
+end
+
 local function RecountSelectedPieces(review)
     if not (review and review.pieces) then
         return 0
@@ -298,6 +305,7 @@ local function BuildSelectedPiecesSummaryLines(review, selectedCount)
     if pieces and pieces.customBarCount and pieces.customBarCount > 0 then
         AddLine(lines, FormatCount("Custom Bars", pieces.customBarCount))
     end
+    AddCharacterEligibilityNotice(lines, review and (review.diagnostic or review.data))
     return lines
 end
 
@@ -353,34 +361,41 @@ local function BuildCustomBarsSummaryLines(data)
         FormatCount("Layout specs", CountPairs(data.layouts)),
     }
     AddLine(lines, data.classFilename and "Class: " .. tostring(data.classFilename))
+    AddCharacterEligibilityNotice(lines, data)
     return lines
 end
 
 local function BuildContainerSummaryLines(data)
-    return {
+    local lines = {
         "Group export",
         "Name: " .. tostring(data.container and data.container.name or "Unnamed"),
         FormatCount("Panels", type(data.panels) == "table" and #data.panels or 0),
     }
+    AddCharacterEligibilityNotice(lines, data)
+    return lines
 end
 
 local function BuildContainersSummaryLines(data)
     local containers = type(data.containers) == "table" and data.containers or {}
-    return {
+    local lines = {
         "Groups export",
         FormatCount("Groups", #containers),
         FormatCount("Panels", CountContainerPanels(containers)),
     }
+    AddCharacterEligibilityNotice(lines, data)
+    return lines
 end
 
 local function BuildFolderSummaryLines(data)
     local containers = type(data.containers) == "table" and data.containers or {}
-    return {
+    local lines = {
         "Folder export",
         "Name: " .. tostring(data.folder and data.folder.name or "Unnamed"),
         FormatCount("Groups", #containers),
         FormatCount("Panels", CountContainerPanels(containers)),
     }
+    AddCharacterEligibilityNotice(lines, data)
+    return lines
 end
 
 local function ValidateProfilePayload(data)
@@ -404,8 +419,11 @@ local function ClassifyProfilePayload(data)
         exporterCharKey = data._exporterCharKey,
     }) or nil
 
+    local lines = BuildProfileSummaryLines(data, "Profile backup export", pieces and pieces.customBarCount)
+    AddCharacterEligibilityNotice(lines, data)
+
     return BuildReview("profile", data, "Profile Backup", "Restore Backup",
-        BuildProfileSummaryLines(data, "Profile backup export", pieces and pieces.customBarCount), {
+        lines, {
         destructive = true,
         mode = DefaultProfileImportMode(pieces),
         pieces = pieces,
@@ -436,6 +454,7 @@ local function ClassifyDiagnosticPayload(data)
     if meta and meta.charName then
         table.insert(lines, 2, "Source: " .. tostring(meta.charName))
     end
+    AddCharacterEligibilityNotice(lines, data)
 
     return BuildReview("diagnostic", data.profile, "Diagnostic Restore",
         "Restore Diagnostic", lines, {

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -449,7 +449,7 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
-    text = "This will remove all spec filters and turn '%s' into a group for your current character. Continue?",
+    text = "This will remove foreign eligibility filters and turn '%s' into a group for your current character. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -475,7 +475,7 @@ StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_GROUP"] = {
-    text = "This will remove foreign spec filters and turn '%s' into a character group. Continue?",
+    text = "This will remove foreign eligibility filters and turn '%s' into a character group. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -520,7 +520,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign spec filters. Moving to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving to character will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -537,7 +537,7 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign spec filters. Moving '%s' to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving '%s' to character will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -595,7 +595,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_SELECTED_GROUPS"] = {
-    text = "Some selected groups have foreign spec filters. Moving to character will remove those filters. Continue?",
+    text = "Some selected groups have foreign eligibility filters. Moving to character will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -1234,6 +1234,8 @@ local function ApplyCustomBarsImportData(data, options)
     if RejectUnsupportedImportPayload(data, "custom bars import") then
         return false
     end
+    local importState = options and options.importState or NewGroupImportState()
+    StripImportCharacterEligibility(data, importState)
 
     local rb = ST._RB
     local settings = CooldownCompanion:GetResourceBarSettings()
@@ -1249,6 +1251,7 @@ local function ApplyCustomBarsImportData(data, options)
     if not (options and options.silentSuccess) then
         CooldownCompanion:Print(message)
     end
+    PrintImportSanitizerNotes(importState)
     CooldownCompanion:ApplyResourceBars()
     CooldownCompanion:UpdateAnchorStacking()
     CooldownCompanion:RefreshConfigPanel()

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -15,6 +15,7 @@ local ClearConfigContainerSelection = ST._ClearConfigContainerSelection
 local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
+local StripCharacterEligibilityFromPayload = ST._StripCharacterEligibilityFromPayload
 
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
     classAllowlist = "class",
@@ -736,6 +737,64 @@ local function BuildContainerExportData(container)
     return data
 end
 
+local function HasTrueMapValue(map)
+    if type(map) ~= "table" then return false end
+    for _, enabled in pairs(map) do
+        if enabled == true then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityHasPortableEligibility(entity)
+    if type(entity) ~= "table" then return false end
+    local loadConditions = entity.loadConditions
+    if type(loadConditions) == "table" then
+        if CopyAllowlistMap(loadConditions.classAllowlist, "class")
+            or CopyAllowlistMap(loadConditions.specAllowlist, "spec")
+        then
+            return true
+        end
+    end
+    return CopyAllowlistMap(entity.specs, "spec") ~= nil
+        or HasTrueMapValue(entity.heroTalents)
+end
+
+local function ContainerEntryHasPortableEligibility(entry)
+    if type(entry) ~= "table" then return false end
+    if EntityHasPortableEligibility(entry.container) then
+        return true
+    end
+    for _, panel in ipairs(entry.panels or {}) do
+        if EntityHasPortableEligibility(panel) then
+            return true
+        end
+    end
+    return false
+end
+
+local function ContainersHavePortableEligibility(entries)
+    if type(entries) ~= "table" then return false end
+    for _, entry in ipairs(entries) do
+        if ContainerEntryHasPortableEligibility(entry) then
+            return true
+        end
+    end
+    return false
+end
+
+local function StripImportCharacterEligibility(data, importState)
+    local stripped = type(data) == "table" and tonumber(data._cdcCharacterEligibilityStripped) or 0
+    stripped = stripped + (StripCharacterEligibilityFromPayload
+        and StripCharacterEligibilityFromPayload(data)
+        or 0)
+    if stripped > 0 and importState then
+        importState.characterEligibilityStripped = (importState.characterEligibilityStripped or 0) + stripped
+    end
+    return stripped
+end
+
 ST._BuildGroupExportData = BuildGroupExportData
 ST._BuildContainerExportData = BuildContainerExportData
 ST._EncodeExportData = EncodeExportData
@@ -824,11 +883,14 @@ local function NewGroupImportState()
         importedGroupIds = {},
         containerCount = 0,
         panelCount = 0,
+        characterEligibilityStripped = 0,
+        globalizedEligibilityImports = 0,
     }
 end
 
-local function ImportContainerEntries(db, entries, charKey, folderId, importState)
+local function ImportContainerEntries(db, entries, charKey, folderId, importState, options)
     importState = importState or NewGroupImportState()
+    options = options or {}
     local firstContainerIndex = #importState.importedContainerIds + 1
     local startContainerCount = importState.containerCount
     local startPanelCount = importState.panelCount
@@ -842,12 +904,17 @@ local function ImportContainerEntries(db, entries, charKey, folderId, importStat
         end
 
         local container = CopyTable(entry.container)
+        local importAsGlobal = options.forceGlobalScope == true
+            or ContainerEntryHasPortableEligibility(entry)
         container.createdBy = charKey
-        container.isGlobal = false
+        container.isGlobal = importAsGlobal
         container.order = containerId
         container.specOrders = nil
         container.folderId = folderId
         container.locked = true
+        if importAsGlobal then
+            importState.globalizedEligibilityImports = (importState.globalizedEligibilityImports or 0) + 1
+        end
         db.groupContainers[containerId] = container
         CooldownCompanion:CreateContainerFrame(containerId)
 
@@ -904,6 +971,18 @@ local function RemapImportedContainerAnchors(db, importState, preserveContainerR
                 end
             end
         end
+    end
+end
+
+local function PrintImportSanitizerNotes(importState)
+    if not (importState and CooldownCompanion and CooldownCompanion.Print) then
+        return
+    end
+    if (importState.characterEligibilityStripped or 0) > 0 then
+        CooldownCompanion:Print("Character eligibility is local and was not imported.")
+    end
+    if (importState.globalizedEligibilityImports or 0) > 0 then
+        CooldownCompanion:Print("Class, specialization, and hero talent eligibility were preserved in Global Groups.")
     end
 end
 
@@ -1001,6 +1080,7 @@ ST._FinishGroupImportBatch = function(token, remapAnchors)
             CooldownCompanion:SanitizeCursorAnchorPolicy(db)
         end
     end
+    PrintImportSanitizerNotes(importState)
 end
 
 ST._AttachGroupImportBatch = function(payload, token)
@@ -1027,7 +1107,9 @@ local function ApplyGroupImportData(data)
     local db = CooldownCompanion.db.profile
     local charKey = CooldownCompanion.db.keys.char
     local sharedImportState = batchToken and activeGroupImportBatches[batchToken] or nil
+    local rootImportState = sharedImportState or NewGroupImportState()
     local deferAnchorRemap = sharedImportState ~= nil
+    StripImportCharacterEligibility(data, rootImportState)
 
     if data.type == "group" and data.group then
         CooldownCompanion:NotifyLegacySupportCutoff("group import")
@@ -1038,7 +1120,7 @@ local function ApplyGroupImportData(data)
         return false
 
     elseif data.type == "containers" and data.containers then
-        local importState, containerCount = ImportContainerEntries(db, data.containers, charKey, nil, sharedImportState)
+        local importState, containerCount = ImportContainerEntries(db, data.containers, charKey, nil, rootImportState)
         if not deferAnchorRemap then
             RemapImportedContainerAnchors(db, importState, true)
             RemapImportedPanelAnchors(db, importState)
@@ -1103,20 +1185,32 @@ local function ApplyGroupImportData(data)
                 importedLoadConditions = nil
             end
         end
+        local folderUsesGlobalEligibility = importedSpecs
+            or importedHeroTalents
+            or (importedLoadConditions and (
+                importedLoadConditions.classAllowlist
+                    or importedLoadConditions.specAllowlist
+            ))
+            or ContainersHavePortableEligibility(data.containers)
         db.folders[folderId] = {
             name = data.folder.name or "Imported Folder",
             order = folderId,
-            section = "char",
+            section = folderUsesGlobalEligibility and "global" or "char",
             createdBy = charKey,
             manualIcon = importedManualIcon,
             specs = importedSpecs,
             heroTalents = importedHeroTalents,
             loadConditions = importedLoadConditions,
         }
+        if folderUsesGlobalEligibility then
+            rootImportState.globalizedEligibilityImports = (rootImportState.globalizedEligibilityImports or 0) + 1
+        end
         local count = 0
         if data.containers then
             local importState, _, panelCount = ImportContainerEntries(
-                db, data.containers, charKey, folderId, sharedImportState
+                db, data.containers, charKey, folderId, rootImportState, {
+                    forceGlobalScope = folderUsesGlobalEligibility and true or false,
+                }
             )
             if not deferAnchorRemap then
                 RemapImportedContainerAnchors(db, importState, true)
@@ -1131,7 +1225,7 @@ local function ApplyGroupImportData(data)
             container = data.container,
             panels = data.panels,
             _originalContainerId = data._originalContainerId,
-        }}, charKey, nil, sharedImportState)
+        }}, charKey, nil, rootImportState)
         local container = db.groupContainers[containerId]
         if not deferAnchorRemap then
             RemapImportedContainerAnchors(db, importState, false)
@@ -1157,6 +1251,9 @@ local function ApplyGroupImportData(data)
 
     CooldownCompanion:RefreshConfigPanel()
     CooldownCompanion:RefreshAllGroups()
+    if not deferAnchorRemap then
+        PrintImportSanitizerNotes(rootImportState)
+    end
     return true
 end
 

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -80,31 +80,6 @@ local function ShowPopupOverConfig(which, textArg1, data)
     return StaticPopup_Show(which, textArg1, nil, data)
 end
 
-local function ClearFolderFiltersForUnglobal(folderId)
-    if not folderId then return end
-
-    local db = CooldownCompanion.db and CooldownCompanion.db.profile
-    if not db then return end
-
-    local folder = db.folders and db.folders[folderId]
-    if folder then
-        folder.specs = nil
-        folder.heroTalents = nil
-        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
-        return
-    end
-
-    -- Fallback: clear specs on child containers (folderId lives on containers post-migration)
-    if db.groupContainers then
-        for _, container in pairs(db.groupContainers) do
-            if container.folderId == folderId and (container.specs or container.heroTalents) then
-                container.specs = nil
-                container.heroTalents = nil
-            end
-        end
-    end
-end
-
 local function PruneDeletedFolderSelection(folderId)
     local db = CooldownCompanion.db and CooldownCompanion.db.profile
     if not db then return end
@@ -482,16 +457,12 @@ StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
         if data.containerId then
             local container = CooldownCompanion.db.profile.groupContainers[data.containerId]
             if container then
-                container.specs = nil
-                container.heroTalents = nil
                 CooldownCompanion:ToggleGroupGlobal(data.containerId)
                 CooldownCompanion:RefreshConfigPanel()
             end
         elseif data.groupId then
             local group = CooldownCompanion.db.profile.groups[data.groupId]
             if group then
-                group.specs = nil
-                group.heroTalents = nil
                 CooldownCompanion:ToggleGroupGlobal(data.groupId)
                 CooldownCompanion:RefreshConfigPanel()
             end
@@ -512,8 +483,6 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_GROUP"] = {
             local db = CooldownCompanion.db.profile
             local container = db.groupContainers[data.dragState.sourceGroupId]
             if container then
-                container.specs = nil
-                container.heroTalents = nil
                 ST._ApplyCol1Drop(data.dragState)
                 CooldownCompanion:RefreshConfigPanel()
             end
@@ -556,8 +525,6 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.dragState then
-            local folderId = data.dragState.sourceFolderId
-            ClearFolderFiltersForUnglobal(folderId)
             ST._ApplyCol1Drop(data.dragState)
             CooldownCompanion:RefreshAllGroups()
             CooldownCompanion:RefreshConfigPanel()
@@ -575,7 +542,6 @@ StaticPopupDialogs["CDC_UNGLOBAL_FOLDER"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.folderId then
-            ClearFolderFiltersForUnglobal(data.folderId)
             CooldownCompanion:ToggleFolderGlobal(data.folderId)
             CooldownCompanion:RefreshConfigPanel()
         end
@@ -634,28 +600,6 @@ StaticPopupDialogs["CDC_UNGLOBAL_SELECTED_GROUPS"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.callback then
-            -- Strip foreign specs from affected containers before executing the operation
-            if data.groupIds then
-                local db = CooldownCompanion.db.profile
-                local numSpecs = GetNumSpecializations()
-                local playerSpecIds = {}
-                for i = 1, numSpecs do
-                    local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-                    if specId then playerSpecIds[specId] = true end
-                end
-                for _, cid in ipairs(data.groupIds) do
-                    local container = db.groupContainers[cid]
-                    if container and container.specs then
-                        for specId in pairs(container.specs) do
-                            if not playerSpecIds[specId] then
-                                container.specs = nil
-                                container.heroTalents = nil
-                                break
-                            end
-                        end
-                    end
-                end
-            end
             data.callback()
         end
     end,

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -16,6 +16,39 @@ local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 
+local LOAD_CONDITION_ALLOWLIST_KEYS = {
+    classAllowlist = "class",
+    specAllowlist = "spec",
+    characterAllowlist = "character",
+}
+
+local function NormalizeAllowlistKey(kind, key)
+    if kind == "class" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return string.upper(key)
+    elseif kind == "spec" then
+        return tonumber(key)
+    elseif kind == "character" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return key
+    end
+    return nil
+end
+
+local function CopyAllowlistMap(map, kind)
+    if type(map) ~= "table" then return nil end
+    local copy = {}
+    for key, enabled in pairs(map) do
+        if enabled == true then
+            local normalizedKey = NormalizeAllowlistKey(kind, key)
+            if normalizedKey ~= nil then
+                copy[normalizedKey] = true
+            end
+        end
+    end
+    return next(copy) and copy or nil
+end
+
 -- Check whether a profile name already exists (case-exact match).
 local function ProfileNameExists(name)
     local profiles = CooldownCompanion.db:GetProfiles()
@@ -1059,6 +1092,11 @@ local function ApplyGroupImportData(data)
             for key, enabled in pairs(data.folder.loadConditions) do
                 if enabled == true then
                     importedLoadConditions[key] = true
+                elseif LOAD_CONDITION_ALLOWLIST_KEYS[key] then
+                    local allowlist = CopyAllowlistMap(enabled, LOAD_CONDITION_ALLOWLIST_KEYS[key])
+                    if allowlist then
+                        importedLoadConditions[key] = allowlist
+                    end
                 end
             end
             if not next(importedLoadConditions) then

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -37,6 +37,118 @@ local function ShouldRemapExporterOwned(createdBy, exporterCharKey)
     return exporterCharKey == nil or createdBy == exporterCharKey
 end
 
+local function HasPortableEligibilityMap(map)
+    if type(map) ~= "table" then
+        return map ~= nil
+    end
+    for _, enabled in pairs(map) do
+        if enabled == true then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityHasPortableEligibility(entity)
+    if type(entity) ~= "table" then return false end
+    if HasPortableEligibilityMap(entity.specs)
+        or HasPortableEligibilityMap(entity.heroTalents)
+    then
+        return true
+    end
+
+    local loadConditions = entity.loadConditions
+    return type(loadConditions) == "table"
+        and (HasPortableEligibilityMap(loadConditions.classAllowlist)
+            or HasPortableEligibilityMap(loadConditions.specAllowlist))
+end
+
+local function ContainerHasPortableEligibility(profile, containerId, container)
+    if EntityHasPortableEligibility(container) then
+        return true
+    end
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table"
+            and group.parentContainerId == containerId
+            and EntityHasPortableEligibility(group)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function FolderHasPortableEligibility(profile, folderId, folder)
+    if EntityHasPortableEligibility(folder) then
+        return true
+    end
+    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+    for containerId, container in pairs(groupContainers) do
+        if type(container) == "table"
+            and container.folderId == folderId
+            and ContainerHasPortableEligibility(profile, containerId, container)
+        then
+            return true
+        end
+    end
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table"
+            and group.folderId == folderId
+            and not group.parentContainerId
+            and EntityHasPortableEligibility(group)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function GlobalizePortableCharacterScopedEligibility(profile)
+    if type(profile) ~= "table" then return 0 end
+
+    local globalized = 0
+    local globalFolders = {}
+    local folders = type(profile.folders) == "table" and profile.folders or {}
+    for folderId, folder in pairs(folders) do
+        if type(folder) == "table"
+            and folder.section == "char"
+            and FolderHasPortableEligibility(profile, folderId, folder)
+        then
+            folder.section = "global"
+            globalFolders[folderId] = true
+            globalized = globalized + 1
+        end
+    end
+
+    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+    for containerId, container in pairs(groupContainers) do
+        if type(container) == "table"
+            and container.isGlobal ~= true
+            and (globalFolders[container.folderId]
+                or ContainerHasPortableEligibility(profile, containerId, container))
+        then
+            container.isGlobal = true
+            globalized = globalized + 1
+        end
+    end
+
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table"
+            and not group.parentContainerId
+            and group.isGlobal ~= true
+            and (globalFolders[group.folderId] or EntityHasPortableEligibility(group))
+        then
+            group.isGlobal = true
+            globalized = globalized + 1
+        end
+    end
+
+    return globalized
+end
+
 local function RemapCurrentCharacterEntities(profile, charKey, exporterCharKey)
     if type(profile) ~= "table" or type(charKey) ~= "string" or charKey == "" then
         return
@@ -366,6 +478,7 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
         local importerCharInfo = db.global and db.global.characterInfo or {}
         RenameForeignCharacters(db.profile, charKey, exportedCharInfo, importerCharInfo)
     end
+    local globalizedEligibilityImports = GlobalizePortableCharacterScopedEligibility(db.profile)
 
     if self.ClearMigrationSentinels then
         self:ClearMigrationSentinels()
@@ -388,6 +501,9 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     end
     if strippedCharacterEligibility > 0 and self.Print then
         self:Print("Character eligibility is local and was not imported.")
+    end
+    if globalizedEligibilityImports > 0 and self.Print then
+        self:Print("Class, specialization, and hero talent eligibility were preserved in Global Groups.")
     end
 
     return true

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -7,10 +7,12 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
 local ResetConfigSelection = ST._ResetConfigSelection
+local StripCharacterEligibilityFromProfile = ST._StripCharacterEligibilityFromProfile
 
 local PROFILE_IMPORT_METADATA_KEYS = {
     _exporterCharKey = true,
     _characterInfo = true,
+    _cdcCharacterEligibilityStripped = true,
 }
 
 local SCOPED_STORE_KEYS = {
@@ -341,7 +343,11 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
         exportedCharInfo = data._characterInfo
     end
 
+    local strippedCharacterEligibility = tonumber(data._cdcCharacterEligibilityStripped) or 0
     CopyProfileDataIntoActiveProfile(db.profile, data)
+    strippedCharacterEligibility = strippedCharacterEligibility + (StripCharacterEligibilityFromProfile
+        and StripCharacterEligibilityFromProfile(db.profile)
+        or 0)
 
     if ResetConfigSelection then
         ResetConfigSelection(true)
@@ -379,6 +385,9 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     end
     if self.EvaluateBarsAndFramesRuntime then
         self:EvaluateBarsAndFramesRuntime(options.runtimeReason or "profile-import")
+    end
+    if strippedCharacterEligibility > 0 and self.Print then
+        self:Print("Character eligibility is local and was not imported.")
     end
 
     return true

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -162,6 +162,21 @@ local function MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, create
     end
 end
 
+local function MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, entity)
+    local allowlist = type(entity) == "table"
+        and type(entity.loadConditions) == "table"
+        and entity.loadConditions.characterAllowlist
+        or nil
+    if type(allowlist) ~= "table" then
+        return
+    end
+    for allowlistKey, enabled in pairs(allowlist) do
+        if enabled == true then
+            MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, allowlistKey)
+        end
+    end
+end
+
 local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
     local foreignKeys = {}
     if type(profile.groups) == "table" then
@@ -169,6 +184,7 @@ local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
             if type(group) == "table" and not group.isGlobal then
                 MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, group.createdBy)
             end
+            MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, group)
         end
     end
     if type(profile.groupContainers) == "table" then
@@ -176,6 +192,7 @@ local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
             if type(container) == "table" and not container.isGlobal then
                 MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, container.createdBy)
             end
+            MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, container)
         end
     end
     if type(profile.folders) == "table" then
@@ -183,6 +200,7 @@ local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
             if type(folder) == "table" and folder.section == "char" then
                 MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, folder.createdBy)
             end
+            MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, folder)
         end
     end
     return foreignKeys
@@ -227,11 +245,31 @@ local function BuildForeignCharacterRenames(foreignKeys, exportedCharInfo, impor
 end
 
 local function ApplyCharacterRenames(profile, renames)
+    local function RenameAllowlist(entity)
+        local allowlist = type(entity) == "table"
+            and type(entity.loadConditions) == "table"
+            and entity.loadConditions.characterAllowlist
+            or nil
+        if type(allowlist) ~= "table" then
+            return
+        end
+        for oldKey, newKey in pairs(renames or {}) do
+            if allowlist[oldKey] == true then
+                allowlist[newKey] = true
+                allowlist[oldKey] = nil
+            end
+        end
+        if not next(allowlist) then
+            entity.loadConditions.characterAllowlist = nil
+        end
+    end
+
     if type(profile.groups) == "table" then
         for _, group in pairs(profile.groups) do
             if type(group) == "table" and group.createdBy and renames[group.createdBy] then
                 group.createdBy = renames[group.createdBy]
             end
+            RenameAllowlist(group)
         end
     end
     if type(profile.groupContainers) == "table" then
@@ -239,6 +277,7 @@ local function ApplyCharacterRenames(profile, renames)
             if type(container) == "table" and container.createdBy and renames[container.createdBy] then
                 container.createdBy = renames[container.createdBy]
             end
+            RenameAllowlist(container)
         end
     end
     if type(profile.folders) == "table" then
@@ -246,6 +285,7 @@ local function ApplyCharacterRenames(profile, renames)
             if type(folder) == "table" and folder.createdBy and renames[folder.createdBy] then
                 folder.createdBy = renames[folder.createdBy]
             end
+            RenameAllowlist(folder)
         end
     end
 end
@@ -309,6 +349,11 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
 
     local charKey = db.keys and db.keys.char
     RemapCurrentCharacterEntities(db.profile, charKey, exporterCharKey)
+    if type(exporterCharKey) == "string" and exporterCharKey ~= ""
+        and type(charKey) == "string" and charKey ~= ""
+    then
+        ApplyCharacterRenames(db.profile, { [exporterCharKey] = charKey })
+    end
     RemapCharacterScopedStores(db.profile, charKey, exporterCharKey)
 
     if options.renameForeignCharacters then

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -1972,7 +1972,10 @@ local function SetupFolderRowIndicators(entry, folder)
 
     local badgeIndex = 0
     local SPEC_BADGE_SIZE = 16
-    local specs = folder and folder.specs
+    local specs = folder and BuildEligibilityBadgeMap(
+        folder.specs,
+        folder.loadConditions and folder.loadConditions.specAllowlist
+    )
     if specs and next(specs) then
         for specId in pairs(specs) do
             local _, _, _, specIcon = GetSpecializationInfoForSpecID(specId)

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -2903,24 +2903,53 @@ end
 local function SpecSetHasForeignSpecs(specs, playerSpecIds)
     if not specs then return false end
     for specId in pairs(specs) do
-        if not playerSpecIds[specId] then
+        local normalizedSpecId = tonumber(specId)
+        if normalizedSpecId and not playerSpecIds[normalizedSpecId] then
             return true
         end
     end
     return false
 end
 
-local function GetEffectiveContainerSpecFilter(container, db)
-    if not container then return nil end
-    return container.specs
+local function BuildPlayerClassKey()
+    if not UnitClass then return nil end
+    local _, classFilename = UnitClass("player")
+    return type(classFilename) == "string" and string.upper(classFilename) or nil
+end
+
+local function ClassAllowlistHasForeignClasses(classAllowlist, playerClassKey)
+    if type(classAllowlist) ~= "table" or not playerClassKey then return false end
+    for classKey, enabled in pairs(classAllowlist) do
+        if enabled == true
+            and type(classKey) == "string"
+            and string.upper(classKey) ~= playerClassKey
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey)
+    if type(entity) ~= "table" then return false end
+    local loadConditions = entity.loadConditions
+    return SpecSetHasForeignSpecs(entity.specs, playerSpecIds)
+        or SpecSetHasForeignSpecs(
+            type(loadConditions) == "table" and loadConditions.specAllowlist or nil,
+            playerSpecIds
+        )
+        or ClassAllowlistHasForeignClasses(
+            type(loadConditions) == "table" and loadConditions.classAllowlist or nil,
+            playerClassKey
+        )
 end
 
 local function ContainersHaveForeignSpecs(containers, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
+    local playerClassKey = BuildPlayerClassKey()
     for _, c in ipairs(containers) do
         if not requireGlobal or c.isGlobal then
-            local effectiveSpecs = GetEffectiveContainerSpecFilter(c)
-            if SpecSetHasForeignSpecs(effectiveSpecs, playerSpecIds) then
+            if EntityHasForeignEligibility(c, playerSpecIds, playerClassKey) then
                 return true
             end
         end
@@ -2930,9 +2959,10 @@ end
 
 local function GroupsHaveForeignSpecs(groups, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
+    local playerClassKey = BuildPlayerClassKey()
     for _, g in ipairs(groups) do
         if not requireGlobal or g.isGlobal then
-            if SpecSetHasForeignSpecs(g.specs, playerSpecIds) then
+            if EntityHasForeignEligibility(g, playerSpecIds, playerClassKey) then
                 return true
             end
         end
@@ -2948,12 +2978,16 @@ local function FolderHasForeignSpecs(folderId)
     if not folder then return false end
 
     local playerSpecIds = BuildPlayerSpecSet()
+    local playerClassKey = BuildPlayerClassKey()
+    if EntityHasForeignEligibility(folder, playerSpecIds, playerClassKey) then
+        return true
+    end
     -- Post-migration: specs live on containers, not folders
     local containers = db.groupContainers
     if containers then
         for _, container in pairs(containers) do
             if container.folderId == folderId then
-                if SpecSetHasForeignSpecs(container.specs, playerSpecIds) then
+                if EntityHasForeignEligibility(container, playerSpecIds, playerClassKey) then
                     return true
                 end
             end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -1829,6 +1829,23 @@ local function AcquireBadge(frame, index)
     return badge
 end
 
+local function BuildEligibilityBadgeMap(...)
+    local badgeMap
+    for i = 1, select("#", ...) do
+        local source = select(i, ...)
+        if type(source) == "table" then
+            for key, enabled in pairs(source) do
+                local numericKey = tonumber(key)
+                if enabled == true and numericKey then
+                    badgeMap = badgeMap or {}
+                    badgeMap[numericKey] = true
+                end
+            end
+        end
+    end
+    return badgeMap
+end
+
 local function SetupGroupRowIndicators(entry, group)
     local frame = entry.frame
     if frame._cdcBadges then
@@ -1875,14 +1892,20 @@ local function SetupGroupRowIndicators(entry, group)
             and CooldownCompanion.db.profile.folders
         local folder = folders and folders[folderId]
         if folder then
-            folderSpecs = folder.specs
+            folderSpecs = BuildEligibilityBadgeMap(
+                folder.specs,
+                folder.loadConditions and folder.loadConditions.specAllowlist
+            )
             folderHeroTalents = folder.heroTalents
         end
     end
 
     -- Spec filter badges: show own specs, skip any that exist at folder level
     local SPEC_BADGE_SIZE = 16
-    local specs = group.specs
+    local specs = BuildEligibilityBadgeMap(
+        group.specs,
+        group.loadConditions and group.loadConditions.specAllowlist
+    )
     if specs then
         for specId in pairs(specs) do
             if not (folderSpecs and folderSpecs[specId]) then
@@ -2911,10 +2934,56 @@ local function SpecSetHasForeignSpecs(specs, playerSpecIds)
     return false
 end
 
+local function BuildPlayerHeroTalentSet(playerSpecIds)
+    local playerHeroTalentIds = {}
+    if not (C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
+        return playerHeroTalentIds, false
+    end
+    for specId in pairs(playerSpecIds or {}) do
+        local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+        for _, subTreeID in ipairs(subTreeIDs or {}) do
+            local normalizedSubTreeID = tonumber(subTreeID)
+            if normalizedSubTreeID then
+                playerHeroTalentIds[normalizedSubTreeID] = true
+            end
+        end
+    end
+    return playerHeroTalentIds, true
+end
+
+local function HasEnabledMapValue(map)
+    if type(map) ~= "table" then return false end
+    for _, enabled in pairs(map) do
+        if enabled == true then return true end
+    end
+    return false
+end
+
+local function HeroTalentSetHasForeignHeroTalents(heroTalents, playerHeroTalentIds, hasHeroTalentData)
+    if type(heroTalents) ~= "table" then return false end
+    if not hasHeroTalentData then
+        return HasEnabledMapValue(heroTalents)
+    end
+    for subTreeID, enabled in pairs(heroTalents) do
+        local normalizedSubTreeID = tonumber(subTreeID)
+        if enabled == true and (not normalizedSubTreeID or not playerHeroTalentIds[normalizedSubTreeID]) then
+            return true
+        end
+    end
+    return false
+end
+
 local function BuildPlayerClassKey()
     if not UnitClass then return nil end
     local _, classFilename = UnitClass("player")
     return type(classFilename) == "string" and string.upper(classFilename) or nil
+end
+
+local function BuildPlayerCharacterKey()
+    return CooldownCompanion.db
+        and CooldownCompanion.db.keys
+        and CooldownCompanion.db.keys.char
+        or nil
 end
 
 local function ClassAllowlistHasForeignClasses(classAllowlist, playerClassKey)
@@ -2930,10 +2999,50 @@ local function ClassAllowlistHasForeignClasses(classAllowlist, playerClassKey)
     return false
 end
 
-local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey)
+local function CharacterInfoClassKey(charKey)
+    local info = charKey
+        and CooldownCompanion.db
+        and CooldownCompanion.db.global
+        and CooldownCompanion.db.global.characterInfo
+        and CooldownCompanion.db.global.characterInfo[charKey]
+        or nil
+    if type(info) ~= "table" then return nil end
+    if type(info.classFilename) == "string" and info.classFilename ~= "" then
+        return string.upper(info.classFilename)
+    end
+    local classID = tonumber(info.classID)
+    if classID and GetClassInfo then
+        local _, classFilename = GetClassInfo(classID)
+        if type(classFilename) == "string" and classFilename ~= "" then
+            return string.upper(classFilename)
+        end
+    end
+    return nil
+end
+
+local function CharacterAllowlistHasForeignClasses(characterAllowlist, playerClassKey, playerCharKey)
+    if type(characterAllowlist) ~= "table" or not playerClassKey then return false end
+    for charKey, enabled in pairs(characterAllowlist) do
+        if enabled == true then
+            if type(charKey) ~= "string" or charKey == "" then
+                return true
+            end
+            if not (playerCharKey and charKey == playerCharKey) then
+                local characterClassKey = CharacterInfoClassKey(charKey)
+                if characterClassKey ~= playerClassKey then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
     if type(entity) ~= "table" then return false end
     local loadConditions = entity.loadConditions
     return SpecSetHasForeignSpecs(entity.specs, playerSpecIds)
+        or HeroTalentSetHasForeignHeroTalents(entity.heroTalents, playerHeroTalentIds, hasHeroTalentData)
         or SpecSetHasForeignSpecs(
             type(loadConditions) == "table" and loadConditions.specAllowlist or nil,
             playerSpecIds
@@ -2942,14 +3051,54 @@ local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey
             type(loadConditions) == "table" and loadConditions.classAllowlist or nil,
             playerClassKey
         )
+        or CharacterAllowlistHasForeignClasses(
+            type(loadConditions) == "table" and loadConditions.characterAllowlist or nil,
+            playerClassKey,
+            playerCharKey
+        )
+end
+
+local function FindContainerId(db, container)
+    if not (db and db.groupContainers and type(container) == "table") then return nil end
+    for containerId, candidate in pairs(db.groupContainers) do
+        if candidate == container then
+            return containerId
+        end
+    end
+    return nil
+end
+
+local function ContainerPanelsHaveForeignEligibility(containerId, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not (db and db.groups and containerId) then return false end
+    for _, group in pairs(db.groups) do
+        if type(group) == "table"
+            and group.parentContainerId == containerId
+            and EntityHasForeignEligibility(group, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityOrChildPanelsHaveForeignEligibility(entity, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
+    if EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
+        return true
+    end
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    local containerId = FindContainerId(db, entity)
+    return ContainerPanelsHaveForeignEligibility(containerId, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
 end
 
 local function ContainersHaveForeignSpecs(containers, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
     local playerClassKey = BuildPlayerClassKey()
+    local playerCharKey = BuildPlayerCharacterKey()
+    local playerHeroTalentIds, hasHeroTalentData = BuildPlayerHeroTalentSet(playerSpecIds)
     for _, c in ipairs(containers) do
         if not requireGlobal or c.isGlobal then
-            if EntityHasForeignEligibility(c, playerSpecIds, playerClassKey) then
+            if EntityOrChildPanelsHaveForeignEligibility(c, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
                 return true
             end
         end
@@ -2960,9 +3109,11 @@ end
 local function GroupsHaveForeignSpecs(groups, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
     local playerClassKey = BuildPlayerClassKey()
+    local playerCharKey = BuildPlayerCharacterKey()
+    local playerHeroTalentIds, hasHeroTalentData = BuildPlayerHeroTalentSet(playerSpecIds)
     for _, g in ipairs(groups) do
         if not requireGlobal or g.isGlobal then
-            if EntityHasForeignEligibility(g, playerSpecIds, playerClassKey) then
+            if EntityOrChildPanelsHaveForeignEligibility(g, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
                 return true
             end
         end
@@ -2979,7 +3130,9 @@ local function FolderHasForeignSpecs(folderId)
 
     local playerSpecIds = BuildPlayerSpecSet()
     local playerClassKey = BuildPlayerClassKey()
-    if EntityHasForeignEligibility(folder, playerSpecIds, playerClassKey) then
+    local playerCharKey = BuildPlayerCharacterKey()
+    local playerHeroTalentIds, hasHeroTalentData = BuildPlayerHeroTalentSet(playerSpecIds)
+    if EntityHasForeignEligibility(folder, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
         return true
     end
     -- Post-migration: specs live on containers, not folders
@@ -2987,7 +3140,7 @@ local function FolderHasForeignSpecs(folderId)
     if containers then
         for _, container in pairs(containers) do
             if container.folderId == folderId then
-                if EntityHasForeignEligibility(container, playerSpecIds, playerClassKey) then
+                if EntityOrChildPanelsHaveForeignEligibility(container, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
                     return true
                 end
             end
@@ -3055,6 +3208,7 @@ ST._ApplyConfigRowIcon = ApplyConfigRowIcon
 ST._ApplyConfigTextRow = ApplyConfigTextRow
 ST._RefreshVisibleConfigCompactRows = RefreshVisibleConfigCompactRows
 ST._AcquireBadge = AcquireBadge
+ST._BuildEligibilityBadgeMap = BuildEligibilityBadgeMap
 ST._SetupGroupRowIndicators = SetupGroupRowIndicators
 ST._SetupFolderRowIndicators = SetupFolderRowIndicators
 ST._GetConfigRowBadgeReserve = GetConfigRowBadgeReserve

--- a/CooldownCompanion_Config/Config/TalentPicker.lua
+++ b/CooldownCompanion_Config/Config/TalentPicker.lua
@@ -547,8 +547,10 @@ local function EnsurePickerViewConfig(specID)
 end
 
 local function BuildSpecDropdownOptions(group)
-    local effectiveSpecs = group and CooldownCompanion:GetEffectiveSpecs(group) or nil
-    local hasSpecFilter = effectiveSpecs and next(effectiveSpecs) ~= nil
+    local effectiveSpecs, _, hasSpecFilter
+    if group then
+        effectiveSpecs, _, hasSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
+    end
     local values = {}
     local order = {}
 
@@ -568,8 +570,10 @@ local function BuildHeroDropdownOptions(configID, specID, group)
         return {}, {}, nil
     end
 
-    local effectiveHeroTalents = group and CooldownCompanion:GetEffectiveHeroTalents(group) or nil
-    local hasHeroFilter = effectiveHeroTalents and next(effectiveHeroTalents) ~= nil
+    local effectiveHeroTalents, _, hasHeroFilter
+    if group then
+        effectiveHeroTalents, _, hasHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
+    end
     local values = {}
     local order = {}
     local preferredSubTreeID = nil

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -574,6 +574,66 @@ local function AttachEligibilityTooltip(widget, title, text)
     end)
 end
 
+local function AddDropdownInfoButton(dropdown, tooltipLines)
+    if not (dropdown and dropdown.frame and dropdown.label and tooltipLines) then return end
+    CreateInfoButton(dropdown.frame, dropdown.label, "LEFT", "RIGHT", 4, 0, tooltipLines, dropdown)
+end
+
+local function GetEligibilitySubjectLabel(opts)
+    return opts and opts.eligibilitySubjectLabel or "selection"
+end
+
+local function GetEligibilitySubjectPluralLabel(opts)
+    return opts and opts.eligibilitySubjectPluralLabel
+        or ((GetEligibilitySubjectLabel(opts)) .. "s")
+end
+
+local function BuildCharacterEligibilityTooltip(subjectLabel)
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    return {
+        "Character Eligibility",
+        {"Choose which characters can use this " .. subjectLabel .. ".", 1, 1, 1, true},
+        " ",
+        {"Leave empty for no character limit.", 1, 1, 1, true},
+        " ",
+        {"Class-scoped " .. subjectPluralLabel .. " only show same-class characters.", 1, 1, 1, true},
+    }
+end
+
+local function BuildClassEligibilityTooltip(subjectLabel)
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    return {
+        "Class Eligibility",
+        {"Global " .. subjectPluralLabel .. " can be limited to selected classes.", 1, 1, 1, true},
+        " ",
+        {"Leave empty to allow all classes.", 1, 1, 1, true},
+        " ",
+        {"Pick a class first to add its specializations.", 1, 1, 1, true},
+    }
+end
+
+local function BuildSpecializationEligibilityTooltip(subjectLabel)
+    return {
+        "Specialization Eligibility",
+        {"Limit this " .. subjectLabel .. " to selected specializations.", 1, 1, 1, true},
+        " ",
+        {"Specializations come from eligible classes.", 1, 1, 1, true},
+        " ",
+        {"Leave empty to allow all specs for those classes.", 1, 1, 1, true},
+    }
+end
+
+local function BuildHeroTalentEligibilityTooltip(subjectLabel)
+    return {
+        "Hero Talent Eligibility",
+        {"Limit this " .. subjectLabel .. " to specific hero talent trees.", 1, 1, 1, true},
+        " ",
+        {"Hero talents come from selected specializations.", 1, 1, 1, true},
+        " ",
+        {"Leave empty to allow any hero talent for that spec.", 1, 1, 1, true},
+    }
+end
+
 local function ResolveOwnerClassChoice(opts)
     if opts.ownerClassChoice then
         return opts.ownerClassChoice
@@ -777,6 +837,7 @@ end
 local function AddCharacterEligibilityControls(container, opts)
     local target = opts.target
     if type(target) ~= "table" then return end
+    local subjectLabel = GetEligibilitySubjectLabel(opts)
 
     local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "characterAllowlist", "character")
     local scopeClassChoice
@@ -847,6 +908,7 @@ local function AddCharacterEligibilityControls(container, opts)
     picker:SetLabel("Add Character")
     picker:SetFullWidth(true)
     picker:SetList(dropdownValues, dropdownOrder)
+    AddDropdownInfoButton(picker, BuildCharacterEligibilityTooltip(subjectLabel))
     if #dropdownOrder == 0 then
         picker:SetDisabled(true)
     else
@@ -862,11 +924,6 @@ local function AddCharacterEligibilityControls(container, opts)
     SortChoices(selected)
 
     if #selected == 0 then
-        local unrestrictedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
-        unrestrictedLabel:SetText("|cff888888No local character restriction.|r")
-        unrestrictedLabel:SetFullWidth(true)
-        container:AddChild(unrestrictedLabel)
         return
     end
 
@@ -1082,17 +1139,59 @@ end
 
 local function FormatEligibilitySpecLabel(specInfo, includeClass)
     if not specInfo then return "" end
+    local classKey = specInfo.classKey
+    if not classKey then
+        local classChoice = GetSpecClassChoice(specInfo.id)
+        classKey = classChoice and classChoice.key or nil
+    end
+    local specLabel = WrapClassColoredText(specInfo.name or specInfo.label or tostring(specInfo.id), classKey)
     if includeClass and specInfo.classLabel then
         local classChoice = GetClassChoiceByFilename(specInfo.classKey)
         local classLabel = GetClassDisplayLabel(classChoice) or specInfo.classLabel
-        return classLabel .. ": " .. (specInfo.name or specInfo.label or tostring(specInfo.id))
+        return classLabel .. ": " .. specLabel
     end
-    return specInfo.name or specInfo.label or tostring(specInfo.id)
+    return specLabel
+end
+
+local function FormatSpecIconPrefix(specInfo)
+    local icon = specInfo and specInfo.icon
+    if not icon then return "" end
+    return ("|T%s:14:14:0:0:64:64:5:59:5:59|t "):format(tostring(icon))
+end
+
+local function FormatSpecDropdownLabel(specInfo)
+    local label = specInfo and specInfo.label or ""
+    if specInfo and specInfo.classKey then
+        label = WrapClassColoredText(label, specInfo.classKey)
+    end
+    return FormatSpecIconPrefix(specInfo) .. label
+end
+
+local function FormatEligibilitySpecRowLabel(specInfo, includeClass)
+    return FormatSpecIconPrefix(specInfo) .. FormatEligibilitySpecLabel(specInfo, includeClass)
+end
+
+local function FormatHeroTalentIconPrefix(heroInfo)
+    local atlas = heroInfo and heroInfo.iconAtlas
+    if not atlas then return "" end
+    return ("|A:%s:14:14|a "):format(tostring(atlas))
+end
+
+local function FormatEligibilityHeroName(heroInfo)
+    return FormatHeroTalentIconPrefix(heroInfo) .. (heroInfo and (heroInfo.label or tostring(heroInfo.id)) or "")
 end
 
 local function FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
     local specLabel = FormatEligibilitySpecLabel(specInfo, includeClass)
-    return specLabel .. " - " .. (heroInfo.label or tostring(heroInfo.id))
+    return specLabel .. " - " .. FormatEligibilityHeroName(heroInfo)
+end
+
+local function FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, includeClass)
+    return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
+end
+
+local function FormatEligibilityHeroRowLabel(heroInfo, specInfo, includeClass)
+    return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
 end
 
 local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
@@ -1123,6 +1222,7 @@ local function AddClassSpecEligibilityControls(container, opts)
     opts = opts or {}
     local target = opts.target
     if type(target) ~= "table" then return end
+    local subjectLabel = GetEligibilitySubjectLabel(opts)
 
     local allowClassEligibility = opts.allowClassEligibility == true
     local scopeClassChoice
@@ -1165,6 +1265,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         classPicker:SetLabel("Add Class")
         classPicker:SetFullWidth(true)
         classPicker:SetList(classValues, classOrder)
+        AddDropdownInfoButton(classPicker, BuildClassEligibilityTooltip(subjectLabel))
         if #classOrder == 0 then
             classPicker:SetDisabled(true)
         else
@@ -1200,7 +1301,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         local localSelected = type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true
         local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
         if specId and not localSelected and not outsideAllowed then
-            specValues[specId] = specInfo.label
+            specValues[specId] = FormatSpecDropdownLabel(specInfo)
             specSortLabels[specId] = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId))
             specOrder[#specOrder + 1] = specId
         end
@@ -1209,17 +1310,12 @@ local function AddClassSpecEligibilityControls(container, opts)
         return tostring(specSortLabels[a] or a) < tostring(specSortLabels[b] or b)
     end)
 
-    if #specChoices == 0 then
-        local emptyLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(emptyLabel)
-        emptyLabel:SetText(allowClassEligibility and "|cff888888Select a class to choose specialization eligibility.|r" or "|cff888888No specializations available for this scope.|r")
-        emptyLabel:SetFullWidth(true)
-        container:AddChild(emptyLabel)
-    else
+    if #specChoices > 0 then
         local specPicker = AceGUI:Create("Dropdown")
         specPicker:SetLabel("Add Specialization")
         specPicker:SetFullWidth(true)
         specPicker:SetList(specValues, specOrder)
+        AddDropdownInfoButton(specPicker, BuildSpecializationEligibilityTooltip(subjectLabel))
         if #specOrder == 0 then
             specPicker:SetDisabled(true)
         else
@@ -1246,7 +1342,7 @@ local function AddClassSpecEligibilityControls(container, opts)
             local selected = type(heroTalentsSource) == "table" and heroTalentsSource[heroInfo.id] == true
             if not selected then
                 local specInfo = specById[heroInfo.specId]
-                heroValues[heroInfo.id] = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility)
+                heroValues[heroInfo.id] = FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, allowClassEligibility)
                 heroSortLabels[heroInfo.id] = (heroInfo.classLabel or "") .. (heroInfo.specLabel or "") .. (heroInfo.label or "")
                 heroOrder[#heroOrder + 1] = heroInfo.id
             end
@@ -1261,6 +1357,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         heroPicker:SetLabel("Add Hero Talent")
         heroPicker:SetFullWidth(true)
         heroPicker:SetList(heroValues, heroOrder)
+        AddDropdownInfoButton(heroPicker, BuildHeroTalentEligibilityTooltip(subjectLabel))
         if #heroOrder == 0 then
             heroPicker:SetDisabled(true)
         else
@@ -1330,7 +1427,7 @@ local function AddClassSpecEligibilityControls(container, opts)
                 end)
                 for _, heroInfo in ipairs(heroRows) do
                     rows[#rows + 1] = {
-                        label = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility),
+                        label = FormatEligibilityHeroRowLabel(heroInfo, specInfo, allowClassEligibility),
                         sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
                         disabled = opts.disableHeroTalents == true,
                         onRemove = function()
@@ -1342,7 +1439,7 @@ local function AddClassSpecEligibilityControls(container, opts)
             else
                 local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
                 rows[#rows + 1] = {
-                    label = FormatEligibilitySpecLabel(specInfo, allowClassEligibility)
+                    label = FormatEligibilitySpecRowLabel(specInfo, allowClassEligibility)
                         .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or ""),
                     sortLabel = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId)),
                     onRemove = function()
@@ -1361,13 +1458,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         return tostring(a.sortLabel or a.label) < tostring(b.sortLabel or b.label)
     end)
 
-    if #rows == 0 then
-        local unrestrictedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
-        unrestrictedLabel:SetText(allowClassEligibility and "|cff888888No local class or specialization restriction.|r" or "|cff888888No local specialization restriction.|r")
-        unrestrictedLabel:SetFullWidth(true)
-        container:AddChild(unrestrictedLabel)
-    else
+    if #rows > 0 then
         for _, row in ipairs(rows) do
             AddEligibilitySelectedRow(container, row, row.onRemove)
         end
@@ -2812,6 +2903,7 @@ local function BuildLoadConditionsTab(container)
     AddCharacterEligibilityControls(container, {
         target = group,
         inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "panel",
         allowClassEligibility = scopeIsGlobal,
         ownerCharKey = ownerCharKey,
         characterCollapsedKey = "loadconditions_panel_character",
@@ -2845,6 +2937,7 @@ local function BuildLoadConditionsTab(container)
         AddClassSpecEligibilityControls(container, {
             target = group,
             inheritedSources = inheritedSources,
+            eligibilitySubjectLabel = "panel",
             allowClassEligibility = scopeIsGlobal,
             ownerCharKey = ownerCharKey,
             useSpecAllowlist = inheritedSpecFilter,

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -475,7 +475,18 @@ local function GetClassChoiceByFilename(classFilename)
 end
 
 local function GetCurrentClassChoice()
-    local className, classFilename, classID = UnitClass("player")
+    local classFilename = CooldownCompanion._playerClassFilename
+    local classID = CooldownCompanion._playerClassID
+    local className
+    if classID and GetClassInfo then
+        className = GetClassInfo(classID)
+    end
+    if (not classFilename or not className) and UnitClass then
+        local unitClassName, unitClassFilename, unitClassID = UnitClass("player")
+        className = className or unitClassName
+        classFilename = classFilename or unitClassFilename
+        classID = classID or unitClassID
+    end
     local classKey = NormalizeAllowlistKey("class", classFilename)
     if not classKey then return nil end
     return {
@@ -518,13 +529,16 @@ local function SplitCharacterKey(charKey)
     return charKey, nil
 end
 
-local function GetCharacterEligibilityInfo(charKey)
+local function GetCharacterEligibilityInfo(charKey, fallbackInfo)
     local db = CooldownCompanion.db
     local info = charKey
         and db and db.global and db.global.characterInfo
         and db.global.characterInfo[charKey]
     if type(info) == "table" then
         return info
+    end
+    if type(fallbackInfo) == "table" and fallbackInfo.charKey == charKey then
+        return fallbackInfo
     end
 
     local characters = CooldownCompanion.EnumerateActiveProfileCharacters
@@ -538,8 +552,8 @@ local function GetCharacterEligibilityInfo(charKey)
     return nil
 end
 
-local function BuildCharacterChoice(charKey)
-    local info = GetCharacterEligibilityInfo(charKey)
+local function BuildCharacterChoice(charKey, fallbackInfo)
+    local info = GetCharacterEligibilityInfo(charKey, fallbackInfo)
     local name, realm = SplitCharacterKey(charKey)
     local classFilename = info and NormalizeAllowlistKey("class", info.classFilename)
     local label = WrapClassColoredText(name, classFilename)
@@ -583,13 +597,12 @@ local function GetEligibilitySubjectLabel(opts)
     return opts and opts.eligibilitySubjectLabel or "selection"
 end
 
-local function GetEligibilitySubjectPluralLabel(opts)
-    return opts and opts.eligibilitySubjectPluralLabel
-        or ((GetEligibilitySubjectLabel(opts)) .. "s")
+local function GetEligibilitySubjectPluralLabel(subjectLabel)
+    return (subjectLabel or "selection") .. "s"
 end
 
 local function BuildCharacterEligibilityTooltip(subjectLabel)
-    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel(subjectLabel)
     return {
         "Character Eligibility",
         {"Choose which characters can use this " .. subjectLabel .. ".", 1, 1, 1, true},
@@ -601,7 +614,7 @@ local function BuildCharacterEligibilityTooltip(subjectLabel)
 end
 
 local function BuildClassEligibilityTooltip(subjectLabel)
-    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel(subjectLabel)
     return {
         "Class Eligibility",
         {"Global " .. subjectPluralLabel .. " can be limited to selected classes.", 1, 1, 1, true},
@@ -704,7 +717,7 @@ local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerC
         and CooldownCompanion:EnumerateActiveProfileCharacters()
         or {}
     for _, info in ipairs(characters) do
-        local choice = BuildCharacterChoice(info.charKey)
+        local choice = BuildCharacterChoice(info.charKey, info)
         choice.classFilename = choice.classFilename or info.classFilename
         choice.classID = choice.classID or info.classID
         if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
@@ -834,6 +847,30 @@ local function CreateEligibilityRemoveBadge(onRemove)
     return removeBadge
 end
 
+local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
+    local row = AceGUI:Create("SimpleGroup")
+    row:SetFullWidth(true)
+    row:SetLayout("Flow")
+
+    local label = AceGUI:Create("Label")
+    label:SetText(rowInfo.label)
+    label:SetRelativeWidth(0.92)
+    AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
+    row:AddChild(label)
+
+    if rowInfo.disabled then
+        local locked = AceGUI:Create("Label")
+        locked:SetText("|cff888888locked|r")
+        locked:SetRelativeWidth(0.1)
+        row:AddChild(locked)
+    else
+        local removeBtn = CreateEligibilityRemoveBadge(onRemove)
+        row:AddChild(removeBtn)
+    end
+
+    container:AddChild(row)
+end
+
 local function AddCharacterEligibilityControls(container, opts)
     local target = opts.target
     if type(target) ~= "table" then return end
@@ -928,23 +965,10 @@ local function AddCharacterEligibilityControls(container, opts)
     end
 
     for _, choice in ipairs(selected) do
-        local row = AceGUI:Create("SimpleGroup")
-        row:SetFullWidth(true)
-        row:SetLayout("Flow")
-
-        local label = AceGUI:Create("Label")
-        label:SetText(choice.label)
-        label:SetRelativeWidth(0.92)
-        AttachEligibilityTooltip(label, choice.tooltipTitle or choice.label, choice.tooltipText)
-        row:AddChild(label)
-
-        local removeBtn = CreateEligibilityRemoveBadge(function()
+        AddEligibilitySelectedRow(container, choice, function()
             SetAllowlistValue(target, "characterAllowlist", "character", choice.key, false)
             if opts.onChanged then opts.onChanged() end
         end)
-        row:AddChild(removeBtn)
-
-        container:AddChild(row)
     end
 end
 
@@ -1186,36 +1210,8 @@ local function FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
     return specLabel .. " - " .. FormatEligibilityHeroName(heroInfo)
 end
 
-local function FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, includeClass)
+local function FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, includeClass)
     return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
-end
-
-local function FormatEligibilityHeroRowLabel(heroInfo, specInfo, includeClass)
-    return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
-end
-
-local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
-    local row = AceGUI:Create("SimpleGroup")
-    row:SetFullWidth(true)
-    row:SetLayout("Flow")
-
-    local label = AceGUI:Create("Label")
-    label:SetText(rowInfo.label)
-    label:SetRelativeWidth(0.92)
-    AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
-    row:AddChild(label)
-
-    if rowInfo.disabled then
-        local locked = AceGUI:Create("Label")
-        locked:SetText("|cff888888locked|r")
-        locked:SetRelativeWidth(0.1)
-        row:AddChild(locked)
-    else
-        local removeBtn = CreateEligibilityRemoveBadge(onRemove)
-        row:AddChild(removeBtn)
-    end
-
-    container:AddChild(row)
 end
 
 local function AddClassSpecEligibilityControls(container, opts)
@@ -1342,7 +1338,7 @@ local function AddClassSpecEligibilityControls(container, opts)
             local selected = type(heroTalentsSource) == "table" and heroTalentsSource[heroInfo.id] == true
             if not selected then
                 local specInfo = specById[heroInfo.specId]
-                heroValues[heroInfo.id] = FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, allowClassEligibility)
+                heroValues[heroInfo.id] = FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility)
                 heroSortLabels[heroInfo.id] = (heroInfo.classLabel or "") .. (heroInfo.specLabel or "") .. (heroInfo.label or "")
                 heroOrder[#heroOrder + 1] = heroInfo.id
             end
@@ -1427,7 +1423,7 @@ local function AddClassSpecEligibilityControls(container, opts)
                 end)
                 for _, heroInfo in ipairs(heroRows) do
                     rows[#rows + 1] = {
-                        label = FormatEligibilityHeroRowLabel(heroInfo, specInfo, allowClassEligibility),
+                        label = FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility),
                         sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
                         disabled = opts.disableHeroTalents == true,
                         onRemove = function()
@@ -2999,8 +2995,6 @@ ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
 ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
 ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
-ST._SetSpecFilterValue = SetSpecFilterValue
-ST._SetSpecAllowlistValue = SetSpecAllowlistValue
 ST._AddCharacterEligibilityControls = AddCharacterEligibilityControls
 ST._AddClassSpecEligibilityControls = AddClassSpecEligibilityControls
 ST._GetConditionDisplayName = GetConditionDisplayName

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -958,7 +958,7 @@ local function BuildEligibilitySpecChoices(opts)
 
         AddClassesForSpecMap(classChoices, classByKey, target.specs)
         AddClassesForSpecMap(classChoices, classByKey, target.loadConditions and target.loadConditions.specAllowlist)
-        AddClassesForSpecMap(classChoices, classByKey, opts.effectiveSpecs)
+        AddClassesForSpecMap(classChoices, classByKey, opts.choiceSpecMap or opts.effectiveSpecs)
     else
         local choice = ResolveOwnerClassChoice(opts)
         if choice then
@@ -1202,6 +1202,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         ownerClassID = opts.ownerClassID,
         ownerClassFilename = opts.ownerClassFilename,
         effectiveSpecs = opts.effectiveSpecs,
+        choiceSpecMap = opts.choiceSpecMap,
     })
     local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
 
@@ -2786,7 +2787,8 @@ local function BuildLoadConditionsTab(container)
             vehicleUI = true,
         }
     end
-    local effectiveSpecs, inheritedSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
+    local effectiveSpecs = CooldownCompanion:GetEffectiveSpecs(group)
+    local inheritedSpecs, inheritedSpecFilter = CooldownCompanion:GetInheritedEffectiveSpecs(group)
     local effectiveHeroTalents, inheritedHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
     local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group)
     local parentContainer = CooldownCompanion:GetParentContainer(group)
@@ -2854,8 +2856,9 @@ local function BuildLoadConditionsTab(container)
             ownerCharKey = ownerCharKey,
             useSpecAllowlist = inheritedSpecFilter,
             allowedSpecRestricted = inheritedSpecFilter,
-            allowedSpecMap = effectiveSpecs,
+            allowedSpecMap = inheritedSpecs,
             effectiveSpecs = effectiveSpecs,
+            choiceSpecMap = inheritedSpecs,
             heroTalentsSource = effectiveHeroTalents,
             useHeroTalentsSource = inheritedHeroFilter,
             disableHeroTalents = inheritedHeroFilter,

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -1085,7 +1085,19 @@ local function GetSpecSelectionMap(target, useSpecAllowlist)
     if useSpecAllowlist then
         return target.loadConditions and target.loadConditions.specAllowlist
     end
-    return target.specs
+    local specs = CopyAllowlist(target.specs, "spec")
+    local loadConditionSpecs = CopyAllowlist(
+        target.loadConditions and target.loadConditions.specAllowlist,
+        "spec"
+    )
+    if not loadConditionSpecs then
+        return specs
+    end
+    specs = specs or {}
+    for specId in pairs(loadConditionSpecs) do
+        specs[specId] = true
+    end
+    return next(specs) and specs or nil
 end
 
 local function SetSpecEligibilityValue(target, specId, value, useSpecAllowlist)

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -9,7 +9,6 @@ local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 
 -- Imports from Helpers.lua and State.lua
-local BuildHeroTalentSubTreeCheckboxes = ST._BuildHeroTalentSubTreeCheckboxes
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local CreateInfoButton = ST._CreateInfoButton
@@ -25,6 +24,88 @@ local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
 
 local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
+local REMOVE_BADGE_WIDGET_TYPE = "CDCEligibilityRemoveBadge"
+
+if AceGUI and not AceGUI:GetWidgetVersion(REMOVE_BADGE_WIDGET_TYPE) then
+    local function Badge_OnClick(frame, button)
+        frame.obj:Fire("OnClick", button)
+        AceGUI:ClearFocus()
+    end
+
+    local function Badge_OnEnter(frame)
+        frame.obj:Fire("OnEnter")
+    end
+
+    local function Badge_OnLeave(frame)
+        frame.obj:Fire("OnLeave")
+    end
+
+    local badgeMethods = {
+        OnAcquire = function(self)
+            self:SetWidth(19)
+            self:SetHeight(19)
+            self:SetDisabled(false)
+            if self.icon then
+                self.icon:SetAtlas("common-icon-redx", false)
+                self.icon:ClearAllPoints()
+                self.icon:SetSize(19, 19)
+                self.icon:SetPoint("CENTER")
+            end
+            if self.frame.SetHighlightAtlas then
+                self.frame:SetHighlightAtlas("common-icon-redx")
+                if self.frame.GetHighlightTexture and self.frame:GetHighlightTexture() then
+                    self.frame:GetHighlightTexture():SetAlpha(0.3)
+                end
+            end
+        end,
+
+        SetDisabled = function(self, disabled)
+            if disabled then
+                self.frame:Disable()
+                if self.icon then self.icon:SetVertexColor(0.5, 0.5, 0.5, 0.5) end
+            else
+                self.frame:Enable()
+                if self.icon then self.icon:SetVertexColor(1, 1, 1, 1) end
+            end
+        end,
+    }
+
+    local function BadgeConstructor()
+        local frame = CreateFrame("Button", nil, UIParent)
+        frame:Hide()
+        frame:SetSize(19, 19)
+        frame:EnableMouse(true)
+        frame:RegisterForClicks("AnyUp")
+        frame:SetScript("OnClick", Badge_OnClick)
+        frame:SetScript("OnEnter", Badge_OnEnter)
+        frame:SetScript("OnLeave", Badge_OnLeave)
+
+        local icon = frame:CreateTexture(nil, "ARTWORK")
+        icon:SetAtlas("common-icon-redx", false)
+        icon:SetSize(19, 19)
+        icon:SetPoint("CENTER")
+
+        if frame.SetHighlightAtlas then
+            frame:SetHighlightAtlas("common-icon-redx")
+            if frame.GetHighlightTexture and frame:GetHighlightTexture() then
+                frame:GetHighlightTexture():SetAlpha(0.3)
+            end
+        end
+
+        local widget = {
+            frame = frame,
+            icon = icon,
+            type = REMOVE_BADGE_WIDGET_TYPE,
+        }
+        for method, func in pairs(badgeMethods) do
+            widget[method] = func
+        end
+
+        return AceGUI:RegisterAsWidget(widget)
+    end
+
+    AceGUI:RegisterWidgetType(REMOVE_BADGE_WIDGET_TYPE, BadgeConstructor, 1)
+end
 
 local function GetLoadConditionValue(loadConditions, key, defaults, optionDefault)
     if type(loadConditions) ~= "table" then return false end
@@ -49,6 +130,80 @@ local function SetLoadConditionValue(loadConditions, key, value, defaults, optio
         loadConditions[key] = nil
     else
         loadConditions[key] = value == true
+    end
+end
+
+local function EnsureLoadConditions(target)
+    if type(target) ~= "table" then return nil end
+    if type(target.loadConditions) ~= "table" then
+        target.loadConditions = {}
+    end
+    return target.loadConditions
+end
+
+local function SetSpecFilterValue(target, specId, value)
+    if type(target) ~= "table" or not specId then return end
+    if value then
+        if not target.specs then target.specs = {} end
+        target.specs[specId] = true
+        local loadConditions = EnsureLoadConditions(target)
+        if type(loadConditions.specAllowlist) ~= "table" then
+            loadConditions.specAllowlist = {}
+        end
+        loadConditions.specAllowlist[specId] = true
+    else
+        if target.specs then
+            target.specs[specId] = nil
+            if not next(target.specs) then
+                target.specs = nil
+            end
+        end
+        local loadConditions = target.loadConditions
+        if type(loadConditions) == "table" and type(loadConditions.specAllowlist) == "table" then
+            loadConditions.specAllowlist[specId] = nil
+            if not next(loadConditions.specAllowlist) then
+                loadConditions.specAllowlist = nil
+            end
+        end
+    end
+end
+
+local function SetSpecAllowlistValue(target, specId, value)
+    if type(target) ~= "table" or not specId then return end
+    if value then
+        local loadConditions = EnsureLoadConditions(target)
+        if type(loadConditions.specAllowlist) ~= "table" then
+            loadConditions.specAllowlist = {}
+        end
+        loadConditions.specAllowlist[specId] = true
+        return
+    end
+
+    local loadConditions = target.loadConditions
+    if type(loadConditions) == "table" and type(loadConditions.specAllowlist) == "table" then
+        loadConditions.specAllowlist[specId] = nil
+        if not next(loadConditions.specAllowlist) then
+            loadConditions.specAllowlist = nil
+        end
+    end
+end
+
+local function SetHeroTalentValue(target, subTreeID, value)
+    subTreeID = tonumber(subTreeID)
+    if type(target) ~= "table" or not subTreeID then return end
+    if value then
+        if type(target.heroTalents) ~= "table" then
+            target.heroTalents = {}
+        end
+        target.heroTalents[subTreeID] = true
+        return
+    end
+
+    if type(target.heroTalents) == "table" then
+        target.heroTalents[subTreeID] = nil
+        if not next(target.heroTalents) then
+            target.heroTalents = nil
+        end
     end
 end
 
@@ -175,6 +330,1047 @@ local function AddScopedLoadConditionToggles(container, opts)
             end)
         end
         container:AddChild(cb)
+    end
+end
+
+local function NormalizeAllowlistKey(kind, key)
+    if kind == "class" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return string.upper(key)
+    elseif kind == "spec" then
+        local specId = tonumber(key)
+        if not specId then return nil end
+        return specId
+    elseif kind == "character" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return key
+    end
+    return nil
+end
+
+local function CopyAllowlist(map, kind)
+    if type(map) ~= "table" then return nil, false end
+    local copy = {}
+    local sawEntry = false
+    for key, enabled in pairs(map) do
+        sawEntry = true
+        if enabled == true then
+            local normalizedKey = NormalizeAllowlistKey(kind, key)
+            if normalizedKey ~= nil then
+                copy[normalizedKey] = true
+            end
+        end
+    end
+    if next(copy) then return copy, true end
+    return nil, sawEntry
+end
+
+local function IntersectAllowlists(left, right)
+    local intersection = {}
+    for key in pairs(left or {}) do
+        if right and right[key] then
+            intersection[key] = true
+        end
+    end
+    return intersection
+end
+
+local function GetInheritedAllowlist(sources, field, kind)
+    local inherited
+    local restricted = false
+    for _, source in ipairs(sources or {}) do
+        local copied, hasRestriction = CopyAllowlist(source.loadConditions and source.loadConditions[field], kind)
+        if hasRestriction then
+            restricted = true
+            if inherited == nil then
+                inherited = copied or {}
+            else
+                inherited = IntersectAllowlists(inherited, copied or {})
+            end
+        end
+    end
+    return inherited, restricted
+end
+
+local function SetAllowlistValue(target, field, kind, key, value)
+    local normalizedKey = NormalizeAllowlistKey(kind, key)
+    if not (type(target) == "table" and normalizedKey ~= nil) then return end
+
+    if value then
+        local loadConditions = EnsureLoadConditions(target)
+        if type(loadConditions[field]) ~= "table" then
+            loadConditions[field] = {}
+        end
+        loadConditions[field][normalizedKey] = true
+        return
+    end
+
+    local loadConditions = target.loadConditions
+    if type(loadConditions) == "table" and type(loadConditions[field]) == "table" then
+        loadConditions[field][normalizedKey] = nil
+        if not next(loadConditions[field]) then
+            loadConditions[field] = nil
+        end
+    end
+end
+
+local function AddChoice(choices, byKey, key, label, meta)
+    if key == nil or byKey[key] then return end
+    byKey[key] = true
+    local choice = {
+        key = key,
+        label = label or tostring(key),
+    }
+    if type(meta) == "table" then
+        for metaKey, metaValue in pairs(meta) do
+            choice[metaKey] = metaValue
+        end
+    end
+    choices[#choices + 1] = choice
+end
+
+local function AddAllowlistKeysAsChoices(choices, byKey, map, kind, labelPrefix)
+    local copied = CopyAllowlist(map, kind)
+    for key in pairs(copied or {}) do
+        AddChoice(choices, byKey, key, (labelPrefix or "") .. tostring(key))
+    end
+end
+
+local function SortChoices(choices)
+    table.sort(choices, function(a, b)
+        return tostring(a.sortLabel or a.label or a.key) < tostring(b.sortLabel or b.label or b.key)
+    end)
+end
+
+local MAX_CLASS_SCAN_ID = 20
+
+local function GetClassChoiceByID(classID)
+    classID = tonumber(classID)
+    if not classID then return nil end
+    local className, classFilename = GetClassInfo(classID)
+    local classKey = NormalizeAllowlistKey("class", classFilename)
+    if not classKey then return nil end
+    return {
+        key = classKey,
+        label = className or classKey,
+        classID = classID,
+        classFilename = classKey,
+    }
+end
+
+local function GetClassChoiceByFilename(classFilename)
+    local classKey = NormalizeAllowlistKey("class", classFilename)
+    if not classKey then return nil end
+    for classID = 1, MAX_CLASS_SCAN_ID do
+        local choice = GetClassChoiceByID(classID)
+        if choice and choice.key == classKey then
+            return choice
+        end
+    end
+    return {
+        key = classKey,
+        label = classKey,
+        classFilename = classKey,
+    }
+end
+
+local function GetCurrentClassChoice()
+    local className, classFilename, classID = UnitClass("player")
+    local classKey = NormalizeAllowlistKey("class", classFilename)
+    if not classKey then return nil end
+    return {
+        key = classKey,
+        label = className or classKey,
+        classID = classID,
+        classFilename = classKey,
+    }
+end
+
+local function WrapClassColoredText(text, classFilename)
+    if classFilename and C_ClassColor then
+        local classColor = C_ClassColor.GetClassColor(classFilename)
+        if classColor and classColor.WrapTextInColorCode then
+            return classColor:WrapTextInColorCode(text)
+        end
+    end
+    return text
+end
+
+local function GetClassDisplayLabel(classChoice)
+    if not classChoice then return nil end
+    return WrapClassColoredText(classChoice.label or classChoice.key, classChoice.classFilename or classChoice.key)
+end
+
+local function GetSpecClassChoice(specId)
+    if not (C_SpecializationInfo and C_SpecializationInfo.GetClassIDFromSpecID) then
+        return nil
+    end
+    local classID = C_SpecializationInfo.GetClassIDFromSpecID(tonumber(specId))
+    return GetClassChoiceByID(classID)
+end
+
+local function SplitCharacterKey(charKey)
+    if type(charKey) ~= "string" then return "", nil end
+    local name, realm = charKey:match("^(.-)%s+%-%s+(.+)$")
+    if name and name ~= "" then
+        return name, realm
+    end
+    return charKey, nil
+end
+
+local function GetCharacterEligibilityInfo(charKey)
+    local db = CooldownCompanion.db
+    local info = charKey
+        and db and db.global and db.global.characterInfo
+        and db.global.characterInfo[charKey]
+    if type(info) == "table" then
+        return info
+    end
+
+    local characters = CooldownCompanion.EnumerateActiveProfileCharacters
+        and CooldownCompanion:EnumerateActiveProfileCharacters()
+        or {}
+    for _, characterInfo in ipairs(characters) do
+        if characterInfo.charKey == charKey then
+            return characterInfo
+        end
+    end
+    return nil
+end
+
+local function BuildCharacterChoice(charKey)
+    local info = GetCharacterEligibilityInfo(charKey)
+    local name, realm = SplitCharacterKey(charKey)
+    local classFilename = info and NormalizeAllowlistKey("class", info.classFilename)
+    local label = WrapClassColoredText(name, classFilename)
+    return {
+        key = charKey,
+        label = label,
+        sortLabel = name,
+        tooltipTitle = label,
+        tooltipText = realm,
+        classFilename = classFilename,
+        classID = info and info.classID or nil,
+    }
+end
+
+local function AttachEligibilityTooltip(widget, title, text)
+    if not (widget and widget.frame and text and text ~= "") then return end
+    widget.frame:EnableMouse(true)
+    widget.frame:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:AddLine(title or "")
+        GameTooltip:AddLine(text, 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    widget.frame:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    widget:SetCallback("OnRelease", function(releasedWidget)
+        if releasedWidget and releasedWidget.frame then
+            releasedWidget.frame:SetScript("OnEnter", nil)
+            releasedWidget.frame:SetScript("OnLeave", nil)
+        end
+    end)
+end
+
+local function ResolveOwnerClassChoice(opts)
+    if opts.ownerClassChoice then
+        return opts.ownerClassChoice
+    end
+    if opts.ownerClassID then
+        local choice = GetClassChoiceByID(opts.ownerClassID)
+        if choice then return choice end
+    end
+    if opts.ownerClassFilename then
+        local choice = GetClassChoiceByFilename(opts.ownerClassFilename)
+        if choice then return choice end
+    end
+
+    local db = CooldownCompanion.db
+    local charKey = opts.ownerCharKey
+        or (type(opts.target) == "table" and opts.target.createdBy)
+    local info = charKey
+        and db and db.global and db.global.characterInfo
+        and db.global.characterInfo[charKey]
+    if type(info) == "table" then
+        if info.classID then
+            local choice = GetClassChoiceByID(info.classID)
+            if choice then return choice end
+        end
+        if info.classFilename then
+            local choice = GetClassChoiceByFilename(info.classFilename)
+            if choice then return choice end
+        end
+    end
+
+    return GetCurrentClassChoice()
+end
+
+local function CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey)
+    if not scopeClassKey then return true end
+    if choice and ownerCharKey and choice.key == ownerCharKey then
+        return true
+    end
+    local classKey = choice and NormalizeAllowlistKey("class", choice.classFilename)
+    return classKey == scopeClassKey
+end
+
+local function BuildClassChoices(target, inheritedMap)
+    local choices, byKey = {}, {}
+    for classID = 1, MAX_CLASS_SCAN_ID do
+        local choice = GetClassChoiceByID(classID)
+        if choice then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    local localMap = target.loadConditions and target.loadConditions.classAllowlist
+    AddAllowlistKeysAsChoices(choices, byKey, localMap, "class")
+    AddAllowlistKeysAsChoices(choices, byKey, inheritedMap, "class")
+    table.sort(choices, function(a, b)
+        if a.classID and b.classID then
+            return a.classID < b.classID
+        end
+        if a.classID then return true end
+        if b.classID then return false end
+        return tostring(a.label or a.key) < tostring(b.label or b.key)
+    end)
+    return choices
+end
+
+local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerCharKey)
+    local choices, byKey = {}, {}
+    local characters = CooldownCompanion.EnumerateActiveProfileCharacters
+        and CooldownCompanion:EnumerateActiveProfileCharacters()
+        or {}
+    for _, info in ipairs(characters) do
+        local choice = BuildCharacterChoice(info.charKey)
+        choice.classFilename = choice.classFilename or info.classFilename
+        choice.classID = choice.classID or info.classID
+        if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    local localMap = target.loadConditions and target.loadConditions.characterAllowlist
+    local copiedLocal = CopyAllowlist(localMap, "character")
+    for key in pairs(copiedLocal or {}) do
+        local choice = BuildCharacterChoice(key)
+        if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    local copiedInherited = CopyAllowlist(inheritedMap, "character")
+    for key in pairs(copiedInherited or {}) do
+        local choice = BuildCharacterChoice(key)
+        if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    SortChoices(choices)
+    return choices
+end
+
+local function ClearEmptyLoadConditions(target)
+    if type(target) ~= "table" or type(target.loadConditions) ~= "table" then return end
+    if not next(target.loadConditions) then
+        target.loadConditions = nil
+    end
+end
+
+local function ClearClassAllowlistWhenScoped(target, allowClassEligibility)
+    if allowClassEligibility or type(target) ~= "table" then return false end
+    local loadConditions = target.loadConditions
+    if type(loadConditions) ~= "table" or loadConditions.classAllowlist == nil then
+        return false
+    end
+    loadConditions.classAllowlist = nil
+    ClearEmptyLoadConditions(target)
+    return true
+end
+
+local function PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey)
+    if type(target) ~= "table" or not scopeClassKey then return false end
+    local loadConditions = target.loadConditions
+    local map = loadConditions and loadConditions.characterAllowlist
+    if type(map) ~= "table" then return false end
+
+    local changed = false
+    for key in pairs(map) do
+        local normalizedKey = NormalizeAllowlistKey("character", key)
+        local choice = normalizedKey and BuildCharacterChoice(normalizedKey) or nil
+        if not (normalizedKey and CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey)) then
+            map[key] = nil
+            changed = true
+        end
+    end
+    if not next(map) then
+        loadConditions.characterAllowlist = nil
+    end
+    ClearEmptyLoadConditions(target)
+    return changed
+end
+
+local function SpecMatchesScopeClass(specId, scopeClassKey)
+    if not scopeClassKey then return true end
+    local classChoice = GetSpecClassChoice(specId)
+    return not classChoice or classChoice.key == scopeClassKey
+end
+
+local function PruneSpecMapToScopeClass(target, map, scopeClassKey)
+    if type(map) ~= "table" or not scopeClassKey then return false end
+    local changed = false
+    for key in pairs(map) do
+        local specId = NormalizeAllowlistKey("spec", key)
+        if not (specId and SpecMatchesScopeClass(specId, scopeClassKey)) then
+            map[key] = nil
+            if specId and map[specId] ~= nil then
+                map[specId] = nil
+            end
+            if specId and CooldownCompanion.CleanHeroTalentsForSpec then
+                CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
+            end
+            changed = true
+        end
+    end
+    return changed
+end
+
+local function PruneClassScopedEligibility(target, scopeClassChoice, ownerCharKey)
+    if type(target) ~= "table" or not scopeClassChoice then return false end
+    local scopeClassKey = scopeClassChoice.key
+    local changed = ClearClassAllowlistWhenScoped(target, false)
+    changed = PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey) or changed
+
+    if PruneSpecMapToScopeClass(target, target.specs, scopeClassKey) then
+        changed = true
+        if type(target.specs) == "table" and not next(target.specs) then
+            target.specs = nil
+        end
+    end
+
+    local loadConditions = target.loadConditions
+    if type(loadConditions) == "table" then
+        if PruneSpecMapToScopeClass(target, loadConditions.specAllowlist, scopeClassKey) then
+            changed = true
+            if type(loadConditions.specAllowlist) == "table" and not next(loadConditions.specAllowlist) then
+                loadConditions.specAllowlist = nil
+            end
+        end
+    end
+
+    ClearEmptyLoadConditions(target)
+    return changed
+end
+
+local function CreateEligibilityRemoveBadge(onRemove)
+    local removeBadge = AceGUI:Create(REMOVE_BADGE_WIDGET_TYPE)
+    removeBadge:SetWidth(19)
+    removeBadge:SetHeight(19)
+    removeBadge:SetCallback("OnClick", function(widget, event, button)
+        if button == "LeftButton" and onRemove then
+            onRemove()
+        end
+    end)
+    return removeBadge
+end
+
+local function AddCharacterEligibilityControls(container, opts)
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "characterAllowlist", "character")
+    local scopeClassChoice
+    if opts.allowClassEligibility == false then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+        if scopeClassChoice then
+            PruneCharacterAllowlistToScopeClass(target, scopeClassChoice.key, opts.ownerCharKey)
+        end
+    end
+    local choices = BuildCharacterChoices(target, inheritedMap, scopeClassChoice and scopeClassChoice.key or nil, opts.ownerCharKey)
+    if #choices == 0 then return end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(opts.characterHeadingText or "Character Eligibility")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
+    local collapsed = opts.characterCollapsedKey and CS.collapsedSections[opts.characterCollapsedKey]
+    if opts.characterCollapsedKey then
+        AttachCollapseButton(heading, collapsed, function()
+            CS.collapsedSections[opts.characterCollapsedKey] = not CS.collapsedSections[opts.characterCollapsedKey]
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+    end
+    if collapsed then return end
+
+    if inheritedRestricted then
+        local inheritedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(inheritedLabel)
+        inheritedLabel:SetText("|cff888888Parent eligibility limits which characters can load here.|r")
+        inheritedLabel:SetFullWidth(true)
+        container:AddChild(inheritedLabel)
+    end
+
+    local localMap = target.loadConditions and target.loadConditions.characterAllowlist
+    local selected = {}
+    local selectedByKey = {}
+    local dropdownValues = {}
+    local dropdownOrder = {}
+    local dropdownSortLabels = {}
+
+    for _, choice in ipairs(choices) do
+        local key = choice.key
+        local localSelected = type(localMap) == "table" and localMap[key] == true
+        local outsideInherited = inheritedRestricted and not (inheritedMap and inheritedMap[key])
+        if localSelected then
+            selectedByKey[key] = true
+            selected[#selected + 1] = {
+                key = key,
+                label = outsideInherited and (choice.label .. " |cff888888(unavailable from parent)|r") or choice.label,
+                tooltipTitle = choice.tooltipTitle,
+                tooltipText = choice.tooltipText,
+                sortLabel = choice.sortLabel,
+            }
+        elseif not outsideInherited then
+            dropdownValues[key] = choice.label
+            dropdownSortLabels[key] = choice.sortLabel or choice.label
+            dropdownOrder[#dropdownOrder + 1] = key
+        end
+    end
+
+    table.sort(dropdownOrder, function(a, b)
+        return tostring(dropdownSortLabels[a] or a) < tostring(dropdownSortLabels[b] or b)
+    end)
+
+    local picker = AceGUI:Create("Dropdown")
+    picker:SetLabel("Add Character")
+    picker:SetFullWidth(true)
+    picker:SetList(dropdownValues, dropdownOrder)
+    if #dropdownOrder == 0 then
+        picker:SetDisabled(true)
+    else
+        picker:SetCallback("OnValueChanged", function(widget, event, value)
+            if value ~= nil and not selectedByKey[value] then
+                SetAllowlistValue(target, "characterAllowlist", "character", value, true)
+                if opts.onChanged then opts.onChanged() end
+            end
+        end)
+    end
+    container:AddChild(picker)
+
+    SortChoices(selected)
+
+    if #selected == 0 then
+        local unrestrictedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
+        unrestrictedLabel:SetText("|cff888888No local character restriction.|r")
+        unrestrictedLabel:SetFullWidth(true)
+        container:AddChild(unrestrictedLabel)
+        return
+    end
+
+    for _, choice in ipairs(selected) do
+        local row = AceGUI:Create("SimpleGroup")
+        row:SetFullWidth(true)
+        row:SetLayout("Flow")
+
+        local label = AceGUI:Create("Label")
+        label:SetText(choice.label)
+        label:SetRelativeWidth(0.92)
+        AttachEligibilityTooltip(label, choice.tooltipTitle or choice.label, choice.tooltipText)
+        row:AddChild(label)
+
+        local removeBtn = CreateEligibilityRemoveBadge(function()
+            SetAllowlistValue(target, "characterAllowlist", "character", choice.key, false)
+            if opts.onChanged then opts.onChanged() end
+        end)
+        row:AddChild(removeBtn)
+
+        container:AddChild(row)
+    end
+end
+
+local function AddClassForSpecId(classChoices, classByKey, specId)
+    if not (C_SpecializationInfo and C_SpecializationInfo.GetClassIDFromSpecID) then
+        return
+    end
+    local classID = C_SpecializationInfo.GetClassIDFromSpecID(tonumber(specId))
+    local choice = GetClassChoiceByID(classID)
+    if choice and not classByKey[choice.key] then
+        classByKey[choice.key] = true
+        classChoices[#classChoices + 1] = choice
+    end
+end
+
+local function AddClassesForSpecMap(classChoices, classByKey, specMap)
+    local copied = CopyAllowlist(specMap, "spec")
+    for specId in pairs(copied or {}) do
+        AddClassForSpecId(classChoices, classByKey, specId)
+    end
+end
+
+local function AddSpecsForClass(specChoices, seenSpecs, classChoice)
+    local classID = classChoice and classChoice.classID
+    if not (classID and C_SpecializationInfo and C_SpecializationInfo.GetNumSpecializationsForClassID) then
+        return
+    end
+
+    local currentClass = GetCurrentClassChoice()
+    local currentClassKey = currentClass and currentClass.key
+    local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
+    for specIndex = 1, numSpecs do
+        local specId, specName, _, specIcon = C_SpecializationInfo.GetSpecializationInfo(
+            specIndex,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
+        if specId and not seenSpecs[specId] then
+            seenSpecs[specId] = true
+            specChoices[#specChoices + 1] = {
+                id = specId,
+                name = specName or ("Spec " .. tostring(specId)),
+                label = specName or ("Spec " .. tostring(specId)),
+                icon = specIcon,
+                classID = classID,
+                classKey = classChoice.key,
+                classLabel = classChoice.label,
+                isCurrentClass = classChoice.key == currentClassKey,
+            }
+        end
+    end
+end
+
+local function BuildEligibilitySpecChoices(opts)
+    opts = opts or {}
+    local target = opts.target
+    if type(target) ~= "table" then return {} end
+
+    local classChoices = {}
+    local classByKey = {}
+
+    if opts.allowClassEligibility then
+        local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")
+        local localMap = CopyAllowlist(target.loadConditions and target.loadConditions.classAllowlist, "class")
+        local seedMap = localMap and next(localMap) and localMap or nil
+        if not seedMap and inheritedRestricted then
+            seedMap = inheritedMap
+        end
+
+        for classKey in pairs(seedMap or {}) do
+            local choice = GetClassChoiceByFilename(classKey)
+            if choice and not classByKey[choice.key] then
+                classByKey[choice.key] = true
+                classChoices[#classChoices + 1] = choice
+            end
+        end
+
+        AddClassesForSpecMap(classChoices, classByKey, target.specs)
+        AddClassesForSpecMap(classChoices, classByKey, target.loadConditions and target.loadConditions.specAllowlist)
+        AddClassesForSpecMap(classChoices, classByKey, opts.effectiveSpecs)
+    else
+        ClearClassAllowlistWhenScoped(target, false)
+        local choice = ResolveOwnerClassChoice(opts)
+        if choice then
+            classByKey[choice.key] = true
+            classChoices[#classChoices + 1] = choice
+        end
+    end
+
+    table.sort(classChoices, function(a, b)
+        if a.classID and b.classID then
+            return a.classID < b.classID
+        end
+        if a.classID then return true end
+        if b.classID then return false end
+        return tostring(a.label or a.key) < tostring(b.label or b.key)
+    end)
+
+    local specs = {}
+    local seenSpecs = {}
+    for _, classChoice in ipairs(classChoices) do
+        AddSpecsForClass(specs, seenSpecs, classChoice)
+    end
+
+    local classCount = #classChoices
+    for _, spec in ipairs(specs) do
+        if opts.allowClassEligibility and classCount > 1 then
+            spec.label = (spec.classLabel or spec.classKey or "Class") .. ": " .. spec.name
+        end
+    end
+    return specs
+end
+
+local function GetSpecSelectionMap(target, useSpecAllowlist)
+    if type(target) ~= "table" then return nil end
+    if useSpecAllowlist then
+        return target.loadConditions and target.loadConditions.specAllowlist
+    end
+    return target.specs
+end
+
+local function SetSpecEligibilityValue(target, specId, value, useSpecAllowlist)
+    if useSpecAllowlist then
+        SetSpecAllowlistValue(target, specId, value)
+    else
+        SetSpecFilterValue(target, specId, value)
+    end
+end
+
+local function BuildSpecChoiceIndex(specChoices)
+    local bySpecId = {}
+    local byClassKey = {}
+    for _, specInfo in ipairs(specChoices or {}) do
+        if specInfo.id then
+            bySpecId[specInfo.id] = specInfo
+            local classKey = specInfo.classKey
+            if classKey then
+                byClassKey[classKey] = byClassKey[classKey] or {}
+                byClassKey[classKey][#byClassKey[classKey] + 1] = specInfo
+            end
+        end
+    end
+    return bySpecId, byClassKey
+end
+
+local function BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+    local choices = {}
+    local bySubTreeID = {}
+    if not (configID and C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
+        return choices, bySubTreeID
+    end
+
+    for _, specInfo in ipairs(specChoices or {}) do
+        local specId = specInfo.id
+        if specId and selectedSpecMap and selectedSpecMap[specId] then
+            local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+            for _, subTreeID in ipairs(subTreeIDs or {}) do
+                local subTreeInfo = C_Traits and C_Traits.GetSubTreeInfo and C_Traits.GetSubTreeInfo(configID, subTreeID) or nil
+                local heroName = subTreeInfo and subTreeInfo.name or ("Hero " .. tostring(subTreeID))
+                local heroChoice = {
+                    id = subTreeID,
+                    label = heroName,
+                    sortLabel = heroName,
+                    specId = specId,
+                    specLabel = specInfo.name,
+                    classKey = specInfo.classKey,
+                    classLabel = specInfo.classLabel,
+                    iconAtlas = subTreeInfo and subTreeInfo.iconElementID or nil,
+                }
+                choices[#choices + 1] = heroChoice
+                bySubTreeID[subTreeID] = heroChoice
+            end
+        end
+    end
+
+    table.sort(choices, function(a, b)
+        local aClass = tostring(a.classLabel or a.classKey or "")
+        local bClass = tostring(b.classLabel or b.classKey or "")
+        if aClass ~= bClass then return aClass < bClass end
+        local aSpec = tostring(a.specLabel or a.specId or "")
+        local bSpec = tostring(b.specLabel or b.specId or "")
+        if aSpec ~= bSpec then return aSpec < bSpec end
+        return tostring(a.sortLabel or a.label or a.id) < tostring(b.sortLabel or b.label or b.id)
+    end)
+
+    return choices, bySubTreeID
+end
+
+local function FormatEligibilitySpecLabel(specInfo, includeClass)
+    if not specInfo then return "" end
+    if includeClass and specInfo.classLabel then
+        local classChoice = GetClassChoiceByFilename(specInfo.classKey)
+        local classLabel = GetClassDisplayLabel(classChoice) or specInfo.classLabel
+        return classLabel .. ": " .. (specInfo.name or specInfo.label or tostring(specInfo.id))
+    end
+    return specInfo.name or specInfo.label or tostring(specInfo.id)
+end
+
+local function FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
+    local specLabel = FormatEligibilitySpecLabel(specInfo, includeClass)
+    return specLabel .. " - " .. (heroInfo.label or tostring(heroInfo.id))
+end
+
+local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
+    local row = AceGUI:Create("SimpleGroup")
+    row:SetFullWidth(true)
+    row:SetLayout("Flow")
+
+    local label = AceGUI:Create("Label")
+    label:SetText(rowInfo.label)
+    label:SetRelativeWidth(0.92)
+    AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
+    row:AddChild(label)
+
+    if rowInfo.disabled then
+        local locked = AceGUI:Create("Label")
+        locked:SetText("|cff888888locked|r")
+        locked:SetRelativeWidth(0.1)
+        row:AddChild(locked)
+    else
+        local removeBtn = CreateEligibilityRemoveBadge(onRemove)
+        row:AddChild(removeBtn)
+    end
+
+    container:AddChild(row)
+end
+
+local function AddClassSpecEligibilityControls(container, opts)
+    opts = opts or {}
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local allowClassEligibility = opts.allowClassEligibility == true
+    local scopeClassChoice
+    if not allowClassEligibility then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+        PruneClassScopedEligibility(target, scopeClassChoice, opts.ownerCharKey)
+    end
+
+    local inheritedClassMap, inheritedClassRestricted = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")
+    local classChoices = BuildClassChoices(target, inheritedClassMap)
+    local localClassMap = target.loadConditions and target.loadConditions.classAllowlist
+
+    if allowClassEligibility then
+        if inheritedClassRestricted then
+            local inheritedLabel = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(inheritedLabel)
+            inheritedLabel:SetText("|cff888888Parent eligibility limits which classes can load here.|r")
+            inheritedLabel:SetFullWidth(true)
+            container:AddChild(inheritedLabel)
+        end
+
+        local classValues = {}
+        local classOrder = {}
+        local classSortLabels = {}
+        for _, choice in ipairs(classChoices) do
+            local key = choice.key
+            local localSelected = type(localClassMap) == "table" and localClassMap[key] == true
+            local outsideInherited = inheritedClassRestricted and not (inheritedClassMap and inheritedClassMap[key])
+            if not localSelected and not outsideInherited then
+                classValues[key] = GetClassDisplayLabel(choice) or choice.label
+                classSortLabels[key] = choice.label or key
+                classOrder[#classOrder + 1] = key
+            end
+        end
+        table.sort(classOrder, function(a, b)
+            return tostring(classSortLabels[a] or a) < tostring(classSortLabels[b] or b)
+        end)
+
+        local classPicker = AceGUI:Create("Dropdown")
+        classPicker:SetLabel("Add Class")
+        classPicker:SetFullWidth(true)
+        classPicker:SetList(classValues, classOrder)
+        if #classOrder == 0 then
+            classPicker:SetDisabled(true)
+        else
+            classPicker:SetCallback("OnValueChanged", function(widget, event, value)
+                SetAllowlistValue(target, "classAllowlist", "class", value, true)
+                if opts.onChanged then opts.onChanged() end
+            end)
+        end
+        container:AddChild(classPicker)
+    end
+
+    local useSpecAllowlist = opts.useSpecAllowlist == true
+    local selectedSpecMap = GetSpecSelectionMap(target, useSpecAllowlist)
+    local allowedSpecMap = opts.allowedSpecMap
+    local allowedSpecRestricted = opts.allowedSpecRestricted == true
+    local specChoices = BuildEligibilitySpecChoices({
+        target = target,
+        inheritedSources = opts.inheritedSources,
+        allowClassEligibility = allowClassEligibility,
+        ownerClassChoice = scopeClassChoice,
+        ownerCharKey = opts.ownerCharKey,
+        ownerClassID = opts.ownerClassID,
+        ownerClassFilename = opts.ownerClassFilename,
+        effectiveSpecs = opts.effectiveSpecs,
+    })
+    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+
+    local specValues = {}
+    local specOrder = {}
+    local specSortLabels = {}
+    for _, specInfo in ipairs(specChoices) do
+        local specId = specInfo.id
+        local localSelected = type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true
+        local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
+        if specId and not localSelected and not outsideAllowed then
+            specValues[specId] = specInfo.label
+            specSortLabels[specId] = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId))
+            specOrder[#specOrder + 1] = specId
+        end
+    end
+    table.sort(specOrder, function(a, b)
+        return tostring(specSortLabels[a] or a) < tostring(specSortLabels[b] or b)
+    end)
+
+    if #specChoices == 0 then
+        local emptyLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(emptyLabel)
+        emptyLabel:SetText(allowClassEligibility and "|cff888888Select a class to choose specialization eligibility.|r" or "|cff888888No specializations available for this scope.|r")
+        emptyLabel:SetFullWidth(true)
+        container:AddChild(emptyLabel)
+    else
+        local specPicker = AceGUI:Create("Dropdown")
+        specPicker:SetLabel("Add Specialization")
+        specPicker:SetFullWidth(true)
+        specPicker:SetList(specValues, specOrder)
+        if #specOrder == 0 then
+            specPicker:SetDisabled(true)
+        else
+            specPicker:SetCallback("OnValueChanged", function(widget, event, value)
+                SetSpecEligibilityValue(target, value, true, useSpecAllowlist)
+                if opts.onChanged then opts.onChanged() end
+            end)
+        end
+        container:AddChild(specPicker)
+    end
+
+    local configID = opts.configID or (C_ClassTalents and C_ClassTalents.GetActiveConfigID and C_ClassTalents.GetActiveConfigID())
+    local mutableHeroTalents = opts.disableHeroTalents ~= true
+    local heroTalentsSource = opts.useHeroTalentsSource and opts.heroTalentsSource or target.heroTalents
+    if type(heroTalentsSource) ~= "table" then
+        heroTalentsSource = nil
+    end
+    local heroChoices, heroById = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+    local heroValues = {}
+    local heroOrder = {}
+    local heroSortLabels = {}
+    if mutableHeroTalents then
+        for _, heroInfo in ipairs(heroChoices) do
+            local selected = type(heroTalentsSource) == "table" and heroTalentsSource[heroInfo.id] == true
+            if not selected then
+                local specInfo = specById[heroInfo.specId]
+                heroValues[heroInfo.id] = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility)
+                heroSortLabels[heroInfo.id] = (heroInfo.classLabel or "") .. (heroInfo.specLabel or "") .. (heroInfo.label or "")
+                heroOrder[#heroOrder + 1] = heroInfo.id
+            end
+        end
+    end
+    table.sort(heroOrder, function(a, b)
+        return tostring(heroSortLabels[a] or a) < tostring(heroSortLabels[b] or b)
+    end)
+
+    if #heroChoices > 0 and mutableHeroTalents then
+        local heroPicker = AceGUI:Create("Dropdown")
+        heroPicker:SetLabel("Add Hero Talent")
+        heroPicker:SetFullWidth(true)
+        heroPicker:SetList(heroValues, heroOrder)
+        if #heroOrder == 0 then
+            heroPicker:SetDisabled(true)
+        else
+            heroPicker:SetCallback("OnValueChanged", function(widget, event, value)
+                SetHeroTalentValue(target, value, true)
+                if opts.onChanged then opts.onChanged() end
+            end)
+        end
+        container:AddChild(heroPicker)
+    elseif opts.disableHeroTalents and type(heroTalentsSource) == "table" and next(heroTalentsSource) then
+        local inheritedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(inheritedLabel)
+        inheritedLabel:SetText("|cff888888Hero talent eligibility is inherited here.|r")
+        inheritedLabel:SetFullWidth(true)
+        container:AddChild(inheritedLabel)
+    end
+
+    local rows = {}
+    local selectedHeroBySpec = {}
+    for subTreeID in pairs(heroTalentsSource or {}) do
+        local heroInfo = heroById[subTreeID]
+        if heroInfo then
+            selectedHeroBySpec[heroInfo.specId] = selectedHeroBySpec[heroInfo.specId] or {}
+            selectedHeroBySpec[heroInfo.specId][#selectedHeroBySpec[heroInfo.specId] + 1] = heroInfo
+        end
+    end
+
+    if allowClassEligibility then
+        for _, classChoice in ipairs(classChoices) do
+            local classKey = classChoice.key
+            local classSelected = type(localClassMap) == "table" and localClassMap[classKey] == true
+            if classSelected then
+                local classSpecs = specsByClassKey[classKey] or {}
+                local selectedSpecs = {}
+                for _, specInfo in ipairs(classSpecs) do
+                    if type(selectedSpecMap) == "table" and selectedSpecMap[specInfo.id] == true then
+                        selectedSpecs[#selectedSpecs + 1] = specInfo
+                    end
+                end
+                if #selectedSpecs == 0 then
+                    rows[#rows + 1] = {
+                        label = GetClassDisplayLabel(classChoice) or classChoice.label,
+                        sortLabel = classChoice.label or classKey,
+                        onRemove = function()
+                            SetAllowlistValue(target, "classAllowlist", "class", classKey, false)
+                            for _, specInfo in ipairs(classSpecs) do
+                                SetSpecEligibilityValue(target, specInfo.id, false, useSpecAllowlist)
+                                if CooldownCompanion.CleanHeroTalentsForSpec then
+                                    CooldownCompanion:CleanHeroTalentsForSpec(target, specInfo.id)
+                                end
+                            end
+                            if opts.onChanged then opts.onChanged() end
+                        end,
+                    }
+                end
+            end
+        end
+    end
+
+    for _, specInfo in ipairs(specChoices) do
+        local specId = specInfo.id
+        if type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true then
+            local heroRows = selectedHeroBySpec[specId]
+            if heroRows and #heroRows > 0 then
+                table.sort(heroRows, function(a, b)
+                    return tostring(a.label or a.id) < tostring(b.label or b.id)
+                end)
+                for _, heroInfo in ipairs(heroRows) do
+                    rows[#rows + 1] = {
+                        label = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility),
+                        sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
+                        disabled = opts.disableHeroTalents == true,
+                        onRemove = function()
+                            SetHeroTalentValue(target, heroInfo.id, false)
+                            if opts.onChanged then opts.onChanged() end
+                        end,
+                    }
+                end
+            else
+                local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
+                rows[#rows + 1] = {
+                    label = FormatEligibilitySpecLabel(specInfo, allowClassEligibility)
+                        .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or ""),
+                    sortLabel = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId)),
+                    onRemove = function()
+                        SetSpecEligibilityValue(target, specId, false, useSpecAllowlist)
+                        if CooldownCompanion.CleanHeroTalentsForSpec then
+                            CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
+                        end
+                        if opts.onChanged then opts.onChanged() end
+                    end,
+                }
+            end
+        end
+    end
+
+    table.sort(rows, function(a, b)
+        return tostring(a.sortLabel or a.label) < tostring(b.sortLabel or b.label)
+    end)
+
+    if #rows == 0 then
+        local unrestrictedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
+        unrestrictedLabel:SetText(allowClassEligibility and "|cff888888No local class or specialization restriction.|r" or "|cff888888No local specialization restriction.|r")
+        unrestrictedLabel:SetFullWidth(true)
+        container:AddChild(unrestrictedLabel)
+    else
+        for _, row in ipairs(rows) do
+            AddEligibilitySelectedRow(container, row, row.onRemove)
+        end
     end
 end
 
@@ -1587,14 +2783,22 @@ local function BuildLoadConditionsTab(container)
             vehicleUI = true,
         }
     end
-    local lc = group.loadConditions
     local effectiveSpecs, inheritedSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
     local effectiveHeroTalents, inheritedHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
+    local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group)
+    local parentContainer = CooldownCompanion:GetParentContainer(group)
+    local scopeIsGlobal
+    if parentContainer then
+        scopeIsGlobal = parentContainer.isGlobal == true
+    else
+        scopeIsGlobal = group.isGlobal == true
+    end
+    local ownerCharKey = parentContainer and parentContainer.createdBy or group.createdBy
 
     AddScopedLoadConditionToggles(container, {
         target = group,
         defaults = CooldownCompanion:GetDefaultLoadConditions(),
-        inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group),
+        inheritedSources = inheritedSources,
         headingText = "Hide This Panel In",
         headingTextWhenInherited = "Also Hide This Panel In",
         inheritedCollapsedKey = "loadconditions_panel_inherited",
@@ -1605,9 +2809,20 @@ local function BuildLoadConditionsTab(container)
         end,
     })
 
-    -- Specialization heading
+    AddCharacterEligibilityControls(container, {
+        target = group,
+        inheritedSources = inheritedSources,
+        allowClassEligibility = scopeIsGlobal,
+        ownerCharKey = ownerCharKey,
+        characterCollapsedKey = "loadconditions_panel_character",
+        onChanged = function()
+            CooldownCompanion:RefreshGroupFrame(groupId)
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
+
     local specHeading = AceGUI:Create("Heading")
-    specHeading:SetText("Specialization Filter")
+    specHeading:SetText("Class & Specialization Eligibility")
     ColorHeading(specHeading)
     specHeading:SetFullWidth(true)
     container:AddChild(specHeading)
@@ -1619,112 +2834,31 @@ local function BuildLoadConditionsTab(container)
     end)
 
     if not specCollapsed then
-    if inheritedSpecFilter or inheritedHeroFilter then
-        local inheritedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(inheritedLabel)
-        inheritedLabel:SetText("|cff888888Some filters inherited from group settings.|r")
-        inheritedLabel:SetFullWidth(true)
-        container:AddChild(inheritedLabel)
-    end
-
-    -- Current class spec checkboxes
-    local numSpecs = GetNumSpecializations()
-    local configID = C_ClassTalents.GetActiveConfigID()
-    for i = 1, numSpecs do
-        local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-        if specId then
-            local cb = AceGUI:Create("CheckBox")
-            cb:SetLabel(name)
-            if icon then cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-            cb:SetFullWidth(true)
-            if inheritedSpecFilter then
-                cb:SetValue(effectiveSpecs and effectiveSpecs[specId] or false)
-            else
-                cb:SetValue(group.specs and group.specs[specId] or false)
-            end
-            if inheritedSpecFilter then
-                cb:SetDisabled(true)
-            else
-                cb:SetCallback("OnValueChanged", function(widget, event, value)
-                    if value then
-                        if not group.specs then group.specs = {} end
-                        group.specs[specId] = true
-                    else
-                        if group.specs then
-                            group.specs[specId] = nil
-                            if not next(group.specs) then
-                                group.specs = nil
-                            end
-                        end
-                        CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
-                    end
-                    CooldownCompanion:RefreshGroupFrame(groupId)
-                    CooldownCompanion:RefreshConfigPanel()
-                end)
-            end
-            container:AddChild(cb)
-            ApplyCheckboxIndent(cb, 0)
-
-            -- Hero talent sub-tree checkboxes (indented, only when spec is checked)
-            BuildHeroTalentSubTreeCheckboxes(container, group, configID, specId, 20, groupId, {
-                specsSource = effectiveSpecs,
-                heroTalentsSource = effectiveHeroTalents,
-                useHeroTalentsSource = inheritedHeroFilter,
-                disableToggles = inheritedHeroFilter,
-            })
+        if inheritedSpecFilter or inheritedHeroFilter then
+            local inheritedLabel = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(inheritedLabel)
+            inheritedLabel:SetText("|cff888888Some filters inherited from group settings.|r")
+            inheritedLabel:SetFullWidth(true)
+            container:AddChild(inheritedLabel)
         end
-    end
 
-    -- Foreign specs (from global groups that may have specs from other classes)
-    local playerSpecIds = {}
-    for i = 1, numSpecs do
-        local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-        if specId then playerSpecIds[specId] = true end
-    end
-
-    local foreignSpecs = {}
-    if effectiveSpecs then
-        for specId in pairs(effectiveSpecs) do
-            if not playerSpecIds[specId] then
-                table.insert(foreignSpecs, specId)
-            end
-        end
-    end
-
-    if #foreignSpecs > 0 then
-        table.sort(foreignSpecs)
-        for _, specId in ipairs(foreignSpecs) do
-            local _, name, _, icon = GetSpecializationInfoForSpecID(specId)
-            if name then
-                local fcb = AceGUI:Create("CheckBox")
-                fcb:SetLabel(name)
-                if icon then fcb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-                fcb:SetFullWidth(true)
-                fcb:SetValue(true)
-                if inheritedSpecFilter then
-                    fcb:SetDisabled(true)
-                else
-                    fcb:SetCallback("OnValueChanged", function(widget, event, value)
-                        if not value then
-                            if group.specs then
-                                group.specs[specId] = nil
-                                if not next(group.specs) then
-                                    group.specs = nil
-                                end
-                            end
-                        else
-                            if not group.specs then group.specs = {} end
-                            group.specs[specId] = true
-                        end
-                        CooldownCompanion:RefreshGroupFrame(groupId)
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                end
-                container:AddChild(fcb)
-                ApplyCheckboxIndent(fcb, 0)
-            end
-        end
-    end
+        AddClassSpecEligibilityControls(container, {
+            target = group,
+            inheritedSources = inheritedSources,
+            allowClassEligibility = scopeIsGlobal,
+            ownerCharKey = ownerCharKey,
+            useSpecAllowlist = inheritedSpecFilter,
+            allowedSpecRestricted = inheritedSpecFilter,
+            allowedSpecMap = effectiveSpecs,
+            effectiveSpecs = effectiveSpecs,
+            heroTalentsSource = effectiveHeroTalents,
+            useHeroTalentsSource = inheritedHeroFilter,
+            disableHeroTalents = inheritedHeroFilter,
+            onChanged = function()
+                CooldownCompanion:RefreshGroupFrame(groupId)
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
     end -- not specCollapsed
 end
 
@@ -1772,5 +2906,9 @@ ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
 ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
 ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
+ST._SetSpecFilterValue = SetSpecFilterValue
+ST._SetSpecAllowlistValue = SetSpecAllowlistValue
+ST._AddCharacterEligibilityControls = AddCharacterEligibilityControls
+ST._AddClassSpecEligibilityControls = AddClassSpecEligibilityControls
 ST._GetConditionDisplayName = GetConditionDisplayName
 ST._GetConditionListContextSuffix = GetConditionListContextSuffix

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -25,6 +25,7 @@ local appearanceTabElements = CS.appearanceTabElements
 
 local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
 local REMOVE_BADGE_WIDGET_TYPE = "CDCEligibilityRemoveBadge"
+local VIEW_TRAIT_CONFIG_ID = (Constants and Constants.TraitConsts and Constants.TraitConsts.VIEW_TRAIT_CONFIG_ID) or -3
 
 if AceGUI and not AceGUI:GetWidgetVersion(REMOVE_BADGE_WIDGET_TYPE) then
     local function Badge_OnClick(frame, button)
@@ -1035,19 +1036,63 @@ local function BuildSpecChoiceIndex(specChoices)
     return bySpecId, byClassKey
 end
 
+local function EnsureHeroTalentViewConfig(specId)
+    if not (specId
+        and C_ClassTalents
+        and C_ClassTalents.InitializeViewLoadout
+        and C_Traits
+        and C_Traits.GetConfigInfo) then
+        return nil
+    end
+
+    local playerLevel = UnitLevel and UnitLevel("player") or nil
+    if not playerLevel or playerLevel < 1 then
+        return nil
+    end
+
+    C_ClassTalents.InitializeViewLoadout(specId, playerLevel)
+    if C_Traits.GetConfigInfo(VIEW_TRAIT_CONFIG_ID) then
+        return VIEW_TRAIT_CONFIG_ID
+    end
+
+    return nil
+end
+
+local function GetHeroTalentSubTreesForSpec(specId, configID)
+    if not (specId and C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
+        return nil, configID
+    end
+
+    local subTreeIDs = configID and C_ClassTalents.GetHeroTalentSpecsForClassSpec(configID, specId) or nil
+    if subTreeIDs and #subTreeIDs > 0 then
+        return subTreeIDs, configID
+    end
+
+    subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+    if subTreeIDs and #subTreeIDs > 0 then
+        return subTreeIDs, configID
+    end
+
+    local viewConfigID = EnsureHeroTalentViewConfig(specId)
+    subTreeIDs = viewConfigID and C_ClassTalents.GetHeroTalentSpecsForClassSpec(viewConfigID, specId) or nil
+    if subTreeIDs and #subTreeIDs > 0 then
+        return subTreeIDs, viewConfigID
+    end
+
+    return nil, configID
+end
+
 local function BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
     local choices = {}
     local bySubTreeID = {}
-    if not (configID and C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
-        return choices, bySubTreeID
-    end
 
     for _, specInfo in ipairs(specChoices or {}) do
         local specId = specInfo.id
         if specId and selectedSpecMap and selectedSpecMap[specId] then
-            local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+            local subTreeIDs, subTreeConfigID = GetHeroTalentSubTreesForSpec(specId, configID)
             for _, subTreeID in ipairs(subTreeIDs or {}) do
-                local subTreeInfo = C_Traits and C_Traits.GetSubTreeInfo and C_Traits.GetSubTreeInfo(configID, subTreeID) or nil
+                local subTreeInfo = subTreeConfigID and C_Traits and C_Traits.GetSubTreeInfo
+                    and C_Traits.GetSubTreeInfo(subTreeConfigID, subTreeID) or nil
                 local heroName = subTreeInfo and subTreeInfo.name or ("Hero " .. tostring(subTreeID))
                 local heroChoice = {
                     id = subTreeID,

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -569,22 +569,19 @@ local function BuildCharacterChoice(charKey, fallbackInfo)
 end
 
 local function AttachEligibilityTooltip(widget, title, text)
-    if not (widget and widget.frame and text and text ~= "") then return end
-    widget.frame:EnableMouse(true)
-    widget.frame:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    if not (widget and text and text ~= "") then return end
+    widget:SetCallback("OnEnter", function(hoveredWidget)
+        if not (hoveredWidget and hoveredWidget.frame) then return end
+        GameTooltip:SetOwner(hoveredWidget.frame, "ANCHOR_RIGHT")
         GameTooltip:AddLine(title or "")
         GameTooltip:AddLine(text, 1, 1, 1, true)
         GameTooltip:Show()
     end)
-    widget.frame:SetScript("OnLeave", function()
+    widget:SetCallback("OnLeave", function()
         GameTooltip:Hide()
     end)
-    widget:SetCallback("OnRelease", function(releasedWidget)
-        if releasedWidget and releasedWidget.frame then
-            releasedWidget.frame:SetScript("OnEnter", nil)
-            releasedWidget.frame:SetScript("OnLeave", nil)
-        end
+    widget:SetCallback("OnRelease", function()
+        GameTooltip:Hide()
     end)
 end
 
@@ -852,7 +849,8 @@ local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
     row:SetFullWidth(true)
     row:SetLayout("Flow")
 
-    local label = AceGUI:Create("Label")
+    local hasTooltip = rowInfo.tooltipText and rowInfo.tooltipText ~= ""
+    local label = AceGUI:Create(hasTooltip and "InteractiveLabel" or "Label")
     label:SetText(rowInfo.label)
     label:SetRelativeWidth(0.92)
     AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
@@ -880,9 +878,6 @@ local function AddCharacterEligibilityControls(container, opts)
     local scopeClassChoice
     if opts.allowClassEligibility == false then
         scopeClassChoice = ResolveOwnerClassChoice(opts)
-        if scopeClassChoice then
-            PruneCharacterAllowlistToScopeClass(target, scopeClassChoice.key, opts.ownerCharKey)
-        end
     end
     local choices = BuildCharacterChoices(target, inheritedMap, scopeClassChoice and scopeClassChoice.key or nil, opts.ownerCharKey)
     if #choices == 0 then return end
@@ -1054,7 +1049,6 @@ local function BuildEligibilitySpecChoices(opts)
         AddClassesForSpecMap(classChoices, classByKey, target.loadConditions and target.loadConditions.specAllowlist)
         AddClassesForSpecMap(classChoices, classByKey, opts.effectiveSpecs)
     else
-        ClearClassAllowlistWhenScoped(target, false)
         local choice = ResolveOwnerClassChoice(opts)
         if choice then
             classByKey[choice.key] = true
@@ -1224,7 +1218,6 @@ local function AddClassSpecEligibilityControls(container, opts)
     local scopeClassChoice
     if not allowClassEligibility then
         scopeClassChoice = ResolveOwnerClassChoice(opts)
-        PruneClassScopedEligibility(target, scopeClassChoice, opts.ownerCharKey)
     end
 
     local inheritedClassMap, inheritedClassRestricted = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -149,6 +149,9 @@ local function SetSpecFilterValue(target, specId, value)
         local loadConditions = EnsureLoadConditions(target)
         if type(loadConditions.specAllowlist) ~= "table" then
             loadConditions.specAllowlist = {}
+            for existingSpecId in pairs(target.specs or {}) do
+                loadConditions.specAllowlist[existingSpecId] = true
+            end
         end
         loadConditions.specAllowlist[specId] = true
     else
@@ -738,98 +741,6 @@ local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerC
     end
     SortChoices(choices)
     return choices
-end
-
-local function ClearEmptyLoadConditions(target)
-    if type(target) ~= "table" or type(target.loadConditions) ~= "table" then return end
-    if not next(target.loadConditions) then
-        target.loadConditions = nil
-    end
-end
-
-local function ClearClassAllowlistWhenScoped(target, allowClassEligibility)
-    if allowClassEligibility or type(target) ~= "table" then return false end
-    local loadConditions = target.loadConditions
-    if type(loadConditions) ~= "table" or loadConditions.classAllowlist == nil then
-        return false
-    end
-    loadConditions.classAllowlist = nil
-    ClearEmptyLoadConditions(target)
-    return true
-end
-
-local function PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey)
-    if type(target) ~= "table" or not scopeClassKey then return false end
-    local loadConditions = target.loadConditions
-    local map = loadConditions and loadConditions.characterAllowlist
-    if type(map) ~= "table" then return false end
-
-    local changed = false
-    for key in pairs(map) do
-        local normalizedKey = NormalizeAllowlistKey("character", key)
-        local choice = normalizedKey and BuildCharacterChoice(normalizedKey) or nil
-        if not (normalizedKey and CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey)) then
-            map[key] = nil
-            changed = true
-        end
-    end
-    if not next(map) then
-        loadConditions.characterAllowlist = nil
-    end
-    ClearEmptyLoadConditions(target)
-    return changed
-end
-
-local function SpecMatchesScopeClass(specId, scopeClassKey)
-    if not scopeClassKey then return true end
-    local classChoice = GetSpecClassChoice(specId)
-    return not classChoice or classChoice.key == scopeClassKey
-end
-
-local function PruneSpecMapToScopeClass(target, map, scopeClassKey)
-    if type(map) ~= "table" or not scopeClassKey then return false end
-    local changed = false
-    for key in pairs(map) do
-        local specId = NormalizeAllowlistKey("spec", key)
-        if not (specId and SpecMatchesScopeClass(specId, scopeClassKey)) then
-            map[key] = nil
-            if specId and map[specId] ~= nil then
-                map[specId] = nil
-            end
-            if specId and CooldownCompanion.CleanHeroTalentsForSpec then
-                CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
-            end
-            changed = true
-        end
-    end
-    return changed
-end
-
-local function PruneClassScopedEligibility(target, scopeClassChoice, ownerCharKey)
-    if type(target) ~= "table" or not scopeClassChoice then return false end
-    local scopeClassKey = scopeClassChoice.key
-    local changed = ClearClassAllowlistWhenScoped(target, false)
-    changed = PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey) or changed
-
-    if PruneSpecMapToScopeClass(target, target.specs, scopeClassKey) then
-        changed = true
-        if type(target.specs) == "table" and not next(target.specs) then
-            target.specs = nil
-        end
-    end
-
-    local loadConditions = target.loadConditions
-    if type(loadConditions) == "table" then
-        if PruneSpecMapToScopeClass(target, loadConditions.specAllowlist, scopeClassKey) then
-            changed = true
-            if type(loadConditions.specAllowlist) == "table" and not next(loadConditions.specAllowlist) then
-                loadConditions.specAllowlist = nil
-            end
-        end
-    end
-
-    ClearEmptyLoadConditions(target)
-    return changed
 end
 
 local function CreateEligibilityRemoveBadge(onRemove)

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3929,10 +3929,14 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     local folder = db.folders and db.folders[folderId]
     if not folder then return end
 
-    local function RefreshFolderDependents()
-        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
+    local function RefreshFolderOnly()
         CooldownCompanion:RefreshAllGroups()
         CooldownCompanion:RefreshConfigPanel()
+    end
+
+    local function RefreshFolderSpecDependents()
+        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
+        RefreshFolderOnly()
     end
 
     AddScopedLoadConditionToggles(scroll, {
@@ -3958,7 +3962,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
         allowClassEligibility = folder.section == "global",
         ownerCharKey = folder.createdBy,
         characterCollapsedKey = "folder_loadconditions_character",
-        onChanged = RefreshFolderDependents,
+        onChanged = RefreshFolderOnly,
     })
 
     local specHeading = AceGUI:Create("Heading")
@@ -3980,7 +3984,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
             eligibilitySubjectLabel = "folder",
             allowClassEligibility = folder.section == "global",
             ownerCharKey = folder.createdBy,
-            onChanged = RefreshFolderDependents,
+            onChanged = RefreshFolderSpecDependents,
         })
 
         if folder.specs or folder.heroTalents then
@@ -3993,7 +3997,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
                 if type(folder.loadConditions) == "table" then
                     folder.loadConditions.specAllowlist = nil
                 end
-                RefreshFolderDependents()
+                RefreshFolderSpecDependents()
             end)
             scroll:AddChild(clearSpecsBtn)
         end

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -27,6 +27,8 @@ local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
+local AddCharacterEligibilityControls = ST._AddCharacterEligibilityControls
+local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
 
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -3776,11 +3778,15 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     local function RefreshPanels()
         CooldownCompanion:RefreshContainerPanels(containerId)
     end
+    local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container)
+    local folder = container.folderId and db.folders and db.folders[container.folderId]
+    local folderSpecs = folder and folder.specs
+    local folderHeroTalents = folder and folder.heroTalents
 
     AddScopedLoadConditionToggles(scroll, {
         target = container,
         defaults = CooldownCompanion:GetDefaultLoadConditions(),
-        inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container),
+        inheritedSources = inheritedSources,
         headingText = "Hide This Group In",
         headingTextWhenInherited = "Also Hide This Group In",
         inheritedCollapsedKey = "container_loadconditions_inherited",
@@ -3791,9 +3797,21 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         end,
     })
 
-    -- Spec filter section
+    AddCharacterEligibilityControls(scroll, {
+        target = container,
+        inheritedSources = inheritedSources,
+        allowClassEligibility = container.isGlobal == true,
+        ownerCharKey = container.createdBy,
+        characterCollapsedKey = "container_loadconditions_character",
+        onChanged = function()
+            RefreshPanels()
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
+
+    -- Class/spec eligibility section
     local specHeading = AceGUI:Create("Heading")
-    specHeading:SetText("Specialization Filter")
+    specHeading:SetText("Class & Specialization Eligibility")
     ColorHeading(specHeading)
     specHeading:SetFullWidth(true)
     scroll:AddChild(specHeading)
@@ -3805,119 +3823,66 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end)
 
     if not specCollapsed then
-    -- Folder spec inheritance: folder-level spec/hero filters are shown as
-    -- disabled (locked) on child containers, but children can still toggle
-    -- specs that the folder does NOT set.
-    local folder = container.folderId and db.folders and db.folders[container.folderId]
-    local folderSpecs = folder and folder.specs
-    local folderHeroTalents = folder and folder.heroTalents
-    local hasFolderSpecs = folderSpecs and next(folderSpecs)
+        local hasFolderSpecs = folderSpecs and next(folderSpecs)
 
-    -- Effective specs for hero talent rendering (union of folder + container specs)
-    local effectiveSpecs
-    if folderSpecs or container.specs then
-        effectiveSpecs = {}
-        if folderSpecs then for k in pairs(folderSpecs) do effectiveSpecs[k] = true end end
-        if container.specs then for k in pairs(container.specs) do effectiveSpecs[k] = true end end
-        if not next(effectiveSpecs) then effectiveSpecs = nil end
-    end
+        if hasFolderSpecs then
+            local inheritedLabel = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(inheritedLabel)
+            inheritedLabel:SetText("|cff888888Specs set by the parent folder cannot be changed here.|r")
+            inheritedLabel:SetFullWidth(true)
+            scroll:AddChild(inheritedLabel)
+        end
 
-    if hasFolderSpecs then
-        local inheritedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(inheritedLabel)
-        inheritedLabel:SetText("|cff888888Specs set by the parent folder cannot be changed here.|r")
-        inheritedLabel:SetFullWidth(true)
-        scroll:AddChild(inheritedLabel)
-    end
+        AddClassSpecEligibilityControls(scroll, {
+            target = container,
+            inheritedSources = inheritedSources,
+            allowClassEligibility = container.isGlobal == true,
+            ownerCharKey = container.createdBy,
+            useSpecAllowlist = hasFolderSpecs,
+            allowedSpecRestricted = hasFolderSpecs,
+            allowedSpecMap = folderSpecs,
+            effectiveSpecs = folderSpecs,
+            heroTalentsSource = folderHeroTalents,
+            useHeroTalentsSource = folderHeroTalents and next(folderHeroTalents) ~= nil,
+            disableHeroTalents = folderHeroTalents and next(folderHeroTalents) ~= nil,
+            onChanged = function()
+                RefreshPanels()
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
 
-    local numSpecs = GetNumSpecializations()
-    local configID = C_ClassTalents.GetActiveConfigID()
-    for i = 1, numSpecs do
-        local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-        if specId then
-            local lockedByFolder = folderSpecs and folderSpecs[specId]
-            local cb = AceGUI:Create("CheckBox")
-            cb:SetLabel(name)
-            if icon then cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-            cb:SetFullWidth(true)
-            cb:SetValue(lockedByFolder or (container.specs and container.specs[specId]) or false)
-            if hasFolderSpecs then
-                cb:SetDisabled(true)
-            else
-                cb:SetCallback("OnValueChanged", function(widget, event, value)
-                    if value then
-                        if not container.specs then container.specs = {} end
-                        container.specs[specId] = true
-                    else
-                        if container.specs then
-                            container.specs[specId] = nil
-                            if not next(container.specs) then
-                                container.specs = nil
-                            end
-                        end
-                        CooldownCompanion:CleanHeroTalentsForSpec(container, specId)
-                    end
-                    RefreshPanels()
-                    CooldownCompanion:RefreshConfigPanel()
-                end)
-            end
-            scroll:AddChild(cb)
-
-            -- Hero talent sub-tree checkboxes
-            local specActive = lockedByFolder or (container.specs and container.specs[specId])
-            if configID and specActive then
-                local htOpts
-                if folderHeroTalents and next(folderHeroTalents) then
-                    htOpts = {
-                        heroTalentsSource = folderHeroTalents,
-                        useHeroTalentsSource = true,
-                        disableToggles = true,
-                        specsSource = effectiveSpecs,
-                    }
-                else
-                    htOpts = {
-                        heroTalentsSource = container.heroTalents,
-                        specsSource = effectiveSpecs,
-                        onChanged = function()
-                            RefreshPanels()
-                            CooldownCompanion:RefreshConfigPanel()
-                        end,
-                    }
+        -- Only show Clear All when container has specs/hero-talents beyond folder cascade
+        local hasOwnSpecs = false
+        if container.specs then
+            for specId in pairs(container.specs) do
+                if not (folderSpecs and folderSpecs[specId]) then
+                    hasOwnSpecs = true
+                    break
                 end
-                ST._BuildHeroTalentSubTreeCheckboxes(scroll, container, configID, specId, 20, containerId, htOpts)
             end
         end
-    end
-
-    -- Only show Clear All when container has specs/hero-talents beyond folder cascade
-    local hasOwnSpecs = false
-    if container.specs then
-        for specId in pairs(container.specs) do
-            if not (folderSpecs and folderSpecs[specId]) then
-                hasOwnSpecs = true
-                break
-            end
+        if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
+            hasOwnSpecs = true
         end
-    end
-    if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
-        hasOwnSpecs = true
-    end
-    if hasOwnSpecs then
-        local clearBtn = AceGUI:Create("Button")
-        clearBtn:SetText("Clear All Spec Filters")
-        clearBtn:SetFullWidth(true)
-        clearBtn:SetCallback("OnClick", function()
-            if folderSpecs then
-                container.specs = CopyTable(folderSpecs)
-            else
-                container.specs = nil
-            end
-            container.heroTalents = nil
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        scroll:AddChild(clearBtn)
-    end
+        if hasOwnSpecs then
+            local clearBtn = AceGUI:Create("Button")
+            clearBtn:SetText("Clear All Spec Filters")
+            clearBtn:SetFullWidth(true)
+            clearBtn:SetCallback("OnClick", function()
+                if folderSpecs then
+                    container.specs = CopyTable(folderSpecs)
+                else
+                    container.specs = nil
+                end
+                if type(container.loadConditions) == "table" then
+                    container.loadConditions.specAllowlist = nil
+                end
+                container.heroTalents = nil
+                RefreshPanels()
+                CooldownCompanion:RefreshConfigPanel()
+            end)
+            scroll:AddChild(clearBtn)
+        end
     end -- not specCollapsed
 end
 
@@ -3962,6 +3927,12 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     local folder = db.folders and db.folders[folderId]
     if not folder then return end
 
+    local function RefreshFolderDependents()
+        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
+        CooldownCompanion:RefreshAllGroups()
+        CooldownCompanion:RefreshConfigPanel()
+    end
+
     AddScopedLoadConditionToggles(scroll, {
         target = folder,
         defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
@@ -3977,6 +3948,52 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
             CooldownCompanion:RefreshConfigPanel()
         end,
     })
+
+    AddCharacterEligibilityControls(scroll, {
+        target = folder,
+        inheritedSources = {},
+        allowClassEligibility = folder.section == "global",
+        ownerCharKey = folder.createdBy,
+        characterCollapsedKey = "folder_loadconditions_character",
+        onChanged = RefreshFolderDependents,
+    })
+
+    local specHeading = AceGUI:Create("Heading")
+    specHeading:SetText("Class & Specialization Eligibility")
+    ColorHeading(specHeading)
+    specHeading:SetFullWidth(true)
+    scroll:AddChild(specHeading)
+
+    local specCollapsed = CS.collapsedSections["folder_loadconditions_spec"]
+    AttachCollapseButton(specHeading, specCollapsed, function()
+        CS.collapsedSections["folder_loadconditions_spec"] = not CS.collapsedSections["folder_loadconditions_spec"]
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+
+    if not specCollapsed then
+        AddClassSpecEligibilityControls(scroll, {
+            target = folder,
+            inheritedSources = {},
+            allowClassEligibility = folder.section == "global",
+            ownerCharKey = folder.createdBy,
+            onChanged = RefreshFolderDependents,
+        })
+
+        if folder.specs or folder.heroTalents then
+            local clearSpecsBtn = AceGUI:Create("Button")
+            clearSpecsBtn:SetText("Clear Folder Spec Filters")
+            clearSpecsBtn:SetFullWidth(true)
+            clearSpecsBtn:SetCallback("OnClick", function()
+                folder.specs = nil
+                folder.heroTalents = nil
+                if type(folder.loadConditions) == "table" then
+                    folder.loadConditions.specAllowlist = nil
+                end
+                RefreshFolderDependents()
+            end)
+            scroll:AddChild(clearSpecsBtn)
+        end
+    end
 
     if CooldownCompanion:HasLocalLoadConditions(folder) then
         local clearBtn = AceGUI:Create("Button")

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -29,6 +29,7 @@ local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
 local AddCharacterEligibilityControls = ST._AddCharacterEligibilityControls
 local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
+local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
 
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -3780,7 +3781,10 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end
     local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container)
     local folder = container.folderId and db.folders and db.folders[container.folderId]
-    local folderSpecs = folder and folder.specs
+    local folderSpecs = folder and BuildEligibilityBadgeMap(
+        folder.specs,
+        folder.loadConditions and folder.loadConditions.specAllowlist
+    )
     local folderHeroTalents = folder and folder.heroTalents
 
     AddScopedLoadConditionToggles(scroll, {
@@ -3855,13 +3859,21 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
 
         -- Only show Clear All when container has specs/hero-talents beyond folder cascade
         local hasOwnSpecs = false
-        if container.specs then
-            for specId in pairs(container.specs) do
-                if not (folderSpecs and folderSpecs[specId]) then
-                    hasOwnSpecs = true
-                    break
+        local function CheckOwnSpecs(specs)
+            if type(specs) ~= "table" then
+                return specs ~= nil
+            end
+            for specId in pairs(specs) do
+                if not (folderSpecs and folderSpecs[tonumber(specId) or specId]) then
+                    return true
                 end
             end
+            return false
+        end
+        if CheckOwnSpecs(container.specs)
+            or CheckOwnSpecs(container.loadConditions and container.loadConditions.specAllowlist)
+        then
+            hasOwnSpecs = true
         end
         if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
             hasOwnSpecs = true

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3800,6 +3800,7 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     AddCharacterEligibilityControls(scroll, {
         target = container,
         inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "group",
         allowClassEligibility = container.isGlobal == true,
         ownerCharKey = container.createdBy,
         characterCollapsedKey = "container_loadconditions_character",
@@ -3836,6 +3837,7 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         AddClassSpecEligibilityControls(scroll, {
             target = container,
             inheritedSources = inheritedSources,
+            eligibilitySubjectLabel = "group",
             allowClassEligibility = container.isGlobal == true,
             ownerCharKey = container.createdBy,
             useSpecAllowlist = hasFolderSpecs,
@@ -3952,6 +3954,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     AddCharacterEligibilityControls(scroll, {
         target = folder,
         inheritedSources = {},
+        eligibilitySubjectLabel = "folder",
         allowClassEligibility = folder.section == "global",
         ownerCharKey = folder.createdBy,
         characterCollapsedKey = "folder_loadconditions_character",
@@ -3974,6 +3977,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
         AddClassSpecEligibilityControls(scroll, {
             target = folder,
             inheritedSources = {},
+            eligibilitySubjectLabel = "folder",
             allowClassEligibility = folder.section == "global",
             ownerCharKey = folder.createdBy,
             onChanged = RefreshFolderDependents,


### PR DESCRIPTION
## What Players Will Notice
- Load Conditions now has organized dropdown-based eligibility controls for characters, classes, specializations, and hero talents.
- Global groups and folders can be limited to selected classes, specs, hero talents, and characters, while class-scoped groups only show same-class character/spec options.
- Selected eligibility entries use class colors, icons, and compact X badges, with character server names kept out of the main row unless hovered.
- Shared/imported layouts keep portable class/spec/hero eligibility while local character eligibility stays local.

## Why This Changed
- The previous eligibility UI mixed overlapping class/spec concepts and could show filters where they did not make sense for the current scope.
- Character allowlists are local to a player's roster, so exporting or importing them could make shared layouts confusing or wrong.
- Global groups need cross-class class/spec/hero gates to work now, before later class-section placement work exists.

## What Changed
- Rebuilt Load Conditions eligibility around dropdown pickers and selected-entry rows for characters, classes, specs, and hero talents.
- Added scope-aware eligibility rendering and cleanup so global groups can carry cross-class filters while character/class-scoped groups stay constrained to their owner class.
- Preserved class/spec/hero eligibility across import/export while stripping character eligibility from profile, group, folder, panel, button, and selected-piece payloads.
- Added import review/print notices when local character eligibility is stripped and kept class-filtered imports global-with-filters for this PR.
- Added an off-class hero talent lookup fallback so global groups can show relevant hero talent options even when the player is logged into another class.

## Validation
- `luac -p` on all touched Lua files.
- `lua tests/eligibility-load-conditions.lua`.
- `lua tests/eligibility-import-export.lua`.
- `lua tests/rotation-assistant-panel.lua`.
- `git diff --check`.
- User-reported in-game config validation passed for the eligibility controls, including off-class hero talent dropdown behavior. Combat/restricted-content runtime validation was not separately performed.