### PR TITLE
Make Resource Bars class-wide with safe migration

### DIFF
--- a/CooldownCompanion/Core/AnchorPolicy.lua
+++ b/CooldownCompanion/Core/AnchorPolicy.lua
@@ -38,6 +38,8 @@ local EXTERNAL_ANCHOR_STORES = {
         legacyName = "Resource Bars Seed",
         scopedKey = "resourceBarsByChar",
         scopedNamePrefix = "Resource Bars ",
+        classScopedKey = "resourceBarsByClass",
+        classScopedNamePrefix = "Resource Bars Class ",
     },
     frameAnchoring = {
         rootKey = "frameAnchoring",
@@ -385,6 +387,13 @@ local function ForEachExternalAnchorSettings(profile, store, apply)
     if type(stores) == "table" then
         for charKey, settings in pairs(stores) do
             apply(settings, store.scopedNamePrefix .. tostring(charKey))
+        end
+    end
+
+    local classStores = store.classScopedKey and profile[store.classScopedKey] or nil
+    if type(classStores) == "table" then
+        for classKey, settings in pairs(classStores) do
+            apply(settings, store.classScopedNamePrefix .. tostring(classKey))
         end
     end
 end

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -445,6 +445,11 @@ local defaults = {
         },
         locked = false,
         cdmHidden = false,
+        resourceBarsByClass = {},
+        resourceBarMigration = {
+            conflicts = {},
+            unsafeCharKeys = {},
+        },
         resourceBars = {
             enabled = false,
             anchorGroupId = nil,

--- a/CooldownCompanion/Core/Migrations.lua
+++ b/CooldownCompanion/Core/Migrations.lua
@@ -322,6 +322,9 @@ function CooldownCompanion:RunAllMigrations()
     self:StampImportCheckpoint(self.db and self.db.profile)
     NormalizePassiveCooldownButtons(self.db and self.db.profile)
     BackfillUnusableVisualOverrideModes(self.db and self.db.profile)
+    if self.RunResourceBarClassScopeMigration then
+        self:RunResourceBarClassScopeMigration()
+    end
     if self.SanitizeCursorAnchorPolicy and not self._deferCursorAnchorPolicySanitizer then
         self:SanitizeCursorAnchorPolicy(self.db and self.db.profile)
     end

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -1321,6 +1321,308 @@ local function BuildResourceBarMigrationBuckets(addon, profile, state)
     return buckets
 end
 
+local function AddMergedCustomBarOrder(store, customBarId)
+    if type(store) ~= "table" or type(customBarId) ~= "string" or customBarId == "" then
+        return
+    end
+    store.order = type(store.order) == "table" and store.order or {}
+    for _, existingId in ipairs(store.order) do
+        if existingId == customBarId then
+            return
+        end
+    end
+    store.order[#store.order + 1] = customBarId
+end
+
+local function AllocateMergedCustomBarId(settings, store)
+    settings.nextCustomBarId = tonumber(settings.nextCustomBarId) or 1
+    local id
+    repeat
+        id = "custom_bar_" .. tostring(settings.nextCustomBarId)
+        settings.nextCustomBarId = settings.nextCustomBarId + 1
+    until type(store.entries[id]) ~= "table"
+    return id
+end
+
+local function EnsureMergedCustomBarLayout(settings, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    if type(settings) ~= "table" or not specID then
+        return nil
+    end
+    settings.layoutOrder = type(settings.layoutOrder) == "table" and settings.layoutOrder or {}
+    local layout = GetSpecKeyedTable(settings.layoutOrder, specID)
+    if type(layout) ~= "table" then
+        layout = {}
+        settings.layoutOrder[specID] = layout
+    end
+    layout.customBars = type(layout.customBars) == "table" and layout.customBars or {}
+    return layout
+end
+
+local function AddMergedSpecID(specIDs, seen, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    if specID and not seen[specID] then
+        seen[specID] = true
+        specIDs[#specIDs + 1] = specID
+    end
+end
+
+local function CollectMergedCustomBarLayoutSpecIDs(sourceSettings, sourceCustomBarId, entry, fallbackSpecID, legacySlotIndex)
+    local specIDs = {}
+    local seen = {}
+    AddMergedSpecID(specIDs, seen, fallbackSpecID)
+
+    if type(entry) == "table" and type(entry.specs) == "table" then
+        for specID, enabled in pairs(entry.specs) do
+            if enabled == true then
+                AddMergedSpecID(specIDs, seen, specID)
+            end
+        end
+    end
+
+    local layoutOrder = type(sourceSettings) == "table" and sourceSettings.layoutOrder or nil
+    if type(layoutOrder) == "table" then
+        for specID, layout in pairs(layoutOrder) do
+            if type(layout) == "table" then
+                local hasCustomLayout = type(sourceCustomBarId) == "string"
+                    and type(layout.customBars) == "table"
+                    and type(layout.customBars[sourceCustomBarId]) == "table"
+                local hasLegacyAuraLayout = legacySlotIndex ~= nil
+                    and type(layout.customAuraBarSlots) == "table"
+                    and type(layout.customAuraBarSlots[legacySlotIndex]) == "table"
+                if hasCustomLayout or hasLegacyAuraLayout then
+                    AddMergedSpecID(specIDs, seen, specID)
+                end
+            end
+        end
+    end
+
+    sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+    return specIDs
+end
+
+local function CopyMergedCustomBarLayout(targetSettings, sourceSettings, specID, sourceCustomBarId, targetCustomBarId, fallbackOrder, legacySlotIndex)
+    local targetLayout = EnsureMergedCustomBarLayout(targetSettings, specID)
+    if type(targetLayout) ~= "table"
+        or type(targetCustomBarId) ~= "string"
+        or type(targetLayout.customBars[targetCustomBarId]) == "table" then
+        return
+    end
+
+    local sourceLayout = type(sourceSettings) == "table"
+        and type(sourceSettings.layoutOrder) == "table"
+        and GetSpecKeyedTable(sourceSettings.layoutOrder, specID)
+        or nil
+    local sourceCustomLayout = nil
+    if type(sourceLayout) == "table" then
+        if type(sourceCustomBarId) == "string"
+            and type(sourceLayout.customBars) == "table"
+            and type(sourceLayout.customBars[sourceCustomBarId]) == "table" then
+            sourceCustomLayout = sourceLayout.customBars[sourceCustomBarId]
+        elseif legacySlotIndex ~= nil
+            and type(sourceLayout.customAuraBarSlots) == "table"
+            and type(sourceLayout.customAuraBarSlots[legacySlotIndex]) == "table" then
+            sourceCustomLayout = sourceLayout.customAuraBarSlots[legacySlotIndex]
+        end
+    end
+
+    targetLayout.customBars[targetCustomBarId] = type(sourceCustomLayout) == "table"
+        and CopyTable(sourceCustomLayout)
+        or {
+            position = "below",
+            order = fallbackOrder or 1000,
+        }
+end
+
+local function NormalizeMergedCustomBarEntry(entry, fallbackSpecID, entryTypeFallback)
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    local copy = CopyTable(entry)
+    if copy.entryType == nil and entryTypeFallback then
+        copy.entryType = entryTypeFallback
+    end
+
+    local specs = {}
+    local sawSpec = false
+    ForEachSharedCustomBarSpec(copy, function(specID)
+        sawSpec = true
+        specs[specID] = true
+    end)
+    fallbackSpecID = NormalizeCustomBarSpecID(fallbackSpecID)
+    if fallbackSpecID then
+        sawSpec = true
+        specs[fallbackSpecID] = true
+    end
+    copy.specs = sawSpec and specs or {}
+    ClearCustomBarLegacySpecFields(copy)
+    return copy
+end
+
+local AddMergedCustomBar
+
+local function MergeLegacyCustomBarBuckets(targetSettings, sourceSettings, barsBySpec, isAuraStore)
+    if type(barsBySpec) ~= "table" then
+        return
+    end
+
+    local specKeys = {}
+    for specID in pairs(barsBySpec) do
+        specKeys[#specKeys + 1] = specID
+    end
+    sort(specKeys, function(a, b) return tostring(a) < tostring(b) end)
+
+    for _, specKey in ipairs(specKeys) do
+        local specID = NormalizeCustomBarSpecID(specKey)
+        local specBars = specID and barsBySpec[specKey] or nil
+        if type(specBars) == "table" then
+            local numericKeys = {}
+            local seen = {}
+            for key in pairs(specBars) do
+                if tonumber(key) then
+                    numericKeys[#numericKeys + 1] = tonumber(key)
+                end
+            end
+            sort(numericKeys)
+            for index, numericKey in ipairs(numericKeys) do
+                local entry = specBars[numericKey] or specBars[tostring(numericKey)]
+                if type(entry) == "table" then
+                    AddMergedCustomBar(targetSettings, sourceSettings, entry, specID, entry.customBarId, 1000 + index, isAuraStore and numericKey or nil, isAuraStore and "aura" or nil)
+                end
+                seen[numericKey] = true
+                seen[tostring(numericKey)] = true
+            end
+            for key, entry in pairs(specBars) do
+                if type(entry) == "table" and not seen[key] then
+                    AddMergedCustomBar(targetSettings, sourceSettings, entry, specID, entry.customBarId, 1000 + #numericKeys + 1, isAuraStore and tonumber(key) or nil, isAuraStore and "aura" or nil)
+                end
+            end
+        end
+    end
+end
+
+local function EnsureMergedCustomBarStore(settings)
+    if type(settings) ~= "table" then
+        return nil
+    end
+
+    if IsSharedCustomBarsStore(settings.customBars) then
+        local store = settings.customBars
+        store.entries = type(store.entries) == "table" and store.entries or {}
+        store.order = type(store.order) == "table" and store.order or {}
+        local ordered = {}
+        for _, customBarId in ipairs(store.order) do
+            ordered[customBarId] = true
+        end
+        for customBarId, entry in pairs(store.entries) do
+            if type(entry) == "table" and type(customBarId) == "string" then
+                entry.customBarId = type(entry.customBarId) == "string" and entry.customBarId or customBarId
+                if not ordered[customBarId] then
+                    store.order[#store.order + 1] = customBarId
+                end
+            end
+        end
+        return store
+    end
+
+    local legacyCustomBars = settings.customBars
+    local legacyCustomAuraBars = settings.customAuraBars
+    settings.customBars = { entries = {}, order = {} }
+    settings.customAuraBars = {}
+    MergeLegacyCustomBarBuckets(settings, settings, legacyCustomBars, false)
+    MergeLegacyCustomBarBuckets(settings, settings, legacyCustomAuraBars, true)
+    return settings.customBars
+end
+
+AddMergedCustomBar = function(targetSettings, sourceSettings, sourceEntry, fallbackSpecID, sourceCustomBarId, fallbackOrder, legacySlotIndex, entryTypeFallback)
+    local store = EnsureMergedCustomBarStore(targetSettings)
+    local entry = NormalizeMergedCustomBarEntry(sourceEntry, fallbackSpecID, entryTypeFallback)
+    if type(store) ~= "table" or type(entry) ~= "table" then
+        return nil
+    end
+
+    local preferredId = type(entry.customBarId) == "string" and entry.customBarId ~= "" and entry.customBarId
+        or (type(sourceCustomBarId) == "string" and sourceCustomBarId ~= "" and sourceCustomBarId or nil)
+    local targetId = preferredId
+    if not targetId then
+        targetId = AllocateMergedCustomBarId(targetSettings, store)
+    elseif type(store.entries[targetId]) == "table" then
+        if DeepEqual(store.entries[targetId], entry) then
+            local specIDs = CollectMergedCustomBarLayoutSpecIDs(sourceSettings, sourceCustomBarId or targetId, entry, fallbackSpecID, legacySlotIndex)
+            for _, specID in ipairs(specIDs) do
+                CopyMergedCustomBarLayout(targetSettings, sourceSettings, specID, sourceCustomBarId or targetId, targetId, fallbackOrder, legacySlotIndex)
+            end
+            return targetId
+        end
+        targetId = AllocateMergedCustomBarId(targetSettings, store)
+    end
+
+    entry.customBarId = targetId
+    store.entries[targetId] = entry
+    AddMergedCustomBarOrder(store, targetId)
+
+    local specIDs = CollectMergedCustomBarLayoutSpecIDs(sourceSettings, sourceCustomBarId or preferredId or targetId, entry, fallbackSpecID, legacySlotIndex)
+    for _, specID in ipairs(specIDs) do
+        CopyMergedCustomBarLayout(targetSettings, sourceSettings, specID, sourceCustomBarId or preferredId or targetId, targetId, fallbackOrder, legacySlotIndex)
+    end
+
+    return targetId
+end
+
+local function MergeCustomBarsFromResourceBarSettings(targetSettings, sourceSettings, classKey)
+    if type(targetSettings) ~= "table" or type(sourceSettings) ~= "table" then
+        return
+    end
+
+    local source = CopyNormalizedResourceBarCandidate(sourceSettings, classKey)
+    EnsureMergedCustomBarStore(targetSettings)
+
+    if IsSharedCustomBarsStore(source.customBars) then
+        local entries = type(source.customBars.entries) == "table" and source.customBars.entries or {}
+        local seen = {}
+        if type(source.customBars.order) == "table" then
+            for _, customBarId in ipairs(source.customBars.order) do
+                local entry = entries[customBarId]
+                if type(entry) == "table" then
+                    AddMergedCustomBar(targetSettings, source, entry, nil, customBarId, 1000 + #targetSettings.customBars.order)
+                    seen[customBarId] = true
+                end
+            end
+        end
+        for customBarId, entry in pairs(entries) do
+            if type(entry) == "table" and not seen[customBarId] then
+                AddMergedCustomBar(targetSettings, source, entry, nil, customBarId, 1000 + #targetSettings.customBars.order + 1)
+            end
+        end
+    else
+        MergeLegacyCustomBarBuckets(targetSettings, source, source.customBars, false)
+    end
+
+    MergeLegacyCustomBarBuckets(targetSettings, source, source.customAuraBars, true)
+    NormalizeResourceBarSettingsForClass(targetSettings, classKey)
+    SanitizeResourceBarAnchors(targetSettings, classKey)
+end
+
+local function MergeResourceBarConflictCustomBars(targetSettings, classKey, conflict, legacyStore, selectedCharKey, existingClassSettings)
+    if type(targetSettings) ~= "table" or type(conflict) ~= "table" then
+        return
+    end
+
+    if type(existingClassSettings) == "table" then
+        MergeCustomBarsFromResourceBarSettings(targetSettings, existingClassSettings, classKey)
+    end
+
+    if type(legacyStore) ~= "table" then
+        return
+    end
+    for _, candidateCharKey in ipairs(conflict.candidateCharKeys or {}) do
+        if candidateCharKey ~= selectedCharKey and type(legacyStore[candidateCharKey]) == "table" then
+            MergeCustomBarsFromResourceBarSettings(targetSettings, legacyStore[candidateCharKey], classKey)
+        end
+    end
+end
+
 local function PromoteResourceBarClassSettings(classStore, classKey, settings)
     classStore[classKey] = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
@@ -1425,6 +1727,31 @@ local function BuildResourceBarConflictSummary(profile)
         end
     end
     return summaries
+end
+
+local function FormatResourceBarConflictExportMessage(summaries)
+    if type(summaries) ~= "table" or #summaries == 0 then
+        return nil
+    end
+
+    local parts = {}
+    for _, summary in ipairs(summaries) do
+        local candidateText = summary.candidateCount .. " candidate"
+        if summary.candidateCount ~= 1 then
+            candidateText = candidateText .. "s"
+        end
+        if summary.includeExistingClass then
+            candidateText = candidateText .. " including current class setup"
+        end
+        if #summary.candidateCharKeys > 0 then
+            candidateText = candidateText .. ": " .. concat(summary.candidateCharKeys, ", ")
+        end
+        parts[#parts + 1] = summary.classKey .. " (" .. candidateText .. ")"
+    end
+
+    return "Resolve pending Resource Bar conflicts before exporting. Affected classes: "
+        .. concat(parts, "; ")
+        .. ". Open Resource Bar settings on the affected class and choose the setup to keep."
 end
 
 local function GetFallbackResourceBarSettings(addon, classKey)
@@ -1692,28 +2019,35 @@ end
 
 function CooldownCompanion:GetPendingResourceBarConflictExportMessage()
     local summaries = self:GetPendingResourceBarConflictSummary()
-    if #summaries == 0 then
+    return FormatResourceBarConflictExportMessage(summaries)
+end
+
+function CooldownCompanion:GetResourceBarConflictExportMessage(classKey)
+    classKey = NormalizeClassKey(classKey)
+    if not classKey then
         return nil
     end
 
-    local parts = {}
-    for _, summary in ipairs(summaries) do
-        local candidateText = summary.candidateCount .. " candidate"
-        if summary.candidateCount ~= 1 then
-            candidateText = candidateText .. "s"
-        end
-        if summary.includeExistingClass then
-            candidateText = candidateText .. " including current class setup"
-        end
-        if #summary.candidateCharKeys > 0 then
-            candidateText = candidateText .. ": " .. concat(summary.candidateCharKeys, ", ")
-        end
-        parts[#parts + 1] = summary.classKey .. " (" .. candidateText .. ")"
+    local profile = self.db and self.db.profile
+    local conflict = GetResourceBarConflict(profile, classKey)
+    if not conflict then
+        return nil
     end
 
-    return "Resolve pending Resource Bar conflicts before exporting. Affected classes: "
-        .. concat(parts, "; ")
-        .. ". Open Resource Bar settings on the affected class and choose the setup to keep."
+    local candidateCharKeys = CopyTable(conflict.candidateCharKeys or {})
+    sort(candidateCharKeys)
+    return FormatResourceBarConflictExportMessage({
+        {
+            classKey = classKey,
+            candidateCharKeys = candidateCharKeys,
+            candidateCount = #candidateCharKeys + (conflict.includeExistingClass and 1 or 0),
+            includeExistingClass = conflict.includeExistingClass == true,
+        },
+    })
+end
+
+function CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
+    return self:GetResourceBarConflictExportMessage(GetCurrentResourceBarClassKey(self))
 end
 
 function CooldownCompanion:GetResourceBarUnsafeLegacySummary()
@@ -1740,6 +2074,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
     end
 
     local classStore = EnsureResourceBarClassStore(profile)
+    local legacyStore = GetResourceBarLegacyStore(profile, false)
     if keepExistingClassStore then
         if conflict.includeExistingClass ~= true then
             return false, "invalid_candidate"
@@ -1751,6 +2086,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         if classKey == GetCurrentResourceBarClassKey(self) then
             SanitizeResourceBarAnchors(classStore[classKey], classKey)
         end
+        MergeResourceBarConflictCustomBars(classStore[classKey], classKey, conflict, legacyStore, nil, nil)
         RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
         ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
         if type(self._resourceBarConflictFallbackSettings) == "table" then
@@ -1770,16 +2106,20 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         return false, "invalid_candidate"
     end
 
-    local legacyStore = GetResourceBarLegacyStore(profile, false)
     local source = type(legacyStore) == "table" and legacyStore[sourceCharKey] or nil
     if type(source) ~= "table" then
         return false, "missing_candidate"
     end
 
+    local existingClassSettings = conflict.includeExistingClass == true
+        and type(classStore[classKey]) == "table"
+        and CopyTable(classStore[classKey])
+        or nil
     PromoteResourceBarClassSettings(classStore, classKey, source)
     if classKey == GetCurrentResourceBarClassKey(self) then
         SanitizeResourceBarAnchors(classStore[classKey], classKey)
     end
+    MergeResourceBarConflictCustomBars(classStore[classKey], classKey, conflict, legacyStore, sourceCharKey, existingClassSettings)
 
     RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
     ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -841,7 +841,18 @@ local function NormalizeCustomAuraBarsForClass(settings, classKey)
     end
 end
 
-local function SanitizeAnchorGroupID(groupId)
+local function IsAnchorGroupVisibleForClass(numericGroupID, container, classKey)
+    classKey = NormalizeClassKey(classKey)
+    if classKey and CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(container, {
+            currentClassKey = classKey,
+        })
+        return type(scope) == "table" and scope.runtimeVisible == true
+    end
+    return CooldownCompanion:IsGroupVisibleToCurrentChar(numericGroupID)
+end
+
+local function SanitizeAnchorGroupID(groupId, classKey)
     if not groupId then
         return nil
     end
@@ -862,18 +873,18 @@ local function SanitizeAnchorGroupID(groupId)
     if not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) or (container and container.isGlobal) then
         return nil
     end
-    if not CooldownCompanion:IsGroupVisibleToCurrentChar(numericGroupID) then
+    if not IsAnchorGroupVisibleForClass(numericGroupID, container, classKey) then
         return nil
     end
     return numericGroupID
 end
 
-local function SanitizeResourceBarAnchors(settings)
+local function SanitizeResourceBarAnchors(settings, classKey)
     if type(settings) ~= "table" then
         return
     end
 
-    settings.anchorGroupId = SanitizeAnchorGroupID(settings.anchorGroupId)
+    settings.anchorGroupId = SanitizeAnchorGroupID(settings.anchorGroupId, classKey)
 
     if settings.independentAnchor ~= nil and type(settings.independentAnchor) ~= "table" then
         settings.independentAnchor = nil
@@ -1033,7 +1044,7 @@ end
 
 local function SanitizeCopiedOrSeededScopedBarSettings(systemKey, settings)
     if systemKey == "resourceBars" then
-        SanitizeResourceBarAnchors(settings)
+        SanitizeResourceBarAnchors(settings, GetCurrentResourceBarClassKey(CooldownCompanion))
     elseif systemKey == "castBar" then
         SanitizeCastBarAnchors(settings)
     elseif systemKey == "frameAnchoring" then
@@ -1104,7 +1115,7 @@ local function IsDefaultResourceBarClassSettings(settings, classKey)
     end
     local defaults = CopySubsystemDefaults("resourceBars")
     NormalizeResourceBarSettingsForClass(defaults, classKey)
-    SanitizeResourceBarAnchors(defaults)
+    SanitizeResourceBarAnchors(defaults, classKey)
     return DeepEqual(settings, defaults)
 end
 
@@ -1184,7 +1195,7 @@ local function SeedImportedLegacyResourceBarBucket(addon, profile)
         if classKey then
             NormalizeResourceBarSettingsForClass(settings, classKey)
         end
-        SanitizeResourceBarAnchors(settings)
+        SanitizeResourceBarAnchors(settings, classKey)
         store = GetResourceBarLegacyStore(profile, true)
         store[exporterCharKey] = settings
     end
@@ -1203,11 +1214,13 @@ local function SeedCurrentLegacyResourceBarBucket(addon, profile)
     local classStore = type(profile) == "table" and rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY) or nil
     local classSettings = type(classStore) == "table" and classStore[classKey] or nil
     if type(classSettings) == "table" and not IsDefaultResourceBarClassSettings(classSettings, classKey) then
+        ClearLegacyResourceBarSeed(profile)
         return
     end
 
     local store = GetResourceBarLegacyStore(profile, false)
     if type(store) == "table" and type(store[currentCharKey]) == "table" then
+        ClearLegacyResourceBarSeed(profile)
         return
     end
 
@@ -1225,14 +1238,15 @@ local function SeedCurrentLegacyResourceBarBucket(addon, profile)
     store = GetResourceBarLegacyStore(profile, true)
     local settings = CopyTable(seed)
     NormalizeResourceBarSettingsForClass(settings, classKey)
-    SanitizeResourceBarAnchors(settings)
+    SanitizeResourceBarAnchors(settings, classKey)
     store[currentCharKey] = settings
+    ClearLegacyResourceBarSeed(profile)
 end
 
 local function CopyNormalizedResourceBarCandidate(settings, classKey)
     local normalized = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(normalized, classKey)
-    SanitizeResourceBarAnchors(normalized)
+    SanitizeResourceBarAnchors(normalized, classKey)
     return normalized
 end
 
@@ -1310,7 +1324,7 @@ end
 local function PromoteResourceBarClassSettings(classStore, classKey, settings)
     classStore[classKey] = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
-    SanitizeResourceBarAnchors(classStore[classKey])
+    SanitizeResourceBarAnchors(classStore[classKey], classKey)
 end
 
 local function MigrateResourceBarClass(profile, classStore, state, classKey, candidates)
@@ -1322,7 +1336,7 @@ local function MigrateResourceBarClass(profile, classStore, state, classKey, can
 
     if type(classStore[classKey]) == "table" then
         NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
-        SanitizeResourceBarAnchors(classStore[classKey])
+        SanitizeResourceBarAnchors(classStore[classKey], classKey)
         if IsDefaultResourceBarClassSettings(classStore[classKey], classKey) then
             classStore[classKey] = nil
         else
@@ -1567,7 +1581,7 @@ function CooldownCompanion:RunResourceBarClassScopeMigration()
     for classKey, settings in pairs(classStore) do
         if type(settings) == "table" then
             NormalizeResourceBarSettingsForClass(settings, classKey)
-            SanitizeResourceBarAnchors(settings)
+            SanitizeResourceBarAnchors(settings, classKey)
         end
     end
 
@@ -1630,7 +1644,7 @@ function CooldownCompanion:GetResourceBarSettings()
     if type(settings) ~= "table" then
         settings = CopySubsystemDefaults("resourceBars")
         NormalizeResourceBarSettingsForClass(settings, classKey)
-        SanitizeResourceBarAnchors(settings)
+        SanitizeResourceBarAnchors(settings, classKey)
         classStore[classKey] = settings
     elseif ResourceBarSettingsNeedsNormalizationForClass(settings, classKey) then
         NormalizeResourceBarSettingsForClass(settings, classKey)
@@ -1735,7 +1749,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         end
         NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
         if classKey == GetCurrentResourceBarClassKey(self) then
-            SanitizeResourceBarAnchors(classStore[classKey])
+            SanitizeResourceBarAnchors(classStore[classKey], classKey)
         end
         RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
         ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
@@ -1764,7 +1778,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
 
     PromoteResourceBarClassSettings(classStore, classKey, source)
     if classKey == GetCurrentResourceBarClassKey(self) then
-        SanitizeResourceBarAnchors(classStore[classKey])
+        SanitizeResourceBarAnchors(classStore[classKey], classKey)
     end
 
     RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -5,9 +5,23 @@ local CopyTable = CopyTable
 local pairs = pairs
 local next = next
 local rawget = rawget
+local setmetatable = setmetatable
 local tonumber = tonumber
 local type = type
 local sort = table.sort
+local concat = table.concat
+
+local CLASS_SCAN_LIMIT = 30
+
+local RESOURCE_BAR_SYSTEM_SPEC = {
+    storeKey = "resourceBarsByChar",
+    seedKey = "legacyResourceBarsSeed",
+    legacyKey = "resourceBars",
+}
+
+local RESOURCE_BAR_CLASS_STORE_KEY = "resourceBarsByClass"
+local RESOURCE_BAR_MIGRATION_KEY = "resourceBarMigration"
+local RESOURCE_BAR_NORMALIZED_CLASS_KEYS = setmetatable({}, { __mode = "k" })
 
 local function GetEnsureCustomAuraBarAuraUnit()
     local rb = ST and ST._RB
@@ -26,11 +40,6 @@ local function BackfillLegacyResourceAuraUnit(resourceAuraEntry)
 end
 
 local SCOPED_BAR_SYSTEMS = {
-    resourceBars = {
-        storeKey = "resourceBarsByChar",
-        seedKey = "legacyResourceBarsSeed",
-        legacyKey = "resourceBars",
-    },
     castBar = {
         storeKey = "castBarByChar",
         seedKey = "legacyCastBarSeed",
@@ -45,6 +54,56 @@ local SCOPED_BAR_SYSTEMS = {
 
 local function GetScopedBarSystemSpec(systemKey)
     return SCOPED_BAR_SYSTEMS[systemKey]
+end
+
+local function NormalizeClassKey(classKey)
+    if type(classKey) ~= "string" or classKey == "" then
+        return nil
+    end
+    return string.upper(classKey)
+end
+
+local function GetClassInfoByID(classID)
+    classID = tonumber(classID)
+    if not classID then
+        return nil, nil, nil
+    end
+    if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return classInfo.className, classInfo.classFile, classInfo.classID
+        end
+    end
+    if GetClassInfo then
+        return GetClassInfo(classID)
+    end
+    return nil, nil, nil
+end
+
+local function GetClassKeyFromClassID(classID)
+    local _, classFilename = GetClassInfoByID(classID)
+    return NormalizeClassKey(classFilename)
+end
+
+local function GetClassIDFromClassKey(classKey)
+    classKey = NormalizeClassKey(classKey)
+    if not classKey then
+        return nil
+    end
+    for classID = 1, CLASS_SCAN_LIMIT do
+        if GetClassKeyFromClassID(classID) == classKey then
+            return classID
+        end
+    end
+    return nil
+end
+
+local function GetCurrentResourceBarClassKey(addon)
+    local classFilename = addon and addon._playerClassFilename
+    if not classFilename and UnitClass then
+        classFilename = select(2, UnitClass("player"))
+    end
+    return NormalizeClassKey(classFilename)
 end
 
 local function CopySubsystemDefaults(defaultKey)
@@ -338,7 +397,6 @@ local function NormalizeResourceThresholdTickEntries(settings)
     end
 end
 
--- Keep these resource mappings aligned with OtherBars/ResourceBarConstants.lua.
 local RESOURCE_HEALTH = -1
 
 local function CopySpecOverrideWithoutAura(sourceSpecData, targetSpecData)
@@ -361,82 +419,6 @@ local function CopySpecOverrideWithoutAura(sourceSpecData, targetSpecData)
     end
 
     return next(copied) and copied or nil
-end
-
-local function PreserveTargetCustomBarLayouts(copied, target)
-    if type(copied) ~= "table"
-        or type(target) ~= "table"
-        or type(target.customBars) ~= "table"
-    then
-        return
-    end
-
-    if type(copied.layoutOrder) ~= "table" then
-        copied.layoutOrder = {}
-    end
-
-    for _, layout in pairs(copied.layoutOrder) do
-        if type(layout) == "table" then
-            layout.customBars = {}
-        end
-    end
-
-    local targetLayoutOrder = type(target.layoutOrder) == "table" and target.layoutOrder or nil
-    local function preserveLayout(specID, customBarId)
-        if type(customBarId) ~= "string" or customBarId == "" then
-            return
-        end
-        local targetLayout = GetSpecKeyedTable(targetLayoutOrder, specID)
-        local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
-        if not copiedLayout then
-            copiedLayout = type(targetLayout) == "table" and CopyTable(targetLayout) or {}
-            copied.layoutOrder[specID] = copiedLayout
-        end
-        if type(copiedLayout.customBars) ~= "table" then
-            copiedLayout.customBars = {}
-        end
-
-        local targetCustomBarLayouts = type(targetLayout) == "table" and targetLayout.customBars or nil
-        local targetCustomBarLayout = type(targetCustomBarLayouts) == "table"
-            and targetCustomBarLayouts[customBarId]
-            or nil
-        if type(targetCustomBarLayout) == "table" then
-            copiedLayout.customBars[customBarId] = CopyTable(targetCustomBarLayout)
-        end
-    end
-
-    if IsSharedCustomBarsStore(target.customBars) then
-        local entries = type(target.customBars.entries) == "table" and target.customBars.entries or {}
-        for _, entry in pairs(entries) do
-            local customBarId = type(entry) == "table" and entry.customBarId or nil
-            local sawSpec = false
-            ForEachSharedCustomBarSpec(entry, function(specID)
-                sawSpec = true
-                preserveLayout(specID, customBarId)
-            end)
-            if not sawSpec and type(targetLayoutOrder) == "table" then
-                for specID, layout in pairs(targetLayoutOrder) do
-                    if type(layout) == "table"
-                        and type(layout.customBars) == "table"
-                        and type(layout.customBars[customBarId]) == "table" then
-                        preserveLayout(specID, customBarId)
-                    end
-                end
-            end
-        end
-    else
-        for specID, targetSpecBars in pairs(target.customBars) do
-            if type(targetSpecBars) == "table" then
-                local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
-                if copiedLayout then
-                    copiedLayout.customBars = {}
-                end
-                for _, entry in pairs(targetSpecBars) do
-                    preserveLayout(specID, type(entry) == "table" and entry.customBarId or nil)
-                end
-            end
-        end
-    end
 end
 
 local function EnsureScopedBarSystemStore(profile, storeKey)
@@ -469,6 +451,11 @@ local function ProfileHasLegacyScopedBarData(profile)
         return false
     end
 
+    if type(rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.seedKey)) == "table"
+        or type(rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.legacyKey)) == "table" then
+        return true
+    end
+
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
         if type(rawget(profile, systemSpec.seedKey)) == "table"
             or type(rawget(profile, systemSpec.legacyKey)) == "table" then
@@ -482,6 +469,11 @@ end
 local function ProfileHasAnyScopedBarBuckets(profile)
     if type(profile) ~= "table" then
         return false
+    end
+
+    local resourceStore = rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.storeKey)
+    if type(resourceStore) == "table" and next(resourceStore) ~= nil then
+        return true
     end
 
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
@@ -501,8 +493,8 @@ local function MarkLegacyScopedBarSeenCharacter(snapshot, charKey)
     snapshot[charKey] = true
 end
 
-local function GetCurrentClassSpecInfo()
-    local _, _, classID = UnitClass("player")
+local function GetClassSpecInfo(classKey)
+    local classID = GetClassIDFromClassKey(classKey)
     if not classID then
         return nil, nil
     end
@@ -524,12 +516,18 @@ local function GetCurrentClassSpecInfo()
     end
 
     local currentSpecID = nil
-    local specIndex = C_SpecializationInfo.GetSpecialization()
-    if specIndex then
-        currentSpecID = C_SpecializationInfo.GetSpecializationInfo(specIndex)
+    if NormalizeClassKey(classKey) == GetCurrentResourceBarClassKey(CooldownCompanion) then
+        local specIndex = C_SpecializationInfo.GetSpecialization()
+        if specIndex then
+            currentSpecID = C_SpecializationInfo.GetSpecializationInfo(specIndex)
+        end
     end
 
     return specIDs, currentSpecID
+end
+
+local function GetCurrentClassSpecInfo()
+    return GetClassSpecInfo(GetCurrentResourceBarClassKey(CooldownCompanion))
 end
 
 local function CopySpecLayoutOrder(settings, sourceSpecID, targetSpecID)
@@ -599,80 +597,6 @@ local function CopyResourceSpecOverrides(settings, sourceSpecID, targetSpecID)
     end
 end
 
-local CLASS_RESOURCES_BY_CLASS_ID = {
-    [1]  = { 1 },
-    [2]  = { 9, 0 },
-    [3]  = { 2 },
-    [4]  = { 4, 3 },
-    [5]  = { 0 },
-    [6]  = { 5, 6 },
-    [7]  = { 0 },
-    [8]  = { 0 },
-    [9]  = { 7, 0 },
-    [10] = { 0 },
-    [11] = { 0 },
-    [12] = { 17 },
-    [13] = { 19, 0 },
-}
-
-local SPEC_RESOURCES_BY_SPEC_ID = {
-    [258] = { 13, 0 },
-    [262] = { 11, 0 },
-    [263] = { 100, 0 },
-    [62]  = { 16, 0 },
-    [269] = { 12, 3 },
-    [268] = { 3 },
-    [581] = { 17 },
-}
-
-local DRUID_FORM_RESOURCES = {
-    { 1 },
-    { 4, 3 },
-    { 8 },
-}
-
-local function BuildResourceSet(resourceList, result)
-    if type(resourceList) ~= "table" or type(result) ~= "table" then
-        return result
-    end
-
-    for _, powerType in pairs(resourceList) do
-        local numericPowerType = tonumber(powerType)
-        if numericPowerType then
-            result[numericPowerType] = true
-        end
-    end
-
-    return result
-end
-
-local function GetCurrentClassApplicableResourceSet()
-    local _, _, classID = UnitClass("player")
-    if not classID then
-        return {}
-    end
-
-    local resourceSet = {}
-    resourceSet[RESOURCE_HEALTH] = true
-    BuildResourceSet(CLASS_RESOURCES_BY_CLASS_ID[classID], resourceSet)
-
-    if classID == 11 then
-        for _, resourceList in pairs(DRUID_FORM_RESOURCES) do
-            BuildResourceSet(resourceList, resourceSet)
-        end
-    end
-
-    local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
-    for i = 1, numSpecs do
-        local specID = GetSpecializationInfoForClassID(classID, i)
-        if specID then
-            BuildResourceSet(SPEC_RESOURCES_BY_SPEC_ID[specID], resourceSet)
-        end
-    end
-
-    return resourceSet
-end
-
 local function CopyResourceAuraOverlayColor(color)
     if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
         return nil
@@ -720,12 +644,12 @@ local function ClearLegacyResourceAuraOverlayFields(resource)
     resource.auraUnitExplicit = nil
 end
 
-local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
+local function NormalizeResourceAuraOverlayEntriesForClass(settings, classKey)
     if type(settings) ~= "table" or type(settings.resources) ~= "table" then
         return
     end
 
-    local allowedSpecIDs, currentSpecID = GetCurrentClassSpecInfo()
+    local allowedSpecIDs, currentSpecID = GetClassSpecInfo(classKey)
     if type(allowedSpecIDs) ~= "table" then
         return
     end
@@ -807,12 +731,12 @@ function ResolveSpecOverrideKey(resource, specID, key)
 end
 ST._ResolveSpecOverrideKey = ResolveSpecOverrideKey
 
-local function NormalizeResourceSpecOverridesForCurrentClass(settings)
+local function NormalizeResourceSpecOverridesForClass(settings, classKey)
     if type(settings) ~= "table" or type(settings.resources) ~= "table" then
         return
     end
 
-    local allowedSpecIDs = GetCurrentClassSpecInfo()
+    local allowedSpecIDs = GetClassSpecInfo(classKey)
     if type(allowedSpecIDs) ~= "table" then
         return
     end
@@ -832,14 +756,14 @@ local function NormalizeResourceSpecOverridesForCurrentClass(settings)
     end
 end
 
-local function NormalizeCustomAuraBarsForCurrentClass(settings)
+local function NormalizeCustomAuraBarsForClass(settings, classKey)
     if type(settings) ~= "table" then
         return
     end
     local barsBySpec = type(settings.customBars) == "table" and settings.customBars or settings.customAuraBars
     if type(barsBySpec) ~= "table" then return end
 
-    local allowedSpecIDs = GetCurrentClassSpecInfo()
+    local allowedSpecIDs = GetClassSpecInfo(classKey)
     if type(allowedSpecIDs) ~= "table" then
         return
     end
@@ -995,107 +919,19 @@ local function SanitizeFrameAnchoringAnchors(settings)
     settings.anchorGroupId = SanitizeAnchorGroupID(settings.anchorGroupId)
 end
 
--- Preserves per-spec state (aura overlay entries, spec overrides) from targetResource
--- when composing a copy. Strips these fields from copiedResource first, then re-applies
--- targetResource's values to prevent copy/seed operations from overwriting per-character
--- spec customizations.
-local function CopyPreservedResourcePerSpecState(targetResource, copiedResource)
-    if type(copiedResource) ~= "table" then
-        return copiedResource
+local function NormalizeResourceBarSettingsForClass(settings, classKey)
+    NormalizeCustomAuraBarsForClass(settings, classKey)
+    NormalizeResourceAuraOverlayEntriesForClass(settings, classKey)
+    NormalizeResourceSpecOverridesForClass(settings, classKey)
+    NormalizeResourceThresholdTickEntries(settings)
+    if type(settings) == "table" then
+        RESOURCE_BAR_NORMALIZED_CLASS_KEYS[settings] = NormalizeClassKey(classKey)
     end
-
-    copiedResource.auraOverlayEnabled = nil
-    copiedResource.auraOverlayEntries = nil
-    copiedResource.specOverrides = nil
-    copiedResource.auraColorSpellID = nil
-    copiedResource.auraActiveColor = nil
-    copiedResource.auraColorTrackingMode = nil
-    copiedResource.auraColorMaxStacks = nil
-    copiedResource.auraUnit = nil
-    copiedResource.auraUnitExplicit = nil
-
-    if type(targetResource) ~= "table" then
-        return copiedResource
-    end
-
-    if type(targetResource.auraOverlayEnabled) == "boolean" then
-        copiedResource.auraOverlayEnabled = targetResource.auraOverlayEnabled
-    end
-    if type(targetResource.auraOverlayEntries) == "table" then
-        copiedResource.auraOverlayEntries = CopyTable(targetResource.auraOverlayEntries)
-    end
-    if type(targetResource.specOverrides) == "table" then
-        copiedResource.specOverrides = CopyTable(targetResource.specOverrides)
-    end
-    if targetResource.auraColorSpellID ~= nil then
-        copiedResource.auraColorSpellID = targetResource.auraColorSpellID
-    end
-    if targetResource.auraActiveColor ~= nil then
-        copiedResource.auraActiveColor = CopyTable(targetResource.auraActiveColor)
-    end
-    if targetResource.auraColorTrackingMode ~= nil then
-        copiedResource.auraColorTrackingMode = targetResource.auraColorTrackingMode
-    end
-    if targetResource.auraColorMaxStacks ~= nil then
-        copiedResource.auraColorMaxStacks = targetResource.auraColorMaxStacks
-    end
-    if targetResource.auraUnit ~= nil then
-        copiedResource.auraUnit = targetResource.auraUnit
-    end
-    if targetResource.auraUnitExplicit ~= nil then
-        copiedResource.auraUnitExplicit = targetResource.auraUnitExplicit
-    end
-
-    return copiedResource
-end
-
-local function ComposeCopiedResourceBarSettings(source, target)
-    local copied = type(target) == "table" and CopyTable(target) or CopySubsystemDefaults("resourceBars")
-    local applicableResources = GetCurrentClassApplicableResourceSet()
-
-    if type(source) == "table" then
-        for key, value in pairs(source) do
-            if key ~= "resources"
-                and key ~= "customAuraBars"
-                and key ~= "customBars"
-                and key ~= "customAuraBarSlots"
-                and key ~= "displayProfiles"
-                and key ~= "layoutOrder"
-                and key ~= "nextCustomBarId" then
-                copied[key] = CloneSettingValue(value)
-            end
-        end
-    end
-
-    if type(copied.resources) ~= "table" then
-        copied.resources = {}
-    end
-
-    local sourceResources = type(source) == "table" and source.resources or nil
-    local targetResources = type(target) == "table" and target.resources or nil
-    if type(sourceResources) == "table" then
-        for powerType in pairs(applicableResources) do
-            local sourceResource = sourceResources[powerType]
-            if type(sourceResource) == "table" then
-                local targetResource = type(targetResources) == "table" and targetResources[powerType] or nil
-                copied.resources[powerType] = CopyPreservedResourcePerSpecState(targetResource, CopyTable(sourceResource))
-            end
-        end
-    end
-
-    copied.customAuraBars = type(target) == "table" and CloneSettingValue(target.customAuraBars) or copied.customAuraBars
-    copied.customBars = type(target) == "table" and CloneSettingValue(target.customBars) or copied.customBars
-    PreserveTargetCustomBarLayouts(copied, target)
-
-    return copied
 end
 
 local function NormalizeScopedBarSettings(systemKey, settings)
     if systemKey == "resourceBars" then
-        NormalizeCustomAuraBarsForCurrentClass(settings)
-        NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
-        NormalizeResourceSpecOverridesForCurrentClass(settings)
-        NormalizeResourceThresholdTickEntries(settings)
+        NormalizeResourceBarSettingsForClass(settings, GetCurrentResourceBarClassKey(CooldownCompanion))
     end
 end
 
@@ -1106,16 +942,17 @@ local function IsResourceAuraUnitNormalized(auraEntry)
     return auraEntry.auraUnit == "player" or auraEntry.auraUnit == "target"
 end
 
-local function ResourceAuraOverlayNeedsNormalization(settings)
+local function ResourceAuraOverlayNeedsNormalizationForClass(settings, classKey)
     if type(settings) ~= "table" or type(settings.resources) ~= "table" then
         return false
     end
+    classKey = NormalizeClassKey(classKey)
 
     local allowedSpecIDs = nil
     local checkedSpecIDs = false
     local function GetAllowedSpecIDs()
         if not checkedSpecIDs then
-            allowedSpecIDs = GetCurrentClassSpecInfo()
+            allowedSpecIDs = GetClassSpecInfo(classKey)
             checkedSpecIDs = true
         end
         return allowedSpecIDs
@@ -1153,6 +990,19 @@ local function ResourceAuraOverlayNeedsNormalization(settings)
     return false
 end
 
+local function ResourceAuraOverlayNeedsNormalization(settings)
+    return ResourceAuraOverlayNeedsNormalizationForClass(settings, GetCurrentResourceBarClassKey(CooldownCompanion))
+end
+
+local function ResourceBarSettingsNeedsNormalizationForClass(settings, classKey)
+    if type(settings) ~= "table" then
+        return false
+    end
+    classKey = NormalizeClassKey(classKey)
+    return RESOURCE_BAR_NORMALIZED_CLASS_KEYS[settings] ~= classKey
+        or ResourceAuraOverlayNeedsNormalizationForClass(settings, classKey)
+end
+
 local function NeedsScopedBarNormalization(systemKey, settings)
     if systemKey == "resourceBars" then
         return ResourceAuraOverlayNeedsNormalization(settings)
@@ -1170,12 +1020,355 @@ local function SanitizeCopiedOrSeededScopedBarSettings(systemKey, settings)
     end
 end
 
+local function EnsureResourceBarClassStore(profile)
+    local store = rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY)
+    if type(store) ~= "table" then
+        store = {}
+        profile[RESOURCE_BAR_CLASS_STORE_KEY] = store
+    end
+    return store
+end
+
+local function EnsureResourceBarMigrationState(profile)
+    local state = rawget(profile, RESOURCE_BAR_MIGRATION_KEY)
+    if type(state) ~= "table" then
+        state = {}
+        profile[RESOURCE_BAR_MIGRATION_KEY] = state
+    end
+    if type(state.conflicts) ~= "table" then
+        state.conflicts = {}
+    end
+    if type(state.unsafeCharKeys) ~= "table" then
+        state.unsafeCharKeys = {}
+    end
+    return state
+end
+
+local function GetResourceBarLegacyStore(profile, create)
+    local store = rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.storeKey)
+    if type(store) == "table" then
+        return store
+    end
+    if not create then
+        return nil
+    end
+    store = {}
+    profile[RESOURCE_BAR_SYSTEM_SPEC.storeKey] = store
+    return store
+end
+
+local function DeepEqual(left, right)
+    if type(left) ~= type(right) then
+        return false
+    end
+    if type(left) ~= "table" then
+        return left == right
+    end
+    for key, value in pairs(left) do
+        if not DeepEqual(value, right and right[key]) then
+            return false
+        end
+    end
+    for key in pairs(right or {}) do
+        if left[key] == nil then
+            return false
+        end
+    end
+    return true
+end
+
+local function IsDefaultResourceBarClassSettings(settings, classKey)
+    if type(settings) ~= "table" then
+        return false
+    end
+    local defaults = CopySubsystemDefaults("resourceBars")
+    NormalizeResourceBarSettingsForClass(defaults, classKey)
+    SanitizeResourceBarAnchors(defaults)
+    return DeepEqual(settings, defaults)
+end
+
+local function SortedMapKeys(map)
+    local keys = {}
+    if type(map) ~= "table" then
+        return keys
+    end
+    for key in pairs(map) do
+        keys[#keys + 1] = key
+    end
+    sort(keys, function(a, b)
+        return tostring(a) < tostring(b)
+    end)
+    return keys
+end
+
+local function NormalizeClassKeyFromInfo(info)
+    if type(info) ~= "table" then
+        return nil
+    end
+    return NormalizeClassKey(info.classFilename or info.classFile or info.className)
+        or GetClassKeyFromClassID(info.classID)
+end
+
+local function GetImportResourceBarCharacterInfo(addon)
+    return addon and addon._resourceBarImportCharacterInfo
+end
+
+local function ResolveResourceBarCandidateClassKey(addon, charKey)
+    local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
+    if charKey == currentCharKey then
+        return GetCurrentResourceBarClassKey(addon)
+    end
+
+    local importInfo = GetImportResourceBarCharacterInfo(addon)
+    local classKey = NormalizeClassKeyFromInfo(type(importInfo) == "table" and importInfo[charKey] or nil)
+    if classKey then
+        return classKey
+    end
+
+    local globalInfo = addon and addon.db and addon.db.global and addon.db.global.characterInfo
+    return NormalizeClassKeyFromInfo(type(globalInfo) == "table" and globalInfo[charKey] or nil)
+end
+
+local function SeedCurrentLegacyResourceBarBucket(addon, profile)
+    local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
+    if type(currentCharKey) ~= "string" or currentCharKey == "" then
+        return
+    end
+
+    local classKey = GetCurrentResourceBarClassKey(addon)
+    local classStore = type(profile) == "table" and rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY) or nil
+    local classSettings = type(classStore) == "table" and classStore[classKey] or nil
+    if type(classSettings) == "table" and not IsDefaultResourceBarClassSettings(classSettings, classKey) then
+        return
+    end
+
+    local store = GetResourceBarLegacyStore(profile, false)
+    if type(store) == "table" and type(store[currentCharKey]) == "table" then
+        return
+    end
+
+    local seed = CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
+    local seenCharacters = addon and addon.EnsureLegacyScopedBarSeenCharacters
+        and addon:EnsureLegacyScopedBarSeenCharacters()
+        or nil
+    local shouldUseLegacySeed = type(seed) == "table"
+        and type(seenCharacters) == "table"
+        and seenCharacters[currentCharKey] == true
+    if not shouldUseLegacySeed then
+        return
+    end
+
+    store = GetResourceBarLegacyStore(profile, true)
+    local settings = CopyTable(seed)
+    NormalizeResourceBarSettingsForClass(settings, classKey)
+    SanitizeResourceBarAnchors(settings)
+    store[currentCharKey] = settings
+end
+
+local function CopyNormalizedResourceBarCandidate(settings, classKey)
+    local normalized = CopyTable(settings)
+    NormalizeResourceBarSettingsForClass(normalized, classKey)
+    return normalized
+end
+
+local function FindMatchingResourceBarCandidateIndex(candidates, normalized)
+    for index, candidate in ipairs(candidates) do
+        if DeepEqual(candidate.normalized, normalized) then
+            return index
+        end
+    end
+    return nil
+end
+
+local function RemoveLegacyResourceBarCandidates(profile, charKeys)
+    local store = GetResourceBarLegacyStore(profile, false)
+    if type(store) ~= "table" then
+        return
+    end
+    for _, charKey in ipairs(charKeys or {}) do
+        store[charKey] = nil
+    end
+    if next(store) == nil then
+        profile[RESOURCE_BAR_SYSTEM_SPEC.storeKey] = nil
+    end
+end
+
+local function ClearResourceBarConflict(state, classKey)
+    if type(state) == "table" and type(state.conflicts) == "table" then
+        state.conflicts[classKey] = nil
+    end
+end
+
+local function StoreResourceBarConflict(state, classKey, charKeys, includeExistingClass)
+    local conflict = {
+        classKey = classKey,
+        candidateCharKeys = CopyTable(charKeys),
+    }
+    if includeExistingClass then
+        conflict.includeExistingClass = true
+    end
+    state.conflicts[classKey] = conflict
+end
+
+local function BuildResourceBarMigrationBuckets(addon, profile, state)
+    local buckets = {}
+    local store = GetResourceBarLegacyStore(profile, false)
+    if type(store) ~= "table" then
+        return buckets
+    end
+
+    state.unsafeCharKeys = {}
+    for _, charKey in ipairs(SortedMapKeys(store)) do
+        local settings = store[charKey]
+        if type(settings) == "table" then
+            local classKey = ResolveResourceBarCandidateClassKey(addon, charKey)
+            if classKey then
+                local bucket = buckets[classKey]
+                if not bucket then
+                    bucket = {}
+                    buckets[classKey] = bucket
+                end
+                bucket[#bucket + 1] = {
+                    charKey = charKey,
+                    settings = settings,
+                    normalized = CopyNormalizedResourceBarCandidate(settings, classKey),
+                }
+            else
+                state.unsafeCharKeys[charKey] = true
+            end
+        end
+    end
+
+    return buckets
+end
+
+local function PromoteResourceBarClassSettings(classStore, classKey, settings)
+    classStore[classKey] = CopyTable(settings)
+    NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+end
+
+local function MigrateResourceBarClass(profile, classStore, state, classKey, candidates)
+    local candidateCharKeys = {}
+    for _, candidate in ipairs(candidates) do
+        candidateCharKeys[#candidateCharKeys + 1] = candidate.charKey
+    end
+    sort(candidateCharKeys)
+
+    if type(classStore[classKey]) == "table" then
+        NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+        if IsDefaultResourceBarClassSettings(classStore[classKey], classKey) then
+            classStore[classKey] = nil
+        else
+            local hasDifferingCandidate = false
+            for _, candidate in ipairs(candidates) do
+                if not DeepEqual(candidate.normalized, classStore[classKey]) then
+                    hasDifferingCandidate = true
+                    break
+                end
+            end
+            if hasDifferingCandidate then
+                StoreResourceBarConflict(state, classKey, candidateCharKeys, true)
+            else
+                RemoveLegacyResourceBarCandidates(profile, candidateCharKeys)
+                ClearResourceBarConflict(state, classKey)
+            end
+            return
+        end
+    end
+
+    local unique = {}
+    for _, candidate in ipairs(candidates) do
+        local matchIndex = FindMatchingResourceBarCandidateIndex(unique, candidate.normalized)
+        if matchIndex then
+            local uniqueCandidate = unique[matchIndex]
+            uniqueCandidate.charKeys[#uniqueCandidate.charKeys + 1] = candidate.charKey
+        else
+            unique[#unique + 1] = {
+                charKeys = { candidate.charKey },
+                normalized = candidate.normalized,
+            }
+        end
+    end
+
+    if #unique == 1 then
+        PromoteResourceBarClassSettings(classStore, classKey, unique[1].normalized)
+        RemoveLegacyResourceBarCandidates(profile, candidateCharKeys)
+        ClearResourceBarConflict(state, classKey)
+        return
+    end
+
+    StoreResourceBarConflict(state, classKey, candidateCharKeys)
+end
+
+local function GetResourceBarConflict(profile, classKey)
+    if not classKey then
+        return nil
+    end
+    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
+    local conflicts = type(state) == "table" and state.conflicts or nil
+    local conflict = type(conflicts) == "table" and conflicts[classKey] or nil
+    if type(conflict) ~= "table" then
+        return nil
+    end
+    local candidateCharKeys = type(conflict.candidateCharKeys) == "table" and conflict.candidateCharKeys or nil
+    if not candidateCharKeys or #candidateCharKeys == 0 then
+        return nil
+    end
+    local classStore = rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY)
+    if type(classStore) == "table"
+        and type(classStore[classKey]) == "table"
+        and conflict.includeExistingClass ~= true then
+        return nil
+    end
+    return conflict
+end
+
+local function BuildResourceBarConflictSummary(profile)
+    local summaries = {}
+    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
+    local conflicts = type(state) == "table" and state.conflicts or nil
+    if type(conflicts) ~= "table" then
+        return summaries
+    end
+    for _, classKey in ipairs(SortedMapKeys(conflicts)) do
+        local conflict = GetResourceBarConflict(profile, classKey)
+        if conflict then
+            local candidateCharKeys = CopyTable(conflict.candidateCharKeys or {})
+            sort(candidateCharKeys)
+            summaries[#summaries + 1] = {
+                classKey = classKey,
+                candidateCharKeys = candidateCharKeys,
+                candidateCount = #candidateCharKeys + (conflict.includeExistingClass and 1 or 0),
+                includeExistingClass = conflict.includeExistingClass == true,
+            }
+        end
+    end
+    return summaries
+end
+
+local function GetFallbackResourceBarSettings(addon, classKey)
+    if type(addon._resourceBarConflictFallbackSettings) ~= "table" then
+        addon._resourceBarConflictFallbackSettings = {}
+    end
+    local settings = addon._resourceBarConflictFallbackSettings[classKey]
+    if type(settings) ~= "table" then
+        local profile = addon.db and addon.db.profile
+        local classStore = type(profile) == "table" and rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY) or nil
+        local classSettings = type(classStore) == "table" and classStore[classKey] or nil
+        settings = type(classSettings) == "table" and CopyTable(classSettings) or CopySubsystemDefaults("resourceBars")
+        NormalizeResourceBarSettingsForClass(settings, classKey)
+        addon._resourceBarConflictFallbackSettings[classKey] = settings
+    end
+    return settings
+end
+
 function CooldownCompanion:CaptureLegacyScopedBarSettingsSeeds()
     local profile = self.db and self.db.profile
     if not profile then
         return
     end
 
+    CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
         CaptureLegacyScopedBarSystemSeed(profile, systemSpec)
     end
@@ -1193,6 +1386,15 @@ function CooldownCompanion:EnsureLegacyScopedBarSeenCharacters()
     end
 
     snapshot = {}
+
+    local resourceStore = rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.storeKey)
+    if type(resourceStore) == "table" then
+        for charKey, settings in pairs(resourceStore) do
+            if type(settings) == "table" then
+                MarkLegacyScopedBarSeenCharacter(snapshot, charKey)
+            end
+        end
+    end
 
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
         local store = rawget(profile, systemSpec.storeKey)
@@ -1280,14 +1482,89 @@ function CooldownCompanion:GetCharacterScopedSettings(systemKey)
     return settings
 end
 
+function CooldownCompanion:RunResourceBarClassScopeMigration()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return
+    end
+
+    local state = EnsureResourceBarMigrationState(profile)
+    state.unsafeCharKeys = {}
+    SeedCurrentLegacyResourceBarBucket(self, profile)
+
+    local classStore = EnsureResourceBarClassStore(profile)
+    for classKey, settings in pairs(classStore) do
+        if type(settings) == "table" then
+            NormalizeResourceBarSettingsForClass(settings, classKey)
+        end
+    end
+
+    local buckets = BuildResourceBarMigrationBuckets(self, profile, state)
+    for classKey in pairs(state.conflicts) do
+        if not buckets[classKey] then
+            state.conflicts[classKey] = nil
+        end
+    end
+    for _, classKey in ipairs(SortedMapKeys(buckets)) do
+        MigrateResourceBarClass(profile, classStore, state, classKey, buckets[classKey])
+    end
+end
+
+function CooldownCompanion:GetResourceBarClassSettingsStore()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+    return EnsureResourceBarClassStore(profile)
+end
+
+function CooldownCompanion:GetCurrentResourceBarClassKey()
+    return GetCurrentResourceBarClassKey(self)
+end
+
 function CooldownCompanion:EnsureCurrentCharacterScopedBarSettings()
-    self:GetCharacterScopedSettings("resourceBars")
+    self:GetResourceBarSettings()
     self:GetCharacterScopedSettings("castBar")
     self:GetCharacterScopedSettings("frameAnchoring")
 end
 
 function CooldownCompanion:GetResourceBarSettings()
-    return self:GetCharacterScopedSettings("resourceBars")
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+
+    local classKey = GetCurrentResourceBarClassKey(self)
+    if not classKey then
+        return nil
+    end
+
+    local conflict = GetResourceBarConflict(profile, classKey)
+    if conflict then
+        local currentCharKey = self.db and self.db.keys and self.db.keys.char
+        local legacyStore = GetResourceBarLegacyStore(profile, false)
+        local currentLegacy = type(legacyStore) == "table" and legacyStore[currentCharKey] or nil
+        if type(currentLegacy) == "table" then
+            if ResourceBarSettingsNeedsNormalizationForClass(currentLegacy, classKey) then
+                NormalizeResourceBarSettingsForClass(currentLegacy, classKey)
+            end
+            return currentLegacy
+        end
+        return GetFallbackResourceBarSettings(self, classKey)
+    end
+
+    local classStore = EnsureResourceBarClassStore(profile)
+    local settings = classStore[classKey]
+    if type(settings) ~= "table" then
+        settings = CopySubsystemDefaults("resourceBars")
+        NormalizeResourceBarSettingsForClass(settings, classKey)
+        SanitizeResourceBarAnchors(settings)
+        classStore[classKey] = settings
+    elseif ResourceBarSettingsNeedsNormalizationForClass(settings, classKey) then
+        NormalizeResourceBarSettingsForClass(settings, classKey)
+    end
+
+    return settings
 end
 
 function CooldownCompanion:GetCastBarSettings()
@@ -1296,6 +1573,134 @@ end
 
 function CooldownCompanion:GetFrameAnchoringSettings()
     return self:GetCharacterScopedSettings("frameAnchoring")
+end
+
+function CooldownCompanion:GetResourceBarMigrationState()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+    return EnsureResourceBarMigrationState(profile)
+end
+
+function CooldownCompanion:GetResourceBarConflict(classKey)
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+    return GetResourceBarConflict(profile, NormalizeClassKey(classKey))
+end
+
+function CooldownCompanion:GetCurrentResourceBarConflict()
+    return self:GetResourceBarConflict(GetCurrentResourceBarClassKey(self))
+end
+
+function CooldownCompanion:GetPendingResourceBarConflictSummary()
+    local profile = self.db and self.db.profile
+    return BuildResourceBarConflictSummary(profile)
+end
+
+function CooldownCompanion:HasPendingResourceBarConflicts()
+    return #self:GetPendingResourceBarConflictSummary() > 0
+end
+
+function CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    local summaries = self:GetPendingResourceBarConflictSummary()
+    if #summaries == 0 then
+        return nil
+    end
+
+    local parts = {}
+    for _, summary in ipairs(summaries) do
+        local candidateText = summary.candidateCount .. " candidate"
+        if summary.candidateCount ~= 1 then
+            candidateText = candidateText .. "s"
+        end
+        if summary.includeExistingClass then
+            candidateText = candidateText .. " including current class setup"
+        end
+        if #summary.candidateCharKeys > 0 then
+            candidateText = candidateText .. ": " .. concat(summary.candidateCharKeys, ", ")
+        end
+        parts[#parts + 1] = summary.classKey .. " (" .. candidateText .. ")"
+    end
+
+    return "Resolve pending Resource Bar conflicts before exporting. Affected classes: "
+        .. concat(parts, "; ")
+        .. ". Open Resource Bar settings on the affected class and choose the setup to keep."
+end
+
+function CooldownCompanion:GetResourceBarUnsafeLegacySummary()
+    local profile = self.db and self.db.profile
+    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
+    local unsafe = type(state) == "table" and state.unsafeCharKeys or nil
+    local keys = SortedMapKeys(unsafe)
+    return keys
+end
+
+function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, options)
+    local profile = self.db and self.db.profile
+    classKey = NormalizeClassKey(classKey)
+    local keepExistingClassStore = type(options) == "table" and options.keepExistingClassStore == true
+    if type(profile) ~= "table"
+        or not classKey
+        or (not keepExistingClassStore and (type(sourceCharKey) ~= "string" or sourceCharKey == "")) then
+        return false, "invalid_request"
+    end
+
+    local conflict = GetResourceBarConflict(profile, classKey)
+    if not conflict then
+        return false, "missing_conflict"
+    end
+
+    local classStore = EnsureResourceBarClassStore(profile)
+    if keepExistingClassStore then
+        if conflict.includeExistingClass ~= true then
+            return false, "invalid_candidate"
+        end
+        if type(classStore[classKey]) ~= "table" then
+            return false, "missing_candidate"
+        end
+        NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+        if classKey == GetCurrentResourceBarClassKey(self) then
+            SanitizeResourceBarAnchors(classStore[classKey])
+        end
+        RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
+        ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
+        if type(self._resourceBarConflictFallbackSettings) == "table" then
+            self._resourceBarConflictFallbackSettings[classKey] = nil
+        end
+        return true
+    end
+
+    local sourceAllowed = false
+    for _, candidateCharKey in ipairs(conflict.candidateCharKeys or {}) do
+        if candidateCharKey == sourceCharKey then
+            sourceAllowed = true
+            break
+        end
+    end
+    if not sourceAllowed then
+        return false, "invalid_candidate"
+    end
+
+    local legacyStore = GetResourceBarLegacyStore(profile, false)
+    local source = type(legacyStore) == "table" and legacyStore[sourceCharKey] or nil
+    if type(source) ~= "table" then
+        return false, "missing_candidate"
+    end
+
+    PromoteResourceBarClassSettings(classStore, classKey, source)
+    if classKey == GetCurrentResourceBarClassKey(self) then
+        SanitizeResourceBarAnchors(classStore[classKey])
+    end
+
+    RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
+    ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
+    if type(self._resourceBarConflictFallbackSettings) == "table" then
+        self._resourceBarConflictFallbackSettings[classKey] = nil
+    end
+    return true
 end
 
 function CooldownCompanion:GetCharacterScopedSettingsStore(systemKey)
@@ -1374,12 +1779,7 @@ function CooldownCompanion:CopyCharacterScopedSettings(systemKey, sourceCharKey)
         return false, "missing_source"
     end
 
-    local copied
-    if systemKey == "resourceBars" then
-        copied = ComposeCopiedResourceBarSettings(source, self:GetResourceBarSettings())
-    else
-        copied = CopyTable(source)
-    end
+    local copied = CopyTable(source)
     NormalizeScopedBarSettings(systemKey, copied)
     SanitizeCopiedOrSeededScopedBarSettings(systemKey, copied)
     store[currentChar] = copied

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -756,18 +756,16 @@ local function NormalizeResourceSpecOverridesForClass(settings, classKey)
     end
 end
 
-local function NormalizeCustomAuraBarsForClass(settings, classKey)
-    if type(settings) ~= "table" then
+local function ClearCustomBarLegacySpecFields(entry)
+    if type(entry) ~= "table" then
         return
     end
-    local barsBySpec = type(settings.customBars) == "table" and settings.customBars or settings.customAuraBars
-    if type(barsBySpec) ~= "table" then return end
+    entry.specID = nil
+    entry.spec = nil
+    entry.sourceSpecID = nil
+end
 
-    local allowedSpecIDs = GetClassSpecInfo(classKey)
-    if type(allowedSpecIDs) ~= "table" then
-        return
-    end
-
+local function NormalizeCustomBarStoreForClass(barsBySpec, allowedSpecIDs)
     local filtered = {}
     if IsSharedCustomBarsStore(barsBySpec) then
         filtered.entries = {}
@@ -787,6 +785,7 @@ local function NormalizeCustomAuraBarsForClass(settings, classKey)
                 end)
                 if not sawSpec or next(normalizedSpecs) then
                     copiedEntry.specs = normalizedSpecs
+                    ClearCustomBarLegacySpecFields(copiedEntry)
                     local customBarId = type(copiedEntry.customBarId) == "string" and copiedEntry.customBarId or key
                     if type(customBarId) == "string" and customBarId ~= "" then
                         filtered.entries[customBarId] = copiedEntry
@@ -812,15 +811,33 @@ local function NormalizeCustomAuraBarsForClass(settings, classKey)
             if type(specBars) == "table" and (
                 numericSpecID and allowedSpecIDs[numericSpecID]
             ) then
-                filtered[numericSpecID or key] = CopyTable(specBars)
+                local copiedSpecBars = CopyTable(specBars)
+                for _, entry in pairs(copiedSpecBars) do
+                    ClearCustomBarLegacySpecFields(entry)
+                end
+                filtered[numericSpecID or key] = copiedSpecBars
             end
         end
     end
 
+    return filtered
+end
+
+local function NormalizeCustomAuraBarsForClass(settings, classKey)
+    if type(settings) ~= "table" then
+        return
+    end
+
+    local allowedSpecIDs = GetClassSpecInfo(classKey)
+    if type(allowedSpecIDs) ~= "table" then
+        return
+    end
+
     if type(settings.customBars) == "table" then
-        settings.customBars = filtered
-    else
-        settings.customAuraBars = filtered
+        settings.customBars = NormalizeCustomBarStoreForClass(settings.customBars, allowedSpecIDs)
+    end
+    if type(settings.customAuraBars) == "table" then
+        settings.customAuraBars = NormalizeCustomBarStoreForClass(settings.customAuraBars, allowedSpecIDs)
     end
 end
 
@@ -862,11 +879,6 @@ local function SanitizeResourceBarAnchors(settings)
         settings.independentAnchor = nil
     end
 
-    local customBarsBySpec = type(settings.customBars) == "table" and settings.customBars or settings.customAuraBars
-    if type(customBarsBySpec) ~= "table" then
-        return
-    end
-
     local ensureCustomAuraBarAuraUnit = GetEnsureCustomAuraBarAuraUnit()
     local function sanitizeCustomBar(customAuraBar)
         if type(customAuraBar) == "table" then
@@ -885,20 +897,29 @@ local function SanitizeResourceBarAnchors(settings)
         end
     end
 
-    if IsSharedCustomBarsStore(customBarsBySpec) then
-        local entries = type(customBarsBySpec.entries) == "table" and customBarsBySpec.entries or {}
-        for _, customAuraBar in pairs(entries) do
-            sanitizeCustomBar(customAuraBar)
+    local function sanitizeCustomBarStore(customBarsBySpec)
+        if type(customBarsBySpec) ~= "table" then
+            return
         end
-    else
-        for _, specBars in pairs(customBarsBySpec) do
-            if type(specBars) == "table" then
-                for _, customAuraBar in pairs(specBars) do
-                    sanitizeCustomBar(customAuraBar)
+
+        if IsSharedCustomBarsStore(customBarsBySpec) then
+            local entries = type(customBarsBySpec.entries) == "table" and customBarsBySpec.entries or {}
+            for _, customAuraBar in pairs(entries) do
+                sanitizeCustomBar(customAuraBar)
+            end
+        else
+            for _, specBars in pairs(customBarsBySpec) do
+                if type(specBars) == "table" then
+                    for _, customAuraBar in pairs(specBars) do
+                        sanitizeCustomBar(customAuraBar)
+                    end
                 end
             end
         end
     end
+
+    sanitizeCustomBarStore(settings.customBars)
+    sanitizeCustomBarStore(settings.customAuraBars)
 end
 
 local function SanitizeCastBarAnchors(settings)
@@ -1113,6 +1134,14 @@ local function GetImportResourceBarCharacterInfo(addon)
     return addon and addon._resourceBarImportCharacterInfo
 end
 
+local function GetImportResourceBarExporterCharKey(addon)
+    local charKey = addon and addon._resourceBarImportExporterCharKey
+    if type(charKey) == "string" and charKey ~= "" then
+        return charKey
+    end
+    return nil
+end
+
 local function ResolveResourceBarCandidateClassKey(addon, charKey)
     local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
     if charKey == currentCharKey then
@@ -1127,6 +1156,41 @@ local function ResolveResourceBarCandidateClassKey(addon, charKey)
 
     local globalInfo = addon and addon.db and addon.db.global and addon.db.global.characterInfo
     return NormalizeClassKeyFromInfo(type(globalInfo) == "table" and globalInfo[charKey] or nil)
+end
+
+local function ClearLegacyResourceBarSeed(profile)
+    if type(profile) ~= "table" then
+        return
+    end
+    profile[RESOURCE_BAR_SYSTEM_SPEC.legacyKey] = nil
+    profile[RESOURCE_BAR_SYSTEM_SPEC.seedKey] = nil
+end
+
+local function SeedImportedLegacyResourceBarBucket(addon, profile)
+    local exporterCharKey = GetImportResourceBarExporterCharKey(addon)
+    if not exporterCharKey then
+        return false
+    end
+
+    local seed = CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
+    if type(seed) ~= "table" then
+        return true
+    end
+
+    local store = GetResourceBarLegacyStore(profile, false)
+    if not (type(store) == "table" and type(store[exporterCharKey]) == "table") then
+        local settings = CopyTable(seed)
+        local classKey = ResolveResourceBarCandidateClassKey(addon, exporterCharKey)
+        if classKey then
+            NormalizeResourceBarSettingsForClass(settings, classKey)
+        end
+        SanitizeResourceBarAnchors(settings)
+        store = GetResourceBarLegacyStore(profile, true)
+        store[exporterCharKey] = settings
+    end
+
+    ClearLegacyResourceBarSeed(profile)
+    return true
 end
 
 local function SeedCurrentLegacyResourceBarBucket(addon, profile)
@@ -1168,6 +1232,7 @@ end
 local function CopyNormalizedResourceBarCandidate(settings, classKey)
     local normalized = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(normalized, classKey)
+    SanitizeResourceBarAnchors(normalized)
     return normalized
 end
 
@@ -1245,6 +1310,7 @@ end
 local function PromoteResourceBarClassSettings(classStore, classKey, settings)
     classStore[classKey] = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+    SanitizeResourceBarAnchors(classStore[classKey])
 end
 
 local function MigrateResourceBarClass(profile, classStore, state, classKey, candidates)
@@ -1256,6 +1322,7 @@ local function MigrateResourceBarClass(profile, classStore, state, classKey, can
 
     if type(classStore[classKey]) == "table" then
         NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+        SanitizeResourceBarAnchors(classStore[classKey])
         if IsDefaultResourceBarClassSettings(classStore[classKey], classKey) then
             classStore[classKey] = nil
         else
@@ -1490,12 +1557,17 @@ function CooldownCompanion:RunResourceBarClassScopeMigration()
 
     local state = EnsureResourceBarMigrationState(profile)
     state.unsafeCharKeys = {}
-    SeedCurrentLegacyResourceBarBucket(self, profile)
+    if GetImportResourceBarExporterCharKey(self) then
+        SeedImportedLegacyResourceBarBucket(self, profile)
+    else
+        SeedCurrentLegacyResourceBarBucket(self, profile)
+    end
 
     local classStore = EnsureResourceBarClassStore(profile)
     for classKey, settings in pairs(classStore) do
         if type(settings) == "table" then
             NormalizeResourceBarSettingsForClass(settings, classKey)
+            SanitizeResourceBarAnchors(settings)
         end
     end
 

--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -16,6 +16,7 @@ local SetConfigCustomBarSettingsTab = ST._SetConfigCustomBarSettingsTab
 local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 local SetConfigResourceSettingsSpecID = ST._SetConfigResourceSettingsSpecID
 local PruneConfigResourceSelection = ST._PruneConfigResourceSelection
+local BlockCustomBarExportForResourceBarConflict = ST._BlockCustomBarExportForResourceBarConflict
 
 ------------------------------------------------------------------------
 -- COLUMN 4: Group / Panel Settings Column
@@ -244,6 +245,9 @@ local function ShowCustomBarMultiSelect(container, selectedIds, selectedEntries)
     exportBtn:SetText("Export Selected")
     exportBtn:SetFullWidth(true)
     exportBtn:SetCallback("OnClick", function()
+        if BlockCustomBarExportForResourceBarConflict and BlockCustomBarExportForResourceBarConflict() then
+            return
+        end
         local settings = CooldownCompanion:GetResourceBarSettings()
         local payload = ST._RB.BuildCustomBarsExportPayload and ST._RB.BuildCustomBarsExportPayload(settings, selectedEntries)
         local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)

--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -140,6 +140,10 @@ local function HideLayoutOrderDisabledScroll(container)
     HideWidgetFrame(container.layoutOrderDisabledScroll)
 end
 
+local function HideLayoutOrderConflictScroll(container)
+    HideWidgetFrame(container.layoutOrderConflictScroll)
+end
+
 local function HideResourceBarPanelSurfaces(container)
     HideFrame(container.placeholderLabel)
     HideWidgetFrame(container.tabGroup)
@@ -152,6 +156,7 @@ local function HideResourceBarPanelSurfaces(container)
     HideWidgetFrame(container.customBarEntryTabGroup)
     HideWidgetFrame(container.resourceSettingsDetailScroll)
     HideWidgetFrame(container.resourceSettingsTabGroup)
+    HideLayoutOrderConflictScroll(container)
     HideFrame(container.layoutOrderHost)
 end
 
@@ -176,6 +181,38 @@ local function ShowLayoutOrderDisabledScroll(container)
     local label = AceGUI:Create("Label")
     ST._ConfigureWrappedHelperLabel(label)
     label:SetText("Enable Resource Bars or Cast Bar to configure layout.")
+    label:SetFullWidth(true)
+    scroll:AddChild(label)
+end
+
+local function ShowLayoutOrderConflictScroll(container)
+    HideResourceBarPanelSurfaces(container)
+
+    if not container.layoutOrderConflictScroll then
+        local scroll = AceGUI:Create("ScrollFrame")
+        scroll:SetLayout("List")
+        scroll.frame:SetParent(container)
+        container.layoutOrderConflictScroll = scroll
+    end
+
+    local scroll = container.layoutOrderConflictScroll
+    scroll.frame:SetParent(container)
+    scroll.frame:ClearAllPoints()
+    scroll.frame:SetPoint("TOPLEFT", container, "TOPLEFT", 0, 0)
+    scroll.frame:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", 0, 0)
+    scroll:ReleaseChildren()
+    scroll.frame:Show()
+
+    local RBP = ST._RBP
+    if RBP and RBP.BuildResourceBarConflictGate
+        and RBP.BuildResourceBarConflictGate(scroll, "Layout & Order", true)
+    then
+        return
+    end
+
+    local label = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(label)
+    label:SetText("Resolve Resource Bars before editing Layout & Order.")
     label:SetFullWidth(true)
     scroll:AddChild(label)
 end
@@ -350,10 +387,16 @@ local function RefreshColumn4(container)
         container._browsePlaceholder:Hide()
     end
     HideLayoutOrderDisabledScroll(container)
+    HideLayoutOrderConflictScroll(container)
 
     -- Resource Bar panel mode: show selected Custom Bar settings, or Layout & Order.
     if CS.resourceBarPanelActive then
         HideResourceBarPanelSurfaces(container)
+        if CooldownCompanion.GetCurrentResourceBarConflict and CooldownCompanion:GetCurrentResourceBarConflict() then
+            ShowLayoutOrderConflictScroll(container)
+            return
+        end
+
         local resourceBarsEnabled = AreResourceBarsConfigEnabled()
         local castBarsEnabled = AreCastBarsConfigEnabled()
         if not (resourceBarsEnabled or castBarsEnabled) then

--- a/CooldownCompanion_Config/Config/Diagnostics.lua
+++ b/CooldownCompanion_Config/Config/Diagnostics.lua
@@ -368,8 +368,10 @@ local function BuildDiagnosticSnapshot()
     for _, folder in pairs(db.profile.folders) do
         cacheSpecsFromTable(folder.specs)
     end
-    local resourceStores = rawget(db.profile, "resourceBarsByChar")
-    if type(resourceStores) == "table" then
+    local function cacheSpecsFromResourceStores(resourceStores)
+        if type(resourceStores) ~= "table" then
+            return
+        end
         for _, resourceSettings in pairs(resourceStores) do
             local customBars = type(resourceSettings) == "table"
                 and (type(resourceSettings.customBars) == "table" and resourceSettings.customBars or resourceSettings.customAuraBars)
@@ -396,6 +398,8 @@ local function BuildDiagnosticSnapshot()
             end
         end
     end
+    cacheSpecsFromResourceStores(rawget(db.profile, "resourceBarsByClass"))
+    cacheSpecsFromResourceStores(rawget(db.profile, "resourceBarsByChar"))
     snapshot.meta.specNameCache = specNameCache
 
     -- Keep the decoded report compact while attaching an importable profile.

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -117,6 +117,11 @@ local function StripCharacterEligibilityFromResourceBarStores(profile)
             stripped = stripped + StripCharacterEligibilityFromResourceBarSettings(settings)
         end
     end
+    if type(profile.resourceBarsByClass) == "table" then
+        for _, settings in pairs(profile.resourceBarsByClass) do
+            stripped = stripped + StripCharacterEligibilityFromResourceBarSettings(settings)
+        end
+    end
     return stripped
 end
 
@@ -300,6 +305,7 @@ local PROFILE_DEFAULT_KEYS = {
     globalStyle = "globalStyle",
     locked = "locked",
     cdmHidden = "cdmHidden",
+    resourceBarMigration = "resourceBarMigration",
     resourceBars = "resourceBars",
     castBar = "castBar",
     frameAnchoring = "frameAnchoring",
@@ -338,6 +344,7 @@ local SCOPED_SYSTEM_DEFAULTS = {
 }
 
 local SCOPED_STORE_KEYS = {
+    resourceBarsByClass = "resourceBars",
     resourceBarsByChar = "resourceBars",
     castBarByChar = "castBar",
     frameAnchoringByChar = "frameAnchoring",

--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -248,14 +248,32 @@ local function BuildProfileSummaryLines(profile, heading, customBarCount)
         AddLine(lines, FormatCount("Custom Bars", customBarCount))
     end
 
-    local scoped = {}
+    local classScoped = {}
+    local characterScoped = {}
+    local legacyScoped = {}
     if type(profile) == "table" then
-        if type(profile.resourceBarsByChar) == "table" then scoped[#scoped + 1] = "Resource/Custom Bars" end
-        if type(profile.castBarByChar) == "table" then scoped[#scoped + 1] = "Cast Bar" end
-        if type(profile.frameAnchoringByChar) == "table" then scoped[#scoped + 1] = "Frame Anchoring" end
+        if type(profile.resourceBarsByClass) == "table" then classScoped[#classScoped + 1] = "Resource/Custom Bars" end
+        if type(profile.resourceBarsByChar) == "table" then legacyScoped[#legacyScoped + 1] = "legacy Resource/Custom Bars" end
+        if type(profile.castBarByChar) == "table" then characterScoped[#characterScoped + 1] = "Cast Bar" end
+        if type(profile.frameAnchoringByChar) == "table" then characterScoped[#characterScoped + 1] = "Frame Anchoring" end
     end
-    if #scoped > 0 then
-        AddLine(lines, "Character-scoped settings: " .. table.concat(scoped, ", "))
+    if #classScoped > 0 then
+        AddLine(lines, "Class-scoped settings: " .. table.concat(classScoped, ", "))
+    end
+    if #characterScoped > 0 then
+        AddLine(lines, "Character-scoped settings: " .. table.concat(characterScoped, ", "))
+    end
+    if #legacyScoped > 0 then
+        AddLine(lines, "Unresolved legacy settings: " .. table.concat(legacyScoped, ", "))
+    end
+    local migration = type(profile) == "table" and profile.resourceBarMigration or nil
+    local conflicts = type(migration) == "table" and migration.conflicts or nil
+    local unsafe = type(migration) == "table" and migration.unsafeCharKeys or nil
+    if CountPairs(conflicts) > 0 then
+        AddLine(lines, FormatCount("Pending Resource Bar conflicts", CountPairs(conflicts)))
+    end
+    if CountPairs(unsafe) > 0 then
+        AddLine(lines, FormatCount("Resource Bar buckets missing class metadata", CountPairs(unsafe)))
     end
     return lines
 end
@@ -567,6 +585,7 @@ function CooldownCompanion:ApplyReviewedImport(review)
             local meta = GetDiagnosticMeta(review.diagnostic)
             options.dataLabel = "diagnostic profile"
             options.exporterCharKey = meta and meta.charKey
+            options.exportedCharInfo = BuildDiagnosticSourceCharacterInfo(meta)
             options.runtimeReason = "diagnostic-profile-import"
             options.renameForeignCharacters = false
             successMessage = "Diagnostic profile restored."

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -1596,6 +1596,7 @@ local function ApplyCustomBarsImportData(data, options)
     return true
 end
 
+ST._BlockCustomBarsImportForResourceBarConflict = BlockCustomBarsImportForResourceBarConflict
 ST._ApplyCustomBarsImportData = ApplyCustomBarsImportData
 
 StaticPopupDialogs["CDC_EXPORT_CUSTOM_BARS"] = {

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -241,8 +241,9 @@ local function ShowResourceBarConflictChooser(classKey, opts)
     AddResourceBarConflictSpacer(chooser, 14)
 
     local bullets = {
-        "The setup you KEEP, including Resource settings, Custom Bars, and Resource Aura overlays, will be saved for the whole class.",
-        "The other listed character setups for this class will be removed.",
+        "The Resource settings and Resource Aura overlays from the setup you KEEP will be saved for the whole class.",
+        "Custom Bars from every listed same-class setup will be preserved and added to the saved class setup.",
+        "The other listed character Resource settings and Resource Aura overlays will be removed.",
         "Going forward, every character of this class will use the saved setup.",
         "Per-spec layouts, resource overrides, and aura overlays still work inside that class setup.",
     }
@@ -708,8 +709,8 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
-        if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
-            local blockMessage = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+        if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
+            local blockMessage = CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
             if blockMessage then
                 self.EditBox:SetText(blockMessage)
                 self.EditBox:HighlightText()
@@ -947,8 +948,8 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
 ------------------------------------------------------------------------
 
 local function GetCustomBarExportConflictBlockMessage()
-    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
-        return CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
+        return CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
     end
     return nil
 end

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -7,6 +7,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CS = ST._configState
+local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 
 local ResetConfigSelection = ST._ResetConfigSelection
 local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
@@ -79,6 +80,282 @@ local function ShowPopupOverConfig(which, textArg1, data)
     end
     return StaticPopup_Show(which, textArg1, nil, data)
 end
+
+local function CountTableEntries(value)
+    local count = 0
+    if type(value) ~= "table" then
+        return count
+    end
+    for _ in pairs(value) do
+        count = count + 1
+    end
+    return count
+end
+
+local function ResourceBarCandidateDetail(settings)
+    if type(settings) ~= "table" then
+        return "Unavailable"
+    end
+    local customBars = settings.customBars
+    local customBarCount = 0
+    if type(customBars) == "table" then
+        if type(customBars.entries) == "table" then
+            customBarCount = CountTableEntries(customBars.entries)
+        else
+            for _, specBars in pairs(customBars) do
+                customBarCount = customBarCount + CountTableEntries(specBars)
+            end
+        end
+    end
+    return ("%d resources, %d custom bars"):format(CountTableEntries(settings.resources), customBarCount)
+end
+
+local function AddResourceBarConflictSpacer(chooser, height)
+    local spacer = AceGUI:Create("SimpleGroup")
+    spacer:SetFullWidth(true)
+    spacer:SetHeight(height)
+    spacer:SetLayout(nil)
+    chooser:AddChild(spacer)
+end
+
+local function AddResourceBarConflictText(chooser, text, fontObject)
+    local label = AceGUI:Create("Label")
+    label:SetText(text)
+    label:SetFullWidth(true)
+    if fontObject then
+        label:SetFontObject(fontObject)
+    end
+    chooser:AddChild(label)
+end
+
+local function ReturnResourceBarConflictFocus()
+    local button = CS and CS.resourceBarConflictResolveButton
+    if button and button.frame and button.frame.SetFocus then
+        button.frame:SetFocus()
+    end
+end
+
+local function AnchorResourceBarConflictChooser(chooser)
+    local frame = chooser and chooser.frame
+    if not frame then
+        return
+    end
+
+    frame:SetParent(UIParent)
+    frame:ClearAllPoints()
+    frame:SetPoint("CENTER", UIParent, "CENTER", 0, 80)
+end
+
+local function RaiseResourceBarConflictChooser(chooser)
+    local frame = chooser and chooser.frame
+    if not frame then
+        return
+    end
+
+    frame:SetParent(UIParent)
+    frame:SetFrameStrata("TOOLTIP")
+    frame:SetToplevel(true)
+    if frame.SetFrameLevel then
+        frame:SetFrameLevel(1000)
+    end
+    if frame.Raise then
+        frame:Raise()
+    end
+end
+
+local function HideResourceBarConflictChooser(markDismissed)
+    local chooser = CS and CS.resourceBarConflictChooser
+    if not chooser then
+        return
+    end
+    if markDismissed and chooser.classKey then
+        CS.resourceBarConflictChooserDismissed = CS.resourceBarConflictChooserDismissed or {}
+        CS.resourceBarConflictChooserDismissed[chooser.classKey] = true
+    end
+    chooser:Hide()
+    if chooser.frame then
+        chooser.frame:SetScript("OnKeyDown", nil)
+        chooser.frame:EnableKeyboard(false)
+        if chooser.frame.SetPropagateKeyboardInput then
+            chooser.frame:SetPropagateKeyboardInput(true)
+        end
+    end
+    ReturnResourceBarConflictFocus()
+end
+
+local function ShowResourceBarConflictChooser(classKey, opts)
+    opts = opts or {}
+    classKey = classKey or (CooldownCompanion.GetCurrentResourceBarClassKey and CooldownCompanion:GetCurrentResourceBarClassKey())
+    local conflict = classKey and CooldownCompanion.GetResourceBarConflict and CooldownCompanion:GetResourceBarConflict(classKey) or nil
+    if not conflict then
+        return false
+    end
+    CS.resourceBarConflictChooserDismissed = CS.resourceBarConflictChooserDismissed or {}
+    if CS.resourceBarConflictChooserDismissed[classKey] and not opts.force then
+        return false
+    end
+    if not AceGUI then
+        CooldownCompanion:Print("Resource Bar conflict chooser is unavailable.")
+        return false
+    end
+
+    local chooser = CS.resourceBarConflictChooser
+    if not chooser then
+        chooser = AceGUI:Create("Window")
+        chooser:SetTitle("Resolve Resource Bars")
+        chooser:SetWidth(560)
+        chooser:SetHeight(360)
+        chooser:SetLayout("List")
+        chooser:EnableResize(false)
+        chooser:SetCallback("OnClose", function()
+            HideResourceBarConflictChooser(true)
+        end)
+        CS.resourceBarConflictChooser = chooser
+    else
+        chooser:Show()
+        chooser:ReleaseChildren()
+    end
+
+    chooser.classKey = classKey
+    chooser.selectedIndex = 1
+
+    local legacyStore = CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.resourceBarsByChar
+        or nil
+    local classStore = CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.resourceBarsByClass
+        or nil
+    local existingClassSettings = conflict.includeExistingClass
+        and type(classStore) == "table"
+        and classStore[classKey]
+        or nil
+    local rows = {}
+    local candidateCharKeys = conflict.candidateCharKeys or {}
+    local candidateCount = #candidateCharKeys + (type(existingClassSettings) == "table" and 1 or 0)
+
+    AddResourceBarConflictText(chooser,
+        "Choose the Resource Bar setup to |cffffd100KEEP|r for " .. tostring(classKey) .. ".",
+        GameFontHighlight)
+    AddResourceBarConflictSpacer(chooser, 14)
+
+    local bullets = {
+        "The setup you KEEP, including Resource settings, Custom Bars, and Resource Aura overlays, will be saved for the whole class.",
+        "The other listed character setups for this class will be removed.",
+        "Going forward, every character of this class will use the saved setup.",
+        "Per-spec layouts, resource overrides, and aura overlays still work inside that class setup.",
+    }
+    for index, text in ipairs(bullets) do
+        AddResourceBarConflictText(chooser, "- " .. text, GameFontHighlight)
+        if index < #bullets then
+            AddResourceBarConflictSpacer(chooser, 14)
+        end
+    end
+    AddResourceBarConflictSpacer(chooser, 24)
+
+    local function selectRow(index)
+        chooser.selectedIndex = index
+        for rowIndex, row in ipairs(rows) do
+            if row.SetText then
+                local prefix = rowIndex == index and "> " or "  "
+                row:SetText(prefix .. (row.candidateText or ""))
+            end
+        end
+    end
+
+    local function chooseRow(index)
+        local row = rows[index]
+        if not row then
+            return
+        end
+        local options = row.keepExistingClassStore and { keepExistingClassStore = true } or nil
+        local ok, reason = CooldownCompanion:ResolveResourceBarConflict(classKey, row.sourceCharKey, options)
+        if not ok then
+            CooldownCompanion:Print("Resource Bar resolution failed: " .. tostring(reason or "unknown error"))
+            return
+        end
+        HideResourceBarConflictChooser(false)
+        if CooldownCompanion.ApplyResourceBars then
+            CooldownCompanion:ApplyResourceBars()
+        end
+        if CooldownCompanion.UpdateAnchorStacking then
+            CooldownCompanion:UpdateAnchorStacking()
+        end
+        if CooldownCompanion.RefreshConfigPanel then
+            CooldownCompanion:RefreshConfigPanel()
+        end
+    end
+
+    local function addCandidateRow(sourceCharKey, candidateText, options)
+        local index = #rows + 1
+        local row = AceGUI:Create("Button")
+        row.sourceCharKey = sourceCharKey
+        row.keepExistingClassStore = options and options.keepExistingClassStore == true
+        row.candidateText = candidateText
+        row:SetFullWidth(true)
+        row:SetText("  " .. candidateText)
+        row:SetCallback("OnClick", function()
+            chooseRow(index)
+        end)
+        rows[index] = row
+        chooser:AddChild(row)
+        if index < candidateCount then
+            AddResourceBarConflictSpacer(chooser, 10)
+        end
+    end
+
+    if type(existingClassSettings) == "table" then
+        addCandidateRow(nil,
+            "Current class setup - " .. ResourceBarCandidateDetail(existingClassSettings),
+            { keepExistingClassStore = true })
+    end
+
+    for _, sourceCharKey in ipairs(candidateCharKeys) do
+        addCandidateRow(sourceCharKey,
+            sourceCharKey .. " - "
+                .. ResourceBarCandidateDetail(type(legacyStore) == "table" and legacyStore[sourceCharKey] or nil))
+    end
+
+    AddResourceBarConflictSpacer(chooser, 14)
+
+    local closeButton = AceGUI:Create("Button")
+    closeButton:SetText("Later")
+    closeButton:SetWidth(90)
+    closeButton:SetCallback("OnClick", function()
+        HideResourceBarConflictChooser(true)
+    end)
+    chooser:AddChild(closeButton)
+
+    chooser:SetHeight(math.max(460, 390 + (candidateCount * 38) + (math.max(candidateCount - 1, 0) * 10)))
+    chooser.frame:SetScript("OnKeyDown", function(_, key)
+        if key == "ESCAPE" then
+            HideResourceBarConflictChooser(true)
+        elseif key == "ENTER" or key == "SPACE" then
+            chooseRow(chooser.selectedIndex or 1)
+        elseif key == "DOWN" or key == "TAB" then
+            local nextIndex = (chooser.selectedIndex or 1) + 1
+            if nextIndex > candidateCount then nextIndex = 1 end
+            selectRow(nextIndex)
+        elseif key == "UP" then
+            local nextIndex = (chooser.selectedIndex or 1) - 1
+            if nextIndex < 1 then nextIndex = candidateCount end
+            selectRow(nextIndex)
+        end
+    end)
+    chooser.frame:EnableKeyboard(true)
+    if chooser.frame.SetPropagateKeyboardInput then
+        chooser.frame:SetPropagateKeyboardInput(false)
+    end
+    chooser:Show()
+    AnchorResourceBarConflictChooser(chooser)
+    RaiseResourceBarConflictChooser(chooser)
+    selectRow(1)
+    return true
+end
+
+ST._ShowResourceBarConflictChooser = ShowResourceBarConflictChooser
+ST._HideResourceBarConflictChooser = HideResourceBarConflictChooser
 
 local function PruneDeletedFolderSelection(folderId)
     local db = CooldownCompanion.db and CooldownCompanion.db.profile
@@ -431,6 +708,18 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
+        if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+            local blockMessage = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+            if blockMessage then
+                self.EditBox:SetText(blockMessage)
+                self.EditBox:HighlightText()
+                self.EditBox:SetFocus()
+                if CooldownCompanion.Print then
+                    CooldownCompanion:Print(blockMessage)
+                end
+                return
+            end
+        end
         local db = CooldownCompanion.db
         local exportData = CopyTable(db.profile)
         exportData._exporterCharKey = db.keys.char
@@ -657,6 +946,24 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
 -- Group/Folder Export and Apply
 ------------------------------------------------------------------------
 
+local function GetCustomBarExportConflictBlockMessage()
+    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+        return CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    end
+    return nil
+end
+
+local function BlockCustomBarExportForResourceBarConflict()
+    local message = GetCustomBarExportConflictBlockMessage()
+    if message then
+        if CooldownCompanion.Print then
+            CooldownCompanion:Print(message)
+        end
+        return true, message
+    end
+    return false, nil
+end
+
 local function BuildGroupExportData(group)
     local data = CopyTable(group)
     data.createdBy = nil
@@ -668,6 +975,12 @@ local function BuildGroupExportData(group)
 end
 
 local function EncodeExportData(payload)
+    if type(payload) == "table" and payload.type == "customBars" then
+        local blocked = BlockCustomBarExportForResourceBarConflict()
+        if blocked then
+            return nil
+        end
+    end
     return EncodeSharedPayload(payload, "entity")
 end
 
@@ -742,6 +1055,7 @@ end
 ST._BuildGroupExportData = BuildGroupExportData
 ST._BuildContainerExportData = BuildContainerExportData
 ST._EncodeExportData = EncodeExportData
+ST._BlockCustomBarExportForResourceBarConflict = BlockCustomBarExportForResourceBarConflict
 
 local function BuildImportedRootAnchor(relativeTo)
     return {
@@ -1223,6 +1537,27 @@ StaticPopupDialogs["CDC_EXPORT_GROUP"] = {
     preferredIndex = 3,
 }
 
+local function BlockCustomBarsImportForResourceBarConflict()
+    local classKey = CooldownCompanion.GetCurrentResourceBarClassKey
+        and CooldownCompanion:GetCurrentResourceBarClassKey()
+        or nil
+    local conflict = CooldownCompanion.GetCurrentResourceBarConflict
+        and CooldownCompanion:GetCurrentResourceBarConflict()
+        or nil
+    if not conflict then
+        return false
+    end
+
+    local message = "Resolve the pending Resource Bar conflict"
+        .. (classKey and (" for " .. tostring(classKey)) or "")
+        .. " before importing Custom Bars. Choose the setup to keep, then import again."
+    CooldownCompanion:Print(message)
+    if ST._ShowResourceBarConflictChooser then
+        ST._ShowResourceBarConflictChooser(classKey, { force = true })
+    end
+    return true
+end
+
 local function ApplyCustomBarsImportData(data, options)
     if type(data) ~= "table" or data.type ~= "customBars" then
         if RejectUnsupportedImportPayload(data, "custom bars import") then
@@ -1232,6 +1567,9 @@ local function ApplyCustomBarsImportData(data, options)
         return false
     end
     if RejectUnsupportedImportPayload(data, "custom bars import") then
+        return false
+    end
+    if BlockCustomBarsImportForResourceBarConflict() then
         return false
     end
     local importState = options and options.importState or NewGroupImportState()
@@ -1265,6 +1603,13 @@ StaticPopupDialogs["CDC_EXPORT_CUSTOM_BARS"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
+        local blocked, blockMessage = BlockCustomBarExportForResourceBarConflict()
+        if blocked then
+            self.EditBox:SetText(blockMessage or "Resolve pending Resource Bar conflicts before exporting Custom Bars.")
+            self.EditBox:HighlightText()
+            self.EditBox:SetFocus()
+            return
+        end
         if self.data and self.data.exportString then
             self.EditBox:SetText(self.data.exportString)
             self.EditBox:HighlightText()

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -564,12 +564,14 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     local globalizedEligibilityImports = GlobalizePortableCharacterScopedEligibility(db.profile)
 
     self._resourceBarImportCharacterInfo = exportedCharInfo
+    self._resourceBarImportExporterCharKey = exporterCharKey
 
     if self.ClearMigrationSentinels then
         self:ClearMigrationSentinels()
     end
     local migrationsOk = not self.RunAllMigrations or self:RunAllMigrations()
     self._resourceBarImportCharacterInfo = nil
+    self._resourceBarImportExporterCharKey = nil
     if not migrationsOk then
         return false
     end

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -16,7 +16,6 @@ local PROFILE_IMPORT_METADATA_KEYS = {
 }
 
 local SCOPED_STORE_KEYS = {
-    "resourceBarsByChar",
     "castBarByChar",
     "frameAnchoringByChar",
 }
@@ -564,10 +563,14 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     end
     local globalizedEligibilityImports = GlobalizePortableCharacterScopedEligibility(db.profile)
 
+    self._resourceBarImportCharacterInfo = exportedCharInfo
+
     if self.ClearMigrationSentinels then
         self:ClearMigrationSentinels()
     end
-    if self.RunAllMigrations and not self:RunAllMigrations() then
+    local migrationsOk = not self.RunAllMigrations or self:RunAllMigrations()
+    self._resourceBarImportCharacterInfo = nil
+    if not migrationsOk then
         return false
     end
     if self.SanitizeCursorAnchorPolicy then

--- a/CooldownCompanion_Config/Config/ProfileImportPieces.lua
+++ b/CooldownCompanion_Config/Config/ProfileImportPieces.lua
@@ -330,15 +330,40 @@ local function GetOwnerInfo(profile, ownerKey, sourceCharacterInfo)
     return type(globalInfo) == "table" and globalInfo[ownerKey] or nil
 end
 
+local function NormalizeClassKey(classKey)
+    if type(classKey) ~= "string" or classKey == "" then return nil end
+    return string.upper(classKey)
+end
+
 local function ClassesMatch(currentInfo, ownerInfo)
     if type(currentInfo) ~= "table" or type(ownerInfo) ~= "table" then
         return nil
     end
-    if currentInfo.classFilename and ownerInfo.classFilename then
-        return currentInfo.classFilename == ownerInfo.classFilename
+    local currentClassKey = NormalizeClassKey(currentInfo.classFilename or currentInfo.classFile or currentInfo.className)
+    local ownerClassKey = NormalizeClassKey(ownerInfo.classFilename or ownerInfo.classFile or ownerInfo.className)
+    if currentClassKey and ownerClassKey then
+        return currentClassKey == ownerClassKey
     end
     if currentInfo.classID and ownerInfo.classID then
         return currentInfo.classID == ownerInfo.classID
+    end
+    return nil
+end
+
+local function ClassKeyFromInfo(info)
+    if type(info) ~= "table" then return nil end
+    local classKey = NormalizeClassKey(info.classFilename or info.classFile or info.className)
+    if classKey then return classKey end
+    local classID = tonumber(info.classID)
+    if classID and C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return NormalizeClassKey(classInfo.classFile)
+        end
+    end
+    if classID and GetClassInfo then
+        local _, classFilename = GetClassInfo(classID)
+        return NormalizeClassKey(classFilename)
     end
     return nil
 end
@@ -347,7 +372,7 @@ local function ClassLabel(info)
     if type(info) ~= "table" then
         return "Unknown class"
     end
-    return info.classFilename or (info.classID and ("Class " .. tostring(info.classID))) or "Unknown class"
+    return info.classFilename or info.classFile or (info.classID and ("Class " .. tostring(info.classID))) or "Unknown class"
 end
 
 local function ResolveOwnerKey(entity, defaultOwnerKey)
@@ -372,6 +397,18 @@ local function BuildEligibility(profile, ownerKey, currentCharKey, currentInfo, 
     end
     if matches == nil then
         return false, false, "Source class unknown"
+    end
+    return true, true, nil
+end
+
+local function BuildClassStoreEligibility(sourceClassKey, currentInfo)
+    sourceClassKey = NormalizeClassKey(sourceClassKey)
+    local currentClassKey = ClassKeyFromInfo(currentInfo)
+    if not sourceClassKey or not currentClassKey then
+        return false, false, "Source class unknown"
+    end
+    if sourceClassKey ~= currentClassKey then
+        return false, false, sourceClassKey .. " content"
     end
     return true, true, nil
 end
@@ -580,13 +617,18 @@ local function AddCustomBarInfo(infos, profile, settings, sourceStoreKey, entryK
     end
     options = options or {}
     local ownerKey = sourceStoreKey
-    local eligible, selected, reason = BuildEligibility(
-        profile,
-        ownerKey,
-        options.currentCharKey,
-        options.currentInfo,
-        options.sourceCharacterInfo
-    )
+    local eligible, selected, reason
+    if options.sourceClassKey then
+        eligible, selected, reason = BuildClassStoreEligibility(options.sourceClassKey, options.currentInfo)
+    else
+        eligible, selected, reason = BuildEligibility(
+            profile,
+            ownerKey,
+            options.currentCharKey,
+            options.currentInfo,
+            options.sourceCharacterInfo
+        )
+    end
     local rawId = type(entry.customBarId) == "string" and entry.customBarId ~= "" and entry.customBarId
         or (type(entryKey) == "string" and entryKey or nil)
     local specs = CollectEntrySpecs(entry, options.fallbackSpecID)
@@ -648,6 +690,7 @@ local function AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey,
                     currentCharKey = options.currentCharKey,
                     currentInfo = options.currentInfo,
                     sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
                     infoByRawId = options.infoByRawId,
                     order = order,
                 })
@@ -661,6 +704,7 @@ local function AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey,
                 currentCharKey = options.currentCharKey,
                 currentInfo = options.currentInfo,
                 sourceCharacterInfo = options.sourceCharacterInfo,
+                sourceClassKey = options.sourceClassKey,
                 infoByRawId = options.infoByRawId,
                 order = order,
             })
@@ -682,6 +726,7 @@ local function AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreK
                         currentCharKey = options.currentCharKey,
                         currentInfo = options.currentInfo,
                         sourceCharacterInfo = options.sourceCharacterInfo,
+                        sourceClassKey = options.sourceClassKey,
                         fallbackSpecID = specID,
                         infoByRawId = options.infoByRawId,
                         legacyAuraSlots = options.legacyAuraSlots,
@@ -695,37 +740,68 @@ end
 
 local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceCharacterInfo)
     local infos = {}
-    local stores = type(profile) == "table" and profile.resourceBarsByChar or nil
-    if type(stores) ~= "table" then
-        return infos
-    end
+    local classStores = type(profile) == "table" and profile.resourceBarsByClass or nil
+    local legacyStores = type(profile) == "table" and profile.resourceBarsByChar or nil
+    local resolvedClassStores = {}
 
-    for sourceStoreKey, settings in pairs(stores) do
+    local function addFromSettings(sourceStoreKey, settings, options)
         if type(settings) == "table" then
             local infoByRawId = {}
             local customBars = settings.customBars
             if IsSharedCustomBarsStore(customBars) then
                 AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey, customBars, {
-                    currentCharKey = currentCharKey,
-                    currentInfo = currentInfo,
-                    sourceCharacterInfo = sourceCharacterInfo,
+                    currentCharKey = options.currentCharKey,
+                    currentInfo = options.currentInfo,
+                    sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
                 })
             elseif type(customBars) == "table" then
                 AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreKey, customBars, {
-                    currentCharKey = currentCharKey,
-                    currentInfo = currentInfo,
-                    sourceCharacterInfo = sourceCharacterInfo,
+                    currentCharKey = options.currentCharKey,
+                    currentInfo = options.currentInfo,
+                    sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
                 })
             end
             if type(settings.customAuraBars) == "table" then
                 AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreKey, settings.customAuraBars, {
+                    currentCharKey = options.currentCharKey,
+                    currentInfo = options.currentInfo,
+                    sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
+                    infoByRawId = infoByRawId,
+                    legacyAuraSlots = true,
+                })
+            end
+        end
+    end
+
+    if type(classStores) == "table" then
+        for sourceClassKey, settings in pairs(classStores) do
+            local normalizedClassKey = NormalizeClassKey(sourceClassKey)
+            if normalizedClassKey and type(settings) == "table" then
+                resolvedClassStores[normalizedClassKey] = true
+                addFromSettings(normalizedClassKey, settings, {
                     currentCharKey = currentCharKey,
                     currentInfo = currentInfo,
                     sourceCharacterInfo = sourceCharacterInfo,
-                    infoByRawId = infoByRawId,
-                    legacyAuraSlots = true,
+                    sourceClassKey = normalizedClassKey,
+                })
+            end
+        end
+    end
+
+    if type(legacyStores) == "table" then
+        for sourceStoreKey, settings in pairs(legacyStores) do
+            local ownerInfo = GetOwnerInfo(profile, sourceStoreKey, sourceCharacterInfo)
+            local ownerClassKey = ClassKeyFromInfo(ownerInfo)
+            if not ownerClassKey or not resolvedClassStores[ownerClassKey] then
+                addFromSettings(sourceStoreKey, settings, {
+                    currentCharKey = currentCharKey,
+                    currentInfo = currentInfo,
+                    sourceCharacterInfo = sourceCharacterInfo,
                 })
             end
         end

--- a/CooldownCompanion_Config/Config/ProfileImportPieces.lua
+++ b/CooldownCompanion_Config/Config/ProfileImportPieces.lua
@@ -9,6 +9,7 @@ local CooldownCompanion = ST.Addon
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local ApplyCustomBarsImportData = ST._ApplyCustomBarsImportData
+local BlockCustomBarsImportForResourceBarConflict = ST._BlockCustomBarsImportForResourceBarConflict
 
 local EMPTY_TABLE = {}
 local CUSTOM_BAR_CONTENT_FIELDS = {
@@ -1034,6 +1035,12 @@ local function ApplyCustomBarsPayload(profile, payload)
     }) == true
 end
 
+local function ShouldBlockSelectedCustomBarsImport()
+    local block = BlockCustomBarsImportForResourceBarConflict
+        or ST._BlockCustomBarsImportForResourceBarConflict
+    return block and block() == true
+end
+
 local function SetChildSelection(row, selected)
     if not (row and row.eligible) then
         return
@@ -1076,6 +1083,11 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
     end
 
     local selectedFolders, selectedContainers, selectedPanels, selectedCustomBars, deselectedContainers, deselectedPanels = SelectionSets(model)
+    local selectedCustomBarsPayload = BuildSelectedCustomBarsPayload(model, selectedCustomBars)
+    if selectedCustomBarsPayload and ShouldBlockSelectedCustomBarsImport() then
+        return false
+    end
+
     local importedContainers = {}
     local batchToken = BeginImportBatch()
     local applied = false
@@ -1132,7 +1144,6 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
         failed = failed or not ok
     end
 
-    local selectedCustomBarsPayload = BuildSelectedCustomBarsPayload(model, selectedCustomBars)
     if selectedCustomBarsPayload then
         local ok = ApplyCustomBarsPayload(profile, selectedCustomBarsPayload)
         applied = ok or applied

--- a/CooldownCompanion_Config/ConfigSettings/Helpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/Helpers.lua
@@ -1027,19 +1027,6 @@ local CHARACTER_COPY_TOOLTIP_DETAILS = {
         "Copies: enable state, anchor/position mode, styling, icon, text, and cast effects.",
         "Does not copy: Resource Bars, Unit Frames, panels, or panel contents.",
     },
-    resourceBars = {
-        "Copies broad Resource Bar defaults from another character without replacing this character's spec-specific setup.",
-        "",
-        "What is copied:",
-        "- Enable state and panel anchor target",
-        "- Shared appearance defaults, like texture, text, and default colors",
-        "- Resource options that apply to this class",
-        "",
-        "What is not copied:",
-        "- The current spec's Layout tab or bar order",
-        "- Custom Bars",
-        "- Aura overlays and per-spec resource overrides",
-    },
 }
 
 local function CreateCharacterCopyButton(enableCb, systemKey, label, onCopied)

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -23,7 +23,6 @@ local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
-local CreateCharacterCopyButton = ST._CreateCharacterCopyButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
@@ -51,6 +50,17 @@ local function RefreshLayoutOrderPreview()
         return
     end
     ST._RefreshColumn4(CS.col4Container)
+end
+
+local function BlockCustomBarExportForResourceBarConflict()
+    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+        local message = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+        if message then
+            CooldownCompanion:Print(message)
+            return true
+        end
+    end
+    return false
 end
 
 -- Shared constants from ResourceBarConstants
@@ -164,6 +174,7 @@ local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForS
 local RBP = ST._RBP
 local resourceBarCollapsedSections = RBP.collapsedSections
 local BuildResourceAuraOverlaySection = RBP.BuildResourceAuraOverlaySection
+local BuildResourceBarConflictGate = RBP.BuildResourceBarConflictGate
 local GetConfigActiveResources = RBP.GetConfigActiveResources
 local GetCurrentConfigSpecID = RBP.GetCurrentConfigSpecID
 local ReadSpecOverrideKey = RBP.ReadSpecOverrideKey
@@ -659,6 +670,9 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
         exportInfo.notCheckable = true
         exportInfo.func = function()
             CloseDropDownMenus()
+            if BlockCustomBarExportForResourceBarConflict() then
+                return
+            end
             local exportSettings = CooldownCompanion:GetResourceBarSettings()
             local payload = RB.BuildCustomBarsExportPayload and RB.BuildCustomBarsExportPayload(exportSettings, { entry })
             local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
@@ -1650,6 +1664,10 @@ ST._AddResourceSettingsListSection = function(container, settings)
 end
 
 local function BuildCustomBarsListPanel(container)
+    if BuildResourceBarConflictGate(container, "Custom Bars", false) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
     if not (settings and settings.enabled) then
         ST._AddResourceSettingsListSection(container, nil)
@@ -1842,6 +1860,9 @@ local function BuildCustomBarsListPanel(container)
     local exportAllBtn = AceGUI:Create("Button")
     exportAllBtn:SetText("Export All")
     exportAllBtn:SetCallback("OnClick", function()
+        if BlockCustomBarExportForResourceBarConflict() then
+            return
+        end
         local payload = RB.BuildCustomBarsExportPayload and RB.BuildCustomBarsExportPayload(settings, customBars)
         local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
         if exportString then
@@ -2256,6 +2277,10 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
 end
 
 local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
+    if BuildResourceBarConflictGate(container, "Custom Bars", false) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
     if not (settings and settings.enabled) then
         AddResourceBarsDisabledLabel(container, "Enable Resource Bars to configure Custom Bar settings.")

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -53,8 +53,8 @@ local function RefreshLayoutOrderPreview()
 end
 
 local function BlockCustomBarExportForResourceBarConflict()
-    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
-        local message = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
+        local message = CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
         if message then
             CooldownCompanion:Print(message)
             return true

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -1483,6 +1483,54 @@ local function GetResourceGapFieldConfig(settings, layout)
     return "yOffset", "Y Offset"
 end
 
+local function OpenResourceBarConflictChooser(force)
+    local classKey = CooldownCompanion.GetCurrentResourceBarClassKey and CooldownCompanion:GetCurrentResourceBarClassKey()
+    local showChooser = ST._ShowResourceBarConflictChooser
+    if showChooser then
+        return showChooser(classKey, { force = force })
+    end
+    CooldownCompanion:Print("Resource Bar conflict chooser is unavailable.")
+    return false
+end
+
+local function BuildResourceBarConflictGate(container, editSurface, autoOpen)
+    local conflict = CooldownCompanion.GetCurrentResourceBarConflict and CooldownCompanion:GetCurrentResourceBarConflict()
+    if not conflict then
+        return false
+    end
+
+    local classKey = CooldownCompanion.GetCurrentResourceBarClassKey and CooldownCompanion:GetCurrentResourceBarClassKey() or "current class"
+    local label = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(label)
+    label:SetText("Resource Bars for " .. tostring(classKey) .. " have multiple legacy setups. Choose one setup before editing " .. (editSurface or "Resource Bars") .. ".")
+    label:SetFullWidth(true)
+    container:AddChild(label)
+
+    local resolveBtn = AceGUI:Create("Button")
+    resolveBtn:SetText("Resolve Resource Bars")
+    resolveBtn:SetFullWidth(true)
+    resolveBtn:SetCallback("OnClick", function()
+        OpenResourceBarConflictChooser(true)
+    end)
+    container:AddChild(resolveBtn)
+    CS.resourceBarConflictResolveButton = resolveBtn
+
+    if autoOpen and not (CS.resourceBarConflictChooserDismissed and CS.resourceBarConflictChooserDismissed[classKey]) then
+        local function openIfStillPending()
+            if CooldownCompanion.GetCurrentResourceBarConflict and CooldownCompanion:GetCurrentResourceBarConflict() then
+                OpenResourceBarConflictChooser(false)
+            end
+        end
+        if C_Timer and C_Timer.After then
+            C_Timer.After(0, openIfStillPending)
+        else
+            openIfStillPending()
+        end
+    end
+
+    return true
+end
+
 ------------------------------------------------------------------------
 -- Export via ST._RBP
 ------------------------------------------------------------------------
@@ -1530,4 +1578,5 @@ ST._RBP = {
     IsResourceBarVerticalConfig = IsResourceBarVerticalConfig,
     GetResourceThicknessFieldConfig = GetResourceThicknessFieldConfig,
     GetResourceGapFieldConfig = GetResourceGapFieldConfig,
+    BuildResourceBarConflictGate = BuildResourceBarConflictGate,
 }

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -17,7 +17,6 @@ local ShowPopupAboveConfig = CS.ShowPopupAboveConfig
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
-local CreateCharacterCopyButton = ST._CreateCharacterCopyButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
@@ -167,6 +166,7 @@ local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForS
 local RBP = ST._RBP
 local resourceBarCollapsedSections = RBP.collapsedSections
 local BuildResourceAuraOverlaySection = RBP.BuildResourceAuraOverlaySection
+local BuildResourceBarConflictGate = RBP.BuildResourceBarConflictGate
 local AddResourceAuraOverrideControls = RBP.AddResourceAuraOverrideControls
 local GetConfigActiveResources = RBP.GetConfigActiveResources
 local GetCurrentConfigSpecID = RBP.GetCurrentConfigSpecID
@@ -993,7 +993,7 @@ end
 
 CS.healthResourceUI = HealthResource
 
-local function AddResourceSpecCopyButton(enableCb, characterCopyButton)
+local function AddResourceSpecCopyButton(enableCb)
     local _, initialSpecOrder, currentSpecID = CooldownCompanion:GetResourceBarSpecCopyOptions()
     if not currentSpecID or #initialSpecOrder == 0 then
         return
@@ -1018,11 +1018,7 @@ local function AddResourceSpecCopyButton(enableCb, characterCopyButton)
     end
 
     btn:ClearAllPoints()
-    if characterCopyButton then
-        btn:SetPoint("LEFT", characterCopyButton, "RIGHT", 2, 0)
-    else
-        btn:SetPoint("LEFT", enableCb.checkbg, "RIGHT", enableCb.text:GetStringWidth() + 4, 0)
-    end
+    btn:SetPoint("LEFT", enableCb.checkbg, "RIGHT", enableCb.text:GetStringWidth() + 4, 0)
     btn:Show()
 
     btn:SetScript("OnEnter", function(self)
@@ -1090,6 +1086,10 @@ local function AddResourceSpecCopyButton(enableCb, characterCopyButton)
 end
 
 local function BuildResourceBarAnchoringPanel(container)
+    if BuildResourceBarConflictGate(container, "Resource Bars", true) then
+        return
+    end
+
     local db = CooldownCompanion.db.profile
     local settings = CooldownCompanion:GetResourceBarSettings()
     local layout = CooldownCompanion:GetSpecLayoutOrder()
@@ -1108,12 +1108,7 @@ local function BuildResourceBarAnchoringPanel(container)
     end)
     container:AddChild(enableCb)
 
-    local characterCopyButton = CreateCharacterCopyButton(enableCb, "resourceBars", "Resource Bars", function()
-        CooldownCompanion:EvaluateResourceBars()
-        CooldownCompanion:UpdateAnchorStacking()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    AddResourceSpecCopyButton(enableCb, characterCopyButton)
+    AddResourceSpecCopyButton(enableCb)
 
     if not settings.enabled then return end
     if not settings.resources then settings.resources = {} end
@@ -1220,6 +1215,10 @@ end
 ------------------------------------------------------------------------
 
 local function BuildResourceBarPositioningPanel(container)
+    if BuildResourceBarConflictGate(container, "Resource Bars", true) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
     local layout = CooldownCompanion:GetSpecLayoutOrder()
 
@@ -1983,6 +1982,10 @@ local function AddThresholdTickEntryEditor(panel, options)
 end
 
 local function BuildResourceBarStylingPanel(container, sectionMode, opts)
+    if BuildResourceBarConflictGate(container, "Resource Bars", true) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
 
     if not settings.enabled then


### PR DESCRIPTION
## What Players Will Notice
- Resource Bars, Resource Aura overlays, and Resource Bar Custom Bars now move into a class-wide setup, so same-class characters share one Resource Bar configuration instead of each carrying hidden character copies.
- Old profiles with multiple same-class Resource Bar setups now show a Resolve Resource Bars window. The setup the player keeps supplies the class Resource settings and overlays, while Custom Bars from the listed same-class characters are preserved and added to the saved class setup.
- Resource Bar editing, Layout & Order, Custom Bar import/export, and profile export now direct players to resolve the current class before changing or exporting conflicted Resource Bars.

## Why This Changed
- The Profile Group Control Center rollout made same-class reuse more visible, but Resource Bars were still stored by character. That made migration risky for players with copied or backup characters because choosing one setup could otherwise discard Custom Bars or silently mix incompatible class/spec data.

## What Changed
- Added `resourceBarsByClass` as the active Resource Bar store while preserving legacy `resourceBarsByChar` only for migration, conflict resolution, and diagnostics.
- Added class-aware normalization, import bridging, pending-conflict tracking, and export blocking for unresolved current-class Resource Bar conflicts.
- Added an AceGUI resolver window that stays above the config, explains what will be kept, and resolves old same-class setup conflicts.
- Updated full-profile and selected-piece import/export paths to understand class-scoped Resource Bars, preserve candidate metadata through migration, and keep Cast Bar and Frame Anchoring character-scoped.
- Merged Custom Bars from losing same-class conflict candidates into the resolved class setup so resolving Resource Bars does not throw away those bars.

## Validation
- `lua tests/resource-bars-class-scope.lua`
- `lua tests/eligibility-import-export.lua`
- `luac -p` over all changed Lua files in the branch diff
- `git diff --check origin/dev...HEAD`
- Five-agent static review via `parallel-review-recommendations`: no actionable static findings
- Manual in-game validation was performed with restored pre-migration SavedVariables for the migration/resolver flow before the final Custom Bar preservation follow-up. The final preservation behavior is covered by local regression tests and should still receive an in-game spot-check before merging.
- Combat/restricted-content validation was not performed for this config/migration work.