### PR TITLE
Add class-scoped group browsing to config

### DIFF
--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -1969,12 +1969,14 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     -- Create buttons
     self:PopulateGroupButtons(groupId)
     
-    -- Show/hide based on enabled state, spec filter, hero talent filter, character visibility, and load conditions
+    -- Show/hide based on runtime activity, plus selected off-class config previews.
     if self:IsGroupActive(groupId, {
         group = group,
         checkCharVisibility = true,
         checkLoadConditions = true,
         requireButtons = true,
+    }) or self:IsGroupEligibleForConfigPreview(groupId, {
+        group = group,
     }) then
         frame:Show()
         -- Apply current alpha from the alpha fade system so frame doesn't flash at 1.0
@@ -2818,12 +2820,15 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     )
     self:UpdateGroupClickthrough(groupId)
 
-    -- Update visibility — unload if disabled, no buttons, wrong spec/hero, wrong character, or load conditions
+    -- Update visibility: runtime-active groups show normally; selected off-class
+    -- groups can also show as config previews without becoming runtime-visible.
     local isActive = CooldownCompanion:IsGroupActive(groupId, {
         group = group,
         checkCharVisibility = true,
         checkLoadConditions = true,
         requireButtons = true,
+    }) or CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, {
+        group = group,
     })
     if isActive then
         if InCombatLockdown() and frame:IsProtected() then

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -4225,10 +4225,11 @@ function CooldownCompanion:SaveContainerPosition(containerId)
 end
 
 function CooldownCompanion:IsContainerVisibleToCurrentChar(containerId)
-    local container = self.db.profile.groupContainers[containerId]
-    if not container then return false end
-    if container.isGlobal then return true end
-    return container.createdBy == self.db.keys.char
+    if not (self.ResolveContainerClassScope and self.db and self.db.profile and self.db.profile.groupContainers) then
+        return false
+    end
+    local scope = self:ResolveContainerClassScope(containerId)
+    return scope.runtimeVisible == true
 end
 
 function CooldownCompanion:CreateAllContainerFrames()

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -798,6 +798,11 @@ function CooldownCompanion:CreateContainer(name)
             y = 0,
         },
     }
+    if self._currentSpecId then
+        db.groupContainers[containerId].specs = {
+            [self._currentSpecId] = true,
+        }
+    end
 
     return containerId
 end
@@ -1428,7 +1433,7 @@ function CooldownCompanion:RenameFolder(folderId, newName)
     return true
 end
 
-function CooldownCompanion:MoveGroupToFolder(id, folderId)
+function CooldownCompanion:MoveGroupToFolder(id, folderId, opts)
     local db = self.db.profile
 
     -- Resolve to container (id may be containerId or panel groupId)
@@ -1442,6 +1447,16 @@ function CooldownCompanion:MoveGroupToFolder(id, folderId)
         end
     end
     if not container then return end
+
+    if folderId and self.CanMoveContainerToFolder then
+        local ok = self:CanMoveContainerToFolder(containerId, folderId, opts)
+        if not ok then
+            if self.Print then
+                self:Print("Groups cannot be moved into folders owned by another class.")
+            end
+            return false
+        end
+    end
 
     container.folderId = folderId  -- nil = loose (no folder)
 
@@ -1460,6 +1475,7 @@ function CooldownCompanion:MoveGroupToFolder(id, folderId)
     for _, p in ipairs(panels) do
         self:RefreshGroupFrame(p.groupId)
     end
+    return true
 end
 
 function CooldownCompanion:ToggleFolderGlobal(folderId)
@@ -1843,35 +1859,6 @@ function CooldownCompanion:FindTalentSpellByName(name)
     return nil
 end
 
-------------------------------------------------------------------------
--- Cross-Character Browse Helpers
-------------------------------------------------------------------------
-
---- Scan profile containers for unique createdBy values other than current char.
---- Returns sorted array of { charKey, classFilename, classID }.
-function CooldownCompanion:EnumerateBrowseCharacters()
-    local db = self.db.profile
-    local currentChar = self.db.keys.char
-    local seen = {}
-    local result = {}
-
-    for _, container in pairs(db.groupContainers) do
-        local key = container.createdBy
-        if key and key ~= currentChar and not container.isGlobal and not seen[key] then
-            seen[key] = true
-            local info = self.db.global.characterInfo and self.db.global.characterInfo[key]
-            result[#result + 1] = {
-                charKey = key,
-                classFilename = info and info.classFilename or nil,
-                classID = info and info.classID or nil,
-            }
-        end
-    end
-
-    table_sort(result, function(a, b) return a.charKey < b.charKey end)
-    return result
-end
-
 --- Return sorted active-profile character choices for Load Conditions.
 --- Includes the current character, AceDB profile keys that point at the active
 --- profile, and owners referenced by entities in the active profile.
@@ -1931,51 +1918,6 @@ function CooldownCompanion:EnumerateActiveProfileCharacters()
 
     table_sort(result, function(a, b) return a.charKey < b.charKey end)
     return result
-end
-
---- Return sorted array of { containerId, container } for a given character key.
-function CooldownCompanion:GetCharacterContainers(charKey)
-    local db = self.db.profile
-    local result = {}
-
-    for containerId, container in pairs(db.groupContainers) do
-        if container.createdBy == charKey and not container.isGlobal then
-            -- Skip empty containers (no panels with buttons)
-            local hasButtons = false
-            for _, group in pairs(db.groups) do
-                if group.parentContainerId == containerId and self:GroupHasUsableButtons(group, {
-                    checkLoadConditions = false,
-                    ignoreSpellAvailability = true,
-                }) then
-                    hasButtons = true
-                    break
-                end
-            end
-            if hasButtons then
-                result[#result + 1] = { containerId = containerId, container = container }
-            end
-        end
-    end
-
-    local specId = self._currentSpecId
-    table_sort(result, function(a, b)
-        return self:GetOrderForSpec(a.container, specId, a.containerId) < self:GetOrderForSpec(b.container, specId, b.containerId)
-    end)
-    return result
-end
-
---- Copy a container from browse mode. Reuses DuplicateContainer, renames to original name.
-function CooldownCompanion:CopyContainerFromBrowse(sourceContainerId)
-    local sourceContainer = self.db.profile.groupContainers[sourceContainerId]
-    if not sourceContainer then return nil end
-
-    local originalName = sourceContainer.name
-    local newContainerId = self:DuplicateContainer(sourceContainerId)
-    if newContainerId then
-        -- Rename from "X (Copy)" back to original name
-        self.db.profile.groupContainers[newContainerId].name = originalName
-    end
-    return newContainerId
 end
 
 --- Copy a panel into an existing container owned by the current character.

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -107,6 +107,22 @@ local function NormalizeCopiedEntityForContainerScope(self, entity, container)
     end
 end
 
+local function ClearInvalidCopiedFolderId(self, entity, sourceEntity)
+    if type(entity) ~= "table" or not entity.folderId then
+        return
+    end
+    if sourceEntity and sourceEntity.isGlobal then
+        entity.folderId = nil
+        return
+    end
+    if self.CanMoveContainerToFolder then
+        local ok = self:CanMoveContainerToFolder(entity, entity.folderId)
+        if not ok then
+            entity.folderId = nil
+        end
+    end
+end
+
 function CooldownCompanion:NormalizeContainerAnchor(anchor, resolveAddonFrames)
     local normalized = type(anchor) == "table" and anchor or {}
     local point = normalized.point or "CENTER"
@@ -984,11 +1000,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
     newContainer.createdBy = self.db.keys.char
     newContainer.isGlobal = false
     NormalizeCopiedEntityForContainerScope(self, newContainer, newContainer)
-
-    -- If source was global, clear folderId on the copy
-    if sourceContainer.isGlobal and newContainer.folderId then
-        newContainer.folderId = nil
-    end
+    ClearInvalidCopiedFolderId(self, newContainer, sourceContainer)
 
     db.groupContainers[newContainerId] = newContainer
 
@@ -1208,6 +1220,15 @@ function CooldownCompanion:MovePanel(groupId, targetContainerId)
 
     local sourceContainerId = group.parentContainerId
     if sourceContainerId == targetContainerId then return false end
+    if self.CanMovePanelToContainer then
+        local ok = self:CanMovePanelToContainer(groupId, targetContainerId)
+        if not ok then
+            if self.Print then
+                self:Print("Panels cannot be moved into groups owned by another class.")
+            end
+            return false
+        end
+    end
 
     -- Reassign to target container
     group.parentContainerId = targetContainerId
@@ -1385,9 +1406,7 @@ function CooldownCompanion:DuplicateGroup(id)
     newGroup.createdBy = self.db.keys.char
     newGroup.isGlobal = false
     NormalizeCopiedEntityForContainerScope(self, newGroup, newGroup)
-    if sourceGroup.isGlobal and newGroup.folderId then
-        newGroup.folderId = nil
-    end
+    ClearInvalidCopiedFolderId(self, newGroup, sourceGroup)
 
     self.db.profile.groups[newGroupId] = newGroup
     self:CreateGroupFrame(newGroupId)

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -383,6 +383,52 @@ local function GroupMatchesDirectStyleCopyMode(group, mode)
     return group.displayMode == nil or group.displayMode == "icons"
 end
 
+function CooldownCompanion:CanCopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
+    sourceGroupId = tonumber(sourceGroupId)
+    targetGroupId = tonumber(targetGroupId)
+    if not IsValidDirectStyleCopyMode(mode) then
+        return false, "invalid_mode"
+    end
+
+    local db = self.db and self.db.profile
+    local sourceGroup = db and db.groups and db.groups[sourceGroupId]
+    local targetGroup = db and db.groups and db.groups[targetGroupId]
+    if not sourceGroup or not targetGroup then
+        return false, "missing_group"
+    end
+    if sourceGroupId == targetGroupId then
+        return false, "same_group"
+    end
+    if not GroupMatchesDirectStyleCopyMode(sourceGroup, mode)
+        or not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
+        return false, "mode_mismatch"
+    end
+
+    if self.ResolveContainerClassScope
+        and sourceGroup.parentContainerId
+        and targetGroup.parentContainerId then
+        local sourceScope = self:ResolveContainerClassScope(sourceGroup.parentContainerId)
+        local targetScope = self:ResolveContainerClassScope(targetGroup.parentContainerId)
+        if not sourceScope or not targetScope or sourceScope.isInvalid or targetScope.isInvalid then
+            return false, "invalid_class_scope"
+        end
+        if sourceScope.runtimeVisible == true then
+            return true
+        end
+        if sourceScope.isOtherClass
+            and targetScope.isOtherClass
+            and sourceScope.ownerClassKey == targetScope.ownerClassKey then
+            return true
+        end
+        return false, "source_unavailable"
+    end
+
+    if self:IsGroupVisibleToCurrentChar(sourceGroupId) then
+        return true
+    end
+    return false, "source_unavailable"
+end
+
 local function CopyCompactLayoutSettings(sourceGroup, targetGroup)
     targetGroup.compactLayout = sourceGroup.compactLayout == true
     targetGroup.compactGrowthDirection = sourceGroup.compactGrowthDirection or "center"
@@ -634,7 +680,7 @@ function CooldownCompanion:GetDirectStyleCopyPanelList(mode, targetGroupId)
     for groupId, group in pairs(db.groups or {}) do
         if groupId ~= targetGroupId
             and GroupMatchesDirectStyleCopyMode(group, mode)
-            and self:IsGroupVisibleToCurrentChar(groupId) then
+            and self:CanCopyDirectStyleFromPanel(mode, groupId, targetGroupId) then
             local parentContainer = self:GetParentContainer(group)
             local containerName = parentContainer and parentContainer.name
                 or group.name
@@ -693,8 +739,9 @@ function CooldownCompanion:CopyDirectStyleFromPanel(mode, sourceGroupId, targetG
         or not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
         return false, "mode_mismatch"
     end
-    if not self:IsGroupVisibleToCurrentChar(sourceGroupId) then
-        return false, "source_unavailable"
+    local canCopy, reason = self:CanCopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
+    if not canCopy then
+        return false, reason
     end
 
     local oldMasqueEnabled = targetGroup.masqueEnabled and true or false

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1308,7 +1308,8 @@ end
 
 function CooldownCompanion:IsGroupActive(groupId, opts)
     opts = opts or {}
-    local group = opts.group or self.db.profile.groups[groupId]
+    local db = self.db and self.db.profile
+    local group = opts.group or (db and db.groups and db.groups[groupId])
     if not group then return false end
 
     -- If this panel has a parent container, check container-level state first
@@ -1362,6 +1363,38 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
     end
 
     return true
+end
+
+function CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, opts)
+    opts = opts or {}
+    if not (groupId and ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(groupId)) then
+        return false
+    end
+
+    local db = self.db and self.db.profile
+    local group = opts.group or (db and db.groups and db.groups[groupId])
+    if not group then return false end
+
+    local container = self:GetParentContainer(group)
+    if container then
+        if container.enabled == false or group.enabled == false then return false end
+    elseif group.enabled == false then
+        return false
+    end
+
+    if not self:IsRotationAssistantGroup(group) and not (group.buttons and #group.buttons > 0) then
+        return false
+    end
+
+    if not self.ResolveContainerClassScope then
+        return false
+    end
+    if not group.parentContainerId then
+        return false
+    end
+
+    local scope = self:ResolveContainerClassScope(group.parentContainerId)
+    return scope and scope.isOtherClass == true and scope.isInvalid ~= true
 end
 
 function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
@@ -1677,6 +1710,41 @@ function CooldownCompanion:CanMovePanelToContainer(groupOrGroupId, targetContain
         return true
     end
     return false, "mixed-class-panel"
+end
+
+function CooldownCompanion:CanMoveEntryToGroup(sourceGroupId, targetGroupId)
+    local db = self.db and self.db.profile
+    if not (db and db.groups) then
+        return false
+    end
+    if sourceGroupId == targetGroupId then
+        return false
+    end
+
+    local sourceGroup = db.groups[sourceGroupId]
+    local targetGroup = db.groups[targetGroupId]
+    if not (sourceGroup and targetGroup and sourceGroup.parentContainerId and targetGroup.parentContainerId) then
+        return false
+    end
+
+    if not self.ResolveContainerClassScope then
+        return self:IsGroupVisibleToCurrentChar(targetGroupId)
+    end
+
+    local sourceScope = self:ResolveContainerClassScope(sourceGroup.parentContainerId)
+    if not sourceScope or sourceScope.isInvalid then
+        return false
+    end
+
+    if sourceScope.isOtherClass then
+        local targetScope = self:ResolveContainerClassScope(targetGroup.parentContainerId)
+        return targetScope
+            and targetScope.isInvalid ~= true
+            and targetScope.isOtherClass == true
+            and targetScope.ownerClassKey == sourceScope.ownerClassKey
+    end
+
+    return self:IsGroupVisibleToCurrentChar(targetGroupId)
 end
 
 local function PruneSpecMapToClass(addon, entity, map, classKey)
@@ -2675,6 +2743,8 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
                 checkCharVisibility = true,
                 checkLoadConditions = true,
                 requireButtons = true,
+            }) or self:IsGroupEligibleForConfigPreview(groupId, {
+                group = group,
             })
             if (active or (wasPreviewed and frame))
                 and (not frame

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1383,15 +1383,29 @@ local function ClearEmptyCoreLoadConditions(entity)
     end
 end
 
+local function GetClassInfoByID(classID)
+    classID = tonumber(classID)
+    if not classID then return nil, nil, nil end
+    if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return classInfo.className, classInfo.classFile, classInfo.classID
+        end
+    end
+    if GetClassInfo then
+        return GetClassInfo(classID)
+    end
+    return nil, nil, nil
+end
+
 local function GetClassKeyFromClassID(classID)
-    if not (classID and GetClassInfo) then return nil end
-    local _, classFilename = GetClassInfo(classID)
+    local _, classFilename = GetClassInfoByID(classID)
     return NormalizeClassKey(classFilename)
 end
 
 local function GetClassIDFromClassKey(classKey)
     classKey = NormalizeClassKey(classKey)
-    if not (classKey and GetClassInfo) then return nil end
+    if not classKey then return nil end
     for classID = 1, CLASS_SCAN_LIMIT do
         if GetClassKeyFromClassID(classID) == classKey then
             return classID

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1628,6 +1628,57 @@ function CooldownCompanion:CanMoveContainerToFolder(containerOrContainerId, fold
     return false, "scope-mismatch"
 end
 
+function CooldownCompanion:CanMovePanelToContainer(groupOrGroupId, targetContainerOrContainerId)
+    local db = self.db and self.db.profile
+    if not (db and db.groups and db.groupContainers) then
+        return false, "missing-profile"
+    end
+
+    local group = groupOrGroupId
+    if type(groupOrGroupId) ~= "table" then
+        group = db.groups[groupOrGroupId]
+    end
+    if type(group) ~= "table" or not group.parentContainerId then
+        return false, "missing-source-panel"
+    end
+
+    local targetContainer = targetContainerOrContainerId
+    local targetContainerId
+    if type(targetContainerOrContainerId) ~= "table" then
+        targetContainerId = targetContainerOrContainerId
+        targetContainer = db.groupContainers[targetContainerOrContainerId]
+    else
+        for containerId, container in pairs(db.groupContainers) do
+            if container == targetContainer then
+                targetContainerId = containerId
+                break
+            end
+        end
+    end
+    if type(targetContainer) ~= "table" then
+        return false, "missing-target-container"
+    end
+    if targetContainerId and group.parentContainerId == targetContainerId then
+        return false, "same-container"
+    end
+
+    local sourceScope = self:ResolveContainerClassScope(group.parentContainerId)
+    local targetScope = self:ResolveContainerClassScope(targetContainer)
+    if sourceScope.isInvalid or targetScope.isInvalid then
+        return false, "invalid-class-scope"
+    end
+    if sourceScope.scope ~= targetScope.scope then
+        return false, "scope-mismatch"
+    end
+    if sourceScope.scope == "global" then
+        return true
+    end
+    if sourceScope.ownerClassKey == targetScope.ownerClassKey then
+        return true
+    end
+    return false, "mixed-class-panel"
+end
+
 local function PruneSpecMapToClass(addon, entity, map, classKey)
     if type(map) ~= "table" or not classKey then return false end
     local changed = false

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -587,8 +587,10 @@ function CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
     end
 
     -- Legacy path (no container)
-    if group.isGlobal then return true end
-    return group.createdBy == self.db.keys.char
+    local scope = self:ResolveProfileEntityClassScope(group, {
+        isGlobal = group.isGlobal == true,
+    })
+    return scope.runtimeVisible == true
 end
 
 -- Resolve the container for a panel group, or nil if the group has no container.
@@ -1468,6 +1470,149 @@ local function GetCharacterClassKey(addon, charKey)
     end
     return NormalizeClassKey(info.classFilename)
         or GetClassKeyFromClassID(info.classID)
+end
+
+local function BuildClassScopeResult(scope, opts)
+    opts = opts or {}
+    return {
+        scope = scope,
+        sectionKey = opts.sectionKey,
+        ownerCharKey = opts.ownerCharKey,
+        ownerClassKey = opts.ownerClassKey,
+        classFilename = opts.ownerClassKey,
+        currentClassKey = opts.currentClassKey,
+        currentCharKey = opts.currentCharKey,
+        isGlobal = scope == "global",
+        isCurrentClass = scope == "current-class",
+        isOtherClass = scope == "other-class",
+        isInvalid = scope == "invalid",
+        runtimeVisible = scope == "global" or scope == "current-class",
+        invalidReason = opts.invalidReason,
+    }
+end
+
+local function ResolveProfileEntityClassScope(addon, entity, opts)
+    opts = opts or {}
+    local currentCharKey = opts.currentCharKey
+        or addon and addon.db and addon.db.keys and addon.db.keys.char
+        or nil
+    local currentClassKey = NormalizeClassKey(opts.currentClassKey)
+        or GetCurrentScopeClassKey(addon)
+
+    if type(entity) ~= "table" then
+        return BuildClassScopeResult("invalid", {
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "invalid",
+            invalidReason = "missing-entity",
+        })
+    end
+
+    if opts.isGlobal == true then
+        return BuildClassScopeResult("global", {
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "global",
+        })
+    end
+
+    local ownerCharKey = opts.ownerCharKey or entity.createdBy
+    if type(ownerCharKey) ~= "string" or ownerCharKey == "" then
+        return BuildClassScopeResult("invalid", {
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "invalid",
+            invalidReason = "missing-owner",
+        })
+    end
+
+    local ownerClassKey = GetCharacterClassKey(addon, ownerCharKey)
+    if not ownerClassKey then
+        return BuildClassScopeResult("invalid", {
+            ownerCharKey = ownerCharKey,
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "invalid",
+            invalidReason = "missing-owner-class",
+        })
+    end
+
+    if ownerClassKey == currentClassKey then
+        return BuildClassScopeResult("current-class", {
+            ownerCharKey = ownerCharKey,
+            ownerClassKey = ownerClassKey,
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "char",
+        })
+    end
+
+    return BuildClassScopeResult("other-class", {
+        ownerCharKey = ownerCharKey,
+        ownerClassKey = ownerClassKey,
+        currentCharKey = currentCharKey,
+        currentClassKey = currentClassKey,
+        sectionKey = "class:" .. ownerClassKey,
+    })
+end
+
+function CooldownCompanion:ResolveProfileEntityClassScope(entity, opts)
+    return ResolveProfileEntityClassScope(self, entity, opts)
+end
+
+function CooldownCompanion:ResolveContainerClassScope(containerOrContainerId, opts)
+    local container = containerOrContainerId
+    if type(containerOrContainerId) == "number" then
+        local db = self.db and self.db.profile
+        container = db and db.groupContainers and db.groupContainers[containerOrContainerId] or nil
+    end
+    opts = opts and CopyTable(opts) or {}
+    opts.isGlobal = type(container) == "table" and container.isGlobal == true
+    return ResolveProfileEntityClassScope(self, container, opts)
+end
+
+function CooldownCompanion:ResolveFolderClassScope(folderOrFolderId, opts)
+    local folder = folderOrFolderId
+    if type(folderOrFolderId) == "number" then
+        local db = self.db and self.db.profile
+        folder = db and db.folders and db.folders[folderOrFolderId] or nil
+    end
+    opts = opts and CopyTable(opts) or {}
+    opts.isGlobal = type(folder) == "table" and folder.section == "global"
+    return ResolveProfileEntityClassScope(self, folder, opts)
+end
+
+function CooldownCompanion:CanMoveContainerToFolder(containerOrContainerId, folderOrFolderId, opts)
+    opts = opts or {}
+    if folderOrFolderId == nil then
+        return true
+    end
+
+    local containerScope = self:ResolveContainerClassScope(containerOrContainerId)
+    local folderScope = self:ResolveFolderClassScope(folderOrFolderId)
+    if containerScope.isInvalid or folderScope.isInvalid then
+        return false, "invalid-class-scope"
+    end
+
+    if containerScope.scope == folderScope.scope then
+        if containerScope.scope == "global" then
+            return true
+        end
+        return containerScope.ownerClassKey == folderScope.ownerClassKey, "mixed-class-folder"
+    end
+
+    if opts.allowScopeChange == true then
+        if containerScope.scope == "global" and folderScope.scope == "current-class" then
+            return true
+        end
+        if folderScope.scope == "global"
+            and (containerScope.scope == "current-class" or containerScope.scope == "other-class")
+        then
+            return true
+        end
+    end
+
+    return false, "scope-mismatch"
 end
 
 local function PruneSpecMapToClass(addon, entity, map, classKey)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1479,7 +1479,6 @@ local function BuildClassScopeResult(scope, opts)
         sectionKey = opts.sectionKey,
         ownerCharKey = opts.ownerCharKey,
         ownerClassKey = opts.ownerClassKey,
-        classFilename = opts.ownerClassKey,
         currentClassKey = opts.currentClassKey,
         currentCharKey = opts.currentCharKey,
         isGlobal = scope == "global",
@@ -1769,9 +1768,16 @@ function CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(folderId,
     opts = WithOwnerCharKey(opts, folder.createdBy or (self.db and self.db.keys and self.db.keys.char))
 
     local changed = self:NormalizeEligibilityForCharacterScope(folder, opts)
+    local childContainerIds = {}
     for containerId, container in pairs(db.groupContainers or {}) do
         if type(container) == "table" and container.folderId == folderId then
-            changed = self:NormalizeContainerEligibilityForCharacterScope(containerId, opts) or changed
+            childContainerIds[containerId] = true
+            changed = self:NormalizeEligibilityForCharacterScope(container, opts) or changed
+        end
+    end
+    for _, group in pairs(db.groups or {}) do
+        if type(group) == "table" and childContainerIds[group.parentContainerId] then
+            changed = self:NormalizeEligibilityForCharacterScope(group, opts) or changed
         end
     end
     return changed

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -1696,7 +1696,7 @@ local function RefreshColumn1(preserveDrag)
             section = {
                 key = scope.sectionKey,
                 classKey = scope.ownerClassKey,
-                title = GetClassDisplayName(scope.ownerClassKey) .. " Groups",
+                title = GetClassDisplayName(scope.ownerClassKey),
                 color = cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
                 containerIds = {},
                 count = 0,

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -10,7 +10,6 @@ local CS = ST._configState
 local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
-local BuildHeroTalentSubTreeCheckboxes = ST._BuildHeroTalentSubTreeCheckboxes
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
 local ApplyConfigTextRow = ST._ApplyConfigTextRow
@@ -35,7 +34,6 @@ local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
 local ContainersHaveForeignSpecs = ST._ContainersHaveForeignSpecs
 local FolderHasForeignSpecs = ST._FolderHasForeignSpecs
-local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
@@ -48,16 +46,12 @@ local SelectConfigPanel = ST._SelectConfigPanel
 local GenerateGroupName
 
 local function OpenContainerLoadConditions(containerId)
-    CS.specExpandedGroupId = nil
-    CS.specExpandedFolderId = nil
     SelectConfigContainer(containerId)
     CS.selectedContainerTab = "loadconditions"
     CooldownCompanion:RefreshConfigPanel()
 end
 
 local function OpenFolderLoadConditions(folderId)
-    CS.specExpandedGroupId = nil
-    CS.specExpandedFolderId = nil
     SelectConfigFolder(folderId)
     CooldownCompanion:RefreshConfigPanel()
 end
@@ -126,204 +120,6 @@ local function ConfigureGenericGroupRenameBadge(entry, container, containerId, n
     badge:Show()
 end
 
-------------------------------------------------------------------------
--- Browse mode: class-colored name helper
-------------------------------------------------------------------------
-local function GetClassColoredCharName(charKey, classFilename)
-    local name = charKey:match("^(.-)%s*%-") or charKey
-    if classFilename then
-        local cc = C_ClassColor.GetClassColor(classFilename)
-        if cc then
-            return cc:WrapTextInColorCode(name), cc
-        end
-    end
-    return name, nil
-end
-
-------------------------------------------------------------------------
--- Browse mode: render cross-character browsing UI in Column 1
-------------------------------------------------------------------------
-local function RenderBrowseMode()
-    if not CS.col1Scroll then return end
-    CS.col1Scroll:ReleaseChildren()
-
-    -- Hide button bar in browse mode
-    if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
-
-    local db = CooldownCompanion.db.profile
-
-    if not CS.browseCharKey then
-        -- Phase A: Character list
-        local backBtn = AceGUI:Create("InteractiveLabel")
-        CleanRecycledEntry(backBtn)
-        backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to My Groups")
-        backBtn:SetFullWidth(true)
-        backBtn:SetFontObject(GameFontHighlight)
-        ApplyConfigTextRow(backBtn)
-        backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-        backBtn:SetCallback("OnClick", function()
-            CS.browseMode = false
-            CS.browseCharKey = nil
-            CS.browseContainerId = nil
-            ClearConfigPrimarySelection()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        CS.col1Scroll:AddChild(backBtn)
-
-        local heading = AceGUI:Create("Heading")
-        heading:SetText("Other Characters")
-        heading:SetFullWidth(true)
-        CS.col1Scroll:AddChild(heading)
-
-        local chars = CooldownCompanion:EnumerateBrowseCharacters()
-        if #chars == 0 then
-            local emptyLabel = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(emptyLabel)
-            emptyLabel:SetText("|cff888888No other characters have groups on this profile.|r")
-            emptyLabel:SetFullWidth(true)
-            CS.col1Scroll:AddChild(emptyLabel)
-            return
-        end
-
-        for _, charInfo in ipairs(chars) do
-            local entry = AceGUI:Create("InteractiveLabel")
-            CleanRecycledEntry(entry)
-            local displayName, cc = GetClassColoredCharName(charInfo.charKey, charInfo.classFilename)
-
-            entry:SetText(displayName)
-            entry:SetFullWidth(true)
-            entry:SetFontObject(GameFontHighlight)
-            -- Class icon (use individual atlas to avoid tiled-sheet border)
-            if charInfo.classFilename then
-                ApplyConfigRowIcon(entry, 134400, { atlas = "classicon-" .. strlower(charInfo.classFilename) })
-            else
-                ApplyConfigRowIcon(entry, 134400)
-            end
-            entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-            entry:SetCallback("OnClick", function()
-                CS.browseCharKey = charInfo.charKey
-                CS.browseContainerId = nil
-                ClearConfigPrimarySelection()
-                CooldownCompanion:RefreshConfigPanel()
-            end)
-            CS.col1Scroll:AddChild(entry)
-        end
-    else
-        -- Phase B: Selected character's groups
-        local backBtn = AceGUI:Create("InteractiveLabel")
-        CleanRecycledEntry(backBtn)
-        backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to Characters")
-        backBtn:SetFullWidth(true)
-        backBtn:SetFontObject(GameFontHighlight)
-        ApplyConfigTextRow(backBtn)
-        backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-        backBtn:SetCallback("OnClick", function()
-            CS.browseCharKey = nil
-            CS.browseContainerId = nil
-            ClearConfigPrimarySelection()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        CS.col1Scroll:AddChild(backBtn)
-
-        -- Character heading with class color
-        local charInfo = CooldownCompanion.db.global.characterInfo and CooldownCompanion.db.global.characterInfo[CS.browseCharKey]
-        local classFilename = charInfo and charInfo.classFilename
-        local charName = CS.browseCharKey:match("^(.-)%s*%-") or CS.browseCharKey
-        local displayHeading = charName .. "'s Groups"
-
-        local heading = AceGUI:Create("Heading")
-        heading:SetText(displayHeading)
-        heading:SetFullWidth(true)
-        if classFilename then
-            local cc = C_ClassColor.GetClassColor(classFilename)
-            if cc then heading.label:SetTextColor(cc.r, cc.g, cc.b) end
-        end
-        CS.col1Scroll:AddChild(heading)
-
-        local containers = CooldownCompanion:GetCharacterContainers(CS.browseCharKey)
-        if #containers == 0 then
-            local emptyLabel = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(emptyLabel)
-            emptyLabel:SetText("|cff888888This character has no groups.|r")
-            emptyLabel:SetFullWidth(true)
-            CS.col1Scroll:AddChild(emptyLabel)
-            return
-        end
-
-        for _, item in ipairs(containers) do
-            local containerId = item.containerId
-            local container = item.container
-
-            local entry = AceGUI:Create("InteractiveLabel")
-            CleanRecycledEntry(entry)
-
-            local panelCount = CooldownCompanion:GetPanelCount(containerId)
-            local displayName = container.name
-            if panelCount > 1 then
-                displayName = displayName .. "  |cff888888(" .. panelCount .. " panels)|r"
-            end
-
-            entry:SetText(displayName)
-            entry:SetFullWidth(true)
-            entry:SetFontObject(GameFontHighlight)
-            ApplyConfigRowIcon(entry, GetContainerIcon(containerId, db))
-            entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-
-            -- Green highlight for selected browse container
-            if CS.browseContainerId == containerId then
-                entry:SetColor(0, 1, 0)
-            end
-
-            -- Neutralize built-in OnClick
-            entry:SetCallback("OnClick", function() end)
-
-            -- Left-click: select for preview; Right-click: copy context menu
-            entry.frame:SetScript("OnMouseUp", function(self, button)
-                if button == "LeftButton" then
-                    if CS.browseContainerId == containerId then
-                        CS.browseContainerId = nil
-                        SelectConfigContainer(nil, { keepContainerMulti = true })
-                    else
-                        CS.browseContainerId = containerId
-                        SelectConfigContainer(containerId, { keepContainerMulti = true })
-                    end
-                    CooldownCompanion:RefreshConfigPanel()
-                elseif button == "RightButton" then
-                    -- Verify source still exists
-                    if not db.groupContainers[containerId] then return end
-                    if not CS.browseContextMenu then
-                        CS.browseContextMenu = CreateFrame("Frame", "CDCBrowseContextMenu", UIParent, "UIDropDownMenuTemplate")
-                    end
-                    UIDropDownMenu_Initialize(CS.browseContextMenu, function(self, level)
-                        local info = UIDropDownMenu_CreateInfo()
-                        info.text = "Copy Entire Group"
-                        info.notCheckable = true
-                        info.func = function()
-                            CloseDropDownMenus()
-                            if not db.groupContainers[containerId] then return end
-                            local newId = CooldownCompanion:CopyContainerFromBrowse(containerId)
-                            if newId then
-                                CS.browseMode = false
-                                CS.browseCharKey = nil
-                                CS.browseContainerId = nil
-                                SelectConfigContainer(newId)
-                                CooldownCompanion:RefreshConfigPanel()
-                                CooldownCompanion:Print("Group copied successfully.")
-                            end
-                        end
-                        UIDropDownMenu_AddButton(info, level)
-                    end, "MENU")
-                    CS.browseContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
-                    ToggleDropDownMenu(1, nil, CS.browseContextMenu, "cursor", 0, 0)
-                end
-            end)
-
-            CS.col1Scroll:AddChild(entry)
-            SetupGroupRowIndicators(entry, container)
-        end
-    end
-end
-
 local PANEL_CREATION_MODES = {
     { mode = "icons", label = "Icon Panel" },
     { mode = "bars", label = "Bar Panel" },
@@ -383,19 +179,44 @@ local function BuildSelectedContainersExportPayload(db, selectedGroups)
     }
 end
 
+local function ResolveContainerScopeForConfig(containerId, container, charKey)
+    if CooldownCompanion.ResolveContainerClassScope then
+        return CooldownCompanion:ResolveContainerClassScope(container or containerId)
+    end
+    if container and container.isGlobal then
+        return { scope = "global", sectionKey = "global", runtimeVisible = true }
+    end
+    if container and container.createdBy == charKey then
+        return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+    end
+    return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+end
+
+local function ResolveFolderScopeForConfig(folderId, folder, charKey)
+    if CooldownCompanion.ResolveFolderClassScope then
+        return CooldownCompanion:ResolveFolderClassScope(folder or folderId)
+    end
+    if folder and folder.section == "global" then
+        return { scope = "global", sectionKey = "global", runtimeVisible = true }
+    end
+    if folder and folder.createdBy == charKey then
+        return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+    end
+    return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+end
+
 local function GetFolderTargetsForSection(db, charKey, section)
     local folderList = {}
     for fid, folder in pairs(db.folders) do
-        if folder.section == section then
-            if section == "char" and folder.createdBy and folder.createdBy ~= charKey then
-                -- skip: belongs to another character
-            else
-                folderList[#folderList + 1] = {
-                    id = fid,
-                    name = folder.name,
-                    order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid),
-                }
-            end
+        local scope = ResolveFolderScopeForConfig(fid, folder, charKey)
+        local folderSection = scope and scope.sectionKey
+            or (folder.section == "global" and "global" or "char")
+        if folderSection == section then
+            folderList[#folderList + 1] = {
+                id = fid,
+                name = folder.name,
+                order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid),
+            }
         end
     end
     table.sort(folderList, function(a, b) return a.order < b.order end)
@@ -465,7 +286,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             UIDropDownMenu_AddButton(info, level)
 
             info = UIDropDownMenu_CreateInfo()
-            info.text = container.isGlobal and "Make Character-Only" or "Make Global"
+            info.text = container.isGlobal and "Move to Current Class" or "Make Global"
             info.notCheckable = true
             info.func = function()
                 CloseDropDownMenus()
@@ -478,7 +299,8 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             end
             UIDropDownMenu_AddButton(info, level)
 
-            local containerSection = container.isGlobal and "global" or "char"
+            local containerScope = ResolveContainerScopeForConfig(containerId, container, charKey)
+            local containerSection = containerScope.sectionKey or (container.isGlobal and "global" or "char")
             local folderTargets = GetFolderTargetsForSection(db, charKey, containerSection)
             if #folderTargets > 0 or container.folderId then
                 info = UIDropDownMenu_CreateInfo()
@@ -631,7 +453,8 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             end
             UIDropDownMenu_AddButton(info, level)
 
-            local containerSection = container.isGlobal and "global" or "char"
+            local containerScope = ResolveContainerScopeForConfig(containerId, container, charKey)
+            local containerSection = containerScope.sectionKey or (container.isGlobal and "global" or "char")
             for _, folderTarget in ipairs(GetFolderTargetsForSection(db, charKey, containerSection)) do
                 info = UIDropDownMenu_CreateInfo()
                 info.text = folderTarget.name
@@ -699,8 +522,18 @@ local function ShowFolderContextMenu(db, folderId, folder)
         info.notCheckable = true
         info.func = function()
             CloseDropDownMenus()
+            local charKey = CooldownCompanion.db and CooldownCompanion.db.keys and CooldownCompanion.db.keys.char
+            local folderScope = ResolveFolderScopeForConfig(folderId, folder, charKey)
+            if folderScope.scope == "other-class" then
+                CooldownCompanion:Print("Create new groups in your current class, then move them to Global if needed.")
+                return
+            end
             local containerId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
-            CooldownCompanion:MoveGroupToFolder(containerId, folderId)
+            local container = db.groupContainers and db.groupContainers[containerId]
+            if container and folderScope.scope == "global" then
+                container.isGlobal = true
+            end
+            CooldownCompanion:MoveGroupToFolder(containerId, folderId, { allowScopeChange = true })
             SelectConfigContainer(containerId)
             CooldownCompanion:RefreshConfigPanel()
         end
@@ -731,7 +564,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
         end
 
         info = UIDropDownMenu_CreateInfo()
-        info.text = folder.section == "global" and "Make Character Folder" or "Make Global Folder"
+        info.text = folder.section == "global" and "Move to Current Class Folder" or "Make Global Folder"
         info.notCheckable = true
         info.func = function()
             CloseDropDownMenus()
@@ -917,6 +750,61 @@ local function PopulateColumn1ButtonBar()
     end)
 end
 
+local function RefreshColumn1FooterLayout()
+    if CS.UpdateColumn1FooterLayout then
+        CS.UpdateColumn1FooterLayout()
+    end
+end
+
+local function ClearOtherClassesFooterDoorway()
+    CS.col1FooterDoorwayVisible = false
+    CS.lastCol1FooterDoorwayRow = nil
+    local row = CS.col1FooterDoorway
+    if row and row.frame then
+        row.frame:SetScript("OnMouseUp", nil)
+        row.frame:Hide()
+    end
+    RefreshColumn1FooterLayout()
+end
+
+local function SetOtherClassesFooterDoorway(text, stableCount, onClick)
+    local row = CS.col1FooterDoorway
+    if not (row and row.frame) then
+        ClearOtherClassesFooterDoorway()
+        return false
+    end
+
+    CleanRecycledEntry(row)
+    row:SetText(text)
+    row:SetFullWidth(true)
+    row:SetFontObject(GameFontHighlight)
+    ApplyConfigTextRow(row, "CENTER")
+    row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+    row.frame:SetScript("OnMouseUp", function(_, button)
+        if CS.dragState and CS.dragState.phase == "active" then return end
+        if button == "LeftButton" and onClick then
+            onClick()
+        end
+    end)
+
+    CS.col1FooterDoorwayVisible = true
+    CS.lastCol1FooterDoorwayRow = {
+        kind = "other-classes-doorway",
+        widget = row,
+        section = "other-classes",
+        loadBucket = "marker",
+        acceptsDrop = false,
+        keepVisibleDuringPreview = false,
+        previewProxy = false,
+        isMarker = true,
+        stableCount = stableCount,
+        visible = true,
+    }
+    row.frame:Show()
+    RefreshColumn1FooterLayout()
+    return true
+end
+
 ------------------------------------------------------------------------
 -- COLUMN 1: Groups
 ------------------------------------------------------------------------
@@ -925,6 +813,9 @@ local function RefreshColumn1(preserveDrag)
 
     -- Bars & Frames panel mode: take over col1 with the bar/frame tab group
     if CS.resourceBarPanelActive then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassesFooterDoorway()
         CancelDrag()
         CS.HideAutocomplete()
         CS.col1Scroll.frame:Hide()
@@ -983,13 +874,6 @@ local function RefreshColumn1(preserveDrag)
     end
     CS.col1Scroll.frame:Show()
 
-    -- Cross-character browse mode: render browse UI instead of normal groups
-    if CS.browseMode then
-        CancelDrag()
-        RenderBrowseMode()
-        return
-    end
-
     if CS.col1ButtonBar then CS.col1ButtonBar:Show() end
 
     if not preserveDrag then CancelDrag() end
@@ -1011,6 +895,9 @@ local function RefreshColumn1(preserveDrag)
     if not db.folders then db.folders = {} end
 
     if CooldownCompanion._unsupportedLegacyProfile then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassesFooterDoorway()
         if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
 
         local spacer = AceGUI:Create("SimpleGroup")
@@ -1080,18 +967,44 @@ local function RefreshColumn1(preserveDrag)
         })
     end
 
+    local function ResolveContainerScope(containerId, container)
+        if CooldownCompanion.ResolveContainerClassScope then
+            return CooldownCompanion:ResolveContainerClassScope(container or containerId)
+        end
+        if container and container.isGlobal then
+            return { scope = "global", sectionKey = "global", runtimeVisible = true }
+        end
+        if container and container.createdBy == charKey then
+            return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+        end
+        return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+    end
+
+    local function ResolveFolderScope(folderId, folder)
+        if CooldownCompanion.ResolveFolderClassScope then
+            return CooldownCompanion:ResolveFolderClassScope(folder or folderId)
+        end
+        if folder and folder.section == "global" then
+            return { scope = "global", sectionKey = "global", runtimeVisible = true }
+        end
+        if folder and folder.createdBy == charKey then
+            return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+        end
+        return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+    end
+
+    local function ScopeMatchesSection(scope, section)
+        return scope and scope.sectionKey == section
+    end
+
     -- Build top-level items for a section (folders + loose containers), sorted by order
     local function BuildSectionItems(section, sectionContainerIds)
         -- Collect folders for this section
         local sectionFolderIds = {}
         for fid, folder in pairs(db.folders) do
-            if folder.section == section then
-                -- Character folders: only show if owned by current character
-                if section == "char" and folder.createdBy and folder.createdBy ~= charKey then
-                    -- skip: belongs to another character
-                else
-                    table.insert(sectionFolderIds, fid)
-                end
+            local scope = ResolveFolderScope(fid, folder)
+            if ScopeMatchesSection(scope, section) then
+                table.insert(sectionFolderIds, fid)
             end
         end
 
@@ -1209,9 +1122,10 @@ local function RefreshColumn1(preserveDrag)
     end
 
     -- Helper: render a single container row (reused by both sections)
-    local function RenderContainerRow(containerId, inFolder, sectionTag, loadBucket)
+    local function RenderContainerRow(containerId, inFolder, sectionTag, loadBucket, options)
         local container = db.groupContainers[containerId]
         if not container then return end
+        local disableDrag = options and options.disableDrag == true
 
         local entry = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(entry)
@@ -1265,32 +1179,34 @@ local function RefreshColumn1(preserveDrag)
             ConfigureGenericGroupRenameBadge(entry, container, containerId, groupNameWidth)
         end
 
-        entry:SetCallback("OnClick", function(widget, event, mouseButton)
-            if mouseButton == "LeftButton"
-                and not searchResults
-                and not IsShiftKeyDown()
-                and not IsControlKeyDown()
-                and not GetCursorInfo()
-            then
-                local isMulti = next(CS.selectedGroups) and CS.selectedGroups[containerId]
-                local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
-                CS.dragState = {
-                    kind = isMulti and "multi-group" or (inFolder and "folder-group" or "group"),
-                    phase = "pending",
-                    sourceGroupId = containerId,
-                    sourceGroupIds = isMulti and CopyTable(CS.selectedGroups) or nil,
-                    sourceSection = sectionTag,
-                    sourceFolderId = inFolder and container.folderId or nil,
-                    sourceLoadBucket = isMulti and ResolveSelectedDragLoadBucket(loadBucket) or (loadBucket or "loaded"),
-                    scrollWidget = CS.col1Scroll,
-                    widget = entry,
-                    startX = cursorX,
-                    startY = cursorY,
-                    col1RenderedRows = col1RenderedRows,
-                }
-                StartDragTracking()
-            end
-        end)
+        if not disableDrag then
+            entry:SetCallback("OnClick", function(widget, event, mouseButton)
+                if mouseButton == "LeftButton"
+                    and not searchResults
+                    and not IsShiftKeyDown()
+                    and not IsControlKeyDown()
+                    and not GetCursorInfo()
+                then
+                    local isMulti = next(CS.selectedGroups) and CS.selectedGroups[containerId]
+                    local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
+                    CS.dragState = {
+                        kind = isMulti and "multi-group" or (inFolder and "folder-group" or "group"),
+                        phase = "pending",
+                        sourceGroupId = containerId,
+                        sourceGroupIds = isMulti and CopyTable(CS.selectedGroups) or nil,
+                        sourceSection = sectionTag,
+                        sourceFolderId = inFolder and container.folderId or nil,
+                        sourceLoadBucket = isMulti and ResolveSelectedDragLoadBucket(loadBucket) or (loadBucket or "loaded"),
+                        scrollWidget = CS.col1Scroll,
+                        widget = entry,
+                        startX = cursorX,
+                        startY = cursorY,
+                        col1RenderedRows = col1RenderedRows,
+                    }
+                    StartDragTracking()
+                end
+            end)
+        end
 
         -- Handle clicks via OnMouseUp
         entry.frame:SetScript("OnMouseUp", function(self, button)
@@ -1338,165 +1254,10 @@ local function RefreshColumn1(preserveDrag)
             inFolder = inFolder and container.folderId or nil,
             section = sectionTag,
             loadBucket = loadBucket or "loaded",
-            acceptsDrop = (loadBucket or "loaded") ~= "unloaded",
-            previewDraggable = true,
+            acceptsDrop = (not disableDrag) and (loadBucket or "loaded") ~= "unloaded",
+            previewDraggable = not disableDrag,
             previewProxy = true,
         })
-
-        -- Inline spec filter panel (expanded via Shift+Left-click)
-        if CS.specExpandedGroupId == containerId then
-            local numSpecs = GetNumSpecializations()
-            local configID = C_ClassTalents.GetActiveConfigID()
-            local htIndent = inFolder and 32 or 20
-            local folder = container.folderId and db.folders and db.folders[container.folderId]
-            local folderSpecs = folder and folder.specs
-            local folderHeroTalents = folder and folder.heroTalents
-            local effectiveSpecs
-            if folderSpecs or container.specs then
-                effectiveSpecs = {}
-                if folderSpecs then for k in pairs(folderSpecs) do effectiveSpecs[k] = true end end
-                if container.specs then for k in pairs(container.specs) do effectiveSpecs[k] = true end end
-                if not next(effectiveSpecs) then effectiveSpecs = nil end
-            end
-            for i = 1, numSpecs do
-                local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-                local lockedByFolder = folderSpecs and folderSpecs[specId]
-                local cb = AceGUI:Create("CheckBox")
-                cb:SetLabel(name)
-                cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92)
-                cb:SetFullWidth(true)
-                cb:SetValue(lockedByFolder or (container.specs and container.specs[specId]) or false)
-                if folderSpecs then
-                    cb:SetDisabled(true)
-                else
-                    cb:SetCallback("OnValueChanged", function(widget, event, value)
-                        if value then
-                            if not container.specs then container.specs = {} end
-                            container.specs[specId] = true
-                        else
-                            if container.specs then
-                                container.specs[specId] = nil
-                                if not next(container.specs) then
-                                    container.specs = nil
-                                end
-                            end
-                            CooldownCompanion:CleanHeroTalentsForSpec(container, specId)
-                        end
-                        CooldownCompanion:RefreshContainerPanels(containerId)
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                end
-                AddAuxWidget(cb, sectionTag, "container", containerId, inFolder and container.folderId or nil)
-                ApplyCheckboxIndent(cb, inFolder and 12 or 0)
-
-                local htOpts = nil
-                if folderHeroTalents and next(folderHeroTalents) then
-                    htOpts = {
-                        heroTalentsSource = folderHeroTalents,
-                        useHeroTalentsSource = true,
-                        disableToggles = true,
-                    }
-                end
-                htOpts = htOpts or {}
-                if effectiveSpecs then
-                    htOpts.specsSource = effectiveSpecs
-                end
-                htOpts.onChanged = function()
-                    CooldownCompanion:RefreshContainerPanels(containerId)
-                    CooldownCompanion:RefreshConfigPanel()
-                end
-                local heroWidgets = BuildHeroTalentSubTreeCheckboxes(CS.col1Scroll, container, configID, specId, htIndent, containerId, htOpts)
-                for _, heroWidget in ipairs(heroWidgets or {}) do
-                    TrackRenderedRow({
-                        kind = "aux-block",
-                        widget = heroWidget,
-                        section = sectionTag,
-                        loadBucket = "aux",
-                        acceptsDrop = false,
-                        previewProxy = false,
-                        layoutOnly = true,
-                        ownerKind = "container",
-                        ownerId = containerId,
-                        ownerFolderId = inFolder and container.folderId or nil,
-                    })
-                end
-            end
-
-            local playerSpecIds = {}
-            for i = 1, numSpecs do
-                local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-                if specId then playerSpecIds[specId] = true end
-            end
-
-            local foreignSpecs = {}
-            if container.specs then
-                for specId in pairs(container.specs) do
-                    if not playerSpecIds[specId] then
-                        table.insert(foreignSpecs, specId)
-                    end
-                end
-            end
-
-            if #foreignSpecs > 0 then
-                table.sort(foreignSpecs)
-                for _, specId in ipairs(foreignSpecs) do
-                    local _, name, _, icon = GetSpecializationInfoForSpecID(specId)
-                    if name then
-                        local fcb = AceGUI:Create("CheckBox")
-                        fcb:SetLabel(name)
-                        if icon then fcb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-                        fcb:SetFullWidth(true)
-                        fcb:SetValue(true)
-                        fcb:SetCallback("OnValueChanged", function(widget, event, value)
-                            if not value then
-                                if container.specs then
-                                    container.specs[specId] = nil
-                                    if not next(container.specs) then
-                                        container.specs = nil
-                                    end
-                                end
-                            else
-                                if not container.specs then container.specs = {} end
-                                container.specs[specId] = true
-                            end
-                            CooldownCompanion:RefreshContainerPanels(containerId)
-                            CooldownCompanion:RefreshConfigPanel()
-                        end)
-                        AddAuxWidget(fcb, sectionTag, "container", containerId, inFolder and container.folderId or nil)
-                        ApplyCheckboxIndent(fcb, inFolder and 12 or 0)
-                    end
-                end
-            end
-
-            local hasOwnSpecs = false
-            if container.specs then
-                for specId in pairs(container.specs) do
-                    if not (folderSpecs and folderSpecs[specId]) then
-                        hasOwnSpecs = true
-                        break
-                    end
-                end
-            end
-            if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
-                hasOwnSpecs = true
-            end
-            if hasOwnSpecs then
-                local clearBtn = AceGUI:Create("Button")
-                clearBtn:SetText("Clear All")
-                clearBtn:SetFullWidth(true)
-                clearBtn:SetCallback("OnClick", function()
-                    if folderSpecs then
-                        container.specs = CopyTable(folderSpecs)
-                    else
-                        container.specs = nil
-                    end
-                    container.heroTalents = nil
-                    CooldownCompanion:RefreshContainerPanels(containerId)
-                    CooldownCompanion:RefreshConfigPanel()
-                end)
-                AddAuxWidget(clearBtn, sectionTag, "container", containerId, inFolder and container.folderId or nil)
-            end
-        end
 
         return entry
     end
@@ -1521,9 +1282,10 @@ local function RefreshColumn1(preserveDrag)
     end
 
     -- Helper: render a folder header row
-    local function RenderFolderRow(folderId, sectionTag, childContainerIds, loadBucket)
+    local function RenderFolderRow(folderId, sectionTag, childContainerIds, loadBucket, options)
         local folder = db.folders[folderId]
         if not folder then return end
+        local disableDrag = options and options.disableDrag == true
 
         local isCollapsed = CS.collapsedFolders[folderId]
         local function ToggleFolderCollapsed()
@@ -1615,29 +1377,31 @@ local function RefreshColumn1(preserveDrag)
             widget = entry,
             section = sectionTag,
             loadBucket = loadBucket or "loaded",
-            acceptsDrop = (loadBucket or "loaded") ~= "unloaded",
-            previewDraggable = true,
+            acceptsDrop = (not disableDrag) and (loadBucket or "loaded") ~= "unloaded",
+            previewDraggable = not disableDrag,
             previewProxy = true,
         })
 
-        entry:SetCallback("OnClick", function(widget, event, mouseButton)
-            if mouseButton == "LeftButton" and not searchResults and not IsShiftKeyDown() and not GetCursorInfo() then
-                local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
-                CS.dragState = {
-                    kind = "folder",
-                    phase = "pending",
-                    sourceFolderId = folderId,
-                    sourceSection = sectionTag,
-                    sourceLoadBucket = loadBucket or "loaded",
-                    scrollWidget = CS.col1Scroll,
-                    widget = entry,
-                    startX = cursorX,
-                    startY = cursorY,
-                    col1RenderedRows = col1RenderedRows,
-                }
-                StartDragTracking()
-            end
-        end)
+        if not disableDrag then
+            entry:SetCallback("OnClick", function(widget, event, mouseButton)
+                if mouseButton == "LeftButton" and not searchResults and not IsShiftKeyDown() and not GetCursorInfo() then
+                    local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
+                    CS.dragState = {
+                        kind = "folder",
+                        phase = "pending",
+                        sourceFolderId = folderId,
+                        sourceSection = sectionTag,
+                        sourceLoadBucket = loadBucket or "loaded",
+                        scrollWidget = CS.col1Scroll,
+                        widget = entry,
+                        startX = cursorX,
+                        startY = cursorY,
+                        col1RenderedRows = col1RenderedRows,
+                    }
+                    StartDragTracking()
+                end
+            end)
+        end
 
         -- Handle clicks via OnMouseUp
         entry.frame:SetScript("OnMouseUp", function(self, button)
@@ -1680,126 +1444,103 @@ local function RefreshColumn1(preserveDrag)
 
     end
 
-    local function RenderFolderSpecPanel(folderId, sectionTag)
-        local folder = db.folders[folderId]
-        if not folder then return end
-
-        local function BuildFolderSpecs(nextSpecId, enabled)
-            local nextSpecs = folder.specs and CopyTable(folder.specs) or {}
-            if enabled then
-                nextSpecs[nextSpecId] = true
-            else
-                nextSpecs[nextSpecId] = nil
-            end
-            if not next(nextSpecs) then
-                nextSpecs = nil
-            end
-            return nextSpecs
-        end
-
-        local numSpecs = GetNumSpecializations()
-        local configID = C_ClassTalents.GetActiveConfigID()
-        local htIndent = 32
-        for i = 1, numSpecs do
-            local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-            local cb = AceGUI:Create("CheckBox")
-            cb:SetLabel(name)
-            cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92)
-            cb:SetFullWidth(true)
-            cb:SetValue(folder.specs and folder.specs[specId] or false)
-            cb:SetCallback("OnValueChanged", function(widget, event, value)
-                CooldownCompanion:SetFolderSpecs(folderId, BuildFolderSpecs(specId, value))
-            end)
-            AddAuxWidget(cb, sectionTag, "folder", folderId, folderId)
-            ApplyCheckboxIndent(cb, 12)
-
-            if configID and folder.specs and folder.specs[specId] then
-                local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
-                if subTreeIDs then
-                    for _, subTreeID in ipairs(subTreeIDs) do
-                        local subTreeInfo = C_Traits.GetSubTreeInfo(configID, subTreeID)
-                        if subTreeInfo then
-                            local htCb = AceGUI:Create("CheckBox")
-                            htCb:SetLabel(subTreeInfo.name or ("Hero " .. subTreeID))
-                            htCb:SetFullWidth(true)
-                            htCb:SetValue(folder.heroTalents and folder.heroTalents[subTreeID] or false)
-                            htCb:SetCallback("OnValueChanged", function(widget, event, value)
-                                CooldownCompanion:SetFolderHeroTalent(folderId, subTreeID, value)
-                            end)
-                            AddAuxWidget(htCb, sectionTag, "folder", folderId, folderId)
-                            ApplyCheckboxIndent(htCb, htIndent)
-                            if subTreeInfo.iconElementID then
-                                htCb:SetImage(136235)
-                                htCb.image:SetAtlas(subTreeInfo.iconElementID, false)
-                                htCb.image:SetTexCoord(0, 1, 0, 1)
-                            end
-                        end
-                    end
-                end
-            end
-        end
-
-        local playerSpecIds = {}
-        for i = 1, numSpecs do
-            local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-            if specId then playerSpecIds[specId] = true end
-        end
-
-        local foreignSpecs = {}
-        if folder.specs then
-            for specId in pairs(folder.specs) do
-                if not playerSpecIds[specId] then
-                    table.insert(foreignSpecs, specId)
-                end
-            end
-        end
-
-        if #foreignSpecs > 0 then
-            table.sort(foreignSpecs)
-            for _, specId in ipairs(foreignSpecs) do
-                local _, name, _, icon = GetSpecializationInfoForSpecID(specId)
-                if name then
-                    local fcb = AceGUI:Create("CheckBox")
-                    fcb:SetLabel(name)
-                    if icon then fcb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-                    fcb:SetFullWidth(true)
-                    fcb:SetValue(true)
-                    fcb:SetCallback("OnValueChanged", function(widget, event, value)
-                        CooldownCompanion:SetFolderSpecs(folderId, BuildFolderSpecs(specId, value))
-                    end)
-                    AddAuxWidget(fcb, sectionTag, "folder", folderId, folderId)
-                    ApplyCheckboxIndent(fcb, 12)
-                end
-            end
-        end
-
-        local clearBtn = AceGUI:Create("Button")
-        clearBtn:SetText("Clear All")
-        clearBtn:SetFullWidth(true)
-        clearBtn:SetCallback("OnClick", function()
-            CooldownCompanion:SetFolderSpecs(folderId, nil)
-        end)
-        AddAuxWidget(clearBtn, sectionTag, "folder", folderId, folderId)
+    local function RenderSectionMarker(section, headingText, headingColor)
+        local heading = AceGUI:Create("Label")
+        heading:SetFullWidth(true)
+        heading:SetHeight(18)
+        CS.col1Scroll:AddChild(heading)
+        SetupColumn1MarkerRow(heading, {
+            text = headingText,
+            color = headingColor,
+        })
+        TrackRenderedRow({
+            kind = "section-title",
+            widget = heading,
+            section = section,
+            loadBucket = "marker",
+            acceptsDrop = false,
+            keepVisibleDuringPreview = true,
+            previewProxy = true,
+            isMarker = true,
+        })
     end
 
-    -- Render a section (global or character)
+    -- Render a section (global, current class, or another class)
     local function RenderSection(section, sectionGroupIds, headingText, headingColor, options)
         local items, folderChildContainers = BuildSectionItems(section, sectionGroupIds)
+        local isClassSection = options and options.classSection == true
+        local stableCount = options and options.stableCount or nil
+
+        if isClassSection then
+            local isCollapsed = CS.collapsedSections[section] ~= false
+            local function ToggleClassSection()
+                local currentlyCollapsed = CS.collapsedSections[section] ~= false
+                if currentlyCollapsed then
+                    CS.collapsedSections[section] = false
+                else
+                    CS.collapsedSections[section] = true
+                end
+                CooldownCompanion:RefreshConfigPanel()
+            end
+            local header = AceGUI:Create("InteractiveLabel")
+            CleanRecycledEntry(header)
+            local countText = stableCount and (" |cff888888(" .. tostring(stableCount) .. ")|r") or ""
+            header:SetText((isCollapsed and "|A:common-icon-plus:12:12|a " or "|A:common-icon-minus:12:12|a ")
+                .. headingText .. countText)
+            header:SetFullWidth(true)
+            header:SetFontObject(GameFontHighlight)
+            if headingColor then
+                header:SetColor(headingColor[1], headingColor[2], headingColor[3])
+            end
+            if options and options.classKey then
+                ApplyConfigRowIcon(header, 134400, { atlas = "classicon-" .. string.lower(options.classKey) })
+            else
+                ApplyConfigTextRow(header)
+            end
+            header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+            if header.frame then
+                header.frame:SetScript("OnMouseUp", function(_, button)
+                    if CS.dragState and CS.dragState.phase == "active" then return end
+                    if button == "LeftButton" then
+                        ToggleClassSection()
+                    end
+                end)
+            end
+            CS.col1Scroll:AddChild(header)
+            TrackRenderedRow({
+                kind = "class-header",
+                widget = header,
+                section = section,
+                loadBucket = "marker",
+                acceptsDrop = false,
+                keepVisibleDuringPreview = true,
+                previewProxy = true,
+                isMarker = true,
+                stableCount = stableCount,
+            })
+            if isCollapsed and not searchResults then
+                return
+            end
+        end
 
         -- Partition into loaded (active) and unloaded (inactive)
         local loadedItems = {}
         local unloadedItems = {}
         for _, item in ipairs(items) do
-            local isInactive
-            if item.kind == "folder" then
-                isInactive = IsFolderFullyInactive(item.id, folderChildContainers[item.id])
-            else
-                isInactive = IsContainerInactive(item.id, db.groupContainers[item.id])
-            end
-            if isInactive then
-                table.insert(unloadedItems, item)
-            else
+            if options and options.noLoadBuckets then
                 table.insert(loadedItems, item)
+            else
+                local isInactive
+                if item.kind == "folder" then
+                    isInactive = IsFolderFullyInactive(item.id, folderChildContainers[item.id])
+                else
+                    isInactive = IsContainerInactive(item.id, db.groupContainers[item.id])
+                end
+                if isInactive then
+                    table.insert(unloadedItems, item)
+                else
+                    table.insert(loadedItems, item)
+                end
             end
         end
 
@@ -1811,25 +1552,27 @@ local function RefreshColumn1(preserveDrag)
             and #loadedItems == 0
             and #unloadedItems > 0
 
-        local heading = AceGUI:Create("Label")
-        heading:SetFullWidth(true)
-        heading:SetHeight(18)
-        CS.col1Scroll:AddChild(heading)
-        SetupColumn1MarkerRow(heading, {
-            text = useUnloadedOnlyHeading and "Unloaded Groups" or headingText,
-            color = useUnloadedOnlyHeading and { 0.53, 0.53, 0.53 } or headingColor,
-        })
+        if not isClassSection then
+            local heading = AceGUI:Create("Label")
+            heading:SetFullWidth(true)
+            heading:SetHeight(18)
+            CS.col1Scroll:AddChild(heading)
+            SetupColumn1MarkerRow(heading, {
+                text = useUnloadedOnlyHeading and "Unloaded Groups" or headingText,
+                color = useUnloadedOnlyHeading and { 0.53, 0.53, 0.53 } or headingColor,
+            })
 
-        TrackRenderedRow({
-            kind = "section-header",
-            widget = heading,
-            section = section,
-            loadBucket = "marker",
-            acceptsDrop = false,
-            keepVisibleDuringPreview = true,
-            previewProxy = true,
-            isMarker = true,
-        })
+            TrackRenderedRow({
+                kind = "section-header",
+                widget = heading,
+                section = section,
+                loadBucket = "marker",
+                acceptsDrop = false,
+                keepVisibleDuringPreview = true,
+                previewProxy = true,
+                isMarker = true,
+            })
+        end
 
         if isEmpty and CS.showPhantomSections then
             local placeholder = AceGUI:Create("Label")
@@ -1855,22 +1598,20 @@ local function RefreshColumn1(preserveDrag)
         end
 
         -- Class color for accent bars
-        local classColor = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
+        local classColor = options and options.classKey and C_ClassColor.GetClassColor(options.classKey)
+            or C_ClassColor.GetClassColor(select(2, UnitClass("player")))
 
         local function RenderItems(itemList, loadBucket)
             for _, item in ipairs(itemList) do
                 if item.kind == "folder" then
-                    RenderFolderRow(item.id, section, folderChildContainers[item.id], loadBucket)
-                    if CS.specExpandedFolderId == item.id then
-                        RenderFolderSpecPanel(item.id, section)
-                    end
+                    RenderFolderRow(item.id, section, folderChildContainers[item.id], loadBucket, options)
                     -- If expanded, render children with accent bar
                     if searchResults or not CS.collapsedFolders[item.id] then
                         local children = folderChildContainers[item.id]
                         if children and #children > 0 then
                             local firstEntry, lastEntry
                             for _, cid in ipairs(children) do
-                                local entry = RenderContainerRow(cid, true, section, loadBucket)
+                                local entry = RenderContainerRow(cid, true, section, loadBucket, options)
                                 if entry then
                                     if not firstEntry then firstEntry = entry end
                                     lastEntry = entry
@@ -1900,7 +1641,7 @@ local function RefreshColumn1(preserveDrag)
                         end
                     end
                 elseif item.kind == "container" then
-                    RenderContainerRow(item.id, false, section, loadBucket)
+                    RenderContainerRow(item.id, false, section, loadBucket, options)
                 end
             end
         end
@@ -1932,31 +1673,258 @@ local function RefreshColumn1(preserveDrag)
         RenderItems(unloadedItems, "unloaded")
     end
 
-    -- Split containers into global and character-owned
+    local function GetClassDisplayName(classKey)
+        if type(classKey) ~= "string" then return "Class" end
+        if GetClassInfo then
+            for classID = 1, 30 do
+                local className, classFilename = GetClassInfo(classID)
+                if classFilename and string.upper(classFilename) == classKey then
+                    return className or classKey
+                end
+            end
+        end
+        return classKey:sub(1, 1) .. string.lower(classKey:sub(2))
+    end
+
+    local function EnsureOtherClassSection(otherSections, otherSectionOrder, scope)
+        if not (scope and scope.ownerClassKey and scope.sectionKey) then
+            return nil
+        end
+        local section = otherSections[scope.sectionKey]
+        if not section then
+            local cc = C_ClassColor.GetClassColor(scope.ownerClassKey)
+            section = {
+                key = scope.sectionKey,
+                classKey = scope.ownerClassKey,
+                title = GetClassDisplayName(scope.ownerClassKey) .. " Groups",
+                color = cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
+                containerIds = {},
+                count = 0,
+            }
+            otherSections[scope.sectionKey] = section
+            otherSectionOrder[#otherSectionOrder + 1] = section
+        end
+        return section
+    end
+
+    local function GetOtherClassVisibleCount(section)
+        if not section then return 0 end
+        if not searchResults then
+            return section.count or 0
+        end
+
+        local count = 0
+        for _, containerId in ipairs(section.containerIds or {}) do
+            if searchResults.containerMatches[containerId] then
+                count = count + 1
+            end
+        end
+        return count
+    end
+
+    local function GetOtherClassSummary(otherSectionOrder)
+        local totalCount = 0
+        local classCount = 0
+        for _, section in ipairs(otherSectionOrder or {}) do
+            local visibleCount = GetOtherClassVisibleCount(section)
+            if visibleCount > 0 then
+                totalCount = totalCount + visibleCount
+                classCount = classCount + 1
+            end
+        end
+        return totalCount, classCount
+    end
+
+    local function RenderNavigationRow(kind, text, options)
+        local row = AceGUI:Create("InteractiveLabel")
+        CleanRecycledEntry(row)
+        row:SetText(text)
+        row:SetFullWidth(true)
+        row:SetFontObject(GameFontHighlight)
+        if options and options.color then
+            row:SetColor(options.color[1], options.color[2], options.color[3])
+        end
+        if options and options.classKey then
+            ApplyConfigRowIcon(row, 134400, { atlas = "classicon-" .. string.lower(options.classKey) })
+        else
+            ApplyConfigTextRow(row)
+        end
+        row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+        if row.frame then
+            row.frame:SetScript("OnMouseUp", function(_, button)
+                if CS.dragState and CS.dragState.phase == "active" then return end
+                if button == "LeftButton" and options and options.onClick then
+                    options.onClick()
+                end
+            end)
+        end
+        CS.col1Scroll:AddChild(row)
+        TrackRenderedRow({
+            kind = kind,
+            widget = row,
+            section = options and options.section or nil,
+            classKey = options and options.classKey or nil,
+            loadBucket = "marker",
+            acceptsDrop = false,
+            keepVisibleDuringPreview = true,
+            previewProxy = true,
+            isMarker = true,
+            stableCount = options and options.stableCount or nil,
+        })
+        return row
+    end
+
+    local function UpdateOtherClassesFooterDoorway(otherSectionOrder)
+        local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
+        if totalCount <= 0 or classCount <= 0 then
+            ClearOtherClassesFooterDoorway()
+            return false
+        end
+
+        return SetOtherClassesFooterDoorway(
+            "Browse Other Classes",
+            totalCount,
+            function()
+                CS.otherClassLibraryActive = true
+                CS.otherClassLibraryClassKey = nil
+                CooldownCompanion:RefreshConfigPanel()
+            end
+        )
+    end
+
+    local function FindOtherClassSectionByClassKey(otherSectionOrder, classKey)
+        if not classKey then return nil end
+        for _, section in ipairs(otherSectionOrder or {}) do
+            if section.classKey == classKey then
+                return section
+            end
+        end
+        return nil
+    end
+
+    local function RenderOtherClassLibrary(otherSectionOrder)
+        local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
+        if totalCount <= 0 or classCount <= 0 then
+            CS.otherClassLibraryActive = false
+            CS.otherClassLibraryClassKey = nil
+            ClearOtherClassesFooterDoorway()
+            return false
+        end
+
+        ClearOtherClassesFooterDoorway()
+
+        local selectedSection = FindOtherClassSectionByClassKey(otherSectionOrder, CS.otherClassLibraryClassKey)
+        if selectedSection and GetOtherClassVisibleCount(selectedSection) <= 0 then
+            selectedSection = nil
+            CS.otherClassLibraryClassKey = nil
+        end
+
+        if selectedSection then
+            RenderNavigationRow("other-class-library-back", "|A:common-icon-backarrow:14:14|a  Back to Other Classes", {
+                section = "other-classes",
+                onClick = function()
+                    CS.otherClassLibraryClassKey = nil
+                    CooldownCompanion:RefreshConfigPanel()
+                end,
+            })
+            RenderSection(
+                selectedSection.key,
+                selectedSection.containerIds,
+                selectedSection.title,
+                selectedSection.color,
+                {
+                    classKey = selectedSection.classKey,
+                    noLoadBuckets = true,
+                    disableDrag = true,
+                }
+            )
+            return true
+        end
+
+        RenderNavigationRow("other-class-library-back", "|A:common-icon-backarrow:14:14|a  Back to Groups", {
+            section = "other-classes",
+            onClick = function()
+                CS.otherClassLibraryActive = false
+                CS.otherClassLibraryClassKey = nil
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
+
+        for _, section in ipairs(otherSectionOrder or {}) do
+            local visibleCount = GetOtherClassVisibleCount(section)
+            if visibleCount > 0 then
+                RenderNavigationRow("other-class-library-class", section.title
+                    .. " |cff888888(" .. tostring(visibleCount) .. ")|r", {
+                    section = section.key,
+                    classKey = section.classKey,
+                    color = section.color,
+                    stableCount = visibleCount,
+                    onClick = function()
+                        CS.otherClassLibraryClassKey = section.classKey
+                        CooldownCompanion:RefreshConfigPanel()
+                    end,
+                })
+            end
+        end
+        return true
+    end
+
+    -- Split containers into global, current-class, and other-class inventory.
     local containers = db.groupContainers or {}
     local showNewUserEmptyState = not next(containers) and not next(db.folders)
     local globalIds = {}
     local charIds = {}
+    local otherSections = {}
+    local otherSectionOrder = {}
     for id, container in pairs(containers) do
-        if container.isGlobal then
+        local scope = ResolveContainerScope(id, container)
+        if scope.scope == "global" then
             table.insert(globalIds, id)
-        elseif container.createdBy == charKey then
+        elseif scope.scope == "current-class" then
             table.insert(charIds, id)
+        elseif scope.scope == "other-class" then
+            local section = EnsureOtherClassSection(otherSections, otherSectionOrder, scope)
+            if section then
+                table.insert(section.containerIds, id)
+                section.count = section.count + 1
+            end
         end
     end
 
+    for folderId, folder in pairs(db.folders or {}) do
+        local scope = ResolveFolderScope(folderId, folder)
+        if scope.scope == "other-class" then
+            local section = EnsureOtherClassSection(otherSections, otherSectionOrder, scope)
+            if section then
+                section.count = section.count + 1
+            end
+        end
+    end
+    table.sort(otherSectionOrder, function(a, b)
+        return (a.title or a.classKey or a.key) < (b.title or b.classKey or b.key)
+    end)
+
     if searchResults and not next(searchResults.containerMatches) then
+        ClearOtherClassesFooterDoorway()
         local label = AceGUI:Create("Label")
         ST._ConfigureWrappedHelperLabel(label)
         label:SetText("|cff888888No matching groups.|r")
         label:SetFullWidth(true)
         CS.col1Scroll:AddChild(label)
         CS.lastCol1RenderedRows = col1RenderedRows
-        PopulateColumn1ButtonBar()
+        if CS.otherClassLibraryActive then
+            if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
+        else
+            PopulateColumn1ButtonBar()
+        end
         return
     end
 
     if showNewUserEmptyState then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassesFooterDoorway()
+
         local spacer = AceGUI:Create("SimpleGroup")
         spacer:SetFullWidth(true)
         spacer:SetHeight(20)
@@ -2001,6 +1969,13 @@ local function RefreshColumn1(preserveDrag)
                 statsContainerIds[id] = true
             end
         end
+        for _, section in ipairs(otherSectionOrder) do
+            for _, id in ipairs(section.containerIds) do
+                if not searchResults or searchResults.containerMatches[id] then
+                    statsContainerIds[id] = true
+                end
+            end
+        end
         for id in pairs(CS.selectedGroups) do
             if containers[id] then
                 statsContainerIds[id] = true
@@ -2009,47 +1984,63 @@ local function RefreshColumn1(preserveDrag)
         containerStats = BuildColumn1ContainerStats(db, statsContainerIds)
 
         -- Render sections
-        local hasGlobalContent = #globalIds > 0
-        if not hasGlobalContent then
-            for _, folder in pairs(db.folders) do
-                if folder.section == "global" then
-                    hasGlobalContent = true
-                    break
-                end
-            end
+        local renderedOtherClassLibrary = false
+        if CS.otherClassLibraryActive then
+            renderedOtherClassLibrary = RenderOtherClassLibrary(otherSectionOrder)
         end
 
-        if #globalIds > 0 or next(db.folders) or CS.showPhantomSections then
-            if hasGlobalContent or CS.showPhantomSections then
-                RenderSection("global", globalIds, "Global Groups", { 0.4, 0.67, 1.0 })
-            end
-        end
-
-        local charName = charKey:match("^(.-)%s*%-") or charKey
-        local hasCharContent = #charIds > 0
-        if not hasCharContent then
-            for _, folder in pairs(db.folders) do
-                if folder.section == "char" and (not folder.createdBy or folder.createdBy == charKey) then
-                    hasCharContent = true
-                    break
+        if not renderedOtherClassLibrary then
+            local hasGlobalContent = #globalIds > 0
+            if not hasGlobalContent then
+                for folderId, folder in pairs(db.folders) do
+                    local scope = ResolveFolderScope(folderId, folder)
+                    if scope.scope == "global" then
+                        hasGlobalContent = true
+                        break
+                    end
                 end
             end
-        end
-        if hasCharContent or CS.showPhantomSections then
-            local cc = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
-            RenderSection(
-                "char",
-                charIds,
-                charName .. "'s Groups",
-                cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
-                { preferUnloadedHeading = not hasGlobalContent }
-            )
+
+            if #globalIds > 0 or next(db.folders) or CS.showPhantomSections then
+                if hasGlobalContent or CS.showPhantomSections then
+                    RenderSection("global", globalIds, "Global Groups", { 0.4, 0.67, 1.0 })
+                end
+            end
+
+            local _, playerClassKey = UnitClass("player")
+            local currentClassName = GetClassDisplayName(playerClassKey)
+            local hasCharContent = #charIds > 0
+            if not hasCharContent then
+                for folderId, folder in pairs(db.folders) do
+                    local scope = ResolveFolderScope(folderId, folder)
+                    if scope.scope == "current-class" then
+                        hasCharContent = true
+                        break
+                    end
+                end
+            end
+            if hasCharContent or CS.showPhantomSections then
+                local cc = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
+                RenderSection(
+                    "char",
+                    charIds,
+                    currentClassName .. " Groups",
+                    cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
+                    { preferUnloadedHeading = not hasGlobalContent }
+                )
+            end
+
+            UpdateOtherClassesFooterDoorway(otherSectionOrder)
         end
     end
 
     CS.lastCol1RenderedRows = col1RenderedRows
 
-    PopulateColumn1ButtonBar()
+    if CS.otherClassLibraryActive then
+        if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
+    else
+        PopulateColumn1ButtonBar()
+    end
 end
 
 ------------------------------------------------------------------------

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -750,61 +750,6 @@ local function PopulateColumn1ButtonBar()
     end)
 end
 
-local function RefreshColumn1FooterLayout()
-    if CS.UpdateColumn1FooterLayout then
-        CS.UpdateColumn1FooterLayout()
-    end
-end
-
-local function ClearOtherClassesFooterDoorway()
-    CS.col1FooterDoorwayVisible = false
-    CS.lastCol1FooterDoorwayRow = nil
-    local row = CS.col1FooterDoorway
-    if row and row.frame then
-        row.frame:SetScript("OnMouseUp", nil)
-        row.frame:Hide()
-    end
-    RefreshColumn1FooterLayout()
-end
-
-local function SetOtherClassesFooterDoorway(text, stableCount, onClick)
-    local row = CS.col1FooterDoorway
-    if not (row and row.frame) then
-        ClearOtherClassesFooterDoorway()
-        return false
-    end
-
-    CleanRecycledEntry(row)
-    row:SetText(text)
-    row:SetFullWidth(true)
-    row:SetFontObject(GameFontHighlight)
-    ApplyConfigTextRow(row, "CENTER")
-    row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-    row.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.dragState and CS.dragState.phase == "active" then return end
-        if button == "LeftButton" and onClick then
-            onClick()
-        end
-    end)
-
-    CS.col1FooterDoorwayVisible = true
-    CS.lastCol1FooterDoorwayRow = {
-        kind = "other-classes-doorway",
-        widget = row,
-        section = "other-classes",
-        loadBucket = "marker",
-        acceptsDrop = false,
-        keepVisibleDuringPreview = false,
-        previewProxy = false,
-        isMarker = true,
-        stableCount = stableCount,
-        visible = true,
-    }
-    row.frame:Show()
-    RefreshColumn1FooterLayout()
-    return true
-end
-
 ------------------------------------------------------------------------
 -- COLUMN 1: Groups
 ------------------------------------------------------------------------
@@ -815,7 +760,6 @@ local function RefreshColumn1(preserveDrag)
     if CS.resourceBarPanelActive then
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
-        ClearOtherClassesFooterDoorway()
         CancelDrag()
         CS.HideAutocomplete()
         CS.col1Scroll.frame:Hide()
@@ -897,7 +841,6 @@ local function RefreshColumn1(preserveDrag)
     if CooldownCompanion._unsupportedLegacyProfile then
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
-        ClearOtherClassesFooterDoorway()
         if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
 
         local spacer = AceGUI:Create("SimpleGroup")
@@ -1774,24 +1717,6 @@ local function RefreshColumn1(preserveDrag)
         return row
     end
 
-    local function UpdateOtherClassesFooterDoorway(otherSectionOrder)
-        local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
-        if totalCount <= 0 or classCount <= 0 then
-            ClearOtherClassesFooterDoorway()
-            return false
-        end
-
-        return SetOtherClassesFooterDoorway(
-            "Browse Other Classes",
-            totalCount,
-            function()
-                CS.otherClassLibraryActive = true
-                CS.otherClassLibraryClassKey = nil
-                CooldownCompanion:RefreshConfigPanel()
-            end
-        )
-    end
-
     local function FindOtherClassSectionByClassKey(otherSectionOrder, classKey)
         if not classKey then return nil end
         for _, section in ipairs(otherSectionOrder or {}) do
@@ -1807,11 +1732,8 @@ local function RefreshColumn1(preserveDrag)
         if totalCount <= 0 or classCount <= 0 then
             CS.otherClassLibraryActive = false
             CS.otherClassLibraryClassKey = nil
-            ClearOtherClassesFooterDoorway()
             return false
         end
-
-        ClearOtherClassesFooterDoorway()
 
         local selectedSection = FindOtherClassSectionByClassKey(otherSectionOrder, CS.otherClassLibraryClassKey)
         if selectedSection and GetOtherClassVisibleCount(selectedSection) <= 0 then
@@ -1905,7 +1827,6 @@ local function RefreshColumn1(preserveDrag)
     end)
 
     if searchResults and not next(searchResults.containerMatches) then
-        ClearOtherClassesFooterDoorway()
         local label = AceGUI:Create("Label")
         ST._ConfigureWrappedHelperLabel(label)
         label:SetText("|cff888888No matching groups.|r")
@@ -1923,7 +1844,6 @@ local function RefreshColumn1(preserveDrag)
     if showNewUserEmptyState then
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
-        ClearOtherClassesFooterDoorway()
 
         local spacer = AceGUI:Create("SimpleGroup")
         spacer:SetFullWidth(true)
@@ -2029,8 +1949,6 @@ local function RefreshColumn1(preserveDrag)
                     { preferUnloadedHeading = not hasGlobalContent }
                 )
             end
-
-            UpdateOtherClassesFooterDoorway(otherSectionOrder)
         end
     end
 

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -1616,14 +1616,27 @@ local function RefreshColumn1(preserveDrag)
         RenderItems(unloadedItems, "unloaded")
     end
 
+    local function GetClassInfoByID(classID)
+        classID = tonumber(classID)
+        if not classID then return nil, nil, nil end
+        if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+            local classInfo = C_CreatureInfo.GetClassInfo(classID)
+            if type(classInfo) == "table" then
+                return classInfo.className, classInfo.classFile, classInfo.classID
+            end
+        end
+        if GetClassInfo then
+            return GetClassInfo(classID)
+        end
+        return nil, nil, nil
+    end
+
     local function GetClassDisplayName(classKey)
         if type(classKey) ~= "string" then return "Class" end
-        if GetClassInfo then
-            for classID = 1, 30 do
-                local className, classFilename = GetClassInfo(classID)
-                if classFilename and string.upper(classFilename) == classKey then
-                    return className or classKey
-                end
+        for classID = 1, 30 do
+            local className, classFilename = GetClassInfoByID(classID)
+            if classFilename and string.upper(classFilename) == classKey then
+                return className or classKey
             end
         end
         return classKey:sub(1, 1) .. string.lower(classKey:sub(2))
@@ -1766,6 +1779,9 @@ local function RefreshColumn1(preserveDrag)
         RenderNavigationRow("other-class-library-back", "|A:common-icon-backarrow:14:14|a  Back to Groups", {
             section = "other-classes",
             onClick = function()
+                if ClearConfigPrimarySelection then
+                    ClearConfigPrimarySelection()
+                end
                 CS.otherClassLibraryActive = false
                 CS.otherClassLibraryClassKey = nil
                 CooldownCompanion:RefreshConfigPanel()
@@ -1879,21 +1895,23 @@ local function RefreshColumn1(preserveDrag)
         CS.col1Scroll:AddChild(desc)
     else
         local statsContainerIds = {}
-        for _, id in ipairs(globalIds) do
-            if not searchResults or searchResults.containerMatches[id] then
-                statsContainerIds[id] = true
+        local function IncludeVisibleStats(containerId)
+            if not searchResults or searchResults.containerMatches[containerId] then
+                statsContainerIds[containerId] = true
             end
+        end
+        for _, id in ipairs(globalIds) do
+            IncludeVisibleStats(id)
         end
         for _, id in ipairs(charIds) do
-            if not searchResults or searchResults.containerMatches[id] then
-                statsContainerIds[id] = true
-            end
+            IncludeVisibleStats(id)
         end
-        for _, section in ipairs(otherSectionOrder) do
-            for _, id in ipairs(section.containerIds) do
-                if not searchResults or searchResults.containerMatches[id] then
-                    statsContainerIds[id] = true
-                end
+        local selectedOtherSection = CS.otherClassLibraryActive
+            and FindOtherClassSectionByClassKey(otherSectionOrder, CS.otherClassLibraryClassKey)
+            or nil
+        if selectedOtherSection then
+            for _, id in ipairs(selectedOtherSection.containerIds) do
+                IncludeVisibleStats(id)
             end
         end
         for id in pairs(CS.selectedGroups) do

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -68,6 +68,13 @@ local function CanPanelMoveToContainer(panelId, containerId)
     return true
 end
 
+local function CanMoveEntryToGroup(sourceGroupId, targetGroupId)
+    if CooldownCompanion.CanMoveEntryToGroup then
+        return CooldownCompanion:CanMoveEntryToGroup(sourceGroupId, targetGroupId) == true
+    end
+    return CooldownCompanion:IsGroupVisibleToCurrentChar(targetGroupId)
+end
+
 local function CanAllContainersMoveToFolder(containerIds, folderId)
     if not CooldownCompanion.CanMoveContainerToFolder then
         return true
@@ -1058,6 +1065,9 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     if not targetGroup then
         return false
     end
+    if not CanMoveEntryToGroup(sourceGroupId, targetGroupId) then
+        return false
+    end
     local rejectMessage = CooldownCompanion:GetPanelManualEntryRejectMessage(targetGroup)
     if rejectMessage then
         CooldownCompanion:Print(rejectMessage)
@@ -1083,7 +1093,7 @@ local function BuildEntryMoveDestinationSections(db, sourceGroupId)
 
     for groupId, group in pairs(db.groups or {}) do
         if groupId ~= sourceGroupId
-            and CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
+            and CanMoveEntryToGroup(sourceGroupId, groupId)
             and CooldownCompanion:CanPanelAcceptManualEntry(group)
         then
             local containerId = group.parentContainerId
@@ -2718,4 +2728,5 @@ end
 ------------------------------------------------------------------------
 -- ST._ exports
 ------------------------------------------------------------------------
+ST._BuildEntryMoveDestinationSections = BuildEntryMoveDestinationSections
 ST._RefreshColumn2 = RefreshColumn2

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -57,6 +57,19 @@ local function IsContainerVisibleInConfig(containerOrContainerId)
     return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
 end
 
+local function CanAllContainersMoveToFolder(containerIds, folderId)
+    if not CooldownCompanion.CanMoveContainerToFolder then
+        return true
+    end
+    for _, containerId in ipairs(containerIds or {}) do
+        local ok = CooldownCompanion:CanMoveContainerToFolder(containerId, folderId)
+        if not ok then
+            return false
+        end
+    end
+    return true
+end
+
 local function OpenPanelLoadConditions(panelId, containerId)
     SelectConfigPanel(panelId, { containerId = containerId })
     CS.selectedTab = "loadconditions"
@@ -1534,7 +1547,9 @@ local function RefreshColumn2()
                     local folderScope = CooldownCompanion.ResolveFolderClassScope
                         and CooldownCompanion:ResolveFolderClassScope(folder)
                         or nil
-                    if not (folderScope and folderScope.isInvalid) then
+                    if not (folderScope and folderScope.isInvalid)
+                        and CanAllContainersMoveToFolder(multiContainerIds, fid)
+                    then
                         local sectionKey = folderScope and folderScope.sectionKey or folder.section
                         table.insert(folderList, {
                             id = fid,
@@ -1564,6 +1579,12 @@ local function RefreshColumn2()
                     info.notCheckable = true
                     info.func = function()
                         CloseDropDownMenus()
+                        if not CanAllContainersMoveToFolder(multiContainerIds, f.id) then
+                            if CooldownCompanion.Print then
+                                CooldownCompanion:Print("Groups cannot be moved into folders owned by another class.")
+                            end
+                            return
+                        end
                         for _, cid in ipairs(multiContainerIds) do
                             CooldownCompanion:MoveGroupToFolder(cid, f.id)
                         end

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -57,6 +57,17 @@ local function IsContainerVisibleInConfig(containerOrContainerId)
     return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
 end
 
+local function CanPanelMoveToContainer(panelId, containerId)
+    if not IsContainerVisibleInConfig(containerId) then
+        return false
+    end
+    if CooldownCompanion.CanMovePanelToContainer then
+        local ok = CooldownCompanion:CanMovePanelToContainer(panelId, containerId)
+        return ok == true
+    end
+    return true
+end
+
 local function CanAllContainersMoveToFolder(containerIds, folderId)
     if not CooldownCompanion.CanMoveContainerToFolder then
         return true
@@ -2158,7 +2169,7 @@ local function RefreshColumn2()
                             local db = CooldownCompanion.db.profile
                             local hasOtherContainer = false
                             for cid, _ in pairs(db.groupContainers) do
-                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
+                                if cid ~= ctxContainerId and CanPanelMoveToContainer(ctxPanelId, cid) then
                                     hasOtherContainer = true
                                     break
                                 end
@@ -2239,7 +2250,7 @@ local function RefreshColumn2()
                             local containers = db.groupContainers or {}
                             local folderContainers, looseContainers = {}, {}
                             for cid, ctr in pairs(containers) do
-                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
+                                if cid ~= ctxContainerId and CanPanelMoveToContainer(ctxPanelId, cid) then
                                     local cName = ctr.name or ("Group " .. cid)
                                     local fid = ctr.folderId
                                     if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -49,6 +49,14 @@ local SelectConfigRotationAssistantEntry = ST._SelectConfigRotationAssistantEntr
 
 local IsTriggerPanelGroup
 
+local function IsContainerVisibleInConfig(containerOrContainerId)
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(containerOrContainerId)
+        return scope.isInvalid ~= true
+    end
+    return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
+end
+
 local function OpenPanelLoadConditions(panelId, containerId)
     SelectConfigPanel(panelId, { containerId = containerId })
     CS.selectedTab = "loadconditions"
@@ -1431,291 +1439,6 @@ local function RefreshColumn2()
     CS.col2Scroll.frame:Show()
     CS.col2Scroll:ReleaseChildren()
 
-    -- Cross-character browse mode: read-only preview
-    if CS.browseMode then
-        if CS.col2ButtonBar then CS.col2ButtonBar:Hide() end
-        -- Extend scroll to full column height (no button bar in browse mode)
-        CS.col2Scroll.frame:SetPoint("BOTTOMRIGHT", CS.col2Scroll.frame:GetParent(), "BOTTOMRIGHT", 0, 0)
-        local db = CooldownCompanion.db.profile
-
-        if not CS.browseContainerId then
-            local label = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(label)
-            label:SetText("|cff888888Select a group to preview its contents.|r")
-            label:SetFullWidth(true)
-            CS.col2Scroll:AddChild(label)
-            return
-        end
-
-        -- Guard: source container may have been deleted
-        if not db.groupContainers[CS.browseContainerId] then
-            CS.browseContainerId = nil
-            local label = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(label)
-            label:SetText("|cff888888Group no longer exists.|r")
-            label:SetFullWidth(true)
-            CS.col2Scroll:AddChild(label)
-            return
-        end
-
-        local panels = CooldownCompanion:GetPanels(CS.browseContainerId)
-
-        -- Class color for accent bars (from browsed character)
-        local browseCharInfo = CooldownCompanion.db.global.characterInfo
-            and CooldownCompanion.db.global.characterInfo[CS.browseCharKey]
-        local browseClassFile = browseCharInfo and browseCharInfo.classFilename
-        local browseCC = browseClassFile and C_ClassColor.GetClassColor(browseClassFile)
-
-        for panelIndex, panelInfo in ipairs(panels) do
-            local panel = panelInfo.group
-            local panelGroupId = panelInfo.groupId
-
-            -- Class-colored accent separator between panels
-            if panelIndex > 1 then
-                local spacer = AceGUI:Create("Label")
-                spacer:SetText(" ")
-                spacer:SetFullWidth(true)
-                spacer:SetHeight(2)
-                local bar = spacer.frame._cdcAccentBar
-                if not bar then
-                    bar = spacer.frame:CreateTexture(nil, "ARTWORK")
-                    spacer.frame._cdcAccentBar = bar
-                end
-                bar:SetHeight(1.5)
-                bar:ClearAllPoints()
-                local barInset = math.floor(spacer.frame:GetWidth() * 0.10 + 0.5)
-                bar:SetPoint("LEFT", spacer.frame, "LEFT", barInset, 1)
-                bar:SetPoint("RIGHT", spacer.frame, "RIGHT", -barInset, 1)
-                if browseCC then
-                    bar:SetColorTexture(browseCC.r, browseCC.g, browseCC.b, 0.8)
-                else
-                    bar:SetColorTexture(1, 1, 1, 0.3)
-                end
-                bar:Show()
-                spacer:SetCallback("OnRelease", function() bar:Hide() end)
-                CS.col2Scroll:AddChild(spacer)
-            end
-
-            -- Bordered container for this panel (matches normal Column 2)
-            local panelContainer = AceGUI:Create("InlineGroup")
-            panelContainer:SetTitle("")
-            panelContainer:SetLayout("List")
-            panelContainer:SetFullWidth(true)
-            CompactUntitledInlineGroupConfig(panelContainer)
-            CS.col2Scroll:AddChild(panelContainer)
-
-            -- Panel header (same badge pattern as normal Column 2 panel headers)
-            local buttonCount = GetConfigPanelButtonCount(panel)
-            local headerText = BuildPanelHeaderText(panel, nil, buttonCount, "888888")
-
-            local header = AceGUI:Create("InteractiveLabel")
-            CleanRecycledEntry(header)
-            header:SetText(headerText)
-
-            header:SetFullWidth(true)
-            header:SetFontObject(GameFontHighlight)
-            header:SetJustifyH("CENTER")
-            ApplyConfigTextRow(header, "CENTER")
-            local textW = header.label:GetStringWidth()
-            ConfigurePanelTypeBadge(header, panel.displayMode, textW)
-
-            -- Disabled badge (shown when panel is individually disabled)
-            local disabledBadge = header.frame._cdcHeaderDisabledBadge
-            if not disabledBadge then
-                disabledBadge = header.frame:CreateTexture(nil, "OVERLAY")
-                header.frame._cdcHeaderDisabledBadge = disabledBadge
-            end
-            disabledBadge:SetSize(16, 16)
-            disabledBadge:ClearAllPoints()
-            disabledBadge:SetPoint("LEFT", header.label, "CENTER", (textW / 2) + 4, 0)
-            if panel.enabled == false then
-                disabledBadge:SetAtlas("GM-icon-visibleDis-pressed", false)
-                disabledBadge:Show()
-            else
-                disabledBadge:Hide()
-            end
-
-            if panel.enabled == false then
-                header:SetColor(0.5, 0.5, 0.5)
-            elseif CS.selectedGroup == panelGroupId
-                and not CS.selectedButton
-                and not CS.selectedRotationAssistantEntry then
-                header:SetColor(0, 1, 0)
-            end
-            header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-            header:SetCallback("OnClick", function()
-                SelectConfigPanel(panelGroupId, { containerId = CS.browseContainerId })
-                CooldownCompanion:RefreshConfigPanel()
-            end)
-            panelContainer:AddChild(header)
-
-            -- Spacer after header
-            local headerSpacer = AceGUI:Create("Label")
-            headerSpacer:SetText(" ")
-            headerSpacer:SetFullWidth(true)
-            headerSpacer:SetHeight(4)
-            panelContainer:AddChild(headerSpacer)
-
-            -- Button list (read-only)
-            if panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
-                AddRotationAssistantLockedRow(panelContainer, panelGroupId, {
-                    containerId = CS.browseContainerId,
-                })
-            elseif panel.buttons then
-                for buttonIndex, buttonData in ipairs(panel.buttons) do
-                    local entry = AceGUI:Create("InteractiveLabel")
-                    CleanRecycledEntry(entry)
-                    local icon = GetButtonIcon(buttonData)
-                    entry:SetImage(icon)
-                    entry:SetImageSize(20, 20)
-                    entry:SetText(buttonData.name or ("ID: " .. (buttonData.id or "?")))
-                    entry:SetFullWidth(true)
-                    entry:SetFontObject(GameFontHighlightSmall)
-                    if buttonData.enabled == false and entry.image and entry.image.SetDesaturated then
-                        entry.image:SetDesaturated(true)
-                    end
-                    entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-                    if CS.selectedGroup == panelGroupId and CS.selectedButton == buttonIndex then
-                        entry:SetColor(0, 1, 0)
-                    elseif buttonData.enabled == false then
-                        entry:SetColor(0.5, 0.5, 0.5)
-                    end
-                    local capturedIndex = buttonIndex
-                    entry:SetCallback("OnClick", function()
-                        SelectConfigButton(panelGroupId, capturedIndex, {
-                            containerId = CS.browseContainerId,
-                            force = true,
-                        })
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                    panelContainer:AddChild(entry)
-                end
-            end
-
-            -- Spacer before copy button
-            local btnSpacer = AceGUI:Create("Label")
-            btnSpacer:SetText(" ")
-            btnSpacer:SetFullWidth(true)
-            btnSpacer:SetHeight(4)
-            panelContainer:AddChild(btnSpacer)
-
-            -- "Copy Panel" button (centered at half width)
-            local btnRow = AceGUI:Create("SimpleGroup")
-            btnRow:SetFullWidth(true)
-            btnRow:SetLayout("Flow")
-            panelContainer:AddChild(btnRow)
-
-            local leftPad = AceGUI:Create("Label")
-            leftPad:SetText("")
-            leftPad:SetRelativeWidth(0.25)
-            btnRow:AddChild(leftPad)
-
-            local copyPanelBtn = AceGUI:Create("Button")
-            copyPanelBtn:SetText("Copy Panel")
-            copyPanelBtn:SetRelativeWidth(0.5)
-            copyPanelBtn:SetCallback("OnClick", function()
-                -- Guard: source still exists
-                if not db.groups[panelGroupId] then
-                    CooldownCompanion:Print("Source panel no longer exists.")
-                    return
-                end
-                if not CS.browseContextMenu then
-                    CS.browseContextMenu = CreateFrame("Frame", "CDCBrowseContextMenu", UIParent, "UIDropDownMenuTemplate")
-                end
-                UIDropDownMenu_Initialize(CS.browseContextMenu, function(self, level)
-                    -- "As New Group"
-                    local info = UIDropDownMenu_CreateInfo()
-                    info.text = "As New Group"
-                    info.notCheckable = true
-                    info.func = function()
-                        CloseDropDownMenus()
-                        if not db.groups[panelGroupId] then return end
-                        local srcContainer = db.groupContainers[CS.browseContainerId]
-                        local groupName = (srcContainer and srcContainer.name) or panel.name or "Copied Group"
-                        local newCid, newGid = CooldownCompanion:CopyPanelAsNewGroup(panelGroupId, groupName)
-                        if newCid then
-                            CS.browseMode = false
-                            CS.browseCharKey = nil
-                            CS.browseContainerId = nil
-                            SelectConfigPanel(newGid, { containerId = newCid })
-                            CooldownCompanion:RefreshConfigPanel()
-                            CooldownCompanion:Print("Panel copied as new group.")
-                        end
-                    end
-                    UIDropDownMenu_AddButton(info, level)
-
-                    -- Separator
-                    info = UIDropDownMenu_CreateInfo()
-                    info.text = ""
-                    info.isTitle = true
-                    info.notCheckable = true
-                    UIDropDownMenu_AddButton(info, level)
-
-                    -- List current character's visible containers
-                    local targets = {}
-                    for cid, c in pairs(db.groupContainers) do
-                        if CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
-                            targets[#targets + 1] = { id = cid, name = c.name, order = CooldownCompanion:GetOrderForSpec(c, CooldownCompanion._currentSpecId, cid) }
-                        end
-                    end
-                    table.sort(targets, function(a, b) return a.order < b.order end)
-
-                    for _, target in ipairs(targets) do
-                        info = UIDropDownMenu_CreateInfo()
-                        info.text = "Into: " .. target.name
-                        info.notCheckable = true
-                        local targetId = target.id
-                        info.func = function()
-                            CloseDropDownMenus()
-                            if not db.groups[panelGroupId] then return end
-                            if not db.groupContainers[targetId] then return end
-                            local newGid = CooldownCompanion:CopyPanelToContainer(panelGroupId, targetId)
-                            if newGid then
-                                CS.browseMode = false
-                                CS.browseCharKey = nil
-                                CS.browseContainerId = nil
-                                SelectConfigPanel(newGid, { containerId = targetId })
-                                CooldownCompanion:RefreshConfigPanel()
-                                CooldownCompanion:Print("Panel copied into " .. target.name .. ".")
-                            end
-                        end
-                        UIDropDownMenu_AddButton(info, level)
-                    end
-                end, "MENU")
-                CS.browseContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
-                ToggleDropDownMenu(1, nil, CS.browseContextMenu, "cursor", 0, 0)
-            end)
-            btnRow:AddChild(copyPanelBtn)
-        end
-
-        -- "Copy Entire Group" button at the bottom
-        local spacer = AceGUI:Create("Label")
-        spacer:SetText(" ")
-        spacer:SetFullWidth(true)
-        CS.col2Scroll:AddChild(spacer)
-
-        local copyAllBtn = AceGUI:Create("Button")
-        copyAllBtn:SetText("Copy Entire Group")
-        copyAllBtn:SetFullWidth(true)
-        copyAllBtn:SetCallback("OnClick", function()
-            if not db.groupContainers[CS.browseContainerId] then
-                CooldownCompanion:Print("Source group no longer exists.")
-                return
-            end
-            local newId = CooldownCompanion:CopyContainerFromBrowse(CS.browseContainerId)
-            if newId then
-                CS.browseMode = false
-                CS.browseCharKey = nil
-                CS.browseContainerId = nil
-                SelectConfigContainer(newId)
-                CooldownCompanion:RefreshConfigPanel()
-                CooldownCompanion:Print("Group copied successfully.")
-            end
-        end)
-        CS.col2Scroll:AddChild(copyAllBtn)
-        return
-    end
-
     if IsConfigFinderActive and IsConfigFinderActive() then
         RenderConfigFinderResults()
         return
@@ -1806,16 +1529,18 @@ local function RefreshColumn2()
                 end
                 UIDropDownMenu_AddButton(info, level)
 
-                local charKey = CooldownCompanion.db.keys.char
                 local folderList = {}
                 for fid, folder in pairs(db.folders) do
-                    if folder.section == "char" and folder.createdBy and folder.createdBy ~= charKey then
-                        -- skip: belongs to another character
-                    else
+                    local folderScope = CooldownCompanion.ResolveFolderClassScope
+                        and CooldownCompanion:ResolveFolderClassScope(folder)
+                        or nil
+                    if not (folderScope and folderScope.isInvalid) then
+                        local sectionKey = folderScope and folderScope.sectionKey or folder.section
                         table.insert(folderList, {
                             id = fid,
                             name = folder.name,
-                            section = folder.section,
+                            section = sectionKey,
+                            classKey = folderScope and folderScope.ownerClassKey or nil,
                             order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid),
                         })
                     end
@@ -1829,7 +1554,12 @@ local function RefreshColumn2()
 
                 for _, f in ipairs(folderList) do
                     info = UIDropDownMenu_CreateInfo()
-                    local sectionLabel = f.section == "global" and " (Global)" or " (Char)"
+                    local sectionLabel = " (Current Class)"
+                    if f.section == "global" then
+                        sectionLabel = " (Global)"
+                    elseif f.classKey then
+                        sectionLabel = " (" .. f.classKey .. ")"
+                    end
                     info.text = f.name .. sectionLabel
                     info.notCheckable = true
                     info.func = function()
@@ -2407,7 +2137,7 @@ local function RefreshColumn2()
                             local db = CooldownCompanion.db.profile
                             local hasOtherContainer = false
                             for cid, _ in pairs(db.groupContainers) do
-                                if cid ~= ctxContainerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
                                     hasOtherContainer = true
                                     break
                                 end
@@ -2488,7 +2218,7 @@ local function RefreshColumn2()
                             local containers = db.groupContainers or {}
                             local folderContainers, looseContainers = {}, {}
                             for cid, ctr in pairs(containers) do
-                                if cid ~= ctxContainerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
                                     local cName = ctr.name or ("Group " .. cid)
                                     local fid = ctr.folderId
                                     if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -571,9 +571,6 @@ local function RefreshColumn4(container)
 
                 ST._BuildFolderLoadConditionsTab(scroll, CS.selectedFolder)
 
-                if CS.browseMode then
-                    ST._DisableAllWidgets(scroll)
-                end
             end)
             tabGroup.frame:SetParent(container)
             tabGroup.frame:ClearAllPoints()
@@ -618,9 +615,6 @@ local function RefreshColumn4(container)
                     ST._BuildContainerLoadConditionsTab(scroll, CS.selectedContainer)
                 end
 
-                if CS.browseMode then
-                    ST._DisableAllWidgets(scroll)
-                end
             end)
             tabGroup.frame:SetParent(container)
             tabGroup.frame:ClearAllPoints()
@@ -710,12 +704,6 @@ local function RefreshColumn4(container)
                 ST._BuildLoadConditionsTab(scroll)
             end
 
-            if CS.browseMode then
-                ST._DisableAllWidgets(scroll)
-                for _, btn in ipairs(CS.tabInfoButtons) do
-                    if btn.Disable then btn:Disable() end
-                end
-            end
         end)
 
         -- Parent the AceGUI widget frame to our raw column frame

--- a/CooldownCompanion_Config/Config/Diagnostics.lua
+++ b/CooldownCompanion_Config/Config/Diagnostics.lua
@@ -192,8 +192,6 @@ local function BuildConfigDiagnosticSummary(profile, groupFrameStates, container
         selectedPanels = CS and SortedSelectionString(CS.selectedPanels) or "",
         selectedGroups = CS and SortedSelectionString(CS.selectedGroups) or "",
         selectedCustomBars = CS and SortedSelectionString(CS.selectedCustomBars) or "",
-        browseMode = CS and CS.browseMode == true,
-        browseCharKey = CS and CS.browseCharKey or nil,
         selectedContainerSummary = SummarizeContainer(selectedContainerId, containers and selectedContainerId and containers[selectedContainerId] or nil),
         selectedPanelSummary = SummarizePanel(selectedPanelId, selectedPanel),
         selectedButtonSummary = SummarizeButton(selectedButton),
@@ -789,9 +787,6 @@ local function FormatDiagnosticBugReportAsText(diag)
             c.selectedPanels ~= "" and c.selectedPanels or "none",
             c.selectedGroups ~= "" and c.selectedGroups or "none",
             c.selectedCustomBars ~= "" and c.selectedCustomBars or "none"))
-    end
-    if c.browseMode then
-        add("Browse Mode: " .. tostring(c.browseCharKey or "unknown"))
     end
     if c.selectedContainerSummary then
         local container = c.selectedContainerSummary

--- a/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
+++ b/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
@@ -53,6 +53,58 @@ local FindCol1TopLevelInsertPos = DR.FindCol1TopLevelInsertPos
 local AssignCol1TopLevelOrders = DR.AssignCol1TopLevelOrders
 local PartitionSelectedContainersByLoadBucket = DR.PartitionSelectedContainersByLoadBucket
 
+local function IsCol1OwnershipMoveAllowed(sourceSection, targetSection)
+    if not targetSection or sourceSection == targetSection then
+        return true
+    end
+    if targetSection == "global" and sourceSection ~= "global" then
+        return true
+    end
+    return sourceSection == "global" and targetSection == "char"
+end
+
+local function GetContainerSection(container)
+    if not container then return nil end
+    if container.isGlobal then return "global" end
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(container)
+        return scope and scope.sectionKey or "invalid"
+    end
+    return "char"
+end
+
+local function ApplyContainerSection(containerId, container, targetSection)
+    if targetSection == "global" then
+        container.isGlobal = true
+        return true
+    end
+    if targetSection == "char" then
+        container.isGlobal = false
+        container.createdBy = CooldownCompanion.db.keys.char
+        if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
+            CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(containerId)
+        end
+        return true
+    end
+    return targetSection == GetContainerSection(container)
+end
+
+local function ApplyFolderSection(folderId, folder, targetSection)
+    if targetSection == "global" then
+        folder.section = "global"
+        return true
+    end
+    if targetSection == "char" then
+        folder.section = "char"
+        folder.createdBy = CooldownCompanion.db.keys.char
+        if CooldownCompanion.NormalizeFolderEligibilityForCharacterScope then
+            CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(folderId)
+        end
+        return true
+    end
+    return false
+end
+
 ------------------------------------------------------------------------
 -- Apply a column-1 folder-aware drop result
 ------------------------------------------------------------------------
@@ -71,20 +123,19 @@ local function ApplyCol1Drop(state)
         if dropTarget.action == "into-folder" or dropTarget.action == "reorder-before" or dropTarget.action == "reorder-after" then
             local targetRow = dropTarget.targetRow
             local targetFolderId = ResolveCol1GroupDropTargetFolderId(state, dropTarget)
-            CooldownCompanion:MoveGroupToFolder(sourceContainerId, targetFolderId)
+            local targetSection = targetRow.section or state.sourceSection
+            if not IsCol1OwnershipMoveAllowed(state.sourceSection, targetSection) then
+                return
+            end
 
             -- Cross-section move: toggle global/character status
-            local targetSection = targetRow.section or state.sourceSection
             if targetSection ~= state.sourceSection then
-                if targetSection == "global" then
-                    container.isGlobal = true
-                else
-                    container.isGlobal = false
-                    container.createdBy = CooldownCompanion.db.keys.char
-                    if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
-                        CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(sourceContainerId)
-                    end
+                if not ApplyContainerSection(sourceContainerId, container, targetSection) then
+                    return
                 end
+            end
+            if CooldownCompanion:MoveGroupToFolder(sourceContainerId, targetFolderId, { allowScopeChange = true }) == false then
+                return
             end
 
             -- Reassign order values for all items in the target section
@@ -172,18 +223,17 @@ local function ApplyCol1Drop(state)
         for cid in pairs(sourceContainerIds) do
             local c = db.groupContainers[cid]
             if c then
-                CooldownCompanion:MoveGroupToFolder(cid, targetFolderId)
-                local containerSection = c.isGlobal and "global" or "char"
+                local containerSection = GetContainerSection(c)
+                if not IsCol1OwnershipMoveAllowed(containerSection, targetSection) then
+                    return
+                end
                 if containerSection ~= targetSection then
-                    if targetSection == "global" then
-                        c.isGlobal = true
-                    else
-                        c.isGlobal = false
-                        c.createdBy = CooldownCompanion.db.keys.char
-                        if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
-                            CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(cid)
-                        end
+                    if not ApplyContainerSection(cid, c, targetSection) then
+                        return
                     end
+                end
+                if CooldownCompanion:MoveGroupToFolder(cid, targetFolderId, { allowScopeChange = true }) == false then
+                    return
                 end
             end
         end
@@ -307,25 +357,21 @@ local function ApplyCol1Drop(state)
         local dropTarget = state.dropTarget
         local targetRow = dropTarget.targetRow
         local section = targetRow.section or state.sourceSection
+        if not IsCol1OwnershipMoveAllowed(state.sourceSection, section) then
+            return
+        end
 
         -- Cross-section move: toggle folder section and update all child containers
         if section ~= state.sourceSection then
-            folder.section = section
-            if section == "char" then
-                folder.createdBy = CooldownCompanion.db.keys.char
+            if not ApplyFolderSection(sourceFolderId, folder, section) then
+                return
             end
             for containerId, container in pairs(db.groupContainers) do
                 if container.folderId == sourceFolderId then
-                    if section == "global" then
-                        container.isGlobal = true
-                    else
-                        container.isGlobal = false
-                        container.createdBy = CooldownCompanion.db.keys.char
+                    if not ApplyContainerSection(containerId, container, section) then
+                        return
                     end
                 end
-            end
-            if section == "char" and CooldownCompanion.NormalizeFolderEligibilityForCharacterScope then
-                CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(sourceFolderId)
             end
         end
 
@@ -521,9 +567,13 @@ local function FinishCol1FolderAwareDrag(state)
 
     if dropTarget and (state.kind == "group" or state.kind == "folder-group") then
         local targetSection = dropTarget.targetRow and dropTarget.targetRow.section
+        if targetSection and not IsCol1OwnershipMoveAllowed(state.sourceSection, targetSection) then
+            return
+        end
         local sourceContainer = CooldownCompanion.db.profile.groupContainers[state.sourceGroupId]
         if targetSection and targetSection ~= state.sourceSection
            and state.sourceSection == "global"
+           and targetSection == "char"
            and sourceContainer
            and GroupsHaveForeignSpecs({ sourceContainer }, false) then
             ShowPopupAboveConfig("CDC_DRAG_UNGLOBAL_GROUP", sourceContainer.name, {
@@ -535,6 +585,15 @@ local function FinishCol1FolderAwareDrag(state)
 
     if dropTarget and state.kind == "multi-group" and state.sourceGroupIds then
         local targetSection = dropTarget.targetRow and dropTarget.targetRow.section
+        if targetSection then
+            local db = CooldownCompanion.db.profile
+            for cid in pairs(state.sourceGroupIds) do
+                local sourceContainer = db.groupContainers[cid]
+                if sourceContainer and not IsCol1OwnershipMoveAllowed(GetContainerSection(sourceContainer), targetSection) then
+                    return
+                end
+            end
+        end
         if targetSection == "char" then
             local db = CooldownCompanion.db.profile
             local groupList = {}
@@ -562,8 +621,12 @@ local function FinishCol1FolderAwareDrag(state)
 
     if dropTarget and state.kind == "folder" then
         local targetSection = dropTarget.targetRow and dropTarget.targetRow.section
+        if targetSection and not IsCol1OwnershipMoveAllowed(state.sourceSection, targetSection) then
+            return
+        end
         if targetSection and targetSection ~= state.sourceSection
            and state.sourceSection == "global"
+           and targetSection == "char"
            and FolderHasForeignSpecs
            and FolderHasForeignSpecs(state.sourceFolderId) then
             ShowPopupAboveConfig("CDC_DRAG_UNGLOBAL_FOLDER", nil, {

--- a/CooldownCompanion_Config/Config/DragReorderTargets.lua
+++ b/CooldownCompanion_Config/Config/DragReorderTargets.lua
@@ -11,6 +11,17 @@ ST._DragReorder = DR
 
 local COL1_HIT_X_PAD = 6
 local FindCol1SectionDividerTarget
+local activeCol1DropSourceSection
+
+local function IsCol1OwnershipMoveAllowed(sourceSection, targetSection)
+    if not targetSection or sourceSection == targetSection then
+        return true
+    end
+    if targetSection == "global" and sourceSection ~= "global" then
+        return true
+    end
+    return sourceSection == "global" and targetSection == "char"
+end
 
 local function FindCol1FolderBlockRange(rows, folderId)
     local headerIndex
@@ -698,6 +709,11 @@ local function BuildCol1DropResult(action, rowIndex, rowMeta, extra)
     if not (rowMeta and frame and frame:IsShown()) then
         return nil
     end
+    if activeCol1DropSourceSection
+        and not IsCol1OwnershipMoveAllowed(activeCol1DropSourceSection, rowMeta.section)
+    then
+        return nil
+    end
 
     local result = {
         action = action,
@@ -1140,6 +1156,7 @@ end
 
 local function GetCol1DropTarget(cursorX, cursorY, scrollWidget, renderedRows, sourceKind, sourceSection, sourceFolderId, sourceLoadBucket, previousDropTarget)
     if not renderedRows or #renderedRows == 0 then return nil end
+    activeCol1DropSourceSection = sourceSection
     local sourceIsMixed = IsCol1MixedDragSource(sourceLoadBucket)
     local sourceIsUnloaded = IsCol1UnloadedDragSource(sourceLoadBucket)
     local contentLeft, contentRight = GetCol1HorizontalBounds(scrollWidget, renderedRows)

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1176,11 +1176,12 @@ local function CreateConfigPanel()
 
     local otherClassBrowseBtnBorder = nil
     local otherClassBrowseAvailable = false
+    local otherClassBrowseActionAvailable = false
     local otherClassBrowseSearchFiltered = false
     local otherClassBrowseHasInventory = false
 
     local function UpdateOtherClassBrowseBtnHighlight()
-        local shouldHighlight = otherClassBrowseAvailable and CS.otherClassLibraryActive == true
+        local shouldHighlight = otherClassBrowseActionAvailable and CS.otherClassLibraryActive == true
         if shouldHighlight then
             if not otherClassBrowseBtnBorder then
                 otherClassBrowseBtnBorder = otherClassBrowseBtn:CreateTexture(nil, "OVERLAY")
@@ -1196,18 +1197,19 @@ local function CreateConfigPanel()
 
     local function UpdateOtherClassBrowseButtonState()
         otherClassBrowseAvailable, otherClassBrowseSearchFiltered, otherClassBrowseHasInventory = HasOtherClassInventory()
+        otherClassBrowseActionAvailable = otherClassBrowseAvailable or CS.otherClassLibraryActive == true
 
         if otherClassBrowseBtn.SetEnabled then
-            otherClassBrowseBtn:SetEnabled(otherClassBrowseAvailable)
-        elseif otherClassBrowseAvailable and otherClassBrowseBtn.Enable then
+            otherClassBrowseBtn:SetEnabled(otherClassBrowseActionAvailable)
+        elseif otherClassBrowseActionAvailable and otherClassBrowseBtn.Enable then
             otherClassBrowseBtn:Enable()
         elseif otherClassBrowseBtn.Disable then
             otherClassBrowseBtn:Disable()
         end
         if otherClassBrowseIcon.SetDesaturated then
-            otherClassBrowseIcon:SetDesaturated(not otherClassBrowseAvailable)
+            otherClassBrowseIcon:SetDesaturated(not otherClassBrowseActionAvailable)
         end
-        if otherClassBrowseAvailable then
+        if otherClassBrowseActionAvailable then
             otherClassBrowseBtn:SetAlpha(1)
             otherClassBrowseIcon:SetVertexColor(1, 1, 1, 1)
             if otherClassBrowseBtn:GetHighlightTexture() then
@@ -1251,14 +1253,14 @@ local function CreateConfigPanel()
     otherClassBrowseBtn:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
         GameTooltip:AddLine("Browse Other Classes")
-        if not otherClassBrowseAvailable then
+        if CS.otherClassLibraryActive then
+            GameTooltip:AddLine("Class library is open. Click to return to the regular config view.", 1, 1, 1, true)
+        elseif not otherClassBrowseActionAvailable then
             if otherClassBrowseSearchFiltered and otherClassBrowseHasInventory then
                 GameTooltip:AddLine("No other classes match the current search.", 1, 1, 1, true)
             else
                 GameTooltip:AddLine("No other classes on this profile currently have groups to browse.", 1, 1, 1, true)
             end
-        elseif CS.otherClassLibraryActive then
-            GameTooltip:AddLine("Class library is open. Click to return to the regular config view.", 1, 1, 1, true)
         else
             GameTooltip:AddLine("View and edit groups saved for other classes on this profile.", 1, 1, 1, true)
         end

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -37,6 +37,8 @@ local RebuildTutorialAnchors = ST._RebuildTutorialAnchors
 local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
 local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
+local CleanRecycledEntry = ST._CleanRecycledEntry
+local ApplyConfigTextRow = ST._ApplyConfigTextRow
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -65,6 +67,8 @@ local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
 local CONFIG_FINDER_BUTTON_GAP = 3
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+local COLUMN1_FOOTER_DOORWAY_HEIGHT = 24
+local COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT = COLUMN1_FOOTER_DOORWAY_HEIGHT + CONFIG_FINDER_BUTTON_GAP
 local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
 local CONFIG_NESTED_INLINE_GROUP_INSET = 20
 local CONFIG_DRAG_ALPHA = 0.40
@@ -436,9 +440,6 @@ end
 local function ApplyConfigColumnTitles(frame)
     if CS.resourceBarPanelActive then
         frame.col1:SetTitle("Bars & Frames")
-    elseif CS.browseMode then
-        frame.col1:SetTitle("Browse Characters")
-        frame.col2:SetTitle("Preview")
     elseif IsConfigFinderActive and IsConfigFinderActive() then
         frame.col1:SetTitle("Groups")
         frame.col2:SetTitle("Search Results")
@@ -538,7 +539,7 @@ local function IsConfigSpellOverrideRefreshMode()
     if not IsConfigFrameOpenForRefresh() then
         return false
     end
-    if CS.browseMode or CS.resourceBarPanelActive then
+    if CS.resourceBarPanelActive then
         return false
     end
     if CountSelections(CS.selectedGroups) >= 2 then
@@ -1132,91 +1133,6 @@ local function CreateConfigPanel()
     end)
     cdmDisplayBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
-    -- Cross-character browse button — between the CDM display toggle and CDM button
-    local browseBtn = CreateFrame("Button", nil, content)
-    browseBtn:SetSize(16, 16)
-    if browseBtn.SetMotionScriptsWhileDisabled then
-        browseBtn:SetMotionScriptsWhileDisabled(true)
-    end
-    local browseIcon = browseBtn:CreateTexture(nil, "ARTWORK")
-    browseIcon:SetAtlas("BattleBar-SwapPetIcon", false)
-    browseIcon:SetAllPoints()
-    browseBtn:SetHighlightAtlas("BattleBar-SwapPetIcon")
-    browseBtn:GetHighlightTexture():SetAlpha(0.3)
-    local browseBtnBorder = nil
-    local browseBtnAvailable = false
-
-    local function UpdateBrowseBtnHighlight()
-        local shouldHighlight = browseBtnAvailable and CS.browseMode == true
-        if shouldHighlight then
-            if not browseBtnBorder then
-                browseBtnBorder = browseBtn:CreateTexture(nil, "OVERLAY")
-                browseBtnBorder:SetPoint("TOPLEFT", -1, 1)
-                browseBtnBorder:SetPoint("BOTTOMRIGHT", 1, -1)
-                browseBtnBorder:SetColorTexture(0.85, 0.65, 0.0, 0.6)
-            end
-            browseBtnBorder:Show()
-        elseif browseBtnBorder then
-            browseBtnBorder:Hide()
-        end
-    end
-
-    local function UpdateBrowseBtnState()
-        local browseChars = CooldownCompanion:EnumerateBrowseCharacters()
-        browseBtnAvailable = #browseChars > 0
-
-        if browseBtn.SetEnabled then
-            browseBtn:SetEnabled(browseBtnAvailable)
-        end
-        if browseIcon.SetDesaturated then
-            browseIcon:SetDesaturated(not browseBtnAvailable)
-        end
-        if browseBtnAvailable then
-            browseBtn:SetAlpha(1)
-            browseIcon:SetVertexColor(1, 1, 1, 1)
-            if browseBtn:GetHighlightTexture() then
-                browseBtn:GetHighlightTexture():SetAlpha(0.3)
-            end
-        else
-            browseBtn:SetAlpha(0.75)
-            browseIcon:SetVertexColor(0.6, 0.6, 0.6, 1)
-            if browseBtn:GetHighlightTexture() then
-                browseBtn:GetHighlightTexture():SetAlpha(0)
-            end
-        end
-
-        UpdateBrowseBtnHighlight()
-    end
-
-    browseBtn:SetScript("OnClick", function()
-        if not browseBtnAvailable then
-            return
-        end
-        CloseDropDownMenus()
-        -- Browse mode lives in the normal button-settings layout, not Bars & Frames.
-        if CS.resourceBarPanelActive then
-            SetPrimaryMode("buttons", { skipRefresh = true })
-        end
-        CS.browseMode = true
-        CS.browseCharKey = nil
-        CS.browseContainerId = nil
-        ClearConfigPrimarySelection()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    browseBtn:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
-        GameTooltip:AddLine("Browse Other Characters")
-        if not browseBtnAvailable then
-            GameTooltip:AddLine("No other characters on this profile currently have groups to browse.", 1, 1, 1, true)
-        elseif CS.browseMode then
-            GameTooltip:AddLine("Browse mode is active. Click to return to the character list and browse groups from other characters on this profile.", 1, 1, 1, true)
-        else
-            GameTooltip:AddLine("View and copy groups from other characters on this profile.", 1, 1, 1, true)
-        end
-        GameTooltip:Show()
-    end)
-    browseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
-
     local changelogOverlay
     local changelogBtn
     local changelogBtnBorder = nil
@@ -1262,8 +1178,7 @@ local function CreateConfigPanel()
     gearBtn:SetPoint("RIGHT", collapseBtn, "LEFT", -4, 0)
     changelogBtn:SetPoint("RIGHT", gearBtn, "LEFT", -4, 0)
     cdmBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
-    browseBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
-    cdmDisplayBtn:SetPoint("RIGHT", browseBtn, "LEFT", -4, 0)
+    cdmDisplayBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
     local gearIcon = gearBtn:CreateTexture(nil, "ARTWORK")
     gearIcon:SetTexture("Interface\\WorldMap\\GEAR_64GREY")
     gearIcon:SetAllPoints()
@@ -1805,6 +1720,19 @@ local function CreateConfigPanel()
     end
     CS.configFinderBox = configFinder
 
+    local otherClassesDoorway = AceGUI:Create("InteractiveLabel")
+    CleanRecycledEntry(otherClassesDoorway)
+    otherClassesDoorway:SetText("")
+    otherClassesDoorway:SetFullWidth(true)
+    otherClassesDoorway:SetFontObject(GameFontHighlight)
+    ApplyConfigTextRow(otherClassesDoorway)
+    otherClassesDoorway:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+    otherClassesDoorway.frame:SetParent(col1.content)
+    otherClassesDoorway.frame:ClearAllPoints()
+    otherClassesDoorway.frame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
+    otherClassesDoorway.frame:Hide()
+    CS.col1FooterDoorway = otherClassesDoorway
+
     -- Column 3: Button Settings
     local col3 = AceGUI:Create("InlineGroup")
     col3:SetTitle("Button Settings")
@@ -2006,12 +1934,6 @@ local function CreateConfigPanel()
                 local buttonData = CooldownCompanion:GetRotationAssistantConfigButtonData(group)
                 ST._BuildEntryLoadConditionsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
             end
-            if CS.browseMode then
-                ST._DisableAllWidgets(scroll)
-                for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                    if btn.Disable then btn:Disable() end
-                end
-            end
             return
         end
 
@@ -2045,13 +1967,6 @@ local function CreateConfigPanel()
             ST._BuildEntryLoadConditionsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
         elseif tab == "overrides" then
             ST._BuildOverridesTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
-        end
-
-        if CS.browseMode then
-            ST._DisableAllWidgets(scroll)
-            for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                if btn.Disable then btn:Disable() end
-            end
         end
 
     end)
@@ -2216,6 +2131,65 @@ local function CreateConfigPanel()
         end
     end
 
+    local function PositionColumn1FooterControls(finderAvailable)
+        finderAvailable = finderAvailable == true
+
+        if CS.configFinderBox and CS.configFinderBox.frame then
+            CS.configFinderBox.frame:ClearAllPoints()
+            CS.configFinderBox.frame:SetPoint("BOTTOMLEFT", col1.content, "BOTTOMLEFT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+            CS.configFinderBox.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+            CS.configFinderBox.frame:SetHeight(CONFIG_FINDER_BOX_HEIGHT)
+        end
+
+        local doorwayVisible = finderAvailable
+            and CS.col1FooterDoorwayVisible == true
+            and CS.col1FooterDoorway
+            and CS.col1FooterDoorway.frame
+
+        if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
+            local doorwayFrame = CS.col1FooterDoorway.frame
+            doorwayFrame:ClearAllPoints()
+            doorwayFrame:SetPoint(
+                "BOTTOMLEFT",
+                col1.content,
+                "BOTTOMLEFT",
+                0,
+                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+            )
+            doorwayFrame:SetPoint(
+                "BOTTOMRIGHT",
+                col1.content,
+                "BOTTOMRIGHT",
+                0,
+                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+            )
+            doorwayFrame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
+            if doorwayVisible then
+                doorwayFrame:Show()
+            else
+                doorwayFrame:Hide()
+            end
+        end
+
+        if CS.col1Scroll and CS.col1Scroll.frame then
+            local bottomInset = 30
+            if finderAvailable then
+                bottomInset = bottomInset + CONFIG_FINDER_RESERVED_HEIGHT
+                if doorwayVisible then
+                    bottomInset = bottomInset + COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT
+                end
+            end
+
+            CS.col1Scroll.frame:ClearAllPoints()
+            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
+            CS.col1Scroll.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, bottomInset)
+        end
+    end
+
+    CS.UpdateColumn1FooterLayout = function()
+        PositionColumn1FooterControls(IsConfigFinderAvailable and IsConfigFinderAvailable())
+    end
+
     -- Layout columns on size change
     local function LayoutColumns()
         local w = colParent:GetWidth()
@@ -2232,6 +2206,11 @@ local function CreateConfigPanel()
         if CS.talentPickerMode then
             if CS.configFinderBox then
                 CS.configFinderBox.frame:Hide()
+            end
+            CS.col1FooterDoorwayVisible = false
+            CS.lastCol1FooterDoorwayRow = nil
+            if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
+                CS.col1FooterDoorway.frame:Hide()
             end
             if ClearConfigFinderText then
                 ClearConfigFinderText()
@@ -2269,17 +2248,7 @@ local function CreateConfigPanel()
                 end
             end
         end
-        if CS.col1Scroll and CS.col1Scroll.frame then
-            CS.col1Scroll.frame:ClearAllPoints()
-            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
-            CS.col1Scroll.frame:SetPoint(
-                "BOTTOMRIGHT",
-                col1.content,
-                "BOTTOMRIGHT",
-                0,
-                finderAvailable and (30 + CONFIG_FINDER_RESERVED_HEIGHT) or 30
-            )
-        end
+        PositionColumn1FooterControls(finderAvailable)
 
         col1.frame:ClearAllPoints()
         col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", 0, 0)
@@ -2334,8 +2303,6 @@ local function CreateConfigPanel()
     frame.LayoutColumns = LayoutColumns
     frame.UpdateCompactConfigRows = UpdateCompactConfigRows
     frame.UpdateModeNavigationUI = UpdateModeNavigationUI
-    frame.UpdateBrowseButtonState = UpdateBrowseBtnState
-    UpdateBrowseBtnState()
     UpdateModeNavigationUI()
 
     CS.configFrame = frame
@@ -2421,9 +2388,6 @@ function CooldownCompanion:_configRefreshPanelImpl()
     CS.configFrame.versionText:SetText(GetVersionFooterText())
     if CS.configFrame.UpdateModeNavigationUI then
         CS.configFrame.UpdateModeNavigationUI()
-    end
-    if CS.configFrame.UpdateBrowseButtonState then
-        CS.configFrame.UpdateBrowseButtonState()
     end
     if CS.configFrame.LayoutColumns then
         CS.configFrame.LayoutColumns()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -933,6 +933,9 @@ local function CreateConfigPanel()
         end
         if not CS.previewToggleRefreshActive then
             CooldownCompanion:ClearAllConfigPreviews()
+            if CooldownCompanion.RefreshConfigSelectedGroupFrames then
+                CooldownCompanion:RefreshConfigSelectedGroupFrames()
+            end
         end
         if ClearConfigShiftTooltipHover then
             ClearConfigShiftTooltipHover()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -30,6 +30,7 @@ local IsConfigFinderActive = ST._IsConfigFinderActive
 local SetConfigFinderText = ST._SetConfigFinderText
 local ClearConfigFinderText = ST._ClearConfigFinderText
 local InvalidateConfigFinderResults = ST._InvalidateConfigFinderResults
+local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
 local StartFirstIconPanelTutorial = ST._StartFirstIconPanelTutorial
 local CancelFirstIconPanelTutorial = ST._CancelFirstIconPanelTutorial
@@ -37,8 +38,6 @@ local RebuildTutorialAnchors = ST._RebuildTutorialAnchors
 local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
 local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
-local CleanRecycledEntry = ST._CleanRecycledEntry
-local ApplyConfigTextRow = ST._ApplyConfigTextRow
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -67,8 +66,6 @@ local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
 local CONFIG_FINDER_BUTTON_GAP = 3
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-local COLUMN1_FOOTER_DOORWAY_HEIGHT = 24
-local COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT = COLUMN1_FOOTER_DOORWAY_HEIGHT + CONFIG_FINDER_BUTTON_GAP
 local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
 local CONFIG_NESTED_INLINE_GROUP_INSET = 20
 local CONFIG_DRAG_ALPHA = 0.40
@@ -247,6 +244,38 @@ local function SetPrimaryMode(mode, opts)
         CooldownCompanion:RefreshConfigPanel()
     end
     return true
+end
+
+local function HasOtherClassInventory()
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not db then return false, false, false end
+
+    local searchFiltered = IsConfigFinderActive and IsConfigFinderActive() and BuildConfigFinderResults ~= nil
+    local searchResults = searchFiltered and BuildConfigFinderResults() or nil
+    local hasOtherInventory = false
+
+    if CooldownCompanion.ResolveContainerClassScope then
+        for id, container in pairs(db.groupContainers or {}) do
+            local scope = CooldownCompanion:ResolveContainerClassScope(container or id)
+            if scope and scope.scope == "other-class" then
+                hasOtherInventory = true
+                if not searchFiltered or (searchResults and searchResults.containerMatches and searchResults.containerMatches[id]) then
+                    return true, searchFiltered == true, true
+                end
+            end
+        end
+    end
+
+    if not searchFiltered and CooldownCompanion.ResolveFolderClassScope then
+        for folderId, folder in pairs(db.folders or {}) do
+            local scope = CooldownCompanion:ResolveFolderClassScope(folder or folderId)
+            if scope and scope.scope == "other-class" then
+                return true, false, true
+            end
+        end
+    end
+
+    return false, searchFiltered == true, hasOtherInventory
 end
 
 local GetClassColoredText = ST._GetClassColoredText
@@ -1133,6 +1162,104 @@ local function CreateConfigPanel()
     end)
     cdmDisplayBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
+    -- Other Classes browse button — between the Changelog and CDM buttons
+    local otherClassBrowseBtn = CreateFrame("Button", nil, content)
+    otherClassBrowseBtn:SetSize(16, 16)
+    if otherClassBrowseBtn.SetMotionScriptsWhileDisabled then
+        otherClassBrowseBtn:SetMotionScriptsWhileDisabled(true)
+    end
+    local otherClassBrowseIcon = otherClassBrowseBtn:CreateTexture(nil, "ARTWORK")
+    otherClassBrowseIcon:SetAtlas("BattleBar-SwapPetIcon", false)
+    otherClassBrowseIcon:SetAllPoints()
+    otherClassBrowseBtn:SetHighlightAtlas("BattleBar-SwapPetIcon")
+    otherClassBrowseBtn:GetHighlightTexture():SetAlpha(0.3)
+
+    local otherClassBrowseBtnBorder = nil
+    local otherClassBrowseAvailable = false
+    local otherClassBrowseSearchFiltered = false
+    local otherClassBrowseHasInventory = false
+
+    local function UpdateOtherClassBrowseBtnHighlight()
+        local shouldHighlight = otherClassBrowseAvailable and CS.otherClassLibraryActive == true
+        if shouldHighlight then
+            if not otherClassBrowseBtnBorder then
+                otherClassBrowseBtnBorder = otherClassBrowseBtn:CreateTexture(nil, "OVERLAY")
+                otherClassBrowseBtnBorder:SetPoint("TOPLEFT", -1, 1)
+                otherClassBrowseBtnBorder:SetPoint("BOTTOMRIGHT", 1, -1)
+                otherClassBrowseBtnBorder:SetColorTexture(0.85, 0.65, 0.0, 0.6)
+            end
+            otherClassBrowseBtnBorder:Show()
+        elseif otherClassBrowseBtnBorder then
+            otherClassBrowseBtnBorder:Hide()
+        end
+    end
+
+    local function UpdateOtherClassBrowseButtonState()
+        otherClassBrowseAvailable, otherClassBrowseSearchFiltered, otherClassBrowseHasInventory = HasOtherClassInventory()
+
+        if otherClassBrowseBtn.SetEnabled then
+            otherClassBrowseBtn:SetEnabled(otherClassBrowseAvailable)
+        elseif otherClassBrowseAvailable and otherClassBrowseBtn.Enable then
+            otherClassBrowseBtn:Enable()
+        elseif otherClassBrowseBtn.Disable then
+            otherClassBrowseBtn:Disable()
+        end
+        if otherClassBrowseIcon.SetDesaturated then
+            otherClassBrowseIcon:SetDesaturated(not otherClassBrowseAvailable)
+        end
+        if otherClassBrowseAvailable then
+            otherClassBrowseBtn:SetAlpha(1)
+            otherClassBrowseIcon:SetVertexColor(1, 1, 1, 1)
+            if otherClassBrowseBtn:GetHighlightTexture() then
+                otherClassBrowseBtn:GetHighlightTexture():SetAlpha(0.3)
+            end
+        else
+            otherClassBrowseBtn:SetAlpha(0.75)
+            otherClassBrowseIcon:SetVertexColor(0.6, 0.6, 0.6, 1)
+            if otherClassBrowseBtn:GetHighlightTexture() then
+                otherClassBrowseBtn:GetHighlightTexture():SetAlpha(0)
+            end
+        end
+
+        UpdateOtherClassBrowseBtnHighlight()
+    end
+
+    otherClassBrowseBtn:SetScript("OnClick", function()
+        CloseDropDownMenus()
+        if CS.otherClassLibraryActive then
+            CS.otherClassLibraryActive = false
+            CS.otherClassLibraryClassKey = nil
+            CooldownCompanion:RefreshConfigPanel()
+            return
+        end
+        if not otherClassBrowseAvailable then
+            return
+        end
+        if CS.resourceBarPanelActive then
+            SetPrimaryMode("buttons", { skipRefresh = true })
+        end
+        CS.otherClassLibraryActive = true
+        CS.otherClassLibraryClassKey = nil
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    otherClassBrowseBtn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
+        GameTooltip:AddLine("Browse Other Classes")
+        if not otherClassBrowseAvailable then
+            if otherClassBrowseSearchFiltered and otherClassBrowseHasInventory then
+                GameTooltip:AddLine("No other classes match the current search.", 1, 1, 1, true)
+            else
+                GameTooltip:AddLine("No other classes on this profile currently have groups to browse.", 1, 1, 1, true)
+            end
+        elseif CS.otherClassLibraryActive then
+            GameTooltip:AddLine("Class library is open. Click to return to the regular config view.", 1, 1, 1, true)
+        else
+            GameTooltip:AddLine("View and edit groups saved for other classes on this profile.", 1, 1, 1, true)
+        end
+        GameTooltip:Show()
+    end)
+    otherClassBrowseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
     local changelogOverlay
     local changelogBtn
     local changelogBtnBorder = nil
@@ -1177,7 +1304,8 @@ local function CreateConfigPanel()
     gearBtn:SetSize(20, 20)
     gearBtn:SetPoint("RIGHT", collapseBtn, "LEFT", -4, 0)
     changelogBtn:SetPoint("RIGHT", gearBtn, "LEFT", -4, 0)
-    cdmBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
+    otherClassBrowseBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
+    cdmBtn:SetPoint("RIGHT", otherClassBrowseBtn, "LEFT", -4, 0)
     cdmDisplayBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
     local gearIcon = gearBtn:CreateTexture(nil, "ARTWORK")
     gearIcon:SetTexture("Interface\\WorldMap\\GEAR_64GREY")
@@ -1720,19 +1848,6 @@ local function CreateConfigPanel()
     end
     CS.configFinderBox = configFinder
 
-    local otherClassesDoorway = AceGUI:Create("InteractiveLabel")
-    CleanRecycledEntry(otherClassesDoorway)
-    otherClassesDoorway:SetText("")
-    otherClassesDoorway:SetFullWidth(true)
-    otherClassesDoorway:SetFontObject(GameFontHighlight)
-    ApplyConfigTextRow(otherClassesDoorway)
-    otherClassesDoorway:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-    otherClassesDoorway.frame:SetParent(col1.content)
-    otherClassesDoorway.frame:ClearAllPoints()
-    otherClassesDoorway.frame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
-    otherClassesDoorway.frame:Hide()
-    CS.col1FooterDoorway = otherClassesDoorway
-
     -- Column 3: Button Settings
     local col3 = AceGUI:Create("InlineGroup")
     col3:SetTitle("Button Settings")
@@ -2131,65 +2246,6 @@ local function CreateConfigPanel()
         end
     end
 
-    local function PositionColumn1FooterControls(finderAvailable)
-        finderAvailable = finderAvailable == true
-
-        if CS.configFinderBox and CS.configFinderBox.frame then
-            CS.configFinderBox.frame:ClearAllPoints()
-            CS.configFinderBox.frame:SetPoint("BOTTOMLEFT", col1.content, "BOTTOMLEFT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
-            CS.configFinderBox.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
-            CS.configFinderBox.frame:SetHeight(CONFIG_FINDER_BOX_HEIGHT)
-        end
-
-        local doorwayVisible = finderAvailable
-            and CS.col1FooterDoorwayVisible == true
-            and CS.col1FooterDoorway
-            and CS.col1FooterDoorway.frame
-
-        if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
-            local doorwayFrame = CS.col1FooterDoorway.frame
-            doorwayFrame:ClearAllPoints()
-            doorwayFrame:SetPoint(
-                "BOTTOMLEFT",
-                col1.content,
-                "BOTTOMLEFT",
-                0,
-                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-            )
-            doorwayFrame:SetPoint(
-                "BOTTOMRIGHT",
-                col1.content,
-                "BOTTOMRIGHT",
-                0,
-                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-            )
-            doorwayFrame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
-            if doorwayVisible then
-                doorwayFrame:Show()
-            else
-                doorwayFrame:Hide()
-            end
-        end
-
-        if CS.col1Scroll and CS.col1Scroll.frame then
-            local bottomInset = 30
-            if finderAvailable then
-                bottomInset = bottomInset + CONFIG_FINDER_RESERVED_HEIGHT
-                if doorwayVisible then
-                    bottomInset = bottomInset + COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT
-                end
-            end
-
-            CS.col1Scroll.frame:ClearAllPoints()
-            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
-            CS.col1Scroll.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, bottomInset)
-        end
-    end
-
-    CS.UpdateColumn1FooterLayout = function()
-        PositionColumn1FooterControls(IsConfigFinderAvailable and IsConfigFinderAvailable())
-    end
-
     -- Layout columns on size change
     local function LayoutColumns()
         local w = colParent:GetWidth()
@@ -2206,11 +2262,6 @@ local function CreateConfigPanel()
         if CS.talentPickerMode then
             if CS.configFinderBox then
                 CS.configFinderBox.frame:Hide()
-            end
-            CS.col1FooterDoorwayVisible = false
-            CS.lastCol1FooterDoorwayRow = nil
-            if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
-                CS.col1FooterDoorway.frame:Hide()
             end
             if ClearConfigFinderText then
                 ClearConfigFinderText()
@@ -2240,6 +2291,10 @@ local function CreateConfigPanel()
 
         if CS.configFinderBox then
             if finderAvailable then
+                CS.configFinderBox.frame:ClearAllPoints()
+                CS.configFinderBox.frame:SetPoint("BOTTOMLEFT", col1.content, "BOTTOMLEFT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+                CS.configFinderBox.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+                CS.configFinderBox.frame:SetHeight(CONFIG_FINDER_BOX_HEIGHT)
                 CS.configFinderBox.frame:Show()
             else
                 CS.configFinderBox.frame:Hide()
@@ -2248,7 +2303,12 @@ local function CreateConfigPanel()
                 end
             end
         end
-        PositionColumn1FooterControls(finderAvailable)
+        if CS.col1Scroll and CS.col1Scroll.frame then
+            local bottomInset = finderAvailable and (30 + CONFIG_FINDER_RESERVED_HEIGHT) or 30
+            CS.col1Scroll.frame:ClearAllPoints()
+            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
+            CS.col1Scroll.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, bottomInset)
+        end
 
         col1.frame:ClearAllPoints()
         col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", 0, 0)
@@ -2295,6 +2355,7 @@ local function CreateConfigPanel()
     frame.modeStatusRow = modeStatusRow
     frame.profileGear = profileGear
     frame.changelogOverlay = changelogOverlay
+    frame.otherClassBrowseButton = otherClassBrowseBtn
     frame.col1 = col1
     frame.col2 = col2
     frame.col3 = col3
@@ -2303,7 +2364,9 @@ local function CreateConfigPanel()
     frame.LayoutColumns = LayoutColumns
     frame.UpdateCompactConfigRows = UpdateCompactConfigRows
     frame.UpdateModeNavigationUI = UpdateModeNavigationUI
+    frame.UpdateOtherClassBrowseButtonState = UpdateOtherClassBrowseButtonState
     UpdateModeNavigationUI()
+    UpdateOtherClassBrowseButtonState()
 
     CS.configFrame = frame
     return frame
@@ -2388,6 +2451,9 @@ function CooldownCompanion:_configRefreshPanelImpl()
     CS.configFrame.versionText:SetText(GetVersionFooterText())
     if CS.configFrame.UpdateModeNavigationUI then
         CS.configFrame.UpdateModeNavigationUI()
+    end
+    if CS.configFrame.UpdateOtherClassBrowseButtonState then
+        CS.configFrame.UpdateOtherClassBrowseButtonState()
     end
     if CS.configFrame.LayoutColumns then
         CS.configFrame.LayoutColumns()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1227,6 +1227,9 @@ local function CreateConfigPanel()
     otherClassBrowseBtn:SetScript("OnClick", function()
         CloseDropDownMenus()
         if CS.otherClassLibraryActive then
+            if ClearConfigPrimarySelection then
+                ClearConfigPrimarySelection()
+            end
             CS.otherClassLibraryActive = false
             CS.otherClassLibraryClassKey = nil
             CooldownCompanion:RefreshConfigPanel()
@@ -1237,6 +1240,9 @@ local function CreateConfigPanel()
         end
         if CS.resourceBarPanelActive then
             SetPrimaryMode("buttons", { skipRefresh = true })
+        end
+        if ClearConfigPrimarySelection then
+            ClearConfigPrimarySelection()
         end
         CS.otherClassLibraryActive = true
         CS.otherClassLibraryClassKey = nil

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -449,7 +449,7 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
-    text = "This will remove foreign eligibility filters and turn '%s' into a group for your current character. Continue?",
+    text = "This will remove foreign eligibility filters and move '%s' into your current class. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -475,7 +475,7 @@ StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_GROUP"] = {
-    text = "This will remove foreign eligibility filters and turn '%s' into a character group. Continue?",
+    text = "This will remove foreign eligibility filters and move '%s' into your current class. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -520,7 +520,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign eligibility filters. Moving to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving to your current class will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -537,7 +537,7 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign eligibility filters. Moving '%s' to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving '%s' to your current class will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -595,7 +595,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_SELECTED_GROUPS"] = {
-    text = "Some selected groups have foreign eligibility filters. Moving to character will remove those filters. Continue?",
+    text = "Some selected groups have foreign eligibility filters. Moving to your current class will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -63,10 +63,65 @@ local function EntityHasPortableEligibility(entity)
             or HasPortableEligibilityMap(loadConditions.specAllowlist))
 end
 
-local function ContainerHasPortableEligibility(profile, containerId, container)
+local function AddIndexedEntity(indexMap, key, entity)
+    if key == nil then return end
+    local bucket = indexMap[key]
+    if not bucket then
+        bucket = {}
+        indexMap[key] = bucket
+    end
+    bucket[#bucket + 1] = entity
+end
+
+local function BuildPortableEligibilityIndex(profile)
+    local index = {
+        panelsByContainerId = {},
+        looseGroupsByFolderId = {},
+        containersByFolderId = {},
+    }
+    if type(profile) ~= "table" then return index end
+
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table" then
+            if group.parentContainerId ~= nil then
+                AddIndexedEntity(index.panelsByContainerId, group.parentContainerId, group)
+            elseif group.folderId ~= nil then
+                AddIndexedEntity(index.looseGroupsByFolderId, group.folderId, group)
+            end
+        end
+    end
+
+    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+    for containerId, container in pairs(groupContainers) do
+        if type(container) == "table" and container.folderId ~= nil then
+            AddIndexedEntity(index.containersByFolderId, container.folderId, {
+                id = containerId,
+                container = container,
+            })
+        end
+    end
+
+    return index
+end
+
+local function ContainerHasPortableEligibility(profile, containerId, container, eligibilityIndex)
     if EntityHasPortableEligibility(container) then
         return true
     end
+
+    local indexedGroups = eligibilityIndex and eligibilityIndex.panelsByContainerId[containerId]
+    if indexedGroups then
+        for _, group in ipairs(indexedGroups) do
+            if EntityHasPortableEligibility(group) then
+                return true
+            end
+        end
+        return false
+    elseif eligibilityIndex then
+        return false
+    end
+
     local groups = type(profile.groups) == "table" and profile.groups or {}
     for _, group in pairs(groups) do
         if type(group) == "table"
@@ -79,19 +134,42 @@ local function ContainerHasPortableEligibility(profile, containerId, container)
     return false
 end
 
-local function FolderHasPortableEligibility(profile, folderId, folder)
+local function FolderHasPortableEligibility(profile, folderId, folder, eligibilityIndex)
     if EntityHasPortableEligibility(folder) then
         return true
     end
-    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
-    for containerId, container in pairs(groupContainers) do
-        if type(container) == "table"
-            and container.folderId == folderId
-            and ContainerHasPortableEligibility(profile, containerId, container)
-        then
-            return true
+
+    local indexedContainers = eligibilityIndex and eligibilityIndex.containersByFolderId[folderId]
+    if indexedContainers then
+        for _, entry in ipairs(indexedContainers) do
+            if ContainerHasPortableEligibility(profile, entry.id, entry.container, eligibilityIndex) then
+                return true
+            end
+        end
+    elseif not eligibilityIndex then
+        local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+        for containerId, container in pairs(groupContainers) do
+            if type(container) == "table"
+                and container.folderId == folderId
+                and ContainerHasPortableEligibility(profile, containerId, container)
+            then
+                return true
+            end
         end
     end
+
+    local indexedLooseGroups = eligibilityIndex and eligibilityIndex.looseGroupsByFolderId[folderId]
+    if indexedLooseGroups then
+        for _, group in ipairs(indexedLooseGroups) do
+            if EntityHasPortableEligibility(group) then
+                return true
+            end
+        end
+        return false
+    elseif eligibilityIndex then
+        return false
+    end
+
     local groups = type(profile.groups) == "table" and profile.groups or {}
     for _, group in pairs(groups) do
         if type(group) == "table"
@@ -110,11 +188,12 @@ local function GlobalizePortableCharacterScopedEligibility(profile)
 
     local globalized = 0
     local globalFolders = {}
+    local eligibilityIndex = BuildPortableEligibilityIndex(profile)
     local folders = type(profile.folders) == "table" and profile.folders or {}
     for folderId, folder in pairs(folders) do
         if type(folder) == "table"
             and folder.section == "char"
-            and FolderHasPortableEligibility(profile, folderId, folder)
+            and FolderHasPortableEligibility(profile, folderId, folder, eligibilityIndex)
         then
             folder.section = "global"
             globalFolders[folderId] = true
@@ -127,7 +206,7 @@ local function GlobalizePortableCharacterScopedEligibility(profile)
         if type(container) == "table"
             and container.isGlobal ~= true
             and (globalFolders[container.folderId]
-                or ContainerHasPortableEligibility(profile, containerId, container))
+                or ContainerHasPortableEligibility(profile, containerId, container, eligibilityIndex))
         then
             container.isGlobal = true
             globalized = globalized + 1
@@ -326,7 +405,12 @@ local function BuildForeignCharacterRenames(foreignKeys, exportedCharInfo, impor
     for foreignKey in pairs(foreignKeys) do
         local info = type(exportedCharInfo) == "table" and exportedCharInfo[foreignKey] or nil
         local classID = info and info.classID
-        local className = classID and GetClassInfo(classID) or "Character"
+        local classInfo = classID and C_CreatureInfo and C_CreatureInfo.GetClassInfo
+            and C_CreatureInfo.GetClassInfo(classID)
+            or nil
+        local className = type(classInfo) == "table" and classInfo.className
+            or (classID and GetClassInfo and GetClassInfo(classID))
+            or "Character"
         classCounts[className] = (classCounts[className] or 0) + 1
         classEntries[foreignKey] = {
             className = className,

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -3017,8 +3017,14 @@ local function CharacterInfoClassKey(charKey)
         return string.upper(info.classFilename)
     end
     local classID = tonumber(info.classID)
-    if classID and GetClassInfo then
-        local _, classFilename = GetClassInfo(classID)
+    if classID then
+        local classInfo = C_CreatureInfo and C_CreatureInfo.GetClassInfo
+            and C_CreatureInfo.GetClassInfo(classID)
+            or nil
+        local classFilename = type(classInfo) == "table" and classInfo.classFile or nil
+        if not classFilename and GetClassInfo then
+            classFilename = select(2, GetClassInfo(classID))
+        end
         if type(classFilename) == "string" and classFilename ~= "" then
             return string.upper(classFilename)
         end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -550,6 +550,8 @@ local function IsConfigFinderActive()
     return IsConfigFinderAvailable() and NormalizeConfigFinderText(CS.configSearchText) ~= ""
 end
 
+local ClearConfigPrimarySelection
+
 local function SetConfigFinderText(text, opts)
     text = type(text) == "string" and text or ""
     local wasSearching = NormalizeConfigFinderText(CS.configSearchText) ~= ""
@@ -562,6 +564,9 @@ local function SetConfigFinderText(text, opts)
     end
     CS.configSearchText = text
     if wasSearching and not willSearch and CS.otherClassLibraryActive then
+        if not (opts and opts.preservePrimarySelection) and ClearConfigPrimarySelection then
+            ClearConfigPrimarySelection()
+        end
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
     end
@@ -701,18 +706,31 @@ end
 
 local RefreshAlphaDriverForConfigSelection
 
-local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
-    CooldownCompanion:ClearAllConfigPreviews()
+local function ResolveConfigContainerClassScope(containerId)
     local selectedContainer = containerId
         and CooldownCompanion.db
         and CooldownCompanion.db.profile
         and CooldownCompanion.db.profile.groupContainers
         and CooldownCompanion.db.profile.groupContainers[containerId]
         or nil
-    local selectedScope = selectedContainer
-        and CooldownCompanion.ResolveContainerClassScope
-        and CooldownCompanion:ResolveContainerClassScope(selectedContainer)
-        or nil
+    if not (selectedContainer and CooldownCompanion.ResolveContainerClassScope) then
+        return nil
+    end
+    return CooldownCompanion:ResolveContainerClassScope(selectedContainer)
+end
+
+local function RestoreOtherClassLibraryForScope(scope)
+    if scope and scope.isOtherClass then
+        CS.otherClassLibraryActive = true
+        CS.otherClassLibraryClassKey = scope.ownerClassKey
+        return true
+    end
+    return false
+end
+
+local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
+    CooldownCompanion:ClearAllConfigPreviews()
+    local selectedScope = ResolveConfigContainerClassScope(containerId)
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
     wipe(CS.selectedButtons)
@@ -725,11 +743,8 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CS.selectedButton = buttonIndex
     CS.selectedRotationAssistantEntry = nil
     CS.addingToPanelId = nil
-    ClearConfigFinderText()
-    if selectedScope and selectedScope.isOtherClass then
-        CS.otherClassLibraryActive = true
-        CS.otherClassLibraryClassKey = selectedScope.ownerClassKey
-    end
+    ClearConfigFinderText({ preservePrimarySelection = true })
+    RestoreOtherClassLibraryForScope(selectedScope)
     RefreshAlphaDriverForConfigSelection()
     CooldownCompanion:RefreshConfigPanel()
 end
@@ -2548,7 +2563,7 @@ local function ClearConfigResourceSelection()
     CS.resourceSettingsSpecID = nil
 end
 
-local function ClearConfigPrimarySelection()
+ClearConfigPrimarySelection = function()
     CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedFolder = nil
     CS.selectedContainer = nil
@@ -2593,7 +2608,9 @@ local function SelectConfigContainer(containerId, opts)
     ClearSelectedButton()
     wipe(CS.selectedPanels)
     if opts and opts.clearFinder then
-        ClearConfigFinderText()
+        local selectedScope = ResolveConfigContainerClassScope(CS.selectedContainer)
+        ClearConfigFinderText({ preservePrimarySelection = true })
+        RestoreOtherClassLibraryForScope(selectedScope)
     end
     RefreshAlphaDriverForConfigSelection()
 end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -228,6 +228,10 @@ ST._configState = {
     -- Column content frames
     col1Scroll = nil,
     col1ButtonBar = nil,
+    col1FooterDoorway = nil,
+    col1FooterDoorwayVisible = false,
+    lastCol1FooterDoorwayRow = nil,
+    UpdateColumn1FooterLayout = nil,
     col2Scroll = nil,
     col2ButtonBar = nil,
     col4Container = nil,
@@ -257,12 +261,6 @@ ST._configState = {
     col2PanelTypeMenu = nil,
     charCopyMenu = nil,
 
-    -- Cross-character browse mode
-    browseMode = false,
-    browseCharKey = nil,
-    browseContainerId = nil,
-    browseContextMenu = nil,
-
     -- Drag-reorder state
     dragState = nil,
     dragIndicator = nil,
@@ -281,6 +279,8 @@ ST._configState = {
     collapsedSections = {},
     collapsedFolders = {},
     collapsedPanels = {},
+    otherClassLibraryActive = false,
+    otherClassLibraryClassKey = nil,
     panelClickTimes = {},
     addingToPanelId = nil,
     folderAccentBars = {},
@@ -298,10 +298,6 @@ ST._configState = {
     configFinderBox = nil,
     configFinderSuppressTextChanged = false,
     compactConfigRows = false,
-
-    -- Spec filter inline expansion
-    specExpandedGroupId = nil,
-    specExpandedFolderId = nil,
 
     -- Auto Add flow state (Column 3 wizard mode)
     autoAddFlowActive = false,
@@ -550,7 +546,6 @@ end
 
 local function IsConfigFinderAvailable()
     return not CS.resourceBarPanelActive
-        and not CS.browseMode
         and not CS.talentPickerMode
         and not CooldownCompanion._unsupportedLegacyProfile
 end
@@ -561,6 +556,8 @@ end
 
 local function SetConfigFinderText(text, opts)
     text = type(text) == "string" and text or ""
+    local wasSearching = NormalizeConfigFinderText(CS.configSearchText) ~= ""
+    local willSearch = NormalizeConfigFinderText(text) ~= ""
     if CS.configSearchText ~= text then
         CS._configFinderResults = nil
         CS._configFinderResultsQuery = nil
@@ -568,6 +565,10 @@ local function SetConfigFinderText(text, opts)
         CS._configFinderResultsCharKey = nil
     end
     CS.configSearchText = text
+    if wasSearching and not willSearch and CS.otherClassLibraryActive then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+    end
 
     if opts and opts.syncWidget == false then
         return
@@ -598,6 +599,10 @@ end
 local function IsContainerVisibleInConfig(container, charKey)
     if not container then
         return false
+    end
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(container)
+        return scope.isInvalid ~= true
     end
     return container.isGlobal or container.createdBy == charKey
 end
@@ -2877,10 +2882,8 @@ local function ResetConfigSelection(full)
         wipe(CS.selectedGroups)
         wipe(CS.selectedCustomBars)
         CS.addingToPanelId = nil
-        -- Exit browse mode on full reset
-        CS.browseMode = false
-        CS.browseCharKey = nil
-        CS.browseContainerId = nil
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
     end
     RefreshAlphaDriverForConfigSelection()
 end
@@ -2899,12 +2902,16 @@ local function SetConfigPrimaryMode(mode, opts)
     if toBars and not wasBars then
         -- Preserve existing behavior when entering Bars & Frames mode.
         ResetConfigSelection(true)
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
     elseif (not toBars) and wasBars then
         -- Stop preview loops when returning to button settings mode.
         CooldownCompanion:ClearAllConfigPreviews()
         CS.selectedCustomBarId = nil
         CS.customBarSettingsTab = "appearance"
         ClearConfigResourceSelection()
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
     end
 
     CS.resourceBarPanelActive = toBars

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -703,6 +703,16 @@ local RefreshAlphaDriverForConfigSelection
 
 local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CooldownCompanion:ClearAllConfigPreviews()
+    local selectedContainer = containerId
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groupContainers
+        and CooldownCompanion.db.profile.groupContainers[containerId]
+        or nil
+    local selectedScope = selectedContainer
+        and CooldownCompanion.ResolveContainerClassScope
+        and CooldownCompanion:ResolveContainerClassScope(selectedContainer)
+        or nil
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
     wipe(CS.selectedButtons)
@@ -716,6 +726,10 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CS.selectedRotationAssistantEntry = nil
     CS.addingToPanelId = nil
     ClearConfigFinderText()
+    if selectedScope and selectedScope.isOtherClass then
+        CS.otherClassLibraryActive = true
+        CS.otherClassLibraryClassKey = selectedScope.ownerClassKey
+    end
     RefreshAlphaDriverForConfigSelection()
     CooldownCompanion:RefreshConfigPanel()
 end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -228,10 +228,6 @@ ST._configState = {
     -- Column content frames
     col1Scroll = nil,
     col1ButtonBar = nil,
-    col1FooterDoorway = nil,
-    col1FooterDoorwayVisible = false,
-    lastCol1FooterDoorwayRow = nil,
-    UpdateColumn1FooterLayout = nil,
     col2Scroll = nil,
     col2ButtonBar = nil,
     col4Container = nil,

--- a/CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua
@@ -65,8 +65,6 @@ local function BuildContext(extra)
         selectedCustomBarId = CS.selectedCustomBarId,
         selectedResourcePowerType = CS.selectedResourcePowerType,
         resourceSettingsSpecID = CS.resourceSettingsSpecID,
-        browseMode = BoolValue(CS.browseMode),
-        browseCharKey = CS.browseCharKey,
         autoAddFlowActive = BoolValue(CS.autoAddFlowActive),
         talentPickerMode = BoolValue(CS.talentPickerMode),
     }

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -1272,7 +1272,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         effectiveSpecs = opts.effectiveSpecs,
         choiceSpecMap = opts.choiceSpecMap,
     })
-    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+    local specById = BuildSpecChoiceIndex(specChoices)
 
     local specValues = {}
     local specOrder = {}
@@ -1314,7 +1314,7 @@ local function AddClassSpecEligibilityControls(container, opts)
     if type(heroTalentsSource) ~= "table" then
         heroTalentsSource = nil
     end
-    local heroChoices, heroById = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+    local heroChoices = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
     local heroValues = {}
     local heroOrder = {}
     local heroSortLabels = {}
@@ -1434,7 +1434,7 @@ local function AddActiveClassSpecEligibilityRows(rows, opts)
         effectiveSpecs = opts.effectiveSpecs,
         choiceSpecMap = opts.choiceSpecMap,
     })
-    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+    local _, specsByClassKey = BuildSpecChoiceIndex(specChoices)
     local configID = opts.configID or (C_ClassTalents and C_ClassTalents.GetActiveConfigID and C_ClassTalents.GetActiveConfigID())
     local heroTalentsSource = opts.useHeroTalentsSource and opts.heroTalentsSource or target.heroTalents
     if type(heroTalentsSource) ~= "table" then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -25,6 +25,7 @@ local appearanceTabElements = CS.appearanceTabElements
 
 local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
 local REMOVE_BADGE_WIDGET_TYPE = "CDCEligibilityRemoveBadge"
+local ACTIVE_FILTER_ROW_HEIGHT = 22
 local VIEW_TRAIT_CONFIG_ID = (Constants and Constants.TraitConsts and Constants.TraitConsts.VIEW_TRAIT_CONFIG_ID) or -3
 
 if AceGUI and not AceGUI:GetWidgetVersion(REMOVE_BADGE_WIDGET_TYPE) then
@@ -779,11 +780,16 @@ local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
     local row = AceGUI:Create("SimpleGroup")
     row:SetFullWidth(true)
     row:SetLayout("Flow")
+    row:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
 
     local hasTooltip = rowInfo.tooltipText and rowInfo.tooltipText ~= ""
     local label = AceGUI:Create(hasTooltip and "InteractiveLabel" or "Label")
     label:SetText(rowInfo.label)
     label:SetRelativeWidth(0.92)
+    label:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
+    if label.SetFontObject and GameFontHighlight then
+        label:SetFontObject(GameFontHighlight)
+    end
     AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
     row:AddChild(label)
 
@@ -791,13 +797,22 @@ local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
         local locked = AceGUI:Create("Label")
         locked:SetText("|cff888888locked|r")
         locked:SetRelativeWidth(0.1)
+        locked:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
+        if locked.SetFontObject and GameFontHighlight then
+            locked:SetFontObject(GameFontHighlight)
+        end
         row:AddChild(locked)
     else
         local removeBtn = CreateEligibilityRemoveBadge(onRemove)
+        removeBtn:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
         row:AddChild(removeBtn)
     end
 
     container:AddChild(row)
+end
+
+local function FormatActiveEligibilityLabel(category, value)
+    return "|cffffd100" .. tostring(category or "Filter") .. ":|r " .. tostring(value or "")
 end
 
 local function AddCharacterEligibilityControls(container, opts)
@@ -885,17 +900,6 @@ local function AddCharacterEligibilityControls(container, opts)
     container:AddChild(picker)
 
     SortChoices(selected)
-
-    if #selected == 0 then
-        return
-    end
-
-    for _, choice in ipairs(selected) do
-        AddEligibilitySelectedRow(container, choice, function()
-            SetAllowlistValue(target, "characterAllowlist", "character", choice.key, false)
-            if opts.onChanged then opts.onChanged() end
-        end)
-    end
 end
 
 local function AddClassForSpecId(classChoices, classByKey, specId)
@@ -1352,7 +1356,92 @@ local function AddClassSpecEligibilityControls(container, opts)
         container:AddChild(inheritedLabel)
     end
 
-    local rows = {}
+end
+
+local function NotifyEligibilityChanged(opts, callbackName)
+    local callback = opts and opts[callbackName]
+    if not callback and opts then
+        callback = opts.onChanged
+    end
+    if callback then callback() end
+end
+
+local function AddActiveCharacterEligibilityRows(rows, opts)
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "characterAllowlist", "character")
+    local scopeClassChoice
+    if opts.allowClassEligibility == false then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+    end
+    local choices = BuildCharacterChoices(target, inheritedMap, scopeClassChoice and scopeClassChoice.key or nil, opts.ownerCharKey)
+    local localMap = target.loadConditions and target.loadConditions.characterAllowlist
+    local characterRows = {}
+
+    for _, choice in ipairs(choices) do
+        local key = choice.key
+        if type(localMap) == "table" and localMap[key] == true then
+            local outsideInherited = inheritedRestricted and not (inheritedMap and inheritedMap[key])
+            characterRows[#characterRows + 1] = {
+                key = key,
+                label = FormatActiveEligibilityLabel(
+                    "Character",
+                    outsideInherited and (choice.label .. " |cff888888(unavailable from parent)|r") or choice.label
+                ),
+                tooltipTitle = choice.tooltipTitle,
+                tooltipText = choice.tooltipText,
+                sortLabel = choice.sortLabel,
+                onRemove = function()
+                    SetAllowlistValue(target, "characterAllowlist", "character", key, false)
+                    NotifyEligibilityChanged(opts, "characterOnChanged")
+                end,
+            }
+        end
+    end
+
+    SortChoices(characterRows)
+    for _, row in ipairs(characterRows) do
+        rows[#rows + 1] = row
+    end
+end
+
+local function AddActiveClassSpecEligibilityRows(rows, opts)
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local allowClassEligibility = opts.allowClassEligibility == true
+    local scopeClassChoice
+    if not allowClassEligibility then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+    end
+
+    local inheritedClassMap = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")
+    local classChoices = BuildClassChoices(target, inheritedClassMap)
+    local localClassMap = target.loadConditions and target.loadConditions.classAllowlist
+    local useSpecAllowlist = opts.useSpecAllowlist == true
+    local selectedSpecMap = GetSpecSelectionMap(target, useSpecAllowlist)
+    local allowedSpecMap = opts.allowedSpecMap
+    local allowedSpecRestricted = opts.allowedSpecRestricted == true
+    local specChoices = BuildEligibilitySpecChoices({
+        target = target,
+        inheritedSources = opts.inheritedSources,
+        allowClassEligibility = allowClassEligibility,
+        ownerClassChoice = scopeClassChoice,
+        ownerCharKey = opts.ownerCharKey,
+        ownerClassID = opts.ownerClassID,
+        ownerClassFilename = opts.ownerClassFilename,
+        effectiveSpecs = opts.effectiveSpecs,
+        choiceSpecMap = opts.choiceSpecMap,
+    })
+    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+    local configID = opts.configID or (C_ClassTalents and C_ClassTalents.GetActiveConfigID and C_ClassTalents.GetActiveConfigID())
+    local heroTalentsSource = opts.useHeroTalentsSource and opts.heroTalentsSource or target.heroTalents
+    if type(heroTalentsSource) ~= "table" then
+        heroTalentsSource = nil
+    end
+    local _, heroById = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+
     local selectedHeroBySpec = {}
     for subTreeID in pairs(heroTalentsSource or {}) do
         local heroInfo = heroById[subTreeID]
@@ -1362,6 +1451,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         end
     end
 
+    local classRows = {}
     if allowClassEligibility then
         for _, classChoice in ipairs(classChoices) do
             local classKey = classChoice.key
@@ -1375,8 +1465,8 @@ local function AddClassSpecEligibilityControls(container, opts)
                     end
                 end
                 if #selectedSpecs == 0 then
-                    rows[#rows + 1] = {
-                        label = GetClassDisplayLabel(classChoice) or classChoice.label,
+                    classRows[#classRows + 1] = {
+                        label = FormatActiveEligibilityLabel("Class", GetClassDisplayLabel(classChoice) or classChoice.label),
                         sortLabel = classChoice.label or classKey,
                         onRemove = function()
                             SetAllowlistValue(target, "classAllowlist", "class", classKey, false)
@@ -1386,14 +1476,19 @@ local function AddClassSpecEligibilityControls(container, opts)
                                     CooldownCompanion:CleanHeroTalentsForSpec(target, specInfo.id)
                                 end
                             end
-                            if opts.onChanged then opts.onChanged() end
+                            NotifyEligibilityChanged(opts, "specOnChanged")
                         end,
                     }
                 end
             end
         end
     end
+    SortChoices(classRows)
+    for _, row in ipairs(classRows) do
+        rows[#rows + 1] = row
+    end
 
+    local specRows = {}
     for _, specInfo in ipairs(specChoices) do
         local specId = specInfo.id
         if type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true then
@@ -1403,43 +1498,65 @@ local function AddClassSpecEligibilityControls(container, opts)
                     return tostring(a.label or a.id) < tostring(b.label or b.id)
                 end)
                 for _, heroInfo in ipairs(heroRows) do
-                    rows[#rows + 1] = {
-                        label = FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility),
+                    specRows[#specRows + 1] = {
+                        label = FormatActiveEligibilityLabel(
+                            "Hero Talent",
+                            FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility)
+                        ),
                         sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
                         disabled = opts.disableHeroTalents == true,
                         onRemove = function()
                             SetHeroTalentValue(target, heroInfo.id, false)
-                            if opts.onChanged then opts.onChanged() end
+                            NotifyEligibilityChanged(opts, "specOnChanged")
                         end,
                     }
                 end
             else
                 local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
-                rows[#rows + 1] = {
-                    label = FormatEligibilitySpecRowLabel(specInfo, allowClassEligibility)
-                        .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or ""),
+                specRows[#specRows + 1] = {
+                    label = FormatActiveEligibilityLabel(
+                        "Specialization",
+                        FormatEligibilitySpecRowLabel(specInfo, allowClassEligibility)
+                            .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or "")
+                    ),
                     sortLabel = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId)),
                     onRemove = function()
                         SetSpecEligibilityValue(target, specId, false, useSpecAllowlist)
                         if CooldownCompanion.CleanHeroTalentsForSpec then
                             CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
                         end
-                        if opts.onChanged then opts.onChanged() end
+                        NotifyEligibilityChanged(opts, "specOnChanged")
                     end,
                 }
             end
         end
     end
 
-    table.sort(rows, function(a, b)
+    table.sort(specRows, function(a, b)
         return tostring(a.sortLabel or a.label) < tostring(b.sortLabel or b.label)
     end)
-
-    if #rows > 0 then
-        for _, row in ipairs(rows) do
-            AddEligibilitySelectedRow(container, row, row.onRemove)
-        end
+    for _, row in ipairs(specRows) do
+        rows[#rows + 1] = row
     end
+end
+
+local function AddActiveEligibilitySummary(container, opts)
+    opts = opts or {}
+    local rows = {}
+    AddActiveCharacterEligibilityRows(rows, opts)
+    AddActiveClassSpecEligibilityRows(rows, opts)
+    if #rows == 0 then return false end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText("Active Filters")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
+    for _, row in ipairs(rows) do
+        AddEligibilitySelectedRow(container, row, row.onRemove)
+    end
+    return true
 end
 
 ------------------------------------------------------------------------
@@ -2863,6 +2980,10 @@ local function BuildLoadConditionsTab(container)
         scopeIsGlobal = group.isGlobal == true
     end
     local ownerCharKey = parentContainer and parentContainer.createdBy or group.createdBy
+    local function RefreshPanelLoadConditions()
+        CooldownCompanion:RefreshGroupFrame(groupId)
+        CooldownCompanion:RefreshConfigPanel()
+    end
 
     AddScopedLoadConditionToggles(container, {
         target = group,
@@ -2872,10 +2993,24 @@ local function BuildLoadConditionsTab(container)
         headingTextWhenInherited = "Also Hide This Panel In",
         inheritedCollapsedKey = "loadconditions_panel_inherited",
         localCollapsedKey = "loadconditions_panel_local",
-        onChanged = function()
-            CooldownCompanion:RefreshGroupFrame(groupId)
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshPanelLoadConditions,
+    })
+
+    AddActiveEligibilitySummary(container, {
+        target = group,
+        inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "panel",
+        allowClassEligibility = scopeIsGlobal,
+        ownerCharKey = ownerCharKey,
+        useSpecAllowlist = inheritedSpecFilter,
+        allowedSpecRestricted = inheritedSpecFilter,
+        allowedSpecMap = inheritedSpecs,
+        effectiveSpecs = effectiveSpecs,
+        choiceSpecMap = inheritedSpecs,
+        heroTalentsSource = effectiveHeroTalents,
+        useHeroTalentsSource = inheritedHeroFilter,
+        disableHeroTalents = inheritedHeroFilter,
+        onChanged = RefreshPanelLoadConditions,
     })
 
     AddCharacterEligibilityControls(container, {
@@ -2885,10 +3020,7 @@ local function BuildLoadConditionsTab(container)
         allowClassEligibility = scopeIsGlobal,
         ownerCharKey = ownerCharKey,
         characterCollapsedKey = "loadconditions_panel_character",
-        onChanged = function()
-            CooldownCompanion:RefreshGroupFrame(groupId)
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshPanelLoadConditions,
     })
 
     local specHeading = AceGUI:Create("Heading")
@@ -2926,10 +3058,7 @@ local function BuildLoadConditionsTab(container)
             heroTalentsSource = effectiveHeroTalents,
             useHeroTalentsSource = inheritedHeroFilter,
             disableHeroTalents = inheritedHeroFilter,
-            onChanged = function()
-                CooldownCompanion:RefreshGroupFrame(groupId)
-                CooldownCompanion:RefreshConfigPanel()
-            end,
+            onChanged = RefreshPanelLoadConditions,
         })
     end -- not specCollapsed
 end
@@ -2978,6 +3107,7 @@ ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
 ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
 ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
+ST._AddActiveEligibilitySummary = AddActiveEligibilitySummary
 ST._AddCharacterEligibilityControls = AddCharacterEligibilityControls
 ST._AddClassSpecEligibilityControls = AddClassSpecEligibilityControls
 ST._GetConditionDisplayName = GetConditionDisplayName

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -690,6 +690,24 @@ local function CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerChar
     return classKey == scopeClassKey
 end
 
+local function AddKnownScopeClassCharacterChoices(choices, byKey, scopeClassKey, ownerCharKey)
+    if not scopeClassKey then return end
+    local db = CooldownCompanion.db
+    local characterInfo = db and db.global and db.global.characterInfo
+    if type(characterInfo) ~= "table" then return end
+
+    for charKey, info in pairs(characterInfo) do
+        if type(charKey) == "string" and charKey ~= "" then
+            local choice = BuildCharacterChoice(charKey, info)
+            choice.classFilename = choice.classFilename or NormalizeAllowlistKey("class", info and info.classFilename)
+            choice.classID = choice.classID or (info and info.classID) or nil
+            if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+                AddChoice(choices, byKey, choice.key, choice.label, choice)
+            end
+        end
+    end
+end
+
 local function BuildClassChoices(target, inheritedMap)
     local choices, byKey = {}, {}
     for classID = 1, MAX_CLASS_SCAN_ID do
@@ -725,6 +743,7 @@ local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerC
             AddChoice(choices, byKey, choice.key, choice.label, choice)
         end
     end
+    AddKnownScopeClassCharacterChoices(choices, byKey, scopeClassKey, ownerCharKey)
     local localMap = target.loadConditions and target.loadConditions.characterAllowlist
     local copiedLocal = CopyAllowlist(localMap, "character")
     for key in pairs(copiedLocal or {}) do

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -449,10 +449,25 @@ end
 
 local MAX_CLASS_SCAN_ID = 20
 
+local function GetClassInfoByID(classID)
+    classID = tonumber(classID)
+    if not classID then return nil, nil, nil end
+    if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return classInfo.className, classInfo.classFile, classInfo.classID
+        end
+    end
+    if GetClassInfo then
+        return GetClassInfo(classID)
+    end
+    return nil, nil, nil
+end
+
 local function GetClassChoiceByID(classID)
     classID = tonumber(classID)
     if not classID then return nil end
-    local className, classFilename = GetClassInfo(classID)
+    local className, classFilename = GetClassInfoByID(classID)
     local classKey = NormalizeAllowlistKey("class", classFilename)
     if not classKey then return nil end
     return {
@@ -483,8 +498,8 @@ local function GetCurrentClassChoice()
     local classFilename = CooldownCompanion._playerClassFilename
     local classID = CooldownCompanion._playerClassID
     local className
-    if classID and GetClassInfo then
-        className = GetClassInfo(classID)
+    if classID then
+        className = GetClassInfoByID(classID)
     end
     if (not classFilename or not className) and UnitClass then
         local unitClassName, unitClassFilename, unitClassID = UnitClass("player")
@@ -1767,7 +1782,7 @@ local function ResolveConditionClassName(cond)
     end
 
     if cond.classID then
-        local name = GetClassInfo(cond.classID)
+        local name = GetClassInfoByID(cond.classID)
         return name or ("Class " .. cond.classID)
     end
 

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -141,7 +141,7 @@ local function BuildSortedSoundOptionOrder(soundOptions)
 end
 
 local function ConfigurePriorityMoveButton(button, rotation, tooltipTitle, tooltipBody, disabled, onClick)
-    local isDisabled = disabled or CS.browseMode
+    local isDisabled = disabled
     button:SetSize(18, 18)
     if button.text then
         button.text:Hide()
@@ -542,10 +542,6 @@ local function BuildAuraTrackingIDRowText(spellID, rowIndex)
 end
 
 local function ShowAuraTrackingIDRowMenu(buttonData, isAuraEntry, rowIndex)
-    if CS.browseMode then
-        return
-    end
-
     if not CS.auraIDContextMenu then
         CS.auraIDContextMenu = CreateFrame("Frame", "CDCAuraIDContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -616,9 +612,6 @@ end
 
 local function InstallAuraTrackingIDRowMenu(entry, buttonData, isAuraEntry, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.browseMode then
-            return
-        end
         if button == "RightButton" then
             ShowAuraTrackingIDRowMenu(buttonData, isAuraEntry, rowIndex)
         end
@@ -936,10 +929,6 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
             RefreshAuraTrackingEntry(CS.selectedGroup)
         end
         auraEditBox:SetCallback("OnTextChanged", function(widget, _, text)
-            if CS.browseMode then
-                CS.HideAutocomplete()
-                return
-            end
             if text and #text >= 1 and CS.SearchCDMAuraAutocomplete then
                 CS.ShowAutocompleteResults(CS.SearchCDMAuraAutocomplete(text), widget, function(entry)
                     CommitAuraTrackingEntry(widget, entry)
@@ -949,10 +938,6 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
             end
         end)
         auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
-            if CS.browseMode then
-                CS.HideAutocomplete()
-                return
-            end
             if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
                 return
             end
@@ -1873,10 +1858,6 @@ local function SearchFallbackAutocomplete(buttonData, query)
 end
 
 local function AddItemFallback(buttonData, itemID)
-    if CS.browseMode then
-        return false
-    end
-
     local validID, err = ValidateFallbackItem(buttonData, itemID)
     if not validID then
         CooldownCompanion:Print(err)
@@ -1892,10 +1873,6 @@ local function AddItemFallback(buttonData, itemID)
 end
 
 local function TryReceiveFallbackItemDrop(buttonData)
-    if CS.browseMode then
-        return false
-    end
-
     local cursorType, cursorID = GetCursorInfo()
     if cursorType ~= "item" or not cursorID then
         return false
@@ -1918,10 +1895,6 @@ local function UpdatePrimaryFallbackItem(buttonData, itemID)
 end
 
 local function MoveFallbackPriorityItem(buttonData, sourceIndex, targetIndex)
-    if CS.browseMode then
-        return false
-    end
-
     if not (buttonData and buttonData.type == "item") then
         return false
     end
@@ -1984,7 +1957,7 @@ local function InstallFallbackDropScript(frame, buttonData)
 
     frame:SetScript("OnReceiveDrag", function(self, ...)
         local activeButtonData = self._cdcFallbackDropButtonData
-        if CS.buttonSettingsTab == "fallbacks" and not CS.browseMode and activeButtonData then
+        if CS.buttonSettingsTab == "fallbacks" and activeButtonData then
             local cursorType = GetCursorInfo()
             if cursorType == "item" then
                 TryReceiveFallbackItemDrop(activeButtonData)
@@ -1998,7 +1971,7 @@ local function InstallFallbackDropScript(frame, buttonData)
     end)
     frame:SetScript("OnMouseUp", function(self, button, ...)
         local activeButtonData = self._cdcFallbackDropButtonData
-        if CS.buttonSettingsTab ~= "fallbacks" or CS.browseMode or button ~= "LeftButton" then
+        if CS.buttonSettingsTab ~= "fallbacks" or button ~= "LeftButton" then
             local original = self._cdcFallbackOriginalOnMouseUp
             if original then
                 return original(self, button, ...)
@@ -2118,10 +2091,6 @@ local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex, isPrimary)
 end
 
 local function ShowFallbackRowMenu(buttonData, rowIndex)
-    if CS.browseMode then
-        return
-    end
-
     if not CS.fallbackContextMenu then
         CS.fallbackContextMenu = CreateFrame("Frame", "CDCFallbackContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -2148,9 +2117,6 @@ end
 
 local function InstallFallbackRowMenu(entry, buttonData, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.browseMode then
-            return
-        end
         if button == "RightButton" then
             ShowFallbackRowMenu(buttonData, rowIndex)
             return
@@ -2243,13 +2209,9 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
     addBox:DisableButton(true)
     addBox:SetFullWidth(true)
     addBox:SetCallback("OnTextChanged", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if text and #text >= 1 then
             CS.ShowAutocompleteResults(SearchFallbackAutocomplete(buttonData, text), widget, function(entry)
-                if entry and not CS.browseMode and AddItemFallback(buttonData, entry.id) then
+                if entry and AddItemFallback(buttonData, entry.id) then
                     RefreshFallbackEntry(CS.selectedGroup)
                 else
                     CS.HideAutocomplete()
@@ -2260,10 +2222,6 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
         end
     end)
     addBox:SetCallback("OnEnterPressed", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
             return
         end

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -10,6 +10,14 @@ local EncodeExportData = ST._EncodeExportData
 local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
 local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 
+local function IsContainerVisibleInConfig(containerOrContainerId)
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(containerOrContainerId)
+        return scope.isInvalid ~= true
+    end
+    return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
+end
+
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
@@ -311,7 +319,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
 
     local hasOtherContainer = false
     for cid in pairs(db.groupContainers) do
-        if cid ~= containerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+        if cid ~= containerId and IsContainerVisibleInConfig(cid) then
             hasOtherContainer = true
             break
         end
@@ -329,7 +337,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                 local containers = db.groupContainers or {}
                 local folderContainers, looseContainers = {}, {}
                 for cid, ctr in pairs(containers) do
-                    if cid ~= containerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                    if cid ~= containerId and IsContainerVisibleInConfig(cid) then
                         local name = ctr.name or ("Group " .. cid)
                         local fid = ctr.folderId
                         if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -34,6 +34,13 @@ local function CanAllPanelsMoveToContainer(panelIds, containerId)
     return true
 end
 
+local function CanMoveEntryToGroup(sourceGroupId, targetGroupId)
+    if CooldownCompanion.CanMoveEntryToGroup then
+        return CooldownCompanion:CanMoveEntryToGroup(sourceGroupId, targetGroupId) == true
+    end
+    return CooldownCompanion:IsGroupVisibleToCurrentChar(targetGroupId)
+end
+
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
@@ -113,7 +120,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
             local folderGroups, looseGroups = {}, {}
             for id, groupInfo in pairs(db.groups) do
                 if id ~= sourceGroupId
-                    and CooldownCompanion:IsGroupVisibleToCurrentChar(id)
+                    and CanMoveEntryToGroup(sourceGroupId, id)
                     and not GetManualMoveRejectMessage(groupInfo, multiCount) then
                     local groupName = groupInfo.name or ("Group " .. id)
                     local cid = groupInfo.parentContainerId
@@ -150,6 +157,9 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                     local info = UIDropDownMenu_CreateInfo()
                     info.text = groupEntry.name
                     info.func = function()
+                        if not CanMoveEntryToGroup(sourceGroupId, groupEntry.id) then
+                            return
+                        end
                         local targetGroup = db.groups[groupEntry.id]
                         local rejectMessage = GetManualMoveRejectMessage(targetGroup, multiCount)
                         if rejectMessage then
@@ -185,6 +195,9 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                     local info = UIDropDownMenu_CreateInfo()
                     info.text = groupEntry.name
                     info.func = function()
+                        if not CanMoveEntryToGroup(sourceGroupId, groupEntry.id) then
+                            return
+                        end
                         local targetGroup = db.groups[groupEntry.id]
                         local rejectMessage = GetManualMoveRejectMessage(targetGroup, multiCount)
                         if rejectMessage then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -18,6 +18,22 @@ local function IsContainerVisibleInConfig(containerOrContainerId)
     return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
 end
 
+local function CanAllPanelsMoveToContainer(panelIds, containerId)
+    if not IsContainerVisibleInConfig(containerId) then
+        return false
+    end
+    if not CooldownCompanion.CanMovePanelToContainer then
+        return true
+    end
+    for _, panelId in ipairs(panelIds or {}) do
+        local ok = CooldownCompanion:CanMovePanelToContainer(panelId, containerId)
+        if not ok then
+            return false
+        end
+    end
+    return true
+end
+
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
@@ -319,7 +335,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
 
     local hasOtherContainer = false
     for cid in pairs(db.groupContainers) do
-        if cid ~= containerId and IsContainerVisibleInConfig(cid) then
+        if cid ~= containerId and CanAllPanelsMoveToContainer(multiPanelIds, cid) then
             hasOtherContainer = true
             break
         end
@@ -337,7 +353,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                 local containers = db.groupContainers or {}
                 local folderContainers, looseContainers = {}, {}
                 for cid, ctr in pairs(containers) do
-                    if cid ~= containerId and IsContainerVisibleInConfig(cid) then
+                    if cid ~= containerId and CanAllPanelsMoveToContainer(multiPanelIds, cid) then
                         local name = ctr.name or ("Group " .. cid)
                         local fid = ctr.folderId
                         if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3895,8 +3895,8 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
             clearBtn:SetText("Clear All Spec Filters")
             clearBtn:SetFullWidth(true)
             clearBtn:SetCallback("OnClick", function()
-                if folderSpecs then
-                    container.specs = CopyTable(folderSpecs)
+                if folder and type(folder.specs) == "table" and next(folder.specs) then
+                    container.specs = CopyTable(folder.specs)
                 else
                     container.specs = nil
                 end

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -27,6 +27,7 @@ local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
+local AddActiveEligibilitySummary = ST._AddActiveEligibilitySummary
 local AddCharacterEligibilityControls = ST._AddCharacterEligibilityControls
 local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
 local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
@@ -3786,6 +3787,12 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         folder.loadConditions and folder.loadConditions.specAllowlist
     )
     local folderHeroTalents = folder and folder.heroTalents
+    local hasFolderSpecs = folderSpecs and next(folderSpecs)
+    local hasFolderHeroTalents = folderHeroTalents and next(folderHeroTalents) ~= nil
+    local function RefreshContainerLoadConditions()
+        RefreshPanels()
+        CooldownCompanion:RefreshConfigPanel()
+    end
 
     AddScopedLoadConditionToggles(scroll, {
         target = container,
@@ -3795,10 +3802,23 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         headingTextWhenInherited = "Also Hide This Group In",
         inheritedCollapsedKey = "container_loadconditions_inherited",
         localCollapsedKey = "container_loadconditions_local",
-        onChanged = function()
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshContainerLoadConditions,
+    })
+
+    AddActiveEligibilitySummary(scroll, {
+        target = container,
+        inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "group",
+        allowClassEligibility = container.isGlobal == true,
+        ownerCharKey = container.createdBy,
+        useSpecAllowlist = hasFolderSpecs,
+        allowedSpecRestricted = hasFolderSpecs,
+        allowedSpecMap = folderSpecs,
+        effectiveSpecs = folderSpecs,
+        heroTalentsSource = folderHeroTalents,
+        useHeroTalentsSource = hasFolderHeroTalents,
+        disableHeroTalents = hasFolderHeroTalents,
+        onChanged = RefreshContainerLoadConditions,
     })
 
     AddCharacterEligibilityControls(scroll, {
@@ -3808,10 +3828,7 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         allowClassEligibility = container.isGlobal == true,
         ownerCharKey = container.createdBy,
         characterCollapsedKey = "container_loadconditions_character",
-        onChanged = function()
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshContainerLoadConditions,
     })
 
     -- Class/spec eligibility section
@@ -3828,8 +3845,6 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end)
 
     if not specCollapsed then
-        local hasFolderSpecs = folderSpecs and next(folderSpecs)
-
         if hasFolderSpecs then
             local inheritedLabel = AceGUI:Create("Label")
             ST._ConfigureWrappedHelperLabel(inheritedLabel)
@@ -3849,12 +3864,9 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
             allowedSpecMap = folderSpecs,
             effectiveSpecs = folderSpecs,
             heroTalentsSource = folderHeroTalents,
-            useHeroTalentsSource = folderHeroTalents and next(folderHeroTalents) ~= nil,
-            disableHeroTalents = folderHeroTalents and next(folderHeroTalents) ~= nil,
-            onChanged = function()
-                RefreshPanels()
-                CooldownCompanion:RefreshConfigPanel()
-            end,
+            useHeroTalentsSource = hasFolderHeroTalents,
+            disableHeroTalents = hasFolderHeroTalents,
+            onChanged = RefreshContainerLoadConditions,
         })
 
         -- Only show Clear All when container has specs/hero-talents beyond folder cascade
@@ -3965,6 +3977,16 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
             CooldownCompanion:RefreshAllGroups()
             CooldownCompanion:RefreshConfigPanel()
         end,
+    })
+
+    AddActiveEligibilitySummary(scroll, {
+        target = folder,
+        inheritedSources = {},
+        eligibilitySubjectLabel = "folder",
+        allowClassEligibility = folder.section == "global",
+        ownerCharKey = folder.createdBy,
+        characterOnChanged = RefreshFolderOnly,
+        specOnChanged = RefreshFolderSpecDependents,
     })
 
     AddCharacterEligibilityControls(scroll, {

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -1046,7 +1046,7 @@ local function BuildCustomBarTrackedAuraRowText(auraID, rowIndex)
 end
 
 local function ConfigureCustomBarTrackedAuraMoveButton(button, rotation, tooltipTitle, tooltipBody, disabled, onClick)
-    local isDisabled = disabled or CS.browseMode
+    local isDisabled = disabled
     button:SetSize(18, 18)
     if button.text then
         button.text:Hide()
@@ -1129,10 +1129,6 @@ local function EnsureCustomBarTrackedAuraMoveButtons(entry, cab, spellID, rowInd
 end
 
 local function ShowCustomBarTrackedAuraRowMenu(cab, spellID, rowIndex)
-    if CS.browseMode then
-        return
-    end
-
     if not CS.customBarTrackedAuraContextMenu then
         CS.customBarTrackedAuraContextMenu = CreateFrame("Frame", "CDCCustomBarTrackedAuraContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -1157,9 +1153,6 @@ end
 
 local function InstallCustomBarTrackedAuraRowMenu(entry, cab, spellID, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.browseMode then
-            return
-        end
         if button == "RightButton" then
             ShowCustomBarTrackedAuraRowMenu(cab, spellID, rowIndex)
         end
@@ -1341,10 +1334,6 @@ local function BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUni
         RefreshCustomBarTrackedAuraEntry(cab, spellID)
     end
     auraEditBox:SetCallback("OnTextChanged", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if text and #text >= 1 and CS.SearchCDMAuraAutocomplete then
             CS.ShowAutocompleteResults(CS.SearchCDMAuraAutocomplete(text), widget, function(entry)
                 CommitCustomBarTrackedAuraEntry(widget, entry)
@@ -1354,10 +1343,6 @@ local function BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUni
         end
     end)
     auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
             return
         end

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -337,9 +337,6 @@ local function ConfigureResourceAuraClearButton(button, onClear)
     button.icon:SetAtlas("common-icon-redx", false)
     button.icon:Show()
     button:SetScript("OnClick", function()
-        if CS.browseMode then
-            return
-        end
         if onClear then
             onClear()
         end
@@ -1011,7 +1008,7 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
     end
 
     auraEditBox:SetCallback("OnTextChanged", function(widget, _, text)
-        if spellID or CS.browseMode then
+        if spellID then
             CS.HideAutocomplete()
             return
         end
@@ -1024,7 +1021,7 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
         end
     end)
     auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
-        if spellID or CS.browseMode then
+        if spellID then
             CS.HideAutocomplete()
             return
         end


### PR DESCRIPTION
## What Players Will Notice
- Group ownership is now class-based instead of tied to one character, so same-class alts share the same current-class group inventory while other classes stay out of the runtime load path.
- The old Browse Other Characters flow is replaced with a compact Browse Other Classes badge in the config header. It opens a class library view where off-class groups can be selected, previewed, and edited without cluttering the main Groups list.
- Load-condition restrictions are easier to see: active character, class, specialization, and hero-talent filters now appear together in a larger Active Filters section.
- Moving groups between Global and current-class scope is more predictable, while direct class-to-class movement and mixed-class non-global folders are blocked.

## Why This Changed
- Character-scoped groups made same-class alts awkward and made cross-character browsing too noisy for Column 1.
- PR2 keeps the useful part of browsing saved off-class inventory while making the main config view feel like a focused current-class workbench.
- Eligibility filters were too easy to miss when active, especially compared with the add-dropdown controls.

## What Changed
- Added a shared class-scope resolver for containers, folders, and runtime visibility, with missing owner-class metadata treated as invalid/corrupt and fail-closed.
- Reworked Column 1 around Global/current-class groups plus a Browse Other Classes library view instead of inline off-class sections.
- Added config-only state for class-library navigation and reset behavior when leaving normal group inventory.
- Tightened drag/drop, panel moves, entry moves, folder assignment, style-copy eligibility, and preview refresh paths around class scope.
- Preserved portable class/spec/hero eligibility through import/export while stripping character-only eligibility from shared exports.
- Moved active eligibility rows into one Active Filters summary across group, folder, panel, and button load-condition surfaces.

## Validation
- `git diff --check origin/dev...HEAD`
- `luac -p` across all changed Lua files in the branch diff against `origin/dev`
- `lua tests\column1-profile-inventory.lua`
- `lua tests\eligibility-load-conditions.lua`
- `lua tests\character-eligibility-choices.lua`
- `lua tests\eligibility-import-export.lua`
- Five-agent static review via `parallel-review-recommendations`; all reviewers reported no actionable findings.
- No live in-game, combat, restricted-content, or DevBridge validation was performed for this publish step.