### PR TITLE
Add class-wide profile controls for groups and Resource Bars

### DIFF
--- a/CooldownCompanion/Core/AnchorPolicy.lua
+++ b/CooldownCompanion/Core/AnchorPolicy.lua
@@ -38,6 +38,8 @@ local EXTERNAL_ANCHOR_STORES = {
         legacyName = "Resource Bars Seed",
         scopedKey = "resourceBarsByChar",
         scopedNamePrefix = "Resource Bars ",
+        classScopedKey = "resourceBarsByClass",
+        classScopedNamePrefix = "Resource Bars Class ",
     },
     frameAnchoring = {
         rootKey = "frameAnchoring",
@@ -385,6 +387,13 @@ local function ForEachExternalAnchorSettings(profile, store, apply)
     if type(stores) == "table" then
         for charKey, settings in pairs(stores) do
             apply(settings, store.scopedNamePrefix .. tostring(charKey))
+        end
+    end
+
+    local classStores = store.classScopedKey and profile[store.classScopedKey] or nil
+    if type(classStores) == "table" then
+        for classKey, settings in pairs(classStores) do
+            apply(settings, store.classScopedNamePrefix .. tostring(classKey))
         end
     end
 end

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -445,6 +445,11 @@ local defaults = {
         },
         locked = false,
         cdmHidden = false,
+        resourceBarsByClass = {},
+        resourceBarMigration = {
+            conflicts = {},
+            unsafeCharKeys = {},
+        },
         resourceBars = {
             enabled = false,
             anchorGroupId = nil,

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -1969,12 +1969,14 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     -- Create buttons
     self:PopulateGroupButtons(groupId)
     
-    -- Show/hide based on enabled state, spec filter, hero talent filter, character visibility, and load conditions
+    -- Show/hide based on runtime activity, plus selected off-class config previews.
     if self:IsGroupActive(groupId, {
         group = group,
         checkCharVisibility = true,
         checkLoadConditions = true,
         requireButtons = true,
+    }) or self:IsGroupEligibleForConfigPreview(groupId, {
+        group = group,
     }) then
         frame:Show()
         -- Apply current alpha from the alpha fade system so frame doesn't flash at 1.0
@@ -2818,12 +2820,15 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     )
     self:UpdateGroupClickthrough(groupId)
 
-    -- Update visibility — unload if disabled, no buttons, wrong spec/hero, wrong character, or load conditions
+    -- Update visibility: runtime-active groups show normally; selected off-class
+    -- groups can also show as config previews without becoming runtime-visible.
     local isActive = CooldownCompanion:IsGroupActive(groupId, {
         group = group,
         checkCharVisibility = true,
         checkLoadConditions = true,
         requireButtons = true,
+    }) or CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, {
+        group = group,
     })
     if isActive then
         if InCombatLockdown() and frame:IsProtected() then

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -4233,6 +4233,22 @@ function CooldownCompanion:IsContainerVisibleToCurrentChar(containerId)
     if not (self.ResolveContainerClassScope and self.db and self.db.profile and self.db.profile.groupContainers) then
         return false
     end
+    local container = self.db.profile.groupContainers[containerId]
+    if type(container) == "table" then
+        if container.isGlobal == true then
+            return true
+        end
+        local currentCharKey = self.db.keys and self.db.keys.char
+        local currentCharInfo = currentCharKey
+            and self.db.global
+            and self.db.global.characterInfo
+            and self.db.global.characterInfo[currentCharKey]
+        if container.createdBy == currentCharKey
+            and type(currentCharInfo) == "table"
+            and (currentCharInfo.classFilename or currentCharInfo.classID) then
+            return true
+        end
+    end
     local scope = self:ResolveContainerClassScope(containerId)
     return scope.runtimeVisible == true
 end

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -4225,10 +4225,11 @@ function CooldownCompanion:SaveContainerPosition(containerId)
 end
 
 function CooldownCompanion:IsContainerVisibleToCurrentChar(containerId)
-    local container = self.db.profile.groupContainers[containerId]
-    if not container then return false end
-    if container.isGlobal then return true end
-    return container.createdBy == self.db.keys.char
+    if not (self.ResolveContainerClassScope and self.db and self.db.profile and self.db.profile.groupContainers) then
+        return false
+    end
+    local scope = self:ResolveContainerClassScope(containerId)
+    return scope.runtimeVisible == true
 end
 
 function CooldownCompanion:CreateAllContainerFrames()

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -798,6 +798,11 @@ function CooldownCompanion:CreateContainer(name)
             y = 0,
         },
     }
+    if self._currentSpecId then
+        db.groupContainers[containerId].specs = {
+            [self._currentSpecId] = true,
+        }
+    end
 
     return containerId
 end
@@ -1428,7 +1433,7 @@ function CooldownCompanion:RenameFolder(folderId, newName)
     return true
 end
 
-function CooldownCompanion:MoveGroupToFolder(id, folderId)
+function CooldownCompanion:MoveGroupToFolder(id, folderId, opts)
     local db = self.db.profile
 
     -- Resolve to container (id may be containerId or panel groupId)
@@ -1442,6 +1447,16 @@ function CooldownCompanion:MoveGroupToFolder(id, folderId)
         end
     end
     if not container then return end
+
+    if folderId and self.CanMoveContainerToFolder then
+        local ok = self:CanMoveContainerToFolder(containerId, folderId, opts)
+        if not ok then
+            if self.Print then
+                self:Print("Groups cannot be moved into folders owned by another class.")
+            end
+            return false
+        end
+    end
 
     container.folderId = folderId  -- nil = loose (no folder)
 
@@ -1460,6 +1475,7 @@ function CooldownCompanion:MoveGroupToFolder(id, folderId)
     for _, p in ipairs(panels) do
         self:RefreshGroupFrame(p.groupId)
     end
+    return true
 end
 
 function CooldownCompanion:ToggleFolderGlobal(folderId)
@@ -1843,35 +1859,6 @@ function CooldownCompanion:FindTalentSpellByName(name)
     return nil
 end
 
-------------------------------------------------------------------------
--- Cross-Character Browse Helpers
-------------------------------------------------------------------------
-
---- Scan profile containers for unique createdBy values other than current char.
---- Returns sorted array of { charKey, classFilename, classID }.
-function CooldownCompanion:EnumerateBrowseCharacters()
-    local db = self.db.profile
-    local currentChar = self.db.keys.char
-    local seen = {}
-    local result = {}
-
-    for _, container in pairs(db.groupContainers) do
-        local key = container.createdBy
-        if key and key ~= currentChar and not container.isGlobal and not seen[key] then
-            seen[key] = true
-            local info = self.db.global.characterInfo and self.db.global.characterInfo[key]
-            result[#result + 1] = {
-                charKey = key,
-                classFilename = info and info.classFilename or nil,
-                classID = info and info.classID or nil,
-            }
-        end
-    end
-
-    table_sort(result, function(a, b) return a.charKey < b.charKey end)
-    return result
-end
-
 --- Return sorted active-profile character choices for Load Conditions.
 --- Includes the current character, AceDB profile keys that point at the active
 --- profile, and owners referenced by entities in the active profile.
@@ -1931,51 +1918,6 @@ function CooldownCompanion:EnumerateActiveProfileCharacters()
 
     table_sort(result, function(a, b) return a.charKey < b.charKey end)
     return result
-end
-
---- Return sorted array of { containerId, container } for a given character key.
-function CooldownCompanion:GetCharacterContainers(charKey)
-    local db = self.db.profile
-    local result = {}
-
-    for containerId, container in pairs(db.groupContainers) do
-        if container.createdBy == charKey and not container.isGlobal then
-            -- Skip empty containers (no panels with buttons)
-            local hasButtons = false
-            for _, group in pairs(db.groups) do
-                if group.parentContainerId == containerId and self:GroupHasUsableButtons(group, {
-                    checkLoadConditions = false,
-                    ignoreSpellAvailability = true,
-                }) then
-                    hasButtons = true
-                    break
-                end
-            end
-            if hasButtons then
-                result[#result + 1] = { containerId = containerId, container = container }
-            end
-        end
-    end
-
-    local specId = self._currentSpecId
-    table_sort(result, function(a, b)
-        return self:GetOrderForSpec(a.container, specId, a.containerId) < self:GetOrderForSpec(b.container, specId, b.containerId)
-    end)
-    return result
-end
-
---- Copy a container from browse mode. Reuses DuplicateContainer, renames to original name.
-function CooldownCompanion:CopyContainerFromBrowse(sourceContainerId)
-    local sourceContainer = self.db.profile.groupContainers[sourceContainerId]
-    if not sourceContainer then return nil end
-
-    local originalName = sourceContainer.name
-    local newContainerId = self:DuplicateContainer(sourceContainerId)
-    if newContainerId then
-        -- Rename from "X (Copy)" back to original name
-        self.db.profile.groupContainers[newContainerId].name = originalName
-    end
-    return newContainerId
 end
 
 --- Copy a panel into an existing container owned by the current character.

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -96,6 +96,17 @@ local function RefreshPanelAlphaDependencyTargets(self)
     end
 end
 
+local function NormalizeCopiedEntityForContainerScope(self, entity, container)
+    if type(entity) ~= "table" or not container or container.isGlobal == true then
+        return
+    end
+    if self.NormalizeEligibilityForCharacterScope then
+        self:NormalizeEligibilityForCharacterScope(entity, {
+            ownerCharKey = container.createdBy or (self.db and self.db.keys and self.db.keys.char),
+        })
+    end
+end
+
 function CooldownCompanion:NormalizeContainerAnchor(anchor, resolveAddonFrames)
     local normalized = type(anchor) == "table" and anchor or {}
     local point = normalized.point or "CENTER"
@@ -967,6 +978,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
     newContainer.specOrders = nil
     newContainer.createdBy = self.db.keys.char
     newContainer.isGlobal = false
+    NormalizeCopiedEntityForContainerScope(self, newContainer, newContainer)
 
     -- If source was global, clear folderId on the copy
     if sourceContainer.isGlobal and newContainer.folderId then
@@ -1001,6 +1013,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
                 x = group.anchor and group.anchor.x or 0,
                 y = group.anchor and group.anchor.y or 0,
             }
+            NormalizeCopiedEntityForContainerScope(self, newPanel, newContainer)
 
             db.groups[newGroupId] = newPanel
             groupIdMap[groupId] = newGroupId
@@ -1165,6 +1178,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
     local db = self.db.profile
     local sourcePanel = db.groups[groupId]
     if not sourcePanel or sourcePanel.parentContainerId ~= containerId then return nil end
+    local container = db.groupContainers[containerId]
 
     local newGroupId = db.nextGroupId
     db.nextGroupId = newGroupId + 1
@@ -1173,6 +1187,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
     newPanel.name = sourcePanel.name .. " (Copy)"
     newPanel.order = self:GetPanelCount(containerId) + 1
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, groupId, containerId, containerId)
+    NormalizeCopiedEntityForContainerScope(self, newPanel, container)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
@@ -1364,6 +1379,7 @@ function CooldownCompanion:DuplicateGroup(id)
     newGroup.order = newGroupId
     newGroup.createdBy = self.db.keys.char
     newGroup.isGlobal = false
+    NormalizeCopiedEntityForContainerScope(self, newGroup, newGroup)
     if sourceGroup.isGlobal and newGroup.folderId then
         newGroup.folderId = nil
     end
@@ -1967,7 +1983,8 @@ function CooldownCompanion:CopyPanelToContainer(sourceGroupId, targetContainerId
     local db = self.db.profile
     local sourcePanel = db.groups[sourceGroupId]
     if not sourcePanel then return nil end
-    if not db.groupContainers[targetContainerId] then return nil end
+    local targetContainer = db.groupContainers[targetContainerId]
+    if not targetContainer then return nil end
 
     local newGroupId = db.nextGroupId
     db.nextGroupId = newGroupId + 1
@@ -1985,6 +2002,7 @@ function CooldownCompanion:CopyPanelToContainer(sourceGroupId, targetContainerId
         y = 0,
     }
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, sourceGroupId, sourcePanel.parentContainerId, targetContainerId)
+    NormalizeCopiedEntityForContainerScope(self, newPanel, targetContainer)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)
@@ -2000,6 +2018,7 @@ function CooldownCompanion:CopyPanelAsNewGroup(sourceGroupId, sourceName)
 
     -- Create a new container
     local containerId = self:CreateContainer(sourceName or "Copied Group")
+    local container = db.groupContainers[containerId]
 
     -- Create container frame
     if self.CreateContainerFrame then
@@ -2024,6 +2043,7 @@ function CooldownCompanion:CopyPanelAsNewGroup(sourceGroupId, sourceName)
         y = 0,
     }
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, sourceGroupId, sourcePanel.parentContainerId, containerId)
+    NormalizeCopiedEntityForContainerScope(self, newPanel, container)
 
     db.groups[newGroupId] = newPanel
     self:CreateGroupFrame(newGroupId)

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -101,9 +101,15 @@ local function NormalizeCopiedEntityForContainerScope(self, entity, container)
         return
     end
     if self.NormalizeEligibilityForCharacterScope then
-        self:NormalizeEligibilityForCharacterScope(entity, {
+        local opts = {
             ownerCharKey = container.createdBy or (self.db and self.db.keys and self.db.keys.char),
-        })
+        }
+        self:NormalizeEligibilityForCharacterScope(entity, opts)
+        if type(entity.buttons) == "table" then
+            for _, button in ipairs(entity.buttons) do
+                self:NormalizeEligibilityForCharacterScope(button, opts)
+            end
+        end
     end
 end
 
@@ -722,27 +728,15 @@ end
 function CooldownCompanion:CopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
     sourceGroupId = tonumber(sourceGroupId)
     targetGroupId = tonumber(targetGroupId)
-    if not IsValidDirectStyleCopyMode(mode) then
-        return false, "invalid_mode"
+
+    local canCopy, reason = self:CanCopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
+    if not canCopy then
+        return false, reason
     end
 
     local db = self.db and self.db.profile
     local sourceGroup = db and db.groups and db.groups[sourceGroupId]
     local targetGroup = db and db.groups and db.groups[targetGroupId]
-    if not sourceGroup or not targetGroup then
-        return false, "missing_group"
-    end
-    if sourceGroupId == targetGroupId then
-        return false, "same_group"
-    end
-    if not GroupMatchesDirectStyleCopyMode(sourceGroup, mode)
-        or not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
-        return false, "mode_mismatch"
-    end
-    local canCopy, reason = self:CanCopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
-    if not canCopy then
-        return false, reason
-    end
 
     local oldMasqueEnabled = targetGroup.masqueEnabled and true or false
     local presetData = CaptureGroupSettingPresetData(db, mode, sourceGroup)
@@ -1261,21 +1255,27 @@ end
 
 function CooldownCompanion:MovePanel(groupId, targetContainerId)
     local db = self.db.profile
-    local group = db.groups[groupId]
-    if not group or not group.parentContainerId then return false end
-    if not db.groupContainers[targetContainerId] then return false end
-
-    local sourceContainerId = group.parentContainerId
-    if sourceContainerId == targetContainerId then return false end
+    local group
     if self.CanMovePanelToContainer then
-        local ok = self:CanMovePanelToContainer(groupId, targetContainerId)
+        local ok, reason = self:CanMovePanelToContainer(groupId, targetContainerId)
         if not ok then
-            if self.Print then
+            if self.Print
+                and (reason == "invalid-class-scope"
+                    or reason == "scope-mismatch"
+                    or reason == "mixed-class-panel") then
                 self:Print("Panels cannot be moved into groups owned by another class.")
             end
             return false
         end
+        group = db.groups[groupId]
+    else
+        group = db.groups[groupId]
+        if not group or not group.parentContainerId then return false end
+        if not db.groupContainers[targetContainerId] then return false end
+        if group.parentContainerId == targetContainerId then return false end
     end
+
+    local sourceContainerId = group.parentContainerId
 
     -- Reassign to target container
     group.parentContainerId = targetContainerId

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1466,6 +1466,9 @@ function CooldownCompanion:ToggleFolderGlobal(folderId)
             end
         end
     end
+    if newSection == "char" and self.NormalizeFolderEligibilityForCharacterScope then
+        self:NormalizeFolderEligibilityForCharacterScope(folderId)
+    end
     self:RefreshAllGroups()
 end
 
@@ -1478,6 +1481,9 @@ function CooldownCompanion:ToggleGroupGlobal(containerId)
     container.isGlobal = newGlobal
     if not newGlobal then
         container.createdBy = self.db.keys.char
+        if self.NormalizeContainerEligibilityForCharacterScope then
+            self:NormalizeContainerEligibilityForCharacterScope(containerId)
+        end
     end
 
     self:RefreshAllGroups()

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1850,6 +1850,67 @@ function CooldownCompanion:EnumerateBrowseCharacters()
     return result
 end
 
+--- Return sorted active-profile character choices for Load Conditions.
+--- Includes the current character, AceDB profile keys that point at the active
+--- profile, and owners referenced by entities in the active profile.
+function CooldownCompanion:EnumerateActiveProfileCharacters()
+    local db = self.db
+    local profile = db and db.profile
+    local currentChar = db and db.keys and db.keys.char
+    local currentProfile = db and db.keys and db.keys.profile
+    if db and db.GetCurrentProfile then
+        currentProfile = db:GetCurrentProfile() or currentProfile
+    end
+
+    local seen = {}
+    local result = {}
+
+    local function AddCharKey(charKey)
+        if type(charKey) ~= "string" or charKey == "" or seen[charKey] then
+            return
+        end
+        seen[charKey] = true
+        local info = db and db.global and db.global.characterInfo and db.global.characterInfo[charKey]
+        result[#result + 1] = {
+            charKey = charKey,
+            classFilename = info and info.classFilename or nil,
+            classID = info and info.classID or nil,
+        }
+    end
+
+    AddCharKey(currentChar)
+
+    local profileKeys = db and db.sv and db.sv.profileKeys
+    if type(profileKeys) == "table" and type(currentProfile) == "string" then
+        for charKey, profileKey in pairs(profileKeys) do
+            if profileKey == currentProfile then
+                AddCharKey(charKey)
+            end
+        end
+    end
+
+    if type(profile) == "table" then
+        for _, group in pairs(profile.groups or {}) do
+            if type(group) == "table" and not group.isGlobal then
+                AddCharKey(group.createdBy)
+            end
+        end
+        for _, container in pairs(profile.groupContainers or {}) do
+            if type(container) == "table" and not container.isGlobal then
+                AddCharKey(container.createdBy)
+            end
+        end
+        for _, folder in pairs(profile.folders or {}) do
+            if type(folder) == "table" and folder.section == "char" then
+                AddCharKey(folder.createdBy)
+            end
+        end
+    end
+
+    table_sort(result, function(a, b) return a.charKey < b.charKey end)
+    return result
+end
+
 --- Return sorted array of { containerId, container } for a given character key.
 function CooldownCompanion:GetCharacterContainers(charKey)
     local db = self.db.profile

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -107,6 +107,22 @@ local function NormalizeCopiedEntityForContainerScope(self, entity, container)
     end
 end
 
+local function ClearInvalidCopiedFolderId(self, entity, sourceEntity)
+    if type(entity) ~= "table" or not entity.folderId then
+        return
+    end
+    if sourceEntity and sourceEntity.isGlobal then
+        entity.folderId = nil
+        return
+    end
+    if self.CanMoveContainerToFolder then
+        local ok = self:CanMoveContainerToFolder(entity, entity.folderId)
+        if not ok then
+            entity.folderId = nil
+        end
+    end
+end
+
 function CooldownCompanion:NormalizeContainerAnchor(anchor, resolveAddonFrames)
     local normalized = type(anchor) == "table" and anchor or {}
     local point = normalized.point or "CENTER"
@@ -984,11 +1000,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
     newContainer.createdBy = self.db.keys.char
     newContainer.isGlobal = false
     NormalizeCopiedEntityForContainerScope(self, newContainer, newContainer)
-
-    -- If source was global, clear folderId on the copy
-    if sourceContainer.isGlobal and newContainer.folderId then
-        newContainer.folderId = nil
-    end
+    ClearInvalidCopiedFolderId(self, newContainer, sourceContainer)
 
     db.groupContainers[newContainerId] = newContainer
 
@@ -1208,6 +1220,15 @@ function CooldownCompanion:MovePanel(groupId, targetContainerId)
 
     local sourceContainerId = group.parentContainerId
     if sourceContainerId == targetContainerId then return false end
+    if self.CanMovePanelToContainer then
+        local ok = self:CanMovePanelToContainer(groupId, targetContainerId)
+        if not ok then
+            if self.Print then
+                self:Print("Panels cannot be moved into groups owned by another class.")
+            end
+            return false
+        end
+    end
 
     -- Reassign to target container
     group.parentContainerId = targetContainerId
@@ -1385,9 +1406,7 @@ function CooldownCompanion:DuplicateGroup(id)
     newGroup.createdBy = self.db.keys.char
     newGroup.isGlobal = false
     NormalizeCopiedEntityForContainerScope(self, newGroup, newGroup)
-    if sourceGroup.isGlobal and newGroup.folderId then
-        newGroup.folderId = nil
-    end
+    ClearInvalidCopiedFolderId(self, newGroup, sourceGroup)
 
     self.db.profile.groups[newGroupId] = newGroup
     self:CreateGroupFrame(newGroupId)

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -383,6 +383,52 @@ local function GroupMatchesDirectStyleCopyMode(group, mode)
     return group.displayMode == nil or group.displayMode == "icons"
 end
 
+function CooldownCompanion:CanCopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
+    sourceGroupId = tonumber(sourceGroupId)
+    targetGroupId = tonumber(targetGroupId)
+    if not IsValidDirectStyleCopyMode(mode) then
+        return false, "invalid_mode"
+    end
+
+    local db = self.db and self.db.profile
+    local sourceGroup = db and db.groups and db.groups[sourceGroupId]
+    local targetGroup = db and db.groups and db.groups[targetGroupId]
+    if not sourceGroup or not targetGroup then
+        return false, "missing_group"
+    end
+    if sourceGroupId == targetGroupId then
+        return false, "same_group"
+    end
+    if not GroupMatchesDirectStyleCopyMode(sourceGroup, mode)
+        or not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
+        return false, "mode_mismatch"
+    end
+
+    if self.ResolveContainerClassScope
+        and sourceGroup.parentContainerId
+        and targetGroup.parentContainerId then
+        local sourceScope = self:ResolveContainerClassScope(sourceGroup.parentContainerId)
+        local targetScope = self:ResolveContainerClassScope(targetGroup.parentContainerId)
+        if not sourceScope or not targetScope or sourceScope.isInvalid or targetScope.isInvalid then
+            return false, "invalid_class_scope"
+        end
+        if sourceScope.runtimeVisible == true then
+            return true
+        end
+        if sourceScope.isOtherClass
+            and targetScope.isOtherClass
+            and sourceScope.ownerClassKey == targetScope.ownerClassKey then
+            return true
+        end
+        return false, "source_unavailable"
+    end
+
+    if self:IsGroupVisibleToCurrentChar(sourceGroupId) then
+        return true
+    end
+    return false, "source_unavailable"
+end
+
 local function CopyCompactLayoutSettings(sourceGroup, targetGroup)
     targetGroup.compactLayout = sourceGroup.compactLayout == true
     targetGroup.compactGrowthDirection = sourceGroup.compactGrowthDirection or "center"
@@ -634,7 +680,7 @@ function CooldownCompanion:GetDirectStyleCopyPanelList(mode, targetGroupId)
     for groupId, group in pairs(db.groups or {}) do
         if groupId ~= targetGroupId
             and GroupMatchesDirectStyleCopyMode(group, mode)
-            and self:IsGroupVisibleToCurrentChar(groupId) then
+            and self:CanCopyDirectStyleFromPanel(mode, groupId, targetGroupId) then
             local parentContainer = self:GetParentContainer(group)
             local containerName = parentContainer and parentContainer.name
                 or group.name
@@ -693,8 +739,9 @@ function CooldownCompanion:CopyDirectStyleFromPanel(mode, sourceGroupId, targetG
         or not GroupMatchesDirectStyleCopyMode(targetGroup, mode) then
         return false, "mode_mismatch"
     end
-    if not self:IsGroupVisibleToCurrentChar(sourceGroupId) then
-        return false, "source_unavailable"
+    local canCopy, reason = self:CanCopyDirectStyleFromPanel(mode, sourceGroupId, targetGroupId)
+    if not canCopy then
+        return false, reason
     end
 
     local oldMasqueEnabled = targetGroup.masqueEnabled and true or false

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1308,7 +1308,8 @@ end
 
 function CooldownCompanion:IsGroupActive(groupId, opts)
     opts = opts or {}
-    local group = opts.group or self.db.profile.groups[groupId]
+    local db = self.db and self.db.profile
+    local group = opts.group or (db and db.groups and db.groups[groupId])
     if not group then return false end
 
     -- If this panel has a parent container, check container-level state first
@@ -1362,6 +1363,38 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
     end
 
     return true
+end
+
+function CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, opts)
+    opts = opts or {}
+    if not (groupId and ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(groupId)) then
+        return false
+    end
+
+    local db = self.db and self.db.profile
+    local group = opts.group or (db and db.groups and db.groups[groupId])
+    if not group then return false end
+
+    local container = self:GetParentContainer(group)
+    if container then
+        if container.enabled == false or group.enabled == false then return false end
+    elseif group.enabled == false then
+        return false
+    end
+
+    if not self:IsRotationAssistantGroup(group) and not (group.buttons and #group.buttons > 0) then
+        return false
+    end
+
+    if not self.ResolveContainerClassScope then
+        return false
+    end
+    if not group.parentContainerId then
+        return false
+    end
+
+    local scope = self:ResolveContainerClassScope(group.parentContainerId)
+    return scope and scope.isOtherClass == true and scope.isInvalid ~= true
 end
 
 function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
@@ -1677,6 +1710,41 @@ function CooldownCompanion:CanMovePanelToContainer(groupOrGroupId, targetContain
         return true
     end
     return false, "mixed-class-panel"
+end
+
+function CooldownCompanion:CanMoveEntryToGroup(sourceGroupId, targetGroupId)
+    local db = self.db and self.db.profile
+    if not (db and db.groups) then
+        return false
+    end
+    if sourceGroupId == targetGroupId then
+        return false
+    end
+
+    local sourceGroup = db.groups[sourceGroupId]
+    local targetGroup = db.groups[targetGroupId]
+    if not (sourceGroup and targetGroup and sourceGroup.parentContainerId and targetGroup.parentContainerId) then
+        return false
+    end
+
+    if not self.ResolveContainerClassScope then
+        return self:IsGroupVisibleToCurrentChar(targetGroupId)
+    end
+
+    local sourceScope = self:ResolveContainerClassScope(sourceGroup.parentContainerId)
+    if not sourceScope or sourceScope.isInvalid then
+        return false
+    end
+
+    if sourceScope.isOtherClass then
+        local targetScope = self:ResolveContainerClassScope(targetGroup.parentContainerId)
+        return targetScope
+            and targetScope.isInvalid ~= true
+            and targetScope.isOtherClass == true
+            and targetScope.ownerClassKey == sourceScope.ownerClassKey
+    end
+
+    return self:IsGroupVisibleToCurrentChar(targetGroupId)
 end
 
 local function PruneSpecMapToClass(addon, entity, map, classKey)
@@ -2675,6 +2743,8 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
                 checkCharVisibility = true,
                 checkLoadConditions = true,
                 requireButtons = true,
+            }) or self:IsGroupEligibleForConfigPreview(groupId, {
+                group = group,
             })
             if (active or (wasPreviewed and frame))
                 and (not frame

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -113,18 +113,24 @@ local function NormalizeTruthyMap(map, normalizer, failClosed)
 
     local normalized = {}
     local sawEntry = false
+    local invalidEnabledEntry = false
     for key, enabled in pairs(map) do
         sawEntry = true
         if enabled == true then
             local normalizedKey = normalizer(key)
             if normalizedKey ~= nil then
                 normalized[normalizedKey] = true
+            else
+                invalidEnabledEntry = true
             end
         end
     end
 
     if next(normalized) then
         return normalized, false, true
+    end
+    if invalidEnabledEntry and failClosed then
+        return {}, true, true
     end
     if sawEntry and failClosed then
         return {}, false, true
@@ -152,11 +158,40 @@ local function IntersectTruthyMaps(left, right)
 end
 
 local function AddEffectiveSource(sources, map, inherited, normalizer)
-    local normalized, _, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
+    local normalized, malformed, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
     if hasRestriction then
         sources[#sources + 1] = {
             values = normalized or {},
             inherited = inherited and true or false,
+            malformed = malformed and true or false,
+        }
+    end
+end
+
+local function AddCombinedEffectiveSource(sources, inherited, normalizer, ...)
+    local values
+    local hasRestriction = false
+    local malformed = false
+
+    for index = 1, select("#", ...) do
+        local normalized, sourceMalformed, sourceHasRestriction = NormalizeTruthyMap(select(index, ...), normalizer, true)
+        if sourceMalformed then
+            malformed = true
+        end
+        if sourceHasRestriction then
+            hasRestriction = true
+            values = values or {}
+            for key in pairs(normalized or {}) do
+                values[key] = true
+            end
+        end
+    end
+
+    if hasRestriction then
+        sources[#sources + 1] = {
+            values = values,
+            inherited = inherited and true or false,
+            malformed = malformed,
         }
     end
 end
@@ -169,10 +204,15 @@ local function ResolveEffectiveSources(sources)
     for _, source in ipairs(sources or {}) do
         hasRestriction = true
         if source.inherited then inherited = true end
-        if effective == nil then
+        if source.malformed then
+            effective = {}
+        elseif effective == nil then
             effective = CopyTruthyMap(source.values) or {}
         else
-            effective = IntersectTruthyMaps(effective, source.values)
+            local intersection = IntersectTruthyMaps(effective, source.values)
+            if next(intersection) then
+                effective = intersection
+            end
         end
     end
 
@@ -194,7 +234,10 @@ local function MergeEligibilityAllowlist(state, key, map, normalizer)
     if state[key] == nil then
         state[key] = CopyTruthyMap(normalized) or {}
     else
-        state[key] = IntersectTruthyMaps(state[key], normalized)
+        local intersection = IntersectTruthyMaps(state[key], normalized)
+        if next(intersection) then
+            state[key] = intersection
+        end
     end
     return true
 end
@@ -861,47 +904,47 @@ function CooldownCompanion:GetEffectiveSpecs(group)
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
-            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
-            AddEffectiveSource(
+            AddCombinedEffectiveSource(
                 sources,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
                 true,
-                NormalizeSpecKey
+                NormalizeSpecKey,
+                folder and folder.specs,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist
             )
         end
-        AddEffectiveSource(sources, container.specs, true, NormalizeSpecKey)
-        AddEffectiveSource(
+        AddCombinedEffectiveSource(
             sources,
-            container.loadConditions and container.loadConditions.specAllowlist,
             true,
-            NormalizeSpecKey
+            NormalizeSpecKey,
+            container.specs,
+            container.loadConditions and container.loadConditions.specAllowlist
         )
-        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
-        AddEffectiveSource(
+        AddCombinedEffectiveSource(
             sources,
-            group.loadConditions and group.loadConditions.specAllowlist,
             false,
-            NormalizeSpecKey
+            NormalizeSpecKey,
+            group.specs,
+            group.loadConditions and group.loadConditions.specAllowlist
         )
     else
         local folderId = group.folderId
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
-            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
-            AddEffectiveSource(
+            AddCombinedEffectiveSource(
                 sources,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
                 true,
-                NormalizeSpecKey
+                NormalizeSpecKey,
+                folder and folder.specs,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist
             )
         end
-        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
-        AddEffectiveSource(
+        AddCombinedEffectiveSource(
             sources,
-            group.loadConditions and group.loadConditions.specAllowlist,
             false,
-            NormalizeSpecKey
+            NormalizeSpecKey,
+            group.specs,
+            group.loadConditions and group.loadConditions.specAllowlist
         )
     end
 
@@ -1335,6 +1378,190 @@ function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
     if not next(group.heroTalents) then
         group.heroTalents = nil
     end
+end
+
+local function ClearEmptyCoreLoadConditions(entity)
+    if type(entity) ~= "table" or type(entity.loadConditions) ~= "table" then return end
+    if not next(entity.loadConditions) then
+        entity.loadConditions = nil
+    end
+end
+
+local function GetClassKeyFromClassID(classID)
+    if not (classID and GetClassInfo) then return nil end
+    local _, classFilename = GetClassInfo(classID)
+    return NormalizeClassKey(classFilename)
+end
+
+local function GetCurrentScopeClassKey(addon)
+    local classFilename = addon and addon._playerClassFilename
+    if not classFilename and UnitClass then
+        classFilename = select(2, UnitClass("player"))
+    end
+    return NormalizeClassKey(classFilename)
+end
+
+local function GetSpecClassKey(specId)
+    if not (C_SpecializationInfo and C_SpecializationInfo.GetClassIDFromSpecID) then
+        return nil
+    end
+    return GetClassKeyFromClassID(C_SpecializationInfo.GetClassIDFromSpecID(tonumber(specId)))
+end
+
+local function SpecBelongsToClass(specId, classKey)
+    if not classKey then return true end
+    local specClassKey = GetSpecClassKey(specId)
+    return specClassKey == classKey
+end
+
+local function GetCharacterClassKey(addon, charKey)
+    local info = charKey
+        and addon
+        and addon.db
+        and addon.db.global
+        and addon.db.global.characterInfo
+        and addon.db.global.characterInfo[charKey]
+    if type(info) ~= "table" then
+        return nil
+    end
+    return NormalizeClassKey(info.classFilename)
+        or GetClassKeyFromClassID(info.classID)
+end
+
+local function PruneSpecMapToClass(addon, entity, map, classKey)
+    if type(map) ~= "table" or not classKey then return false end
+    local changed = false
+    for key in pairs(map) do
+        local specId = NormalizeSpecKey(key)
+        if specId and SpecBelongsToClass(specId, classKey) then
+            if key ~= specId then
+                map[specId] = true
+                map[key] = nil
+                changed = true
+            end
+        else
+            map[key] = nil
+            if specId then
+                map[specId] = nil
+                if addon and addon.CleanHeroTalentsForSpec then
+                    addon:CleanHeroTalentsForSpec(entity, specId)
+                end
+            end
+            changed = true
+        end
+    end
+    return changed
+end
+
+local function CharacterKeyMatchesClass(addon, charKey, classKey, ownerCharKey)
+    if not classKey then return true end
+    if charKey and ownerCharKey and charKey == ownerCharKey then
+        return true
+    end
+    local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
+    if charKey and currentCharKey and charKey == currentCharKey then
+        return true
+    end
+    return GetCharacterClassKey(addon, charKey) == classKey
+end
+
+local function PruneCharacterMapToClass(addon, map, classKey, ownerCharKey)
+    if type(map) ~= "table" or not classKey then return false end
+    local changed = false
+    for key in pairs(map) do
+        local charKey = NormalizeCharacterKey(key)
+        if not (charKey and CharacterKeyMatchesClass(addon, charKey, classKey, ownerCharKey)) then
+            map[key] = nil
+            if charKey then
+                map[charKey] = nil
+            end
+            changed = true
+        end
+    end
+    return changed
+end
+
+local function WithOwnerCharKey(opts, ownerCharKey)
+    if opts and opts.ownerCharKey then return opts end
+    local scopedOpts = opts and CopyTable(opts) or {}
+    scopedOpts.ownerCharKey = ownerCharKey
+    return scopedOpts
+end
+
+function CooldownCompanion:NormalizeEligibilityForCharacterScope(entity, opts)
+    if type(entity) ~= "table" then return false end
+    opts = opts or {}
+    local ownerCharKey = opts.ownerCharKey
+        or entity.createdBy
+        or (self.db and self.db.keys and self.db.keys.char)
+    local classKey = NormalizeClassKey(opts.scopeClassKey)
+        or GetCharacterClassKey(self, ownerCharKey)
+        or GetCurrentScopeClassKey(self)
+    local changed = false
+
+    if PruneSpecMapToClass(self, entity, entity.specs, classKey) then
+        changed = true
+        if type(entity.specs) == "table" and not next(entity.specs) then
+            entity.specs = nil
+        end
+    end
+
+    local loadConditions = entity.loadConditions
+    if type(loadConditions) == "table" then
+        if loadConditions.classAllowlist ~= nil then
+            loadConditions.classAllowlist = nil
+            changed = true
+        end
+        if PruneSpecMapToClass(self, entity, loadConditions.specAllowlist, classKey) then
+            changed = true
+            if type(loadConditions.specAllowlist) == "table" and not next(loadConditions.specAllowlist) then
+                loadConditions.specAllowlist = nil
+            end
+        end
+        if PruneCharacterMapToClass(self, loadConditions.characterAllowlist, classKey, ownerCharKey) then
+            changed = true
+            if type(loadConditions.characterAllowlist) == "table"
+                and not next(loadConditions.characterAllowlist)
+            then
+                loadConditions.characterAllowlist = nil
+            end
+        end
+        ClearEmptyCoreLoadConditions(entity)
+    end
+
+    return changed
+end
+
+function CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(containerId, opts)
+    local db = self.db and self.db.profile
+    if not (db and db.groupContainers) then return false end
+    local container = db.groupContainers[containerId]
+    if not container then return false end
+    opts = WithOwnerCharKey(opts, container.createdBy or (self.db and self.db.keys and self.db.keys.char))
+
+    local changed = self:NormalizeEligibilityForCharacterScope(container, opts)
+    for _, group in pairs(db.groups or {}) do
+        if type(group) == "table" and group.parentContainerId == containerId then
+            changed = self:NormalizeEligibilityForCharacterScope(group, opts) or changed
+        end
+    end
+    return changed
+end
+
+function CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(folderId, opts)
+    local db = self.db and self.db.profile
+    if not (db and db.folders) then return false end
+    local folder = db.folders[folderId]
+    if not folder then return false end
+    opts = WithOwnerCharKey(opts, folder.createdBy or (self.db and self.db.keys and self.db.keys.char))
+
+    local changed = self:NormalizeEligibilityForCharacterScope(folder, opts)
+    for containerId, container in pairs(db.groupContainers or {}) do
+        if type(container) == "table" and container.folderId == folderId then
+            changed = self:NormalizeContainerEligibilityForCharacterScope(containerId, opts) or changed
+        end
+    end
+    return changed
 end
 
 function CooldownCompanion:IsGroupAvailableForAnchoring(groupId)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -78,6 +78,8 @@ local LOAD_CONDITION_ALLOWLIST_KEYS = {
     characterAllowlist = true,
 }
 
+local CLASS_SCAN_LIMIT = 30
+
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -209,10 +211,7 @@ local function ResolveEffectiveSources(sources)
         elseif effective == nil then
             effective = CopyTruthyMap(source.values) or {}
         else
-            local intersection = IntersectTruthyMaps(effective, source.values)
-            if next(intersection) then
-                effective = intersection
-            end
+            effective = IntersectTruthyMaps(effective, source.values)
         end
     end
 
@@ -234,10 +233,7 @@ local function MergeEligibilityAllowlist(state, key, map, normalizer)
     if state[key] == nil then
         state[key] = CopyTruthyMap(normalized) or {}
     else
-        local intersection = IntersectTruthyMaps(state[key], normalized)
-        if next(intersection) then
-            state[key] = intersection
-        end
+        state[key] = IntersectTruthyMaps(state[key], normalized)
     end
     return true
 end
@@ -1393,6 +1389,17 @@ local function GetClassKeyFromClassID(classID)
     return NormalizeClassKey(classFilename)
 end
 
+local function GetClassIDFromClassKey(classKey)
+    classKey = NormalizeClassKey(classKey)
+    if not (classKey and GetClassInfo) then return nil end
+    for classID = 1, CLASS_SCAN_LIMIT do
+        if GetClassKeyFromClassID(classID) == classKey then
+            return classID
+        end
+    end
+    return nil
+end
+
 local function GetCurrentScopeClassKey(addon)
     local classFilename = addon and addon._playerClassFilename
     if not classFilename and UnitClass then
@@ -1412,6 +1419,43 @@ local function SpecBelongsToClass(specId, classKey)
     if not classKey then return true end
     local specClassKey = GetSpecClassKey(specId)
     return specClassKey == classKey
+end
+
+local function HeroTalentBelongsToClass(subTreeID, classKey)
+    subTreeID = tonumber(subTreeID)
+    if not classKey then return true end
+    if not (subTreeID
+        and C_ClassTalents
+        and C_ClassTalents.GetHeroTalentSpecsForClassSpec
+        and C_SpecializationInfo
+        and C_SpecializationInfo.GetNumSpecializationsForClassID
+        and C_SpecializationInfo.GetSpecializationInfo)
+    then
+        return false
+    end
+
+    local classID = GetClassIDFromClassKey(classKey)
+    if not classID then return false end
+
+    local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
+    for specIndex = 1, numSpecs do
+        local specId = C_SpecializationInfo.GetSpecializationInfo(
+            specIndex,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
+        local subTreeIDs = specId and C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+        for _, availableSubTreeID in ipairs(subTreeIDs or {}) do
+            if tonumber(availableSubTreeID) == subTreeID then
+                return true
+            end
+        end
+    end
+    return false
 end
 
 local function GetCharacterClassKey(addon, charKey)
@@ -1481,6 +1525,31 @@ local function PruneCharacterMapToClass(addon, map, classKey, ownerCharKey)
     return changed
 end
 
+local function PruneHeroTalentMapToClass(entity, classKey)
+    if type(entity) ~= "table" or type(entity.heroTalents) ~= "table" or not classKey then return false end
+    local changed = false
+    for subTreeID in pairs(entity.heroTalents) do
+        local normalizedSubTreeID = tonumber(subTreeID)
+        if normalizedSubTreeID and HeroTalentBelongsToClass(normalizedSubTreeID, classKey) then
+            if subTreeID ~= normalizedSubTreeID then
+                entity.heroTalents[normalizedSubTreeID] = true
+                entity.heroTalents[subTreeID] = nil
+                changed = true
+            end
+        else
+            entity.heroTalents[subTreeID] = nil
+            if normalizedSubTreeID then
+                entity.heroTalents[normalizedSubTreeID] = nil
+            end
+            changed = true
+        end
+    end
+    if not next(entity.heroTalents) then
+        entity.heroTalents = nil
+    end
+    return changed
+end
+
 local function WithOwnerCharKey(opts, ownerCharKey)
     if opts and opts.ownerCharKey then return opts end
     local scopedOpts = opts and CopyTable(opts) or {}
@@ -1505,6 +1574,7 @@ function CooldownCompanion:NormalizeEligibilityForCharacterScope(entity, opts)
             entity.specs = nil
         end
     end
+    changed = PruneHeroTalentMapToClass(entity, classKey) or changed
 
     local loadConditions = entity.loadConditions
     if type(loadConditions) == "table" then

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1383,15 +1383,29 @@ local function ClearEmptyCoreLoadConditions(entity)
     end
 end
 
+local function GetClassInfoByID(classID)
+    classID = tonumber(classID)
+    if not classID then return nil, nil, nil end
+    if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return classInfo.className, classInfo.classFile, classInfo.classID
+        end
+    end
+    if GetClassInfo then
+        return GetClassInfo(classID)
+    end
+    return nil, nil, nil
+end
+
 local function GetClassKeyFromClassID(classID)
-    if not (classID and GetClassInfo) then return nil end
-    local _, classFilename = GetClassInfo(classID)
+    local _, classFilename = GetClassInfoByID(classID)
     return NormalizeClassKey(classFilename)
 end
 
 local function GetClassIDFromClassKey(classKey)
     classKey = NormalizeClassKey(classKey)
-    if not (classKey and GetClassInfo) then return nil end
+    if not classKey then return nil end
     for classID = 1, CLASS_SCAN_LIMIT do
         if GetClassKeyFromClassID(classID) == classKey then
             return classID

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1628,6 +1628,57 @@ function CooldownCompanion:CanMoveContainerToFolder(containerOrContainerId, fold
     return false, "scope-mismatch"
 end
 
+function CooldownCompanion:CanMovePanelToContainer(groupOrGroupId, targetContainerOrContainerId)
+    local db = self.db and self.db.profile
+    if not (db and db.groups and db.groupContainers) then
+        return false, "missing-profile"
+    end
+
+    local group = groupOrGroupId
+    if type(groupOrGroupId) ~= "table" then
+        group = db.groups[groupOrGroupId]
+    end
+    if type(group) ~= "table" or not group.parentContainerId then
+        return false, "missing-source-panel"
+    end
+
+    local targetContainer = targetContainerOrContainerId
+    local targetContainerId
+    if type(targetContainerOrContainerId) ~= "table" then
+        targetContainerId = targetContainerOrContainerId
+        targetContainer = db.groupContainers[targetContainerOrContainerId]
+    else
+        for containerId, container in pairs(db.groupContainers) do
+            if container == targetContainer then
+                targetContainerId = containerId
+                break
+            end
+        end
+    end
+    if type(targetContainer) ~= "table" then
+        return false, "missing-target-container"
+    end
+    if targetContainerId and group.parentContainerId == targetContainerId then
+        return false, "same-container"
+    end
+
+    local sourceScope = self:ResolveContainerClassScope(group.parentContainerId)
+    local targetScope = self:ResolveContainerClassScope(targetContainer)
+    if sourceScope.isInvalid or targetScope.isInvalid then
+        return false, "invalid-class-scope"
+    end
+    if sourceScope.scope ~= targetScope.scope then
+        return false, "scope-mismatch"
+    end
+    if sourceScope.scope == "global" then
+        return true
+    end
+    if sourceScope.ownerClassKey == targetScope.ownerClassKey then
+        return true
+    end
+    return false, "mixed-class-panel"
+end
+
 local function PruneSpecMapToClass(addon, entity, map, classKey)
     if type(map) ~= "table" or not classKey then return false end
     local changed = false

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2939,7 +2939,14 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
     end
 
     for groupId, group in pairs(self.db.profile.groups) do
-        if not self:IsGroupVisibleToCurrentChar(groupId) then
+        local visible = self:IsGroupVisibleToCurrentChar(groupId)
+        local previewEligible = false
+        if not visible then
+            previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
+                group = group,
+            })
+        end
+        if not visible and not previewEligible then
             self:UnloadGroup(groupId)
         else
             local active = self:IsGroupActive(groupId, {
@@ -2947,7 +2954,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
                 checkCharVisibility = true,
                 checkLoadConditions = true,
                 requireButtons = true,
-            })
+            }) or previewEligible
 
             if not active then
                 self:UnloadGroup(groupId)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -587,8 +587,10 @@ function CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
     end
 
     -- Legacy path (no container)
-    if group.isGlobal then return true end
-    return group.createdBy == self.db.keys.char
+    local scope = self:ResolveProfileEntityClassScope(group, {
+        isGlobal = group.isGlobal == true,
+    })
+    return scope.runtimeVisible == true
 end
 
 -- Resolve the container for a panel group, or nil if the group has no container.
@@ -1468,6 +1470,149 @@ local function GetCharacterClassKey(addon, charKey)
     end
     return NormalizeClassKey(info.classFilename)
         or GetClassKeyFromClassID(info.classID)
+end
+
+local function BuildClassScopeResult(scope, opts)
+    opts = opts or {}
+    return {
+        scope = scope,
+        sectionKey = opts.sectionKey,
+        ownerCharKey = opts.ownerCharKey,
+        ownerClassKey = opts.ownerClassKey,
+        classFilename = opts.ownerClassKey,
+        currentClassKey = opts.currentClassKey,
+        currentCharKey = opts.currentCharKey,
+        isGlobal = scope == "global",
+        isCurrentClass = scope == "current-class",
+        isOtherClass = scope == "other-class",
+        isInvalid = scope == "invalid",
+        runtimeVisible = scope == "global" or scope == "current-class",
+        invalidReason = opts.invalidReason,
+    }
+end
+
+local function ResolveProfileEntityClassScope(addon, entity, opts)
+    opts = opts or {}
+    local currentCharKey = opts.currentCharKey
+        or addon and addon.db and addon.db.keys and addon.db.keys.char
+        or nil
+    local currentClassKey = NormalizeClassKey(opts.currentClassKey)
+        or GetCurrentScopeClassKey(addon)
+
+    if type(entity) ~= "table" then
+        return BuildClassScopeResult("invalid", {
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "invalid",
+            invalidReason = "missing-entity",
+        })
+    end
+
+    if opts.isGlobal == true then
+        return BuildClassScopeResult("global", {
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "global",
+        })
+    end
+
+    local ownerCharKey = opts.ownerCharKey or entity.createdBy
+    if type(ownerCharKey) ~= "string" or ownerCharKey == "" then
+        return BuildClassScopeResult("invalid", {
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "invalid",
+            invalidReason = "missing-owner",
+        })
+    end
+
+    local ownerClassKey = GetCharacterClassKey(addon, ownerCharKey)
+    if not ownerClassKey then
+        return BuildClassScopeResult("invalid", {
+            ownerCharKey = ownerCharKey,
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "invalid",
+            invalidReason = "missing-owner-class",
+        })
+    end
+
+    if ownerClassKey == currentClassKey then
+        return BuildClassScopeResult("current-class", {
+            ownerCharKey = ownerCharKey,
+            ownerClassKey = ownerClassKey,
+            currentCharKey = currentCharKey,
+            currentClassKey = currentClassKey,
+            sectionKey = "char",
+        })
+    end
+
+    return BuildClassScopeResult("other-class", {
+        ownerCharKey = ownerCharKey,
+        ownerClassKey = ownerClassKey,
+        currentCharKey = currentCharKey,
+        currentClassKey = currentClassKey,
+        sectionKey = "class:" .. ownerClassKey,
+    })
+end
+
+function CooldownCompanion:ResolveProfileEntityClassScope(entity, opts)
+    return ResolveProfileEntityClassScope(self, entity, opts)
+end
+
+function CooldownCompanion:ResolveContainerClassScope(containerOrContainerId, opts)
+    local container = containerOrContainerId
+    if type(containerOrContainerId) == "number" then
+        local db = self.db and self.db.profile
+        container = db and db.groupContainers and db.groupContainers[containerOrContainerId] or nil
+    end
+    opts = opts and CopyTable(opts) or {}
+    opts.isGlobal = type(container) == "table" and container.isGlobal == true
+    return ResolveProfileEntityClassScope(self, container, opts)
+end
+
+function CooldownCompanion:ResolveFolderClassScope(folderOrFolderId, opts)
+    local folder = folderOrFolderId
+    if type(folderOrFolderId) == "number" then
+        local db = self.db and self.db.profile
+        folder = db and db.folders and db.folders[folderOrFolderId] or nil
+    end
+    opts = opts and CopyTable(opts) or {}
+    opts.isGlobal = type(folder) == "table" and folder.section == "global"
+    return ResolveProfileEntityClassScope(self, folder, opts)
+end
+
+function CooldownCompanion:CanMoveContainerToFolder(containerOrContainerId, folderOrFolderId, opts)
+    opts = opts or {}
+    if folderOrFolderId == nil then
+        return true
+    end
+
+    local containerScope = self:ResolveContainerClassScope(containerOrContainerId)
+    local folderScope = self:ResolveFolderClassScope(folderOrFolderId)
+    if containerScope.isInvalid or folderScope.isInvalid then
+        return false, "invalid-class-scope"
+    end
+
+    if containerScope.scope == folderScope.scope then
+        if containerScope.scope == "global" then
+            return true
+        end
+        return containerScope.ownerClassKey == folderScope.ownerClassKey, "mixed-class-folder"
+    end
+
+    if opts.allowScopeChange == true then
+        if containerScope.scope == "global" and folderScope.scope == "current-class" then
+            return true
+        end
+        if folderScope.scope == "global"
+            and (containerScope.scope == "current-class" or containerScope.scope == "other-class")
+        then
+            return true
+        end
+    end
+
+    return false, "scope-mismatch"
 end
 
 local function PruneSpecMapToClass(addon, entity, map, classKey)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -218,6 +218,22 @@ local function ResolveEffectiveSources(sources)
     return effective, inherited, hasRestriction
 end
 
+local function AddEntityEffectiveSpecSource(sources, entity, inherited)
+    AddCombinedEffectiveSource(
+        sources,
+        inherited,
+        NormalizeSpecKey,
+        entity and entity.specs,
+        entity and entity.loadConditions and entity.loadConditions.specAllowlist
+    )
+end
+
+local function AddFolderEffectiveSpecSource(sources, profile, folderId)
+    local folders = profile and profile.folders
+    local folder = folderId and folders and folders[folderId]
+    AddEntityEffectiveSpecSource(sources, folder, true)
+end
+
 local function MergeEligibilityAllowlist(state, key, map, normalizer)
     local normalized, malformed, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
     if malformed then
@@ -865,6 +881,10 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
         return false
     end
 
+    if self.IsGroupEligibilityMet and not self:IsGroupEligibilityMet(group) then
+        return false
+    end
+
     local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
     if hasSpecFilter then
         if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
@@ -893,55 +913,33 @@ function CooldownCompanion:GetEffectiveSpecs(group)
     if not group then return nil, false end
 
     local sources = {}
+    local profile = self.db and self.db.profile
 
     local container = self:GetParentContainer(group)
     if container then
-        local folderId = container.folderId
-        if folderId then
-            local folders = self.db and self.db.profile and self.db.profile.folders
-            local folder = folders and folders[folderId]
-            AddCombinedEffectiveSource(
-                sources,
-                true,
-                NormalizeSpecKey,
-                folder and folder.specs,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist
-            )
-        end
-        AddCombinedEffectiveSource(
-            sources,
-            true,
-            NormalizeSpecKey,
-            container.specs,
-            container.loadConditions and container.loadConditions.specAllowlist
-        )
-        AddCombinedEffectiveSource(
-            sources,
-            false,
-            NormalizeSpecKey,
-            group.specs,
-            group.loadConditions and group.loadConditions.specAllowlist
-        )
+        AddFolderEffectiveSpecSource(sources, profile, container.folderId)
+        AddEntityEffectiveSpecSource(sources, container, true)
+        AddEntityEffectiveSpecSource(sources, group, false)
     else
-        local folderId = group.folderId
-        if folderId then
-            local folders = self.db and self.db.profile and self.db.profile.folders
-            local folder = folders and folders[folderId]
-            AddCombinedEffectiveSource(
-                sources,
-                true,
-                NormalizeSpecKey,
-                folder and folder.specs,
-                folder and folder.loadConditions and folder.loadConditions.specAllowlist
-            )
-        end
-        AddCombinedEffectiveSource(
-            sources,
-            false,
-            NormalizeSpecKey,
-            group.specs,
-            group.loadConditions and group.loadConditions.specAllowlist
-        )
+        AddFolderEffectiveSpecSource(sources, profile, group.folderId)
+        AddEntityEffectiveSpecSource(sources, group, false)
+    end
+
+    return ResolveEffectiveSources(sources)
+end
+
+function CooldownCompanion:GetInheritedEffectiveSpecs(group)
+    if not group then return nil, false end
+
+    local sources = {}
+    local profile = self.db and self.db.profile
+
+    local container = self:GetParentContainer(group)
+    if container then
+        AddFolderEffectiveSpecSource(sources, profile, container.folderId)
+        AddEntityEffectiveSpecSource(sources, container, true)
+    else
+        AddFolderEffectiveSpecSource(sources, profile, group.folderId)
     end
 
     return ResolveEffectiveSources(sources)
@@ -2103,12 +2101,15 @@ function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
     return sources
 end
 
-function CooldownCompanion:EvaluateLoadConditionSources(sources)
+function CooldownCompanion:EvaluateLoadConditionSources(sources, opts)
+    opts = opts or {}
     local eligibility
     local identity
 
     for _, source in ipairs(sources or {}) do
-        if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
+        if opts.eligibilityOnly ~= true
+            and not self:EvaluateLoadConditions(source.loadConditions, source.defaults)
+        then
             return false, source.label
         end
         local loadConditions = source.loadConditions
@@ -2137,8 +2138,20 @@ function CooldownCompanion:IsGroupLoadConditionMet(group)
     return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForGroup(group))
 end
 
+function CooldownCompanion:IsGroupEligibilityMet(group)
+    return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForGroup(group), {
+        eligibilityOnly = true,
+    })
+end
+
 function CooldownCompanion:IsButtonLoadConditionMet(buttonData, group)
     return self:EvaluateLoadConditionSources(self:GetLoadConditionSourcesForEntry(buttonData, group))
+end
+
+function CooldownCompanion:IsCustomBarLoadConditionMet(customBar)
+    local sources = {}
+    AddLoadConditionSource(sources, "Custom Bar", customBar, LOCAL_LOAD_CONDITION_DEFAULTS, true)
+    return self:EvaluateLoadConditionSources(sources)
 end
 
 

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -72,6 +72,12 @@ local LOCAL_LOAD_CONDITION_DEFAULTS = {
     vehicleUI = false,
 }
 
+local LOAD_CONDITION_ALLOWLIST_KEYS = {
+    classAllowlist = true,
+    specAllowlist = true,
+    characterAllowlist = true,
+}
+
 local function GetFrameName(frame)
     if not frame then
         return nil
@@ -83,6 +89,121 @@ local function GetFrameName(frame)
         return "CooldownCompanionGroup" .. frame.groupId
     end
     return frame.name
+end
+
+local function NormalizeClassKey(key)
+    if type(key) ~= "string" or key == "" then return nil end
+    return string.upper(key)
+end
+
+local function NormalizeSpecKey(key)
+    local specId = tonumber(key)
+    if not specId then return nil end
+    return specId
+end
+
+local function NormalizeCharacterKey(key)
+    if type(key) ~= "string" or key == "" then return nil end
+    return key
+end
+
+local function NormalizeTruthyMap(map, normalizer, failClosed)
+    if map == nil then return nil, false, false end
+    if type(map) ~= "table" then return nil, true, true end
+
+    local normalized = {}
+    local sawEntry = false
+    for key, enabled in pairs(map) do
+        sawEntry = true
+        if enabled == true then
+            local normalizedKey = normalizer(key)
+            if normalizedKey ~= nil then
+                normalized[normalizedKey] = true
+            end
+        end
+    end
+
+    if next(normalized) then
+        return normalized, false, true
+    end
+    if sawEntry and failClosed then
+        return {}, false, true
+    end
+    return nil, false, false
+end
+
+local function CopyTruthyMap(map)
+    if not map then return nil end
+    local copy = {}
+    for key in pairs(map) do
+        copy[key] = true
+    end
+    return copy
+end
+
+local function IntersectTruthyMaps(left, right)
+    local intersection = {}
+    for key in pairs(left or {}) do
+        if right and right[key] then
+            intersection[key] = true
+        end
+    end
+    return intersection
+end
+
+local function AddEffectiveSource(sources, map, inherited, normalizer)
+    local normalized, _, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
+    if hasRestriction then
+        sources[#sources + 1] = {
+            values = normalized or {},
+            inherited = inherited and true or false,
+        }
+    end
+end
+
+local function ResolveEffectiveSources(sources)
+    local effective
+    local inherited = false
+    local hasRestriction = false
+
+    for _, source in ipairs(sources or {}) do
+        hasRestriction = true
+        if source.inherited then inherited = true end
+        if effective == nil then
+            effective = CopyTruthyMap(source.values) or {}
+        else
+            effective = IntersectTruthyMaps(effective, source.values)
+        end
+    end
+
+    return effective, inherited, hasRestriction
+end
+
+local function MergeEligibilityAllowlist(state, key, map, normalizer)
+    local normalized, malformed, hasRestriction = NormalizeTruthyMap(map, normalizer, true)
+    if malformed then
+        state[key .. "Restricted"] = true
+        state[key .. "NoMatch"] = true
+        state[key] = {}
+        return false
+    end
+    if not hasRestriction then return true end
+
+    local restrictedKey = key .. "Restricted"
+    state[restrictedKey] = true
+    if state[key] == nil then
+        state[key] = CopyTruthyMap(normalized) or {}
+    else
+        state[key] = IntersectTruthyMaps(state[key], normalized)
+    end
+    return true
+end
+
+local function AllowlistMatches(state, key, currentValue)
+    if not state[key .. "Restricted"] then return true end
+    if state[key .. "NoMatch"] then return false end
+    if currentValue == nil then return false end
+    return state[key] and state[key][currentValue] == true
 end
 
 local function GetCurrentAnchorTargetName(frame)
@@ -705,8 +826,8 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
         return false
     end
 
-    local effectiveSpecs = self:GetEffectiveSpecs(group)
-    if effectiveSpecs and next(effectiveSpecs) then
+    local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
+    if hasSpecFilter then
         if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
             return false
         end
@@ -732,61 +853,57 @@ end
 function CooldownCompanion:GetEffectiveSpecs(group)
     if not group then return nil, false end
 
-    -- Panel: container specs (includes stamped folder specs) → panel's own
+    local sources = {}
+
     local container = self:GetParentContainer(group)
     if container then
-        if container.specs and next(container.specs) then
-            return container.specs, true
+        local folderId = container.folderId
+        if folderId then
+            local folders = self.db and self.db.profile and self.db.profile.folders
+            local folder = folders and folders[folderId]
+            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
         end
-        -- Fall through to panel's own
-        return group.specs, false
+        AddEffectiveSource(sources, container.specs, true, NormalizeSpecKey)
+        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
+    else
+        local folderId = group.folderId
+        if folderId then
+            local folders = self.db and self.db.profile and self.db.profile.folders
+            local folder = folders and folders[folderId]
+            AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
+        end
+        AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
     end
 
-    -- Non-panel group: check folder cascade
-    local folderId = group.folderId
-    if folderId then
-        local folders = self.db and self.db.profile and self.db.profile.folders
-        local folder = folders and folders[folderId]
-        if folder and folder.specs and next(folder.specs) then
-            return folder.specs, true
-        end
-    end
-    return group.specs, false
+    return ResolveEffectiveSources(sources)
 end
 
 function CooldownCompanion:GetEffectiveHeroTalents(group)
     if not group then return nil, false end
 
-    -- Panel cascade: folder → container → panel's own heroTalents
+    local sources = {}
+
     local container = self:GetParentContainer(group)
     if container then
-        -- Check folder first
         local folderId = container.folderId
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
-            if folder and folder.heroTalents and next(folder.heroTalents) then
-                return folder.heroTalents, true
-            end
+            AddEffectiveSource(sources, folder and folder.heroTalents, true, NormalizeSpecKey)
         end
-        -- Then container's own heroTalents
-        if container.heroTalents and next(container.heroTalents) then
-            return container.heroTalents, true
+        AddEffectiveSource(sources, container.heroTalents, true, NormalizeSpecKey)
+        AddEffectiveSource(sources, group.heroTalents, false, NormalizeSpecKey)
+    else
+        local folderId = group.folderId
+        if folderId then
+            local folders = self.db and self.db.profile and self.db.profile.folders
+            local folder = folders and folders[folderId]
+            AddEffectiveSource(sources, folder and folder.heroTalents, true, NormalizeSpecKey)
         end
-        -- Fall through to panel's own
-        return group.heroTalents, false
+        AddEffectiveSource(sources, group.heroTalents, false, NormalizeSpecKey)
     end
 
-    -- Non-panel container: check folder cascade
-    local folderId = group.folderId
-    if folderId then
-        local folders = self.db and self.db.profile and self.db.profile.folders
-        local folder = folders and folders[folderId]
-        if folder and folder.heroTalents and next(folder.heroTalents) then
-            return folder.heroTalents, true
-        end
-    end
-    return group.heroTalents, false
+    return ResolveEffectiveSources(sources)
 end
 
 local function CopyTalentCondition(cond)
@@ -1071,8 +1188,8 @@ function CooldownCompanion:SetFolderHeroTalent(folderId, subTreeID, enabled)
 end
 
 function CooldownCompanion:IsHeroTalentAllowed(group)
-    local effectiveHeroTalents = self:GetEffectiveHeroTalents(group)
-    if not (effectiveHeroTalents and next(effectiveHeroTalents)) then return true end
+    local effectiveHeroTalents, _, hasHeroTalentFilter = self:GetEffectiveHeroTalents(group)
+    if not hasHeroTalentFilter then return true end
     local heroSpecId = self._currentHeroSpecId
     if not heroSpecId then return true end  -- low level, no hero talent selected
     return effectiveHeroTalents[heroSpecId] == true
@@ -1154,8 +1271,8 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
     end
 
     -- Spec and hero talent filtering (GetEffectiveSpecs already delegates to container)
-    local effectiveSpecs = self:GetEffectiveSpecs(group)
-    if effectiveSpecs and next(effectiveSpecs) then
+    local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
+    if hasSpecFilter then
         if not (self._currentSpecId and effectiveSpecs[self._currentSpecId]) then
             return false
         end
@@ -1521,8 +1638,11 @@ function CooldownCompanion:HasLocalLoadConditions(entity)
     if not (type(entity) == "table" and type(entity.loadConditions) == "table") then
         return false
     end
-    for _, value in pairs(entity.loadConditions) do
+    for key, value in pairs(entity.loadConditions) do
         if value == true then
+            return true
+        end
+        if LOAD_CONDITION_ALLOWLIST_KEYS[key] and type(value) == "table" and next(value) then
             return true
         end
     end
@@ -1573,18 +1693,39 @@ function CooldownCompanion:EvaluateLoadConditions(loadConditions, defaults)
     return true
 end
 
+function CooldownCompanion:GetCurrentEligibilityIdentity()
+    local classFilename = self._playerClassFilename
+    if not classFilename and UnitClass then
+        classFilename = select(2, UnitClass("player"))
+    end
+    return {
+        classFilename = NormalizeClassKey(classFilename),
+        specId = self._currentSpecId,
+        charKey = self.db and self.db.keys and self.db.keys.char or nil,
+    }
+end
+
 function CooldownCompanion:CheckLoadConditions(group)
     return self:EvaluateLoadConditions(group and group.loadConditions)
 end
 
-local function AddLoadConditionSource(sources, label, entity, defaults)
+local function AddLoadConditionSource(sources, label, entity, defaults, allowClassEligibility)
     if type(entity) == "table" and type(entity.loadConditions) == "table" then
         sources[#sources + 1] = {
             label = label,
             loadConditions = entity.loadConditions,
             defaults = defaults,
+            allowClassEligibility = allowClassEligibility == true,
         }
     end
+end
+
+local function IsFolderGlobalScope(folder)
+    return type(folder) == "table" and folder.section == "global"
+end
+
+local function IsContainerGlobalScope(container)
+    return type(container) == "table" and container.isGlobal == true
 end
 
 function CooldownCompanion:GetInheritedLoadConditionSources(group)
@@ -1595,34 +1736,58 @@ function CooldownCompanion:GetInheritedLoadConditionSources(group)
     local container = self:GetParentContainer(group)
     if container then
         local folder = container.folderId and db.folders and db.folders[container.folderId]
-        AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS)
-        AddLoadConditionSource(sources, "Group", container, LOAD_CONDITION_DEFAULTS)
+        AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS, IsFolderGlobalScope(folder))
+        AddLoadConditionSource(sources, "Group", container, LOAD_CONDITION_DEFAULTS, IsContainerGlobalScope(container))
         return sources
     end
 
     local folder = group.folderId and db.folders and db.folders[group.folderId]
-    AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS)
+    AddLoadConditionSource(sources, "Folder", folder, LOCAL_LOAD_CONDITION_DEFAULTS, IsFolderGlobalScope(folder))
     return sources
 end
 
 function CooldownCompanion:GetLoadConditionSourcesForGroup(group)
     local sources = self:GetInheritedLoadConditionSources(group)
     if group then
-        AddLoadConditionSource(sources, group.parentContainerId and "Panel" or "Group", group, LOAD_CONDITION_DEFAULTS)
+        local container = self:GetParentContainer(group)
+        local allowClassEligibility
+        if container then
+            allowClassEligibility = IsContainerGlobalScope(container)
+        else
+            allowClassEligibility = group.isGlobal == true
+        end
+        AddLoadConditionSource(sources, group.parentContainerId and "Panel" or "Group", group, LOAD_CONDITION_DEFAULTS, allowClassEligibility)
     end
     return sources
 end
 
 function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
     local sources = self:GetLoadConditionSourcesForGroup(group)
-    AddLoadConditionSource(sources, "Entry", buttonData, LOCAL_LOAD_CONDITION_DEFAULTS)
+    AddLoadConditionSource(sources, "Entry", buttonData, LOCAL_LOAD_CONDITION_DEFAULTS, false)
     return sources
 end
 
 function CooldownCompanion:EvaluateLoadConditionSources(sources)
+    local eligibility = {}
+    local identity = self:GetCurrentEligibilityIdentity()
+
     for _, source in ipairs(sources or {}) do
         if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
             return false, source.label
+        end
+        local loadConditions = source.loadConditions
+        if type(loadConditions) == "table" then
+            if source.allowClassEligibility then
+                MergeEligibilityAllowlist(eligibility, "class", loadConditions.classAllowlist, NormalizeClassKey)
+            end
+            MergeEligibilityAllowlist(eligibility, "spec", loadConditions.specAllowlist, NormalizeSpecKey)
+            MergeEligibilityAllowlist(eligibility, "character", loadConditions.characterAllowlist, NormalizeCharacterKey)
+            if not AllowlistMatches(eligibility, "class", identity.classFilename)
+                or not AllowlistMatches(eligibility, "spec", identity.specId)
+                or not AllowlistMatches(eligibility, "character", identity.charKey)
+            then
+                return false, source.label
+            end
         end
     end
     return true, nil

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1720,6 +1720,15 @@ local function AddLoadConditionSource(sources, label, entity, defaults, allowCla
     end
 end
 
+local function HasEligibilityAllowlist(loadConditions, allowClassEligibility)
+    if type(loadConditions) ~= "table" then return false end
+    if allowClassEligibility and loadConditions.classAllowlist ~= nil then
+        return true
+    end
+    return loadConditions.specAllowlist ~= nil
+        or loadConditions.characterAllowlist ~= nil
+end
+
 local function IsFolderGlobalScope(folder)
     return type(folder) == "table" and folder.section == "global"
 end
@@ -1768,15 +1777,19 @@ function CooldownCompanion:GetLoadConditionSourcesForEntry(buttonData, group)
 end
 
 function CooldownCompanion:EvaluateLoadConditionSources(sources)
-    local eligibility = {}
-    local identity = self:GetCurrentEligibilityIdentity()
+    local eligibility
+    local identity
 
     for _, source in ipairs(sources or {}) do
         if not self:EvaluateLoadConditions(source.loadConditions, source.defaults) then
             return false, source.label
         end
         local loadConditions = source.loadConditions
-        if type(loadConditions) == "table" then
+        if HasEligibilityAllowlist(loadConditions, source.allowClassEligibility) then
+            if not eligibility then
+                eligibility = {}
+                identity = self:GetCurrentEligibilityIdentity()
+            end
             if source.allowClassEligibility then
                 MergeEligibilityAllowlist(eligibility, "class", loadConditions.classAllowlist, NormalizeClassKey)
             end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1479,7 +1479,6 @@ local function BuildClassScopeResult(scope, opts)
         sectionKey = opts.sectionKey,
         ownerCharKey = opts.ownerCharKey,
         ownerClassKey = opts.ownerClassKey,
-        classFilename = opts.ownerClassKey,
         currentClassKey = opts.currentClassKey,
         currentCharKey = opts.currentCharKey,
         isGlobal = scope == "global",
@@ -1769,9 +1768,16 @@ function CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(folderId,
     opts = WithOwnerCharKey(opts, folder.createdBy or (self.db and self.db.keys and self.db.keys.char))
 
     local changed = self:NormalizeEligibilityForCharacterScope(folder, opts)
+    local childContainerIds = {}
     for containerId, container in pairs(db.groupContainers or {}) do
         if type(container) == "table" and container.folderId == folderId then
-            changed = self:NormalizeContainerEligibilityForCharacterScope(containerId, opts) or changed
+            childContainerIds[containerId] = true
+            changed = self:NormalizeEligibilityForCharacterScope(container, opts) or changed
+        end
+    end
+    for _, group in pairs(db.groups or {}) do
+        if type(group) == "table" and childContainerIds[group.parentContainerId] then
+            changed = self:NormalizeEligibilityForCharacterScope(group, opts) or changed
         end
     end
     return changed

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -862,17 +862,47 @@ function CooldownCompanion:GetEffectiveSpecs(group)
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
             AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
+            AddEffectiveSource(
+                sources,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
+                true,
+                NormalizeSpecKey
+            )
         end
         AddEffectiveSource(sources, container.specs, true, NormalizeSpecKey)
+        AddEffectiveSource(
+            sources,
+            container.loadConditions and container.loadConditions.specAllowlist,
+            true,
+            NormalizeSpecKey
+        )
         AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
+        AddEffectiveSource(
+            sources,
+            group.loadConditions and group.loadConditions.specAllowlist,
+            false,
+            NormalizeSpecKey
+        )
     else
         local folderId = group.folderId
         if folderId then
             local folders = self.db and self.db.profile and self.db.profile.folders
             local folder = folders and folders[folderId]
             AddEffectiveSource(sources, folder and folder.specs, true, NormalizeSpecKey)
+            AddEffectiveSource(
+                sources,
+                folder and folder.loadConditions and folder.loadConditions.specAllowlist,
+                true,
+                NormalizeSpecKey
+            )
         end
         AddEffectiveSource(sources, group.specs, false, NormalizeSpecKey)
+        AddEffectiveSource(
+            sources,
+            group.loadConditions and group.loadConditions.specAllowlist,
+            false,
+            NormalizeSpecKey
+        )
     end
 
     return ResolveEffectiveSources(sources)
@@ -1260,16 +1290,6 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if group.enabled == false then return false end
     end
 
-    local buttonUsabilityOptions = opts.buttonUsabilityOptions
-        or (self.GetGroupButtonUsabilityOptions and self:GetGroupButtonUsabilityOptions(groupId, group))
-
-    if opts.requireButtons and not self:GroupHasUsableButtons(group, {
-        checkLoadConditions = opts.checkLoadConditions,
-        ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
-    }) then
-        return false
-    end
-
     -- Spec and hero talent filtering (GetEffectiveSpecs already delegates to container)
     local effectiveSpecs, _, hasSpecFilter = self:GetEffectiveSpecs(group)
     if hasSpecFilter then
@@ -1290,6 +1310,16 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
         if not self:IsGroupLoadConditionMet(group) then
             return false
         end
+    end
+
+    local buttonUsabilityOptions = opts.buttonUsabilityOptions
+        or (self.GetGroupButtonUsabilityOptions and self:GetGroupButtonUsabilityOptions(groupId, group))
+
+    if opts.requireButtons and not self:GroupHasUsableButtons(group, {
+        checkLoadConditions = opts.checkLoadConditions,
+        ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
+    }) then
+        return false
     end
 
     return true

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -284,12 +284,14 @@ function CooldownCompanion:OnEnable()
     self:RegisterEvent("PET_BAR_UPDATE", "OnActionBarLayoutChanged")
 
     -- Cache player identity for class/race-specific checks.
-    self._playerClassID = select(3, UnitClass("player"))
+    local _, classFilename, classID = UnitClass("player")
+    self._playerClassFilename = classFilename
+    self._playerClassID = classID
     self._isDracthyr = (select(2, UnitRace("player")) == "Dracthyr")
 
     -- Store class info in global scope for cross-character browse mode
     self.db.global.characterInfo[self.db.keys.char] = {
-        classFilename = select(2, UnitClass("player")),
+        classFilename = classFilename,
         classID = self._playerClassID,
     }
 

--- a/CooldownCompanion/Core/Migrations.lua
+++ b/CooldownCompanion/Core/Migrations.lua
@@ -322,6 +322,9 @@ function CooldownCompanion:RunAllMigrations()
     self:StampImportCheckpoint(self.db and self.db.profile)
     NormalizePassiveCooldownButtons(self.db and self.db.profile)
     BackfillUnusableVisualOverrideModes(self.db and self.db.profile)
+    if self.RunResourceBarClassScopeMigration then
+        self:RunResourceBarClassScopeMigration()
+    end
     if self.SanitizeCursorAnchorPolicy and not self._deferCursorAnchorPolicySanitizer then
         self:SanitizeCursorAnchorPolicy(self.db and self.db.profile)
     end

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -1272,6 +1272,16 @@ local function RemoveLegacyResourceBarCandidates(profile, charKeys)
     end
 end
 
+local function ClearResourceBarUnsafeLegacyKeys(state, charKeys)
+    local unsafe = type(state) == "table" and state.unsafeCharKeys or nil
+    if type(unsafe) ~= "table" then
+        return
+    end
+    for _, charKey in ipairs(charKeys or {}) do
+        unsafe[charKey] = nil
+    end
+end
+
 local function ClearResourceBarConflict(state, classKey)
     if type(state) == "table" and type(state.conflicts) == "table" then
         state.conflicts[classKey] = nil
@@ -1653,6 +1663,7 @@ local function MigrateResourceBarClass(profile, classStore, state, classKey, can
                 StoreResourceBarConflict(state, classKey, candidateCharKeys, true)
             else
                 RemoveLegacyResourceBarCandidates(profile, candidateCharKeys)
+                ClearResourceBarUnsafeLegacyKeys(state, candidateCharKeys)
                 ClearResourceBarConflict(state, classKey)
             end
             return
@@ -1676,6 +1687,7 @@ local function MigrateResourceBarClass(profile, classStore, state, classKey, can
     if #unique == 1 then
         PromoteResourceBarClassSettings(classStore, classKey, unique[1].normalized)
         RemoveLegacyResourceBarCandidates(profile, candidateCharKeys)
+        ClearResourceBarUnsafeLegacyKeys(state, candidateCharKeys)
         ClearResourceBarConflict(state, classKey)
         return
     end
@@ -2088,7 +2100,9 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         end
         MergeResourceBarConflictCustomBars(classStore[classKey], classKey, conflict, legacyStore, nil, nil)
         RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
-        ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
+        local state = EnsureResourceBarMigrationState(profile)
+        ClearResourceBarUnsafeLegacyKeys(state, conflict.candidateCharKeys)
+        ClearResourceBarConflict(state, classKey)
         if type(self._resourceBarConflictFallbackSettings) == "table" then
             self._resourceBarConflictFallbackSettings[classKey] = nil
         end
@@ -2122,7 +2136,9 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
     MergeResourceBarConflictCustomBars(classStore[classKey], classKey, conflict, legacyStore, sourceCharKey, existingClassSettings)
 
     RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
-    ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
+    local state = EnsureResourceBarMigrationState(profile)
+    ClearResourceBarUnsafeLegacyKeys(state, conflict.candidateCharKeys)
+    ClearResourceBarConflict(state, classKey)
     if type(self._resourceBarConflictFallbackSettings) == "table" then
         self._resourceBarConflictFallbackSettings[classKey] = nil
     end

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -1321,6 +1321,308 @@ local function BuildResourceBarMigrationBuckets(addon, profile, state)
     return buckets
 end
 
+local function AddMergedCustomBarOrder(store, customBarId)
+    if type(store) ~= "table" or type(customBarId) ~= "string" or customBarId == "" then
+        return
+    end
+    store.order = type(store.order) == "table" and store.order or {}
+    for _, existingId in ipairs(store.order) do
+        if existingId == customBarId then
+            return
+        end
+    end
+    store.order[#store.order + 1] = customBarId
+end
+
+local function AllocateMergedCustomBarId(settings, store)
+    settings.nextCustomBarId = tonumber(settings.nextCustomBarId) or 1
+    local id
+    repeat
+        id = "custom_bar_" .. tostring(settings.nextCustomBarId)
+        settings.nextCustomBarId = settings.nextCustomBarId + 1
+    until type(store.entries[id]) ~= "table"
+    return id
+end
+
+local function EnsureMergedCustomBarLayout(settings, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    if type(settings) ~= "table" or not specID then
+        return nil
+    end
+    settings.layoutOrder = type(settings.layoutOrder) == "table" and settings.layoutOrder or {}
+    local layout = GetSpecKeyedTable(settings.layoutOrder, specID)
+    if type(layout) ~= "table" then
+        layout = {}
+        settings.layoutOrder[specID] = layout
+    end
+    layout.customBars = type(layout.customBars) == "table" and layout.customBars or {}
+    return layout
+end
+
+local function AddMergedSpecID(specIDs, seen, specID)
+    specID = NormalizeCustomBarSpecID(specID)
+    if specID and not seen[specID] then
+        seen[specID] = true
+        specIDs[#specIDs + 1] = specID
+    end
+end
+
+local function CollectMergedCustomBarLayoutSpecIDs(sourceSettings, sourceCustomBarId, entry, fallbackSpecID, legacySlotIndex)
+    local specIDs = {}
+    local seen = {}
+    AddMergedSpecID(specIDs, seen, fallbackSpecID)
+
+    if type(entry) == "table" and type(entry.specs) == "table" then
+        for specID, enabled in pairs(entry.specs) do
+            if enabled == true then
+                AddMergedSpecID(specIDs, seen, specID)
+            end
+        end
+    end
+
+    local layoutOrder = type(sourceSettings) == "table" and sourceSettings.layoutOrder or nil
+    if type(layoutOrder) == "table" then
+        for specID, layout in pairs(layoutOrder) do
+            if type(layout) == "table" then
+                local hasCustomLayout = type(sourceCustomBarId) == "string"
+                    and type(layout.customBars) == "table"
+                    and type(layout.customBars[sourceCustomBarId]) == "table"
+                local hasLegacyAuraLayout = legacySlotIndex ~= nil
+                    and type(layout.customAuraBarSlots) == "table"
+                    and type(layout.customAuraBarSlots[legacySlotIndex]) == "table"
+                if hasCustomLayout or hasLegacyAuraLayout then
+                    AddMergedSpecID(specIDs, seen, specID)
+                end
+            end
+        end
+    end
+
+    sort(specIDs, function(a, b) return tostring(a) < tostring(b) end)
+    return specIDs
+end
+
+local function CopyMergedCustomBarLayout(targetSettings, sourceSettings, specID, sourceCustomBarId, targetCustomBarId, fallbackOrder, legacySlotIndex)
+    local targetLayout = EnsureMergedCustomBarLayout(targetSettings, specID)
+    if type(targetLayout) ~= "table"
+        or type(targetCustomBarId) ~= "string"
+        or type(targetLayout.customBars[targetCustomBarId]) == "table" then
+        return
+    end
+
+    local sourceLayout = type(sourceSettings) == "table"
+        and type(sourceSettings.layoutOrder) == "table"
+        and GetSpecKeyedTable(sourceSettings.layoutOrder, specID)
+        or nil
+    local sourceCustomLayout = nil
+    if type(sourceLayout) == "table" then
+        if type(sourceCustomBarId) == "string"
+            and type(sourceLayout.customBars) == "table"
+            and type(sourceLayout.customBars[sourceCustomBarId]) == "table" then
+            sourceCustomLayout = sourceLayout.customBars[sourceCustomBarId]
+        elseif legacySlotIndex ~= nil
+            and type(sourceLayout.customAuraBarSlots) == "table"
+            and type(sourceLayout.customAuraBarSlots[legacySlotIndex]) == "table" then
+            sourceCustomLayout = sourceLayout.customAuraBarSlots[legacySlotIndex]
+        end
+    end
+
+    targetLayout.customBars[targetCustomBarId] = type(sourceCustomLayout) == "table"
+        and CopyTable(sourceCustomLayout)
+        or {
+            position = "below",
+            order = fallbackOrder or 1000,
+        }
+end
+
+local function NormalizeMergedCustomBarEntry(entry, fallbackSpecID, entryTypeFallback)
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    local copy = CopyTable(entry)
+    if copy.entryType == nil and entryTypeFallback then
+        copy.entryType = entryTypeFallback
+    end
+
+    local specs = {}
+    local sawSpec = false
+    ForEachSharedCustomBarSpec(copy, function(specID)
+        sawSpec = true
+        specs[specID] = true
+    end)
+    fallbackSpecID = NormalizeCustomBarSpecID(fallbackSpecID)
+    if fallbackSpecID then
+        sawSpec = true
+        specs[fallbackSpecID] = true
+    end
+    copy.specs = sawSpec and specs or {}
+    ClearCustomBarLegacySpecFields(copy)
+    return copy
+end
+
+local AddMergedCustomBar
+
+local function MergeLegacyCustomBarBuckets(targetSettings, sourceSettings, barsBySpec, isAuraStore)
+    if type(barsBySpec) ~= "table" then
+        return
+    end
+
+    local specKeys = {}
+    for specID in pairs(barsBySpec) do
+        specKeys[#specKeys + 1] = specID
+    end
+    sort(specKeys, function(a, b) return tostring(a) < tostring(b) end)
+
+    for _, specKey in ipairs(specKeys) do
+        local specID = NormalizeCustomBarSpecID(specKey)
+        local specBars = specID and barsBySpec[specKey] or nil
+        if type(specBars) == "table" then
+            local numericKeys = {}
+            local seen = {}
+            for key in pairs(specBars) do
+                if tonumber(key) then
+                    numericKeys[#numericKeys + 1] = tonumber(key)
+                end
+            end
+            sort(numericKeys)
+            for index, numericKey in ipairs(numericKeys) do
+                local entry = specBars[numericKey] or specBars[tostring(numericKey)]
+                if type(entry) == "table" then
+                    AddMergedCustomBar(targetSettings, sourceSettings, entry, specID, entry.customBarId, 1000 + index, isAuraStore and numericKey or nil, isAuraStore and "aura" or nil)
+                end
+                seen[numericKey] = true
+                seen[tostring(numericKey)] = true
+            end
+            for key, entry in pairs(specBars) do
+                if type(entry) == "table" and not seen[key] then
+                    AddMergedCustomBar(targetSettings, sourceSettings, entry, specID, entry.customBarId, 1000 + #numericKeys + 1, isAuraStore and tonumber(key) or nil, isAuraStore and "aura" or nil)
+                end
+            end
+        end
+    end
+end
+
+local function EnsureMergedCustomBarStore(settings)
+    if type(settings) ~= "table" then
+        return nil
+    end
+
+    if IsSharedCustomBarsStore(settings.customBars) then
+        local store = settings.customBars
+        store.entries = type(store.entries) == "table" and store.entries or {}
+        store.order = type(store.order) == "table" and store.order or {}
+        local ordered = {}
+        for _, customBarId in ipairs(store.order) do
+            ordered[customBarId] = true
+        end
+        for customBarId, entry in pairs(store.entries) do
+            if type(entry) == "table" and type(customBarId) == "string" then
+                entry.customBarId = type(entry.customBarId) == "string" and entry.customBarId or customBarId
+                if not ordered[customBarId] then
+                    store.order[#store.order + 1] = customBarId
+                end
+            end
+        end
+        return store
+    end
+
+    local legacyCustomBars = settings.customBars
+    local legacyCustomAuraBars = settings.customAuraBars
+    settings.customBars = { entries = {}, order = {} }
+    settings.customAuraBars = {}
+    MergeLegacyCustomBarBuckets(settings, settings, legacyCustomBars, false)
+    MergeLegacyCustomBarBuckets(settings, settings, legacyCustomAuraBars, true)
+    return settings.customBars
+end
+
+AddMergedCustomBar = function(targetSettings, sourceSettings, sourceEntry, fallbackSpecID, sourceCustomBarId, fallbackOrder, legacySlotIndex, entryTypeFallback)
+    local store = EnsureMergedCustomBarStore(targetSettings)
+    local entry = NormalizeMergedCustomBarEntry(sourceEntry, fallbackSpecID, entryTypeFallback)
+    if type(store) ~= "table" or type(entry) ~= "table" then
+        return nil
+    end
+
+    local preferredId = type(entry.customBarId) == "string" and entry.customBarId ~= "" and entry.customBarId
+        or (type(sourceCustomBarId) == "string" and sourceCustomBarId ~= "" and sourceCustomBarId or nil)
+    local targetId = preferredId
+    if not targetId then
+        targetId = AllocateMergedCustomBarId(targetSettings, store)
+    elseif type(store.entries[targetId]) == "table" then
+        if DeepEqual(store.entries[targetId], entry) then
+            local specIDs = CollectMergedCustomBarLayoutSpecIDs(sourceSettings, sourceCustomBarId or targetId, entry, fallbackSpecID, legacySlotIndex)
+            for _, specID in ipairs(specIDs) do
+                CopyMergedCustomBarLayout(targetSettings, sourceSettings, specID, sourceCustomBarId or targetId, targetId, fallbackOrder, legacySlotIndex)
+            end
+            return targetId
+        end
+        targetId = AllocateMergedCustomBarId(targetSettings, store)
+    end
+
+    entry.customBarId = targetId
+    store.entries[targetId] = entry
+    AddMergedCustomBarOrder(store, targetId)
+
+    local specIDs = CollectMergedCustomBarLayoutSpecIDs(sourceSettings, sourceCustomBarId or preferredId or targetId, entry, fallbackSpecID, legacySlotIndex)
+    for _, specID in ipairs(specIDs) do
+        CopyMergedCustomBarLayout(targetSettings, sourceSettings, specID, sourceCustomBarId or preferredId or targetId, targetId, fallbackOrder, legacySlotIndex)
+    end
+
+    return targetId
+end
+
+local function MergeCustomBarsFromResourceBarSettings(targetSettings, sourceSettings, classKey)
+    if type(targetSettings) ~= "table" or type(sourceSettings) ~= "table" then
+        return
+    end
+
+    local source = CopyNormalizedResourceBarCandidate(sourceSettings, classKey)
+    EnsureMergedCustomBarStore(targetSettings)
+
+    if IsSharedCustomBarsStore(source.customBars) then
+        local entries = type(source.customBars.entries) == "table" and source.customBars.entries or {}
+        local seen = {}
+        if type(source.customBars.order) == "table" then
+            for _, customBarId in ipairs(source.customBars.order) do
+                local entry = entries[customBarId]
+                if type(entry) == "table" then
+                    AddMergedCustomBar(targetSettings, source, entry, nil, customBarId, 1000 + #targetSettings.customBars.order)
+                    seen[customBarId] = true
+                end
+            end
+        end
+        for customBarId, entry in pairs(entries) do
+            if type(entry) == "table" and not seen[customBarId] then
+                AddMergedCustomBar(targetSettings, source, entry, nil, customBarId, 1000 + #targetSettings.customBars.order + 1)
+            end
+        end
+    else
+        MergeLegacyCustomBarBuckets(targetSettings, source, source.customBars, false)
+    end
+
+    MergeLegacyCustomBarBuckets(targetSettings, source, source.customAuraBars, true)
+    NormalizeResourceBarSettingsForClass(targetSettings, classKey)
+    SanitizeResourceBarAnchors(targetSettings, classKey)
+end
+
+local function MergeResourceBarConflictCustomBars(targetSettings, classKey, conflict, legacyStore, selectedCharKey, existingClassSettings)
+    if type(targetSettings) ~= "table" or type(conflict) ~= "table" then
+        return
+    end
+
+    if type(existingClassSettings) == "table" then
+        MergeCustomBarsFromResourceBarSettings(targetSettings, existingClassSettings, classKey)
+    end
+
+    if type(legacyStore) ~= "table" then
+        return
+    end
+    for _, candidateCharKey in ipairs(conflict.candidateCharKeys or {}) do
+        if candidateCharKey ~= selectedCharKey and type(legacyStore[candidateCharKey]) == "table" then
+            MergeCustomBarsFromResourceBarSettings(targetSettings, legacyStore[candidateCharKey], classKey)
+        end
+    end
+end
+
 local function PromoteResourceBarClassSettings(classStore, classKey, settings)
     classStore[classKey] = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
@@ -1425,6 +1727,31 @@ local function BuildResourceBarConflictSummary(profile)
         end
     end
     return summaries
+end
+
+local function FormatResourceBarConflictExportMessage(summaries)
+    if type(summaries) ~= "table" or #summaries == 0 then
+        return nil
+    end
+
+    local parts = {}
+    for _, summary in ipairs(summaries) do
+        local candidateText = summary.candidateCount .. " candidate"
+        if summary.candidateCount ~= 1 then
+            candidateText = candidateText .. "s"
+        end
+        if summary.includeExistingClass then
+            candidateText = candidateText .. " including current class setup"
+        end
+        if #summary.candidateCharKeys > 0 then
+            candidateText = candidateText .. ": " .. concat(summary.candidateCharKeys, ", ")
+        end
+        parts[#parts + 1] = summary.classKey .. " (" .. candidateText .. ")"
+    end
+
+    return "Resolve pending Resource Bar conflicts before exporting. Affected classes: "
+        .. concat(parts, "; ")
+        .. ". Open Resource Bar settings on the affected class and choose the setup to keep."
 end
 
 local function GetFallbackResourceBarSettings(addon, classKey)
@@ -1692,28 +2019,35 @@ end
 
 function CooldownCompanion:GetPendingResourceBarConflictExportMessage()
     local summaries = self:GetPendingResourceBarConflictSummary()
-    if #summaries == 0 then
+    return FormatResourceBarConflictExportMessage(summaries)
+end
+
+function CooldownCompanion:GetResourceBarConflictExportMessage(classKey)
+    classKey = NormalizeClassKey(classKey)
+    if not classKey then
         return nil
     end
 
-    local parts = {}
-    for _, summary in ipairs(summaries) do
-        local candidateText = summary.candidateCount .. " candidate"
-        if summary.candidateCount ~= 1 then
-            candidateText = candidateText .. "s"
-        end
-        if summary.includeExistingClass then
-            candidateText = candidateText .. " including current class setup"
-        end
-        if #summary.candidateCharKeys > 0 then
-            candidateText = candidateText .. ": " .. concat(summary.candidateCharKeys, ", ")
-        end
-        parts[#parts + 1] = summary.classKey .. " (" .. candidateText .. ")"
+    local profile = self.db and self.db.profile
+    local conflict = GetResourceBarConflict(profile, classKey)
+    if not conflict then
+        return nil
     end
 
-    return "Resolve pending Resource Bar conflicts before exporting. Affected classes: "
-        .. concat(parts, "; ")
-        .. ". Open Resource Bar settings on the affected class and choose the setup to keep."
+    local candidateCharKeys = CopyTable(conflict.candidateCharKeys or {})
+    sort(candidateCharKeys)
+    return FormatResourceBarConflictExportMessage({
+        {
+            classKey = classKey,
+            candidateCharKeys = candidateCharKeys,
+            candidateCount = #candidateCharKeys + (conflict.includeExistingClass and 1 or 0),
+            includeExistingClass = conflict.includeExistingClass == true,
+        },
+    })
+end
+
+function CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
+    return self:GetResourceBarConflictExportMessage(GetCurrentResourceBarClassKey(self))
 end
 
 function CooldownCompanion:GetResourceBarUnsafeLegacySummary()
@@ -1740,6 +2074,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
     end
 
     local classStore = EnsureResourceBarClassStore(profile)
+    local legacyStore = GetResourceBarLegacyStore(profile, false)
     if keepExistingClassStore then
         if conflict.includeExistingClass ~= true then
             return false, "invalid_candidate"
@@ -1751,6 +2086,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         if classKey == GetCurrentResourceBarClassKey(self) then
             SanitizeResourceBarAnchors(classStore[classKey], classKey)
         end
+        MergeResourceBarConflictCustomBars(classStore[classKey], classKey, conflict, legacyStore, nil, nil)
         RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
         ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
         if type(self._resourceBarConflictFallbackSettings) == "table" then
@@ -1770,16 +2106,20 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         return false, "invalid_candidate"
     end
 
-    local legacyStore = GetResourceBarLegacyStore(profile, false)
     local source = type(legacyStore) == "table" and legacyStore[sourceCharKey] or nil
     if type(source) ~= "table" then
         return false, "missing_candidate"
     end
 
+    local existingClassSettings = conflict.includeExistingClass == true
+        and type(classStore[classKey]) == "table"
+        and CopyTable(classStore[classKey])
+        or nil
     PromoteResourceBarClassSettings(classStore, classKey, source)
     if classKey == GetCurrentResourceBarClassKey(self) then
         SanitizeResourceBarAnchors(classStore[classKey], classKey)
     end
+    MergeResourceBarConflictCustomBars(classStore[classKey], classKey, conflict, legacyStore, sourceCharKey, existingClassSettings)
 
     RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
     ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -841,7 +841,18 @@ local function NormalizeCustomAuraBarsForClass(settings, classKey)
     end
 end
 
-local function SanitizeAnchorGroupID(groupId)
+local function IsAnchorGroupVisibleForClass(numericGroupID, container, classKey)
+    classKey = NormalizeClassKey(classKey)
+    if classKey and CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(container, {
+            currentClassKey = classKey,
+        })
+        return type(scope) == "table" and scope.runtimeVisible == true
+    end
+    return CooldownCompanion:IsGroupVisibleToCurrentChar(numericGroupID)
+end
+
+local function SanitizeAnchorGroupID(groupId, classKey)
     if not groupId then
         return nil
     end
@@ -862,18 +873,18 @@ local function SanitizeAnchorGroupID(groupId)
     if not CooldownCompanion:IsIconLikeDisplayMode(group.displayMode) or (container and container.isGlobal) then
         return nil
     end
-    if not CooldownCompanion:IsGroupVisibleToCurrentChar(numericGroupID) then
+    if not IsAnchorGroupVisibleForClass(numericGroupID, container, classKey) then
         return nil
     end
     return numericGroupID
 end
 
-local function SanitizeResourceBarAnchors(settings)
+local function SanitizeResourceBarAnchors(settings, classKey)
     if type(settings) ~= "table" then
         return
     end
 
-    settings.anchorGroupId = SanitizeAnchorGroupID(settings.anchorGroupId)
+    settings.anchorGroupId = SanitizeAnchorGroupID(settings.anchorGroupId, classKey)
 
     if settings.independentAnchor ~= nil and type(settings.independentAnchor) ~= "table" then
         settings.independentAnchor = nil
@@ -1033,7 +1044,7 @@ end
 
 local function SanitizeCopiedOrSeededScopedBarSettings(systemKey, settings)
     if systemKey == "resourceBars" then
-        SanitizeResourceBarAnchors(settings)
+        SanitizeResourceBarAnchors(settings, GetCurrentResourceBarClassKey(CooldownCompanion))
     elseif systemKey == "castBar" then
         SanitizeCastBarAnchors(settings)
     elseif systemKey == "frameAnchoring" then
@@ -1104,7 +1115,7 @@ local function IsDefaultResourceBarClassSettings(settings, classKey)
     end
     local defaults = CopySubsystemDefaults("resourceBars")
     NormalizeResourceBarSettingsForClass(defaults, classKey)
-    SanitizeResourceBarAnchors(defaults)
+    SanitizeResourceBarAnchors(defaults, classKey)
     return DeepEqual(settings, defaults)
 end
 
@@ -1184,7 +1195,7 @@ local function SeedImportedLegacyResourceBarBucket(addon, profile)
         if classKey then
             NormalizeResourceBarSettingsForClass(settings, classKey)
         end
-        SanitizeResourceBarAnchors(settings)
+        SanitizeResourceBarAnchors(settings, classKey)
         store = GetResourceBarLegacyStore(profile, true)
         store[exporterCharKey] = settings
     end
@@ -1203,11 +1214,13 @@ local function SeedCurrentLegacyResourceBarBucket(addon, profile)
     local classStore = type(profile) == "table" and rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY) or nil
     local classSettings = type(classStore) == "table" and classStore[classKey] or nil
     if type(classSettings) == "table" and not IsDefaultResourceBarClassSettings(classSettings, classKey) then
+        ClearLegacyResourceBarSeed(profile)
         return
     end
 
     local store = GetResourceBarLegacyStore(profile, false)
     if type(store) == "table" and type(store[currentCharKey]) == "table" then
+        ClearLegacyResourceBarSeed(profile)
         return
     end
 
@@ -1225,14 +1238,15 @@ local function SeedCurrentLegacyResourceBarBucket(addon, profile)
     store = GetResourceBarLegacyStore(profile, true)
     local settings = CopyTable(seed)
     NormalizeResourceBarSettingsForClass(settings, classKey)
-    SanitizeResourceBarAnchors(settings)
+    SanitizeResourceBarAnchors(settings, classKey)
     store[currentCharKey] = settings
+    ClearLegacyResourceBarSeed(profile)
 end
 
 local function CopyNormalizedResourceBarCandidate(settings, classKey)
     local normalized = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(normalized, classKey)
-    SanitizeResourceBarAnchors(normalized)
+    SanitizeResourceBarAnchors(normalized, classKey)
     return normalized
 end
 
@@ -1310,7 +1324,7 @@ end
 local function PromoteResourceBarClassSettings(classStore, classKey, settings)
     classStore[classKey] = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
-    SanitizeResourceBarAnchors(classStore[classKey])
+    SanitizeResourceBarAnchors(classStore[classKey], classKey)
 end
 
 local function MigrateResourceBarClass(profile, classStore, state, classKey, candidates)
@@ -1322,7 +1336,7 @@ local function MigrateResourceBarClass(profile, classStore, state, classKey, can
 
     if type(classStore[classKey]) == "table" then
         NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
-        SanitizeResourceBarAnchors(classStore[classKey])
+        SanitizeResourceBarAnchors(classStore[classKey], classKey)
         if IsDefaultResourceBarClassSettings(classStore[classKey], classKey) then
             classStore[classKey] = nil
         else
@@ -1567,7 +1581,7 @@ function CooldownCompanion:RunResourceBarClassScopeMigration()
     for classKey, settings in pairs(classStore) do
         if type(settings) == "table" then
             NormalizeResourceBarSettingsForClass(settings, classKey)
-            SanitizeResourceBarAnchors(settings)
+            SanitizeResourceBarAnchors(settings, classKey)
         end
     end
 
@@ -1630,7 +1644,7 @@ function CooldownCompanion:GetResourceBarSettings()
     if type(settings) ~= "table" then
         settings = CopySubsystemDefaults("resourceBars")
         NormalizeResourceBarSettingsForClass(settings, classKey)
-        SanitizeResourceBarAnchors(settings)
+        SanitizeResourceBarAnchors(settings, classKey)
         classStore[classKey] = settings
     elseif ResourceBarSettingsNeedsNormalizationForClass(settings, classKey) then
         NormalizeResourceBarSettingsForClass(settings, classKey)
@@ -1735,7 +1749,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
         end
         NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
         if classKey == GetCurrentResourceBarClassKey(self) then
-            SanitizeResourceBarAnchors(classStore[classKey])
+            SanitizeResourceBarAnchors(classStore[classKey], classKey)
         end
         RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
         ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
@@ -1764,7 +1778,7 @@ function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, o
 
     PromoteResourceBarClassSettings(classStore, classKey, source)
     if classKey == GetCurrentResourceBarClassKey(self) then
-        SanitizeResourceBarAnchors(classStore[classKey])
+        SanitizeResourceBarAnchors(classStore[classKey], classKey)
     end
 
     RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -5,9 +5,23 @@ local CopyTable = CopyTable
 local pairs = pairs
 local next = next
 local rawget = rawget
+local setmetatable = setmetatable
 local tonumber = tonumber
 local type = type
 local sort = table.sort
+local concat = table.concat
+
+local CLASS_SCAN_LIMIT = 30
+
+local RESOURCE_BAR_SYSTEM_SPEC = {
+    storeKey = "resourceBarsByChar",
+    seedKey = "legacyResourceBarsSeed",
+    legacyKey = "resourceBars",
+}
+
+local RESOURCE_BAR_CLASS_STORE_KEY = "resourceBarsByClass"
+local RESOURCE_BAR_MIGRATION_KEY = "resourceBarMigration"
+local RESOURCE_BAR_NORMALIZED_CLASS_KEYS = setmetatable({}, { __mode = "k" })
 
 local function GetEnsureCustomAuraBarAuraUnit()
     local rb = ST and ST._RB
@@ -26,11 +40,6 @@ local function BackfillLegacyResourceAuraUnit(resourceAuraEntry)
 end
 
 local SCOPED_BAR_SYSTEMS = {
-    resourceBars = {
-        storeKey = "resourceBarsByChar",
-        seedKey = "legacyResourceBarsSeed",
-        legacyKey = "resourceBars",
-    },
     castBar = {
         storeKey = "castBarByChar",
         seedKey = "legacyCastBarSeed",
@@ -45,6 +54,56 @@ local SCOPED_BAR_SYSTEMS = {
 
 local function GetScopedBarSystemSpec(systemKey)
     return SCOPED_BAR_SYSTEMS[systemKey]
+end
+
+local function NormalizeClassKey(classKey)
+    if type(classKey) ~= "string" or classKey == "" then
+        return nil
+    end
+    return string.upper(classKey)
+end
+
+local function GetClassInfoByID(classID)
+    classID = tonumber(classID)
+    if not classID then
+        return nil, nil, nil
+    end
+    if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return classInfo.className, classInfo.classFile, classInfo.classID
+        end
+    end
+    if GetClassInfo then
+        return GetClassInfo(classID)
+    end
+    return nil, nil, nil
+end
+
+local function GetClassKeyFromClassID(classID)
+    local _, classFilename = GetClassInfoByID(classID)
+    return NormalizeClassKey(classFilename)
+end
+
+local function GetClassIDFromClassKey(classKey)
+    classKey = NormalizeClassKey(classKey)
+    if not classKey then
+        return nil
+    end
+    for classID = 1, CLASS_SCAN_LIMIT do
+        if GetClassKeyFromClassID(classID) == classKey then
+            return classID
+        end
+    end
+    return nil
+end
+
+local function GetCurrentResourceBarClassKey(addon)
+    local classFilename = addon and addon._playerClassFilename
+    if not classFilename and UnitClass then
+        classFilename = select(2, UnitClass("player"))
+    end
+    return NormalizeClassKey(classFilename)
 end
 
 local function CopySubsystemDefaults(defaultKey)
@@ -338,7 +397,6 @@ local function NormalizeResourceThresholdTickEntries(settings)
     end
 end
 
--- Keep these resource mappings aligned with OtherBars/ResourceBarConstants.lua.
 local RESOURCE_HEALTH = -1
 
 local function CopySpecOverrideWithoutAura(sourceSpecData, targetSpecData)
@@ -361,82 +419,6 @@ local function CopySpecOverrideWithoutAura(sourceSpecData, targetSpecData)
     end
 
     return next(copied) and copied or nil
-end
-
-local function PreserveTargetCustomBarLayouts(copied, target)
-    if type(copied) ~= "table"
-        or type(target) ~= "table"
-        or type(target.customBars) ~= "table"
-    then
-        return
-    end
-
-    if type(copied.layoutOrder) ~= "table" then
-        copied.layoutOrder = {}
-    end
-
-    for _, layout in pairs(copied.layoutOrder) do
-        if type(layout) == "table" then
-            layout.customBars = {}
-        end
-    end
-
-    local targetLayoutOrder = type(target.layoutOrder) == "table" and target.layoutOrder or nil
-    local function preserveLayout(specID, customBarId)
-        if type(customBarId) ~= "string" or customBarId == "" then
-            return
-        end
-        local targetLayout = GetSpecKeyedTable(targetLayoutOrder, specID)
-        local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
-        if not copiedLayout then
-            copiedLayout = type(targetLayout) == "table" and CopyTable(targetLayout) or {}
-            copied.layoutOrder[specID] = copiedLayout
-        end
-        if type(copiedLayout.customBars) ~= "table" then
-            copiedLayout.customBars = {}
-        end
-
-        local targetCustomBarLayouts = type(targetLayout) == "table" and targetLayout.customBars or nil
-        local targetCustomBarLayout = type(targetCustomBarLayouts) == "table"
-            and targetCustomBarLayouts[customBarId]
-            or nil
-        if type(targetCustomBarLayout) == "table" then
-            copiedLayout.customBars[customBarId] = CopyTable(targetCustomBarLayout)
-        end
-    end
-
-    if IsSharedCustomBarsStore(target.customBars) then
-        local entries = type(target.customBars.entries) == "table" and target.customBars.entries or {}
-        for _, entry in pairs(entries) do
-            local customBarId = type(entry) == "table" and entry.customBarId or nil
-            local sawSpec = false
-            ForEachSharedCustomBarSpec(entry, function(specID)
-                sawSpec = true
-                preserveLayout(specID, customBarId)
-            end)
-            if not sawSpec and type(targetLayoutOrder) == "table" then
-                for specID, layout in pairs(targetLayoutOrder) do
-                    if type(layout) == "table"
-                        and type(layout.customBars) == "table"
-                        and type(layout.customBars[customBarId]) == "table" then
-                        preserveLayout(specID, customBarId)
-                    end
-                end
-            end
-        end
-    else
-        for specID, targetSpecBars in pairs(target.customBars) do
-            if type(targetSpecBars) == "table" then
-                local copiedLayout = GetSpecKeyedTable(copied.layoutOrder, specID)
-                if copiedLayout then
-                    copiedLayout.customBars = {}
-                end
-                for _, entry in pairs(targetSpecBars) do
-                    preserveLayout(specID, type(entry) == "table" and entry.customBarId or nil)
-                end
-            end
-        end
-    end
 end
 
 local function EnsureScopedBarSystemStore(profile, storeKey)
@@ -469,6 +451,11 @@ local function ProfileHasLegacyScopedBarData(profile)
         return false
     end
 
+    if type(rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.seedKey)) == "table"
+        or type(rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.legacyKey)) == "table" then
+        return true
+    end
+
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
         if type(rawget(profile, systemSpec.seedKey)) == "table"
             or type(rawget(profile, systemSpec.legacyKey)) == "table" then
@@ -482,6 +469,11 @@ end
 local function ProfileHasAnyScopedBarBuckets(profile)
     if type(profile) ~= "table" then
         return false
+    end
+
+    local resourceStore = rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.storeKey)
+    if type(resourceStore) == "table" and next(resourceStore) ~= nil then
+        return true
     end
 
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
@@ -501,8 +493,8 @@ local function MarkLegacyScopedBarSeenCharacter(snapshot, charKey)
     snapshot[charKey] = true
 end
 
-local function GetCurrentClassSpecInfo()
-    local _, _, classID = UnitClass("player")
+local function GetClassSpecInfo(classKey)
+    local classID = GetClassIDFromClassKey(classKey)
     if not classID then
         return nil, nil
     end
@@ -524,12 +516,18 @@ local function GetCurrentClassSpecInfo()
     end
 
     local currentSpecID = nil
-    local specIndex = C_SpecializationInfo.GetSpecialization()
-    if specIndex then
-        currentSpecID = C_SpecializationInfo.GetSpecializationInfo(specIndex)
+    if NormalizeClassKey(classKey) == GetCurrentResourceBarClassKey(CooldownCompanion) then
+        local specIndex = C_SpecializationInfo.GetSpecialization()
+        if specIndex then
+            currentSpecID = C_SpecializationInfo.GetSpecializationInfo(specIndex)
+        end
     end
 
     return specIDs, currentSpecID
+end
+
+local function GetCurrentClassSpecInfo()
+    return GetClassSpecInfo(GetCurrentResourceBarClassKey(CooldownCompanion))
 end
 
 local function CopySpecLayoutOrder(settings, sourceSpecID, targetSpecID)
@@ -599,80 +597,6 @@ local function CopyResourceSpecOverrides(settings, sourceSpecID, targetSpecID)
     end
 end
 
-local CLASS_RESOURCES_BY_CLASS_ID = {
-    [1]  = { 1 },
-    [2]  = { 9, 0 },
-    [3]  = { 2 },
-    [4]  = { 4, 3 },
-    [5]  = { 0 },
-    [6]  = { 5, 6 },
-    [7]  = { 0 },
-    [8]  = { 0 },
-    [9]  = { 7, 0 },
-    [10] = { 0 },
-    [11] = { 0 },
-    [12] = { 17 },
-    [13] = { 19, 0 },
-}
-
-local SPEC_RESOURCES_BY_SPEC_ID = {
-    [258] = { 13, 0 },
-    [262] = { 11, 0 },
-    [263] = { 100, 0 },
-    [62]  = { 16, 0 },
-    [269] = { 12, 3 },
-    [268] = { 3 },
-    [581] = { 17 },
-}
-
-local DRUID_FORM_RESOURCES = {
-    { 1 },
-    { 4, 3 },
-    { 8 },
-}
-
-local function BuildResourceSet(resourceList, result)
-    if type(resourceList) ~= "table" or type(result) ~= "table" then
-        return result
-    end
-
-    for _, powerType in pairs(resourceList) do
-        local numericPowerType = tonumber(powerType)
-        if numericPowerType then
-            result[numericPowerType] = true
-        end
-    end
-
-    return result
-end
-
-local function GetCurrentClassApplicableResourceSet()
-    local _, _, classID = UnitClass("player")
-    if not classID then
-        return {}
-    end
-
-    local resourceSet = {}
-    resourceSet[RESOURCE_HEALTH] = true
-    BuildResourceSet(CLASS_RESOURCES_BY_CLASS_ID[classID], resourceSet)
-
-    if classID == 11 then
-        for _, resourceList in pairs(DRUID_FORM_RESOURCES) do
-            BuildResourceSet(resourceList, resourceSet)
-        end
-    end
-
-    local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
-    for i = 1, numSpecs do
-        local specID = GetSpecializationInfoForClassID(classID, i)
-        if specID then
-            BuildResourceSet(SPEC_RESOURCES_BY_SPEC_ID[specID], resourceSet)
-        end
-    end
-
-    return resourceSet
-end
-
 local function CopyResourceAuraOverlayColor(color)
     if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
         return nil
@@ -720,12 +644,12 @@ local function ClearLegacyResourceAuraOverlayFields(resource)
     resource.auraUnitExplicit = nil
 end
 
-local function NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
+local function NormalizeResourceAuraOverlayEntriesForClass(settings, classKey)
     if type(settings) ~= "table" or type(settings.resources) ~= "table" then
         return
     end
 
-    local allowedSpecIDs, currentSpecID = GetCurrentClassSpecInfo()
+    local allowedSpecIDs, currentSpecID = GetClassSpecInfo(classKey)
     if type(allowedSpecIDs) ~= "table" then
         return
     end
@@ -807,12 +731,12 @@ function ResolveSpecOverrideKey(resource, specID, key)
 end
 ST._ResolveSpecOverrideKey = ResolveSpecOverrideKey
 
-local function NormalizeResourceSpecOverridesForCurrentClass(settings)
+local function NormalizeResourceSpecOverridesForClass(settings, classKey)
     if type(settings) ~= "table" or type(settings.resources) ~= "table" then
         return
     end
 
-    local allowedSpecIDs = GetCurrentClassSpecInfo()
+    local allowedSpecIDs = GetClassSpecInfo(classKey)
     if type(allowedSpecIDs) ~= "table" then
         return
     end
@@ -832,14 +756,14 @@ local function NormalizeResourceSpecOverridesForCurrentClass(settings)
     end
 end
 
-local function NormalizeCustomAuraBarsForCurrentClass(settings)
+local function NormalizeCustomAuraBarsForClass(settings, classKey)
     if type(settings) ~= "table" then
         return
     end
     local barsBySpec = type(settings.customBars) == "table" and settings.customBars or settings.customAuraBars
     if type(barsBySpec) ~= "table" then return end
 
-    local allowedSpecIDs = GetCurrentClassSpecInfo()
+    local allowedSpecIDs = GetClassSpecInfo(classKey)
     if type(allowedSpecIDs) ~= "table" then
         return
     end
@@ -995,107 +919,19 @@ local function SanitizeFrameAnchoringAnchors(settings)
     settings.anchorGroupId = SanitizeAnchorGroupID(settings.anchorGroupId)
 end
 
--- Preserves per-spec state (aura overlay entries, spec overrides) from targetResource
--- when composing a copy. Strips these fields from copiedResource first, then re-applies
--- targetResource's values to prevent copy/seed operations from overwriting per-character
--- spec customizations.
-local function CopyPreservedResourcePerSpecState(targetResource, copiedResource)
-    if type(copiedResource) ~= "table" then
-        return copiedResource
+local function NormalizeResourceBarSettingsForClass(settings, classKey)
+    NormalizeCustomAuraBarsForClass(settings, classKey)
+    NormalizeResourceAuraOverlayEntriesForClass(settings, classKey)
+    NormalizeResourceSpecOverridesForClass(settings, classKey)
+    NormalizeResourceThresholdTickEntries(settings)
+    if type(settings) == "table" then
+        RESOURCE_BAR_NORMALIZED_CLASS_KEYS[settings] = NormalizeClassKey(classKey)
     end
-
-    copiedResource.auraOverlayEnabled = nil
-    copiedResource.auraOverlayEntries = nil
-    copiedResource.specOverrides = nil
-    copiedResource.auraColorSpellID = nil
-    copiedResource.auraActiveColor = nil
-    copiedResource.auraColorTrackingMode = nil
-    copiedResource.auraColorMaxStacks = nil
-    copiedResource.auraUnit = nil
-    copiedResource.auraUnitExplicit = nil
-
-    if type(targetResource) ~= "table" then
-        return copiedResource
-    end
-
-    if type(targetResource.auraOverlayEnabled) == "boolean" then
-        copiedResource.auraOverlayEnabled = targetResource.auraOverlayEnabled
-    end
-    if type(targetResource.auraOverlayEntries) == "table" then
-        copiedResource.auraOverlayEntries = CopyTable(targetResource.auraOverlayEntries)
-    end
-    if type(targetResource.specOverrides) == "table" then
-        copiedResource.specOverrides = CopyTable(targetResource.specOverrides)
-    end
-    if targetResource.auraColorSpellID ~= nil then
-        copiedResource.auraColorSpellID = targetResource.auraColorSpellID
-    end
-    if targetResource.auraActiveColor ~= nil then
-        copiedResource.auraActiveColor = CopyTable(targetResource.auraActiveColor)
-    end
-    if targetResource.auraColorTrackingMode ~= nil then
-        copiedResource.auraColorTrackingMode = targetResource.auraColorTrackingMode
-    end
-    if targetResource.auraColorMaxStacks ~= nil then
-        copiedResource.auraColorMaxStacks = targetResource.auraColorMaxStacks
-    end
-    if targetResource.auraUnit ~= nil then
-        copiedResource.auraUnit = targetResource.auraUnit
-    end
-    if targetResource.auraUnitExplicit ~= nil then
-        copiedResource.auraUnitExplicit = targetResource.auraUnitExplicit
-    end
-
-    return copiedResource
-end
-
-local function ComposeCopiedResourceBarSettings(source, target)
-    local copied = type(target) == "table" and CopyTable(target) or CopySubsystemDefaults("resourceBars")
-    local applicableResources = GetCurrentClassApplicableResourceSet()
-
-    if type(source) == "table" then
-        for key, value in pairs(source) do
-            if key ~= "resources"
-                and key ~= "customAuraBars"
-                and key ~= "customBars"
-                and key ~= "customAuraBarSlots"
-                and key ~= "displayProfiles"
-                and key ~= "layoutOrder"
-                and key ~= "nextCustomBarId" then
-                copied[key] = CloneSettingValue(value)
-            end
-        end
-    end
-
-    if type(copied.resources) ~= "table" then
-        copied.resources = {}
-    end
-
-    local sourceResources = type(source) == "table" and source.resources or nil
-    local targetResources = type(target) == "table" and target.resources or nil
-    if type(sourceResources) == "table" then
-        for powerType in pairs(applicableResources) do
-            local sourceResource = sourceResources[powerType]
-            if type(sourceResource) == "table" then
-                local targetResource = type(targetResources) == "table" and targetResources[powerType] or nil
-                copied.resources[powerType] = CopyPreservedResourcePerSpecState(targetResource, CopyTable(sourceResource))
-            end
-        end
-    end
-
-    copied.customAuraBars = type(target) == "table" and CloneSettingValue(target.customAuraBars) or copied.customAuraBars
-    copied.customBars = type(target) == "table" and CloneSettingValue(target.customBars) or copied.customBars
-    PreserveTargetCustomBarLayouts(copied, target)
-
-    return copied
 end
 
 local function NormalizeScopedBarSettings(systemKey, settings)
     if systemKey == "resourceBars" then
-        NormalizeCustomAuraBarsForCurrentClass(settings)
-        NormalizeResourceAuraOverlayEntriesForCurrentClass(settings)
-        NormalizeResourceSpecOverridesForCurrentClass(settings)
-        NormalizeResourceThresholdTickEntries(settings)
+        NormalizeResourceBarSettingsForClass(settings, GetCurrentResourceBarClassKey(CooldownCompanion))
     end
 end
 
@@ -1106,16 +942,17 @@ local function IsResourceAuraUnitNormalized(auraEntry)
     return auraEntry.auraUnit == "player" or auraEntry.auraUnit == "target"
 end
 
-local function ResourceAuraOverlayNeedsNormalization(settings)
+local function ResourceAuraOverlayNeedsNormalizationForClass(settings, classKey)
     if type(settings) ~= "table" or type(settings.resources) ~= "table" then
         return false
     end
+    classKey = NormalizeClassKey(classKey)
 
     local allowedSpecIDs = nil
     local checkedSpecIDs = false
     local function GetAllowedSpecIDs()
         if not checkedSpecIDs then
-            allowedSpecIDs = GetCurrentClassSpecInfo()
+            allowedSpecIDs = GetClassSpecInfo(classKey)
             checkedSpecIDs = true
         end
         return allowedSpecIDs
@@ -1153,6 +990,19 @@ local function ResourceAuraOverlayNeedsNormalization(settings)
     return false
 end
 
+local function ResourceAuraOverlayNeedsNormalization(settings)
+    return ResourceAuraOverlayNeedsNormalizationForClass(settings, GetCurrentResourceBarClassKey(CooldownCompanion))
+end
+
+local function ResourceBarSettingsNeedsNormalizationForClass(settings, classKey)
+    if type(settings) ~= "table" then
+        return false
+    end
+    classKey = NormalizeClassKey(classKey)
+    return RESOURCE_BAR_NORMALIZED_CLASS_KEYS[settings] ~= classKey
+        or ResourceAuraOverlayNeedsNormalizationForClass(settings, classKey)
+end
+
 local function NeedsScopedBarNormalization(systemKey, settings)
     if systemKey == "resourceBars" then
         return ResourceAuraOverlayNeedsNormalization(settings)
@@ -1170,12 +1020,355 @@ local function SanitizeCopiedOrSeededScopedBarSettings(systemKey, settings)
     end
 end
 
+local function EnsureResourceBarClassStore(profile)
+    local store = rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY)
+    if type(store) ~= "table" then
+        store = {}
+        profile[RESOURCE_BAR_CLASS_STORE_KEY] = store
+    end
+    return store
+end
+
+local function EnsureResourceBarMigrationState(profile)
+    local state = rawget(profile, RESOURCE_BAR_MIGRATION_KEY)
+    if type(state) ~= "table" then
+        state = {}
+        profile[RESOURCE_BAR_MIGRATION_KEY] = state
+    end
+    if type(state.conflicts) ~= "table" then
+        state.conflicts = {}
+    end
+    if type(state.unsafeCharKeys) ~= "table" then
+        state.unsafeCharKeys = {}
+    end
+    return state
+end
+
+local function GetResourceBarLegacyStore(profile, create)
+    local store = rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.storeKey)
+    if type(store) == "table" then
+        return store
+    end
+    if not create then
+        return nil
+    end
+    store = {}
+    profile[RESOURCE_BAR_SYSTEM_SPEC.storeKey] = store
+    return store
+end
+
+local function DeepEqual(left, right)
+    if type(left) ~= type(right) then
+        return false
+    end
+    if type(left) ~= "table" then
+        return left == right
+    end
+    for key, value in pairs(left) do
+        if not DeepEqual(value, right and right[key]) then
+            return false
+        end
+    end
+    for key in pairs(right or {}) do
+        if left[key] == nil then
+            return false
+        end
+    end
+    return true
+end
+
+local function IsDefaultResourceBarClassSettings(settings, classKey)
+    if type(settings) ~= "table" then
+        return false
+    end
+    local defaults = CopySubsystemDefaults("resourceBars")
+    NormalizeResourceBarSettingsForClass(defaults, classKey)
+    SanitizeResourceBarAnchors(defaults)
+    return DeepEqual(settings, defaults)
+end
+
+local function SortedMapKeys(map)
+    local keys = {}
+    if type(map) ~= "table" then
+        return keys
+    end
+    for key in pairs(map) do
+        keys[#keys + 1] = key
+    end
+    sort(keys, function(a, b)
+        return tostring(a) < tostring(b)
+    end)
+    return keys
+end
+
+local function NormalizeClassKeyFromInfo(info)
+    if type(info) ~= "table" then
+        return nil
+    end
+    return NormalizeClassKey(info.classFilename or info.classFile or info.className)
+        or GetClassKeyFromClassID(info.classID)
+end
+
+local function GetImportResourceBarCharacterInfo(addon)
+    return addon and addon._resourceBarImportCharacterInfo
+end
+
+local function ResolveResourceBarCandidateClassKey(addon, charKey)
+    local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
+    if charKey == currentCharKey then
+        return GetCurrentResourceBarClassKey(addon)
+    end
+
+    local importInfo = GetImportResourceBarCharacterInfo(addon)
+    local classKey = NormalizeClassKeyFromInfo(type(importInfo) == "table" and importInfo[charKey] or nil)
+    if classKey then
+        return classKey
+    end
+
+    local globalInfo = addon and addon.db and addon.db.global and addon.db.global.characterInfo
+    return NormalizeClassKeyFromInfo(type(globalInfo) == "table" and globalInfo[charKey] or nil)
+end
+
+local function SeedCurrentLegacyResourceBarBucket(addon, profile)
+    local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
+    if type(currentCharKey) ~= "string" or currentCharKey == "" then
+        return
+    end
+
+    local classKey = GetCurrentResourceBarClassKey(addon)
+    local classStore = type(profile) == "table" and rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY) or nil
+    local classSettings = type(classStore) == "table" and classStore[classKey] or nil
+    if type(classSettings) == "table" and not IsDefaultResourceBarClassSettings(classSettings, classKey) then
+        return
+    end
+
+    local store = GetResourceBarLegacyStore(profile, false)
+    if type(store) == "table" and type(store[currentCharKey]) == "table" then
+        return
+    end
+
+    local seed = CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
+    local seenCharacters = addon and addon.EnsureLegacyScopedBarSeenCharacters
+        and addon:EnsureLegacyScopedBarSeenCharacters()
+        or nil
+    local shouldUseLegacySeed = type(seed) == "table"
+        and type(seenCharacters) == "table"
+        and seenCharacters[currentCharKey] == true
+    if not shouldUseLegacySeed then
+        return
+    end
+
+    store = GetResourceBarLegacyStore(profile, true)
+    local settings = CopyTable(seed)
+    NormalizeResourceBarSettingsForClass(settings, classKey)
+    SanitizeResourceBarAnchors(settings)
+    store[currentCharKey] = settings
+end
+
+local function CopyNormalizedResourceBarCandidate(settings, classKey)
+    local normalized = CopyTable(settings)
+    NormalizeResourceBarSettingsForClass(normalized, classKey)
+    return normalized
+end
+
+local function FindMatchingResourceBarCandidateIndex(candidates, normalized)
+    for index, candidate in ipairs(candidates) do
+        if DeepEqual(candidate.normalized, normalized) then
+            return index
+        end
+    end
+    return nil
+end
+
+local function RemoveLegacyResourceBarCandidates(profile, charKeys)
+    local store = GetResourceBarLegacyStore(profile, false)
+    if type(store) ~= "table" then
+        return
+    end
+    for _, charKey in ipairs(charKeys or {}) do
+        store[charKey] = nil
+    end
+    if next(store) == nil then
+        profile[RESOURCE_BAR_SYSTEM_SPEC.storeKey] = nil
+    end
+end
+
+local function ClearResourceBarConflict(state, classKey)
+    if type(state) == "table" and type(state.conflicts) == "table" then
+        state.conflicts[classKey] = nil
+    end
+end
+
+local function StoreResourceBarConflict(state, classKey, charKeys, includeExistingClass)
+    local conflict = {
+        classKey = classKey,
+        candidateCharKeys = CopyTable(charKeys),
+    }
+    if includeExistingClass then
+        conflict.includeExistingClass = true
+    end
+    state.conflicts[classKey] = conflict
+end
+
+local function BuildResourceBarMigrationBuckets(addon, profile, state)
+    local buckets = {}
+    local store = GetResourceBarLegacyStore(profile, false)
+    if type(store) ~= "table" then
+        return buckets
+    end
+
+    state.unsafeCharKeys = {}
+    for _, charKey in ipairs(SortedMapKeys(store)) do
+        local settings = store[charKey]
+        if type(settings) == "table" then
+            local classKey = ResolveResourceBarCandidateClassKey(addon, charKey)
+            if classKey then
+                local bucket = buckets[classKey]
+                if not bucket then
+                    bucket = {}
+                    buckets[classKey] = bucket
+                end
+                bucket[#bucket + 1] = {
+                    charKey = charKey,
+                    settings = settings,
+                    normalized = CopyNormalizedResourceBarCandidate(settings, classKey),
+                }
+            else
+                state.unsafeCharKeys[charKey] = true
+            end
+        end
+    end
+
+    return buckets
+end
+
+local function PromoteResourceBarClassSettings(classStore, classKey, settings)
+    classStore[classKey] = CopyTable(settings)
+    NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+end
+
+local function MigrateResourceBarClass(profile, classStore, state, classKey, candidates)
+    local candidateCharKeys = {}
+    for _, candidate in ipairs(candidates) do
+        candidateCharKeys[#candidateCharKeys + 1] = candidate.charKey
+    end
+    sort(candidateCharKeys)
+
+    if type(classStore[classKey]) == "table" then
+        NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+        if IsDefaultResourceBarClassSettings(classStore[classKey], classKey) then
+            classStore[classKey] = nil
+        else
+            local hasDifferingCandidate = false
+            for _, candidate in ipairs(candidates) do
+                if not DeepEqual(candidate.normalized, classStore[classKey]) then
+                    hasDifferingCandidate = true
+                    break
+                end
+            end
+            if hasDifferingCandidate then
+                StoreResourceBarConflict(state, classKey, candidateCharKeys, true)
+            else
+                RemoveLegacyResourceBarCandidates(profile, candidateCharKeys)
+                ClearResourceBarConflict(state, classKey)
+            end
+            return
+        end
+    end
+
+    local unique = {}
+    for _, candidate in ipairs(candidates) do
+        local matchIndex = FindMatchingResourceBarCandidateIndex(unique, candidate.normalized)
+        if matchIndex then
+            local uniqueCandidate = unique[matchIndex]
+            uniqueCandidate.charKeys[#uniqueCandidate.charKeys + 1] = candidate.charKey
+        else
+            unique[#unique + 1] = {
+                charKeys = { candidate.charKey },
+                normalized = candidate.normalized,
+            }
+        end
+    end
+
+    if #unique == 1 then
+        PromoteResourceBarClassSettings(classStore, classKey, unique[1].normalized)
+        RemoveLegacyResourceBarCandidates(profile, candidateCharKeys)
+        ClearResourceBarConflict(state, classKey)
+        return
+    end
+
+    StoreResourceBarConflict(state, classKey, candidateCharKeys)
+end
+
+local function GetResourceBarConflict(profile, classKey)
+    if not classKey then
+        return nil
+    end
+    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
+    local conflicts = type(state) == "table" and state.conflicts or nil
+    local conflict = type(conflicts) == "table" and conflicts[classKey] or nil
+    if type(conflict) ~= "table" then
+        return nil
+    end
+    local candidateCharKeys = type(conflict.candidateCharKeys) == "table" and conflict.candidateCharKeys or nil
+    if not candidateCharKeys or #candidateCharKeys == 0 then
+        return nil
+    end
+    local classStore = rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY)
+    if type(classStore) == "table"
+        and type(classStore[classKey]) == "table"
+        and conflict.includeExistingClass ~= true then
+        return nil
+    end
+    return conflict
+end
+
+local function BuildResourceBarConflictSummary(profile)
+    local summaries = {}
+    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
+    local conflicts = type(state) == "table" and state.conflicts or nil
+    if type(conflicts) ~= "table" then
+        return summaries
+    end
+    for _, classKey in ipairs(SortedMapKeys(conflicts)) do
+        local conflict = GetResourceBarConflict(profile, classKey)
+        if conflict then
+            local candidateCharKeys = CopyTable(conflict.candidateCharKeys or {})
+            sort(candidateCharKeys)
+            summaries[#summaries + 1] = {
+                classKey = classKey,
+                candidateCharKeys = candidateCharKeys,
+                candidateCount = #candidateCharKeys + (conflict.includeExistingClass and 1 or 0),
+                includeExistingClass = conflict.includeExistingClass == true,
+            }
+        end
+    end
+    return summaries
+end
+
+local function GetFallbackResourceBarSettings(addon, classKey)
+    if type(addon._resourceBarConflictFallbackSettings) ~= "table" then
+        addon._resourceBarConflictFallbackSettings = {}
+    end
+    local settings = addon._resourceBarConflictFallbackSettings[classKey]
+    if type(settings) ~= "table" then
+        local profile = addon.db and addon.db.profile
+        local classStore = type(profile) == "table" and rawget(profile, RESOURCE_BAR_CLASS_STORE_KEY) or nil
+        local classSettings = type(classStore) == "table" and classStore[classKey] or nil
+        settings = type(classSettings) == "table" and CopyTable(classSettings) or CopySubsystemDefaults("resourceBars")
+        NormalizeResourceBarSettingsForClass(settings, classKey)
+        addon._resourceBarConflictFallbackSettings[classKey] = settings
+    end
+    return settings
+end
+
 function CooldownCompanion:CaptureLegacyScopedBarSettingsSeeds()
     local profile = self.db and self.db.profile
     if not profile then
         return
     end
 
+    CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
         CaptureLegacyScopedBarSystemSeed(profile, systemSpec)
     end
@@ -1193,6 +1386,15 @@ function CooldownCompanion:EnsureLegacyScopedBarSeenCharacters()
     end
 
     snapshot = {}
+
+    local resourceStore = rawget(profile, RESOURCE_BAR_SYSTEM_SPEC.storeKey)
+    if type(resourceStore) == "table" then
+        for charKey, settings in pairs(resourceStore) do
+            if type(settings) == "table" then
+                MarkLegacyScopedBarSeenCharacter(snapshot, charKey)
+            end
+        end
+    end
 
     for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
         local store = rawget(profile, systemSpec.storeKey)
@@ -1280,14 +1482,89 @@ function CooldownCompanion:GetCharacterScopedSettings(systemKey)
     return settings
 end
 
+function CooldownCompanion:RunResourceBarClassScopeMigration()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return
+    end
+
+    local state = EnsureResourceBarMigrationState(profile)
+    state.unsafeCharKeys = {}
+    SeedCurrentLegacyResourceBarBucket(self, profile)
+
+    local classStore = EnsureResourceBarClassStore(profile)
+    for classKey, settings in pairs(classStore) do
+        if type(settings) == "table" then
+            NormalizeResourceBarSettingsForClass(settings, classKey)
+        end
+    end
+
+    local buckets = BuildResourceBarMigrationBuckets(self, profile, state)
+    for classKey in pairs(state.conflicts) do
+        if not buckets[classKey] then
+            state.conflicts[classKey] = nil
+        end
+    end
+    for _, classKey in ipairs(SortedMapKeys(buckets)) do
+        MigrateResourceBarClass(profile, classStore, state, classKey, buckets[classKey])
+    end
+end
+
+function CooldownCompanion:GetResourceBarClassSettingsStore()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+    return EnsureResourceBarClassStore(profile)
+end
+
+function CooldownCompanion:GetCurrentResourceBarClassKey()
+    return GetCurrentResourceBarClassKey(self)
+end
+
 function CooldownCompanion:EnsureCurrentCharacterScopedBarSettings()
-    self:GetCharacterScopedSettings("resourceBars")
+    self:GetResourceBarSettings()
     self:GetCharacterScopedSettings("castBar")
     self:GetCharacterScopedSettings("frameAnchoring")
 end
 
 function CooldownCompanion:GetResourceBarSettings()
-    return self:GetCharacterScopedSettings("resourceBars")
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+
+    local classKey = GetCurrentResourceBarClassKey(self)
+    if not classKey then
+        return nil
+    end
+
+    local conflict = GetResourceBarConflict(profile, classKey)
+    if conflict then
+        local currentCharKey = self.db and self.db.keys and self.db.keys.char
+        local legacyStore = GetResourceBarLegacyStore(profile, false)
+        local currentLegacy = type(legacyStore) == "table" and legacyStore[currentCharKey] or nil
+        if type(currentLegacy) == "table" then
+            if ResourceBarSettingsNeedsNormalizationForClass(currentLegacy, classKey) then
+                NormalizeResourceBarSettingsForClass(currentLegacy, classKey)
+            end
+            return currentLegacy
+        end
+        return GetFallbackResourceBarSettings(self, classKey)
+    end
+
+    local classStore = EnsureResourceBarClassStore(profile)
+    local settings = classStore[classKey]
+    if type(settings) ~= "table" then
+        settings = CopySubsystemDefaults("resourceBars")
+        NormalizeResourceBarSettingsForClass(settings, classKey)
+        SanitizeResourceBarAnchors(settings)
+        classStore[classKey] = settings
+    elseif ResourceBarSettingsNeedsNormalizationForClass(settings, classKey) then
+        NormalizeResourceBarSettingsForClass(settings, classKey)
+    end
+
+    return settings
 end
 
 function CooldownCompanion:GetCastBarSettings()
@@ -1296,6 +1573,134 @@ end
 
 function CooldownCompanion:GetFrameAnchoringSettings()
     return self:GetCharacterScopedSettings("frameAnchoring")
+end
+
+function CooldownCompanion:GetResourceBarMigrationState()
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+    return EnsureResourceBarMigrationState(profile)
+end
+
+function CooldownCompanion:GetResourceBarConflict(classKey)
+    local profile = self.db and self.db.profile
+    if type(profile) ~= "table" then
+        return nil
+    end
+    return GetResourceBarConflict(profile, NormalizeClassKey(classKey))
+end
+
+function CooldownCompanion:GetCurrentResourceBarConflict()
+    return self:GetResourceBarConflict(GetCurrentResourceBarClassKey(self))
+end
+
+function CooldownCompanion:GetPendingResourceBarConflictSummary()
+    local profile = self.db and self.db.profile
+    return BuildResourceBarConflictSummary(profile)
+end
+
+function CooldownCompanion:HasPendingResourceBarConflicts()
+    return #self:GetPendingResourceBarConflictSummary() > 0
+end
+
+function CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    local summaries = self:GetPendingResourceBarConflictSummary()
+    if #summaries == 0 then
+        return nil
+    end
+
+    local parts = {}
+    for _, summary in ipairs(summaries) do
+        local candidateText = summary.candidateCount .. " candidate"
+        if summary.candidateCount ~= 1 then
+            candidateText = candidateText .. "s"
+        end
+        if summary.includeExistingClass then
+            candidateText = candidateText .. " including current class setup"
+        end
+        if #summary.candidateCharKeys > 0 then
+            candidateText = candidateText .. ": " .. concat(summary.candidateCharKeys, ", ")
+        end
+        parts[#parts + 1] = summary.classKey .. " (" .. candidateText .. ")"
+    end
+
+    return "Resolve pending Resource Bar conflicts before exporting. Affected classes: "
+        .. concat(parts, "; ")
+        .. ". Open Resource Bar settings on the affected class and choose the setup to keep."
+end
+
+function CooldownCompanion:GetResourceBarUnsafeLegacySummary()
+    local profile = self.db and self.db.profile
+    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
+    local unsafe = type(state) == "table" and state.unsafeCharKeys or nil
+    local keys = SortedMapKeys(unsafe)
+    return keys
+end
+
+function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, options)
+    local profile = self.db and self.db.profile
+    classKey = NormalizeClassKey(classKey)
+    local keepExistingClassStore = type(options) == "table" and options.keepExistingClassStore == true
+    if type(profile) ~= "table"
+        or not classKey
+        or (not keepExistingClassStore and (type(sourceCharKey) ~= "string" or sourceCharKey == "")) then
+        return false, "invalid_request"
+    end
+
+    local conflict = GetResourceBarConflict(profile, classKey)
+    if not conflict then
+        return false, "missing_conflict"
+    end
+
+    local classStore = EnsureResourceBarClassStore(profile)
+    if keepExistingClassStore then
+        if conflict.includeExistingClass ~= true then
+            return false, "invalid_candidate"
+        end
+        if type(classStore[classKey]) ~= "table" then
+            return false, "missing_candidate"
+        end
+        NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+        if classKey == GetCurrentResourceBarClassKey(self) then
+            SanitizeResourceBarAnchors(classStore[classKey])
+        end
+        RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
+        ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
+        if type(self._resourceBarConflictFallbackSettings) == "table" then
+            self._resourceBarConflictFallbackSettings[classKey] = nil
+        end
+        return true
+    end
+
+    local sourceAllowed = false
+    for _, candidateCharKey in ipairs(conflict.candidateCharKeys or {}) do
+        if candidateCharKey == sourceCharKey then
+            sourceAllowed = true
+            break
+        end
+    end
+    if not sourceAllowed then
+        return false, "invalid_candidate"
+    end
+
+    local legacyStore = GetResourceBarLegacyStore(profile, false)
+    local source = type(legacyStore) == "table" and legacyStore[sourceCharKey] or nil
+    if type(source) ~= "table" then
+        return false, "missing_candidate"
+    end
+
+    PromoteResourceBarClassSettings(classStore, classKey, source)
+    if classKey == GetCurrentResourceBarClassKey(self) then
+        SanitizeResourceBarAnchors(classStore[classKey])
+    end
+
+    RemoveLegacyResourceBarCandidates(profile, conflict.candidateCharKeys)
+    ClearResourceBarConflict(EnsureResourceBarMigrationState(profile), classKey)
+    if type(self._resourceBarConflictFallbackSettings) == "table" then
+        self._resourceBarConflictFallbackSettings[classKey] = nil
+    end
+    return true
 end
 
 function CooldownCompanion:GetCharacterScopedSettingsStore(systemKey)
@@ -1374,12 +1779,7 @@ function CooldownCompanion:CopyCharacterScopedSettings(systemKey, sourceCharKey)
         return false, "missing_source"
     end
 
-    local copied
-    if systemKey == "resourceBars" then
-        copied = ComposeCopiedResourceBarSettings(source, self:GetResourceBarSettings())
-    else
-        copied = CopyTable(source)
-    end
+    local copied = CopyTable(source)
     NormalizeScopedBarSettings(systemKey, copied)
     SanitizeCopiedOrSeededScopedBarSettings(systemKey, copied)
     store[currentChar] = copied

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -756,18 +756,16 @@ local function NormalizeResourceSpecOverridesForClass(settings, classKey)
     end
 end
 
-local function NormalizeCustomAuraBarsForClass(settings, classKey)
-    if type(settings) ~= "table" then
+local function ClearCustomBarLegacySpecFields(entry)
+    if type(entry) ~= "table" then
         return
     end
-    local barsBySpec = type(settings.customBars) == "table" and settings.customBars or settings.customAuraBars
-    if type(barsBySpec) ~= "table" then return end
+    entry.specID = nil
+    entry.spec = nil
+    entry.sourceSpecID = nil
+end
 
-    local allowedSpecIDs = GetClassSpecInfo(classKey)
-    if type(allowedSpecIDs) ~= "table" then
-        return
-    end
-
+local function NormalizeCustomBarStoreForClass(barsBySpec, allowedSpecIDs)
     local filtered = {}
     if IsSharedCustomBarsStore(barsBySpec) then
         filtered.entries = {}
@@ -787,6 +785,7 @@ local function NormalizeCustomAuraBarsForClass(settings, classKey)
                 end)
                 if not sawSpec or next(normalizedSpecs) then
                     copiedEntry.specs = normalizedSpecs
+                    ClearCustomBarLegacySpecFields(copiedEntry)
                     local customBarId = type(copiedEntry.customBarId) == "string" and copiedEntry.customBarId or key
                     if type(customBarId) == "string" and customBarId ~= "" then
                         filtered.entries[customBarId] = copiedEntry
@@ -812,15 +811,33 @@ local function NormalizeCustomAuraBarsForClass(settings, classKey)
             if type(specBars) == "table" and (
                 numericSpecID and allowedSpecIDs[numericSpecID]
             ) then
-                filtered[numericSpecID or key] = CopyTable(specBars)
+                local copiedSpecBars = CopyTable(specBars)
+                for _, entry in pairs(copiedSpecBars) do
+                    ClearCustomBarLegacySpecFields(entry)
+                end
+                filtered[numericSpecID or key] = copiedSpecBars
             end
         end
     end
 
+    return filtered
+end
+
+local function NormalizeCustomAuraBarsForClass(settings, classKey)
+    if type(settings) ~= "table" then
+        return
+    end
+
+    local allowedSpecIDs = GetClassSpecInfo(classKey)
+    if type(allowedSpecIDs) ~= "table" then
+        return
+    end
+
     if type(settings.customBars) == "table" then
-        settings.customBars = filtered
-    else
-        settings.customAuraBars = filtered
+        settings.customBars = NormalizeCustomBarStoreForClass(settings.customBars, allowedSpecIDs)
+    end
+    if type(settings.customAuraBars) == "table" then
+        settings.customAuraBars = NormalizeCustomBarStoreForClass(settings.customAuraBars, allowedSpecIDs)
     end
 end
 
@@ -862,11 +879,6 @@ local function SanitizeResourceBarAnchors(settings)
         settings.independentAnchor = nil
     end
 
-    local customBarsBySpec = type(settings.customBars) == "table" and settings.customBars or settings.customAuraBars
-    if type(customBarsBySpec) ~= "table" then
-        return
-    end
-
     local ensureCustomAuraBarAuraUnit = GetEnsureCustomAuraBarAuraUnit()
     local function sanitizeCustomBar(customAuraBar)
         if type(customAuraBar) == "table" then
@@ -885,20 +897,29 @@ local function SanitizeResourceBarAnchors(settings)
         end
     end
 
-    if IsSharedCustomBarsStore(customBarsBySpec) then
-        local entries = type(customBarsBySpec.entries) == "table" and customBarsBySpec.entries or {}
-        for _, customAuraBar in pairs(entries) do
-            sanitizeCustomBar(customAuraBar)
+    local function sanitizeCustomBarStore(customBarsBySpec)
+        if type(customBarsBySpec) ~= "table" then
+            return
         end
-    else
-        for _, specBars in pairs(customBarsBySpec) do
-            if type(specBars) == "table" then
-                for _, customAuraBar in pairs(specBars) do
-                    sanitizeCustomBar(customAuraBar)
+
+        if IsSharedCustomBarsStore(customBarsBySpec) then
+            local entries = type(customBarsBySpec.entries) == "table" and customBarsBySpec.entries or {}
+            for _, customAuraBar in pairs(entries) do
+                sanitizeCustomBar(customAuraBar)
+            end
+        else
+            for _, specBars in pairs(customBarsBySpec) do
+                if type(specBars) == "table" then
+                    for _, customAuraBar in pairs(specBars) do
+                        sanitizeCustomBar(customAuraBar)
+                    end
                 end
             end
         end
     end
+
+    sanitizeCustomBarStore(settings.customBars)
+    sanitizeCustomBarStore(settings.customAuraBars)
 end
 
 local function SanitizeCastBarAnchors(settings)
@@ -1113,6 +1134,14 @@ local function GetImportResourceBarCharacterInfo(addon)
     return addon and addon._resourceBarImportCharacterInfo
 end
 
+local function GetImportResourceBarExporterCharKey(addon)
+    local charKey = addon and addon._resourceBarImportExporterCharKey
+    if type(charKey) == "string" and charKey ~= "" then
+        return charKey
+    end
+    return nil
+end
+
 local function ResolveResourceBarCandidateClassKey(addon, charKey)
     local currentCharKey = addon and addon.db and addon.db.keys and addon.db.keys.char
     if charKey == currentCharKey then
@@ -1127,6 +1156,41 @@ local function ResolveResourceBarCandidateClassKey(addon, charKey)
 
     local globalInfo = addon and addon.db and addon.db.global and addon.db.global.characterInfo
     return NormalizeClassKeyFromInfo(type(globalInfo) == "table" and globalInfo[charKey] or nil)
+end
+
+local function ClearLegacyResourceBarSeed(profile)
+    if type(profile) ~= "table" then
+        return
+    end
+    profile[RESOURCE_BAR_SYSTEM_SPEC.legacyKey] = nil
+    profile[RESOURCE_BAR_SYSTEM_SPEC.seedKey] = nil
+end
+
+local function SeedImportedLegacyResourceBarBucket(addon, profile)
+    local exporterCharKey = GetImportResourceBarExporterCharKey(addon)
+    if not exporterCharKey then
+        return false
+    end
+
+    local seed = CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
+    if type(seed) ~= "table" then
+        return true
+    end
+
+    local store = GetResourceBarLegacyStore(profile, false)
+    if not (type(store) == "table" and type(store[exporterCharKey]) == "table") then
+        local settings = CopyTable(seed)
+        local classKey = ResolveResourceBarCandidateClassKey(addon, exporterCharKey)
+        if classKey then
+            NormalizeResourceBarSettingsForClass(settings, classKey)
+        end
+        SanitizeResourceBarAnchors(settings)
+        store = GetResourceBarLegacyStore(profile, true)
+        store[exporterCharKey] = settings
+    end
+
+    ClearLegacyResourceBarSeed(profile)
+    return true
 end
 
 local function SeedCurrentLegacyResourceBarBucket(addon, profile)
@@ -1168,6 +1232,7 @@ end
 local function CopyNormalizedResourceBarCandidate(settings, classKey)
     local normalized = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(normalized, classKey)
+    SanitizeResourceBarAnchors(normalized)
     return normalized
 end
 
@@ -1245,6 +1310,7 @@ end
 local function PromoteResourceBarClassSettings(classStore, classKey, settings)
     classStore[classKey] = CopyTable(settings)
     NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+    SanitizeResourceBarAnchors(classStore[classKey])
 end
 
 local function MigrateResourceBarClass(profile, classStore, state, classKey, candidates)
@@ -1256,6 +1322,7 @@ local function MigrateResourceBarClass(profile, classStore, state, classKey, can
 
     if type(classStore[classKey]) == "table" then
         NormalizeResourceBarSettingsForClass(classStore[classKey], classKey)
+        SanitizeResourceBarAnchors(classStore[classKey])
         if IsDefaultResourceBarClassSettings(classStore[classKey], classKey) then
             classStore[classKey] = nil
         else
@@ -1490,12 +1557,17 @@ function CooldownCompanion:RunResourceBarClassScopeMigration()
 
     local state = EnsureResourceBarMigrationState(profile)
     state.unsafeCharKeys = {}
-    SeedCurrentLegacyResourceBarBucket(self, profile)
+    if GetImportResourceBarExporterCharKey(self) then
+        SeedImportedLegacyResourceBarBucket(self, profile)
+    else
+        SeedCurrentLegacyResourceBarBucket(self, profile)
+    end
 
     local classStore = EnsureResourceBarClassStore(profile)
     for classKey, settings in pairs(classStore) do
         if type(settings) == "table" then
             NormalizeResourceBarSettingsForClass(settings, classKey)
+            SanitizeResourceBarAnchors(settings)
         end
     end
 

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -1848,11 +1848,10 @@ function CooldownCompanion:ApplyResourceBars(opts)
 
     -- Append enabled Custom Bars
     local customBars = GetSpecCustomAuraBars(settings)
-    local customBarLoadDefaults = CooldownCompanion:GetLocalLoadConditionDefaults()
     for i, cab in ipairs(customBars) do
         if cab and cab.enabled and cab.spellID
             and CooldownCompanion:IsTalentConditionMet(cab)
-            and CooldownCompanion:EvaluateLoadConditions(cab.loadConditions, customBarLoadDefaults) then
+            and CooldownCompanion:IsCustomBarLoadConditionMet(cab) then
             table.insert(filtered, {
                 kind = "custom",
                 customBarIndex = i,

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -1696,7 +1696,7 @@ local function RefreshColumn1(preserveDrag)
             section = {
                 key = scope.sectionKey,
                 classKey = scope.ownerClassKey,
-                title = GetClassDisplayName(scope.ownerClassKey) .. " Groups",
+                title = GetClassDisplayName(scope.ownerClassKey),
                 color = cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
                 containerIds = {},
                 count = 0,

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -10,7 +10,6 @@ local CS = ST._configState
 local AceGUI = LibStub("AceGUI-3.0")
 
 -- Imports from earlier Config/ files
-local BuildHeroTalentSubTreeCheckboxes = ST._BuildHeroTalentSubTreeCheckboxes
 local CleanRecycledEntry = ST._CleanRecycledEntry
 local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
 local ApplyConfigTextRow = ST._ApplyConfigTextRow
@@ -35,7 +34,6 @@ local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
 local ContainersHaveForeignSpecs = ST._ContainersHaveForeignSpecs
 local FolderHasForeignSpecs = ST._FolderHasForeignSpecs
-local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
@@ -48,16 +46,12 @@ local SelectConfigPanel = ST._SelectConfigPanel
 local GenerateGroupName
 
 local function OpenContainerLoadConditions(containerId)
-    CS.specExpandedGroupId = nil
-    CS.specExpandedFolderId = nil
     SelectConfigContainer(containerId)
     CS.selectedContainerTab = "loadconditions"
     CooldownCompanion:RefreshConfigPanel()
 end
 
 local function OpenFolderLoadConditions(folderId)
-    CS.specExpandedGroupId = nil
-    CS.specExpandedFolderId = nil
     SelectConfigFolder(folderId)
     CooldownCompanion:RefreshConfigPanel()
 end
@@ -126,204 +120,6 @@ local function ConfigureGenericGroupRenameBadge(entry, container, containerId, n
     badge:Show()
 end
 
-------------------------------------------------------------------------
--- Browse mode: class-colored name helper
-------------------------------------------------------------------------
-local function GetClassColoredCharName(charKey, classFilename)
-    local name = charKey:match("^(.-)%s*%-") or charKey
-    if classFilename then
-        local cc = C_ClassColor.GetClassColor(classFilename)
-        if cc then
-            return cc:WrapTextInColorCode(name), cc
-        end
-    end
-    return name, nil
-end
-
-------------------------------------------------------------------------
--- Browse mode: render cross-character browsing UI in Column 1
-------------------------------------------------------------------------
-local function RenderBrowseMode()
-    if not CS.col1Scroll then return end
-    CS.col1Scroll:ReleaseChildren()
-
-    -- Hide button bar in browse mode
-    if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
-
-    local db = CooldownCompanion.db.profile
-
-    if not CS.browseCharKey then
-        -- Phase A: Character list
-        local backBtn = AceGUI:Create("InteractiveLabel")
-        CleanRecycledEntry(backBtn)
-        backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to My Groups")
-        backBtn:SetFullWidth(true)
-        backBtn:SetFontObject(GameFontHighlight)
-        ApplyConfigTextRow(backBtn)
-        backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-        backBtn:SetCallback("OnClick", function()
-            CS.browseMode = false
-            CS.browseCharKey = nil
-            CS.browseContainerId = nil
-            ClearConfigPrimarySelection()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        CS.col1Scroll:AddChild(backBtn)
-
-        local heading = AceGUI:Create("Heading")
-        heading:SetText("Other Characters")
-        heading:SetFullWidth(true)
-        CS.col1Scroll:AddChild(heading)
-
-        local chars = CooldownCompanion:EnumerateBrowseCharacters()
-        if #chars == 0 then
-            local emptyLabel = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(emptyLabel)
-            emptyLabel:SetText("|cff888888No other characters have groups on this profile.|r")
-            emptyLabel:SetFullWidth(true)
-            CS.col1Scroll:AddChild(emptyLabel)
-            return
-        end
-
-        for _, charInfo in ipairs(chars) do
-            local entry = AceGUI:Create("InteractiveLabel")
-            CleanRecycledEntry(entry)
-            local displayName, cc = GetClassColoredCharName(charInfo.charKey, charInfo.classFilename)
-
-            entry:SetText(displayName)
-            entry:SetFullWidth(true)
-            entry:SetFontObject(GameFontHighlight)
-            -- Class icon (use individual atlas to avoid tiled-sheet border)
-            if charInfo.classFilename then
-                ApplyConfigRowIcon(entry, 134400, { atlas = "classicon-" .. strlower(charInfo.classFilename) })
-            else
-                ApplyConfigRowIcon(entry, 134400)
-            end
-            entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-            entry:SetCallback("OnClick", function()
-                CS.browseCharKey = charInfo.charKey
-                CS.browseContainerId = nil
-                ClearConfigPrimarySelection()
-                CooldownCompanion:RefreshConfigPanel()
-            end)
-            CS.col1Scroll:AddChild(entry)
-        end
-    else
-        -- Phase B: Selected character's groups
-        local backBtn = AceGUI:Create("InteractiveLabel")
-        CleanRecycledEntry(backBtn)
-        backBtn:SetText("|A:common-icon-backarrow:14:14|a  Back to Characters")
-        backBtn:SetFullWidth(true)
-        backBtn:SetFontObject(GameFontHighlight)
-        ApplyConfigTextRow(backBtn)
-        backBtn:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-        backBtn:SetCallback("OnClick", function()
-            CS.browseCharKey = nil
-            CS.browseContainerId = nil
-            ClearConfigPrimarySelection()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        CS.col1Scroll:AddChild(backBtn)
-
-        -- Character heading with class color
-        local charInfo = CooldownCompanion.db.global.characterInfo and CooldownCompanion.db.global.characterInfo[CS.browseCharKey]
-        local classFilename = charInfo and charInfo.classFilename
-        local charName = CS.browseCharKey:match("^(.-)%s*%-") or CS.browseCharKey
-        local displayHeading = charName .. "'s Groups"
-
-        local heading = AceGUI:Create("Heading")
-        heading:SetText(displayHeading)
-        heading:SetFullWidth(true)
-        if classFilename then
-            local cc = C_ClassColor.GetClassColor(classFilename)
-            if cc then heading.label:SetTextColor(cc.r, cc.g, cc.b) end
-        end
-        CS.col1Scroll:AddChild(heading)
-
-        local containers = CooldownCompanion:GetCharacterContainers(CS.browseCharKey)
-        if #containers == 0 then
-            local emptyLabel = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(emptyLabel)
-            emptyLabel:SetText("|cff888888This character has no groups.|r")
-            emptyLabel:SetFullWidth(true)
-            CS.col1Scroll:AddChild(emptyLabel)
-            return
-        end
-
-        for _, item in ipairs(containers) do
-            local containerId = item.containerId
-            local container = item.container
-
-            local entry = AceGUI:Create("InteractiveLabel")
-            CleanRecycledEntry(entry)
-
-            local panelCount = CooldownCompanion:GetPanelCount(containerId)
-            local displayName = container.name
-            if panelCount > 1 then
-                displayName = displayName .. "  |cff888888(" .. panelCount .. " panels)|r"
-            end
-
-            entry:SetText(displayName)
-            entry:SetFullWidth(true)
-            entry:SetFontObject(GameFontHighlight)
-            ApplyConfigRowIcon(entry, GetContainerIcon(containerId, db))
-            entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-
-            -- Green highlight for selected browse container
-            if CS.browseContainerId == containerId then
-                entry:SetColor(0, 1, 0)
-            end
-
-            -- Neutralize built-in OnClick
-            entry:SetCallback("OnClick", function() end)
-
-            -- Left-click: select for preview; Right-click: copy context menu
-            entry.frame:SetScript("OnMouseUp", function(self, button)
-                if button == "LeftButton" then
-                    if CS.browseContainerId == containerId then
-                        CS.browseContainerId = nil
-                        SelectConfigContainer(nil, { keepContainerMulti = true })
-                    else
-                        CS.browseContainerId = containerId
-                        SelectConfigContainer(containerId, { keepContainerMulti = true })
-                    end
-                    CooldownCompanion:RefreshConfigPanel()
-                elseif button == "RightButton" then
-                    -- Verify source still exists
-                    if not db.groupContainers[containerId] then return end
-                    if not CS.browseContextMenu then
-                        CS.browseContextMenu = CreateFrame("Frame", "CDCBrowseContextMenu", UIParent, "UIDropDownMenuTemplate")
-                    end
-                    UIDropDownMenu_Initialize(CS.browseContextMenu, function(self, level)
-                        local info = UIDropDownMenu_CreateInfo()
-                        info.text = "Copy Entire Group"
-                        info.notCheckable = true
-                        info.func = function()
-                            CloseDropDownMenus()
-                            if not db.groupContainers[containerId] then return end
-                            local newId = CooldownCompanion:CopyContainerFromBrowse(containerId)
-                            if newId then
-                                CS.browseMode = false
-                                CS.browseCharKey = nil
-                                CS.browseContainerId = nil
-                                SelectConfigContainer(newId)
-                                CooldownCompanion:RefreshConfigPanel()
-                                CooldownCompanion:Print("Group copied successfully.")
-                            end
-                        end
-                        UIDropDownMenu_AddButton(info, level)
-                    end, "MENU")
-                    CS.browseContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
-                    ToggleDropDownMenu(1, nil, CS.browseContextMenu, "cursor", 0, 0)
-                end
-            end)
-
-            CS.col1Scroll:AddChild(entry)
-            SetupGroupRowIndicators(entry, container)
-        end
-    end
-end
-
 local PANEL_CREATION_MODES = {
     { mode = "icons", label = "Icon Panel" },
     { mode = "bars", label = "Bar Panel" },
@@ -383,19 +179,44 @@ local function BuildSelectedContainersExportPayload(db, selectedGroups)
     }
 end
 
+local function ResolveContainerScopeForConfig(containerId, container, charKey)
+    if CooldownCompanion.ResolveContainerClassScope then
+        return CooldownCompanion:ResolveContainerClassScope(container or containerId)
+    end
+    if container and container.isGlobal then
+        return { scope = "global", sectionKey = "global", runtimeVisible = true }
+    end
+    if container and container.createdBy == charKey then
+        return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+    end
+    return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+end
+
+local function ResolveFolderScopeForConfig(folderId, folder, charKey)
+    if CooldownCompanion.ResolveFolderClassScope then
+        return CooldownCompanion:ResolveFolderClassScope(folder or folderId)
+    end
+    if folder and folder.section == "global" then
+        return { scope = "global", sectionKey = "global", runtimeVisible = true }
+    end
+    if folder and folder.createdBy == charKey then
+        return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+    end
+    return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+end
+
 local function GetFolderTargetsForSection(db, charKey, section)
     local folderList = {}
     for fid, folder in pairs(db.folders) do
-        if folder.section == section then
-            if section == "char" and folder.createdBy and folder.createdBy ~= charKey then
-                -- skip: belongs to another character
-            else
-                folderList[#folderList + 1] = {
-                    id = fid,
-                    name = folder.name,
-                    order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid),
-                }
-            end
+        local scope = ResolveFolderScopeForConfig(fid, folder, charKey)
+        local folderSection = scope and scope.sectionKey
+            or (folder.section == "global" and "global" or "char")
+        if folderSection == section then
+            folderList[#folderList + 1] = {
+                id = fid,
+                name = folder.name,
+                order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid),
+            }
         end
     end
     table.sort(folderList, function(a, b) return a.order < b.order end)
@@ -465,7 +286,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             UIDropDownMenu_AddButton(info, level)
 
             info = UIDropDownMenu_CreateInfo()
-            info.text = container.isGlobal and "Make Character-Only" or "Make Global"
+            info.text = container.isGlobal and "Move to Current Class" or "Make Global"
             info.notCheckable = true
             info.func = function()
                 CloseDropDownMenus()
@@ -478,7 +299,8 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             end
             UIDropDownMenu_AddButton(info, level)
 
-            local containerSection = container.isGlobal and "global" or "char"
+            local containerScope = ResolveContainerScopeForConfig(containerId, container, charKey)
+            local containerSection = containerScope.sectionKey or (container.isGlobal and "global" or "char")
             local folderTargets = GetFolderTargetsForSection(db, charKey, containerSection)
             if #folderTargets > 0 or container.folderId then
                 info = UIDropDownMenu_CreateInfo()
@@ -631,7 +453,8 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             end
             UIDropDownMenu_AddButton(info, level)
 
-            local containerSection = container.isGlobal and "global" or "char"
+            local containerScope = ResolveContainerScopeForConfig(containerId, container, charKey)
+            local containerSection = containerScope.sectionKey or (container.isGlobal and "global" or "char")
             for _, folderTarget in ipairs(GetFolderTargetsForSection(db, charKey, containerSection)) do
                 info = UIDropDownMenu_CreateInfo()
                 info.text = folderTarget.name
@@ -699,8 +522,18 @@ local function ShowFolderContextMenu(db, folderId, folder)
         info.notCheckable = true
         info.func = function()
             CloseDropDownMenus()
+            local charKey = CooldownCompanion.db and CooldownCompanion.db.keys and CooldownCompanion.db.keys.char
+            local folderScope = ResolveFolderScopeForConfig(folderId, folder, charKey)
+            if folderScope.scope == "other-class" then
+                CooldownCompanion:Print("Create new groups in your current class, then move them to Global if needed.")
+                return
+            end
             local containerId = CooldownCompanion:CreateGroup(GenerateGroupName("New Group"))
-            CooldownCompanion:MoveGroupToFolder(containerId, folderId)
+            local container = db.groupContainers and db.groupContainers[containerId]
+            if container and folderScope.scope == "global" then
+                container.isGlobal = true
+            end
+            CooldownCompanion:MoveGroupToFolder(containerId, folderId, { allowScopeChange = true })
             SelectConfigContainer(containerId)
             CooldownCompanion:RefreshConfigPanel()
         end
@@ -731,7 +564,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
         end
 
         info = UIDropDownMenu_CreateInfo()
-        info.text = folder.section == "global" and "Make Character Folder" or "Make Global Folder"
+        info.text = folder.section == "global" and "Move to Current Class Folder" or "Make Global Folder"
         info.notCheckable = true
         info.func = function()
             CloseDropDownMenus()
@@ -917,6 +750,61 @@ local function PopulateColumn1ButtonBar()
     end)
 end
 
+local function RefreshColumn1FooterLayout()
+    if CS.UpdateColumn1FooterLayout then
+        CS.UpdateColumn1FooterLayout()
+    end
+end
+
+local function ClearOtherClassesFooterDoorway()
+    CS.col1FooterDoorwayVisible = false
+    CS.lastCol1FooterDoorwayRow = nil
+    local row = CS.col1FooterDoorway
+    if row and row.frame then
+        row.frame:SetScript("OnMouseUp", nil)
+        row.frame:Hide()
+    end
+    RefreshColumn1FooterLayout()
+end
+
+local function SetOtherClassesFooterDoorway(text, stableCount, onClick)
+    local row = CS.col1FooterDoorway
+    if not (row and row.frame) then
+        ClearOtherClassesFooterDoorway()
+        return false
+    end
+
+    CleanRecycledEntry(row)
+    row:SetText(text)
+    row:SetFullWidth(true)
+    row:SetFontObject(GameFontHighlight)
+    ApplyConfigTextRow(row, "CENTER")
+    row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+    row.frame:SetScript("OnMouseUp", function(_, button)
+        if CS.dragState and CS.dragState.phase == "active" then return end
+        if button == "LeftButton" and onClick then
+            onClick()
+        end
+    end)
+
+    CS.col1FooterDoorwayVisible = true
+    CS.lastCol1FooterDoorwayRow = {
+        kind = "other-classes-doorway",
+        widget = row,
+        section = "other-classes",
+        loadBucket = "marker",
+        acceptsDrop = false,
+        keepVisibleDuringPreview = false,
+        previewProxy = false,
+        isMarker = true,
+        stableCount = stableCount,
+        visible = true,
+    }
+    row.frame:Show()
+    RefreshColumn1FooterLayout()
+    return true
+end
+
 ------------------------------------------------------------------------
 -- COLUMN 1: Groups
 ------------------------------------------------------------------------
@@ -925,6 +813,9 @@ local function RefreshColumn1(preserveDrag)
 
     -- Bars & Frames panel mode: take over col1 with the bar/frame tab group
     if CS.resourceBarPanelActive then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassesFooterDoorway()
         CancelDrag()
         CS.HideAutocomplete()
         CS.col1Scroll.frame:Hide()
@@ -983,13 +874,6 @@ local function RefreshColumn1(preserveDrag)
     end
     CS.col1Scroll.frame:Show()
 
-    -- Cross-character browse mode: render browse UI instead of normal groups
-    if CS.browseMode then
-        CancelDrag()
-        RenderBrowseMode()
-        return
-    end
-
     if CS.col1ButtonBar then CS.col1ButtonBar:Show() end
 
     if not preserveDrag then CancelDrag() end
@@ -1011,6 +895,9 @@ local function RefreshColumn1(preserveDrag)
     if not db.folders then db.folders = {} end
 
     if CooldownCompanion._unsupportedLegacyProfile then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassesFooterDoorway()
         if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
 
         local spacer = AceGUI:Create("SimpleGroup")
@@ -1080,18 +967,44 @@ local function RefreshColumn1(preserveDrag)
         })
     end
 
+    local function ResolveContainerScope(containerId, container)
+        if CooldownCompanion.ResolveContainerClassScope then
+            return CooldownCompanion:ResolveContainerClassScope(container or containerId)
+        end
+        if container and container.isGlobal then
+            return { scope = "global", sectionKey = "global", runtimeVisible = true }
+        end
+        if container and container.createdBy == charKey then
+            return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+        end
+        return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+    end
+
+    local function ResolveFolderScope(folderId, folder)
+        if CooldownCompanion.ResolveFolderClassScope then
+            return CooldownCompanion:ResolveFolderClassScope(folder or folderId)
+        end
+        if folder and folder.section == "global" then
+            return { scope = "global", sectionKey = "global", runtimeVisible = true }
+        end
+        if folder and folder.createdBy == charKey then
+            return { scope = "current-class", sectionKey = "char", runtimeVisible = true }
+        end
+        return { scope = "invalid", sectionKey = "invalid", runtimeVisible = false }
+    end
+
+    local function ScopeMatchesSection(scope, section)
+        return scope and scope.sectionKey == section
+    end
+
     -- Build top-level items for a section (folders + loose containers), sorted by order
     local function BuildSectionItems(section, sectionContainerIds)
         -- Collect folders for this section
         local sectionFolderIds = {}
         for fid, folder in pairs(db.folders) do
-            if folder.section == section then
-                -- Character folders: only show if owned by current character
-                if section == "char" and folder.createdBy and folder.createdBy ~= charKey then
-                    -- skip: belongs to another character
-                else
-                    table.insert(sectionFolderIds, fid)
-                end
+            local scope = ResolveFolderScope(fid, folder)
+            if ScopeMatchesSection(scope, section) then
+                table.insert(sectionFolderIds, fid)
             end
         end
 
@@ -1209,9 +1122,10 @@ local function RefreshColumn1(preserveDrag)
     end
 
     -- Helper: render a single container row (reused by both sections)
-    local function RenderContainerRow(containerId, inFolder, sectionTag, loadBucket)
+    local function RenderContainerRow(containerId, inFolder, sectionTag, loadBucket, options)
         local container = db.groupContainers[containerId]
         if not container then return end
+        local disableDrag = options and options.disableDrag == true
 
         local entry = AceGUI:Create("InteractiveLabel")
         CleanRecycledEntry(entry)
@@ -1265,32 +1179,34 @@ local function RefreshColumn1(preserveDrag)
             ConfigureGenericGroupRenameBadge(entry, container, containerId, groupNameWidth)
         end
 
-        entry:SetCallback("OnClick", function(widget, event, mouseButton)
-            if mouseButton == "LeftButton"
-                and not searchResults
-                and not IsShiftKeyDown()
-                and not IsControlKeyDown()
-                and not GetCursorInfo()
-            then
-                local isMulti = next(CS.selectedGroups) and CS.selectedGroups[containerId]
-                local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
-                CS.dragState = {
-                    kind = isMulti and "multi-group" or (inFolder and "folder-group" or "group"),
-                    phase = "pending",
-                    sourceGroupId = containerId,
-                    sourceGroupIds = isMulti and CopyTable(CS.selectedGroups) or nil,
-                    sourceSection = sectionTag,
-                    sourceFolderId = inFolder and container.folderId or nil,
-                    sourceLoadBucket = isMulti and ResolveSelectedDragLoadBucket(loadBucket) or (loadBucket or "loaded"),
-                    scrollWidget = CS.col1Scroll,
-                    widget = entry,
-                    startX = cursorX,
-                    startY = cursorY,
-                    col1RenderedRows = col1RenderedRows,
-                }
-                StartDragTracking()
-            end
-        end)
+        if not disableDrag then
+            entry:SetCallback("OnClick", function(widget, event, mouseButton)
+                if mouseButton == "LeftButton"
+                    and not searchResults
+                    and not IsShiftKeyDown()
+                    and not IsControlKeyDown()
+                    and not GetCursorInfo()
+                then
+                    local isMulti = next(CS.selectedGroups) and CS.selectedGroups[containerId]
+                    local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
+                    CS.dragState = {
+                        kind = isMulti and "multi-group" or (inFolder and "folder-group" or "group"),
+                        phase = "pending",
+                        sourceGroupId = containerId,
+                        sourceGroupIds = isMulti and CopyTable(CS.selectedGroups) or nil,
+                        sourceSection = sectionTag,
+                        sourceFolderId = inFolder and container.folderId or nil,
+                        sourceLoadBucket = isMulti and ResolveSelectedDragLoadBucket(loadBucket) or (loadBucket or "loaded"),
+                        scrollWidget = CS.col1Scroll,
+                        widget = entry,
+                        startX = cursorX,
+                        startY = cursorY,
+                        col1RenderedRows = col1RenderedRows,
+                    }
+                    StartDragTracking()
+                end
+            end)
+        end
 
         -- Handle clicks via OnMouseUp
         entry.frame:SetScript("OnMouseUp", function(self, button)
@@ -1338,165 +1254,10 @@ local function RefreshColumn1(preserveDrag)
             inFolder = inFolder and container.folderId or nil,
             section = sectionTag,
             loadBucket = loadBucket or "loaded",
-            acceptsDrop = (loadBucket or "loaded") ~= "unloaded",
-            previewDraggable = true,
+            acceptsDrop = (not disableDrag) and (loadBucket or "loaded") ~= "unloaded",
+            previewDraggable = not disableDrag,
             previewProxy = true,
         })
-
-        -- Inline spec filter panel (expanded via Shift+Left-click)
-        if CS.specExpandedGroupId == containerId then
-            local numSpecs = GetNumSpecializations()
-            local configID = C_ClassTalents.GetActiveConfigID()
-            local htIndent = inFolder and 32 or 20
-            local folder = container.folderId and db.folders and db.folders[container.folderId]
-            local folderSpecs = folder and folder.specs
-            local folderHeroTalents = folder and folder.heroTalents
-            local effectiveSpecs
-            if folderSpecs or container.specs then
-                effectiveSpecs = {}
-                if folderSpecs then for k in pairs(folderSpecs) do effectiveSpecs[k] = true end end
-                if container.specs then for k in pairs(container.specs) do effectiveSpecs[k] = true end end
-                if not next(effectiveSpecs) then effectiveSpecs = nil end
-            end
-            for i = 1, numSpecs do
-                local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-                local lockedByFolder = folderSpecs and folderSpecs[specId]
-                local cb = AceGUI:Create("CheckBox")
-                cb:SetLabel(name)
-                cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92)
-                cb:SetFullWidth(true)
-                cb:SetValue(lockedByFolder or (container.specs and container.specs[specId]) or false)
-                if folderSpecs then
-                    cb:SetDisabled(true)
-                else
-                    cb:SetCallback("OnValueChanged", function(widget, event, value)
-                        if value then
-                            if not container.specs then container.specs = {} end
-                            container.specs[specId] = true
-                        else
-                            if container.specs then
-                                container.specs[specId] = nil
-                                if not next(container.specs) then
-                                    container.specs = nil
-                                end
-                            end
-                            CooldownCompanion:CleanHeroTalentsForSpec(container, specId)
-                        end
-                        CooldownCompanion:RefreshContainerPanels(containerId)
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                end
-                AddAuxWidget(cb, sectionTag, "container", containerId, inFolder and container.folderId or nil)
-                ApplyCheckboxIndent(cb, inFolder and 12 or 0)
-
-                local htOpts = nil
-                if folderHeroTalents and next(folderHeroTalents) then
-                    htOpts = {
-                        heroTalentsSource = folderHeroTalents,
-                        useHeroTalentsSource = true,
-                        disableToggles = true,
-                    }
-                end
-                htOpts = htOpts or {}
-                if effectiveSpecs then
-                    htOpts.specsSource = effectiveSpecs
-                end
-                htOpts.onChanged = function()
-                    CooldownCompanion:RefreshContainerPanels(containerId)
-                    CooldownCompanion:RefreshConfigPanel()
-                end
-                local heroWidgets = BuildHeroTalentSubTreeCheckboxes(CS.col1Scroll, container, configID, specId, htIndent, containerId, htOpts)
-                for _, heroWidget in ipairs(heroWidgets or {}) do
-                    TrackRenderedRow({
-                        kind = "aux-block",
-                        widget = heroWidget,
-                        section = sectionTag,
-                        loadBucket = "aux",
-                        acceptsDrop = false,
-                        previewProxy = false,
-                        layoutOnly = true,
-                        ownerKind = "container",
-                        ownerId = containerId,
-                        ownerFolderId = inFolder and container.folderId or nil,
-                    })
-                end
-            end
-
-            local playerSpecIds = {}
-            for i = 1, numSpecs do
-                local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-                if specId then playerSpecIds[specId] = true end
-            end
-
-            local foreignSpecs = {}
-            if container.specs then
-                for specId in pairs(container.specs) do
-                    if not playerSpecIds[specId] then
-                        table.insert(foreignSpecs, specId)
-                    end
-                end
-            end
-
-            if #foreignSpecs > 0 then
-                table.sort(foreignSpecs)
-                for _, specId in ipairs(foreignSpecs) do
-                    local _, name, _, icon = GetSpecializationInfoForSpecID(specId)
-                    if name then
-                        local fcb = AceGUI:Create("CheckBox")
-                        fcb:SetLabel(name)
-                        if icon then fcb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-                        fcb:SetFullWidth(true)
-                        fcb:SetValue(true)
-                        fcb:SetCallback("OnValueChanged", function(widget, event, value)
-                            if not value then
-                                if container.specs then
-                                    container.specs[specId] = nil
-                                    if not next(container.specs) then
-                                        container.specs = nil
-                                    end
-                                end
-                            else
-                                if not container.specs then container.specs = {} end
-                                container.specs[specId] = true
-                            end
-                            CooldownCompanion:RefreshContainerPanels(containerId)
-                            CooldownCompanion:RefreshConfigPanel()
-                        end)
-                        AddAuxWidget(fcb, sectionTag, "container", containerId, inFolder and container.folderId or nil)
-                        ApplyCheckboxIndent(fcb, inFolder and 12 or 0)
-                    end
-                end
-            end
-
-            local hasOwnSpecs = false
-            if container.specs then
-                for specId in pairs(container.specs) do
-                    if not (folderSpecs and folderSpecs[specId]) then
-                        hasOwnSpecs = true
-                        break
-                    end
-                end
-            end
-            if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
-                hasOwnSpecs = true
-            end
-            if hasOwnSpecs then
-                local clearBtn = AceGUI:Create("Button")
-                clearBtn:SetText("Clear All")
-                clearBtn:SetFullWidth(true)
-                clearBtn:SetCallback("OnClick", function()
-                    if folderSpecs then
-                        container.specs = CopyTable(folderSpecs)
-                    else
-                        container.specs = nil
-                    end
-                    container.heroTalents = nil
-                    CooldownCompanion:RefreshContainerPanels(containerId)
-                    CooldownCompanion:RefreshConfigPanel()
-                end)
-                AddAuxWidget(clearBtn, sectionTag, "container", containerId, inFolder and container.folderId or nil)
-            end
-        end
 
         return entry
     end
@@ -1521,9 +1282,10 @@ local function RefreshColumn1(preserveDrag)
     end
 
     -- Helper: render a folder header row
-    local function RenderFolderRow(folderId, sectionTag, childContainerIds, loadBucket)
+    local function RenderFolderRow(folderId, sectionTag, childContainerIds, loadBucket, options)
         local folder = db.folders[folderId]
         if not folder then return end
+        local disableDrag = options and options.disableDrag == true
 
         local isCollapsed = CS.collapsedFolders[folderId]
         local function ToggleFolderCollapsed()
@@ -1615,29 +1377,31 @@ local function RefreshColumn1(preserveDrag)
             widget = entry,
             section = sectionTag,
             loadBucket = loadBucket or "loaded",
-            acceptsDrop = (loadBucket or "loaded") ~= "unloaded",
-            previewDraggable = true,
+            acceptsDrop = (not disableDrag) and (loadBucket or "loaded") ~= "unloaded",
+            previewDraggable = not disableDrag,
             previewProxy = true,
         })
 
-        entry:SetCallback("OnClick", function(widget, event, mouseButton)
-            if mouseButton == "LeftButton" and not searchResults and not IsShiftKeyDown() and not GetCursorInfo() then
-                local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
-                CS.dragState = {
-                    kind = "folder",
-                    phase = "pending",
-                    sourceFolderId = folderId,
-                    sourceSection = sectionTag,
-                    sourceLoadBucket = loadBucket or "loaded",
-                    scrollWidget = CS.col1Scroll,
-                    widget = entry,
-                    startX = cursorX,
-                    startY = cursorY,
-                    col1RenderedRows = col1RenderedRows,
-                }
-                StartDragTracking()
-            end
-        end)
+        if not disableDrag then
+            entry:SetCallback("OnClick", function(widget, event, mouseButton)
+                if mouseButton == "LeftButton" and not searchResults and not IsShiftKeyDown() and not GetCursorInfo() then
+                    local cursorX, cursorY = GetScaledCursorPosition(CS.col1Scroll)
+                    CS.dragState = {
+                        kind = "folder",
+                        phase = "pending",
+                        sourceFolderId = folderId,
+                        sourceSection = sectionTag,
+                        sourceLoadBucket = loadBucket or "loaded",
+                        scrollWidget = CS.col1Scroll,
+                        widget = entry,
+                        startX = cursorX,
+                        startY = cursorY,
+                        col1RenderedRows = col1RenderedRows,
+                    }
+                    StartDragTracking()
+                end
+            end)
+        end
 
         -- Handle clicks via OnMouseUp
         entry.frame:SetScript("OnMouseUp", function(self, button)
@@ -1680,126 +1444,103 @@ local function RefreshColumn1(preserveDrag)
 
     end
 
-    local function RenderFolderSpecPanel(folderId, sectionTag)
-        local folder = db.folders[folderId]
-        if not folder then return end
-
-        local function BuildFolderSpecs(nextSpecId, enabled)
-            local nextSpecs = folder.specs and CopyTable(folder.specs) or {}
-            if enabled then
-                nextSpecs[nextSpecId] = true
-            else
-                nextSpecs[nextSpecId] = nil
-            end
-            if not next(nextSpecs) then
-                nextSpecs = nil
-            end
-            return nextSpecs
-        end
-
-        local numSpecs = GetNumSpecializations()
-        local configID = C_ClassTalents.GetActiveConfigID()
-        local htIndent = 32
-        for i = 1, numSpecs do
-            local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-            local cb = AceGUI:Create("CheckBox")
-            cb:SetLabel(name)
-            cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92)
-            cb:SetFullWidth(true)
-            cb:SetValue(folder.specs and folder.specs[specId] or false)
-            cb:SetCallback("OnValueChanged", function(widget, event, value)
-                CooldownCompanion:SetFolderSpecs(folderId, BuildFolderSpecs(specId, value))
-            end)
-            AddAuxWidget(cb, sectionTag, "folder", folderId, folderId)
-            ApplyCheckboxIndent(cb, 12)
-
-            if configID and folder.specs and folder.specs[specId] then
-                local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
-                if subTreeIDs then
-                    for _, subTreeID in ipairs(subTreeIDs) do
-                        local subTreeInfo = C_Traits.GetSubTreeInfo(configID, subTreeID)
-                        if subTreeInfo then
-                            local htCb = AceGUI:Create("CheckBox")
-                            htCb:SetLabel(subTreeInfo.name or ("Hero " .. subTreeID))
-                            htCb:SetFullWidth(true)
-                            htCb:SetValue(folder.heroTalents and folder.heroTalents[subTreeID] or false)
-                            htCb:SetCallback("OnValueChanged", function(widget, event, value)
-                                CooldownCompanion:SetFolderHeroTalent(folderId, subTreeID, value)
-                            end)
-                            AddAuxWidget(htCb, sectionTag, "folder", folderId, folderId)
-                            ApplyCheckboxIndent(htCb, htIndent)
-                            if subTreeInfo.iconElementID then
-                                htCb:SetImage(136235)
-                                htCb.image:SetAtlas(subTreeInfo.iconElementID, false)
-                                htCb.image:SetTexCoord(0, 1, 0, 1)
-                            end
-                        end
-                    end
-                end
-            end
-        end
-
-        local playerSpecIds = {}
-        for i = 1, numSpecs do
-            local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-            if specId then playerSpecIds[specId] = true end
-        end
-
-        local foreignSpecs = {}
-        if folder.specs then
-            for specId in pairs(folder.specs) do
-                if not playerSpecIds[specId] then
-                    table.insert(foreignSpecs, specId)
-                end
-            end
-        end
-
-        if #foreignSpecs > 0 then
-            table.sort(foreignSpecs)
-            for _, specId in ipairs(foreignSpecs) do
-                local _, name, _, icon = GetSpecializationInfoForSpecID(specId)
-                if name then
-                    local fcb = AceGUI:Create("CheckBox")
-                    fcb:SetLabel(name)
-                    if icon then fcb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-                    fcb:SetFullWidth(true)
-                    fcb:SetValue(true)
-                    fcb:SetCallback("OnValueChanged", function(widget, event, value)
-                        CooldownCompanion:SetFolderSpecs(folderId, BuildFolderSpecs(specId, value))
-                    end)
-                    AddAuxWidget(fcb, sectionTag, "folder", folderId, folderId)
-                    ApplyCheckboxIndent(fcb, 12)
-                end
-            end
-        end
-
-        local clearBtn = AceGUI:Create("Button")
-        clearBtn:SetText("Clear All")
-        clearBtn:SetFullWidth(true)
-        clearBtn:SetCallback("OnClick", function()
-            CooldownCompanion:SetFolderSpecs(folderId, nil)
-        end)
-        AddAuxWidget(clearBtn, sectionTag, "folder", folderId, folderId)
+    local function RenderSectionMarker(section, headingText, headingColor)
+        local heading = AceGUI:Create("Label")
+        heading:SetFullWidth(true)
+        heading:SetHeight(18)
+        CS.col1Scroll:AddChild(heading)
+        SetupColumn1MarkerRow(heading, {
+            text = headingText,
+            color = headingColor,
+        })
+        TrackRenderedRow({
+            kind = "section-title",
+            widget = heading,
+            section = section,
+            loadBucket = "marker",
+            acceptsDrop = false,
+            keepVisibleDuringPreview = true,
+            previewProxy = true,
+            isMarker = true,
+        })
     end
 
-    -- Render a section (global or character)
+    -- Render a section (global, current class, or another class)
     local function RenderSection(section, sectionGroupIds, headingText, headingColor, options)
         local items, folderChildContainers = BuildSectionItems(section, sectionGroupIds)
+        local isClassSection = options and options.classSection == true
+        local stableCount = options and options.stableCount or nil
+
+        if isClassSection then
+            local isCollapsed = CS.collapsedSections[section] ~= false
+            local function ToggleClassSection()
+                local currentlyCollapsed = CS.collapsedSections[section] ~= false
+                if currentlyCollapsed then
+                    CS.collapsedSections[section] = false
+                else
+                    CS.collapsedSections[section] = true
+                end
+                CooldownCompanion:RefreshConfigPanel()
+            end
+            local header = AceGUI:Create("InteractiveLabel")
+            CleanRecycledEntry(header)
+            local countText = stableCount and (" |cff888888(" .. tostring(stableCount) .. ")|r") or ""
+            header:SetText((isCollapsed and "|A:common-icon-plus:12:12|a " or "|A:common-icon-minus:12:12|a ")
+                .. headingText .. countText)
+            header:SetFullWidth(true)
+            header:SetFontObject(GameFontHighlight)
+            if headingColor then
+                header:SetColor(headingColor[1], headingColor[2], headingColor[3])
+            end
+            if options and options.classKey then
+                ApplyConfigRowIcon(header, 134400, { atlas = "classicon-" .. string.lower(options.classKey) })
+            else
+                ApplyConfigTextRow(header)
+            end
+            header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+            if header.frame then
+                header.frame:SetScript("OnMouseUp", function(_, button)
+                    if CS.dragState and CS.dragState.phase == "active" then return end
+                    if button == "LeftButton" then
+                        ToggleClassSection()
+                    end
+                end)
+            end
+            CS.col1Scroll:AddChild(header)
+            TrackRenderedRow({
+                kind = "class-header",
+                widget = header,
+                section = section,
+                loadBucket = "marker",
+                acceptsDrop = false,
+                keepVisibleDuringPreview = true,
+                previewProxy = true,
+                isMarker = true,
+                stableCount = stableCount,
+            })
+            if isCollapsed and not searchResults then
+                return
+            end
+        end
 
         -- Partition into loaded (active) and unloaded (inactive)
         local loadedItems = {}
         local unloadedItems = {}
         for _, item in ipairs(items) do
-            local isInactive
-            if item.kind == "folder" then
-                isInactive = IsFolderFullyInactive(item.id, folderChildContainers[item.id])
-            else
-                isInactive = IsContainerInactive(item.id, db.groupContainers[item.id])
-            end
-            if isInactive then
-                table.insert(unloadedItems, item)
-            else
+            if options and options.noLoadBuckets then
                 table.insert(loadedItems, item)
+            else
+                local isInactive
+                if item.kind == "folder" then
+                    isInactive = IsFolderFullyInactive(item.id, folderChildContainers[item.id])
+                else
+                    isInactive = IsContainerInactive(item.id, db.groupContainers[item.id])
+                end
+                if isInactive then
+                    table.insert(unloadedItems, item)
+                else
+                    table.insert(loadedItems, item)
+                end
             end
         end
 
@@ -1811,25 +1552,27 @@ local function RefreshColumn1(preserveDrag)
             and #loadedItems == 0
             and #unloadedItems > 0
 
-        local heading = AceGUI:Create("Label")
-        heading:SetFullWidth(true)
-        heading:SetHeight(18)
-        CS.col1Scroll:AddChild(heading)
-        SetupColumn1MarkerRow(heading, {
-            text = useUnloadedOnlyHeading and "Unloaded Groups" or headingText,
-            color = useUnloadedOnlyHeading and { 0.53, 0.53, 0.53 } or headingColor,
-        })
+        if not isClassSection then
+            local heading = AceGUI:Create("Label")
+            heading:SetFullWidth(true)
+            heading:SetHeight(18)
+            CS.col1Scroll:AddChild(heading)
+            SetupColumn1MarkerRow(heading, {
+                text = useUnloadedOnlyHeading and "Unloaded Groups" or headingText,
+                color = useUnloadedOnlyHeading and { 0.53, 0.53, 0.53 } or headingColor,
+            })
 
-        TrackRenderedRow({
-            kind = "section-header",
-            widget = heading,
-            section = section,
-            loadBucket = "marker",
-            acceptsDrop = false,
-            keepVisibleDuringPreview = true,
-            previewProxy = true,
-            isMarker = true,
-        })
+            TrackRenderedRow({
+                kind = "section-header",
+                widget = heading,
+                section = section,
+                loadBucket = "marker",
+                acceptsDrop = false,
+                keepVisibleDuringPreview = true,
+                previewProxy = true,
+                isMarker = true,
+            })
+        end
 
         if isEmpty and CS.showPhantomSections then
             local placeholder = AceGUI:Create("Label")
@@ -1855,22 +1598,20 @@ local function RefreshColumn1(preserveDrag)
         end
 
         -- Class color for accent bars
-        local classColor = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
+        local classColor = options and options.classKey and C_ClassColor.GetClassColor(options.classKey)
+            or C_ClassColor.GetClassColor(select(2, UnitClass("player")))
 
         local function RenderItems(itemList, loadBucket)
             for _, item in ipairs(itemList) do
                 if item.kind == "folder" then
-                    RenderFolderRow(item.id, section, folderChildContainers[item.id], loadBucket)
-                    if CS.specExpandedFolderId == item.id then
-                        RenderFolderSpecPanel(item.id, section)
-                    end
+                    RenderFolderRow(item.id, section, folderChildContainers[item.id], loadBucket, options)
                     -- If expanded, render children with accent bar
                     if searchResults or not CS.collapsedFolders[item.id] then
                         local children = folderChildContainers[item.id]
                         if children and #children > 0 then
                             local firstEntry, lastEntry
                             for _, cid in ipairs(children) do
-                                local entry = RenderContainerRow(cid, true, section, loadBucket)
+                                local entry = RenderContainerRow(cid, true, section, loadBucket, options)
                                 if entry then
                                     if not firstEntry then firstEntry = entry end
                                     lastEntry = entry
@@ -1900,7 +1641,7 @@ local function RefreshColumn1(preserveDrag)
                         end
                     end
                 elseif item.kind == "container" then
-                    RenderContainerRow(item.id, false, section, loadBucket)
+                    RenderContainerRow(item.id, false, section, loadBucket, options)
                 end
             end
         end
@@ -1932,31 +1673,258 @@ local function RefreshColumn1(preserveDrag)
         RenderItems(unloadedItems, "unloaded")
     end
 
-    -- Split containers into global and character-owned
+    local function GetClassDisplayName(classKey)
+        if type(classKey) ~= "string" then return "Class" end
+        if GetClassInfo then
+            for classID = 1, 30 do
+                local className, classFilename = GetClassInfo(classID)
+                if classFilename and string.upper(classFilename) == classKey then
+                    return className or classKey
+                end
+            end
+        end
+        return classKey:sub(1, 1) .. string.lower(classKey:sub(2))
+    end
+
+    local function EnsureOtherClassSection(otherSections, otherSectionOrder, scope)
+        if not (scope and scope.ownerClassKey and scope.sectionKey) then
+            return nil
+        end
+        local section = otherSections[scope.sectionKey]
+        if not section then
+            local cc = C_ClassColor.GetClassColor(scope.ownerClassKey)
+            section = {
+                key = scope.sectionKey,
+                classKey = scope.ownerClassKey,
+                title = GetClassDisplayName(scope.ownerClassKey) .. " Groups",
+                color = cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
+                containerIds = {},
+                count = 0,
+            }
+            otherSections[scope.sectionKey] = section
+            otherSectionOrder[#otherSectionOrder + 1] = section
+        end
+        return section
+    end
+
+    local function GetOtherClassVisibleCount(section)
+        if not section then return 0 end
+        if not searchResults then
+            return section.count or 0
+        end
+
+        local count = 0
+        for _, containerId in ipairs(section.containerIds or {}) do
+            if searchResults.containerMatches[containerId] then
+                count = count + 1
+            end
+        end
+        return count
+    end
+
+    local function GetOtherClassSummary(otherSectionOrder)
+        local totalCount = 0
+        local classCount = 0
+        for _, section in ipairs(otherSectionOrder or {}) do
+            local visibleCount = GetOtherClassVisibleCount(section)
+            if visibleCount > 0 then
+                totalCount = totalCount + visibleCount
+                classCount = classCount + 1
+            end
+        end
+        return totalCount, classCount
+    end
+
+    local function RenderNavigationRow(kind, text, options)
+        local row = AceGUI:Create("InteractiveLabel")
+        CleanRecycledEntry(row)
+        row:SetText(text)
+        row:SetFullWidth(true)
+        row:SetFontObject(GameFontHighlight)
+        if options and options.color then
+            row:SetColor(options.color[1], options.color[2], options.color[3])
+        end
+        if options and options.classKey then
+            ApplyConfigRowIcon(row, 134400, { atlas = "classicon-" .. string.lower(options.classKey) })
+        else
+            ApplyConfigTextRow(row)
+        end
+        row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+        if row.frame then
+            row.frame:SetScript("OnMouseUp", function(_, button)
+                if CS.dragState and CS.dragState.phase == "active" then return end
+                if button == "LeftButton" and options and options.onClick then
+                    options.onClick()
+                end
+            end)
+        end
+        CS.col1Scroll:AddChild(row)
+        TrackRenderedRow({
+            kind = kind,
+            widget = row,
+            section = options and options.section or nil,
+            classKey = options and options.classKey or nil,
+            loadBucket = "marker",
+            acceptsDrop = false,
+            keepVisibleDuringPreview = true,
+            previewProxy = true,
+            isMarker = true,
+            stableCount = options and options.stableCount or nil,
+        })
+        return row
+    end
+
+    local function UpdateOtherClassesFooterDoorway(otherSectionOrder)
+        local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
+        if totalCount <= 0 or classCount <= 0 then
+            ClearOtherClassesFooterDoorway()
+            return false
+        end
+
+        return SetOtherClassesFooterDoorway(
+            "Browse Other Classes",
+            totalCount,
+            function()
+                CS.otherClassLibraryActive = true
+                CS.otherClassLibraryClassKey = nil
+                CooldownCompanion:RefreshConfigPanel()
+            end
+        )
+    end
+
+    local function FindOtherClassSectionByClassKey(otherSectionOrder, classKey)
+        if not classKey then return nil end
+        for _, section in ipairs(otherSectionOrder or {}) do
+            if section.classKey == classKey then
+                return section
+            end
+        end
+        return nil
+    end
+
+    local function RenderOtherClassLibrary(otherSectionOrder)
+        local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
+        if totalCount <= 0 or classCount <= 0 then
+            CS.otherClassLibraryActive = false
+            CS.otherClassLibraryClassKey = nil
+            ClearOtherClassesFooterDoorway()
+            return false
+        end
+
+        ClearOtherClassesFooterDoorway()
+
+        local selectedSection = FindOtherClassSectionByClassKey(otherSectionOrder, CS.otherClassLibraryClassKey)
+        if selectedSection and GetOtherClassVisibleCount(selectedSection) <= 0 then
+            selectedSection = nil
+            CS.otherClassLibraryClassKey = nil
+        end
+
+        if selectedSection then
+            RenderNavigationRow("other-class-library-back", "|A:common-icon-backarrow:14:14|a  Back to Other Classes", {
+                section = "other-classes",
+                onClick = function()
+                    CS.otherClassLibraryClassKey = nil
+                    CooldownCompanion:RefreshConfigPanel()
+                end,
+            })
+            RenderSection(
+                selectedSection.key,
+                selectedSection.containerIds,
+                selectedSection.title,
+                selectedSection.color,
+                {
+                    classKey = selectedSection.classKey,
+                    noLoadBuckets = true,
+                    disableDrag = true,
+                }
+            )
+            return true
+        end
+
+        RenderNavigationRow("other-class-library-back", "|A:common-icon-backarrow:14:14|a  Back to Groups", {
+            section = "other-classes",
+            onClick = function()
+                CS.otherClassLibraryActive = false
+                CS.otherClassLibraryClassKey = nil
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
+
+        for _, section in ipairs(otherSectionOrder or {}) do
+            local visibleCount = GetOtherClassVisibleCount(section)
+            if visibleCount > 0 then
+                RenderNavigationRow("other-class-library-class", section.title
+                    .. " |cff888888(" .. tostring(visibleCount) .. ")|r", {
+                    section = section.key,
+                    classKey = section.classKey,
+                    color = section.color,
+                    stableCount = visibleCount,
+                    onClick = function()
+                        CS.otherClassLibraryClassKey = section.classKey
+                        CooldownCompanion:RefreshConfigPanel()
+                    end,
+                })
+            end
+        end
+        return true
+    end
+
+    -- Split containers into global, current-class, and other-class inventory.
     local containers = db.groupContainers or {}
     local showNewUserEmptyState = not next(containers) and not next(db.folders)
     local globalIds = {}
     local charIds = {}
+    local otherSections = {}
+    local otherSectionOrder = {}
     for id, container in pairs(containers) do
-        if container.isGlobal then
+        local scope = ResolveContainerScope(id, container)
+        if scope.scope == "global" then
             table.insert(globalIds, id)
-        elseif container.createdBy == charKey then
+        elseif scope.scope == "current-class" then
             table.insert(charIds, id)
+        elseif scope.scope == "other-class" then
+            local section = EnsureOtherClassSection(otherSections, otherSectionOrder, scope)
+            if section then
+                table.insert(section.containerIds, id)
+                section.count = section.count + 1
+            end
         end
     end
 
+    for folderId, folder in pairs(db.folders or {}) do
+        local scope = ResolveFolderScope(folderId, folder)
+        if scope.scope == "other-class" then
+            local section = EnsureOtherClassSection(otherSections, otherSectionOrder, scope)
+            if section then
+                section.count = section.count + 1
+            end
+        end
+    end
+    table.sort(otherSectionOrder, function(a, b)
+        return (a.title or a.classKey or a.key) < (b.title or b.classKey or b.key)
+    end)
+
     if searchResults and not next(searchResults.containerMatches) then
+        ClearOtherClassesFooterDoorway()
         local label = AceGUI:Create("Label")
         ST._ConfigureWrappedHelperLabel(label)
         label:SetText("|cff888888No matching groups.|r")
         label:SetFullWidth(true)
         CS.col1Scroll:AddChild(label)
         CS.lastCol1RenderedRows = col1RenderedRows
-        PopulateColumn1ButtonBar()
+        if CS.otherClassLibraryActive then
+            if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
+        else
+            PopulateColumn1ButtonBar()
+        end
         return
     end
 
     if showNewUserEmptyState then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassesFooterDoorway()
+
         local spacer = AceGUI:Create("SimpleGroup")
         spacer:SetFullWidth(true)
         spacer:SetHeight(20)
@@ -2001,6 +1969,13 @@ local function RefreshColumn1(preserveDrag)
                 statsContainerIds[id] = true
             end
         end
+        for _, section in ipairs(otherSectionOrder) do
+            for _, id in ipairs(section.containerIds) do
+                if not searchResults or searchResults.containerMatches[id] then
+                    statsContainerIds[id] = true
+                end
+            end
+        end
         for id in pairs(CS.selectedGroups) do
             if containers[id] then
                 statsContainerIds[id] = true
@@ -2009,47 +1984,63 @@ local function RefreshColumn1(preserveDrag)
         containerStats = BuildColumn1ContainerStats(db, statsContainerIds)
 
         -- Render sections
-        local hasGlobalContent = #globalIds > 0
-        if not hasGlobalContent then
-            for _, folder in pairs(db.folders) do
-                if folder.section == "global" then
-                    hasGlobalContent = true
-                    break
-                end
-            end
+        local renderedOtherClassLibrary = false
+        if CS.otherClassLibraryActive then
+            renderedOtherClassLibrary = RenderOtherClassLibrary(otherSectionOrder)
         end
 
-        if #globalIds > 0 or next(db.folders) or CS.showPhantomSections then
-            if hasGlobalContent or CS.showPhantomSections then
-                RenderSection("global", globalIds, "Global Groups", { 0.4, 0.67, 1.0 })
-            end
-        end
-
-        local charName = charKey:match("^(.-)%s*%-") or charKey
-        local hasCharContent = #charIds > 0
-        if not hasCharContent then
-            for _, folder in pairs(db.folders) do
-                if folder.section == "char" and (not folder.createdBy or folder.createdBy == charKey) then
-                    hasCharContent = true
-                    break
+        if not renderedOtherClassLibrary then
+            local hasGlobalContent = #globalIds > 0
+            if not hasGlobalContent then
+                for folderId, folder in pairs(db.folders) do
+                    local scope = ResolveFolderScope(folderId, folder)
+                    if scope.scope == "global" then
+                        hasGlobalContent = true
+                        break
+                    end
                 end
             end
-        end
-        if hasCharContent or CS.showPhantomSections then
-            local cc = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
-            RenderSection(
-                "char",
-                charIds,
-                charName .. "'s Groups",
-                cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
-                { preferUnloadedHeading = not hasGlobalContent }
-            )
+
+            if #globalIds > 0 or next(db.folders) or CS.showPhantomSections then
+                if hasGlobalContent or CS.showPhantomSections then
+                    RenderSection("global", globalIds, "Global Groups", { 0.4, 0.67, 1.0 })
+                end
+            end
+
+            local _, playerClassKey = UnitClass("player")
+            local currentClassName = GetClassDisplayName(playerClassKey)
+            local hasCharContent = #charIds > 0
+            if not hasCharContent then
+                for folderId, folder in pairs(db.folders) do
+                    local scope = ResolveFolderScope(folderId, folder)
+                    if scope.scope == "current-class" then
+                        hasCharContent = true
+                        break
+                    end
+                end
+            end
+            if hasCharContent or CS.showPhantomSections then
+                local cc = C_ClassColor.GetClassColor(select(2, UnitClass("player")))
+                RenderSection(
+                    "char",
+                    charIds,
+                    currentClassName .. " Groups",
+                    cc and { cc.r, cc.g, cc.b } or { 1, 1, 1 },
+                    { preferUnloadedHeading = not hasGlobalContent }
+                )
+            end
+
+            UpdateOtherClassesFooterDoorway(otherSectionOrder)
         end
     end
 
     CS.lastCol1RenderedRows = col1RenderedRows
 
-    PopulateColumn1ButtonBar()
+    if CS.otherClassLibraryActive then
+        if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
+    else
+        PopulateColumn1ButtonBar()
+    end
 end
 
 ------------------------------------------------------------------------

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -750,61 +750,6 @@ local function PopulateColumn1ButtonBar()
     end)
 end
 
-local function RefreshColumn1FooterLayout()
-    if CS.UpdateColumn1FooterLayout then
-        CS.UpdateColumn1FooterLayout()
-    end
-end
-
-local function ClearOtherClassesFooterDoorway()
-    CS.col1FooterDoorwayVisible = false
-    CS.lastCol1FooterDoorwayRow = nil
-    local row = CS.col1FooterDoorway
-    if row and row.frame then
-        row.frame:SetScript("OnMouseUp", nil)
-        row.frame:Hide()
-    end
-    RefreshColumn1FooterLayout()
-end
-
-local function SetOtherClassesFooterDoorway(text, stableCount, onClick)
-    local row = CS.col1FooterDoorway
-    if not (row and row.frame) then
-        ClearOtherClassesFooterDoorway()
-        return false
-    end
-
-    CleanRecycledEntry(row)
-    row:SetText(text)
-    row:SetFullWidth(true)
-    row:SetFontObject(GameFontHighlight)
-    ApplyConfigTextRow(row, "CENTER")
-    row:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-    row.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.dragState and CS.dragState.phase == "active" then return end
-        if button == "LeftButton" and onClick then
-            onClick()
-        end
-    end)
-
-    CS.col1FooterDoorwayVisible = true
-    CS.lastCol1FooterDoorwayRow = {
-        kind = "other-classes-doorway",
-        widget = row,
-        section = "other-classes",
-        loadBucket = "marker",
-        acceptsDrop = false,
-        keepVisibleDuringPreview = false,
-        previewProxy = false,
-        isMarker = true,
-        stableCount = stableCount,
-        visible = true,
-    }
-    row.frame:Show()
-    RefreshColumn1FooterLayout()
-    return true
-end
-
 ------------------------------------------------------------------------
 -- COLUMN 1: Groups
 ------------------------------------------------------------------------
@@ -815,7 +760,6 @@ local function RefreshColumn1(preserveDrag)
     if CS.resourceBarPanelActive then
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
-        ClearOtherClassesFooterDoorway()
         CancelDrag()
         CS.HideAutocomplete()
         CS.col1Scroll.frame:Hide()
@@ -897,7 +841,6 @@ local function RefreshColumn1(preserveDrag)
     if CooldownCompanion._unsupportedLegacyProfile then
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
-        ClearOtherClassesFooterDoorway()
         if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
 
         local spacer = AceGUI:Create("SimpleGroup")
@@ -1774,24 +1717,6 @@ local function RefreshColumn1(preserveDrag)
         return row
     end
 
-    local function UpdateOtherClassesFooterDoorway(otherSectionOrder)
-        local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
-        if totalCount <= 0 or classCount <= 0 then
-            ClearOtherClassesFooterDoorway()
-            return false
-        end
-
-        return SetOtherClassesFooterDoorway(
-            "Browse Other Classes",
-            totalCount,
-            function()
-                CS.otherClassLibraryActive = true
-                CS.otherClassLibraryClassKey = nil
-                CooldownCompanion:RefreshConfigPanel()
-            end
-        )
-    end
-
     local function FindOtherClassSectionByClassKey(otherSectionOrder, classKey)
         if not classKey then return nil end
         for _, section in ipairs(otherSectionOrder or {}) do
@@ -1807,11 +1732,8 @@ local function RefreshColumn1(preserveDrag)
         if totalCount <= 0 or classCount <= 0 then
             CS.otherClassLibraryActive = false
             CS.otherClassLibraryClassKey = nil
-            ClearOtherClassesFooterDoorway()
             return false
         end
-
-        ClearOtherClassesFooterDoorway()
 
         local selectedSection = FindOtherClassSectionByClassKey(otherSectionOrder, CS.otherClassLibraryClassKey)
         if selectedSection and GetOtherClassVisibleCount(selectedSection) <= 0 then
@@ -1905,7 +1827,6 @@ local function RefreshColumn1(preserveDrag)
     end)
 
     if searchResults and not next(searchResults.containerMatches) then
-        ClearOtherClassesFooterDoorway()
         local label = AceGUI:Create("Label")
         ST._ConfigureWrappedHelperLabel(label)
         label:SetText("|cff888888No matching groups.|r")
@@ -1923,7 +1844,6 @@ local function RefreshColumn1(preserveDrag)
     if showNewUserEmptyState then
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
-        ClearOtherClassesFooterDoorway()
 
         local spacer = AceGUI:Create("SimpleGroup")
         spacer:SetFullWidth(true)
@@ -2029,8 +1949,6 @@ local function RefreshColumn1(preserveDrag)
                     { preferUnloadedHeading = not hasGlobalContent }
                 )
             end
-
-            UpdateOtherClassesFooterDoorway(otherSectionOrder)
         end
     end
 

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -1616,14 +1616,27 @@ local function RefreshColumn1(preserveDrag)
         RenderItems(unloadedItems, "unloaded")
     end
 
+    local function GetClassInfoByID(classID)
+        classID = tonumber(classID)
+        if not classID then return nil, nil, nil end
+        if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+            local classInfo = C_CreatureInfo.GetClassInfo(classID)
+            if type(classInfo) == "table" then
+                return classInfo.className, classInfo.classFile, classInfo.classID
+            end
+        end
+        if GetClassInfo then
+            return GetClassInfo(classID)
+        end
+        return nil, nil, nil
+    end
+
     local function GetClassDisplayName(classKey)
         if type(classKey) ~= "string" then return "Class" end
-        if GetClassInfo then
-            for classID = 1, 30 do
-                local className, classFilename = GetClassInfo(classID)
-                if classFilename and string.upper(classFilename) == classKey then
-                    return className or classKey
-                end
+        for classID = 1, 30 do
+            local className, classFilename = GetClassInfoByID(classID)
+            if classFilename and string.upper(classFilename) == classKey then
+                return className or classKey
             end
         end
         return classKey:sub(1, 1) .. string.lower(classKey:sub(2))
@@ -1766,6 +1779,9 @@ local function RefreshColumn1(preserveDrag)
         RenderNavigationRow("other-class-library-back", "|A:common-icon-backarrow:14:14|a  Back to Groups", {
             section = "other-classes",
             onClick = function()
+                if ClearConfigPrimarySelection then
+                    ClearConfigPrimarySelection()
+                end
                 CS.otherClassLibraryActive = false
                 CS.otherClassLibraryClassKey = nil
                 CooldownCompanion:RefreshConfigPanel()
@@ -1879,21 +1895,23 @@ local function RefreshColumn1(preserveDrag)
         CS.col1Scroll:AddChild(desc)
     else
         local statsContainerIds = {}
-        for _, id in ipairs(globalIds) do
-            if not searchResults or searchResults.containerMatches[id] then
-                statsContainerIds[id] = true
+        local function IncludeVisibleStats(containerId)
+            if not searchResults or searchResults.containerMatches[containerId] then
+                statsContainerIds[containerId] = true
             end
+        end
+        for _, id in ipairs(globalIds) do
+            IncludeVisibleStats(id)
         end
         for _, id in ipairs(charIds) do
-            if not searchResults or searchResults.containerMatches[id] then
-                statsContainerIds[id] = true
-            end
+            IncludeVisibleStats(id)
         end
-        for _, section in ipairs(otherSectionOrder) do
-            for _, id in ipairs(section.containerIds) do
-                if not searchResults or searchResults.containerMatches[id] then
-                    statsContainerIds[id] = true
-                end
+        local selectedOtherSection = CS.otherClassLibraryActive
+            and FindOtherClassSectionByClassKey(otherSectionOrder, CS.otherClassLibraryClassKey)
+            or nil
+        if selectedOtherSection then
+            for _, id in ipairs(selectedOtherSection.containerIds) do
+                IncludeVisibleStats(id)
             end
         end
         for id in pairs(CS.selectedGroups) do

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -469,7 +469,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             info.notCheckable = true
             info.func = function()
                 CloseDropDownMenus()
-                if container.isGlobal and container.specs and ContainersHaveForeignSpecs({ container }, false) then
+                if container.isGlobal and ContainersHaveForeignSpecs({ container }, false) then
                     ShowPopupAboveConfig("CDC_UNGLOBAL_GROUP", container.name, { containerId = containerId })
                     return
                 end

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -47,6 +47,21 @@ local SelectConfigPanel = ST._SelectConfigPanel
 
 local GenerateGroupName
 
+local function OpenContainerLoadConditions(containerId)
+    CS.specExpandedGroupId = nil
+    CS.specExpandedFolderId = nil
+    SelectConfigContainer(containerId)
+    CS.selectedContainerTab = "loadconditions"
+    CooldownCompanion:RefreshConfigPanel()
+end
+
+local function OpenFolderLoadConditions(folderId)
+    CS.specExpandedGroupId = nil
+    CS.specExpandedFolderId = nil
+    SelectConfigFolder(folderId)
+    CooldownCompanion:RefreshConfigPanel()
+end
+
 local function TrimGroupName(name)
     if name == nil then return "" end
     return tostring(name):match("^%s*(.-)%s*$") or ""
@@ -560,13 +575,7 @@ local function ShowContainerContextMenu(db, charKey, containerId, container)
             info.notCheckable = true
             info.func = function()
                 CloseDropDownMenus()
-                if CS.specExpandedGroupId == containerId then
-                    CS.specExpandedGroupId = nil
-                else
-                    CS.specExpandedGroupId = containerId
-                    CS.specExpandedFolderId = nil
-                end
-                CooldownCompanion:RefreshConfigPanel()
+                OpenContainerLoadConditions(containerId)
             end
             UIDropDownMenu_AddButton(info, level)
 
@@ -766,13 +775,7 @@ local function ShowFolderContextMenu(db, folderId, folder)
         info.notCheckable = true
         info.func = function()
             CloseDropDownMenus()
-            if CS.specExpandedFolderId == folderId then
-                CS.specExpandedFolderId = nil
-            else
-                CS.specExpandedFolderId = folderId
-                CS.specExpandedGroupId = nil
-            end
-            CooldownCompanion:RefreshConfigPanel()
+            OpenFolderLoadConditions(folderId)
         end
         UIDropDownMenu_AddButton(info, level)
 
@@ -1299,13 +1302,7 @@ local function RefreshColumn1(preserveDrag)
                     return
                 end
                 if IsShiftKeyDown() then
-                    if CS.specExpandedGroupId == containerId then
-                        CS.specExpandedGroupId = nil
-                    else
-                        CS.specExpandedGroupId = containerId
-                        CS.specExpandedFolderId = nil
-                    end
-                    CooldownCompanion:RefreshConfigPanel()
+                    OpenContainerLoadConditions(containerId)
                     return
                 elseif IsControlKeyDown() then
                     -- Ctrl+click: toggle multi-select (container IDs)
@@ -1650,13 +1647,7 @@ local function RefreshColumn1(preserveDrag)
                     return
                 end
                 if IsShiftKeyDown() then
-                    if CS.specExpandedFolderId == folderId then
-                        CS.specExpandedFolderId = nil
-                    else
-                        CS.specExpandedFolderId = folderId
-                        CS.specExpandedGroupId = nil
-                    end
-                    CooldownCompanion:RefreshConfigPanel()
+                    OpenFolderLoadConditions(folderId)
                     return
                 end
                 SelectConfigFolder(folderId)

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -68,6 +68,13 @@ local function CanPanelMoveToContainer(panelId, containerId)
     return true
 end
 
+local function CanMoveEntryToGroup(sourceGroupId, targetGroupId)
+    if CooldownCompanion.CanMoveEntryToGroup then
+        return CooldownCompanion:CanMoveEntryToGroup(sourceGroupId, targetGroupId) == true
+    end
+    return CooldownCompanion:IsGroupVisibleToCurrentChar(targetGroupId)
+end
+
 local function CanAllContainersMoveToFolder(containerIds, folderId)
     if not CooldownCompanion.CanMoveContainerToFolder then
         return true
@@ -1058,6 +1065,9 @@ local function MoveEntryBetweenGroups(db, sourceGroupId, sourceIndex, targetGrou
     if not targetGroup then
         return false
     end
+    if not CanMoveEntryToGroup(sourceGroupId, targetGroupId) then
+        return false
+    end
     local rejectMessage = CooldownCompanion:GetPanelManualEntryRejectMessage(targetGroup)
     if rejectMessage then
         CooldownCompanion:Print(rejectMessage)
@@ -1083,7 +1093,7 @@ local function BuildEntryMoveDestinationSections(db, sourceGroupId)
 
     for groupId, group in pairs(db.groups or {}) do
         if groupId ~= sourceGroupId
-            and CooldownCompanion:IsGroupVisibleToCurrentChar(groupId)
+            and CanMoveEntryToGroup(sourceGroupId, groupId)
             and CooldownCompanion:CanPanelAcceptManualEntry(group)
         then
             local containerId = group.parentContainerId
@@ -2718,4 +2728,5 @@ end
 ------------------------------------------------------------------------
 -- ST._ exports
 ------------------------------------------------------------------------
+ST._BuildEntryMoveDestinationSections = BuildEntryMoveDestinationSections
 ST._RefreshColumn2 = RefreshColumn2

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -57,6 +57,19 @@ local function IsContainerVisibleInConfig(containerOrContainerId)
     return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
 end
 
+local function CanAllContainersMoveToFolder(containerIds, folderId)
+    if not CooldownCompanion.CanMoveContainerToFolder then
+        return true
+    end
+    for _, containerId in ipairs(containerIds or {}) do
+        local ok = CooldownCompanion:CanMoveContainerToFolder(containerId, folderId)
+        if not ok then
+            return false
+        end
+    end
+    return true
+end
+
 local function OpenPanelLoadConditions(panelId, containerId)
     SelectConfigPanel(panelId, { containerId = containerId })
     CS.selectedTab = "loadconditions"
@@ -1534,7 +1547,9 @@ local function RefreshColumn2()
                     local folderScope = CooldownCompanion.ResolveFolderClassScope
                         and CooldownCompanion:ResolveFolderClassScope(folder)
                         or nil
-                    if not (folderScope and folderScope.isInvalid) then
+                    if not (folderScope and folderScope.isInvalid)
+                        and CanAllContainersMoveToFolder(multiContainerIds, fid)
+                    then
                         local sectionKey = folderScope and folderScope.sectionKey or folder.section
                         table.insert(folderList, {
                             id = fid,
@@ -1564,6 +1579,12 @@ local function RefreshColumn2()
                     info.notCheckable = true
                     info.func = function()
                         CloseDropDownMenus()
+                        if not CanAllContainersMoveToFolder(multiContainerIds, f.id) then
+                            if CooldownCompanion.Print then
+                                CooldownCompanion:Print("Groups cannot be moved into folders owned by another class.")
+                            end
+                            return
+                        end
                         for _, cid in ipairs(multiContainerIds) do
                             CooldownCompanion:MoveGroupToFolder(cid, f.id)
                         end

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -57,6 +57,17 @@ local function IsContainerVisibleInConfig(containerOrContainerId)
     return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
 end
 
+local function CanPanelMoveToContainer(panelId, containerId)
+    if not IsContainerVisibleInConfig(containerId) then
+        return false
+    end
+    if CooldownCompanion.CanMovePanelToContainer then
+        local ok = CooldownCompanion:CanMovePanelToContainer(panelId, containerId)
+        return ok == true
+    end
+    return true
+end
+
 local function CanAllContainersMoveToFolder(containerIds, folderId)
     if not CooldownCompanion.CanMoveContainerToFolder then
         return true
@@ -2158,7 +2169,7 @@ local function RefreshColumn2()
                             local db = CooldownCompanion.db.profile
                             local hasOtherContainer = false
                             for cid, _ in pairs(db.groupContainers) do
-                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
+                                if cid ~= ctxContainerId and CanPanelMoveToContainer(ctxPanelId, cid) then
                                     hasOtherContainer = true
                                     break
                                 end
@@ -2239,7 +2250,7 @@ local function RefreshColumn2()
                             local containers = db.groupContainers or {}
                             local folderContainers, looseContainers = {}, {}
                             for cid, ctr in pairs(containers) do
-                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
+                                if cid ~= ctxContainerId and CanPanelMoveToContainer(ctxPanelId, cid) then
                                     local cName = ctr.name or ("Group " .. cid)
                                     local fid = ctr.folderId
                                     if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -48,6 +48,13 @@ local SelectConfigRotationAssistantEntry = ST._SelectConfigRotationAssistantEntr
 
 local IsTriggerPanelGroup
 
+local function OpenPanelLoadConditions(panelId, containerId)
+    SelectConfigPanel(panelId, { containerId = containerId })
+    CS.selectedTab = "loadconditions"
+    CS.panelSettingsTab = "loadconditions"
+    CooldownCompanion:RefreshConfigPanel()
+end
+
 local function HideAllBarWidgets(col2)
     if col2._barsStylingScroll then col2._barsStylingScroll.frame:Hide() end
     if col2._resourceStylingTabGroup then col2._resourceStylingTabGroup.frame:Hide() end
@@ -2240,6 +2247,11 @@ local function RefreshColumn2()
                             return
                         end
 
+                        if IsShiftKeyDown() then
+                            OpenPanelLoadConditions(panelId, CS.selectedContainer)
+                            return
+                        end
+
                         SelectConfigPanel(panelId, { toggle = true })
                         CooldownCompanion:RefreshConfigPanel()
                         return
@@ -2287,6 +2299,15 @@ local function RefreshColumn2()
                                 ctxPanel.enabled = not (ctxPanel.enabled ~= false)
                                 CooldownCompanion:RefreshGroupFrame(ctxPanelId)
                                 CooldownCompanion:RefreshConfigPanel()
+                            end
+                            UIDropDownMenu_AddButton(info, level)
+
+                            info = UIDropDownMenu_CreateInfo()
+                            info.text = "Load Conditions"
+                            info.notCheckable = true
+                            info.func = function()
+                                CloseDropDownMenus()
+                                OpenPanelLoadConditions(ctxPanelId, ctxContainerId)
                             end
                             UIDropDownMenu_AddButton(info, level)
 

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -34,6 +34,7 @@ local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local EncodeExportData = ST._EncodeExportData
 local GroupsHaveForeignSpecs = ST._GroupsHaveForeignSpecs
+local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
 local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
 local NotifyTutorialAction = ST._NotifyTutorialAction
 local IsConfigFinderActive = ST._IsConfigFinderActive
@@ -2111,21 +2112,31 @@ local function RefreshColumn2()
                     sb:Hide()
                 end
 
-                local containerSpecs = container.specs
+                local containerSpecs = BuildEligibilityBadgeMap(
+                    container.specs,
+                    container.loadConditions and container.loadConditions.specAllowlist
+                )
                 local containerHeroTalents = container.heroTalents
                 local folderSpecs, folderHeroTalents
                 if container.folderId and profile.folders then
                     local folder = profile.folders[container.folderId]
                     if folder then
-                        folderSpecs = folder.specs
+                        folderSpecs = BuildEligibilityBadgeMap(
+                            folder.specs,
+                            folder.loadConditions and folder.loadConditions.specAllowlist
+                        )
                         folderHeroTalents = folder.heroTalents
                     end
                 end
 
                 local specBadgeIdx = 0
+                local panelSpecs = BuildEligibilityBadgeMap(
+                    panel.specs,
+                    panel.loadConditions and panel.loadConditions.specAllowlist
+                )
 
-                if panel.specs then
-                    for specId in pairs(panel.specs) do
+                if panelSpecs then
+                    for specId in pairs(panelSpecs) do
                         if not (containerSpecs and containerSpecs[specId])
                            and not (folderSpecs and folderSpecs[specId]) then
                             local _, _, _, specIcon = GetSpecializationInfoForSpecID(specId)

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -49,6 +49,14 @@ local SelectConfigRotationAssistantEntry = ST._SelectConfigRotationAssistantEntr
 
 local IsTriggerPanelGroup
 
+local function IsContainerVisibleInConfig(containerOrContainerId)
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(containerOrContainerId)
+        return scope.isInvalid ~= true
+    end
+    return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
+end
+
 local function OpenPanelLoadConditions(panelId, containerId)
     SelectConfigPanel(panelId, { containerId = containerId })
     CS.selectedTab = "loadconditions"
@@ -1431,291 +1439,6 @@ local function RefreshColumn2()
     CS.col2Scroll.frame:Show()
     CS.col2Scroll:ReleaseChildren()
 
-    -- Cross-character browse mode: read-only preview
-    if CS.browseMode then
-        if CS.col2ButtonBar then CS.col2ButtonBar:Hide() end
-        -- Extend scroll to full column height (no button bar in browse mode)
-        CS.col2Scroll.frame:SetPoint("BOTTOMRIGHT", CS.col2Scroll.frame:GetParent(), "BOTTOMRIGHT", 0, 0)
-        local db = CooldownCompanion.db.profile
-
-        if not CS.browseContainerId then
-            local label = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(label)
-            label:SetText("|cff888888Select a group to preview its contents.|r")
-            label:SetFullWidth(true)
-            CS.col2Scroll:AddChild(label)
-            return
-        end
-
-        -- Guard: source container may have been deleted
-        if not db.groupContainers[CS.browseContainerId] then
-            CS.browseContainerId = nil
-            local label = AceGUI:Create("Label")
-            ST._ConfigureWrappedHelperLabel(label)
-            label:SetText("|cff888888Group no longer exists.|r")
-            label:SetFullWidth(true)
-            CS.col2Scroll:AddChild(label)
-            return
-        end
-
-        local panels = CooldownCompanion:GetPanels(CS.browseContainerId)
-
-        -- Class color for accent bars (from browsed character)
-        local browseCharInfo = CooldownCompanion.db.global.characterInfo
-            and CooldownCompanion.db.global.characterInfo[CS.browseCharKey]
-        local browseClassFile = browseCharInfo and browseCharInfo.classFilename
-        local browseCC = browseClassFile and C_ClassColor.GetClassColor(browseClassFile)
-
-        for panelIndex, panelInfo in ipairs(panels) do
-            local panel = panelInfo.group
-            local panelGroupId = panelInfo.groupId
-
-            -- Class-colored accent separator between panels
-            if panelIndex > 1 then
-                local spacer = AceGUI:Create("Label")
-                spacer:SetText(" ")
-                spacer:SetFullWidth(true)
-                spacer:SetHeight(2)
-                local bar = spacer.frame._cdcAccentBar
-                if not bar then
-                    bar = spacer.frame:CreateTexture(nil, "ARTWORK")
-                    spacer.frame._cdcAccentBar = bar
-                end
-                bar:SetHeight(1.5)
-                bar:ClearAllPoints()
-                local barInset = math.floor(spacer.frame:GetWidth() * 0.10 + 0.5)
-                bar:SetPoint("LEFT", spacer.frame, "LEFT", barInset, 1)
-                bar:SetPoint("RIGHT", spacer.frame, "RIGHT", -barInset, 1)
-                if browseCC then
-                    bar:SetColorTexture(browseCC.r, browseCC.g, browseCC.b, 0.8)
-                else
-                    bar:SetColorTexture(1, 1, 1, 0.3)
-                end
-                bar:Show()
-                spacer:SetCallback("OnRelease", function() bar:Hide() end)
-                CS.col2Scroll:AddChild(spacer)
-            end
-
-            -- Bordered container for this panel (matches normal Column 2)
-            local panelContainer = AceGUI:Create("InlineGroup")
-            panelContainer:SetTitle("")
-            panelContainer:SetLayout("List")
-            panelContainer:SetFullWidth(true)
-            CompactUntitledInlineGroupConfig(panelContainer)
-            CS.col2Scroll:AddChild(panelContainer)
-
-            -- Panel header (same badge pattern as normal Column 2 panel headers)
-            local buttonCount = GetConfigPanelButtonCount(panel)
-            local headerText = BuildPanelHeaderText(panel, nil, buttonCount, "888888")
-
-            local header = AceGUI:Create("InteractiveLabel")
-            CleanRecycledEntry(header)
-            header:SetText(headerText)
-
-            header:SetFullWidth(true)
-            header:SetFontObject(GameFontHighlight)
-            header:SetJustifyH("CENTER")
-            ApplyConfigTextRow(header, "CENTER")
-            local textW = header.label:GetStringWidth()
-            ConfigurePanelTypeBadge(header, panel.displayMode, textW)
-
-            -- Disabled badge (shown when panel is individually disabled)
-            local disabledBadge = header.frame._cdcHeaderDisabledBadge
-            if not disabledBadge then
-                disabledBadge = header.frame:CreateTexture(nil, "OVERLAY")
-                header.frame._cdcHeaderDisabledBadge = disabledBadge
-            end
-            disabledBadge:SetSize(16, 16)
-            disabledBadge:ClearAllPoints()
-            disabledBadge:SetPoint("LEFT", header.label, "CENTER", (textW / 2) + 4, 0)
-            if panel.enabled == false then
-                disabledBadge:SetAtlas("GM-icon-visibleDis-pressed", false)
-                disabledBadge:Show()
-            else
-                disabledBadge:Hide()
-            end
-
-            if panel.enabled == false then
-                header:SetColor(0.5, 0.5, 0.5)
-            elseif CS.selectedGroup == panelGroupId
-                and not CS.selectedButton
-                and not CS.selectedRotationAssistantEntry then
-                header:SetColor(0, 1, 0)
-            end
-            header:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-            header:SetCallback("OnClick", function()
-                SelectConfigPanel(panelGroupId, { containerId = CS.browseContainerId })
-                CooldownCompanion:RefreshConfigPanel()
-            end)
-            panelContainer:AddChild(header)
-
-            -- Spacer after header
-            local headerSpacer = AceGUI:Create("Label")
-            headerSpacer:SetText(" ")
-            headerSpacer:SetFullWidth(true)
-            headerSpacer:SetHeight(4)
-            panelContainer:AddChild(headerSpacer)
-
-            -- Button list (read-only)
-            if panel.displayMode == ST.DISPLAY_MODE_ROTATION_ASSISTANT then
-                AddRotationAssistantLockedRow(panelContainer, panelGroupId, {
-                    containerId = CS.browseContainerId,
-                })
-            elseif panel.buttons then
-                for buttonIndex, buttonData in ipairs(panel.buttons) do
-                    local entry = AceGUI:Create("InteractiveLabel")
-                    CleanRecycledEntry(entry)
-                    local icon = GetButtonIcon(buttonData)
-                    entry:SetImage(icon)
-                    entry:SetImageSize(20, 20)
-                    entry:SetText(buttonData.name or ("ID: " .. (buttonData.id or "?")))
-                    entry:SetFullWidth(true)
-                    entry:SetFontObject(GameFontHighlightSmall)
-                    if buttonData.enabled == false and entry.image and entry.image.SetDesaturated then
-                        entry.image:SetDesaturated(true)
-                    end
-                    entry:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-                    if CS.selectedGroup == panelGroupId and CS.selectedButton == buttonIndex then
-                        entry:SetColor(0, 1, 0)
-                    elseif buttonData.enabled == false then
-                        entry:SetColor(0.5, 0.5, 0.5)
-                    end
-                    local capturedIndex = buttonIndex
-                    entry:SetCallback("OnClick", function()
-                        SelectConfigButton(panelGroupId, capturedIndex, {
-                            containerId = CS.browseContainerId,
-                            force = true,
-                        })
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                    panelContainer:AddChild(entry)
-                end
-            end
-
-            -- Spacer before copy button
-            local btnSpacer = AceGUI:Create("Label")
-            btnSpacer:SetText(" ")
-            btnSpacer:SetFullWidth(true)
-            btnSpacer:SetHeight(4)
-            panelContainer:AddChild(btnSpacer)
-
-            -- "Copy Panel" button (centered at half width)
-            local btnRow = AceGUI:Create("SimpleGroup")
-            btnRow:SetFullWidth(true)
-            btnRow:SetLayout("Flow")
-            panelContainer:AddChild(btnRow)
-
-            local leftPad = AceGUI:Create("Label")
-            leftPad:SetText("")
-            leftPad:SetRelativeWidth(0.25)
-            btnRow:AddChild(leftPad)
-
-            local copyPanelBtn = AceGUI:Create("Button")
-            copyPanelBtn:SetText("Copy Panel")
-            copyPanelBtn:SetRelativeWidth(0.5)
-            copyPanelBtn:SetCallback("OnClick", function()
-                -- Guard: source still exists
-                if not db.groups[panelGroupId] then
-                    CooldownCompanion:Print("Source panel no longer exists.")
-                    return
-                end
-                if not CS.browseContextMenu then
-                    CS.browseContextMenu = CreateFrame("Frame", "CDCBrowseContextMenu", UIParent, "UIDropDownMenuTemplate")
-                end
-                UIDropDownMenu_Initialize(CS.browseContextMenu, function(self, level)
-                    -- "As New Group"
-                    local info = UIDropDownMenu_CreateInfo()
-                    info.text = "As New Group"
-                    info.notCheckable = true
-                    info.func = function()
-                        CloseDropDownMenus()
-                        if not db.groups[panelGroupId] then return end
-                        local srcContainer = db.groupContainers[CS.browseContainerId]
-                        local groupName = (srcContainer and srcContainer.name) or panel.name or "Copied Group"
-                        local newCid, newGid = CooldownCompanion:CopyPanelAsNewGroup(panelGroupId, groupName)
-                        if newCid then
-                            CS.browseMode = false
-                            CS.browseCharKey = nil
-                            CS.browseContainerId = nil
-                            SelectConfigPanel(newGid, { containerId = newCid })
-                            CooldownCompanion:RefreshConfigPanel()
-                            CooldownCompanion:Print("Panel copied as new group.")
-                        end
-                    end
-                    UIDropDownMenu_AddButton(info, level)
-
-                    -- Separator
-                    info = UIDropDownMenu_CreateInfo()
-                    info.text = ""
-                    info.isTitle = true
-                    info.notCheckable = true
-                    UIDropDownMenu_AddButton(info, level)
-
-                    -- List current character's visible containers
-                    local targets = {}
-                    for cid, c in pairs(db.groupContainers) do
-                        if CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
-                            targets[#targets + 1] = { id = cid, name = c.name, order = CooldownCompanion:GetOrderForSpec(c, CooldownCompanion._currentSpecId, cid) }
-                        end
-                    end
-                    table.sort(targets, function(a, b) return a.order < b.order end)
-
-                    for _, target in ipairs(targets) do
-                        info = UIDropDownMenu_CreateInfo()
-                        info.text = "Into: " .. target.name
-                        info.notCheckable = true
-                        local targetId = target.id
-                        info.func = function()
-                            CloseDropDownMenus()
-                            if not db.groups[panelGroupId] then return end
-                            if not db.groupContainers[targetId] then return end
-                            local newGid = CooldownCompanion:CopyPanelToContainer(panelGroupId, targetId)
-                            if newGid then
-                                CS.browseMode = false
-                                CS.browseCharKey = nil
-                                CS.browseContainerId = nil
-                                SelectConfigPanel(newGid, { containerId = targetId })
-                                CooldownCompanion:RefreshConfigPanel()
-                                CooldownCompanion:Print("Panel copied into " .. target.name .. ".")
-                            end
-                        end
-                        UIDropDownMenu_AddButton(info, level)
-                    end
-                end, "MENU")
-                CS.browseContextMenu:SetFrameStrata("FULLSCREEN_DIALOG")
-                ToggleDropDownMenu(1, nil, CS.browseContextMenu, "cursor", 0, 0)
-            end)
-            btnRow:AddChild(copyPanelBtn)
-        end
-
-        -- "Copy Entire Group" button at the bottom
-        local spacer = AceGUI:Create("Label")
-        spacer:SetText(" ")
-        spacer:SetFullWidth(true)
-        CS.col2Scroll:AddChild(spacer)
-
-        local copyAllBtn = AceGUI:Create("Button")
-        copyAllBtn:SetText("Copy Entire Group")
-        copyAllBtn:SetFullWidth(true)
-        copyAllBtn:SetCallback("OnClick", function()
-            if not db.groupContainers[CS.browseContainerId] then
-                CooldownCompanion:Print("Source group no longer exists.")
-                return
-            end
-            local newId = CooldownCompanion:CopyContainerFromBrowse(CS.browseContainerId)
-            if newId then
-                CS.browseMode = false
-                CS.browseCharKey = nil
-                CS.browseContainerId = nil
-                SelectConfigContainer(newId)
-                CooldownCompanion:RefreshConfigPanel()
-                CooldownCompanion:Print("Group copied successfully.")
-            end
-        end)
-        CS.col2Scroll:AddChild(copyAllBtn)
-        return
-    end
-
     if IsConfigFinderActive and IsConfigFinderActive() then
         RenderConfigFinderResults()
         return
@@ -1806,16 +1529,18 @@ local function RefreshColumn2()
                 end
                 UIDropDownMenu_AddButton(info, level)
 
-                local charKey = CooldownCompanion.db.keys.char
                 local folderList = {}
                 for fid, folder in pairs(db.folders) do
-                    if folder.section == "char" and folder.createdBy and folder.createdBy ~= charKey then
-                        -- skip: belongs to another character
-                    else
+                    local folderScope = CooldownCompanion.ResolveFolderClassScope
+                        and CooldownCompanion:ResolveFolderClassScope(folder)
+                        or nil
+                    if not (folderScope and folderScope.isInvalid) then
+                        local sectionKey = folderScope and folderScope.sectionKey or folder.section
                         table.insert(folderList, {
                             id = fid,
                             name = folder.name,
-                            section = folder.section,
+                            section = sectionKey,
+                            classKey = folderScope and folderScope.ownerClassKey or nil,
                             order = CooldownCompanion:GetOrderForSpec(folder, CooldownCompanion._currentSpecId, fid),
                         })
                     end
@@ -1829,7 +1554,12 @@ local function RefreshColumn2()
 
                 for _, f in ipairs(folderList) do
                     info = UIDropDownMenu_CreateInfo()
-                    local sectionLabel = f.section == "global" and " (Global)" or " (Char)"
+                    local sectionLabel = " (Current Class)"
+                    if f.section == "global" then
+                        sectionLabel = " (Global)"
+                    elseif f.classKey then
+                        sectionLabel = " (" .. f.classKey .. ")"
+                    end
                     info.text = f.name .. sectionLabel
                     info.notCheckable = true
                     info.func = function()
@@ -2407,7 +2137,7 @@ local function RefreshColumn2()
                             local db = CooldownCompanion.db.profile
                             local hasOtherContainer = false
                             for cid, _ in pairs(db.groupContainers) do
-                                if cid ~= ctxContainerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
                                     hasOtherContainer = true
                                     break
                                 end
@@ -2488,7 +2218,7 @@ local function RefreshColumn2()
                             local containers = db.groupContainers or {}
                             local folderContainers, looseContainers = {}, {}
                             for cid, ctr in pairs(containers) do
-                                if cid ~= ctxContainerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                                if cid ~= ctxContainerId and IsContainerVisibleInConfig(cid) then
                                     local cName = ctr.name or ("Group " .. cid)
                                     local fid = ctr.folderId
                                     if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -16,6 +16,7 @@ local SetConfigCustomBarSettingsTab = ST._SetConfigCustomBarSettingsTab
 local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 local SetConfigResourceSettingsSpecID = ST._SetConfigResourceSettingsSpecID
 local PruneConfigResourceSelection = ST._PruneConfigResourceSelection
+local BlockCustomBarExportForResourceBarConflict = ST._BlockCustomBarExportForResourceBarConflict
 
 ------------------------------------------------------------------------
 -- COLUMN 4: Group / Panel Settings Column
@@ -244,6 +245,9 @@ local function ShowCustomBarMultiSelect(container, selectedIds, selectedEntries)
     exportBtn:SetText("Export Selected")
     exportBtn:SetFullWidth(true)
     exportBtn:SetCallback("OnClick", function()
+        if BlockCustomBarExportForResourceBarConflict and BlockCustomBarExportForResourceBarConflict() then
+            return
+        end
         local settings = CooldownCompanion:GetResourceBarSettings()
         local payload = ST._RB.BuildCustomBarsExportPayload and ST._RB.BuildCustomBarsExportPayload(settings, selectedEntries)
         local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)

--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -140,6 +140,10 @@ local function HideLayoutOrderDisabledScroll(container)
     HideWidgetFrame(container.layoutOrderDisabledScroll)
 end
 
+local function HideLayoutOrderConflictScroll(container)
+    HideWidgetFrame(container.layoutOrderConflictScroll)
+end
+
 local function HideResourceBarPanelSurfaces(container)
     HideFrame(container.placeholderLabel)
     HideWidgetFrame(container.tabGroup)
@@ -152,6 +156,7 @@ local function HideResourceBarPanelSurfaces(container)
     HideWidgetFrame(container.customBarEntryTabGroup)
     HideWidgetFrame(container.resourceSettingsDetailScroll)
     HideWidgetFrame(container.resourceSettingsTabGroup)
+    HideLayoutOrderConflictScroll(container)
     HideFrame(container.layoutOrderHost)
 end
 
@@ -176,6 +181,38 @@ local function ShowLayoutOrderDisabledScroll(container)
     local label = AceGUI:Create("Label")
     ST._ConfigureWrappedHelperLabel(label)
     label:SetText("Enable Resource Bars or Cast Bar to configure layout.")
+    label:SetFullWidth(true)
+    scroll:AddChild(label)
+end
+
+local function ShowLayoutOrderConflictScroll(container)
+    HideResourceBarPanelSurfaces(container)
+
+    if not container.layoutOrderConflictScroll then
+        local scroll = AceGUI:Create("ScrollFrame")
+        scroll:SetLayout("List")
+        scroll.frame:SetParent(container)
+        container.layoutOrderConflictScroll = scroll
+    end
+
+    local scroll = container.layoutOrderConflictScroll
+    scroll.frame:SetParent(container)
+    scroll.frame:ClearAllPoints()
+    scroll.frame:SetPoint("TOPLEFT", container, "TOPLEFT", 0, 0)
+    scroll.frame:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", 0, 0)
+    scroll:ReleaseChildren()
+    scroll.frame:Show()
+
+    local RBP = ST._RBP
+    if RBP and RBP.BuildResourceBarConflictGate
+        and RBP.BuildResourceBarConflictGate(scroll, "Layout & Order", true)
+    then
+        return
+    end
+
+    local label = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(label)
+    label:SetText("Resolve Resource Bars before editing Layout & Order.")
     label:SetFullWidth(true)
     scroll:AddChild(label)
 end
@@ -350,10 +387,16 @@ local function RefreshColumn4(container)
         container._browsePlaceholder:Hide()
     end
     HideLayoutOrderDisabledScroll(container)
+    HideLayoutOrderConflictScroll(container)
 
     -- Resource Bar panel mode: show selected Custom Bar settings, or Layout & Order.
     if CS.resourceBarPanelActive then
         HideResourceBarPanelSurfaces(container)
+        if CooldownCompanion.GetCurrentResourceBarConflict and CooldownCompanion:GetCurrentResourceBarConflict() then
+            ShowLayoutOrderConflictScroll(container)
+            return
+        end
+
         local resourceBarsEnabled = AreResourceBarsConfigEnabled()
         local castBarsEnabled = AreCastBarsConfigEnabled()
         if not (resourceBarsEnabled or castBarsEnabled) then

--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -571,9 +571,6 @@ local function RefreshColumn4(container)
 
                 ST._BuildFolderLoadConditionsTab(scroll, CS.selectedFolder)
 
-                if CS.browseMode then
-                    ST._DisableAllWidgets(scroll)
-                end
             end)
             tabGroup.frame:SetParent(container)
             tabGroup.frame:ClearAllPoints()
@@ -618,9 +615,6 @@ local function RefreshColumn4(container)
                     ST._BuildContainerLoadConditionsTab(scroll, CS.selectedContainer)
                 end
 
-                if CS.browseMode then
-                    ST._DisableAllWidgets(scroll)
-                end
             end)
             tabGroup.frame:SetParent(container)
             tabGroup.frame:ClearAllPoints()
@@ -710,12 +704,6 @@ local function RefreshColumn4(container)
                 ST._BuildLoadConditionsTab(scroll)
             end
 
-            if CS.browseMode then
-                ST._DisableAllWidgets(scroll)
-                for _, btn in ipairs(CS.tabInfoButtons) do
-                    if btn.Disable then btn:Disable() end
-                end
-            end
         end)
 
         -- Parent the AceGUI widget frame to our raw column frame

--- a/CooldownCompanion_Config/Config/Diagnostics.lua
+++ b/CooldownCompanion_Config/Config/Diagnostics.lua
@@ -192,8 +192,6 @@ local function BuildConfigDiagnosticSummary(profile, groupFrameStates, container
         selectedPanels = CS and SortedSelectionString(CS.selectedPanels) or "",
         selectedGroups = CS and SortedSelectionString(CS.selectedGroups) or "",
         selectedCustomBars = CS and SortedSelectionString(CS.selectedCustomBars) or "",
-        browseMode = CS and CS.browseMode == true,
-        browseCharKey = CS and CS.browseCharKey or nil,
         selectedContainerSummary = SummarizeContainer(selectedContainerId, containers and selectedContainerId and containers[selectedContainerId] or nil),
         selectedPanelSummary = SummarizePanel(selectedPanelId, selectedPanel),
         selectedButtonSummary = SummarizeButton(selectedButton),
@@ -789,9 +787,6 @@ local function FormatDiagnosticBugReportAsText(diag)
             c.selectedPanels ~= "" and c.selectedPanels or "none",
             c.selectedGroups ~= "" and c.selectedGroups or "none",
             c.selectedCustomBars ~= "" and c.selectedCustomBars or "none"))
-    end
-    if c.browseMode then
-        add("Browse Mode: " .. tostring(c.browseCharKey or "unknown"))
     end
     if c.selectedContainerSummary then
         local container = c.selectedContainerSummary

--- a/CooldownCompanion_Config/Config/Diagnostics.lua
+++ b/CooldownCompanion_Config/Config/Diagnostics.lua
@@ -368,8 +368,10 @@ local function BuildDiagnosticSnapshot()
     for _, folder in pairs(db.profile.folders) do
         cacheSpecsFromTable(folder.specs)
     end
-    local resourceStores = rawget(db.profile, "resourceBarsByChar")
-    if type(resourceStores) == "table" then
+    local function cacheSpecsFromResourceStores(resourceStores)
+        if type(resourceStores) ~= "table" then
+            return
+        end
         for _, resourceSettings in pairs(resourceStores) do
             local customBars = type(resourceSettings) == "table"
                 and (type(resourceSettings.customBars) == "table" and resourceSettings.customBars or resourceSettings.customAuraBars)
@@ -396,6 +398,8 @@ local function BuildDiagnosticSnapshot()
             end
         end
     end
+    cacheSpecsFromResourceStores(rawget(db.profile, "resourceBarsByClass"))
+    cacheSpecsFromResourceStores(rawget(db.profile, "resourceBarsByChar"))
     snapshot.meta.specNameCache = specNameCache
 
     -- Keep the decoded report compact while attaching an importable profile.

--- a/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
+++ b/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
@@ -53,6 +53,58 @@ local FindCol1TopLevelInsertPos = DR.FindCol1TopLevelInsertPos
 local AssignCol1TopLevelOrders = DR.AssignCol1TopLevelOrders
 local PartitionSelectedContainersByLoadBucket = DR.PartitionSelectedContainersByLoadBucket
 
+local function IsCol1OwnershipMoveAllowed(sourceSection, targetSection)
+    if not targetSection or sourceSection == targetSection then
+        return true
+    end
+    if targetSection == "global" and sourceSection ~= "global" then
+        return true
+    end
+    return sourceSection == "global" and targetSection == "char"
+end
+
+local function GetContainerSection(container)
+    if not container then return nil end
+    if container.isGlobal then return "global" end
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(container)
+        return scope and scope.sectionKey or "invalid"
+    end
+    return "char"
+end
+
+local function ApplyContainerSection(containerId, container, targetSection)
+    if targetSection == "global" then
+        container.isGlobal = true
+        return true
+    end
+    if targetSection == "char" then
+        container.isGlobal = false
+        container.createdBy = CooldownCompanion.db.keys.char
+        if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
+            CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(containerId)
+        end
+        return true
+    end
+    return targetSection == GetContainerSection(container)
+end
+
+local function ApplyFolderSection(folderId, folder, targetSection)
+    if targetSection == "global" then
+        folder.section = "global"
+        return true
+    end
+    if targetSection == "char" then
+        folder.section = "char"
+        folder.createdBy = CooldownCompanion.db.keys.char
+        if CooldownCompanion.NormalizeFolderEligibilityForCharacterScope then
+            CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(folderId)
+        end
+        return true
+    end
+    return false
+end
+
 ------------------------------------------------------------------------
 -- Apply a column-1 folder-aware drop result
 ------------------------------------------------------------------------
@@ -71,20 +123,19 @@ local function ApplyCol1Drop(state)
         if dropTarget.action == "into-folder" or dropTarget.action == "reorder-before" or dropTarget.action == "reorder-after" then
             local targetRow = dropTarget.targetRow
             local targetFolderId = ResolveCol1GroupDropTargetFolderId(state, dropTarget)
-            CooldownCompanion:MoveGroupToFolder(sourceContainerId, targetFolderId)
+            local targetSection = targetRow.section or state.sourceSection
+            if not IsCol1OwnershipMoveAllowed(state.sourceSection, targetSection) then
+                return
+            end
 
             -- Cross-section move: toggle global/character status
-            local targetSection = targetRow.section or state.sourceSection
             if targetSection ~= state.sourceSection then
-                if targetSection == "global" then
-                    container.isGlobal = true
-                else
-                    container.isGlobal = false
-                    container.createdBy = CooldownCompanion.db.keys.char
-                    if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
-                        CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(sourceContainerId)
-                    end
+                if not ApplyContainerSection(sourceContainerId, container, targetSection) then
+                    return
                 end
+            end
+            if CooldownCompanion:MoveGroupToFolder(sourceContainerId, targetFolderId, { allowScopeChange = true }) == false then
+                return
             end
 
             -- Reassign order values for all items in the target section
@@ -172,18 +223,17 @@ local function ApplyCol1Drop(state)
         for cid in pairs(sourceContainerIds) do
             local c = db.groupContainers[cid]
             if c then
-                CooldownCompanion:MoveGroupToFolder(cid, targetFolderId)
-                local containerSection = c.isGlobal and "global" or "char"
+                local containerSection = GetContainerSection(c)
+                if not IsCol1OwnershipMoveAllowed(containerSection, targetSection) then
+                    return
+                end
                 if containerSection ~= targetSection then
-                    if targetSection == "global" then
-                        c.isGlobal = true
-                    else
-                        c.isGlobal = false
-                        c.createdBy = CooldownCompanion.db.keys.char
-                        if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
-                            CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(cid)
-                        end
+                    if not ApplyContainerSection(cid, c, targetSection) then
+                        return
                     end
+                end
+                if CooldownCompanion:MoveGroupToFolder(cid, targetFolderId, { allowScopeChange = true }) == false then
+                    return
                 end
             end
         end
@@ -307,25 +357,21 @@ local function ApplyCol1Drop(state)
         local dropTarget = state.dropTarget
         local targetRow = dropTarget.targetRow
         local section = targetRow.section or state.sourceSection
+        if not IsCol1OwnershipMoveAllowed(state.sourceSection, section) then
+            return
+        end
 
         -- Cross-section move: toggle folder section and update all child containers
         if section ~= state.sourceSection then
-            folder.section = section
-            if section == "char" then
-                folder.createdBy = CooldownCompanion.db.keys.char
+            if not ApplyFolderSection(sourceFolderId, folder, section) then
+                return
             end
             for containerId, container in pairs(db.groupContainers) do
                 if container.folderId == sourceFolderId then
-                    if section == "global" then
-                        container.isGlobal = true
-                    else
-                        container.isGlobal = false
-                        container.createdBy = CooldownCompanion.db.keys.char
+                    if not ApplyContainerSection(containerId, container, section) then
+                        return
                     end
                 end
-            end
-            if section == "char" and CooldownCompanion.NormalizeFolderEligibilityForCharacterScope then
-                CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(sourceFolderId)
             end
         end
 
@@ -521,9 +567,13 @@ local function FinishCol1FolderAwareDrag(state)
 
     if dropTarget and (state.kind == "group" or state.kind == "folder-group") then
         local targetSection = dropTarget.targetRow and dropTarget.targetRow.section
+        if targetSection and not IsCol1OwnershipMoveAllowed(state.sourceSection, targetSection) then
+            return
+        end
         local sourceContainer = CooldownCompanion.db.profile.groupContainers[state.sourceGroupId]
         if targetSection and targetSection ~= state.sourceSection
            and state.sourceSection == "global"
+           and targetSection == "char"
            and sourceContainer
            and GroupsHaveForeignSpecs({ sourceContainer }, false) then
             ShowPopupAboveConfig("CDC_DRAG_UNGLOBAL_GROUP", sourceContainer.name, {
@@ -535,6 +585,15 @@ local function FinishCol1FolderAwareDrag(state)
 
     if dropTarget and state.kind == "multi-group" and state.sourceGroupIds then
         local targetSection = dropTarget.targetRow and dropTarget.targetRow.section
+        if targetSection then
+            local db = CooldownCompanion.db.profile
+            for cid in pairs(state.sourceGroupIds) do
+                local sourceContainer = db.groupContainers[cid]
+                if sourceContainer and not IsCol1OwnershipMoveAllowed(GetContainerSection(sourceContainer), targetSection) then
+                    return
+                end
+            end
+        end
         if targetSection == "char" then
             local db = CooldownCompanion.db.profile
             local groupList = {}
@@ -562,8 +621,12 @@ local function FinishCol1FolderAwareDrag(state)
 
     if dropTarget and state.kind == "folder" then
         local targetSection = dropTarget.targetRow and dropTarget.targetRow.section
+        if targetSection and not IsCol1OwnershipMoveAllowed(state.sourceSection, targetSection) then
+            return
+        end
         if targetSection and targetSection ~= state.sourceSection
            and state.sourceSection == "global"
+           and targetSection == "char"
            and FolderHasForeignSpecs
            and FolderHasForeignSpecs(state.sourceFolderId) then
             ShowPopupAboveConfig("CDC_DRAG_UNGLOBAL_FOLDER", nil, {

--- a/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
+++ b/CooldownCompanion_Config/Config/DragReorderLifecycle.lua
@@ -81,6 +81,9 @@ local function ApplyCol1Drop(state)
                 else
                     container.isGlobal = false
                     container.createdBy = CooldownCompanion.db.keys.char
+                    if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
+                        CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(sourceContainerId)
+                    end
                 end
             end
 
@@ -177,6 +180,9 @@ local function ApplyCol1Drop(state)
                     else
                         c.isGlobal = false
                         c.createdBy = CooldownCompanion.db.keys.char
+                        if CooldownCompanion.NormalizeContainerEligibilityForCharacterScope then
+                            CooldownCompanion:NormalizeContainerEligibilityForCharacterScope(cid)
+                        end
                     end
                 end
             end
@@ -317,6 +323,9 @@ local function ApplyCol1Drop(state)
                         container.createdBy = CooldownCompanion.db.keys.char
                     end
                 end
+            end
+            if section == "char" and CooldownCompanion.NormalizeFolderEligibilityForCharacterScope then
+                CooldownCompanion:NormalizeFolderEligibilityForCharacterScope(sourceFolderId)
             end
         end
 
@@ -515,7 +524,7 @@ local function FinishCol1FolderAwareDrag(state)
         local sourceContainer = CooldownCompanion.db.profile.groupContainers[state.sourceGroupId]
         if targetSection and targetSection ~= state.sourceSection
            and state.sourceSection == "global"
-           and sourceContainer and sourceContainer.specs
+           and sourceContainer
            and GroupsHaveForeignSpecs({ sourceContainer }, false) then
             ShowPopupAboveConfig("CDC_DRAG_UNGLOBAL_GROUP", sourceContainer.name, {
                 dragState = state,

--- a/CooldownCompanion_Config/Config/DragReorderTargets.lua
+++ b/CooldownCompanion_Config/Config/DragReorderTargets.lua
@@ -11,6 +11,17 @@ ST._DragReorder = DR
 
 local COL1_HIT_X_PAD = 6
 local FindCol1SectionDividerTarget
+local activeCol1DropSourceSection
+
+local function IsCol1OwnershipMoveAllowed(sourceSection, targetSection)
+    if not targetSection or sourceSection == targetSection then
+        return true
+    end
+    if targetSection == "global" and sourceSection ~= "global" then
+        return true
+    end
+    return sourceSection == "global" and targetSection == "char"
+end
 
 local function FindCol1FolderBlockRange(rows, folderId)
     local headerIndex
@@ -698,6 +709,11 @@ local function BuildCol1DropResult(action, rowIndex, rowMeta, extra)
     if not (rowMeta and frame and frame:IsShown()) then
         return nil
     end
+    if activeCol1DropSourceSection
+        and not IsCol1OwnershipMoveAllowed(activeCol1DropSourceSection, rowMeta.section)
+    then
+        return nil
+    end
 
     local result = {
         action = action,
@@ -1140,6 +1156,7 @@ end
 
 local function GetCol1DropTarget(cursorX, cursorY, scrollWidget, renderedRows, sourceKind, sourceSection, sourceFolderId, sourceLoadBucket, previousDropTarget)
     if not renderedRows or #renderedRows == 0 then return nil end
+    activeCol1DropSourceSection = sourceSection
     local sourceIsMixed = IsCol1MixedDragSource(sourceLoadBucket)
     local sourceIsUnloaded = IsCol1UnloadedDragSource(sourceLoadBucket)
     local contentLeft, contentRight = GetCol1HorizontalBounds(scrollWidget, renderedRows)

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -17,11 +17,55 @@ local UNSUPPORTED_COMPACT_FORMATS = {
     compact2 = true,
 }
 
+local LOAD_CONDITION_ALLOWLIST_KEYS = {
+    classAllowlist = "class",
+    specAllowlist = "spec",
+    characterAllowlist = "character",
+}
+
 local function CopyValue(value)
     if type(value) == "table" then
         return CopyTable(value)
     end
     return value
+end
+
+local function NormalizeAllowlistKey(kind, key)
+    if kind == "class" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return string.upper(key)
+    elseif kind == "spec" then
+        return tonumber(key)
+    elseif kind == "character" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return key
+    end
+    return nil
+end
+
+local function CopyAllowlistMap(map, kind)
+    if type(map) ~= "table" then return nil end
+    local copy = {}
+    for key, enabled in pairs(map) do
+        if enabled == true then
+            local normalizedKey = NormalizeAllowlistKey(kind, key)
+            if normalizedKey ~= nil then
+                copy[normalizedKey] = true
+            end
+        end
+    end
+    return next(copy) and copy or nil
+end
+
+local function NormalizeLoadConditionAllowlists(loadConditions)
+    if type(loadConditions) ~= "table" then return loadConditions end
+    local normalized = CopyTable(loadConditions)
+    for key, kind in pairs(LOAD_CONDITION_ALLOWLIST_KEYS or {}) do
+        if normalized[key] ~= nil then
+            normalized[key] = CopyAllowlistMap(normalized[key], kind)
+        end
+    end
+    return normalized
 end
 
 local LOAD_CONDITIONS_DEFAULTS = {
@@ -423,7 +467,8 @@ local function CompactLoadConditions(loadConditions, formatVersion, localScope)
     if type(loadConditions) ~= "table" then
         return nil
     end
-    local compact = CompactTableAgainstDefaults(loadConditions, GetLoadConditionsDefaults(formatVersion, localScope))
+    local normalized = NormalizeLoadConditionAllowlists(loadConditions)
+    local compact = CompactTableAgainstDefaults(normalized, GetLoadConditionsDefaults(formatVersion, localScope))
     if localScope then
         return compact
     end
@@ -439,6 +484,11 @@ local function RehydrateLoadConditions(loadConditions, formatVersion, localScope
         for key, value in pairs(loadConditions) do
             if value == true then
                 localOnly[key] = true
+            elseif LOAD_CONDITION_ALLOWLIST_KEYS[key] then
+                local allowlist = CopyAllowlistMap(value, LOAD_CONDITION_ALLOWLIST_KEYS[key])
+                if allowlist then
+                    localOnly[key] = allowlist
+                end
             end
         end
         return next(localOnly) and localOnly or nil

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -11,6 +11,7 @@ local LibDeflate = LibStub("LibDeflate")
 
 local COMPRESSION_CONFIG = { level = 9 }
 local COMPACT_FORMAT_KEY = "_cdcExportFormat"
+local STRIPPED_CHARACTER_ELIGIBILITY_KEY = "_cdcCharacterEligibilityStripped"
 local CURRENT_COMPACT_FORMAT_VALUE = "compact3"
 local UNSUPPORTED_COMPACT_FORMATS = {
     compact1 = true,
@@ -20,7 +21,6 @@ local UNSUPPORTED_COMPACT_FORMATS = {
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
     classAllowlist = "class",
     specAllowlist = "spec",
-    characterAllowlist = "character",
 }
 
 local function CopyValue(value)
@@ -57,9 +57,94 @@ local function CopyAllowlistMap(map, kind)
     return next(copy) and copy or nil
 end
 
+local function StripCharacterEligibilityFromLoadConditions(loadConditions)
+    if type(loadConditions) ~= "table" then return 0 end
+    if loadConditions.characterAllowlist == nil then return 0 end
+    loadConditions.characterAllowlist = nil
+    return 1
+end
+
+local function StripCharacterEligibilityFromEntity(entity)
+    if type(entity) ~= "table" then return 0 end
+    local stripped = StripCharacterEligibilityFromLoadConditions(entity.loadConditions)
+    if type(entity.buttons) == "table" then
+        for _, button in ipairs(entity.buttons) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(button)
+        end
+    end
+    if type(entity.loadConditions) == "table" and not next(entity.loadConditions) then
+        entity.loadConditions = nil
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromContainerEntry(entry)
+    if type(entry) ~= "table" then return 0 end
+    local stripped = StripCharacterEligibilityFromEntity(entry.container)
+    if type(entry.panels) == "table" then
+        for _, panel in ipairs(entry.panels) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(panel)
+        end
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromProfile(profile)
+    if type(profile) ~= "table" then return 0 end
+    local stripped = 0
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(group)
+        end
+    end
+    if type(profile.groupContainers) == "table" then
+        for _, container in pairs(profile.groupContainers) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(container)
+        end
+    end
+    if type(profile.folders) == "table" then
+        for _, folder in pairs(profile.folders) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(folder)
+        end
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromPayload(payload)
+    if type(payload) ~= "table" then return 0 end
+    local stripped = 0
+    stripped = stripped + StripCharacterEligibilityFromProfile(payload)
+    stripped = stripped + StripCharacterEligibilityFromProfile(payload.profile)
+    stripped = stripped + StripCharacterEligibilityFromEntity(payload.group)
+    stripped = stripped + StripCharacterEligibilityFromEntity(payload.container)
+    stripped = stripped + StripCharacterEligibilityFromEntity(payload.folder)
+    if type(payload.groups) == "table" then
+        for _, group in ipairs(payload.groups) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(group)
+        end
+    end
+    if type(payload.panels) == "table" then
+        for _, panel in ipairs(payload.panels) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(panel)
+        end
+    end
+    if type(payload.containers) == "table" then
+        for _, entry in ipairs(payload.containers) do
+            stripped = stripped + StripCharacterEligibilityFromContainerEntry(entry)
+        end
+    end
+    if type(payload.bars) == "table" then
+        for _, bar in ipairs(payload.bars) do
+            stripped = stripped + StripCharacterEligibilityFromEntity(bar)
+        end
+    end
+    return stripped
+end
+
 local function NormalizeLoadConditionAllowlists(loadConditions)
     if type(loadConditions) ~= "table" then return loadConditions end
     local normalized = CopyTable(loadConditions)
+    normalized.characterAllowlist = nil
     for key, kind in pairs(LOAD_CONDITION_ALLOWLIST_KEYS or {}) do
         if normalized[key] ~= nil then
             normalized[key] = CopyAllowlistMap(normalized[key], kind)
@@ -479,6 +564,7 @@ local function RehydrateLoadConditions(loadConditions, formatVersion, localScope
     if type(loadConditions) ~= "table" then
         return nil
     end
+    loadConditions.characterAllowlist = nil
     if localScope then
         local localOnly = {}
         for key, value in pairs(loadConditions) do
@@ -1126,6 +1212,8 @@ local function EncodeSharedPayload(payload, exportKind)
     local exportData = CopyTable(payload)
     local formatVersion = CURRENT_COMPACT_FORMAT_VALUE
 
+    StripCharacterEligibilityFromPayload(exportData)
+
     if CooldownCompanion.StampExportPayloadCheckpoint then
         CooldownCompanion:StampExportPayloadCheckpoint(exportData, exportKind)
     end
@@ -1181,9 +1269,18 @@ local function DecodeSharedPayload(text)
         data = NormalizeTextureLibraryPayload(data)
     end
 
+    local strippedCharacterEligibility = StripCharacterEligibilityFromPayload(data)
+    if strippedCharacterEligibility > 0 then
+        data[STRIPPED_CHARACTER_ELIGIBILITY_KEY] = strippedCharacterEligibility
+    end
+
     return true, data
 end
 
+ST._StripCharacterEligibilityFromLoadConditions = StripCharacterEligibilityFromLoadConditions
+ST._StripCharacterEligibilityFromEntity = StripCharacterEligibilityFromEntity
+ST._StripCharacterEligibilityFromProfile = StripCharacterEligibilityFromProfile
+ST._StripCharacterEligibilityFromPayload = StripCharacterEligibilityFromPayload
 ST._EncodeSharedPayload = EncodeSharedPayload
 ST._DecodeSharedPayload = DecodeSharedPayload
 ST._PrepareSharedImportText = PrepareSharedImportText

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -141,6 +141,14 @@ local function StripCharacterEligibilityFromPayload(payload)
     return stripped
 end
 
+local function StripAndTagCharacterEligibility(payload)
+    local stripped = StripCharacterEligibilityFromPayload(payload)
+    if stripped > 0 then
+        payload[STRIPPED_CHARACTER_ELIGIBILITY_KEY] = stripped
+    end
+    return stripped
+end
+
 local function NormalizeLoadConditionAllowlists(loadConditions)
     if type(loadConditions) ~= "table" then return loadConditions end
     local normalized = CopyTable(loadConditions)
@@ -1212,7 +1220,7 @@ local function EncodeSharedPayload(payload, exportKind)
     local exportData = CopyTable(payload)
     local formatVersion = CURRENT_COMPACT_FORMAT_VALUE
 
-    StripCharacterEligibilityFromPayload(exportData)
+    StripAndTagCharacterEligibility(exportData)
 
     if CooldownCompanion.StampExportPayloadCheckpoint then
         CooldownCompanion:StampExportPayloadCheckpoint(exportData, exportKind)
@@ -1269,10 +1277,7 @@ local function DecodeSharedPayload(text)
         data = NormalizeTextureLibraryPayload(data)
     end
 
-    local strippedCharacterEligibility = StripCharacterEligibilityFromPayload(data)
-    if strippedCharacterEligibility > 0 then
-        data[STRIPPED_CHARACTER_ELIGIBILITY_KEY] = strippedCharacterEligibility
-    end
+    StripAndTagCharacterEligibility(data)
 
     return true, data
 end

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -89,6 +89,37 @@ local function StripCharacterEligibilityFromContainerEntry(entry)
     return stripped
 end
 
+local function StripCharacterEligibilityFromCustomBarTree(value, seen)
+    if type(value) ~= "table" then return 0 end
+    seen = seen or {}
+    if seen[value] then return 0 end
+    seen[value] = true
+
+    local stripped = StripCharacterEligibilityFromEntity(value)
+    for _, child in pairs(value) do
+        stripped = stripped + StripCharacterEligibilityFromCustomBarTree(child, seen)
+    end
+    return stripped
+end
+
+local function StripCharacterEligibilityFromResourceBarSettings(settings)
+    if type(settings) ~= "table" then return 0 end
+    return StripCharacterEligibilityFromCustomBarTree(settings.customBars)
+        + StripCharacterEligibilityFromCustomBarTree(settings.customAuraBars)
+end
+
+local function StripCharacterEligibilityFromResourceBarStores(profile)
+    if type(profile) ~= "table" then return 0 end
+    local stripped = StripCharacterEligibilityFromResourceBarSettings(profile.resourceBars)
+        + StripCharacterEligibilityFromResourceBarSettings(profile.legacyResourceBarsSeed)
+    if type(profile.resourceBarsByChar) == "table" then
+        for _, settings in pairs(profile.resourceBarsByChar) do
+            stripped = stripped + StripCharacterEligibilityFromResourceBarSettings(settings)
+        end
+    end
+    return stripped
+end
+
 local function StripCharacterEligibilityFromProfile(profile)
     if type(profile) ~= "table" then return 0 end
     local stripped = 0
@@ -107,6 +138,7 @@ local function StripCharacterEligibilityFromProfile(profile)
             stripped = stripped + StripCharacterEligibilityFromEntity(folder)
         end
     end
+    stripped = stripped + StripCharacterEligibilityFromResourceBarStores(profile)
     return stripped
 end
 

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -117,6 +117,11 @@ local function StripCharacterEligibilityFromResourceBarStores(profile)
             stripped = stripped + StripCharacterEligibilityFromResourceBarSettings(settings)
         end
     end
+    if type(profile.resourceBarsByClass) == "table" then
+        for _, settings in pairs(profile.resourceBarsByClass) do
+            stripped = stripped + StripCharacterEligibilityFromResourceBarSettings(settings)
+        end
+    end
     return stripped
 end
 
@@ -300,6 +305,7 @@ local PROFILE_DEFAULT_KEYS = {
     globalStyle = "globalStyle",
     locked = "locked",
     cdmHidden = "cdmHidden",
+    resourceBarMigration = "resourceBarMigration",
     resourceBars = "resourceBars",
     castBar = "castBar",
     frameAnchoring = "frameAnchoring",
@@ -338,6 +344,7 @@ local SCOPED_SYSTEM_DEFAULTS = {
 }
 
 local SCOPED_STORE_KEYS = {
+    resourceBarsByClass = "resourceBars",
     resourceBarsByChar = "resourceBars",
     castBarByChar = "castBar",
     frameAnchoringByChar = "frameAnchoring",

--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -268,6 +268,13 @@ local function ReviewUsesSelectedPieces(review)
     return IsProfileReviewKind(review) and review.mode == "selected"
 end
 
+local function AddCharacterEligibilityNotice(lines, data)
+    local stripped = type(data) == "table" and tonumber(data._cdcCharacterEligibilityStripped) or 0
+    if stripped and stripped > 0 then
+        AddLine(lines, "Character eligibility is local and will not be imported.")
+    end
+end
+
 local function RecountSelectedPieces(review)
     if not (review and review.pieces) then
         return 0
@@ -298,6 +305,7 @@ local function BuildSelectedPiecesSummaryLines(review, selectedCount)
     if pieces and pieces.customBarCount and pieces.customBarCount > 0 then
         AddLine(lines, FormatCount("Custom Bars", pieces.customBarCount))
     end
+    AddCharacterEligibilityNotice(lines, review and (review.diagnostic or review.data))
     return lines
 end
 
@@ -353,34 +361,41 @@ local function BuildCustomBarsSummaryLines(data)
         FormatCount("Layout specs", CountPairs(data.layouts)),
     }
     AddLine(lines, data.classFilename and "Class: " .. tostring(data.classFilename))
+    AddCharacterEligibilityNotice(lines, data)
     return lines
 end
 
 local function BuildContainerSummaryLines(data)
-    return {
+    local lines = {
         "Group export",
         "Name: " .. tostring(data.container and data.container.name or "Unnamed"),
         FormatCount("Panels", type(data.panels) == "table" and #data.panels or 0),
     }
+    AddCharacterEligibilityNotice(lines, data)
+    return lines
 end
 
 local function BuildContainersSummaryLines(data)
     local containers = type(data.containers) == "table" and data.containers or {}
-    return {
+    local lines = {
         "Groups export",
         FormatCount("Groups", #containers),
         FormatCount("Panels", CountContainerPanels(containers)),
     }
+    AddCharacterEligibilityNotice(lines, data)
+    return lines
 end
 
 local function BuildFolderSummaryLines(data)
     local containers = type(data.containers) == "table" and data.containers or {}
-    return {
+    local lines = {
         "Folder export",
         "Name: " .. tostring(data.folder and data.folder.name or "Unnamed"),
         FormatCount("Groups", #containers),
         FormatCount("Panels", CountContainerPanels(containers)),
     }
+    AddCharacterEligibilityNotice(lines, data)
+    return lines
 end
 
 local function ValidateProfilePayload(data)
@@ -404,8 +419,11 @@ local function ClassifyProfilePayload(data)
         exporterCharKey = data._exporterCharKey,
     }) or nil
 
+    local lines = BuildProfileSummaryLines(data, "Profile backup export", pieces and pieces.customBarCount)
+    AddCharacterEligibilityNotice(lines, data)
+
     return BuildReview("profile", data, "Profile Backup", "Restore Backup",
-        BuildProfileSummaryLines(data, "Profile backup export", pieces and pieces.customBarCount), {
+        lines, {
         destructive = true,
         mode = DefaultProfileImportMode(pieces),
         pieces = pieces,
@@ -436,6 +454,7 @@ local function ClassifyDiagnosticPayload(data)
     if meta and meta.charName then
         table.insert(lines, 2, "Source: " .. tostring(meta.charName))
     end
+    AddCharacterEligibilityNotice(lines, data)
 
     return BuildReview("diagnostic", data.profile, "Diagnostic Restore",
         "Restore Diagnostic", lines, {

--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -252,7 +252,7 @@ local function BuildProfileSummaryLines(profile, heading, customBarCount)
     local characterScoped = {}
     local legacyScoped = {}
     if type(profile) == "table" then
-        if type(profile.resourceBarsByClass) == "table" then classScoped[#classScoped + 1] = "Resource/Custom Bars" end
+        if CountPairs(profile.resourceBarsByClass) > 0 then classScoped[#classScoped + 1] = "Resource/Custom Bars" end
         if type(profile.resourceBarsByChar) == "table" then legacyScoped[#legacyScoped + 1] = "legacy Resource/Custom Bars" end
         if type(profile.castBarByChar) == "table" then characterScoped[#characterScoped + 1] = "Cast Bar" end
         if type(profile.frameAnchoringByChar) == "table" then characterScoped[#characterScoped + 1] = "Frame Anchoring" end

--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -248,14 +248,32 @@ local function BuildProfileSummaryLines(profile, heading, customBarCount)
         AddLine(lines, FormatCount("Custom Bars", customBarCount))
     end
 
-    local scoped = {}
+    local classScoped = {}
+    local characterScoped = {}
+    local legacyScoped = {}
     if type(profile) == "table" then
-        if type(profile.resourceBarsByChar) == "table" then scoped[#scoped + 1] = "Resource/Custom Bars" end
-        if type(profile.castBarByChar) == "table" then scoped[#scoped + 1] = "Cast Bar" end
-        if type(profile.frameAnchoringByChar) == "table" then scoped[#scoped + 1] = "Frame Anchoring" end
+        if type(profile.resourceBarsByClass) == "table" then classScoped[#classScoped + 1] = "Resource/Custom Bars" end
+        if type(profile.resourceBarsByChar) == "table" then legacyScoped[#legacyScoped + 1] = "legacy Resource/Custom Bars" end
+        if type(profile.castBarByChar) == "table" then characterScoped[#characterScoped + 1] = "Cast Bar" end
+        if type(profile.frameAnchoringByChar) == "table" then characterScoped[#characterScoped + 1] = "Frame Anchoring" end
     end
-    if #scoped > 0 then
-        AddLine(lines, "Character-scoped settings: " .. table.concat(scoped, ", "))
+    if #classScoped > 0 then
+        AddLine(lines, "Class-scoped settings: " .. table.concat(classScoped, ", "))
+    end
+    if #characterScoped > 0 then
+        AddLine(lines, "Character-scoped settings: " .. table.concat(characterScoped, ", "))
+    end
+    if #legacyScoped > 0 then
+        AddLine(lines, "Unresolved legacy settings: " .. table.concat(legacyScoped, ", "))
+    end
+    local migration = type(profile) == "table" and profile.resourceBarMigration or nil
+    local conflicts = type(migration) == "table" and migration.conflicts or nil
+    local unsafe = type(migration) == "table" and migration.unsafeCharKeys or nil
+    if CountPairs(conflicts) > 0 then
+        AddLine(lines, FormatCount("Pending Resource Bar conflicts", CountPairs(conflicts)))
+    end
+    if CountPairs(unsafe) > 0 then
+        AddLine(lines, FormatCount("Resource Bar buckets missing class metadata", CountPairs(unsafe)))
     end
     return lines
 end
@@ -567,6 +585,7 @@ function CooldownCompanion:ApplyReviewedImport(review)
             local meta = GetDiagnosticMeta(review.diagnostic)
             options.dataLabel = "diagnostic profile"
             options.exporterCharKey = meta and meta.charKey
+            options.exportedCharInfo = BuildDiagnosticSourceCharacterInfo(meta)
             options.runtimeReason = "diagnostic-profile-import"
             options.renameForeignCharacters = false
             successMessage = "Diagnostic profile restored."

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1176,11 +1176,12 @@ local function CreateConfigPanel()
 
     local otherClassBrowseBtnBorder = nil
     local otherClassBrowseAvailable = false
+    local otherClassBrowseActionAvailable = false
     local otherClassBrowseSearchFiltered = false
     local otherClassBrowseHasInventory = false
 
     local function UpdateOtherClassBrowseBtnHighlight()
-        local shouldHighlight = otherClassBrowseAvailable and CS.otherClassLibraryActive == true
+        local shouldHighlight = otherClassBrowseActionAvailable and CS.otherClassLibraryActive == true
         if shouldHighlight then
             if not otherClassBrowseBtnBorder then
                 otherClassBrowseBtnBorder = otherClassBrowseBtn:CreateTexture(nil, "OVERLAY")
@@ -1196,18 +1197,19 @@ local function CreateConfigPanel()
 
     local function UpdateOtherClassBrowseButtonState()
         otherClassBrowseAvailable, otherClassBrowseSearchFiltered, otherClassBrowseHasInventory = HasOtherClassInventory()
+        otherClassBrowseActionAvailable = otherClassBrowseAvailable or CS.otherClassLibraryActive == true
 
         if otherClassBrowseBtn.SetEnabled then
-            otherClassBrowseBtn:SetEnabled(otherClassBrowseAvailable)
-        elseif otherClassBrowseAvailable and otherClassBrowseBtn.Enable then
+            otherClassBrowseBtn:SetEnabled(otherClassBrowseActionAvailable)
+        elseif otherClassBrowseActionAvailable and otherClassBrowseBtn.Enable then
             otherClassBrowseBtn:Enable()
         elseif otherClassBrowseBtn.Disable then
             otherClassBrowseBtn:Disable()
         end
         if otherClassBrowseIcon.SetDesaturated then
-            otherClassBrowseIcon:SetDesaturated(not otherClassBrowseAvailable)
+            otherClassBrowseIcon:SetDesaturated(not otherClassBrowseActionAvailable)
         end
-        if otherClassBrowseAvailable then
+        if otherClassBrowseActionAvailable then
             otherClassBrowseBtn:SetAlpha(1)
             otherClassBrowseIcon:SetVertexColor(1, 1, 1, 1)
             if otherClassBrowseBtn:GetHighlightTexture() then
@@ -1251,14 +1253,14 @@ local function CreateConfigPanel()
     otherClassBrowseBtn:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
         GameTooltip:AddLine("Browse Other Classes")
-        if not otherClassBrowseAvailable then
+        if CS.otherClassLibraryActive then
+            GameTooltip:AddLine("Class library is open. Click to return to the regular config view.", 1, 1, 1, true)
+        elseif not otherClassBrowseActionAvailable then
             if otherClassBrowseSearchFiltered and otherClassBrowseHasInventory then
                 GameTooltip:AddLine("No other classes match the current search.", 1, 1, 1, true)
             else
                 GameTooltip:AddLine("No other classes on this profile currently have groups to browse.", 1, 1, 1, true)
             end
-        elseif CS.otherClassLibraryActive then
-            GameTooltip:AddLine("Class library is open. Click to return to the regular config view.", 1, 1, 1, true)
         else
             GameTooltip:AddLine("View and edit groups saved for other classes on this profile.", 1, 1, 1, true)
         end

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -37,6 +37,8 @@ local RebuildTutorialAnchors = ST._RebuildTutorialAnchors
 local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
 local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
+local CleanRecycledEntry = ST._CleanRecycledEntry
+local ApplyConfigTextRow = ST._ApplyConfigTextRow
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -65,6 +67,8 @@ local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
 local CONFIG_FINDER_BUTTON_GAP = 3
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+local COLUMN1_FOOTER_DOORWAY_HEIGHT = 24
+local COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT = COLUMN1_FOOTER_DOORWAY_HEIGHT + CONFIG_FINDER_BUTTON_GAP
 local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
 local CONFIG_NESTED_INLINE_GROUP_INSET = 20
 local CONFIG_DRAG_ALPHA = 0.40
@@ -436,9 +440,6 @@ end
 local function ApplyConfigColumnTitles(frame)
     if CS.resourceBarPanelActive then
         frame.col1:SetTitle("Bars & Frames")
-    elseif CS.browseMode then
-        frame.col1:SetTitle("Browse Characters")
-        frame.col2:SetTitle("Preview")
     elseif IsConfigFinderActive and IsConfigFinderActive() then
         frame.col1:SetTitle("Groups")
         frame.col2:SetTitle("Search Results")
@@ -538,7 +539,7 @@ local function IsConfigSpellOverrideRefreshMode()
     if not IsConfigFrameOpenForRefresh() then
         return false
     end
-    if CS.browseMode or CS.resourceBarPanelActive then
+    if CS.resourceBarPanelActive then
         return false
     end
     if CountSelections(CS.selectedGroups) >= 2 then
@@ -1132,91 +1133,6 @@ local function CreateConfigPanel()
     end)
     cdmDisplayBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
-    -- Cross-character browse button — between the CDM display toggle and CDM button
-    local browseBtn = CreateFrame("Button", nil, content)
-    browseBtn:SetSize(16, 16)
-    if browseBtn.SetMotionScriptsWhileDisabled then
-        browseBtn:SetMotionScriptsWhileDisabled(true)
-    end
-    local browseIcon = browseBtn:CreateTexture(nil, "ARTWORK")
-    browseIcon:SetAtlas("BattleBar-SwapPetIcon", false)
-    browseIcon:SetAllPoints()
-    browseBtn:SetHighlightAtlas("BattleBar-SwapPetIcon")
-    browseBtn:GetHighlightTexture():SetAlpha(0.3)
-    local browseBtnBorder = nil
-    local browseBtnAvailable = false
-
-    local function UpdateBrowseBtnHighlight()
-        local shouldHighlight = browseBtnAvailable and CS.browseMode == true
-        if shouldHighlight then
-            if not browseBtnBorder then
-                browseBtnBorder = browseBtn:CreateTexture(nil, "OVERLAY")
-                browseBtnBorder:SetPoint("TOPLEFT", -1, 1)
-                browseBtnBorder:SetPoint("BOTTOMRIGHT", 1, -1)
-                browseBtnBorder:SetColorTexture(0.85, 0.65, 0.0, 0.6)
-            end
-            browseBtnBorder:Show()
-        elseif browseBtnBorder then
-            browseBtnBorder:Hide()
-        end
-    end
-
-    local function UpdateBrowseBtnState()
-        local browseChars = CooldownCompanion:EnumerateBrowseCharacters()
-        browseBtnAvailable = #browseChars > 0
-
-        if browseBtn.SetEnabled then
-            browseBtn:SetEnabled(browseBtnAvailable)
-        end
-        if browseIcon.SetDesaturated then
-            browseIcon:SetDesaturated(not browseBtnAvailable)
-        end
-        if browseBtnAvailable then
-            browseBtn:SetAlpha(1)
-            browseIcon:SetVertexColor(1, 1, 1, 1)
-            if browseBtn:GetHighlightTexture() then
-                browseBtn:GetHighlightTexture():SetAlpha(0.3)
-            end
-        else
-            browseBtn:SetAlpha(0.75)
-            browseIcon:SetVertexColor(0.6, 0.6, 0.6, 1)
-            if browseBtn:GetHighlightTexture() then
-                browseBtn:GetHighlightTexture():SetAlpha(0)
-            end
-        end
-
-        UpdateBrowseBtnHighlight()
-    end
-
-    browseBtn:SetScript("OnClick", function()
-        if not browseBtnAvailable then
-            return
-        end
-        CloseDropDownMenus()
-        -- Browse mode lives in the normal button-settings layout, not Bars & Frames.
-        if CS.resourceBarPanelActive then
-            SetPrimaryMode("buttons", { skipRefresh = true })
-        end
-        CS.browseMode = true
-        CS.browseCharKey = nil
-        CS.browseContainerId = nil
-        ClearConfigPrimarySelection()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    browseBtn:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
-        GameTooltip:AddLine("Browse Other Characters")
-        if not browseBtnAvailable then
-            GameTooltip:AddLine("No other characters on this profile currently have groups to browse.", 1, 1, 1, true)
-        elseif CS.browseMode then
-            GameTooltip:AddLine("Browse mode is active. Click to return to the character list and browse groups from other characters on this profile.", 1, 1, 1, true)
-        else
-            GameTooltip:AddLine("View and copy groups from other characters on this profile.", 1, 1, 1, true)
-        end
-        GameTooltip:Show()
-    end)
-    browseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
-
     local changelogOverlay
     local changelogBtn
     local changelogBtnBorder = nil
@@ -1262,8 +1178,7 @@ local function CreateConfigPanel()
     gearBtn:SetPoint("RIGHT", collapseBtn, "LEFT", -4, 0)
     changelogBtn:SetPoint("RIGHT", gearBtn, "LEFT", -4, 0)
     cdmBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
-    browseBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
-    cdmDisplayBtn:SetPoint("RIGHT", browseBtn, "LEFT", -4, 0)
+    cdmDisplayBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
     local gearIcon = gearBtn:CreateTexture(nil, "ARTWORK")
     gearIcon:SetTexture("Interface\\WorldMap\\GEAR_64GREY")
     gearIcon:SetAllPoints()
@@ -1805,6 +1720,19 @@ local function CreateConfigPanel()
     end
     CS.configFinderBox = configFinder
 
+    local otherClassesDoorway = AceGUI:Create("InteractiveLabel")
+    CleanRecycledEntry(otherClassesDoorway)
+    otherClassesDoorway:SetText("")
+    otherClassesDoorway:SetFullWidth(true)
+    otherClassesDoorway:SetFontObject(GameFontHighlight)
+    ApplyConfigTextRow(otherClassesDoorway)
+    otherClassesDoorway:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
+    otherClassesDoorway.frame:SetParent(col1.content)
+    otherClassesDoorway.frame:ClearAllPoints()
+    otherClassesDoorway.frame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
+    otherClassesDoorway.frame:Hide()
+    CS.col1FooterDoorway = otherClassesDoorway
+
     -- Column 3: Button Settings
     local col3 = AceGUI:Create("InlineGroup")
     col3:SetTitle("Button Settings")
@@ -2006,12 +1934,6 @@ local function CreateConfigPanel()
                 local buttonData = CooldownCompanion:GetRotationAssistantConfigButtonData(group)
                 ST._BuildEntryLoadConditionsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
             end
-            if CS.browseMode then
-                ST._DisableAllWidgets(scroll)
-                for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                    if btn.Disable then btn:Disable() end
-                end
-            end
             return
         end
 
@@ -2045,13 +1967,6 @@ local function CreateConfigPanel()
             ST._BuildEntryLoadConditionsTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
         elseif tab == "overrides" then
             ST._BuildOverridesTab(scroll, buttonData, CS.buttonSettingsInfoButtons)
-        end
-
-        if CS.browseMode then
-            ST._DisableAllWidgets(scroll)
-            for _, btn in ipairs(CS.buttonSettingsInfoButtons) do
-                if btn.Disable then btn:Disable() end
-            end
         end
 
     end)
@@ -2216,6 +2131,65 @@ local function CreateConfigPanel()
         end
     end
 
+    local function PositionColumn1FooterControls(finderAvailable)
+        finderAvailable = finderAvailable == true
+
+        if CS.configFinderBox and CS.configFinderBox.frame then
+            CS.configFinderBox.frame:ClearAllPoints()
+            CS.configFinderBox.frame:SetPoint("BOTTOMLEFT", col1.content, "BOTTOMLEFT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+            CS.configFinderBox.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+            CS.configFinderBox.frame:SetHeight(CONFIG_FINDER_BOX_HEIGHT)
+        end
+
+        local doorwayVisible = finderAvailable
+            and CS.col1FooterDoorwayVisible == true
+            and CS.col1FooterDoorway
+            and CS.col1FooterDoorway.frame
+
+        if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
+            local doorwayFrame = CS.col1FooterDoorway.frame
+            doorwayFrame:ClearAllPoints()
+            doorwayFrame:SetPoint(
+                "BOTTOMLEFT",
+                col1.content,
+                "BOTTOMLEFT",
+                0,
+                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+            )
+            doorwayFrame:SetPoint(
+                "BOTTOMRIGHT",
+                col1.content,
+                "BOTTOMRIGHT",
+                0,
+                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+            )
+            doorwayFrame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
+            if doorwayVisible then
+                doorwayFrame:Show()
+            else
+                doorwayFrame:Hide()
+            end
+        end
+
+        if CS.col1Scroll and CS.col1Scroll.frame then
+            local bottomInset = 30
+            if finderAvailable then
+                bottomInset = bottomInset + CONFIG_FINDER_RESERVED_HEIGHT
+                if doorwayVisible then
+                    bottomInset = bottomInset + COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT
+                end
+            end
+
+            CS.col1Scroll.frame:ClearAllPoints()
+            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
+            CS.col1Scroll.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, bottomInset)
+        end
+    end
+
+    CS.UpdateColumn1FooterLayout = function()
+        PositionColumn1FooterControls(IsConfigFinderAvailable and IsConfigFinderAvailable())
+    end
+
     -- Layout columns on size change
     local function LayoutColumns()
         local w = colParent:GetWidth()
@@ -2232,6 +2206,11 @@ local function CreateConfigPanel()
         if CS.talentPickerMode then
             if CS.configFinderBox then
                 CS.configFinderBox.frame:Hide()
+            end
+            CS.col1FooterDoorwayVisible = false
+            CS.lastCol1FooterDoorwayRow = nil
+            if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
+                CS.col1FooterDoorway.frame:Hide()
             end
             if ClearConfigFinderText then
                 ClearConfigFinderText()
@@ -2269,17 +2248,7 @@ local function CreateConfigPanel()
                 end
             end
         end
-        if CS.col1Scroll and CS.col1Scroll.frame then
-            CS.col1Scroll.frame:ClearAllPoints()
-            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
-            CS.col1Scroll.frame:SetPoint(
-                "BOTTOMRIGHT",
-                col1.content,
-                "BOTTOMRIGHT",
-                0,
-                finderAvailable and (30 + CONFIG_FINDER_RESERVED_HEIGHT) or 30
-            )
-        end
+        PositionColumn1FooterControls(finderAvailable)
 
         col1.frame:ClearAllPoints()
         col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", 0, 0)
@@ -2334,8 +2303,6 @@ local function CreateConfigPanel()
     frame.LayoutColumns = LayoutColumns
     frame.UpdateCompactConfigRows = UpdateCompactConfigRows
     frame.UpdateModeNavigationUI = UpdateModeNavigationUI
-    frame.UpdateBrowseButtonState = UpdateBrowseBtnState
-    UpdateBrowseBtnState()
     UpdateModeNavigationUI()
 
     CS.configFrame = frame
@@ -2421,9 +2388,6 @@ function CooldownCompanion:_configRefreshPanelImpl()
     CS.configFrame.versionText:SetText(GetVersionFooterText())
     if CS.configFrame.UpdateModeNavigationUI then
         CS.configFrame.UpdateModeNavigationUI()
-    end
-    if CS.configFrame.UpdateBrowseButtonState then
-        CS.configFrame.UpdateBrowseButtonState()
     end
     if CS.configFrame.LayoutColumns then
         CS.configFrame.LayoutColumns()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -933,6 +933,9 @@ local function CreateConfigPanel()
         end
         if not CS.previewToggleRefreshActive then
             CooldownCompanion:ClearAllConfigPreviews()
+            if CooldownCompanion.RefreshConfigSelectedGroupFrames then
+                CooldownCompanion:RefreshConfigSelectedGroupFrames()
+            end
         end
         if ClearConfigShiftTooltipHover then
             ClearConfigShiftTooltipHover()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -30,6 +30,7 @@ local IsConfigFinderActive = ST._IsConfigFinderActive
 local SetConfigFinderText = ST._SetConfigFinderText
 local ClearConfigFinderText = ST._ClearConfigFinderText
 local InvalidateConfigFinderResults = ST._InvalidateConfigFinderResults
+local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
 local StartFirstIconPanelTutorial = ST._StartFirstIconPanelTutorial
 local CancelFirstIconPanelTutorial = ST._CancelFirstIconPanelTutorial
@@ -37,8 +38,6 @@ local RebuildTutorialAnchors = ST._RebuildTutorialAnchors
 local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
 local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
-local CleanRecycledEntry = ST._CleanRecycledEntry
-local ApplyConfigTextRow = ST._ApplyConfigTextRow
 
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
@@ -67,8 +66,6 @@ local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
 local CONFIG_FINDER_BUTTON_GAP = 3
 local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-local COLUMN1_FOOTER_DOORWAY_HEIGHT = 24
-local COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT = COLUMN1_FOOTER_DOORWAY_HEIGHT + CONFIG_FINDER_BUTTON_GAP
 local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
 local CONFIG_NESTED_INLINE_GROUP_INSET = 20
 local CONFIG_DRAG_ALPHA = 0.40
@@ -247,6 +244,38 @@ local function SetPrimaryMode(mode, opts)
         CooldownCompanion:RefreshConfigPanel()
     end
     return true
+end
+
+local function HasOtherClassInventory()
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not db then return false, false, false end
+
+    local searchFiltered = IsConfigFinderActive and IsConfigFinderActive() and BuildConfigFinderResults ~= nil
+    local searchResults = searchFiltered and BuildConfigFinderResults() or nil
+    local hasOtherInventory = false
+
+    if CooldownCompanion.ResolveContainerClassScope then
+        for id, container in pairs(db.groupContainers or {}) do
+            local scope = CooldownCompanion:ResolveContainerClassScope(container or id)
+            if scope and scope.scope == "other-class" then
+                hasOtherInventory = true
+                if not searchFiltered or (searchResults and searchResults.containerMatches and searchResults.containerMatches[id]) then
+                    return true, searchFiltered == true, true
+                end
+            end
+        end
+    end
+
+    if not searchFiltered and CooldownCompanion.ResolveFolderClassScope then
+        for folderId, folder in pairs(db.folders or {}) do
+            local scope = CooldownCompanion:ResolveFolderClassScope(folder or folderId)
+            if scope and scope.scope == "other-class" then
+                return true, false, true
+            end
+        end
+    end
+
+    return false, searchFiltered == true, hasOtherInventory
 end
 
 local GetClassColoredText = ST._GetClassColoredText
@@ -1133,6 +1162,104 @@ local function CreateConfigPanel()
     end)
     cdmDisplayBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
+    -- Other Classes browse button — between the Changelog and CDM buttons
+    local otherClassBrowseBtn = CreateFrame("Button", nil, content)
+    otherClassBrowseBtn:SetSize(16, 16)
+    if otherClassBrowseBtn.SetMotionScriptsWhileDisabled then
+        otherClassBrowseBtn:SetMotionScriptsWhileDisabled(true)
+    end
+    local otherClassBrowseIcon = otherClassBrowseBtn:CreateTexture(nil, "ARTWORK")
+    otherClassBrowseIcon:SetAtlas("BattleBar-SwapPetIcon", false)
+    otherClassBrowseIcon:SetAllPoints()
+    otherClassBrowseBtn:SetHighlightAtlas("BattleBar-SwapPetIcon")
+    otherClassBrowseBtn:GetHighlightTexture():SetAlpha(0.3)
+
+    local otherClassBrowseBtnBorder = nil
+    local otherClassBrowseAvailable = false
+    local otherClassBrowseSearchFiltered = false
+    local otherClassBrowseHasInventory = false
+
+    local function UpdateOtherClassBrowseBtnHighlight()
+        local shouldHighlight = otherClassBrowseAvailable and CS.otherClassLibraryActive == true
+        if shouldHighlight then
+            if not otherClassBrowseBtnBorder then
+                otherClassBrowseBtnBorder = otherClassBrowseBtn:CreateTexture(nil, "OVERLAY")
+                otherClassBrowseBtnBorder:SetPoint("TOPLEFT", -1, 1)
+                otherClassBrowseBtnBorder:SetPoint("BOTTOMRIGHT", 1, -1)
+                otherClassBrowseBtnBorder:SetColorTexture(0.85, 0.65, 0.0, 0.6)
+            end
+            otherClassBrowseBtnBorder:Show()
+        elseif otherClassBrowseBtnBorder then
+            otherClassBrowseBtnBorder:Hide()
+        end
+    end
+
+    local function UpdateOtherClassBrowseButtonState()
+        otherClassBrowseAvailable, otherClassBrowseSearchFiltered, otherClassBrowseHasInventory = HasOtherClassInventory()
+
+        if otherClassBrowseBtn.SetEnabled then
+            otherClassBrowseBtn:SetEnabled(otherClassBrowseAvailable)
+        elseif otherClassBrowseAvailable and otherClassBrowseBtn.Enable then
+            otherClassBrowseBtn:Enable()
+        elseif otherClassBrowseBtn.Disable then
+            otherClassBrowseBtn:Disable()
+        end
+        if otherClassBrowseIcon.SetDesaturated then
+            otherClassBrowseIcon:SetDesaturated(not otherClassBrowseAvailable)
+        end
+        if otherClassBrowseAvailable then
+            otherClassBrowseBtn:SetAlpha(1)
+            otherClassBrowseIcon:SetVertexColor(1, 1, 1, 1)
+            if otherClassBrowseBtn:GetHighlightTexture() then
+                otherClassBrowseBtn:GetHighlightTexture():SetAlpha(0.3)
+            end
+        else
+            otherClassBrowseBtn:SetAlpha(0.75)
+            otherClassBrowseIcon:SetVertexColor(0.6, 0.6, 0.6, 1)
+            if otherClassBrowseBtn:GetHighlightTexture() then
+                otherClassBrowseBtn:GetHighlightTexture():SetAlpha(0)
+            end
+        end
+
+        UpdateOtherClassBrowseBtnHighlight()
+    end
+
+    otherClassBrowseBtn:SetScript("OnClick", function()
+        CloseDropDownMenus()
+        if CS.otherClassLibraryActive then
+            CS.otherClassLibraryActive = false
+            CS.otherClassLibraryClassKey = nil
+            CooldownCompanion:RefreshConfigPanel()
+            return
+        end
+        if not otherClassBrowseAvailable then
+            return
+        end
+        if CS.resourceBarPanelActive then
+            SetPrimaryMode("buttons", { skipRefresh = true })
+        end
+        CS.otherClassLibraryActive = true
+        CS.otherClassLibraryClassKey = nil
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+    otherClassBrowseBtn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
+        GameTooltip:AddLine("Browse Other Classes")
+        if not otherClassBrowseAvailable then
+            if otherClassBrowseSearchFiltered and otherClassBrowseHasInventory then
+                GameTooltip:AddLine("No other classes match the current search.", 1, 1, 1, true)
+            else
+                GameTooltip:AddLine("No other classes on this profile currently have groups to browse.", 1, 1, 1, true)
+            end
+        elseif CS.otherClassLibraryActive then
+            GameTooltip:AddLine("Class library is open. Click to return to the regular config view.", 1, 1, 1, true)
+        else
+            GameTooltip:AddLine("View and edit groups saved for other classes on this profile.", 1, 1, 1, true)
+        end
+        GameTooltip:Show()
+    end)
+    otherClassBrowseBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
     local changelogOverlay
     local changelogBtn
     local changelogBtnBorder = nil
@@ -1177,7 +1304,8 @@ local function CreateConfigPanel()
     gearBtn:SetSize(20, 20)
     gearBtn:SetPoint("RIGHT", collapseBtn, "LEFT", -4, 0)
     changelogBtn:SetPoint("RIGHT", gearBtn, "LEFT", -4, 0)
-    cdmBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
+    otherClassBrowseBtn:SetPoint("RIGHT", changelogBtn, "LEFT", -4, 0)
+    cdmBtn:SetPoint("RIGHT", otherClassBrowseBtn, "LEFT", -4, 0)
     cdmDisplayBtn:SetPoint("RIGHT", cdmBtn, "LEFT", -4, 0)
     local gearIcon = gearBtn:CreateTexture(nil, "ARTWORK")
     gearIcon:SetTexture("Interface\\WorldMap\\GEAR_64GREY")
@@ -1720,19 +1848,6 @@ local function CreateConfigPanel()
     end
     CS.configFinderBox = configFinder
 
-    local otherClassesDoorway = AceGUI:Create("InteractiveLabel")
-    CleanRecycledEntry(otherClassesDoorway)
-    otherClassesDoorway:SetText("")
-    otherClassesDoorway:SetFullWidth(true)
-    otherClassesDoorway:SetFontObject(GameFontHighlight)
-    ApplyConfigTextRow(otherClassesDoorway)
-    otherClassesDoorway:SetHighlight("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-    otherClassesDoorway.frame:SetParent(col1.content)
-    otherClassesDoorway.frame:ClearAllPoints()
-    otherClassesDoorway.frame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
-    otherClassesDoorway.frame:Hide()
-    CS.col1FooterDoorway = otherClassesDoorway
-
     -- Column 3: Button Settings
     local col3 = AceGUI:Create("InlineGroup")
     col3:SetTitle("Button Settings")
@@ -2131,65 +2246,6 @@ local function CreateConfigPanel()
         end
     end
 
-    local function PositionColumn1FooterControls(finderAvailable)
-        finderAvailable = finderAvailable == true
-
-        if CS.configFinderBox and CS.configFinderBox.frame then
-            CS.configFinderBox.frame:ClearAllPoints()
-            CS.configFinderBox.frame:SetPoint("BOTTOMLEFT", col1.content, "BOTTOMLEFT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
-            CS.configFinderBox.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
-            CS.configFinderBox.frame:SetHeight(CONFIG_FINDER_BOX_HEIGHT)
-        end
-
-        local doorwayVisible = finderAvailable
-            and CS.col1FooterDoorwayVisible == true
-            and CS.col1FooterDoorway
-            and CS.col1FooterDoorway.frame
-
-        if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
-            local doorwayFrame = CS.col1FooterDoorway.frame
-            doorwayFrame:ClearAllPoints()
-            doorwayFrame:SetPoint(
-                "BOTTOMLEFT",
-                col1.content,
-                "BOTTOMLEFT",
-                0,
-                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-            )
-            doorwayFrame:SetPoint(
-                "BOTTOMRIGHT",
-                col1.content,
-                "BOTTOMRIGHT",
-                0,
-                30 + CONFIG_FINDER_RESERVED_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-            )
-            doorwayFrame:SetHeight(COLUMN1_FOOTER_DOORWAY_HEIGHT)
-            if doorwayVisible then
-                doorwayFrame:Show()
-            else
-                doorwayFrame:Hide()
-            end
-        end
-
-        if CS.col1Scroll and CS.col1Scroll.frame then
-            local bottomInset = 30
-            if finderAvailable then
-                bottomInset = bottomInset + CONFIG_FINDER_RESERVED_HEIGHT
-                if doorwayVisible then
-                    bottomInset = bottomInset + COLUMN1_FOOTER_DOORWAY_RESERVED_HEIGHT
-                end
-            end
-
-            CS.col1Scroll.frame:ClearAllPoints()
-            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
-            CS.col1Scroll.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, bottomInset)
-        end
-    end
-
-    CS.UpdateColumn1FooterLayout = function()
-        PositionColumn1FooterControls(IsConfigFinderAvailable and IsConfigFinderAvailable())
-    end
-
     -- Layout columns on size change
     local function LayoutColumns()
         local w = colParent:GetWidth()
@@ -2206,11 +2262,6 @@ local function CreateConfigPanel()
         if CS.talentPickerMode then
             if CS.configFinderBox then
                 CS.configFinderBox.frame:Hide()
-            end
-            CS.col1FooterDoorwayVisible = false
-            CS.lastCol1FooterDoorwayRow = nil
-            if CS.col1FooterDoorway and CS.col1FooterDoorway.frame then
-                CS.col1FooterDoorway.frame:Hide()
             end
             if ClearConfigFinderText then
                 ClearConfigFinderText()
@@ -2240,6 +2291,10 @@ local function CreateConfigPanel()
 
         if CS.configFinderBox then
             if finderAvailable then
+                CS.configFinderBox.frame:ClearAllPoints()
+                CS.configFinderBox.frame:SetPoint("BOTTOMLEFT", col1.content, "BOTTOMLEFT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+                CS.configFinderBox.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, 30 + CONFIG_FINDER_BUTTON_GAP)
+                CS.configFinderBox.frame:SetHeight(CONFIG_FINDER_BOX_HEIGHT)
                 CS.configFinderBox.frame:Show()
             else
                 CS.configFinderBox.frame:Hide()
@@ -2248,7 +2303,12 @@ local function CreateConfigPanel()
                 end
             end
         end
-        PositionColumn1FooterControls(finderAvailable)
+        if CS.col1Scroll and CS.col1Scroll.frame then
+            local bottomInset = finderAvailable and (30 + CONFIG_FINDER_RESERVED_HEIGHT) or 30
+            CS.col1Scroll.frame:ClearAllPoints()
+            CS.col1Scroll.frame:SetPoint("TOPLEFT", col1.content, "TOPLEFT", 0, 0)
+            CS.col1Scroll.frame:SetPoint("BOTTOMRIGHT", col1.content, "BOTTOMRIGHT", 0, bottomInset)
+        end
 
         col1.frame:ClearAllPoints()
         col1.frame:SetPoint("TOPLEFT", colParent, "TOPLEFT", 0, 0)
@@ -2295,6 +2355,7 @@ local function CreateConfigPanel()
     frame.modeStatusRow = modeStatusRow
     frame.profileGear = profileGear
     frame.changelogOverlay = changelogOverlay
+    frame.otherClassBrowseButton = otherClassBrowseBtn
     frame.col1 = col1
     frame.col2 = col2
     frame.col3 = col3
@@ -2303,7 +2364,9 @@ local function CreateConfigPanel()
     frame.LayoutColumns = LayoutColumns
     frame.UpdateCompactConfigRows = UpdateCompactConfigRows
     frame.UpdateModeNavigationUI = UpdateModeNavigationUI
+    frame.UpdateOtherClassBrowseButtonState = UpdateOtherClassBrowseButtonState
     UpdateModeNavigationUI()
+    UpdateOtherClassBrowseButtonState()
 
     CS.configFrame = frame
     return frame
@@ -2388,6 +2451,9 @@ function CooldownCompanion:_configRefreshPanelImpl()
     CS.configFrame.versionText:SetText(GetVersionFooterText())
     if CS.configFrame.UpdateModeNavigationUI then
         CS.configFrame.UpdateModeNavigationUI()
+    end
+    if CS.configFrame.UpdateOtherClassBrowseButtonState then
+        CS.configFrame.UpdateOtherClassBrowseButtonState()
     end
     if CS.configFrame.LayoutColumns then
         CS.configFrame.LayoutColumns()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1227,6 +1227,9 @@ local function CreateConfigPanel()
     otherClassBrowseBtn:SetScript("OnClick", function()
         CloseDropDownMenus()
         if CS.otherClassLibraryActive then
+            if ClearConfigPrimarySelection then
+                ClearConfigPrimarySelection()
+            end
             CS.otherClassLibraryActive = false
             CS.otherClassLibraryClassKey = nil
             CooldownCompanion:RefreshConfigPanel()
@@ -1237,6 +1240,9 @@ local function CreateConfigPanel()
         end
         if CS.resourceBarPanelActive then
             SetPrimaryMode("buttons", { skipRefresh = true })
+        end
+        if ClearConfigPrimarySelection then
+            ClearConfigPrimarySelection()
         end
         CS.otherClassLibraryActive = true
         CS.otherClassLibraryClassKey = nil

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -449,7 +449,7 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
-    text = "This will remove all spec filters and turn '%s' into a group for your current character. Continue?",
+    text = "This will remove foreign eligibility filters and turn '%s' into a group for your current character. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -475,7 +475,7 @@ StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_GROUP"] = {
-    text = "This will remove foreign spec filters and turn '%s' into a character group. Continue?",
+    text = "This will remove foreign eligibility filters and turn '%s' into a character group. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -520,7 +520,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign spec filters. Moving to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving to character will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -537,7 +537,7 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign spec filters. Moving '%s' to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving '%s' to character will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -595,7 +595,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_SELECTED_GROUPS"] = {
-    text = "Some selected groups have foreign spec filters. Moving to character will remove those filters. Continue?",
+    text = "Some selected groups have foreign eligibility filters. Moving to character will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -1234,6 +1234,8 @@ local function ApplyCustomBarsImportData(data, options)
     if RejectUnsupportedImportPayload(data, "custom bars import") then
         return false
     end
+    local importState = options and options.importState or NewGroupImportState()
+    StripImportCharacterEligibility(data, importState)
 
     local rb = ST._RB
     local settings = CooldownCompanion:GetResourceBarSettings()
@@ -1249,6 +1251,7 @@ local function ApplyCustomBarsImportData(data, options)
     if not (options and options.silentSuccess) then
         CooldownCompanion:Print(message)
     end
+    PrintImportSanitizerNotes(importState)
     CooldownCompanion:ApplyResourceBars()
     CooldownCompanion:UpdateAnchorStacking()
     CooldownCompanion:RefreshConfigPanel()

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -15,6 +15,7 @@ local ClearConfigContainerSelection = ST._ClearConfigContainerSelection
 local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
+local StripCharacterEligibilityFromPayload = ST._StripCharacterEligibilityFromPayload
 
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
     classAllowlist = "class",
@@ -736,6 +737,64 @@ local function BuildContainerExportData(container)
     return data
 end
 
+local function HasTrueMapValue(map)
+    if type(map) ~= "table" then return false end
+    for _, enabled in pairs(map) do
+        if enabled == true then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityHasPortableEligibility(entity)
+    if type(entity) ~= "table" then return false end
+    local loadConditions = entity.loadConditions
+    if type(loadConditions) == "table" then
+        if CopyAllowlistMap(loadConditions.classAllowlist, "class")
+            or CopyAllowlistMap(loadConditions.specAllowlist, "spec")
+        then
+            return true
+        end
+    end
+    return CopyAllowlistMap(entity.specs, "spec") ~= nil
+        or HasTrueMapValue(entity.heroTalents)
+end
+
+local function ContainerEntryHasPortableEligibility(entry)
+    if type(entry) ~= "table" then return false end
+    if EntityHasPortableEligibility(entry.container) then
+        return true
+    end
+    for _, panel in ipairs(entry.panels or {}) do
+        if EntityHasPortableEligibility(panel) then
+            return true
+        end
+    end
+    return false
+end
+
+local function ContainersHavePortableEligibility(entries)
+    if type(entries) ~= "table" then return false end
+    for _, entry in ipairs(entries) do
+        if ContainerEntryHasPortableEligibility(entry) then
+            return true
+        end
+    end
+    return false
+end
+
+local function StripImportCharacterEligibility(data, importState)
+    local stripped = type(data) == "table" and tonumber(data._cdcCharacterEligibilityStripped) or 0
+    stripped = stripped + (StripCharacterEligibilityFromPayload
+        and StripCharacterEligibilityFromPayload(data)
+        or 0)
+    if stripped > 0 and importState then
+        importState.characterEligibilityStripped = (importState.characterEligibilityStripped or 0) + stripped
+    end
+    return stripped
+end
+
 ST._BuildGroupExportData = BuildGroupExportData
 ST._BuildContainerExportData = BuildContainerExportData
 ST._EncodeExportData = EncodeExportData
@@ -824,11 +883,14 @@ local function NewGroupImportState()
         importedGroupIds = {},
         containerCount = 0,
         panelCount = 0,
+        characterEligibilityStripped = 0,
+        globalizedEligibilityImports = 0,
     }
 end
 
-local function ImportContainerEntries(db, entries, charKey, folderId, importState)
+local function ImportContainerEntries(db, entries, charKey, folderId, importState, options)
     importState = importState or NewGroupImportState()
+    options = options or {}
     local firstContainerIndex = #importState.importedContainerIds + 1
     local startContainerCount = importState.containerCount
     local startPanelCount = importState.panelCount
@@ -842,12 +904,17 @@ local function ImportContainerEntries(db, entries, charKey, folderId, importStat
         end
 
         local container = CopyTable(entry.container)
+        local importAsGlobal = options.forceGlobalScope == true
+            or ContainerEntryHasPortableEligibility(entry)
         container.createdBy = charKey
-        container.isGlobal = false
+        container.isGlobal = importAsGlobal
         container.order = containerId
         container.specOrders = nil
         container.folderId = folderId
         container.locked = true
+        if importAsGlobal then
+            importState.globalizedEligibilityImports = (importState.globalizedEligibilityImports or 0) + 1
+        end
         db.groupContainers[containerId] = container
         CooldownCompanion:CreateContainerFrame(containerId)
 
@@ -904,6 +971,18 @@ local function RemapImportedContainerAnchors(db, importState, preserveContainerR
                 end
             end
         end
+    end
+end
+
+local function PrintImportSanitizerNotes(importState)
+    if not (importState and CooldownCompanion and CooldownCompanion.Print) then
+        return
+    end
+    if (importState.characterEligibilityStripped or 0) > 0 then
+        CooldownCompanion:Print("Character eligibility is local and was not imported.")
+    end
+    if (importState.globalizedEligibilityImports or 0) > 0 then
+        CooldownCompanion:Print("Class, specialization, and hero talent eligibility were preserved in Global Groups.")
     end
 end
 
@@ -1001,6 +1080,7 @@ ST._FinishGroupImportBatch = function(token, remapAnchors)
             CooldownCompanion:SanitizeCursorAnchorPolicy(db)
         end
     end
+    PrintImportSanitizerNotes(importState)
 end
 
 ST._AttachGroupImportBatch = function(payload, token)
@@ -1027,7 +1107,9 @@ local function ApplyGroupImportData(data)
     local db = CooldownCompanion.db.profile
     local charKey = CooldownCompanion.db.keys.char
     local sharedImportState = batchToken and activeGroupImportBatches[batchToken] or nil
+    local rootImportState = sharedImportState or NewGroupImportState()
     local deferAnchorRemap = sharedImportState ~= nil
+    StripImportCharacterEligibility(data, rootImportState)
 
     if data.type == "group" and data.group then
         CooldownCompanion:NotifyLegacySupportCutoff("group import")
@@ -1038,7 +1120,7 @@ local function ApplyGroupImportData(data)
         return false
 
     elseif data.type == "containers" and data.containers then
-        local importState, containerCount = ImportContainerEntries(db, data.containers, charKey, nil, sharedImportState)
+        local importState, containerCount = ImportContainerEntries(db, data.containers, charKey, nil, rootImportState)
         if not deferAnchorRemap then
             RemapImportedContainerAnchors(db, importState, true)
             RemapImportedPanelAnchors(db, importState)
@@ -1103,20 +1185,32 @@ local function ApplyGroupImportData(data)
                 importedLoadConditions = nil
             end
         end
+        local folderUsesGlobalEligibility = importedSpecs
+            or importedHeroTalents
+            or (importedLoadConditions and (
+                importedLoadConditions.classAllowlist
+                    or importedLoadConditions.specAllowlist
+            ))
+            or ContainersHavePortableEligibility(data.containers)
         db.folders[folderId] = {
             name = data.folder.name or "Imported Folder",
             order = folderId,
-            section = "char",
+            section = folderUsesGlobalEligibility and "global" or "char",
             createdBy = charKey,
             manualIcon = importedManualIcon,
             specs = importedSpecs,
             heroTalents = importedHeroTalents,
             loadConditions = importedLoadConditions,
         }
+        if folderUsesGlobalEligibility then
+            rootImportState.globalizedEligibilityImports = (rootImportState.globalizedEligibilityImports or 0) + 1
+        end
         local count = 0
         if data.containers then
             local importState, _, panelCount = ImportContainerEntries(
-                db, data.containers, charKey, folderId, sharedImportState
+                db, data.containers, charKey, folderId, rootImportState, {
+                    forceGlobalScope = folderUsesGlobalEligibility and true or false,
+                }
             )
             if not deferAnchorRemap then
                 RemapImportedContainerAnchors(db, importState, true)
@@ -1131,7 +1225,7 @@ local function ApplyGroupImportData(data)
             container = data.container,
             panels = data.panels,
             _originalContainerId = data._originalContainerId,
-        }}, charKey, nil, sharedImportState)
+        }}, charKey, nil, rootImportState)
         local container = db.groupContainers[containerId]
         if not deferAnchorRemap then
             RemapImportedContainerAnchors(db, importState, false)
@@ -1157,6 +1251,9 @@ local function ApplyGroupImportData(data)
 
     CooldownCompanion:RefreshConfigPanel()
     CooldownCompanion:RefreshAllGroups()
+    if not deferAnchorRemap then
+        PrintImportSanitizerNotes(rootImportState)
+    end
     return true
 end
 

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -80,31 +80,6 @@ local function ShowPopupOverConfig(which, textArg1, data)
     return StaticPopup_Show(which, textArg1, nil, data)
 end
 
-local function ClearFolderFiltersForUnglobal(folderId)
-    if not folderId then return end
-
-    local db = CooldownCompanion.db and CooldownCompanion.db.profile
-    if not db then return end
-
-    local folder = db.folders and db.folders[folderId]
-    if folder then
-        folder.specs = nil
-        folder.heroTalents = nil
-        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
-        return
-    end
-
-    -- Fallback: clear specs on child containers (folderId lives on containers post-migration)
-    if db.groupContainers then
-        for _, container in pairs(db.groupContainers) do
-            if container.folderId == folderId and (container.specs or container.heroTalents) then
-                container.specs = nil
-                container.heroTalents = nil
-            end
-        end
-    end
-end
-
 local function PruneDeletedFolderSelection(folderId)
     local db = CooldownCompanion.db and CooldownCompanion.db.profile
     if not db then return end
@@ -482,16 +457,12 @@ StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
         if data.containerId then
             local container = CooldownCompanion.db.profile.groupContainers[data.containerId]
             if container then
-                container.specs = nil
-                container.heroTalents = nil
                 CooldownCompanion:ToggleGroupGlobal(data.containerId)
                 CooldownCompanion:RefreshConfigPanel()
             end
         elseif data.groupId then
             local group = CooldownCompanion.db.profile.groups[data.groupId]
             if group then
-                group.specs = nil
-                group.heroTalents = nil
                 CooldownCompanion:ToggleGroupGlobal(data.groupId)
                 CooldownCompanion:RefreshConfigPanel()
             end
@@ -512,8 +483,6 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_GROUP"] = {
             local db = CooldownCompanion.db.profile
             local container = db.groupContainers[data.dragState.sourceGroupId]
             if container then
-                container.specs = nil
-                container.heroTalents = nil
                 ST._ApplyCol1Drop(data.dragState)
                 CooldownCompanion:RefreshConfigPanel()
             end
@@ -556,8 +525,6 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.dragState then
-            local folderId = data.dragState.sourceFolderId
-            ClearFolderFiltersForUnglobal(folderId)
             ST._ApplyCol1Drop(data.dragState)
             CooldownCompanion:RefreshAllGroups()
             CooldownCompanion:RefreshConfigPanel()
@@ -575,7 +542,6 @@ StaticPopupDialogs["CDC_UNGLOBAL_FOLDER"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.folderId then
-            ClearFolderFiltersForUnglobal(data.folderId)
             CooldownCompanion:ToggleFolderGlobal(data.folderId)
             CooldownCompanion:RefreshConfigPanel()
         end
@@ -634,28 +600,6 @@ StaticPopupDialogs["CDC_UNGLOBAL_SELECTED_GROUPS"] = {
     button2 = "Cancel",
     OnAccept = function(self, data)
         if data and data.callback then
-            -- Strip foreign specs from affected containers before executing the operation
-            if data.groupIds then
-                local db = CooldownCompanion.db.profile
-                local numSpecs = GetNumSpecializations()
-                local playerSpecIds = {}
-                for i = 1, numSpecs do
-                    local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-                    if specId then playerSpecIds[specId] = true end
-                end
-                for _, cid in ipairs(data.groupIds) do
-                    local container = db.groupContainers[cid]
-                    if container and container.specs then
-                        for specId in pairs(container.specs) do
-                            if not playerSpecIds[specId] then
-                                container.specs = nil
-                                container.heroTalents = nil
-                                break
-                            end
-                        end
-                    end
-                end
-            end
             data.callback()
         end
     end,

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -449,7 +449,7 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
-    text = "This will remove foreign eligibility filters and turn '%s' into a group for your current character. Continue?",
+    text = "This will remove foreign eligibility filters and move '%s' into your current class. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -475,7 +475,7 @@ StaticPopupDialogs["CDC_UNGLOBAL_GROUP"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_GROUP"] = {
-    text = "This will remove foreign eligibility filters and turn '%s' into a character group. Continue?",
+    text = "This will remove foreign eligibility filters and move '%s' into your current class. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -520,7 +520,7 @@ StaticPopupDialogs["CDC_CROSS_PANEL_STRIP_OVERRIDES"] = {
 }
 
 StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign eligibility filters. Moving to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving to your current class will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -537,7 +537,7 @@ StaticPopupDialogs["CDC_DRAG_UNGLOBAL_FOLDER"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_FOLDER"] = {
-    text = "This folder contains groups with foreign eligibility filters. Moving '%s' to character will remove those filters. Continue?",
+    text = "This folder contains groups with foreign eligibility filters. Moving '%s' to your current class will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)
@@ -595,7 +595,7 @@ StaticPopupDialogs["CDC_DELETE_SELECTED_CUSTOM_BARS"] = {
 }
 
 StaticPopupDialogs["CDC_UNGLOBAL_SELECTED_GROUPS"] = {
-    text = "Some selected groups have foreign eligibility filters. Moving to character will remove those filters. Continue?",
+    text = "Some selected groups have foreign eligibility filters. Moving to your current class will remove those filters. Continue?",
     button1 = "Continue",
     button2 = "Cancel",
     OnAccept = function(self, data)

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -16,6 +16,39 @@ local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 
+local LOAD_CONDITION_ALLOWLIST_KEYS = {
+    classAllowlist = "class",
+    specAllowlist = "spec",
+    characterAllowlist = "character",
+}
+
+local function NormalizeAllowlistKey(kind, key)
+    if kind == "class" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return string.upper(key)
+    elseif kind == "spec" then
+        return tonumber(key)
+    elseif kind == "character" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return key
+    end
+    return nil
+end
+
+local function CopyAllowlistMap(map, kind)
+    if type(map) ~= "table" then return nil end
+    local copy = {}
+    for key, enabled in pairs(map) do
+        if enabled == true then
+            local normalizedKey = NormalizeAllowlistKey(kind, key)
+            if normalizedKey ~= nil then
+                copy[normalizedKey] = true
+            end
+        end
+    end
+    return next(copy) and copy or nil
+end
+
 -- Check whether a profile name already exists (case-exact match).
 local function ProfileNameExists(name)
     local profiles = CooldownCompanion.db:GetProfiles()
@@ -1059,6 +1092,11 @@ local function ApplyGroupImportData(data)
             for key, enabled in pairs(data.folder.loadConditions) do
                 if enabled == true then
                     importedLoadConditions[key] = true
+                elseif LOAD_CONDITION_ALLOWLIST_KEYS[key] then
+                    local allowlist = CopyAllowlistMap(enabled, LOAD_CONDITION_ALLOWLIST_KEYS[key])
+                    if allowlist then
+                        importedLoadConditions[key] = allowlist
+                    end
                 end
             end
             if not next(importedLoadConditions) then

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -1596,6 +1596,7 @@ local function ApplyCustomBarsImportData(data, options)
     return true
 end
 
+ST._BlockCustomBarsImportForResourceBarConflict = BlockCustomBarsImportForResourceBarConflict
 ST._ApplyCustomBarsImportData = ApplyCustomBarsImportData
 
 StaticPopupDialogs["CDC_EXPORT_CUSTOM_BARS"] = {

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -709,8 +709,8 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
-        if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
-            local blockMessage = CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
+        if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+            local blockMessage = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
             if blockMessage then
                 self.EditBox:SetText(blockMessage)
                 self.EditBox:HighlightText()

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -241,8 +241,9 @@ local function ShowResourceBarConflictChooser(classKey, opts)
     AddResourceBarConflictSpacer(chooser, 14)
 
     local bullets = {
-        "The setup you KEEP, including Resource settings, Custom Bars, and Resource Aura overlays, will be saved for the whole class.",
-        "The other listed character setups for this class will be removed.",
+        "The Resource settings and Resource Aura overlays from the setup you KEEP will be saved for the whole class.",
+        "Custom Bars from every listed same-class setup will be preserved and added to the saved class setup.",
+        "The other listed character Resource settings and Resource Aura overlays will be removed.",
         "Going forward, every character of this class will use the saved setup.",
         "Per-spec layouts, resource overrides, and aura overlays still work inside that class setup.",
     }
@@ -708,8 +709,8 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
-        if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
-            local blockMessage = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+        if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
+            local blockMessage = CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
             if blockMessage then
                 self.EditBox:SetText(blockMessage)
                 self.EditBox:HighlightText()
@@ -947,8 +948,8 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
 ------------------------------------------------------------------------
 
 local function GetCustomBarExportConflictBlockMessage()
-    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
-        return CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
+        return CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
     end
     return nil
 end

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -7,6 +7,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CS = ST._configState
+local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 
 local ResetConfigSelection = ST._ResetConfigSelection
 local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
@@ -79,6 +80,282 @@ local function ShowPopupOverConfig(which, textArg1, data)
     end
     return StaticPopup_Show(which, textArg1, nil, data)
 end
+
+local function CountTableEntries(value)
+    local count = 0
+    if type(value) ~= "table" then
+        return count
+    end
+    for _ in pairs(value) do
+        count = count + 1
+    end
+    return count
+end
+
+local function ResourceBarCandidateDetail(settings)
+    if type(settings) ~= "table" then
+        return "Unavailable"
+    end
+    local customBars = settings.customBars
+    local customBarCount = 0
+    if type(customBars) == "table" then
+        if type(customBars.entries) == "table" then
+            customBarCount = CountTableEntries(customBars.entries)
+        else
+            for _, specBars in pairs(customBars) do
+                customBarCount = customBarCount + CountTableEntries(specBars)
+            end
+        end
+    end
+    return ("%d resources, %d custom bars"):format(CountTableEntries(settings.resources), customBarCount)
+end
+
+local function AddResourceBarConflictSpacer(chooser, height)
+    local spacer = AceGUI:Create("SimpleGroup")
+    spacer:SetFullWidth(true)
+    spacer:SetHeight(height)
+    spacer:SetLayout(nil)
+    chooser:AddChild(spacer)
+end
+
+local function AddResourceBarConflictText(chooser, text, fontObject)
+    local label = AceGUI:Create("Label")
+    label:SetText(text)
+    label:SetFullWidth(true)
+    if fontObject then
+        label:SetFontObject(fontObject)
+    end
+    chooser:AddChild(label)
+end
+
+local function ReturnResourceBarConflictFocus()
+    local button = CS and CS.resourceBarConflictResolveButton
+    if button and button.frame and button.frame.SetFocus then
+        button.frame:SetFocus()
+    end
+end
+
+local function AnchorResourceBarConflictChooser(chooser)
+    local frame = chooser and chooser.frame
+    if not frame then
+        return
+    end
+
+    frame:SetParent(UIParent)
+    frame:ClearAllPoints()
+    frame:SetPoint("CENTER", UIParent, "CENTER", 0, 80)
+end
+
+local function RaiseResourceBarConflictChooser(chooser)
+    local frame = chooser and chooser.frame
+    if not frame then
+        return
+    end
+
+    frame:SetParent(UIParent)
+    frame:SetFrameStrata("TOOLTIP")
+    frame:SetToplevel(true)
+    if frame.SetFrameLevel then
+        frame:SetFrameLevel(1000)
+    end
+    if frame.Raise then
+        frame:Raise()
+    end
+end
+
+local function HideResourceBarConflictChooser(markDismissed)
+    local chooser = CS and CS.resourceBarConflictChooser
+    if not chooser then
+        return
+    end
+    if markDismissed and chooser.classKey then
+        CS.resourceBarConflictChooserDismissed = CS.resourceBarConflictChooserDismissed or {}
+        CS.resourceBarConflictChooserDismissed[chooser.classKey] = true
+    end
+    chooser:Hide()
+    if chooser.frame then
+        chooser.frame:SetScript("OnKeyDown", nil)
+        chooser.frame:EnableKeyboard(false)
+        if chooser.frame.SetPropagateKeyboardInput then
+            chooser.frame:SetPropagateKeyboardInput(true)
+        end
+    end
+    ReturnResourceBarConflictFocus()
+end
+
+local function ShowResourceBarConflictChooser(classKey, opts)
+    opts = opts or {}
+    classKey = classKey or (CooldownCompanion.GetCurrentResourceBarClassKey and CooldownCompanion:GetCurrentResourceBarClassKey())
+    local conflict = classKey and CooldownCompanion.GetResourceBarConflict and CooldownCompanion:GetResourceBarConflict(classKey) or nil
+    if not conflict then
+        return false
+    end
+    CS.resourceBarConflictChooserDismissed = CS.resourceBarConflictChooserDismissed or {}
+    if CS.resourceBarConflictChooserDismissed[classKey] and not opts.force then
+        return false
+    end
+    if not AceGUI then
+        CooldownCompanion:Print("Resource Bar conflict chooser is unavailable.")
+        return false
+    end
+
+    local chooser = CS.resourceBarConflictChooser
+    if not chooser then
+        chooser = AceGUI:Create("Window")
+        chooser:SetTitle("Resolve Resource Bars")
+        chooser:SetWidth(560)
+        chooser:SetHeight(360)
+        chooser:SetLayout("List")
+        chooser:EnableResize(false)
+        chooser:SetCallback("OnClose", function()
+            HideResourceBarConflictChooser(true)
+        end)
+        CS.resourceBarConflictChooser = chooser
+    else
+        chooser:Show()
+        chooser:ReleaseChildren()
+    end
+
+    chooser.classKey = classKey
+    chooser.selectedIndex = 1
+
+    local legacyStore = CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.resourceBarsByChar
+        or nil
+    local classStore = CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.resourceBarsByClass
+        or nil
+    local existingClassSettings = conflict.includeExistingClass
+        and type(classStore) == "table"
+        and classStore[classKey]
+        or nil
+    local rows = {}
+    local candidateCharKeys = conflict.candidateCharKeys or {}
+    local candidateCount = #candidateCharKeys + (type(existingClassSettings) == "table" and 1 or 0)
+
+    AddResourceBarConflictText(chooser,
+        "Choose the Resource Bar setup to |cffffd100KEEP|r for " .. tostring(classKey) .. ".",
+        GameFontHighlight)
+    AddResourceBarConflictSpacer(chooser, 14)
+
+    local bullets = {
+        "The setup you KEEP, including Resource settings, Custom Bars, and Resource Aura overlays, will be saved for the whole class.",
+        "The other listed character setups for this class will be removed.",
+        "Going forward, every character of this class will use the saved setup.",
+        "Per-spec layouts, resource overrides, and aura overlays still work inside that class setup.",
+    }
+    for index, text in ipairs(bullets) do
+        AddResourceBarConflictText(chooser, "- " .. text, GameFontHighlight)
+        if index < #bullets then
+            AddResourceBarConflictSpacer(chooser, 14)
+        end
+    end
+    AddResourceBarConflictSpacer(chooser, 24)
+
+    local function selectRow(index)
+        chooser.selectedIndex = index
+        for rowIndex, row in ipairs(rows) do
+            if row.SetText then
+                local prefix = rowIndex == index and "> " or "  "
+                row:SetText(prefix .. (row.candidateText or ""))
+            end
+        end
+    end
+
+    local function chooseRow(index)
+        local row = rows[index]
+        if not row then
+            return
+        end
+        local options = row.keepExistingClassStore and { keepExistingClassStore = true } or nil
+        local ok, reason = CooldownCompanion:ResolveResourceBarConflict(classKey, row.sourceCharKey, options)
+        if not ok then
+            CooldownCompanion:Print("Resource Bar resolution failed: " .. tostring(reason or "unknown error"))
+            return
+        end
+        HideResourceBarConflictChooser(false)
+        if CooldownCompanion.ApplyResourceBars then
+            CooldownCompanion:ApplyResourceBars()
+        end
+        if CooldownCompanion.UpdateAnchorStacking then
+            CooldownCompanion:UpdateAnchorStacking()
+        end
+        if CooldownCompanion.RefreshConfigPanel then
+            CooldownCompanion:RefreshConfigPanel()
+        end
+    end
+
+    local function addCandidateRow(sourceCharKey, candidateText, options)
+        local index = #rows + 1
+        local row = AceGUI:Create("Button")
+        row.sourceCharKey = sourceCharKey
+        row.keepExistingClassStore = options and options.keepExistingClassStore == true
+        row.candidateText = candidateText
+        row:SetFullWidth(true)
+        row:SetText("  " .. candidateText)
+        row:SetCallback("OnClick", function()
+            chooseRow(index)
+        end)
+        rows[index] = row
+        chooser:AddChild(row)
+        if index < candidateCount then
+            AddResourceBarConflictSpacer(chooser, 10)
+        end
+    end
+
+    if type(existingClassSettings) == "table" then
+        addCandidateRow(nil,
+            "Current class setup - " .. ResourceBarCandidateDetail(existingClassSettings),
+            { keepExistingClassStore = true })
+    end
+
+    for _, sourceCharKey in ipairs(candidateCharKeys) do
+        addCandidateRow(sourceCharKey,
+            sourceCharKey .. " - "
+                .. ResourceBarCandidateDetail(type(legacyStore) == "table" and legacyStore[sourceCharKey] or nil))
+    end
+
+    AddResourceBarConflictSpacer(chooser, 14)
+
+    local closeButton = AceGUI:Create("Button")
+    closeButton:SetText("Later")
+    closeButton:SetWidth(90)
+    closeButton:SetCallback("OnClick", function()
+        HideResourceBarConflictChooser(true)
+    end)
+    chooser:AddChild(closeButton)
+
+    chooser:SetHeight(math.max(460, 390 + (candidateCount * 38) + (math.max(candidateCount - 1, 0) * 10)))
+    chooser.frame:SetScript("OnKeyDown", function(_, key)
+        if key == "ESCAPE" then
+            HideResourceBarConflictChooser(true)
+        elseif key == "ENTER" or key == "SPACE" then
+            chooseRow(chooser.selectedIndex or 1)
+        elseif key == "DOWN" or key == "TAB" then
+            local nextIndex = (chooser.selectedIndex or 1) + 1
+            if nextIndex > candidateCount then nextIndex = 1 end
+            selectRow(nextIndex)
+        elseif key == "UP" then
+            local nextIndex = (chooser.selectedIndex or 1) - 1
+            if nextIndex < 1 then nextIndex = candidateCount end
+            selectRow(nextIndex)
+        end
+    end)
+    chooser.frame:EnableKeyboard(true)
+    if chooser.frame.SetPropagateKeyboardInput then
+        chooser.frame:SetPropagateKeyboardInput(false)
+    end
+    chooser:Show()
+    AnchorResourceBarConflictChooser(chooser)
+    RaiseResourceBarConflictChooser(chooser)
+    selectRow(1)
+    return true
+end
+
+ST._ShowResourceBarConflictChooser = ShowResourceBarConflictChooser
+ST._HideResourceBarConflictChooser = HideResourceBarConflictChooser
 
 local function PruneDeletedFolderSelection(folderId)
     local db = CooldownCompanion.db and CooldownCompanion.db.profile
@@ -431,6 +708,18 @@ StaticPopupDialogs["CDC_EXPORT_PROFILE"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
+        if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+            local blockMessage = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+            if blockMessage then
+                self.EditBox:SetText(blockMessage)
+                self.EditBox:HighlightText()
+                self.EditBox:SetFocus()
+                if CooldownCompanion.Print then
+                    CooldownCompanion:Print(blockMessage)
+                end
+                return
+            end
+        end
         local db = CooldownCompanion.db
         local exportData = CopyTable(db.profile)
         exportData._exporterCharKey = db.keys.char
@@ -657,6 +946,24 @@ StaticPopupDialogs["CDC_DELETE_FOLDER"] = {
 -- Group/Folder Export and Apply
 ------------------------------------------------------------------------
 
+local function GetCustomBarExportConflictBlockMessage()
+    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+        return CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    end
+    return nil
+end
+
+local function BlockCustomBarExportForResourceBarConflict()
+    local message = GetCustomBarExportConflictBlockMessage()
+    if message then
+        if CooldownCompanion.Print then
+            CooldownCompanion:Print(message)
+        end
+        return true, message
+    end
+    return false, nil
+end
+
 local function BuildGroupExportData(group)
     local data = CopyTable(group)
     data.createdBy = nil
@@ -668,6 +975,12 @@ local function BuildGroupExportData(group)
 end
 
 local function EncodeExportData(payload)
+    if type(payload) == "table" and payload.type == "customBars" then
+        local blocked = BlockCustomBarExportForResourceBarConflict()
+        if blocked then
+            return nil
+        end
+    end
     return EncodeSharedPayload(payload, "entity")
 end
 
@@ -742,6 +1055,7 @@ end
 ST._BuildGroupExportData = BuildGroupExportData
 ST._BuildContainerExportData = BuildContainerExportData
 ST._EncodeExportData = EncodeExportData
+ST._BlockCustomBarExportForResourceBarConflict = BlockCustomBarExportForResourceBarConflict
 
 local function BuildImportedRootAnchor(relativeTo)
     return {
@@ -1223,6 +1537,27 @@ StaticPopupDialogs["CDC_EXPORT_GROUP"] = {
     preferredIndex = 3,
 }
 
+local function BlockCustomBarsImportForResourceBarConflict()
+    local classKey = CooldownCompanion.GetCurrentResourceBarClassKey
+        and CooldownCompanion:GetCurrentResourceBarClassKey()
+        or nil
+    local conflict = CooldownCompanion.GetCurrentResourceBarConflict
+        and CooldownCompanion:GetCurrentResourceBarConflict()
+        or nil
+    if not conflict then
+        return false
+    end
+
+    local message = "Resolve the pending Resource Bar conflict"
+        .. (classKey and (" for " .. tostring(classKey)) or "")
+        .. " before importing Custom Bars. Choose the setup to keep, then import again."
+    CooldownCompanion:Print(message)
+    if ST._ShowResourceBarConflictChooser then
+        ST._ShowResourceBarConflictChooser(classKey, { force = true })
+    end
+    return true
+end
+
 local function ApplyCustomBarsImportData(data, options)
     if type(data) ~= "table" or data.type ~= "customBars" then
         if RejectUnsupportedImportPayload(data, "custom bars import") then
@@ -1232,6 +1567,9 @@ local function ApplyCustomBarsImportData(data, options)
         return false
     end
     if RejectUnsupportedImportPayload(data, "custom bars import") then
+        return false
+    end
+    if BlockCustomBarsImportForResourceBarConflict() then
         return false
     end
     local importState = options and options.importState or NewGroupImportState()
@@ -1265,6 +1603,13 @@ StaticPopupDialogs["CDC_EXPORT_CUSTOM_BARS"] = {
     button1 = "Close",
     hasEditBox = true,
     OnShow = function(self)
+        local blocked, blockMessage = BlockCustomBarExportForResourceBarConflict()
+        if blocked then
+            self.EditBox:SetText(blockMessage or "Resolve pending Resource Bar conflicts before exporting Custom Bars.")
+            self.EditBox:HighlightText()
+            self.EditBox:SetFocus()
+            return
+        end
         if self.data and self.data.exportString then
             self.EditBox:SetText(self.data.exportString)
             self.EditBox:HighlightText()

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -37,6 +37,118 @@ local function ShouldRemapExporterOwned(createdBy, exporterCharKey)
     return exporterCharKey == nil or createdBy == exporterCharKey
 end
 
+local function HasPortableEligibilityMap(map)
+    if type(map) ~= "table" then
+        return map ~= nil
+    end
+    for _, enabled in pairs(map) do
+        if enabled == true then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityHasPortableEligibility(entity)
+    if type(entity) ~= "table" then return false end
+    if HasPortableEligibilityMap(entity.specs)
+        or HasPortableEligibilityMap(entity.heroTalents)
+    then
+        return true
+    end
+
+    local loadConditions = entity.loadConditions
+    return type(loadConditions) == "table"
+        and (HasPortableEligibilityMap(loadConditions.classAllowlist)
+            or HasPortableEligibilityMap(loadConditions.specAllowlist))
+end
+
+local function ContainerHasPortableEligibility(profile, containerId, container)
+    if EntityHasPortableEligibility(container) then
+        return true
+    end
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table"
+            and group.parentContainerId == containerId
+            and EntityHasPortableEligibility(group)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function FolderHasPortableEligibility(profile, folderId, folder)
+    if EntityHasPortableEligibility(folder) then
+        return true
+    end
+    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+    for containerId, container in pairs(groupContainers) do
+        if type(container) == "table"
+            and container.folderId == folderId
+            and ContainerHasPortableEligibility(profile, containerId, container)
+        then
+            return true
+        end
+    end
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table"
+            and group.folderId == folderId
+            and not group.parentContainerId
+            and EntityHasPortableEligibility(group)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function GlobalizePortableCharacterScopedEligibility(profile)
+    if type(profile) ~= "table" then return 0 end
+
+    local globalized = 0
+    local globalFolders = {}
+    local folders = type(profile.folders) == "table" and profile.folders or {}
+    for folderId, folder in pairs(folders) do
+        if type(folder) == "table"
+            and folder.section == "char"
+            and FolderHasPortableEligibility(profile, folderId, folder)
+        then
+            folder.section = "global"
+            globalFolders[folderId] = true
+            globalized = globalized + 1
+        end
+    end
+
+    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+    for containerId, container in pairs(groupContainers) do
+        if type(container) == "table"
+            and container.isGlobal ~= true
+            and (globalFolders[container.folderId]
+                or ContainerHasPortableEligibility(profile, containerId, container))
+        then
+            container.isGlobal = true
+            globalized = globalized + 1
+        end
+    end
+
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table"
+            and not group.parentContainerId
+            and group.isGlobal ~= true
+            and (globalFolders[group.folderId] or EntityHasPortableEligibility(group))
+        then
+            group.isGlobal = true
+            globalized = globalized + 1
+        end
+    end
+
+    return globalized
+end
+
 local function RemapCurrentCharacterEntities(profile, charKey, exporterCharKey)
     if type(profile) ~= "table" or type(charKey) ~= "string" or charKey == "" then
         return
@@ -366,6 +478,7 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
         local importerCharInfo = db.global and db.global.characterInfo or {}
         RenameForeignCharacters(db.profile, charKey, exportedCharInfo, importerCharInfo)
     end
+    local globalizedEligibilityImports = GlobalizePortableCharacterScopedEligibility(db.profile)
 
     if self.ClearMigrationSentinels then
         self:ClearMigrationSentinels()
@@ -388,6 +501,9 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     end
     if strippedCharacterEligibility > 0 and self.Print then
         self:Print("Character eligibility is local and was not imported.")
+    end
+    if globalizedEligibilityImports > 0 and self.Print then
+        self:Print("Class, specialization, and hero talent eligibility were preserved in Global Groups.")
     end
 
     return true

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -564,12 +564,14 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     local globalizedEligibilityImports = GlobalizePortableCharacterScopedEligibility(db.profile)
 
     self._resourceBarImportCharacterInfo = exportedCharInfo
+    self._resourceBarImportExporterCharKey = exporterCharKey
 
     if self.ClearMigrationSentinels then
         self:ClearMigrationSentinels()
     end
     local migrationsOk = not self.RunAllMigrations or self:RunAllMigrations()
     self._resourceBarImportCharacterInfo = nil
+    self._resourceBarImportExporterCharKey = nil
     if not migrationsOk then
         return false
     end

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -16,7 +16,6 @@ local PROFILE_IMPORT_METADATA_KEYS = {
 }
 
 local SCOPED_STORE_KEYS = {
-    "resourceBarsByChar",
     "castBarByChar",
     "frameAnchoringByChar",
 }
@@ -564,10 +563,14 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     end
     local globalizedEligibilityImports = GlobalizePortableCharacterScopedEligibility(db.profile)
 
+    self._resourceBarImportCharacterInfo = exportedCharInfo
+
     if self.ClearMigrationSentinels then
         self:ClearMigrationSentinels()
     end
-    if self.RunAllMigrations and not self:RunAllMigrations() then
+    local migrationsOk = not self.RunAllMigrations or self:RunAllMigrations()
+    self._resourceBarImportCharacterInfo = nil
+    if not migrationsOk then
         return false
     end
     if self.SanitizeCursorAnchorPolicy then

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -63,10 +63,65 @@ local function EntityHasPortableEligibility(entity)
             or HasPortableEligibilityMap(loadConditions.specAllowlist))
 end
 
-local function ContainerHasPortableEligibility(profile, containerId, container)
+local function AddIndexedEntity(indexMap, key, entity)
+    if key == nil then return end
+    local bucket = indexMap[key]
+    if not bucket then
+        bucket = {}
+        indexMap[key] = bucket
+    end
+    bucket[#bucket + 1] = entity
+end
+
+local function BuildPortableEligibilityIndex(profile)
+    local index = {
+        panelsByContainerId = {},
+        looseGroupsByFolderId = {},
+        containersByFolderId = {},
+    }
+    if type(profile) ~= "table" then return index end
+
+    local groups = type(profile.groups) == "table" and profile.groups or {}
+    for _, group in pairs(groups) do
+        if type(group) == "table" then
+            if group.parentContainerId ~= nil then
+                AddIndexedEntity(index.panelsByContainerId, group.parentContainerId, group)
+            elseif group.folderId ~= nil then
+                AddIndexedEntity(index.looseGroupsByFolderId, group.folderId, group)
+            end
+        end
+    end
+
+    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+    for containerId, container in pairs(groupContainers) do
+        if type(container) == "table" and container.folderId ~= nil then
+            AddIndexedEntity(index.containersByFolderId, container.folderId, {
+                id = containerId,
+                container = container,
+            })
+        end
+    end
+
+    return index
+end
+
+local function ContainerHasPortableEligibility(profile, containerId, container, eligibilityIndex)
     if EntityHasPortableEligibility(container) then
         return true
     end
+
+    local indexedGroups = eligibilityIndex and eligibilityIndex.panelsByContainerId[containerId]
+    if indexedGroups then
+        for _, group in ipairs(indexedGroups) do
+            if EntityHasPortableEligibility(group) then
+                return true
+            end
+        end
+        return false
+    elseif eligibilityIndex then
+        return false
+    end
+
     local groups = type(profile.groups) == "table" and profile.groups or {}
     for _, group in pairs(groups) do
         if type(group) == "table"
@@ -79,19 +134,42 @@ local function ContainerHasPortableEligibility(profile, containerId, container)
     return false
 end
 
-local function FolderHasPortableEligibility(profile, folderId, folder)
+local function FolderHasPortableEligibility(profile, folderId, folder, eligibilityIndex)
     if EntityHasPortableEligibility(folder) then
         return true
     end
-    local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
-    for containerId, container in pairs(groupContainers) do
-        if type(container) == "table"
-            and container.folderId == folderId
-            and ContainerHasPortableEligibility(profile, containerId, container)
-        then
-            return true
+
+    local indexedContainers = eligibilityIndex and eligibilityIndex.containersByFolderId[folderId]
+    if indexedContainers then
+        for _, entry in ipairs(indexedContainers) do
+            if ContainerHasPortableEligibility(profile, entry.id, entry.container, eligibilityIndex) then
+                return true
+            end
+        end
+    elseif not eligibilityIndex then
+        local groupContainers = type(profile.groupContainers) == "table" and profile.groupContainers or {}
+        for containerId, container in pairs(groupContainers) do
+            if type(container) == "table"
+                and container.folderId == folderId
+                and ContainerHasPortableEligibility(profile, containerId, container)
+            then
+                return true
+            end
         end
     end
+
+    local indexedLooseGroups = eligibilityIndex and eligibilityIndex.looseGroupsByFolderId[folderId]
+    if indexedLooseGroups then
+        for _, group in ipairs(indexedLooseGroups) do
+            if EntityHasPortableEligibility(group) then
+                return true
+            end
+        end
+        return false
+    elseif eligibilityIndex then
+        return false
+    end
+
     local groups = type(profile.groups) == "table" and profile.groups or {}
     for _, group in pairs(groups) do
         if type(group) == "table"
@@ -110,11 +188,12 @@ local function GlobalizePortableCharacterScopedEligibility(profile)
 
     local globalized = 0
     local globalFolders = {}
+    local eligibilityIndex = BuildPortableEligibilityIndex(profile)
     local folders = type(profile.folders) == "table" and profile.folders or {}
     for folderId, folder in pairs(folders) do
         if type(folder) == "table"
             and folder.section == "char"
-            and FolderHasPortableEligibility(profile, folderId, folder)
+            and FolderHasPortableEligibility(profile, folderId, folder, eligibilityIndex)
         then
             folder.section = "global"
             globalFolders[folderId] = true
@@ -127,7 +206,7 @@ local function GlobalizePortableCharacterScopedEligibility(profile)
         if type(container) == "table"
             and container.isGlobal ~= true
             and (globalFolders[container.folderId]
-                or ContainerHasPortableEligibility(profile, containerId, container))
+                or ContainerHasPortableEligibility(profile, containerId, container, eligibilityIndex))
         then
             container.isGlobal = true
             globalized = globalized + 1
@@ -326,7 +405,12 @@ local function BuildForeignCharacterRenames(foreignKeys, exportedCharInfo, impor
     for foreignKey in pairs(foreignKeys) do
         local info = type(exportedCharInfo) == "table" and exportedCharInfo[foreignKey] or nil
         local classID = info and info.classID
-        local className = classID and GetClassInfo(classID) or "Character"
+        local classInfo = classID and C_CreatureInfo and C_CreatureInfo.GetClassInfo
+            and C_CreatureInfo.GetClassInfo(classID)
+            or nil
+        local className = type(classInfo) == "table" and classInfo.className
+            or (classID and GetClassInfo and GetClassInfo(classID))
+            or "Character"
         classCounts[className] = (classCounts[className] or 0) + 1
         classEntries[foreignKey] = {
             className = className,

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -7,10 +7,12 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 
 local ResetConfigSelection = ST._ResetConfigSelection
+local StripCharacterEligibilityFromProfile = ST._StripCharacterEligibilityFromProfile
 
 local PROFILE_IMPORT_METADATA_KEYS = {
     _exporterCharKey = true,
     _characterInfo = true,
+    _cdcCharacterEligibilityStripped = true,
 }
 
 local SCOPED_STORE_KEYS = {
@@ -341,7 +343,11 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
         exportedCharInfo = data._characterInfo
     end
 
+    local strippedCharacterEligibility = tonumber(data._cdcCharacterEligibilityStripped) or 0
     CopyProfileDataIntoActiveProfile(db.profile, data)
+    strippedCharacterEligibility = strippedCharacterEligibility + (StripCharacterEligibilityFromProfile
+        and StripCharacterEligibilityFromProfile(db.profile)
+        or 0)
 
     if ResetConfigSelection then
         ResetConfigSelection(true)
@@ -379,6 +385,9 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
     end
     if self.EvaluateBarsAndFramesRuntime then
         self:EvaluateBarsAndFramesRuntime(options.runtimeReason or "profile-import")
+    end
+    if strippedCharacterEligibility > 0 and self.Print then
+        self:Print("Character eligibility is local and was not imported.")
     end
 
     return true

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -13,6 +13,7 @@ local PROFILE_IMPORT_METADATA_KEYS = {
     _exporterCharKey = true,
     _characterInfo = true,
     _cdcCharacterEligibilityStripped = true,
+    resourceBarMigration = true,
 }
 
 local SCOPED_STORE_KEYS = {

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -162,6 +162,21 @@ local function MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, create
     end
 end
 
+local function MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, entity)
+    local allowlist = type(entity) == "table"
+        and type(entity.loadConditions) == "table"
+        and entity.loadConditions.characterAllowlist
+        or nil
+    if type(allowlist) ~= "table" then
+        return
+    end
+    for allowlistKey, enabled in pairs(allowlist) do
+        if enabled == true then
+            MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, allowlistKey)
+        end
+    end
+end
+
 local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
     local foreignKeys = {}
     if type(profile.groups) == "table" then
@@ -169,6 +184,7 @@ local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
             if type(group) == "table" and not group.isGlobal then
                 MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, group.createdBy)
             end
+            MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, group)
         end
     end
     if type(profile.groupContainers) == "table" then
@@ -176,6 +192,7 @@ local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
             if type(container) == "table" and not container.isGlobal then
                 MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, container.createdBy)
             end
+            MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, container)
         end
     end
     if type(profile.folders) == "table" then
@@ -183,6 +200,7 @@ local function CollectForeignCharacterKeys(profile, importerCharInfo, charKey)
             if type(folder) == "table" and folder.section == "char" then
                 MarkForeignCharKey(foreignKeys, importerCharInfo, charKey, folder.createdBy)
             end
+            MarkForeignAllowlistKeys(foreignKeys, importerCharInfo, charKey, folder)
         end
     end
     return foreignKeys
@@ -227,11 +245,31 @@ local function BuildForeignCharacterRenames(foreignKeys, exportedCharInfo, impor
 end
 
 local function ApplyCharacterRenames(profile, renames)
+    local function RenameAllowlist(entity)
+        local allowlist = type(entity) == "table"
+            and type(entity.loadConditions) == "table"
+            and entity.loadConditions.characterAllowlist
+            or nil
+        if type(allowlist) ~= "table" then
+            return
+        end
+        for oldKey, newKey in pairs(renames or {}) do
+            if allowlist[oldKey] == true then
+                allowlist[newKey] = true
+                allowlist[oldKey] = nil
+            end
+        end
+        if not next(allowlist) then
+            entity.loadConditions.characterAllowlist = nil
+        end
+    end
+
     if type(profile.groups) == "table" then
         for _, group in pairs(profile.groups) do
             if type(group) == "table" and group.createdBy and renames[group.createdBy] then
                 group.createdBy = renames[group.createdBy]
             end
+            RenameAllowlist(group)
         end
     end
     if type(profile.groupContainers) == "table" then
@@ -239,6 +277,7 @@ local function ApplyCharacterRenames(profile, renames)
             if type(container) == "table" and container.createdBy and renames[container.createdBy] then
                 container.createdBy = renames[container.createdBy]
             end
+            RenameAllowlist(container)
         end
     end
     if type(profile.folders) == "table" then
@@ -246,6 +285,7 @@ local function ApplyCharacterRenames(profile, renames)
             if type(folder) == "table" and folder.createdBy and renames[folder.createdBy] then
                 folder.createdBy = renames[folder.createdBy]
             end
+            RenameAllowlist(folder)
         end
     end
 end
@@ -309,6 +349,11 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
 
     local charKey = db.keys and db.keys.char
     RemapCurrentCharacterEntities(db.profile, charKey, exporterCharKey)
+    if type(exporterCharKey) == "string" and exporterCharKey ~= ""
+        and type(charKey) == "string" and charKey ~= ""
+    then
+        ApplyCharacterRenames(db.profile, { [exporterCharKey] = charKey })
+    end
     RemapCharacterScopedStores(db.profile, charKey, exporterCharKey)
 
     if options.renameForeignCharacters then

--- a/CooldownCompanion_Config/Config/ProfileImportPieces.lua
+++ b/CooldownCompanion_Config/Config/ProfileImportPieces.lua
@@ -632,6 +632,9 @@ local function AddCustomBarInfo(infos, profile, settings, sourceStoreKey, entryK
     end
     local rawId = type(entry.customBarId) == "string" and entry.customBarId ~= "" and entry.customBarId
         or (type(entryKey) == "string" and entryKey or nil)
+    if rawId and options.skipRawIds and options.skipRawIds[rawId] then
+        return
+    end
     local specs = CollectEntrySpecs(entry, options.fallbackSpecID)
     local layouts = CollectCustomBarLayouts(settings, rawId)
     if options.legacyAuraSlots then
@@ -693,6 +696,7 @@ local function AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey,
                     sourceCharacterInfo = options.sourceCharacterInfo,
                     sourceClassKey = options.sourceClassKey,
                     infoByRawId = options.infoByRawId,
+                    skipRawIds = options.skipRawIds,
                     order = order,
                 })
             end
@@ -707,6 +711,7 @@ local function AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey,
                 sourceCharacterInfo = options.sourceCharacterInfo,
                 sourceClassKey = options.sourceClassKey,
                 infoByRawId = options.infoByRawId,
+                skipRawIds = options.skipRawIds,
                 order = order,
             })
         end
@@ -731,6 +736,7 @@ local function AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreK
                         fallbackSpecID = specID,
                         infoByRawId = options.infoByRawId,
                         legacyAuraSlots = options.legacyAuraSlots,
+                        skipRawIds = options.skipRawIds,
                         order = order,
                     })
                 end
@@ -743,9 +749,10 @@ local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceC
     local infos = {}
     local classStores = type(profile) == "table" and profile.resourceBarsByClass or nil
     local legacyStores = type(profile) == "table" and profile.resourceBarsByChar or nil
-    local resolvedClassStores = {}
+    local classStoreRawIds = {}
 
     local function addFromSettings(sourceStoreKey, settings, options)
+        local initialCount = #infos
         if type(settings) == "table" then
             local infoByRawId = {}
             local customBars = settings.customBars
@@ -756,6 +763,7 @@ local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceC
                     sourceCharacterInfo = options.sourceCharacterInfo,
                     sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
+                    skipRawIds = options.skipRawIds,
                 })
             elseif type(customBars) == "table" then
                 AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreKey, customBars, {
@@ -764,6 +772,7 @@ local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceC
                     sourceCharacterInfo = options.sourceCharacterInfo,
                     sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
+                    skipRawIds = options.skipRawIds,
                 })
             end
             if type(settings.customAuraBars) == "table" then
@@ -774,22 +783,33 @@ local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceC
                     sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
                     legacyAuraSlots = true,
+                    skipRawIds = options.skipRawIds,
                 })
             end
+            if options.recordRawIds then
+                for rawId in pairs(infoByRawId) do
+                    options.recordRawIds[rawId] = true
+                end
+            end
         end
+        return #infos > initialCount
     end
 
     if type(classStores) == "table" then
         for sourceClassKey, settings in pairs(classStores) do
             local normalizedClassKey = NormalizeClassKey(sourceClassKey)
             if normalizedClassKey and type(settings) == "table" then
-                resolvedClassStores[normalizedClassKey] = true
-                addFromSettings(normalizedClassKey, settings, {
+                local rawIds = {}
+                local added = addFromSettings(normalizedClassKey, settings, {
                     currentCharKey = currentCharKey,
                     currentInfo = currentInfo,
                     sourceCharacterInfo = sourceCharacterInfo,
                     sourceClassKey = normalizedClassKey,
+                    recordRawIds = rawIds,
                 })
+                if added then
+                    classStoreRawIds[normalizedClassKey] = rawIds
+                end
             end
         end
     end
@@ -798,13 +818,12 @@ local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceC
         for sourceStoreKey, settings in pairs(legacyStores) do
             local ownerInfo = GetOwnerInfo(profile, sourceStoreKey, sourceCharacterInfo)
             local ownerClassKey = ClassKeyFromInfo(ownerInfo)
-            if not ownerClassKey or not resolvedClassStores[ownerClassKey] then
-                addFromSettings(sourceStoreKey, settings, {
-                    currentCharKey = currentCharKey,
-                    currentInfo = currentInfo,
-                    sourceCharacterInfo = sourceCharacterInfo,
-                })
-            end
+            addFromSettings(sourceStoreKey, settings, {
+                currentCharKey = currentCharKey,
+                currentInfo = currentInfo,
+                sourceCharacterInfo = sourceCharacterInfo,
+                skipRawIds = ownerClassKey and classStoreRawIds[ownerClassKey] or nil,
+            })
         end
     end
 
@@ -1084,9 +1103,6 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
 
     local selectedFolders, selectedContainers, selectedPanels, selectedCustomBars, deselectedContainers, deselectedPanels = SelectionSets(model)
     local selectedCustomBarsPayload = BuildSelectedCustomBarsPayload(model, selectedCustomBars)
-    if selectedCustomBarsPayload and ShouldBlockSelectedCustomBarsImport() then
-        return false
-    end
 
     local importedContainers = {}
     local batchToken = BeginImportBatch()
@@ -1144,7 +1160,9 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
         failed = failed or not ok
     end
 
-    if selectedCustomBarsPayload then
+    if selectedCustomBarsPayload and ShouldBlockSelectedCustomBarsImport() then
+        failed = true
+    elseif selectedCustomBarsPayload then
         local ok = ApplyCustomBarsPayload(profile, selectedCustomBarsPayload)
         applied = ok or applied
         failed = failed or not ok

--- a/CooldownCompanion_Config/Config/ProfileImportPieces.lua
+++ b/CooldownCompanion_Config/Config/ProfileImportPieces.lua
@@ -330,15 +330,40 @@ local function GetOwnerInfo(profile, ownerKey, sourceCharacterInfo)
     return type(globalInfo) == "table" and globalInfo[ownerKey] or nil
 end
 
+local function NormalizeClassKey(classKey)
+    if type(classKey) ~= "string" or classKey == "" then return nil end
+    return string.upper(classKey)
+end
+
 local function ClassesMatch(currentInfo, ownerInfo)
     if type(currentInfo) ~= "table" or type(ownerInfo) ~= "table" then
         return nil
     end
-    if currentInfo.classFilename and ownerInfo.classFilename then
-        return currentInfo.classFilename == ownerInfo.classFilename
+    local currentClassKey = NormalizeClassKey(currentInfo.classFilename or currentInfo.classFile or currentInfo.className)
+    local ownerClassKey = NormalizeClassKey(ownerInfo.classFilename or ownerInfo.classFile or ownerInfo.className)
+    if currentClassKey and ownerClassKey then
+        return currentClassKey == ownerClassKey
     end
     if currentInfo.classID and ownerInfo.classID then
         return currentInfo.classID == ownerInfo.classID
+    end
+    return nil
+end
+
+local function ClassKeyFromInfo(info)
+    if type(info) ~= "table" then return nil end
+    local classKey = NormalizeClassKey(info.classFilename or info.classFile or info.className)
+    if classKey then return classKey end
+    local classID = tonumber(info.classID)
+    if classID and C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return NormalizeClassKey(classInfo.classFile)
+        end
+    end
+    if classID and GetClassInfo then
+        local _, classFilename = GetClassInfo(classID)
+        return NormalizeClassKey(classFilename)
     end
     return nil
 end
@@ -347,7 +372,7 @@ local function ClassLabel(info)
     if type(info) ~= "table" then
         return "Unknown class"
     end
-    return info.classFilename or (info.classID and ("Class " .. tostring(info.classID))) or "Unknown class"
+    return info.classFilename or info.classFile or (info.classID and ("Class " .. tostring(info.classID))) or "Unknown class"
 end
 
 local function ResolveOwnerKey(entity, defaultOwnerKey)
@@ -372,6 +397,18 @@ local function BuildEligibility(profile, ownerKey, currentCharKey, currentInfo, 
     end
     if matches == nil then
         return false, false, "Source class unknown"
+    end
+    return true, true, nil
+end
+
+local function BuildClassStoreEligibility(sourceClassKey, currentInfo)
+    sourceClassKey = NormalizeClassKey(sourceClassKey)
+    local currentClassKey = ClassKeyFromInfo(currentInfo)
+    if not sourceClassKey or not currentClassKey then
+        return false, false, "Source class unknown"
+    end
+    if sourceClassKey ~= currentClassKey then
+        return false, false, sourceClassKey .. " content"
     end
     return true, true, nil
 end
@@ -580,13 +617,18 @@ local function AddCustomBarInfo(infos, profile, settings, sourceStoreKey, entryK
     end
     options = options or {}
     local ownerKey = sourceStoreKey
-    local eligible, selected, reason = BuildEligibility(
-        profile,
-        ownerKey,
-        options.currentCharKey,
-        options.currentInfo,
-        options.sourceCharacterInfo
-    )
+    local eligible, selected, reason
+    if options.sourceClassKey then
+        eligible, selected, reason = BuildClassStoreEligibility(options.sourceClassKey, options.currentInfo)
+    else
+        eligible, selected, reason = BuildEligibility(
+            profile,
+            ownerKey,
+            options.currentCharKey,
+            options.currentInfo,
+            options.sourceCharacterInfo
+        )
+    end
     local rawId = type(entry.customBarId) == "string" and entry.customBarId ~= "" and entry.customBarId
         or (type(entryKey) == "string" and entryKey or nil)
     local specs = CollectEntrySpecs(entry, options.fallbackSpecID)
@@ -648,6 +690,7 @@ local function AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey,
                     currentCharKey = options.currentCharKey,
                     currentInfo = options.currentInfo,
                     sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
                     infoByRawId = options.infoByRawId,
                     order = order,
                 })
@@ -661,6 +704,7 @@ local function AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey,
                 currentCharKey = options.currentCharKey,
                 currentInfo = options.currentInfo,
                 sourceCharacterInfo = options.sourceCharacterInfo,
+                sourceClassKey = options.sourceClassKey,
                 infoByRawId = options.infoByRawId,
                 order = order,
             })
@@ -682,6 +726,7 @@ local function AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreK
                         currentCharKey = options.currentCharKey,
                         currentInfo = options.currentInfo,
                         sourceCharacterInfo = options.sourceCharacterInfo,
+                        sourceClassKey = options.sourceClassKey,
                         fallbackSpecID = specID,
                         infoByRawId = options.infoByRawId,
                         legacyAuraSlots = options.legacyAuraSlots,
@@ -695,37 +740,68 @@ end
 
 local function BuildCustomBarInfos(profile, currentCharKey, currentInfo, sourceCharacterInfo)
     local infos = {}
-    local stores = type(profile) == "table" and profile.resourceBarsByChar or nil
-    if type(stores) ~= "table" then
-        return infos
-    end
+    local classStores = type(profile) == "table" and profile.resourceBarsByClass or nil
+    local legacyStores = type(profile) == "table" and profile.resourceBarsByChar or nil
+    local resolvedClassStores = {}
 
-    for sourceStoreKey, settings in pairs(stores) do
+    local function addFromSettings(sourceStoreKey, settings, options)
         if type(settings) == "table" then
             local infoByRawId = {}
             local customBars = settings.customBars
             if IsSharedCustomBarsStore(customBars) then
                 AddSharedCustomBarInfos(infos, profile, settings, sourceStoreKey, customBars, {
-                    currentCharKey = currentCharKey,
-                    currentInfo = currentInfo,
-                    sourceCharacterInfo = sourceCharacterInfo,
+                    currentCharKey = options.currentCharKey,
+                    currentInfo = options.currentInfo,
+                    sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
                 })
             elseif type(customBars) == "table" then
                 AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreKey, customBars, {
-                    currentCharKey = currentCharKey,
-                    currentInfo = currentInfo,
-                    sourceCharacterInfo = sourceCharacterInfo,
+                    currentCharKey = options.currentCharKey,
+                    currentInfo = options.currentInfo,
+                    sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
                     infoByRawId = infoByRawId,
                 })
             end
             if type(settings.customAuraBars) == "table" then
                 AddSpecKeyedCustomBarInfos(infos, profile, settings, sourceStoreKey, settings.customAuraBars, {
+                    currentCharKey = options.currentCharKey,
+                    currentInfo = options.currentInfo,
+                    sourceCharacterInfo = options.sourceCharacterInfo,
+                    sourceClassKey = options.sourceClassKey,
+                    infoByRawId = infoByRawId,
+                    legacyAuraSlots = true,
+                })
+            end
+        end
+    end
+
+    if type(classStores) == "table" then
+        for sourceClassKey, settings in pairs(classStores) do
+            local normalizedClassKey = NormalizeClassKey(sourceClassKey)
+            if normalizedClassKey and type(settings) == "table" then
+                resolvedClassStores[normalizedClassKey] = true
+                addFromSettings(normalizedClassKey, settings, {
                     currentCharKey = currentCharKey,
                     currentInfo = currentInfo,
                     sourceCharacterInfo = sourceCharacterInfo,
-                    infoByRawId = infoByRawId,
-                    legacyAuraSlots = true,
+                    sourceClassKey = normalizedClassKey,
+                })
+            end
+        end
+    end
+
+    if type(legacyStores) == "table" then
+        for sourceStoreKey, settings in pairs(legacyStores) do
+            local ownerInfo = GetOwnerInfo(profile, sourceStoreKey, sourceCharacterInfo)
+            local ownerClassKey = ClassKeyFromInfo(ownerInfo)
+            if not ownerClassKey or not resolvedClassStores[ownerClassKey] then
+                addFromSettings(sourceStoreKey, settings, {
+                    currentCharKey = currentCharKey,
+                    currentInfo = currentInfo,
+                    sourceCharacterInfo = sourceCharacterInfo,
                 })
             end
         end

--- a/CooldownCompanion_Config/Config/ProfileImportPieces.lua
+++ b/CooldownCompanion_Config/Config/ProfileImportPieces.lua
@@ -9,6 +9,7 @@ local CooldownCompanion = ST.Addon
 local BuildGroupExportData = ST._BuildGroupExportData
 local BuildContainerExportData = ST._BuildContainerExportData
 local ApplyCustomBarsImportData = ST._ApplyCustomBarsImportData
+local BlockCustomBarsImportForResourceBarConflict = ST._BlockCustomBarsImportForResourceBarConflict
 
 local EMPTY_TABLE = {}
 local CUSTOM_BAR_CONTENT_FIELDS = {
@@ -1034,6 +1035,12 @@ local function ApplyCustomBarsPayload(profile, payload)
     }) == true
 end
 
+local function ShouldBlockSelectedCustomBarsImport()
+    local block = BlockCustomBarsImportForResourceBarConflict
+        or ST._BlockCustomBarsImportForResourceBarConflict
+    return block and block() == true
+end
+
 local function SetChildSelection(row, selected)
     if not (row and row.eligible) then
         return
@@ -1076,6 +1083,11 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
     end
 
     local selectedFolders, selectedContainers, selectedPanels, selectedCustomBars, deselectedContainers, deselectedPanels = SelectionSets(model)
+    local selectedCustomBarsPayload = BuildSelectedCustomBarsPayload(model, selectedCustomBars)
+    if selectedCustomBarsPayload and ShouldBlockSelectedCustomBarsImport() then
+        return false
+    end
+
     local importedContainers = {}
     local batchToken = BeginImportBatch()
     local applied = false
@@ -1132,7 +1144,6 @@ function CooldownCompanion:ApplyProfileImportPieces(profile, model)
         failed = failed or not ok
     end
 
-    local selectedCustomBarsPayload = BuildSelectedCustomBarsPayload(model, selectedCustomBars)
     if selectedCustomBarsPayload then
         local ok = ApplyCustomBarsPayload(profile, selectedCustomBarsPayload)
         applied = ok or applied

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -3017,8 +3017,14 @@ local function CharacterInfoClassKey(charKey)
         return string.upper(info.classFilename)
     end
     local classID = tonumber(info.classID)
-    if classID and GetClassInfo then
-        local _, classFilename = GetClassInfo(classID)
+    if classID then
+        local classInfo = C_CreatureInfo and C_CreatureInfo.GetClassInfo
+            and C_CreatureInfo.GetClassInfo(classID)
+            or nil
+        local classFilename = type(classInfo) == "table" and classInfo.classFile or nil
+        if not classFilename and GetClassInfo then
+            classFilename = select(2, GetClassInfo(classID))
+        end
         if type(classFilename) == "string" and classFilename ~= "" then
             return string.upper(classFilename)
         end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -1972,7 +1972,10 @@ local function SetupFolderRowIndicators(entry, folder)
 
     local badgeIndex = 0
     local SPEC_BADGE_SIZE = 16
-    local specs = folder and folder.specs
+    local specs = folder and BuildEligibilityBadgeMap(
+        folder.specs,
+        folder.loadConditions and folder.loadConditions.specAllowlist
+    )
     if specs and next(specs) then
         for specId in pairs(specs) do
             local _, _, _, specIcon = GetSpecializationInfoForSpecID(specId)

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -2903,24 +2903,53 @@ end
 local function SpecSetHasForeignSpecs(specs, playerSpecIds)
     if not specs then return false end
     for specId in pairs(specs) do
-        if not playerSpecIds[specId] then
+        local normalizedSpecId = tonumber(specId)
+        if normalizedSpecId and not playerSpecIds[normalizedSpecId] then
             return true
         end
     end
     return false
 end
 
-local function GetEffectiveContainerSpecFilter(container, db)
-    if not container then return nil end
-    return container.specs
+local function BuildPlayerClassKey()
+    if not UnitClass then return nil end
+    local _, classFilename = UnitClass("player")
+    return type(classFilename) == "string" and string.upper(classFilename) or nil
+end
+
+local function ClassAllowlistHasForeignClasses(classAllowlist, playerClassKey)
+    if type(classAllowlist) ~= "table" or not playerClassKey then return false end
+    for classKey, enabled in pairs(classAllowlist) do
+        if enabled == true
+            and type(classKey) == "string"
+            and string.upper(classKey) ~= playerClassKey
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey)
+    if type(entity) ~= "table" then return false end
+    local loadConditions = entity.loadConditions
+    return SpecSetHasForeignSpecs(entity.specs, playerSpecIds)
+        or SpecSetHasForeignSpecs(
+            type(loadConditions) == "table" and loadConditions.specAllowlist or nil,
+            playerSpecIds
+        )
+        or ClassAllowlistHasForeignClasses(
+            type(loadConditions) == "table" and loadConditions.classAllowlist or nil,
+            playerClassKey
+        )
 end
 
 local function ContainersHaveForeignSpecs(containers, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
+    local playerClassKey = BuildPlayerClassKey()
     for _, c in ipairs(containers) do
         if not requireGlobal or c.isGlobal then
-            local effectiveSpecs = GetEffectiveContainerSpecFilter(c)
-            if SpecSetHasForeignSpecs(effectiveSpecs, playerSpecIds) then
+            if EntityHasForeignEligibility(c, playerSpecIds, playerClassKey) then
                 return true
             end
         end
@@ -2930,9 +2959,10 @@ end
 
 local function GroupsHaveForeignSpecs(groups, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
+    local playerClassKey = BuildPlayerClassKey()
     for _, g in ipairs(groups) do
         if not requireGlobal or g.isGlobal then
-            if SpecSetHasForeignSpecs(g.specs, playerSpecIds) then
+            if EntityHasForeignEligibility(g, playerSpecIds, playerClassKey) then
                 return true
             end
         end
@@ -2948,12 +2978,16 @@ local function FolderHasForeignSpecs(folderId)
     if not folder then return false end
 
     local playerSpecIds = BuildPlayerSpecSet()
+    local playerClassKey = BuildPlayerClassKey()
+    if EntityHasForeignEligibility(folder, playerSpecIds, playerClassKey) then
+        return true
+    end
     -- Post-migration: specs live on containers, not folders
     local containers = db.groupContainers
     if containers then
         for _, container in pairs(containers) do
             if container.folderId == folderId then
-                if SpecSetHasForeignSpecs(container.specs, playerSpecIds) then
+                if EntityHasForeignEligibility(container, playerSpecIds, playerClassKey) then
                     return true
                 end
             end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -550,6 +550,8 @@ local function IsConfigFinderActive()
     return IsConfigFinderAvailable() and NormalizeConfigFinderText(CS.configSearchText) ~= ""
 end
 
+local ClearConfigPrimarySelection
+
 local function SetConfigFinderText(text, opts)
     text = type(text) == "string" and text or ""
     local wasSearching = NormalizeConfigFinderText(CS.configSearchText) ~= ""
@@ -562,6 +564,9 @@ local function SetConfigFinderText(text, opts)
     end
     CS.configSearchText = text
     if wasSearching and not willSearch and CS.otherClassLibraryActive then
+        if not (opts and opts.preservePrimarySelection) and ClearConfigPrimarySelection then
+            ClearConfigPrimarySelection()
+        end
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
     end
@@ -701,18 +706,31 @@ end
 
 local RefreshAlphaDriverForConfigSelection
 
-local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
-    CooldownCompanion:ClearAllConfigPreviews()
+local function ResolveConfigContainerClassScope(containerId)
     local selectedContainer = containerId
         and CooldownCompanion.db
         and CooldownCompanion.db.profile
         and CooldownCompanion.db.profile.groupContainers
         and CooldownCompanion.db.profile.groupContainers[containerId]
         or nil
-    local selectedScope = selectedContainer
-        and CooldownCompanion.ResolveContainerClassScope
-        and CooldownCompanion:ResolveContainerClassScope(selectedContainer)
-        or nil
+    if not (selectedContainer and CooldownCompanion.ResolveContainerClassScope) then
+        return nil
+    end
+    return CooldownCompanion:ResolveContainerClassScope(selectedContainer)
+end
+
+local function RestoreOtherClassLibraryForScope(scope)
+    if scope and scope.isOtherClass then
+        CS.otherClassLibraryActive = true
+        CS.otherClassLibraryClassKey = scope.ownerClassKey
+        return true
+    end
+    return false
+end
+
+local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
+    CooldownCompanion:ClearAllConfigPreviews()
+    local selectedScope = ResolveConfigContainerClassScope(containerId)
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
     wipe(CS.selectedButtons)
@@ -725,11 +743,8 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CS.selectedButton = buttonIndex
     CS.selectedRotationAssistantEntry = nil
     CS.addingToPanelId = nil
-    ClearConfigFinderText()
-    if selectedScope and selectedScope.isOtherClass then
-        CS.otherClassLibraryActive = true
-        CS.otherClassLibraryClassKey = selectedScope.ownerClassKey
-    end
+    ClearConfigFinderText({ preservePrimarySelection = true })
+    RestoreOtherClassLibraryForScope(selectedScope)
     RefreshAlphaDriverForConfigSelection()
     CooldownCompanion:RefreshConfigPanel()
 end
@@ -2548,7 +2563,7 @@ local function ClearConfigResourceSelection()
     CS.resourceSettingsSpecID = nil
 end
 
-local function ClearConfigPrimarySelection()
+ClearConfigPrimarySelection = function()
     CooldownCompanion:ClearAllConfigPreviews()
     CS.selectedFolder = nil
     CS.selectedContainer = nil
@@ -2593,7 +2608,9 @@ local function SelectConfigContainer(containerId, opts)
     ClearSelectedButton()
     wipe(CS.selectedPanels)
     if opts and opts.clearFinder then
-        ClearConfigFinderText()
+        local selectedScope = ResolveConfigContainerClassScope(CS.selectedContainer)
+        ClearConfigFinderText({ preservePrimarySelection = true })
+        RestoreOtherClassLibraryForScope(selectedScope)
     end
     RefreshAlphaDriverForConfigSelection()
 end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -228,6 +228,10 @@ ST._configState = {
     -- Column content frames
     col1Scroll = nil,
     col1ButtonBar = nil,
+    col1FooterDoorway = nil,
+    col1FooterDoorwayVisible = false,
+    lastCol1FooterDoorwayRow = nil,
+    UpdateColumn1FooterLayout = nil,
     col2Scroll = nil,
     col2ButtonBar = nil,
     col4Container = nil,
@@ -257,12 +261,6 @@ ST._configState = {
     col2PanelTypeMenu = nil,
     charCopyMenu = nil,
 
-    -- Cross-character browse mode
-    browseMode = false,
-    browseCharKey = nil,
-    browseContainerId = nil,
-    browseContextMenu = nil,
-
     -- Drag-reorder state
     dragState = nil,
     dragIndicator = nil,
@@ -281,6 +279,8 @@ ST._configState = {
     collapsedSections = {},
     collapsedFolders = {},
     collapsedPanels = {},
+    otherClassLibraryActive = false,
+    otherClassLibraryClassKey = nil,
     panelClickTimes = {},
     addingToPanelId = nil,
     folderAccentBars = {},
@@ -298,10 +298,6 @@ ST._configState = {
     configFinderBox = nil,
     configFinderSuppressTextChanged = false,
     compactConfigRows = false,
-
-    -- Spec filter inline expansion
-    specExpandedGroupId = nil,
-    specExpandedFolderId = nil,
 
     -- Auto Add flow state (Column 3 wizard mode)
     autoAddFlowActive = false,
@@ -550,7 +546,6 @@ end
 
 local function IsConfigFinderAvailable()
     return not CS.resourceBarPanelActive
-        and not CS.browseMode
         and not CS.talentPickerMode
         and not CooldownCompanion._unsupportedLegacyProfile
 end
@@ -561,6 +556,8 @@ end
 
 local function SetConfigFinderText(text, opts)
     text = type(text) == "string" and text or ""
+    local wasSearching = NormalizeConfigFinderText(CS.configSearchText) ~= ""
+    local willSearch = NormalizeConfigFinderText(text) ~= ""
     if CS.configSearchText ~= text then
         CS._configFinderResults = nil
         CS._configFinderResultsQuery = nil
@@ -568,6 +565,10 @@ local function SetConfigFinderText(text, opts)
         CS._configFinderResultsCharKey = nil
     end
     CS.configSearchText = text
+    if wasSearching and not willSearch and CS.otherClassLibraryActive then
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
+    end
 
     if opts and opts.syncWidget == false then
         return
@@ -598,6 +599,10 @@ end
 local function IsContainerVisibleInConfig(container, charKey)
     if not container then
         return false
+    end
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(container)
+        return scope.isInvalid ~= true
     end
     return container.isGlobal or container.createdBy == charKey
 end
@@ -2877,10 +2882,8 @@ local function ResetConfigSelection(full)
         wipe(CS.selectedGroups)
         wipe(CS.selectedCustomBars)
         CS.addingToPanelId = nil
-        -- Exit browse mode on full reset
-        CS.browseMode = false
-        CS.browseCharKey = nil
-        CS.browseContainerId = nil
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
     end
     RefreshAlphaDriverForConfigSelection()
 end
@@ -2899,12 +2902,16 @@ local function SetConfigPrimaryMode(mode, opts)
     if toBars and not wasBars then
         -- Preserve existing behavior when entering Bars & Frames mode.
         ResetConfigSelection(true)
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
     elseif (not toBars) and wasBars then
         -- Stop preview loops when returning to button settings mode.
         CooldownCompanion:ClearAllConfigPreviews()
         CS.selectedCustomBarId = nil
         CS.customBarSettingsTab = "appearance"
         ClearConfigResourceSelection()
+        CS.otherClassLibraryActive = false
+        CS.otherClassLibraryClassKey = nil
     end
 
     CS.resourceBarPanelActive = toBars

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -703,6 +703,16 @@ local RefreshAlphaDriverForConfigSelection
 
 local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CooldownCompanion:ClearAllConfigPreviews()
+    local selectedContainer = containerId
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groupContainers
+        and CooldownCompanion.db.profile.groupContainers[containerId]
+        or nil
+    local selectedScope = selectedContainer
+        and CooldownCompanion.ResolveContainerClassScope
+        and CooldownCompanion:ResolveContainerClassScope(selectedContainer)
+        or nil
     wipe(CS.selectedGroups)
     wipe(CS.selectedPanels)
     wipe(CS.selectedButtons)
@@ -716,6 +726,10 @@ local function SelectConfigFinderResult(containerId, panelId, buttonIndex)
     CS.selectedRotationAssistantEntry = nil
     CS.addingToPanelId = nil
     ClearConfigFinderText()
+    if selectedScope and selectedScope.isOtherClass then
+        CS.otherClassLibraryActive = true
+        CS.otherClassLibraryClassKey = selectedScope.ownerClassKey
+    end
     RefreshAlphaDriverForConfigSelection()
     CooldownCompanion:RefreshConfigPanel()
 end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -1829,6 +1829,23 @@ local function AcquireBadge(frame, index)
     return badge
 end
 
+local function BuildEligibilityBadgeMap(...)
+    local badgeMap
+    for i = 1, select("#", ...) do
+        local source = select(i, ...)
+        if type(source) == "table" then
+            for key, enabled in pairs(source) do
+                local numericKey = tonumber(key)
+                if enabled == true and numericKey then
+                    badgeMap = badgeMap or {}
+                    badgeMap[numericKey] = true
+                end
+            end
+        end
+    end
+    return badgeMap
+end
+
 local function SetupGroupRowIndicators(entry, group)
     local frame = entry.frame
     if frame._cdcBadges then
@@ -1875,14 +1892,20 @@ local function SetupGroupRowIndicators(entry, group)
             and CooldownCompanion.db.profile.folders
         local folder = folders and folders[folderId]
         if folder then
-            folderSpecs = folder.specs
+            folderSpecs = BuildEligibilityBadgeMap(
+                folder.specs,
+                folder.loadConditions and folder.loadConditions.specAllowlist
+            )
             folderHeroTalents = folder.heroTalents
         end
     end
 
     -- Spec filter badges: show own specs, skip any that exist at folder level
     local SPEC_BADGE_SIZE = 16
-    local specs = group.specs
+    local specs = BuildEligibilityBadgeMap(
+        group.specs,
+        group.loadConditions and group.loadConditions.specAllowlist
+    )
     if specs then
         for specId in pairs(specs) do
             if not (folderSpecs and folderSpecs[specId]) then
@@ -2911,10 +2934,56 @@ local function SpecSetHasForeignSpecs(specs, playerSpecIds)
     return false
 end
 
+local function BuildPlayerHeroTalentSet(playerSpecIds)
+    local playerHeroTalentIds = {}
+    if not (C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
+        return playerHeroTalentIds, false
+    end
+    for specId in pairs(playerSpecIds or {}) do
+        local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+        for _, subTreeID in ipairs(subTreeIDs or {}) do
+            local normalizedSubTreeID = tonumber(subTreeID)
+            if normalizedSubTreeID then
+                playerHeroTalentIds[normalizedSubTreeID] = true
+            end
+        end
+    end
+    return playerHeroTalentIds, true
+end
+
+local function HasEnabledMapValue(map)
+    if type(map) ~= "table" then return false end
+    for _, enabled in pairs(map) do
+        if enabled == true then return true end
+    end
+    return false
+end
+
+local function HeroTalentSetHasForeignHeroTalents(heroTalents, playerHeroTalentIds, hasHeroTalentData)
+    if type(heroTalents) ~= "table" then return false end
+    if not hasHeroTalentData then
+        return HasEnabledMapValue(heroTalents)
+    end
+    for subTreeID, enabled in pairs(heroTalents) do
+        local normalizedSubTreeID = tonumber(subTreeID)
+        if enabled == true and (not normalizedSubTreeID or not playerHeroTalentIds[normalizedSubTreeID]) then
+            return true
+        end
+    end
+    return false
+end
+
 local function BuildPlayerClassKey()
     if not UnitClass then return nil end
     local _, classFilename = UnitClass("player")
     return type(classFilename) == "string" and string.upper(classFilename) or nil
+end
+
+local function BuildPlayerCharacterKey()
+    return CooldownCompanion.db
+        and CooldownCompanion.db.keys
+        and CooldownCompanion.db.keys.char
+        or nil
 end
 
 local function ClassAllowlistHasForeignClasses(classAllowlist, playerClassKey)
@@ -2930,10 +2999,50 @@ local function ClassAllowlistHasForeignClasses(classAllowlist, playerClassKey)
     return false
 end
 
-local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey)
+local function CharacterInfoClassKey(charKey)
+    local info = charKey
+        and CooldownCompanion.db
+        and CooldownCompanion.db.global
+        and CooldownCompanion.db.global.characterInfo
+        and CooldownCompanion.db.global.characterInfo[charKey]
+        or nil
+    if type(info) ~= "table" then return nil end
+    if type(info.classFilename) == "string" and info.classFilename ~= "" then
+        return string.upper(info.classFilename)
+    end
+    local classID = tonumber(info.classID)
+    if classID and GetClassInfo then
+        local _, classFilename = GetClassInfo(classID)
+        if type(classFilename) == "string" and classFilename ~= "" then
+            return string.upper(classFilename)
+        end
+    end
+    return nil
+end
+
+local function CharacterAllowlistHasForeignClasses(characterAllowlist, playerClassKey, playerCharKey)
+    if type(characterAllowlist) ~= "table" or not playerClassKey then return false end
+    for charKey, enabled in pairs(characterAllowlist) do
+        if enabled == true then
+            if type(charKey) ~= "string" or charKey == "" then
+                return true
+            end
+            if not (playerCharKey and charKey == playerCharKey) then
+                local characterClassKey = CharacterInfoClassKey(charKey)
+                if characterClassKey ~= playerClassKey then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
     if type(entity) ~= "table" then return false end
     local loadConditions = entity.loadConditions
     return SpecSetHasForeignSpecs(entity.specs, playerSpecIds)
+        or HeroTalentSetHasForeignHeroTalents(entity.heroTalents, playerHeroTalentIds, hasHeroTalentData)
         or SpecSetHasForeignSpecs(
             type(loadConditions) == "table" and loadConditions.specAllowlist or nil,
             playerSpecIds
@@ -2942,14 +3051,54 @@ local function EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey
             type(loadConditions) == "table" and loadConditions.classAllowlist or nil,
             playerClassKey
         )
+        or CharacterAllowlistHasForeignClasses(
+            type(loadConditions) == "table" and loadConditions.characterAllowlist or nil,
+            playerClassKey,
+            playerCharKey
+        )
+end
+
+local function FindContainerId(db, container)
+    if not (db and db.groupContainers and type(container) == "table") then return nil end
+    for containerId, candidate in pairs(db.groupContainers) do
+        if candidate == container then
+            return containerId
+        end
+    end
+    return nil
+end
+
+local function ContainerPanelsHaveForeignEligibility(containerId, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    if not (db and db.groups and containerId) then return false end
+    for _, group in pairs(db.groups) do
+        if type(group) == "table"
+            and group.parentContainerId == containerId
+            and EntityHasForeignEligibility(group, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+local function EntityOrChildPanelsHaveForeignEligibility(entity, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
+    if EntityHasForeignEligibility(entity, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
+        return true
+    end
+    local db = CooldownCompanion.db and CooldownCompanion.db.profile
+    local containerId = FindContainerId(db, entity)
+    return ContainerPanelsHaveForeignEligibility(containerId, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData)
 end
 
 local function ContainersHaveForeignSpecs(containers, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
     local playerClassKey = BuildPlayerClassKey()
+    local playerCharKey = BuildPlayerCharacterKey()
+    local playerHeroTalentIds, hasHeroTalentData = BuildPlayerHeroTalentSet(playerSpecIds)
     for _, c in ipairs(containers) do
         if not requireGlobal or c.isGlobal then
-            if EntityHasForeignEligibility(c, playerSpecIds, playerClassKey) then
+            if EntityOrChildPanelsHaveForeignEligibility(c, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
                 return true
             end
         end
@@ -2960,9 +3109,11 @@ end
 local function GroupsHaveForeignSpecs(groups, requireGlobal)
     local playerSpecIds = BuildPlayerSpecSet()
     local playerClassKey = BuildPlayerClassKey()
+    local playerCharKey = BuildPlayerCharacterKey()
+    local playerHeroTalentIds, hasHeroTalentData = BuildPlayerHeroTalentSet(playerSpecIds)
     for _, g in ipairs(groups) do
         if not requireGlobal or g.isGlobal then
-            if EntityHasForeignEligibility(g, playerSpecIds, playerClassKey) then
+            if EntityOrChildPanelsHaveForeignEligibility(g, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
                 return true
             end
         end
@@ -2979,7 +3130,9 @@ local function FolderHasForeignSpecs(folderId)
 
     local playerSpecIds = BuildPlayerSpecSet()
     local playerClassKey = BuildPlayerClassKey()
-    if EntityHasForeignEligibility(folder, playerSpecIds, playerClassKey) then
+    local playerCharKey = BuildPlayerCharacterKey()
+    local playerHeroTalentIds, hasHeroTalentData = BuildPlayerHeroTalentSet(playerSpecIds)
+    if EntityHasForeignEligibility(folder, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
         return true
     end
     -- Post-migration: specs live on containers, not folders
@@ -2987,7 +3140,7 @@ local function FolderHasForeignSpecs(folderId)
     if containers then
         for _, container in pairs(containers) do
             if container.folderId == folderId then
-                if EntityHasForeignEligibility(container, playerSpecIds, playerClassKey) then
+                if EntityOrChildPanelsHaveForeignEligibility(container, playerSpecIds, playerClassKey, playerCharKey, playerHeroTalentIds, hasHeroTalentData) then
                     return true
                 end
             end
@@ -3055,6 +3208,7 @@ ST._ApplyConfigRowIcon = ApplyConfigRowIcon
 ST._ApplyConfigTextRow = ApplyConfigTextRow
 ST._RefreshVisibleConfigCompactRows = RefreshVisibleConfigCompactRows
 ST._AcquireBadge = AcquireBadge
+ST._BuildEligibilityBadgeMap = BuildEligibilityBadgeMap
 ST._SetupGroupRowIndicators = SetupGroupRowIndicators
 ST._SetupFolderRowIndicators = SetupFolderRowIndicators
 ST._GetConfigRowBadgeReserve = GetConfigRowBadgeReserve

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -228,10 +228,6 @@ ST._configState = {
     -- Column content frames
     col1Scroll = nil,
     col1ButtonBar = nil,
-    col1FooterDoorway = nil,
-    col1FooterDoorwayVisible = false,
-    lastCol1FooterDoorwayRow = nil,
-    UpdateColumn1FooterLayout = nil,
     col2Scroll = nil,
     col2ButtonBar = nil,
     col4Container = nil,

--- a/CooldownCompanion_Config/Config/TalentPicker.lua
+++ b/CooldownCompanion_Config/Config/TalentPicker.lua
@@ -547,8 +547,10 @@ local function EnsurePickerViewConfig(specID)
 end
 
 local function BuildSpecDropdownOptions(group)
-    local effectiveSpecs = group and CooldownCompanion:GetEffectiveSpecs(group) or nil
-    local hasSpecFilter = effectiveSpecs and next(effectiveSpecs) ~= nil
+    local effectiveSpecs, _, hasSpecFilter
+    if group then
+        effectiveSpecs, _, hasSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
+    end
     local values = {}
     local order = {}
 
@@ -568,8 +570,10 @@ local function BuildHeroDropdownOptions(configID, specID, group)
         return {}, {}, nil
     end
 
-    local effectiveHeroTalents = group and CooldownCompanion:GetEffectiveHeroTalents(group) or nil
-    local hasHeroFilter = effectiveHeroTalents and next(effectiveHeroTalents) ~= nil
+    local effectiveHeroTalents, _, hasHeroFilter
+    if group then
+        effectiveHeroTalents, _, hasHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
+    end
     local values = {}
     local order = {}
     local preferredSubTreeID = nil

--- a/CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua
@@ -65,8 +65,6 @@ local function BuildContext(extra)
         selectedCustomBarId = CS.selectedCustomBarId,
         selectedResourcePowerType = CS.selectedResourcePowerType,
         resourceSettingsSpecID = CS.resourceSettingsSpecID,
-        browseMode = BoolValue(CS.browseMode),
-        browseCharKey = CS.browseCharKey,
         autoAddFlowActive = BoolValue(CS.autoAddFlowActive),
         talentPickerMode = BoolValue(CS.talentPickerMode),
     }

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -1272,7 +1272,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         effectiveSpecs = opts.effectiveSpecs,
         choiceSpecMap = opts.choiceSpecMap,
     })
-    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+    local specById = BuildSpecChoiceIndex(specChoices)
 
     local specValues = {}
     local specOrder = {}
@@ -1314,7 +1314,7 @@ local function AddClassSpecEligibilityControls(container, opts)
     if type(heroTalentsSource) ~= "table" then
         heroTalentsSource = nil
     end
-    local heroChoices, heroById = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+    local heroChoices = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
     local heroValues = {}
     local heroOrder = {}
     local heroSortLabels = {}
@@ -1434,7 +1434,7 @@ local function AddActiveClassSpecEligibilityRows(rows, opts)
         effectiveSpecs = opts.effectiveSpecs,
         choiceSpecMap = opts.choiceSpecMap,
     })
-    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+    local _, specsByClassKey = BuildSpecChoiceIndex(specChoices)
     local configID = opts.configID or (C_ClassTalents and C_ClassTalents.GetActiveConfigID and C_ClassTalents.GetActiveConfigID())
     local heroTalentsSource = opts.useHeroTalentsSource and opts.heroTalentsSource or target.heroTalents
     if type(heroTalentsSource) ~= "table" then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -574,6 +574,66 @@ local function AttachEligibilityTooltip(widget, title, text)
     end)
 end
 
+local function AddDropdownInfoButton(dropdown, tooltipLines)
+    if not (dropdown and dropdown.frame and dropdown.label and tooltipLines) then return end
+    CreateInfoButton(dropdown.frame, dropdown.label, "LEFT", "RIGHT", 4, 0, tooltipLines, dropdown)
+end
+
+local function GetEligibilitySubjectLabel(opts)
+    return opts and opts.eligibilitySubjectLabel or "selection"
+end
+
+local function GetEligibilitySubjectPluralLabel(opts)
+    return opts and opts.eligibilitySubjectPluralLabel
+        or ((GetEligibilitySubjectLabel(opts)) .. "s")
+end
+
+local function BuildCharacterEligibilityTooltip(subjectLabel)
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    return {
+        "Character Eligibility",
+        {"Choose which characters can use this " .. subjectLabel .. ".", 1, 1, 1, true},
+        " ",
+        {"Leave empty for no character limit.", 1, 1, 1, true},
+        " ",
+        {"Class-scoped " .. subjectPluralLabel .. " only show same-class characters.", 1, 1, 1, true},
+    }
+end
+
+local function BuildClassEligibilityTooltip(subjectLabel)
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    return {
+        "Class Eligibility",
+        {"Global " .. subjectPluralLabel .. " can be limited to selected classes.", 1, 1, 1, true},
+        " ",
+        {"Leave empty to allow all classes.", 1, 1, 1, true},
+        " ",
+        {"Pick a class first to add its specializations.", 1, 1, 1, true},
+    }
+end
+
+local function BuildSpecializationEligibilityTooltip(subjectLabel)
+    return {
+        "Specialization Eligibility",
+        {"Limit this " .. subjectLabel .. " to selected specializations.", 1, 1, 1, true},
+        " ",
+        {"Specializations come from eligible classes.", 1, 1, 1, true},
+        " ",
+        {"Leave empty to allow all specs for those classes.", 1, 1, 1, true},
+    }
+end
+
+local function BuildHeroTalentEligibilityTooltip(subjectLabel)
+    return {
+        "Hero Talent Eligibility",
+        {"Limit this " .. subjectLabel .. " to specific hero talent trees.", 1, 1, 1, true},
+        " ",
+        {"Hero talents come from selected specializations.", 1, 1, 1, true},
+        " ",
+        {"Leave empty to allow any hero talent for that spec.", 1, 1, 1, true},
+    }
+end
+
 local function ResolveOwnerClassChoice(opts)
     if opts.ownerClassChoice then
         return opts.ownerClassChoice
@@ -777,6 +837,7 @@ end
 local function AddCharacterEligibilityControls(container, opts)
     local target = opts.target
     if type(target) ~= "table" then return end
+    local subjectLabel = GetEligibilitySubjectLabel(opts)
 
     local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "characterAllowlist", "character")
     local scopeClassChoice
@@ -847,6 +908,7 @@ local function AddCharacterEligibilityControls(container, opts)
     picker:SetLabel("Add Character")
     picker:SetFullWidth(true)
     picker:SetList(dropdownValues, dropdownOrder)
+    AddDropdownInfoButton(picker, BuildCharacterEligibilityTooltip(subjectLabel))
     if #dropdownOrder == 0 then
         picker:SetDisabled(true)
     else
@@ -862,11 +924,6 @@ local function AddCharacterEligibilityControls(container, opts)
     SortChoices(selected)
 
     if #selected == 0 then
-        local unrestrictedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
-        unrestrictedLabel:SetText("|cff888888No local character restriction.|r")
-        unrestrictedLabel:SetFullWidth(true)
-        container:AddChild(unrestrictedLabel)
         return
     end
 
@@ -1082,17 +1139,59 @@ end
 
 local function FormatEligibilitySpecLabel(specInfo, includeClass)
     if not specInfo then return "" end
+    local classKey = specInfo.classKey
+    if not classKey then
+        local classChoice = GetSpecClassChoice(specInfo.id)
+        classKey = classChoice and classChoice.key or nil
+    end
+    local specLabel = WrapClassColoredText(specInfo.name or specInfo.label or tostring(specInfo.id), classKey)
     if includeClass and specInfo.classLabel then
         local classChoice = GetClassChoiceByFilename(specInfo.classKey)
         local classLabel = GetClassDisplayLabel(classChoice) or specInfo.classLabel
-        return classLabel .. ": " .. (specInfo.name or specInfo.label or tostring(specInfo.id))
+        return classLabel .. ": " .. specLabel
     end
-    return specInfo.name or specInfo.label or tostring(specInfo.id)
+    return specLabel
+end
+
+local function FormatSpecIconPrefix(specInfo)
+    local icon = specInfo and specInfo.icon
+    if not icon then return "" end
+    return ("|T%s:14:14:0:0:64:64:5:59:5:59|t "):format(tostring(icon))
+end
+
+local function FormatSpecDropdownLabel(specInfo)
+    local label = specInfo and specInfo.label or ""
+    if specInfo and specInfo.classKey then
+        label = WrapClassColoredText(label, specInfo.classKey)
+    end
+    return FormatSpecIconPrefix(specInfo) .. label
+end
+
+local function FormatEligibilitySpecRowLabel(specInfo, includeClass)
+    return FormatSpecIconPrefix(specInfo) .. FormatEligibilitySpecLabel(specInfo, includeClass)
+end
+
+local function FormatHeroTalentIconPrefix(heroInfo)
+    local atlas = heroInfo and heroInfo.iconAtlas
+    if not atlas then return "" end
+    return ("|A:%s:14:14|a "):format(tostring(atlas))
+end
+
+local function FormatEligibilityHeroName(heroInfo)
+    return FormatHeroTalentIconPrefix(heroInfo) .. (heroInfo and (heroInfo.label or tostring(heroInfo.id)) or "")
 end
 
 local function FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
     local specLabel = FormatEligibilitySpecLabel(specInfo, includeClass)
-    return specLabel .. " - " .. (heroInfo.label or tostring(heroInfo.id))
+    return specLabel .. " - " .. FormatEligibilityHeroName(heroInfo)
+end
+
+local function FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, includeClass)
+    return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
+end
+
+local function FormatEligibilityHeroRowLabel(heroInfo, specInfo, includeClass)
+    return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
 end
 
 local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
@@ -1123,6 +1222,7 @@ local function AddClassSpecEligibilityControls(container, opts)
     opts = opts or {}
     local target = opts.target
     if type(target) ~= "table" then return end
+    local subjectLabel = GetEligibilitySubjectLabel(opts)
 
     local allowClassEligibility = opts.allowClassEligibility == true
     local scopeClassChoice
@@ -1165,6 +1265,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         classPicker:SetLabel("Add Class")
         classPicker:SetFullWidth(true)
         classPicker:SetList(classValues, classOrder)
+        AddDropdownInfoButton(classPicker, BuildClassEligibilityTooltip(subjectLabel))
         if #classOrder == 0 then
             classPicker:SetDisabled(true)
         else
@@ -1200,7 +1301,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         local localSelected = type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true
         local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
         if specId and not localSelected and not outsideAllowed then
-            specValues[specId] = specInfo.label
+            specValues[specId] = FormatSpecDropdownLabel(specInfo)
             specSortLabels[specId] = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId))
             specOrder[#specOrder + 1] = specId
         end
@@ -1209,17 +1310,12 @@ local function AddClassSpecEligibilityControls(container, opts)
         return tostring(specSortLabels[a] or a) < tostring(specSortLabels[b] or b)
     end)
 
-    if #specChoices == 0 then
-        local emptyLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(emptyLabel)
-        emptyLabel:SetText(allowClassEligibility and "|cff888888Select a class to choose specialization eligibility.|r" or "|cff888888No specializations available for this scope.|r")
-        emptyLabel:SetFullWidth(true)
-        container:AddChild(emptyLabel)
-    else
+    if #specChoices > 0 then
         local specPicker = AceGUI:Create("Dropdown")
         specPicker:SetLabel("Add Specialization")
         specPicker:SetFullWidth(true)
         specPicker:SetList(specValues, specOrder)
+        AddDropdownInfoButton(specPicker, BuildSpecializationEligibilityTooltip(subjectLabel))
         if #specOrder == 0 then
             specPicker:SetDisabled(true)
         else
@@ -1246,7 +1342,7 @@ local function AddClassSpecEligibilityControls(container, opts)
             local selected = type(heroTalentsSource) == "table" and heroTalentsSource[heroInfo.id] == true
             if not selected then
                 local specInfo = specById[heroInfo.specId]
-                heroValues[heroInfo.id] = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility)
+                heroValues[heroInfo.id] = FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, allowClassEligibility)
                 heroSortLabels[heroInfo.id] = (heroInfo.classLabel or "") .. (heroInfo.specLabel or "") .. (heroInfo.label or "")
                 heroOrder[#heroOrder + 1] = heroInfo.id
             end
@@ -1261,6 +1357,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         heroPicker:SetLabel("Add Hero Talent")
         heroPicker:SetFullWidth(true)
         heroPicker:SetList(heroValues, heroOrder)
+        AddDropdownInfoButton(heroPicker, BuildHeroTalentEligibilityTooltip(subjectLabel))
         if #heroOrder == 0 then
             heroPicker:SetDisabled(true)
         else
@@ -1330,7 +1427,7 @@ local function AddClassSpecEligibilityControls(container, opts)
                 end)
                 for _, heroInfo in ipairs(heroRows) do
                     rows[#rows + 1] = {
-                        label = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility),
+                        label = FormatEligibilityHeroRowLabel(heroInfo, specInfo, allowClassEligibility),
                         sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
                         disabled = opts.disableHeroTalents == true,
                         onRemove = function()
@@ -1342,7 +1439,7 @@ local function AddClassSpecEligibilityControls(container, opts)
             else
                 local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
                 rows[#rows + 1] = {
-                    label = FormatEligibilitySpecLabel(specInfo, allowClassEligibility)
+                    label = FormatEligibilitySpecRowLabel(specInfo, allowClassEligibility)
                         .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or ""),
                     sortLabel = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId)),
                     onRemove = function()
@@ -1361,13 +1458,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         return tostring(a.sortLabel or a.label) < tostring(b.sortLabel or b.label)
     end)
 
-    if #rows == 0 then
-        local unrestrictedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
-        unrestrictedLabel:SetText(allowClassEligibility and "|cff888888No local class or specialization restriction.|r" or "|cff888888No local specialization restriction.|r")
-        unrestrictedLabel:SetFullWidth(true)
-        container:AddChild(unrestrictedLabel)
-    else
+    if #rows > 0 then
         for _, row in ipairs(rows) do
             AddEligibilitySelectedRow(container, row, row.onRemove)
         end
@@ -2812,6 +2903,7 @@ local function BuildLoadConditionsTab(container)
     AddCharacterEligibilityControls(container, {
         target = group,
         inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "panel",
         allowClassEligibility = scopeIsGlobal,
         ownerCharKey = ownerCharKey,
         characterCollapsedKey = "loadconditions_panel_character",
@@ -2845,6 +2937,7 @@ local function BuildLoadConditionsTab(container)
         AddClassSpecEligibilityControls(container, {
             target = group,
             inheritedSources = inheritedSources,
+            eligibilitySubjectLabel = "panel",
             allowClassEligibility = scopeIsGlobal,
             ownerCharKey = ownerCharKey,
             useSpecAllowlist = inheritedSpecFilter,

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -475,7 +475,18 @@ local function GetClassChoiceByFilename(classFilename)
 end
 
 local function GetCurrentClassChoice()
-    local className, classFilename, classID = UnitClass("player")
+    local classFilename = CooldownCompanion._playerClassFilename
+    local classID = CooldownCompanion._playerClassID
+    local className
+    if classID and GetClassInfo then
+        className = GetClassInfo(classID)
+    end
+    if (not classFilename or not className) and UnitClass then
+        local unitClassName, unitClassFilename, unitClassID = UnitClass("player")
+        className = className or unitClassName
+        classFilename = classFilename or unitClassFilename
+        classID = classID or unitClassID
+    end
     local classKey = NormalizeAllowlistKey("class", classFilename)
     if not classKey then return nil end
     return {
@@ -518,13 +529,16 @@ local function SplitCharacterKey(charKey)
     return charKey, nil
 end
 
-local function GetCharacterEligibilityInfo(charKey)
+local function GetCharacterEligibilityInfo(charKey, fallbackInfo)
     local db = CooldownCompanion.db
     local info = charKey
         and db and db.global and db.global.characterInfo
         and db.global.characterInfo[charKey]
     if type(info) == "table" then
         return info
+    end
+    if type(fallbackInfo) == "table" and fallbackInfo.charKey == charKey then
+        return fallbackInfo
     end
 
     local characters = CooldownCompanion.EnumerateActiveProfileCharacters
@@ -538,8 +552,8 @@ local function GetCharacterEligibilityInfo(charKey)
     return nil
 end
 
-local function BuildCharacterChoice(charKey)
-    local info = GetCharacterEligibilityInfo(charKey)
+local function BuildCharacterChoice(charKey, fallbackInfo)
+    local info = GetCharacterEligibilityInfo(charKey, fallbackInfo)
     local name, realm = SplitCharacterKey(charKey)
     local classFilename = info and NormalizeAllowlistKey("class", info.classFilename)
     local label = WrapClassColoredText(name, classFilename)
@@ -583,13 +597,12 @@ local function GetEligibilitySubjectLabel(opts)
     return opts and opts.eligibilitySubjectLabel or "selection"
 end
 
-local function GetEligibilitySubjectPluralLabel(opts)
-    return opts and opts.eligibilitySubjectPluralLabel
-        or ((GetEligibilitySubjectLabel(opts)) .. "s")
+local function GetEligibilitySubjectPluralLabel(subjectLabel)
+    return (subjectLabel or "selection") .. "s"
 end
 
 local function BuildCharacterEligibilityTooltip(subjectLabel)
-    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel(subjectLabel)
     return {
         "Character Eligibility",
         {"Choose which characters can use this " .. subjectLabel .. ".", 1, 1, 1, true},
@@ -601,7 +614,7 @@ local function BuildCharacterEligibilityTooltip(subjectLabel)
 end
 
 local function BuildClassEligibilityTooltip(subjectLabel)
-    local subjectPluralLabel = GetEligibilitySubjectPluralLabel({ eligibilitySubjectLabel = subjectLabel })
+    local subjectPluralLabel = GetEligibilitySubjectPluralLabel(subjectLabel)
     return {
         "Class Eligibility",
         {"Global " .. subjectPluralLabel .. " can be limited to selected classes.", 1, 1, 1, true},
@@ -704,7 +717,7 @@ local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerC
         and CooldownCompanion:EnumerateActiveProfileCharacters()
         or {}
     for _, info in ipairs(characters) do
-        local choice = BuildCharacterChoice(info.charKey)
+        local choice = BuildCharacterChoice(info.charKey, info)
         choice.classFilename = choice.classFilename or info.classFilename
         choice.classID = choice.classID or info.classID
         if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
@@ -834,6 +847,30 @@ local function CreateEligibilityRemoveBadge(onRemove)
     return removeBadge
 end
 
+local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
+    local row = AceGUI:Create("SimpleGroup")
+    row:SetFullWidth(true)
+    row:SetLayout("Flow")
+
+    local label = AceGUI:Create("Label")
+    label:SetText(rowInfo.label)
+    label:SetRelativeWidth(0.92)
+    AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
+    row:AddChild(label)
+
+    if rowInfo.disabled then
+        local locked = AceGUI:Create("Label")
+        locked:SetText("|cff888888locked|r")
+        locked:SetRelativeWidth(0.1)
+        row:AddChild(locked)
+    else
+        local removeBtn = CreateEligibilityRemoveBadge(onRemove)
+        row:AddChild(removeBtn)
+    end
+
+    container:AddChild(row)
+end
+
 local function AddCharacterEligibilityControls(container, opts)
     local target = opts.target
     if type(target) ~= "table" then return end
@@ -928,23 +965,10 @@ local function AddCharacterEligibilityControls(container, opts)
     end
 
     for _, choice in ipairs(selected) do
-        local row = AceGUI:Create("SimpleGroup")
-        row:SetFullWidth(true)
-        row:SetLayout("Flow")
-
-        local label = AceGUI:Create("Label")
-        label:SetText(choice.label)
-        label:SetRelativeWidth(0.92)
-        AttachEligibilityTooltip(label, choice.tooltipTitle or choice.label, choice.tooltipText)
-        row:AddChild(label)
-
-        local removeBtn = CreateEligibilityRemoveBadge(function()
+        AddEligibilitySelectedRow(container, choice, function()
             SetAllowlistValue(target, "characterAllowlist", "character", choice.key, false)
             if opts.onChanged then opts.onChanged() end
         end)
-        row:AddChild(removeBtn)
-
-        container:AddChild(row)
     end
 end
 
@@ -1186,36 +1210,8 @@ local function FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
     return specLabel .. " - " .. FormatEligibilityHeroName(heroInfo)
 end
 
-local function FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, includeClass)
+local function FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, includeClass)
     return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
-end
-
-local function FormatEligibilityHeroRowLabel(heroInfo, specInfo, includeClass)
-    return FormatSpecIconPrefix(specInfo) .. FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
-end
-
-local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
-    local row = AceGUI:Create("SimpleGroup")
-    row:SetFullWidth(true)
-    row:SetLayout("Flow")
-
-    local label = AceGUI:Create("Label")
-    label:SetText(rowInfo.label)
-    label:SetRelativeWidth(0.92)
-    AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
-    row:AddChild(label)
-
-    if rowInfo.disabled then
-        local locked = AceGUI:Create("Label")
-        locked:SetText("|cff888888locked|r")
-        locked:SetRelativeWidth(0.1)
-        row:AddChild(locked)
-    else
-        local removeBtn = CreateEligibilityRemoveBadge(onRemove)
-        row:AddChild(removeBtn)
-    end
-
-    container:AddChild(row)
 end
 
 local function AddClassSpecEligibilityControls(container, opts)
@@ -1342,7 +1338,7 @@ local function AddClassSpecEligibilityControls(container, opts)
             local selected = type(heroTalentsSource) == "table" and heroTalentsSource[heroInfo.id] == true
             if not selected then
                 local specInfo = specById[heroInfo.specId]
-                heroValues[heroInfo.id] = FormatEligibilityHeroDropdownLabel(heroInfo, specInfo, allowClassEligibility)
+                heroValues[heroInfo.id] = FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility)
                 heroSortLabels[heroInfo.id] = (heroInfo.classLabel or "") .. (heroInfo.specLabel or "") .. (heroInfo.label or "")
                 heroOrder[#heroOrder + 1] = heroInfo.id
             end
@@ -1427,7 +1423,7 @@ local function AddClassSpecEligibilityControls(container, opts)
                 end)
                 for _, heroInfo in ipairs(heroRows) do
                     rows[#rows + 1] = {
-                        label = FormatEligibilityHeroRowLabel(heroInfo, specInfo, allowClassEligibility),
+                        label = FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility),
                         sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
                         disabled = opts.disableHeroTalents == true,
                         onRemove = function()
@@ -2999,8 +2995,6 @@ ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
 ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
 ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
-ST._SetSpecFilterValue = SetSpecFilterValue
-ST._SetSpecAllowlistValue = SetSpecAllowlistValue
 ST._AddCharacterEligibilityControls = AddCharacterEligibilityControls
 ST._AddClassSpecEligibilityControls = AddClassSpecEligibilityControls
 ST._GetConditionDisplayName = GetConditionDisplayName

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -958,7 +958,7 @@ local function BuildEligibilitySpecChoices(opts)
 
         AddClassesForSpecMap(classChoices, classByKey, target.specs)
         AddClassesForSpecMap(classChoices, classByKey, target.loadConditions and target.loadConditions.specAllowlist)
-        AddClassesForSpecMap(classChoices, classByKey, opts.effectiveSpecs)
+        AddClassesForSpecMap(classChoices, classByKey, opts.choiceSpecMap or opts.effectiveSpecs)
     else
         local choice = ResolveOwnerClassChoice(opts)
         if choice then
@@ -1202,6 +1202,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         ownerClassID = opts.ownerClassID,
         ownerClassFilename = opts.ownerClassFilename,
         effectiveSpecs = opts.effectiveSpecs,
+        choiceSpecMap = opts.choiceSpecMap,
     })
     local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
 
@@ -2786,7 +2787,8 @@ local function BuildLoadConditionsTab(container)
             vehicleUI = true,
         }
     end
-    local effectiveSpecs, inheritedSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
+    local effectiveSpecs = CooldownCompanion:GetEffectiveSpecs(group)
+    local inheritedSpecs, inheritedSpecFilter = CooldownCompanion:GetInheritedEffectiveSpecs(group)
     local effectiveHeroTalents, inheritedHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
     local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group)
     local parentContainer = CooldownCompanion:GetParentContainer(group)
@@ -2854,8 +2856,9 @@ local function BuildLoadConditionsTab(container)
             ownerCharKey = ownerCharKey,
             useSpecAllowlist = inheritedSpecFilter,
             allowedSpecRestricted = inheritedSpecFilter,
-            allowedSpecMap = effectiveSpecs,
+            allowedSpecMap = inheritedSpecs,
             effectiveSpecs = effectiveSpecs,
+            choiceSpecMap = inheritedSpecs,
             heroTalentsSource = effectiveHeroTalents,
             useHeroTalentsSource = inheritedHeroFilter,
             disableHeroTalents = inheritedHeroFilter,

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -1085,7 +1085,19 @@ local function GetSpecSelectionMap(target, useSpecAllowlist)
     if useSpecAllowlist then
         return target.loadConditions and target.loadConditions.specAllowlist
     end
-    return target.specs
+    local specs = CopyAllowlist(target.specs, "spec")
+    local loadConditionSpecs = CopyAllowlist(
+        target.loadConditions and target.loadConditions.specAllowlist,
+        "spec"
+    )
+    if not loadConditionSpecs then
+        return specs
+    end
+    specs = specs or {}
+    for specId in pairs(loadConditionSpecs) do
+        specs[specId] = true
+    end
+    return next(specs) and specs or nil
 end
 
 local function SetSpecEligibilityValue(target, specId, value, useSpecAllowlist)

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -25,6 +25,7 @@ local appearanceTabElements = CS.appearanceTabElements
 
 local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
 local REMOVE_BADGE_WIDGET_TYPE = "CDCEligibilityRemoveBadge"
+local ACTIVE_FILTER_ROW_HEIGHT = 22
 local VIEW_TRAIT_CONFIG_ID = (Constants and Constants.TraitConsts and Constants.TraitConsts.VIEW_TRAIT_CONFIG_ID) or -3
 
 if AceGUI and not AceGUI:GetWidgetVersion(REMOVE_BADGE_WIDGET_TYPE) then
@@ -779,11 +780,16 @@ local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
     local row = AceGUI:Create("SimpleGroup")
     row:SetFullWidth(true)
     row:SetLayout("Flow")
+    row:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
 
     local hasTooltip = rowInfo.tooltipText and rowInfo.tooltipText ~= ""
     local label = AceGUI:Create(hasTooltip and "InteractiveLabel" or "Label")
     label:SetText(rowInfo.label)
     label:SetRelativeWidth(0.92)
+    label:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
+    if label.SetFontObject and GameFontHighlight then
+        label:SetFontObject(GameFontHighlight)
+    end
     AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
     row:AddChild(label)
 
@@ -791,13 +797,22 @@ local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
         local locked = AceGUI:Create("Label")
         locked:SetText("|cff888888locked|r")
         locked:SetRelativeWidth(0.1)
+        locked:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
+        if locked.SetFontObject and GameFontHighlight then
+            locked:SetFontObject(GameFontHighlight)
+        end
         row:AddChild(locked)
     else
         local removeBtn = CreateEligibilityRemoveBadge(onRemove)
+        removeBtn:SetHeight(ACTIVE_FILTER_ROW_HEIGHT)
         row:AddChild(removeBtn)
     end
 
     container:AddChild(row)
+end
+
+local function FormatActiveEligibilityLabel(category, value)
+    return "|cffffd100" .. tostring(category or "Filter") .. ":|r " .. tostring(value or "")
 end
 
 local function AddCharacterEligibilityControls(container, opts)
@@ -885,17 +900,6 @@ local function AddCharacterEligibilityControls(container, opts)
     container:AddChild(picker)
 
     SortChoices(selected)
-
-    if #selected == 0 then
-        return
-    end
-
-    for _, choice in ipairs(selected) do
-        AddEligibilitySelectedRow(container, choice, function()
-            SetAllowlistValue(target, "characterAllowlist", "character", choice.key, false)
-            if opts.onChanged then opts.onChanged() end
-        end)
-    end
 end
 
 local function AddClassForSpecId(classChoices, classByKey, specId)
@@ -1352,7 +1356,92 @@ local function AddClassSpecEligibilityControls(container, opts)
         container:AddChild(inheritedLabel)
     end
 
-    local rows = {}
+end
+
+local function NotifyEligibilityChanged(opts, callbackName)
+    local callback = opts and opts[callbackName]
+    if not callback and opts then
+        callback = opts.onChanged
+    end
+    if callback then callback() end
+end
+
+local function AddActiveCharacterEligibilityRows(rows, opts)
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "characterAllowlist", "character")
+    local scopeClassChoice
+    if opts.allowClassEligibility == false then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+    end
+    local choices = BuildCharacterChoices(target, inheritedMap, scopeClassChoice and scopeClassChoice.key or nil, opts.ownerCharKey)
+    local localMap = target.loadConditions and target.loadConditions.characterAllowlist
+    local characterRows = {}
+
+    for _, choice in ipairs(choices) do
+        local key = choice.key
+        if type(localMap) == "table" and localMap[key] == true then
+            local outsideInherited = inheritedRestricted and not (inheritedMap and inheritedMap[key])
+            characterRows[#characterRows + 1] = {
+                key = key,
+                label = FormatActiveEligibilityLabel(
+                    "Character",
+                    outsideInherited and (choice.label .. " |cff888888(unavailable from parent)|r") or choice.label
+                ),
+                tooltipTitle = choice.tooltipTitle,
+                tooltipText = choice.tooltipText,
+                sortLabel = choice.sortLabel,
+                onRemove = function()
+                    SetAllowlistValue(target, "characterAllowlist", "character", key, false)
+                    NotifyEligibilityChanged(opts, "characterOnChanged")
+                end,
+            }
+        end
+    end
+
+    SortChoices(characterRows)
+    for _, row in ipairs(characterRows) do
+        rows[#rows + 1] = row
+    end
+end
+
+local function AddActiveClassSpecEligibilityRows(rows, opts)
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local allowClassEligibility = opts.allowClassEligibility == true
+    local scopeClassChoice
+    if not allowClassEligibility then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+    end
+
+    local inheritedClassMap = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")
+    local classChoices = BuildClassChoices(target, inheritedClassMap)
+    local localClassMap = target.loadConditions and target.loadConditions.classAllowlist
+    local useSpecAllowlist = opts.useSpecAllowlist == true
+    local selectedSpecMap = GetSpecSelectionMap(target, useSpecAllowlist)
+    local allowedSpecMap = opts.allowedSpecMap
+    local allowedSpecRestricted = opts.allowedSpecRestricted == true
+    local specChoices = BuildEligibilitySpecChoices({
+        target = target,
+        inheritedSources = opts.inheritedSources,
+        allowClassEligibility = allowClassEligibility,
+        ownerClassChoice = scopeClassChoice,
+        ownerCharKey = opts.ownerCharKey,
+        ownerClassID = opts.ownerClassID,
+        ownerClassFilename = opts.ownerClassFilename,
+        effectiveSpecs = opts.effectiveSpecs,
+        choiceSpecMap = opts.choiceSpecMap,
+    })
+    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+    local configID = opts.configID or (C_ClassTalents and C_ClassTalents.GetActiveConfigID and C_ClassTalents.GetActiveConfigID())
+    local heroTalentsSource = opts.useHeroTalentsSource and opts.heroTalentsSource or target.heroTalents
+    if type(heroTalentsSource) ~= "table" then
+        heroTalentsSource = nil
+    end
+    local _, heroById = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+
     local selectedHeroBySpec = {}
     for subTreeID in pairs(heroTalentsSource or {}) do
         local heroInfo = heroById[subTreeID]
@@ -1362,6 +1451,7 @@ local function AddClassSpecEligibilityControls(container, opts)
         end
     end
 
+    local classRows = {}
     if allowClassEligibility then
         for _, classChoice in ipairs(classChoices) do
             local classKey = classChoice.key
@@ -1375,8 +1465,8 @@ local function AddClassSpecEligibilityControls(container, opts)
                     end
                 end
                 if #selectedSpecs == 0 then
-                    rows[#rows + 1] = {
-                        label = GetClassDisplayLabel(classChoice) or classChoice.label,
+                    classRows[#classRows + 1] = {
+                        label = FormatActiveEligibilityLabel("Class", GetClassDisplayLabel(classChoice) or classChoice.label),
                         sortLabel = classChoice.label or classKey,
                         onRemove = function()
                             SetAllowlistValue(target, "classAllowlist", "class", classKey, false)
@@ -1386,14 +1476,19 @@ local function AddClassSpecEligibilityControls(container, opts)
                                     CooldownCompanion:CleanHeroTalentsForSpec(target, specInfo.id)
                                 end
                             end
-                            if opts.onChanged then opts.onChanged() end
+                            NotifyEligibilityChanged(opts, "specOnChanged")
                         end,
                     }
                 end
             end
         end
     end
+    SortChoices(classRows)
+    for _, row in ipairs(classRows) do
+        rows[#rows + 1] = row
+    end
 
+    local specRows = {}
     for _, specInfo in ipairs(specChoices) do
         local specId = specInfo.id
         if type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true then
@@ -1403,43 +1498,65 @@ local function AddClassSpecEligibilityControls(container, opts)
                     return tostring(a.label or a.id) < tostring(b.label or b.id)
                 end)
                 for _, heroInfo in ipairs(heroRows) do
-                    rows[#rows + 1] = {
-                        label = FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility),
+                    specRows[#specRows + 1] = {
+                        label = FormatActiveEligibilityLabel(
+                            "Hero Talent",
+                            FormatEligibilityHeroChoiceLabel(heroInfo, specInfo, allowClassEligibility)
+                        ),
                         sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
                         disabled = opts.disableHeroTalents == true,
                         onRemove = function()
                             SetHeroTalentValue(target, heroInfo.id, false)
-                            if opts.onChanged then opts.onChanged() end
+                            NotifyEligibilityChanged(opts, "specOnChanged")
                         end,
                     }
                 end
             else
                 local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
-                rows[#rows + 1] = {
-                    label = FormatEligibilitySpecRowLabel(specInfo, allowClassEligibility)
-                        .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or ""),
+                specRows[#specRows + 1] = {
+                    label = FormatActiveEligibilityLabel(
+                        "Specialization",
+                        FormatEligibilitySpecRowLabel(specInfo, allowClassEligibility)
+                            .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or "")
+                    ),
                     sortLabel = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId)),
                     onRemove = function()
                         SetSpecEligibilityValue(target, specId, false, useSpecAllowlist)
                         if CooldownCompanion.CleanHeroTalentsForSpec then
                             CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
                         end
-                        if opts.onChanged then opts.onChanged() end
+                        NotifyEligibilityChanged(opts, "specOnChanged")
                     end,
                 }
             end
         end
     end
 
-    table.sort(rows, function(a, b)
+    table.sort(specRows, function(a, b)
         return tostring(a.sortLabel or a.label) < tostring(b.sortLabel or b.label)
     end)
-
-    if #rows > 0 then
-        for _, row in ipairs(rows) do
-            AddEligibilitySelectedRow(container, row, row.onRemove)
-        end
+    for _, row in ipairs(specRows) do
+        rows[#rows + 1] = row
     end
+end
+
+local function AddActiveEligibilitySummary(container, opts)
+    opts = opts or {}
+    local rows = {}
+    AddActiveCharacterEligibilityRows(rows, opts)
+    AddActiveClassSpecEligibilityRows(rows, opts)
+    if #rows == 0 then return false end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText("Active Filters")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
+    for _, row in ipairs(rows) do
+        AddEligibilitySelectedRow(container, row, row.onRemove)
+    end
+    return true
 end
 
 ------------------------------------------------------------------------
@@ -2863,6 +2980,10 @@ local function BuildLoadConditionsTab(container)
         scopeIsGlobal = group.isGlobal == true
     end
     local ownerCharKey = parentContainer and parentContainer.createdBy or group.createdBy
+    local function RefreshPanelLoadConditions()
+        CooldownCompanion:RefreshGroupFrame(groupId)
+        CooldownCompanion:RefreshConfigPanel()
+    end
 
     AddScopedLoadConditionToggles(container, {
         target = group,
@@ -2872,10 +2993,24 @@ local function BuildLoadConditionsTab(container)
         headingTextWhenInherited = "Also Hide This Panel In",
         inheritedCollapsedKey = "loadconditions_panel_inherited",
         localCollapsedKey = "loadconditions_panel_local",
-        onChanged = function()
-            CooldownCompanion:RefreshGroupFrame(groupId)
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshPanelLoadConditions,
+    })
+
+    AddActiveEligibilitySummary(container, {
+        target = group,
+        inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "panel",
+        allowClassEligibility = scopeIsGlobal,
+        ownerCharKey = ownerCharKey,
+        useSpecAllowlist = inheritedSpecFilter,
+        allowedSpecRestricted = inheritedSpecFilter,
+        allowedSpecMap = inheritedSpecs,
+        effectiveSpecs = effectiveSpecs,
+        choiceSpecMap = inheritedSpecs,
+        heroTalentsSource = effectiveHeroTalents,
+        useHeroTalentsSource = inheritedHeroFilter,
+        disableHeroTalents = inheritedHeroFilter,
+        onChanged = RefreshPanelLoadConditions,
     })
 
     AddCharacterEligibilityControls(container, {
@@ -2885,10 +3020,7 @@ local function BuildLoadConditionsTab(container)
         allowClassEligibility = scopeIsGlobal,
         ownerCharKey = ownerCharKey,
         characterCollapsedKey = "loadconditions_panel_character",
-        onChanged = function()
-            CooldownCompanion:RefreshGroupFrame(groupId)
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshPanelLoadConditions,
     })
 
     local specHeading = AceGUI:Create("Heading")
@@ -2926,10 +3058,7 @@ local function BuildLoadConditionsTab(container)
             heroTalentsSource = effectiveHeroTalents,
             useHeroTalentsSource = inheritedHeroFilter,
             disableHeroTalents = inheritedHeroFilter,
-            onChanged = function()
-                CooldownCompanion:RefreshGroupFrame(groupId)
-                CooldownCompanion:RefreshConfigPanel()
-            end,
+            onChanged = RefreshPanelLoadConditions,
         })
     end -- not specCollapsed
 end
@@ -2978,6 +3107,7 @@ ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
 ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
 ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
+ST._AddActiveEligibilitySummary = AddActiveEligibilitySummary
 ST._AddCharacterEligibilityControls = AddCharacterEligibilityControls
 ST._AddClassSpecEligibilityControls = AddClassSpecEligibilityControls
 ST._GetConditionDisplayName = GetConditionDisplayName

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -690,6 +690,24 @@ local function CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerChar
     return classKey == scopeClassKey
 end
 
+local function AddKnownScopeClassCharacterChoices(choices, byKey, scopeClassKey, ownerCharKey)
+    if not scopeClassKey then return end
+    local db = CooldownCompanion.db
+    local characterInfo = db and db.global and db.global.characterInfo
+    if type(characterInfo) ~= "table" then return end
+
+    for charKey, info in pairs(characterInfo) do
+        if type(charKey) == "string" and charKey ~= "" then
+            local choice = BuildCharacterChoice(charKey, info)
+            choice.classFilename = choice.classFilename or NormalizeAllowlistKey("class", info and info.classFilename)
+            choice.classID = choice.classID or (info and info.classID) or nil
+            if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+                AddChoice(choices, byKey, choice.key, choice.label, choice)
+            end
+        end
+    end
+end
+
 local function BuildClassChoices(target, inheritedMap)
     local choices, byKey = {}, {}
     for classID = 1, MAX_CLASS_SCAN_ID do
@@ -725,6 +743,7 @@ local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerC
             AddChoice(choices, byKey, choice.key, choice.label, choice)
         end
     end
+    AddKnownScopeClassCharacterChoices(choices, byKey, scopeClassKey, ownerCharKey)
     local localMap = target.loadConditions and target.loadConditions.characterAllowlist
     local copiedLocal = CopyAllowlist(localMap, "character")
     for key in pairs(copiedLocal or {}) do

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -9,7 +9,6 @@ local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 
 -- Imports from Helpers.lua and State.lua
-local BuildHeroTalentSubTreeCheckboxes = ST._BuildHeroTalentSubTreeCheckboxes
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local CreateInfoButton = ST._CreateInfoButton
@@ -25,6 +24,88 @@ local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
 
 local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
+local REMOVE_BADGE_WIDGET_TYPE = "CDCEligibilityRemoveBadge"
+
+if AceGUI and not AceGUI:GetWidgetVersion(REMOVE_BADGE_WIDGET_TYPE) then
+    local function Badge_OnClick(frame, button)
+        frame.obj:Fire("OnClick", button)
+        AceGUI:ClearFocus()
+    end
+
+    local function Badge_OnEnter(frame)
+        frame.obj:Fire("OnEnter")
+    end
+
+    local function Badge_OnLeave(frame)
+        frame.obj:Fire("OnLeave")
+    end
+
+    local badgeMethods = {
+        OnAcquire = function(self)
+            self:SetWidth(19)
+            self:SetHeight(19)
+            self:SetDisabled(false)
+            if self.icon then
+                self.icon:SetAtlas("common-icon-redx", false)
+                self.icon:ClearAllPoints()
+                self.icon:SetSize(19, 19)
+                self.icon:SetPoint("CENTER")
+            end
+            if self.frame.SetHighlightAtlas then
+                self.frame:SetHighlightAtlas("common-icon-redx")
+                if self.frame.GetHighlightTexture and self.frame:GetHighlightTexture() then
+                    self.frame:GetHighlightTexture():SetAlpha(0.3)
+                end
+            end
+        end,
+
+        SetDisabled = function(self, disabled)
+            if disabled then
+                self.frame:Disable()
+                if self.icon then self.icon:SetVertexColor(0.5, 0.5, 0.5, 0.5) end
+            else
+                self.frame:Enable()
+                if self.icon then self.icon:SetVertexColor(1, 1, 1, 1) end
+            end
+        end,
+    }
+
+    local function BadgeConstructor()
+        local frame = CreateFrame("Button", nil, UIParent)
+        frame:Hide()
+        frame:SetSize(19, 19)
+        frame:EnableMouse(true)
+        frame:RegisterForClicks("AnyUp")
+        frame:SetScript("OnClick", Badge_OnClick)
+        frame:SetScript("OnEnter", Badge_OnEnter)
+        frame:SetScript("OnLeave", Badge_OnLeave)
+
+        local icon = frame:CreateTexture(nil, "ARTWORK")
+        icon:SetAtlas("common-icon-redx", false)
+        icon:SetSize(19, 19)
+        icon:SetPoint("CENTER")
+
+        if frame.SetHighlightAtlas then
+            frame:SetHighlightAtlas("common-icon-redx")
+            if frame.GetHighlightTexture and frame:GetHighlightTexture() then
+                frame:GetHighlightTexture():SetAlpha(0.3)
+            end
+        end
+
+        local widget = {
+            frame = frame,
+            icon = icon,
+            type = REMOVE_BADGE_WIDGET_TYPE,
+        }
+        for method, func in pairs(badgeMethods) do
+            widget[method] = func
+        end
+
+        return AceGUI:RegisterAsWidget(widget)
+    end
+
+    AceGUI:RegisterWidgetType(REMOVE_BADGE_WIDGET_TYPE, BadgeConstructor, 1)
+end
 
 local function GetLoadConditionValue(loadConditions, key, defaults, optionDefault)
     if type(loadConditions) ~= "table" then return false end
@@ -49,6 +130,80 @@ local function SetLoadConditionValue(loadConditions, key, value, defaults, optio
         loadConditions[key] = nil
     else
         loadConditions[key] = value == true
+    end
+end
+
+local function EnsureLoadConditions(target)
+    if type(target) ~= "table" then return nil end
+    if type(target.loadConditions) ~= "table" then
+        target.loadConditions = {}
+    end
+    return target.loadConditions
+end
+
+local function SetSpecFilterValue(target, specId, value)
+    if type(target) ~= "table" or not specId then return end
+    if value then
+        if not target.specs then target.specs = {} end
+        target.specs[specId] = true
+        local loadConditions = EnsureLoadConditions(target)
+        if type(loadConditions.specAllowlist) ~= "table" then
+            loadConditions.specAllowlist = {}
+        end
+        loadConditions.specAllowlist[specId] = true
+    else
+        if target.specs then
+            target.specs[specId] = nil
+            if not next(target.specs) then
+                target.specs = nil
+            end
+        end
+        local loadConditions = target.loadConditions
+        if type(loadConditions) == "table" and type(loadConditions.specAllowlist) == "table" then
+            loadConditions.specAllowlist[specId] = nil
+            if not next(loadConditions.specAllowlist) then
+                loadConditions.specAllowlist = nil
+            end
+        end
+    end
+end
+
+local function SetSpecAllowlistValue(target, specId, value)
+    if type(target) ~= "table" or not specId then return end
+    if value then
+        local loadConditions = EnsureLoadConditions(target)
+        if type(loadConditions.specAllowlist) ~= "table" then
+            loadConditions.specAllowlist = {}
+        end
+        loadConditions.specAllowlist[specId] = true
+        return
+    end
+
+    local loadConditions = target.loadConditions
+    if type(loadConditions) == "table" and type(loadConditions.specAllowlist) == "table" then
+        loadConditions.specAllowlist[specId] = nil
+        if not next(loadConditions.specAllowlist) then
+            loadConditions.specAllowlist = nil
+        end
+    end
+end
+
+local function SetHeroTalentValue(target, subTreeID, value)
+    subTreeID = tonumber(subTreeID)
+    if type(target) ~= "table" or not subTreeID then return end
+    if value then
+        if type(target.heroTalents) ~= "table" then
+            target.heroTalents = {}
+        end
+        target.heroTalents[subTreeID] = true
+        return
+    end
+
+    if type(target.heroTalents) == "table" then
+        target.heroTalents[subTreeID] = nil
+        if not next(target.heroTalents) then
+            target.heroTalents = nil
+        end
     end
 end
 
@@ -175,6 +330,1047 @@ local function AddScopedLoadConditionToggles(container, opts)
             end)
         end
         container:AddChild(cb)
+    end
+end
+
+local function NormalizeAllowlistKey(kind, key)
+    if kind == "class" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return string.upper(key)
+    elseif kind == "spec" then
+        local specId = tonumber(key)
+        if not specId then return nil end
+        return specId
+    elseif kind == "character" then
+        if type(key) ~= "string" or key == "" then return nil end
+        return key
+    end
+    return nil
+end
+
+local function CopyAllowlist(map, kind)
+    if type(map) ~= "table" then return nil, false end
+    local copy = {}
+    local sawEntry = false
+    for key, enabled in pairs(map) do
+        sawEntry = true
+        if enabled == true then
+            local normalizedKey = NormalizeAllowlistKey(kind, key)
+            if normalizedKey ~= nil then
+                copy[normalizedKey] = true
+            end
+        end
+    end
+    if next(copy) then return copy, true end
+    return nil, sawEntry
+end
+
+local function IntersectAllowlists(left, right)
+    local intersection = {}
+    for key in pairs(left or {}) do
+        if right and right[key] then
+            intersection[key] = true
+        end
+    end
+    return intersection
+end
+
+local function GetInheritedAllowlist(sources, field, kind)
+    local inherited
+    local restricted = false
+    for _, source in ipairs(sources or {}) do
+        local copied, hasRestriction = CopyAllowlist(source.loadConditions and source.loadConditions[field], kind)
+        if hasRestriction then
+            restricted = true
+            if inherited == nil then
+                inherited = copied or {}
+            else
+                inherited = IntersectAllowlists(inherited, copied or {})
+            end
+        end
+    end
+    return inherited, restricted
+end
+
+local function SetAllowlistValue(target, field, kind, key, value)
+    local normalizedKey = NormalizeAllowlistKey(kind, key)
+    if not (type(target) == "table" and normalizedKey ~= nil) then return end
+
+    if value then
+        local loadConditions = EnsureLoadConditions(target)
+        if type(loadConditions[field]) ~= "table" then
+            loadConditions[field] = {}
+        end
+        loadConditions[field][normalizedKey] = true
+        return
+    end
+
+    local loadConditions = target.loadConditions
+    if type(loadConditions) == "table" and type(loadConditions[field]) == "table" then
+        loadConditions[field][normalizedKey] = nil
+        if not next(loadConditions[field]) then
+            loadConditions[field] = nil
+        end
+    end
+end
+
+local function AddChoice(choices, byKey, key, label, meta)
+    if key == nil or byKey[key] then return end
+    byKey[key] = true
+    local choice = {
+        key = key,
+        label = label or tostring(key),
+    }
+    if type(meta) == "table" then
+        for metaKey, metaValue in pairs(meta) do
+            choice[metaKey] = metaValue
+        end
+    end
+    choices[#choices + 1] = choice
+end
+
+local function AddAllowlistKeysAsChoices(choices, byKey, map, kind, labelPrefix)
+    local copied = CopyAllowlist(map, kind)
+    for key in pairs(copied or {}) do
+        AddChoice(choices, byKey, key, (labelPrefix or "") .. tostring(key))
+    end
+end
+
+local function SortChoices(choices)
+    table.sort(choices, function(a, b)
+        return tostring(a.sortLabel or a.label or a.key) < tostring(b.sortLabel or b.label or b.key)
+    end)
+end
+
+local MAX_CLASS_SCAN_ID = 20
+
+local function GetClassChoiceByID(classID)
+    classID = tonumber(classID)
+    if not classID then return nil end
+    local className, classFilename = GetClassInfo(classID)
+    local classKey = NormalizeAllowlistKey("class", classFilename)
+    if not classKey then return nil end
+    return {
+        key = classKey,
+        label = className or classKey,
+        classID = classID,
+        classFilename = classKey,
+    }
+end
+
+local function GetClassChoiceByFilename(classFilename)
+    local classKey = NormalizeAllowlistKey("class", classFilename)
+    if not classKey then return nil end
+    for classID = 1, MAX_CLASS_SCAN_ID do
+        local choice = GetClassChoiceByID(classID)
+        if choice and choice.key == classKey then
+            return choice
+        end
+    end
+    return {
+        key = classKey,
+        label = classKey,
+        classFilename = classKey,
+    }
+end
+
+local function GetCurrentClassChoice()
+    local className, classFilename, classID = UnitClass("player")
+    local classKey = NormalizeAllowlistKey("class", classFilename)
+    if not classKey then return nil end
+    return {
+        key = classKey,
+        label = className or classKey,
+        classID = classID,
+        classFilename = classKey,
+    }
+end
+
+local function WrapClassColoredText(text, classFilename)
+    if classFilename and C_ClassColor then
+        local classColor = C_ClassColor.GetClassColor(classFilename)
+        if classColor and classColor.WrapTextInColorCode then
+            return classColor:WrapTextInColorCode(text)
+        end
+    end
+    return text
+end
+
+local function GetClassDisplayLabel(classChoice)
+    if not classChoice then return nil end
+    return WrapClassColoredText(classChoice.label or classChoice.key, classChoice.classFilename or classChoice.key)
+end
+
+local function GetSpecClassChoice(specId)
+    if not (C_SpecializationInfo and C_SpecializationInfo.GetClassIDFromSpecID) then
+        return nil
+    end
+    local classID = C_SpecializationInfo.GetClassIDFromSpecID(tonumber(specId))
+    return GetClassChoiceByID(classID)
+end
+
+local function SplitCharacterKey(charKey)
+    if type(charKey) ~= "string" then return "", nil end
+    local name, realm = charKey:match("^(.-)%s+%-%s+(.+)$")
+    if name and name ~= "" then
+        return name, realm
+    end
+    return charKey, nil
+end
+
+local function GetCharacterEligibilityInfo(charKey)
+    local db = CooldownCompanion.db
+    local info = charKey
+        and db and db.global and db.global.characterInfo
+        and db.global.characterInfo[charKey]
+    if type(info) == "table" then
+        return info
+    end
+
+    local characters = CooldownCompanion.EnumerateActiveProfileCharacters
+        and CooldownCompanion:EnumerateActiveProfileCharacters()
+        or {}
+    for _, characterInfo in ipairs(characters) do
+        if characterInfo.charKey == charKey then
+            return characterInfo
+        end
+    end
+    return nil
+end
+
+local function BuildCharacterChoice(charKey)
+    local info = GetCharacterEligibilityInfo(charKey)
+    local name, realm = SplitCharacterKey(charKey)
+    local classFilename = info and NormalizeAllowlistKey("class", info.classFilename)
+    local label = WrapClassColoredText(name, classFilename)
+    return {
+        key = charKey,
+        label = label,
+        sortLabel = name,
+        tooltipTitle = label,
+        tooltipText = realm,
+        classFilename = classFilename,
+        classID = info and info.classID or nil,
+    }
+end
+
+local function AttachEligibilityTooltip(widget, title, text)
+    if not (widget and widget.frame and text and text ~= "") then return end
+    widget.frame:EnableMouse(true)
+    widget.frame:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:AddLine(title or "")
+        GameTooltip:AddLine(text, 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    widget.frame:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    widget:SetCallback("OnRelease", function(releasedWidget)
+        if releasedWidget and releasedWidget.frame then
+            releasedWidget.frame:SetScript("OnEnter", nil)
+            releasedWidget.frame:SetScript("OnLeave", nil)
+        end
+    end)
+end
+
+local function ResolveOwnerClassChoice(opts)
+    if opts.ownerClassChoice then
+        return opts.ownerClassChoice
+    end
+    if opts.ownerClassID then
+        local choice = GetClassChoiceByID(opts.ownerClassID)
+        if choice then return choice end
+    end
+    if opts.ownerClassFilename then
+        local choice = GetClassChoiceByFilename(opts.ownerClassFilename)
+        if choice then return choice end
+    end
+
+    local db = CooldownCompanion.db
+    local charKey = opts.ownerCharKey
+        or (type(opts.target) == "table" and opts.target.createdBy)
+    local info = charKey
+        and db and db.global and db.global.characterInfo
+        and db.global.characterInfo[charKey]
+    if type(info) == "table" then
+        if info.classID then
+            local choice = GetClassChoiceByID(info.classID)
+            if choice then return choice end
+        end
+        if info.classFilename then
+            local choice = GetClassChoiceByFilename(info.classFilename)
+            if choice then return choice end
+        end
+    end
+
+    return GetCurrentClassChoice()
+end
+
+local function CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey)
+    if not scopeClassKey then return true end
+    if choice and ownerCharKey and choice.key == ownerCharKey then
+        return true
+    end
+    local classKey = choice and NormalizeAllowlistKey("class", choice.classFilename)
+    return classKey == scopeClassKey
+end
+
+local function BuildClassChoices(target, inheritedMap)
+    local choices, byKey = {}, {}
+    for classID = 1, MAX_CLASS_SCAN_ID do
+        local choice = GetClassChoiceByID(classID)
+        if choice then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    local localMap = target.loadConditions and target.loadConditions.classAllowlist
+    AddAllowlistKeysAsChoices(choices, byKey, localMap, "class")
+    AddAllowlistKeysAsChoices(choices, byKey, inheritedMap, "class")
+    table.sort(choices, function(a, b)
+        if a.classID and b.classID then
+            return a.classID < b.classID
+        end
+        if a.classID then return true end
+        if b.classID then return false end
+        return tostring(a.label or a.key) < tostring(b.label or b.key)
+    end)
+    return choices
+end
+
+local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerCharKey)
+    local choices, byKey = {}, {}
+    local characters = CooldownCompanion.EnumerateActiveProfileCharacters
+        and CooldownCompanion:EnumerateActiveProfileCharacters()
+        or {}
+    for _, info in ipairs(characters) do
+        local choice = BuildCharacterChoice(info.charKey)
+        choice.classFilename = choice.classFilename or info.classFilename
+        choice.classID = choice.classID or info.classID
+        if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    local localMap = target.loadConditions and target.loadConditions.characterAllowlist
+    local copiedLocal = CopyAllowlist(localMap, "character")
+    for key in pairs(copiedLocal or {}) do
+        local choice = BuildCharacterChoice(key)
+        if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    local copiedInherited = CopyAllowlist(inheritedMap, "character")
+    for key in pairs(copiedInherited or {}) do
+        local choice = BuildCharacterChoice(key)
+        if CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey) then
+            AddChoice(choices, byKey, choice.key, choice.label, choice)
+        end
+    end
+    SortChoices(choices)
+    return choices
+end
+
+local function ClearEmptyLoadConditions(target)
+    if type(target) ~= "table" or type(target.loadConditions) ~= "table" then return end
+    if not next(target.loadConditions) then
+        target.loadConditions = nil
+    end
+end
+
+local function ClearClassAllowlistWhenScoped(target, allowClassEligibility)
+    if allowClassEligibility or type(target) ~= "table" then return false end
+    local loadConditions = target.loadConditions
+    if type(loadConditions) ~= "table" or loadConditions.classAllowlist == nil then
+        return false
+    end
+    loadConditions.classAllowlist = nil
+    ClearEmptyLoadConditions(target)
+    return true
+end
+
+local function PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey)
+    if type(target) ~= "table" or not scopeClassKey then return false end
+    local loadConditions = target.loadConditions
+    local map = loadConditions and loadConditions.characterAllowlist
+    if type(map) ~= "table" then return false end
+
+    local changed = false
+    for key in pairs(map) do
+        local normalizedKey = NormalizeAllowlistKey("character", key)
+        local choice = normalizedKey and BuildCharacterChoice(normalizedKey) or nil
+        if not (normalizedKey and CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey)) then
+            map[key] = nil
+            changed = true
+        end
+    end
+    if not next(map) then
+        loadConditions.characterAllowlist = nil
+    end
+    ClearEmptyLoadConditions(target)
+    return changed
+end
+
+local function SpecMatchesScopeClass(specId, scopeClassKey)
+    if not scopeClassKey then return true end
+    local classChoice = GetSpecClassChoice(specId)
+    return not classChoice or classChoice.key == scopeClassKey
+end
+
+local function PruneSpecMapToScopeClass(target, map, scopeClassKey)
+    if type(map) ~= "table" or not scopeClassKey then return false end
+    local changed = false
+    for key in pairs(map) do
+        local specId = NormalizeAllowlistKey("spec", key)
+        if not (specId and SpecMatchesScopeClass(specId, scopeClassKey)) then
+            map[key] = nil
+            if specId and map[specId] ~= nil then
+                map[specId] = nil
+            end
+            if specId and CooldownCompanion.CleanHeroTalentsForSpec then
+                CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
+            end
+            changed = true
+        end
+    end
+    return changed
+end
+
+local function PruneClassScopedEligibility(target, scopeClassChoice, ownerCharKey)
+    if type(target) ~= "table" or not scopeClassChoice then return false end
+    local scopeClassKey = scopeClassChoice.key
+    local changed = ClearClassAllowlistWhenScoped(target, false)
+    changed = PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey) or changed
+
+    if PruneSpecMapToScopeClass(target, target.specs, scopeClassKey) then
+        changed = true
+        if type(target.specs) == "table" and not next(target.specs) then
+            target.specs = nil
+        end
+    end
+
+    local loadConditions = target.loadConditions
+    if type(loadConditions) == "table" then
+        if PruneSpecMapToScopeClass(target, loadConditions.specAllowlist, scopeClassKey) then
+            changed = true
+            if type(loadConditions.specAllowlist) == "table" and not next(loadConditions.specAllowlist) then
+                loadConditions.specAllowlist = nil
+            end
+        end
+    end
+
+    ClearEmptyLoadConditions(target)
+    return changed
+end
+
+local function CreateEligibilityRemoveBadge(onRemove)
+    local removeBadge = AceGUI:Create(REMOVE_BADGE_WIDGET_TYPE)
+    removeBadge:SetWidth(19)
+    removeBadge:SetHeight(19)
+    removeBadge:SetCallback("OnClick", function(widget, event, button)
+        if button == "LeftButton" and onRemove then
+            onRemove()
+        end
+    end)
+    return removeBadge
+end
+
+local function AddCharacterEligibilityControls(container, opts)
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "characterAllowlist", "character")
+    local scopeClassChoice
+    if opts.allowClassEligibility == false then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+        if scopeClassChoice then
+            PruneCharacterAllowlistToScopeClass(target, scopeClassChoice.key, opts.ownerCharKey)
+        end
+    end
+    local choices = BuildCharacterChoices(target, inheritedMap, scopeClassChoice and scopeClassChoice.key or nil, opts.ownerCharKey)
+    if #choices == 0 then return end
+
+    local heading = AceGUI:Create("Heading")
+    heading:SetText(opts.characterHeadingText or "Character Eligibility")
+    ColorHeading(heading)
+    heading:SetFullWidth(true)
+    container:AddChild(heading)
+
+    local collapsed = opts.characterCollapsedKey and CS.collapsedSections[opts.characterCollapsedKey]
+    if opts.characterCollapsedKey then
+        AttachCollapseButton(heading, collapsed, function()
+            CS.collapsedSections[opts.characterCollapsedKey] = not CS.collapsedSections[opts.characterCollapsedKey]
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+    end
+    if collapsed then return end
+
+    if inheritedRestricted then
+        local inheritedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(inheritedLabel)
+        inheritedLabel:SetText("|cff888888Parent eligibility limits which characters can load here.|r")
+        inheritedLabel:SetFullWidth(true)
+        container:AddChild(inheritedLabel)
+    end
+
+    local localMap = target.loadConditions and target.loadConditions.characterAllowlist
+    local selected = {}
+    local selectedByKey = {}
+    local dropdownValues = {}
+    local dropdownOrder = {}
+    local dropdownSortLabels = {}
+
+    for _, choice in ipairs(choices) do
+        local key = choice.key
+        local localSelected = type(localMap) == "table" and localMap[key] == true
+        local outsideInherited = inheritedRestricted and not (inheritedMap and inheritedMap[key])
+        if localSelected then
+            selectedByKey[key] = true
+            selected[#selected + 1] = {
+                key = key,
+                label = outsideInherited and (choice.label .. " |cff888888(unavailable from parent)|r") or choice.label,
+                tooltipTitle = choice.tooltipTitle,
+                tooltipText = choice.tooltipText,
+                sortLabel = choice.sortLabel,
+            }
+        elseif not outsideInherited then
+            dropdownValues[key] = choice.label
+            dropdownSortLabels[key] = choice.sortLabel or choice.label
+            dropdownOrder[#dropdownOrder + 1] = key
+        end
+    end
+
+    table.sort(dropdownOrder, function(a, b)
+        return tostring(dropdownSortLabels[a] or a) < tostring(dropdownSortLabels[b] or b)
+    end)
+
+    local picker = AceGUI:Create("Dropdown")
+    picker:SetLabel("Add Character")
+    picker:SetFullWidth(true)
+    picker:SetList(dropdownValues, dropdownOrder)
+    if #dropdownOrder == 0 then
+        picker:SetDisabled(true)
+    else
+        picker:SetCallback("OnValueChanged", function(widget, event, value)
+            if value ~= nil and not selectedByKey[value] then
+                SetAllowlistValue(target, "characterAllowlist", "character", value, true)
+                if opts.onChanged then opts.onChanged() end
+            end
+        end)
+    end
+    container:AddChild(picker)
+
+    SortChoices(selected)
+
+    if #selected == 0 then
+        local unrestrictedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
+        unrestrictedLabel:SetText("|cff888888No local character restriction.|r")
+        unrestrictedLabel:SetFullWidth(true)
+        container:AddChild(unrestrictedLabel)
+        return
+    end
+
+    for _, choice in ipairs(selected) do
+        local row = AceGUI:Create("SimpleGroup")
+        row:SetFullWidth(true)
+        row:SetLayout("Flow")
+
+        local label = AceGUI:Create("Label")
+        label:SetText(choice.label)
+        label:SetRelativeWidth(0.92)
+        AttachEligibilityTooltip(label, choice.tooltipTitle or choice.label, choice.tooltipText)
+        row:AddChild(label)
+
+        local removeBtn = CreateEligibilityRemoveBadge(function()
+            SetAllowlistValue(target, "characterAllowlist", "character", choice.key, false)
+            if opts.onChanged then opts.onChanged() end
+        end)
+        row:AddChild(removeBtn)
+
+        container:AddChild(row)
+    end
+end
+
+local function AddClassForSpecId(classChoices, classByKey, specId)
+    if not (C_SpecializationInfo and C_SpecializationInfo.GetClassIDFromSpecID) then
+        return
+    end
+    local classID = C_SpecializationInfo.GetClassIDFromSpecID(tonumber(specId))
+    local choice = GetClassChoiceByID(classID)
+    if choice and not classByKey[choice.key] then
+        classByKey[choice.key] = true
+        classChoices[#classChoices + 1] = choice
+    end
+end
+
+local function AddClassesForSpecMap(classChoices, classByKey, specMap)
+    local copied = CopyAllowlist(specMap, "spec")
+    for specId in pairs(copied or {}) do
+        AddClassForSpecId(classChoices, classByKey, specId)
+    end
+end
+
+local function AddSpecsForClass(specChoices, seenSpecs, classChoice)
+    local classID = classChoice and classChoice.classID
+    if not (classID and C_SpecializationInfo and C_SpecializationInfo.GetNumSpecializationsForClassID) then
+        return
+    end
+
+    local currentClass = GetCurrentClassChoice()
+    local currentClassKey = currentClass and currentClass.key
+    local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
+    for specIndex = 1, numSpecs do
+        local specId, specName, _, specIcon = C_SpecializationInfo.GetSpecializationInfo(
+            specIndex,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
+        if specId and not seenSpecs[specId] then
+            seenSpecs[specId] = true
+            specChoices[#specChoices + 1] = {
+                id = specId,
+                name = specName or ("Spec " .. tostring(specId)),
+                label = specName or ("Spec " .. tostring(specId)),
+                icon = specIcon,
+                classID = classID,
+                classKey = classChoice.key,
+                classLabel = classChoice.label,
+                isCurrentClass = classChoice.key == currentClassKey,
+            }
+        end
+    end
+end
+
+local function BuildEligibilitySpecChoices(opts)
+    opts = opts or {}
+    local target = opts.target
+    if type(target) ~= "table" then return {} end
+
+    local classChoices = {}
+    local classByKey = {}
+
+    if opts.allowClassEligibility then
+        local inheritedMap, inheritedRestricted = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")
+        local localMap = CopyAllowlist(target.loadConditions and target.loadConditions.classAllowlist, "class")
+        local seedMap = localMap and next(localMap) and localMap or nil
+        if not seedMap and inheritedRestricted then
+            seedMap = inheritedMap
+        end
+
+        for classKey in pairs(seedMap or {}) do
+            local choice = GetClassChoiceByFilename(classKey)
+            if choice and not classByKey[choice.key] then
+                classByKey[choice.key] = true
+                classChoices[#classChoices + 1] = choice
+            end
+        end
+
+        AddClassesForSpecMap(classChoices, classByKey, target.specs)
+        AddClassesForSpecMap(classChoices, classByKey, target.loadConditions and target.loadConditions.specAllowlist)
+        AddClassesForSpecMap(classChoices, classByKey, opts.effectiveSpecs)
+    else
+        ClearClassAllowlistWhenScoped(target, false)
+        local choice = ResolveOwnerClassChoice(opts)
+        if choice then
+            classByKey[choice.key] = true
+            classChoices[#classChoices + 1] = choice
+        end
+    end
+
+    table.sort(classChoices, function(a, b)
+        if a.classID and b.classID then
+            return a.classID < b.classID
+        end
+        if a.classID then return true end
+        if b.classID then return false end
+        return tostring(a.label or a.key) < tostring(b.label or b.key)
+    end)
+
+    local specs = {}
+    local seenSpecs = {}
+    for _, classChoice in ipairs(classChoices) do
+        AddSpecsForClass(specs, seenSpecs, classChoice)
+    end
+
+    local classCount = #classChoices
+    for _, spec in ipairs(specs) do
+        if opts.allowClassEligibility and classCount > 1 then
+            spec.label = (spec.classLabel or spec.classKey or "Class") .. ": " .. spec.name
+        end
+    end
+    return specs
+end
+
+local function GetSpecSelectionMap(target, useSpecAllowlist)
+    if type(target) ~= "table" then return nil end
+    if useSpecAllowlist then
+        return target.loadConditions and target.loadConditions.specAllowlist
+    end
+    return target.specs
+end
+
+local function SetSpecEligibilityValue(target, specId, value, useSpecAllowlist)
+    if useSpecAllowlist then
+        SetSpecAllowlistValue(target, specId, value)
+    else
+        SetSpecFilterValue(target, specId, value)
+    end
+end
+
+local function BuildSpecChoiceIndex(specChoices)
+    local bySpecId = {}
+    local byClassKey = {}
+    for _, specInfo in ipairs(specChoices or {}) do
+        if specInfo.id then
+            bySpecId[specInfo.id] = specInfo
+            local classKey = specInfo.classKey
+            if classKey then
+                byClassKey[classKey] = byClassKey[classKey] or {}
+                byClassKey[classKey][#byClassKey[classKey] + 1] = specInfo
+            end
+        end
+    end
+    return bySpecId, byClassKey
+end
+
+local function BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+    local choices = {}
+    local bySubTreeID = {}
+    if not (configID and C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
+        return choices, bySubTreeID
+    end
+
+    for _, specInfo in ipairs(specChoices or {}) do
+        local specId = specInfo.id
+        if specId and selectedSpecMap and selectedSpecMap[specId] then
+            local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+            for _, subTreeID in ipairs(subTreeIDs or {}) do
+                local subTreeInfo = C_Traits and C_Traits.GetSubTreeInfo and C_Traits.GetSubTreeInfo(configID, subTreeID) or nil
+                local heroName = subTreeInfo and subTreeInfo.name or ("Hero " .. tostring(subTreeID))
+                local heroChoice = {
+                    id = subTreeID,
+                    label = heroName,
+                    sortLabel = heroName,
+                    specId = specId,
+                    specLabel = specInfo.name,
+                    classKey = specInfo.classKey,
+                    classLabel = specInfo.classLabel,
+                    iconAtlas = subTreeInfo and subTreeInfo.iconElementID or nil,
+                }
+                choices[#choices + 1] = heroChoice
+                bySubTreeID[subTreeID] = heroChoice
+            end
+        end
+    end
+
+    table.sort(choices, function(a, b)
+        local aClass = tostring(a.classLabel or a.classKey or "")
+        local bClass = tostring(b.classLabel or b.classKey or "")
+        if aClass ~= bClass then return aClass < bClass end
+        local aSpec = tostring(a.specLabel or a.specId or "")
+        local bSpec = tostring(b.specLabel or b.specId or "")
+        if aSpec ~= bSpec then return aSpec < bSpec end
+        return tostring(a.sortLabel or a.label or a.id) < tostring(b.sortLabel or b.label or b.id)
+    end)
+
+    return choices, bySubTreeID
+end
+
+local function FormatEligibilitySpecLabel(specInfo, includeClass)
+    if not specInfo then return "" end
+    if includeClass and specInfo.classLabel then
+        local classChoice = GetClassChoiceByFilename(specInfo.classKey)
+        local classLabel = GetClassDisplayLabel(classChoice) or specInfo.classLabel
+        return classLabel .. ": " .. (specInfo.name or specInfo.label or tostring(specInfo.id))
+    end
+    return specInfo.name or specInfo.label or tostring(specInfo.id)
+end
+
+local function FormatEligibilityHeroLabel(heroInfo, specInfo, includeClass)
+    local specLabel = FormatEligibilitySpecLabel(specInfo, includeClass)
+    return specLabel .. " - " .. (heroInfo.label or tostring(heroInfo.id))
+end
+
+local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
+    local row = AceGUI:Create("SimpleGroup")
+    row:SetFullWidth(true)
+    row:SetLayout("Flow")
+
+    local label = AceGUI:Create("Label")
+    label:SetText(rowInfo.label)
+    label:SetRelativeWidth(0.92)
+    AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
+    row:AddChild(label)
+
+    if rowInfo.disabled then
+        local locked = AceGUI:Create("Label")
+        locked:SetText("|cff888888locked|r")
+        locked:SetRelativeWidth(0.1)
+        row:AddChild(locked)
+    else
+        local removeBtn = CreateEligibilityRemoveBadge(onRemove)
+        row:AddChild(removeBtn)
+    end
+
+    container:AddChild(row)
+end
+
+local function AddClassSpecEligibilityControls(container, opts)
+    opts = opts or {}
+    local target = opts.target
+    if type(target) ~= "table" then return end
+
+    local allowClassEligibility = opts.allowClassEligibility == true
+    local scopeClassChoice
+    if not allowClassEligibility then
+        scopeClassChoice = ResolveOwnerClassChoice(opts)
+        PruneClassScopedEligibility(target, scopeClassChoice, opts.ownerCharKey)
+    end
+
+    local inheritedClassMap, inheritedClassRestricted = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")
+    local classChoices = BuildClassChoices(target, inheritedClassMap)
+    local localClassMap = target.loadConditions and target.loadConditions.classAllowlist
+
+    if allowClassEligibility then
+        if inheritedClassRestricted then
+            local inheritedLabel = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(inheritedLabel)
+            inheritedLabel:SetText("|cff888888Parent eligibility limits which classes can load here.|r")
+            inheritedLabel:SetFullWidth(true)
+            container:AddChild(inheritedLabel)
+        end
+
+        local classValues = {}
+        local classOrder = {}
+        local classSortLabels = {}
+        for _, choice in ipairs(classChoices) do
+            local key = choice.key
+            local localSelected = type(localClassMap) == "table" and localClassMap[key] == true
+            local outsideInherited = inheritedClassRestricted and not (inheritedClassMap and inheritedClassMap[key])
+            if not localSelected and not outsideInherited then
+                classValues[key] = GetClassDisplayLabel(choice) or choice.label
+                classSortLabels[key] = choice.label or key
+                classOrder[#classOrder + 1] = key
+            end
+        end
+        table.sort(classOrder, function(a, b)
+            return tostring(classSortLabels[a] or a) < tostring(classSortLabels[b] or b)
+        end)
+
+        local classPicker = AceGUI:Create("Dropdown")
+        classPicker:SetLabel("Add Class")
+        classPicker:SetFullWidth(true)
+        classPicker:SetList(classValues, classOrder)
+        if #classOrder == 0 then
+            classPicker:SetDisabled(true)
+        else
+            classPicker:SetCallback("OnValueChanged", function(widget, event, value)
+                SetAllowlistValue(target, "classAllowlist", "class", value, true)
+                if opts.onChanged then opts.onChanged() end
+            end)
+        end
+        container:AddChild(classPicker)
+    end
+
+    local useSpecAllowlist = opts.useSpecAllowlist == true
+    local selectedSpecMap = GetSpecSelectionMap(target, useSpecAllowlist)
+    local allowedSpecMap = opts.allowedSpecMap
+    local allowedSpecRestricted = opts.allowedSpecRestricted == true
+    local specChoices = BuildEligibilitySpecChoices({
+        target = target,
+        inheritedSources = opts.inheritedSources,
+        allowClassEligibility = allowClassEligibility,
+        ownerClassChoice = scopeClassChoice,
+        ownerCharKey = opts.ownerCharKey,
+        ownerClassID = opts.ownerClassID,
+        ownerClassFilename = opts.ownerClassFilename,
+        effectiveSpecs = opts.effectiveSpecs,
+    })
+    local specById, specsByClassKey = BuildSpecChoiceIndex(specChoices)
+
+    local specValues = {}
+    local specOrder = {}
+    local specSortLabels = {}
+    for _, specInfo in ipairs(specChoices) do
+        local specId = specInfo.id
+        local localSelected = type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true
+        local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
+        if specId and not localSelected and not outsideAllowed then
+            specValues[specId] = specInfo.label
+            specSortLabels[specId] = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId))
+            specOrder[#specOrder + 1] = specId
+        end
+    end
+    table.sort(specOrder, function(a, b)
+        return tostring(specSortLabels[a] or a) < tostring(specSortLabels[b] or b)
+    end)
+
+    if #specChoices == 0 then
+        local emptyLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(emptyLabel)
+        emptyLabel:SetText(allowClassEligibility and "|cff888888Select a class to choose specialization eligibility.|r" or "|cff888888No specializations available for this scope.|r")
+        emptyLabel:SetFullWidth(true)
+        container:AddChild(emptyLabel)
+    else
+        local specPicker = AceGUI:Create("Dropdown")
+        specPicker:SetLabel("Add Specialization")
+        specPicker:SetFullWidth(true)
+        specPicker:SetList(specValues, specOrder)
+        if #specOrder == 0 then
+            specPicker:SetDisabled(true)
+        else
+            specPicker:SetCallback("OnValueChanged", function(widget, event, value)
+                SetSpecEligibilityValue(target, value, true, useSpecAllowlist)
+                if opts.onChanged then opts.onChanged() end
+            end)
+        end
+        container:AddChild(specPicker)
+    end
+
+    local configID = opts.configID or (C_ClassTalents and C_ClassTalents.GetActiveConfigID and C_ClassTalents.GetActiveConfigID())
+    local mutableHeroTalents = opts.disableHeroTalents ~= true
+    local heroTalentsSource = opts.useHeroTalentsSource and opts.heroTalentsSource or target.heroTalents
+    if type(heroTalentsSource) ~= "table" then
+        heroTalentsSource = nil
+    end
+    local heroChoices, heroById = BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
+    local heroValues = {}
+    local heroOrder = {}
+    local heroSortLabels = {}
+    if mutableHeroTalents then
+        for _, heroInfo in ipairs(heroChoices) do
+            local selected = type(heroTalentsSource) == "table" and heroTalentsSource[heroInfo.id] == true
+            if not selected then
+                local specInfo = specById[heroInfo.specId]
+                heroValues[heroInfo.id] = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility)
+                heroSortLabels[heroInfo.id] = (heroInfo.classLabel or "") .. (heroInfo.specLabel or "") .. (heroInfo.label or "")
+                heroOrder[#heroOrder + 1] = heroInfo.id
+            end
+        end
+    end
+    table.sort(heroOrder, function(a, b)
+        return tostring(heroSortLabels[a] or a) < tostring(heroSortLabels[b] or b)
+    end)
+
+    if #heroChoices > 0 and mutableHeroTalents then
+        local heroPicker = AceGUI:Create("Dropdown")
+        heroPicker:SetLabel("Add Hero Talent")
+        heroPicker:SetFullWidth(true)
+        heroPicker:SetList(heroValues, heroOrder)
+        if #heroOrder == 0 then
+            heroPicker:SetDisabled(true)
+        else
+            heroPicker:SetCallback("OnValueChanged", function(widget, event, value)
+                SetHeroTalentValue(target, value, true)
+                if opts.onChanged then opts.onChanged() end
+            end)
+        end
+        container:AddChild(heroPicker)
+    elseif opts.disableHeroTalents and type(heroTalentsSource) == "table" and next(heroTalentsSource) then
+        local inheritedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(inheritedLabel)
+        inheritedLabel:SetText("|cff888888Hero talent eligibility is inherited here.|r")
+        inheritedLabel:SetFullWidth(true)
+        container:AddChild(inheritedLabel)
+    end
+
+    local rows = {}
+    local selectedHeroBySpec = {}
+    for subTreeID in pairs(heroTalentsSource or {}) do
+        local heroInfo = heroById[subTreeID]
+        if heroInfo then
+            selectedHeroBySpec[heroInfo.specId] = selectedHeroBySpec[heroInfo.specId] or {}
+            selectedHeroBySpec[heroInfo.specId][#selectedHeroBySpec[heroInfo.specId] + 1] = heroInfo
+        end
+    end
+
+    if allowClassEligibility then
+        for _, classChoice in ipairs(classChoices) do
+            local classKey = classChoice.key
+            local classSelected = type(localClassMap) == "table" and localClassMap[classKey] == true
+            if classSelected then
+                local classSpecs = specsByClassKey[classKey] or {}
+                local selectedSpecs = {}
+                for _, specInfo in ipairs(classSpecs) do
+                    if type(selectedSpecMap) == "table" and selectedSpecMap[specInfo.id] == true then
+                        selectedSpecs[#selectedSpecs + 1] = specInfo
+                    end
+                end
+                if #selectedSpecs == 0 then
+                    rows[#rows + 1] = {
+                        label = GetClassDisplayLabel(classChoice) or classChoice.label,
+                        sortLabel = classChoice.label or classKey,
+                        onRemove = function()
+                            SetAllowlistValue(target, "classAllowlist", "class", classKey, false)
+                            for _, specInfo in ipairs(classSpecs) do
+                                SetSpecEligibilityValue(target, specInfo.id, false, useSpecAllowlist)
+                                if CooldownCompanion.CleanHeroTalentsForSpec then
+                                    CooldownCompanion:CleanHeroTalentsForSpec(target, specInfo.id)
+                                end
+                            end
+                            if opts.onChanged then opts.onChanged() end
+                        end,
+                    }
+                end
+            end
+        end
+    end
+
+    for _, specInfo in ipairs(specChoices) do
+        local specId = specInfo.id
+        if type(selectedSpecMap) == "table" and selectedSpecMap[specId] == true then
+            local heroRows = selectedHeroBySpec[specId]
+            if heroRows and #heroRows > 0 then
+                table.sort(heroRows, function(a, b)
+                    return tostring(a.label or a.id) < tostring(b.label or b.id)
+                end)
+                for _, heroInfo in ipairs(heroRows) do
+                    rows[#rows + 1] = {
+                        label = FormatEligibilityHeroLabel(heroInfo, specInfo, allowClassEligibility),
+                        sortLabel = (specInfo.classLabel or "") .. (specInfo.name or "") .. (heroInfo.label or ""),
+                        disabled = opts.disableHeroTalents == true,
+                        onRemove = function()
+                            SetHeroTalentValue(target, heroInfo.id, false)
+                            if opts.onChanged then opts.onChanged() end
+                        end,
+                    }
+                end
+            else
+                local outsideAllowed = allowedSpecRestricted and not (allowedSpecMap and allowedSpecMap[specId])
+                rows[#rows + 1] = {
+                    label = FormatEligibilitySpecLabel(specInfo, allowClassEligibility)
+                        .. (outsideAllowed and " |cff888888(unavailable from parent)|r" or ""),
+                    sortLabel = (specInfo.classLabel or "") .. (specInfo.name or specInfo.label or tostring(specId)),
+                    onRemove = function()
+                        SetSpecEligibilityValue(target, specId, false, useSpecAllowlist)
+                        if CooldownCompanion.CleanHeroTalentsForSpec then
+                            CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
+                        end
+                        if opts.onChanged then opts.onChanged() end
+                    end,
+                }
+            end
+        end
+    end
+
+    table.sort(rows, function(a, b)
+        return tostring(a.sortLabel or a.label) < tostring(b.sortLabel or b.label)
+    end)
+
+    if #rows == 0 then
+        local unrestrictedLabel = AceGUI:Create("Label")
+        ST._ConfigureWrappedHelperLabel(unrestrictedLabel)
+        unrestrictedLabel:SetText(allowClassEligibility and "|cff888888No local class or specialization restriction.|r" or "|cff888888No local specialization restriction.|r")
+        unrestrictedLabel:SetFullWidth(true)
+        container:AddChild(unrestrictedLabel)
+    else
+        for _, row in ipairs(rows) do
+            AddEligibilitySelectedRow(container, row, row.onRemove)
+        end
     end
 end
 
@@ -1587,14 +2783,22 @@ local function BuildLoadConditionsTab(container)
             vehicleUI = true,
         }
     end
-    local lc = group.loadConditions
     local effectiveSpecs, inheritedSpecFilter = CooldownCompanion:GetEffectiveSpecs(group)
     local effectiveHeroTalents, inheritedHeroFilter = CooldownCompanion:GetEffectiveHeroTalents(group)
+    local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group)
+    local parentContainer = CooldownCompanion:GetParentContainer(group)
+    local scopeIsGlobal
+    if parentContainer then
+        scopeIsGlobal = parentContainer.isGlobal == true
+    else
+        scopeIsGlobal = group.isGlobal == true
+    end
+    local ownerCharKey = parentContainer and parentContainer.createdBy or group.createdBy
 
     AddScopedLoadConditionToggles(container, {
         target = group,
         defaults = CooldownCompanion:GetDefaultLoadConditions(),
-        inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(group),
+        inheritedSources = inheritedSources,
         headingText = "Hide This Panel In",
         headingTextWhenInherited = "Also Hide This Panel In",
         inheritedCollapsedKey = "loadconditions_panel_inherited",
@@ -1605,9 +2809,20 @@ local function BuildLoadConditionsTab(container)
         end,
     })
 
-    -- Specialization heading
+    AddCharacterEligibilityControls(container, {
+        target = group,
+        inheritedSources = inheritedSources,
+        allowClassEligibility = scopeIsGlobal,
+        ownerCharKey = ownerCharKey,
+        characterCollapsedKey = "loadconditions_panel_character",
+        onChanged = function()
+            CooldownCompanion:RefreshGroupFrame(groupId)
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
+
     local specHeading = AceGUI:Create("Heading")
-    specHeading:SetText("Specialization Filter")
+    specHeading:SetText("Class & Specialization Eligibility")
     ColorHeading(specHeading)
     specHeading:SetFullWidth(true)
     container:AddChild(specHeading)
@@ -1619,112 +2834,31 @@ local function BuildLoadConditionsTab(container)
     end)
 
     if not specCollapsed then
-    if inheritedSpecFilter or inheritedHeroFilter then
-        local inheritedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(inheritedLabel)
-        inheritedLabel:SetText("|cff888888Some filters inherited from group settings.|r")
-        inheritedLabel:SetFullWidth(true)
-        container:AddChild(inheritedLabel)
-    end
-
-    -- Current class spec checkboxes
-    local numSpecs = GetNumSpecializations()
-    local configID = C_ClassTalents.GetActiveConfigID()
-    for i = 1, numSpecs do
-        local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-        if specId then
-            local cb = AceGUI:Create("CheckBox")
-            cb:SetLabel(name)
-            if icon then cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-            cb:SetFullWidth(true)
-            if inheritedSpecFilter then
-                cb:SetValue(effectiveSpecs and effectiveSpecs[specId] or false)
-            else
-                cb:SetValue(group.specs and group.specs[specId] or false)
-            end
-            if inheritedSpecFilter then
-                cb:SetDisabled(true)
-            else
-                cb:SetCallback("OnValueChanged", function(widget, event, value)
-                    if value then
-                        if not group.specs then group.specs = {} end
-                        group.specs[specId] = true
-                    else
-                        if group.specs then
-                            group.specs[specId] = nil
-                            if not next(group.specs) then
-                                group.specs = nil
-                            end
-                        end
-                        CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
-                    end
-                    CooldownCompanion:RefreshGroupFrame(groupId)
-                    CooldownCompanion:RefreshConfigPanel()
-                end)
-            end
-            container:AddChild(cb)
-            ApplyCheckboxIndent(cb, 0)
-
-            -- Hero talent sub-tree checkboxes (indented, only when spec is checked)
-            BuildHeroTalentSubTreeCheckboxes(container, group, configID, specId, 20, groupId, {
-                specsSource = effectiveSpecs,
-                heroTalentsSource = effectiveHeroTalents,
-                useHeroTalentsSource = inheritedHeroFilter,
-                disableToggles = inheritedHeroFilter,
-            })
+        if inheritedSpecFilter or inheritedHeroFilter then
+            local inheritedLabel = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(inheritedLabel)
+            inheritedLabel:SetText("|cff888888Some filters inherited from group settings.|r")
+            inheritedLabel:SetFullWidth(true)
+            container:AddChild(inheritedLabel)
         end
-    end
 
-    -- Foreign specs (from global groups that may have specs from other classes)
-    local playerSpecIds = {}
-    for i = 1, numSpecs do
-        local specId = C_SpecializationInfo.GetSpecializationInfo(i)
-        if specId then playerSpecIds[specId] = true end
-    end
-
-    local foreignSpecs = {}
-    if effectiveSpecs then
-        for specId in pairs(effectiveSpecs) do
-            if not playerSpecIds[specId] then
-                table.insert(foreignSpecs, specId)
-            end
-        end
-    end
-
-    if #foreignSpecs > 0 then
-        table.sort(foreignSpecs)
-        for _, specId in ipairs(foreignSpecs) do
-            local _, name, _, icon = GetSpecializationInfoForSpecID(specId)
-            if name then
-                local fcb = AceGUI:Create("CheckBox")
-                fcb:SetLabel(name)
-                if icon then fcb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-                fcb:SetFullWidth(true)
-                fcb:SetValue(true)
-                if inheritedSpecFilter then
-                    fcb:SetDisabled(true)
-                else
-                    fcb:SetCallback("OnValueChanged", function(widget, event, value)
-                        if not value then
-                            if group.specs then
-                                group.specs[specId] = nil
-                                if not next(group.specs) then
-                                    group.specs = nil
-                                end
-                            end
-                        else
-                            if not group.specs then group.specs = {} end
-                            group.specs[specId] = true
-                        end
-                        CooldownCompanion:RefreshGroupFrame(groupId)
-                        CooldownCompanion:RefreshConfigPanel()
-                    end)
-                end
-                container:AddChild(fcb)
-                ApplyCheckboxIndent(fcb, 0)
-            end
-        end
-    end
+        AddClassSpecEligibilityControls(container, {
+            target = group,
+            inheritedSources = inheritedSources,
+            allowClassEligibility = scopeIsGlobal,
+            ownerCharKey = ownerCharKey,
+            useSpecAllowlist = inheritedSpecFilter,
+            allowedSpecRestricted = inheritedSpecFilter,
+            allowedSpecMap = effectiveSpecs,
+            effectiveSpecs = effectiveSpecs,
+            heroTalentsSource = effectiveHeroTalents,
+            useHeroTalentsSource = inheritedHeroFilter,
+            disableHeroTalents = inheritedHeroFilter,
+            onChanged = function()
+                CooldownCompanion:RefreshGroupFrame(groupId)
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
     end -- not specCollapsed
 end
 
@@ -1772,5 +2906,9 @@ ST._BuildVisibilitySettings = BuildVisibilitySettings
 ST._BuildLoadConditionsTab = BuildLoadConditionsTab
 ST._BuildEntryLoadConditionsTab = BuildEntryLoadConditionsTab
 ST._AddScopedLoadConditionToggles = AddScopedLoadConditionToggles
+ST._SetSpecFilterValue = SetSpecFilterValue
+ST._SetSpecAllowlistValue = SetSpecAllowlistValue
+ST._AddCharacterEligibilityControls = AddCharacterEligibilityControls
+ST._AddClassSpecEligibilityControls = AddClassSpecEligibilityControls
 ST._GetConditionDisplayName = GetConditionDisplayName
 ST._GetConditionListContextSuffix = GetConditionListContextSuffix

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -25,6 +25,7 @@ local appearanceTabElements = CS.appearanceTabElements
 
 local LOAD_CONDITION_OPTIONS = ST.LOAD_CONDITION_OPTIONS
 local REMOVE_BADGE_WIDGET_TYPE = "CDCEligibilityRemoveBadge"
+local VIEW_TRAIT_CONFIG_ID = (Constants and Constants.TraitConsts and Constants.TraitConsts.VIEW_TRAIT_CONFIG_ID) or -3
 
 if AceGUI and not AceGUI:GetWidgetVersion(REMOVE_BADGE_WIDGET_TYPE) then
     local function Badge_OnClick(frame, button)
@@ -1035,19 +1036,63 @@ local function BuildSpecChoiceIndex(specChoices)
     return bySpecId, byClassKey
 end
 
+local function EnsureHeroTalentViewConfig(specId)
+    if not (specId
+        and C_ClassTalents
+        and C_ClassTalents.InitializeViewLoadout
+        and C_Traits
+        and C_Traits.GetConfigInfo) then
+        return nil
+    end
+
+    local playerLevel = UnitLevel and UnitLevel("player") or nil
+    if not playerLevel or playerLevel < 1 then
+        return nil
+    end
+
+    C_ClassTalents.InitializeViewLoadout(specId, playerLevel)
+    if C_Traits.GetConfigInfo(VIEW_TRAIT_CONFIG_ID) then
+        return VIEW_TRAIT_CONFIG_ID
+    end
+
+    return nil
+end
+
+local function GetHeroTalentSubTreesForSpec(specId, configID)
+    if not (specId and C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
+        return nil, configID
+    end
+
+    local subTreeIDs = configID and C_ClassTalents.GetHeroTalentSpecsForClassSpec(configID, specId) or nil
+    if subTreeIDs and #subTreeIDs > 0 then
+        return subTreeIDs, configID
+    end
+
+    subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+    if subTreeIDs and #subTreeIDs > 0 then
+        return subTreeIDs, configID
+    end
+
+    local viewConfigID = EnsureHeroTalentViewConfig(specId)
+    subTreeIDs = viewConfigID and C_ClassTalents.GetHeroTalentSpecsForClassSpec(viewConfigID, specId) or nil
+    if subTreeIDs and #subTreeIDs > 0 then
+        return subTreeIDs, viewConfigID
+    end
+
+    return nil, configID
+end
+
 local function BuildHeroTalentChoicesForSpecs(specChoices, selectedSpecMap, configID)
     local choices = {}
     local bySubTreeID = {}
-    if not (configID and C_ClassTalents and C_ClassTalents.GetHeroTalentSpecsForClassSpec) then
-        return choices, bySubTreeID
-    end
 
     for _, specInfo in ipairs(specChoices or {}) do
         local specId = specInfo.id
         if specId and selectedSpecMap and selectedSpecMap[specId] then
-            local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
+            local subTreeIDs, subTreeConfigID = GetHeroTalentSubTreesForSpec(specId, configID)
             for _, subTreeID in ipairs(subTreeIDs or {}) do
-                local subTreeInfo = C_Traits and C_Traits.GetSubTreeInfo and C_Traits.GetSubTreeInfo(configID, subTreeID) or nil
+                local subTreeInfo = subTreeConfigID and C_Traits and C_Traits.GetSubTreeInfo
+                    and C_Traits.GetSubTreeInfo(subTreeConfigID, subTreeID) or nil
                 local heroName = subTreeInfo and subTreeInfo.name or ("Hero " .. tostring(subTreeID))
                 local heroChoice = {
                     id = subTreeID,

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -569,22 +569,19 @@ local function BuildCharacterChoice(charKey, fallbackInfo)
 end
 
 local function AttachEligibilityTooltip(widget, title, text)
-    if not (widget and widget.frame and text and text ~= "") then return end
-    widget.frame:EnableMouse(true)
-    widget.frame:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+    if not (widget and text and text ~= "") then return end
+    widget:SetCallback("OnEnter", function(hoveredWidget)
+        if not (hoveredWidget and hoveredWidget.frame) then return end
+        GameTooltip:SetOwner(hoveredWidget.frame, "ANCHOR_RIGHT")
         GameTooltip:AddLine(title or "")
         GameTooltip:AddLine(text, 1, 1, 1, true)
         GameTooltip:Show()
     end)
-    widget.frame:SetScript("OnLeave", function()
+    widget:SetCallback("OnLeave", function()
         GameTooltip:Hide()
     end)
-    widget:SetCallback("OnRelease", function(releasedWidget)
-        if releasedWidget and releasedWidget.frame then
-            releasedWidget.frame:SetScript("OnEnter", nil)
-            releasedWidget.frame:SetScript("OnLeave", nil)
-        end
+    widget:SetCallback("OnRelease", function()
+        GameTooltip:Hide()
     end)
 end
 
@@ -852,7 +849,8 @@ local function AddEligibilitySelectedRow(container, rowInfo, onRemove)
     row:SetFullWidth(true)
     row:SetLayout("Flow")
 
-    local label = AceGUI:Create("Label")
+    local hasTooltip = rowInfo.tooltipText and rowInfo.tooltipText ~= ""
+    local label = AceGUI:Create(hasTooltip and "InteractiveLabel" or "Label")
     label:SetText(rowInfo.label)
     label:SetRelativeWidth(0.92)
     AttachEligibilityTooltip(label, rowInfo.tooltipTitle or rowInfo.label, rowInfo.tooltipText)
@@ -880,9 +878,6 @@ local function AddCharacterEligibilityControls(container, opts)
     local scopeClassChoice
     if opts.allowClassEligibility == false then
         scopeClassChoice = ResolveOwnerClassChoice(opts)
-        if scopeClassChoice then
-            PruneCharacterAllowlistToScopeClass(target, scopeClassChoice.key, opts.ownerCharKey)
-        end
     end
     local choices = BuildCharacterChoices(target, inheritedMap, scopeClassChoice and scopeClassChoice.key or nil, opts.ownerCharKey)
     if #choices == 0 then return end
@@ -1054,7 +1049,6 @@ local function BuildEligibilitySpecChoices(opts)
         AddClassesForSpecMap(classChoices, classByKey, target.loadConditions and target.loadConditions.specAllowlist)
         AddClassesForSpecMap(classChoices, classByKey, opts.effectiveSpecs)
     else
-        ClearClassAllowlistWhenScoped(target, false)
         local choice = ResolveOwnerClassChoice(opts)
         if choice then
             classByKey[choice.key] = true
@@ -1224,7 +1218,6 @@ local function AddClassSpecEligibilityControls(container, opts)
     local scopeClassChoice
     if not allowClassEligibility then
         scopeClassChoice = ResolveOwnerClassChoice(opts)
-        PruneClassScopedEligibility(target, scopeClassChoice, opts.ownerCharKey)
     end
 
     local inheritedClassMap, inheritedClassRestricted = GetInheritedAllowlist(opts.inheritedSources, "classAllowlist", "class")

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -449,10 +449,25 @@ end
 
 local MAX_CLASS_SCAN_ID = 20
 
+local function GetClassInfoByID(classID)
+    classID = tonumber(classID)
+    if not classID then return nil, nil, nil end
+    if C_CreatureInfo and C_CreatureInfo.GetClassInfo then
+        local classInfo = C_CreatureInfo.GetClassInfo(classID)
+        if type(classInfo) == "table" then
+            return classInfo.className, classInfo.classFile, classInfo.classID
+        end
+    end
+    if GetClassInfo then
+        return GetClassInfo(classID)
+    end
+    return nil, nil, nil
+end
+
 local function GetClassChoiceByID(classID)
     classID = tonumber(classID)
     if not classID then return nil end
-    local className, classFilename = GetClassInfo(classID)
+    local className, classFilename = GetClassInfoByID(classID)
     local classKey = NormalizeAllowlistKey("class", classFilename)
     if not classKey then return nil end
     return {
@@ -483,8 +498,8 @@ local function GetCurrentClassChoice()
     local classFilename = CooldownCompanion._playerClassFilename
     local classID = CooldownCompanion._playerClassID
     local className
-    if classID and GetClassInfo then
-        className = GetClassInfo(classID)
+    if classID then
+        className = GetClassInfoByID(classID)
     end
     if (not classFilename or not className) and UnitClass then
         local unitClassName, unitClassFilename, unitClassID = UnitClass("player")
@@ -1767,7 +1782,7 @@ local function ResolveConditionClassName(cond)
     end
 
     if cond.classID then
-        local name = GetClassInfo(cond.classID)
+        local name = GetClassInfoByID(cond.classID)
         return name or ("Class " .. cond.classID)
     end
 

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -149,6 +149,9 @@ local function SetSpecFilterValue(target, specId, value)
         local loadConditions = EnsureLoadConditions(target)
         if type(loadConditions.specAllowlist) ~= "table" then
             loadConditions.specAllowlist = {}
+            for existingSpecId in pairs(target.specs or {}) do
+                loadConditions.specAllowlist[existingSpecId] = true
+            end
         end
         loadConditions.specAllowlist[specId] = true
     else
@@ -738,98 +741,6 @@ local function BuildCharacterChoices(target, inheritedMap, scopeClassKey, ownerC
     end
     SortChoices(choices)
     return choices
-end
-
-local function ClearEmptyLoadConditions(target)
-    if type(target) ~= "table" or type(target.loadConditions) ~= "table" then return end
-    if not next(target.loadConditions) then
-        target.loadConditions = nil
-    end
-end
-
-local function ClearClassAllowlistWhenScoped(target, allowClassEligibility)
-    if allowClassEligibility or type(target) ~= "table" then return false end
-    local loadConditions = target.loadConditions
-    if type(loadConditions) ~= "table" or loadConditions.classAllowlist == nil then
-        return false
-    end
-    loadConditions.classAllowlist = nil
-    ClearEmptyLoadConditions(target)
-    return true
-end
-
-local function PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey)
-    if type(target) ~= "table" or not scopeClassKey then return false end
-    local loadConditions = target.loadConditions
-    local map = loadConditions and loadConditions.characterAllowlist
-    if type(map) ~= "table" then return false end
-
-    local changed = false
-    for key in pairs(map) do
-        local normalizedKey = NormalizeAllowlistKey("character", key)
-        local choice = normalizedKey and BuildCharacterChoice(normalizedKey) or nil
-        if not (normalizedKey and CharacterChoiceMatchesScopeClass(choice, scopeClassKey, ownerCharKey)) then
-            map[key] = nil
-            changed = true
-        end
-    end
-    if not next(map) then
-        loadConditions.characterAllowlist = nil
-    end
-    ClearEmptyLoadConditions(target)
-    return changed
-end
-
-local function SpecMatchesScopeClass(specId, scopeClassKey)
-    if not scopeClassKey then return true end
-    local classChoice = GetSpecClassChoice(specId)
-    return not classChoice or classChoice.key == scopeClassKey
-end
-
-local function PruneSpecMapToScopeClass(target, map, scopeClassKey)
-    if type(map) ~= "table" or not scopeClassKey then return false end
-    local changed = false
-    for key in pairs(map) do
-        local specId = NormalizeAllowlistKey("spec", key)
-        if not (specId and SpecMatchesScopeClass(specId, scopeClassKey)) then
-            map[key] = nil
-            if specId and map[specId] ~= nil then
-                map[specId] = nil
-            end
-            if specId and CooldownCompanion.CleanHeroTalentsForSpec then
-                CooldownCompanion:CleanHeroTalentsForSpec(target, specId)
-            end
-            changed = true
-        end
-    end
-    return changed
-end
-
-local function PruneClassScopedEligibility(target, scopeClassChoice, ownerCharKey)
-    if type(target) ~= "table" or not scopeClassChoice then return false end
-    local scopeClassKey = scopeClassChoice.key
-    local changed = ClearClassAllowlistWhenScoped(target, false)
-    changed = PruneCharacterAllowlistToScopeClass(target, scopeClassKey, ownerCharKey) or changed
-
-    if PruneSpecMapToScopeClass(target, target.specs, scopeClassKey) then
-        changed = true
-        if type(target.specs) == "table" and not next(target.specs) then
-            target.specs = nil
-        end
-    end
-
-    local loadConditions = target.loadConditions
-    if type(loadConditions) == "table" then
-        if PruneSpecMapToScopeClass(target, loadConditions.specAllowlist, scopeClassKey) then
-            changed = true
-            if type(loadConditions.specAllowlist) == "table" and not next(loadConditions.specAllowlist) then
-                loadConditions.specAllowlist = nil
-            end
-        end
-    end
-
-    ClearEmptyLoadConditions(target)
-    return changed
 end
 
 local function CreateEligibilityRemoveBadge(onRemove)

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -141,7 +141,7 @@ local function BuildSortedSoundOptionOrder(soundOptions)
 end
 
 local function ConfigurePriorityMoveButton(button, rotation, tooltipTitle, tooltipBody, disabled, onClick)
-    local isDisabled = disabled or CS.browseMode
+    local isDisabled = disabled
     button:SetSize(18, 18)
     if button.text then
         button.text:Hide()
@@ -542,10 +542,6 @@ local function BuildAuraTrackingIDRowText(spellID, rowIndex)
 end
 
 local function ShowAuraTrackingIDRowMenu(buttonData, isAuraEntry, rowIndex)
-    if CS.browseMode then
-        return
-    end
-
     if not CS.auraIDContextMenu then
         CS.auraIDContextMenu = CreateFrame("Frame", "CDCAuraIDContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -616,9 +612,6 @@ end
 
 local function InstallAuraTrackingIDRowMenu(entry, buttonData, isAuraEntry, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.browseMode then
-            return
-        end
         if button == "RightButton" then
             ShowAuraTrackingIDRowMenu(buttonData, isAuraEntry, rowIndex)
         end
@@ -936,10 +929,6 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
             RefreshAuraTrackingEntry(CS.selectedGroup)
         end
         auraEditBox:SetCallback("OnTextChanged", function(widget, _, text)
-            if CS.browseMode then
-                CS.HideAutocomplete()
-                return
-            end
             if text and #text >= 1 and CS.SearchCDMAuraAutocomplete then
                 CS.ShowAutocompleteResults(CS.SearchCDMAuraAutocomplete(text), widget, function(entry)
                     CommitAuraTrackingEntry(widget, entry)
@@ -949,10 +938,6 @@ local function BuildAuraTrackingSettingsSection(scroll, buttonData, infoButtons,
             end
         end)
         auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
-            if CS.browseMode then
-                CS.HideAutocomplete()
-                return
-            end
             if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
                 return
             end
@@ -1873,10 +1858,6 @@ local function SearchFallbackAutocomplete(buttonData, query)
 end
 
 local function AddItemFallback(buttonData, itemID)
-    if CS.browseMode then
-        return false
-    end
-
     local validID, err = ValidateFallbackItem(buttonData, itemID)
     if not validID then
         CooldownCompanion:Print(err)
@@ -1892,10 +1873,6 @@ local function AddItemFallback(buttonData, itemID)
 end
 
 local function TryReceiveFallbackItemDrop(buttonData)
-    if CS.browseMode then
-        return false
-    end
-
     local cursorType, cursorID = GetCursorInfo()
     if cursorType ~= "item" or not cursorID then
         return false
@@ -1918,10 +1895,6 @@ local function UpdatePrimaryFallbackItem(buttonData, itemID)
 end
 
 local function MoveFallbackPriorityItem(buttonData, sourceIndex, targetIndex)
-    if CS.browseMode then
-        return false
-    end
-
     if not (buttonData and buttonData.type == "item") then
         return false
     end
@@ -1984,7 +1957,7 @@ local function InstallFallbackDropScript(frame, buttonData)
 
     frame:SetScript("OnReceiveDrag", function(self, ...)
         local activeButtonData = self._cdcFallbackDropButtonData
-        if CS.buttonSettingsTab == "fallbacks" and not CS.browseMode and activeButtonData then
+        if CS.buttonSettingsTab == "fallbacks" and activeButtonData then
             local cursorType = GetCursorInfo()
             if cursorType == "item" then
                 TryReceiveFallbackItemDrop(activeButtonData)
@@ -1998,7 +1971,7 @@ local function InstallFallbackDropScript(frame, buttonData)
     end)
     frame:SetScript("OnMouseUp", function(self, button, ...)
         local activeButtonData = self._cdcFallbackDropButtonData
-        if CS.buttonSettingsTab ~= "fallbacks" or CS.browseMode or button ~= "LeftButton" then
+        if CS.buttonSettingsTab ~= "fallbacks" or button ~= "LeftButton" then
             local original = self._cdcFallbackOriginalOnMouseUp
             if original then
                 return original(self, button, ...)
@@ -2118,10 +2091,6 @@ local function EnsureFallbackMoveButtons(entry, buttonData, rowIndex, isPrimary)
 end
 
 local function ShowFallbackRowMenu(buttonData, rowIndex)
-    if CS.browseMode then
-        return
-    end
-
     if not CS.fallbackContextMenu then
         CS.fallbackContextMenu = CreateFrame("Frame", "CDCFallbackContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -2148,9 +2117,6 @@ end
 
 local function InstallFallbackRowMenu(entry, buttonData, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.browseMode then
-            return
-        end
         if button == "RightButton" then
             ShowFallbackRowMenu(buttonData, rowIndex)
             return
@@ -2243,13 +2209,9 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
     addBox:DisableButton(true)
     addBox:SetFullWidth(true)
     addBox:SetCallback("OnTextChanged", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if text and #text >= 1 then
             CS.ShowAutocompleteResults(SearchFallbackAutocomplete(buttonData, text), widget, function(entry)
-                if entry and not CS.browseMode and AddItemFallback(buttonData, entry.id) then
+                if entry and AddItemFallback(buttonData, entry.id) then
                     RefreshFallbackEntry(CS.selectedGroup)
                 else
                     CS.HideAutocomplete()
@@ -2260,10 +2222,6 @@ local function BuildItemFallbacksTab(scroll, buttonData, infoButtons)
         end
     end)
     addBox:SetCallback("OnEnterPressed", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
             return
         end

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -10,6 +10,14 @@ local EncodeExportData = ST._EncodeExportData
 local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
 local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 
+local function IsContainerVisibleInConfig(containerOrContainerId)
+    if CooldownCompanion.ResolveContainerClassScope then
+        local scope = CooldownCompanion:ResolveContainerClassScope(containerOrContainerId)
+        return scope.isInvalid ~= true
+    end
+    return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
+end
+
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
@@ -311,7 +319,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
 
     local hasOtherContainer = false
     for cid in pairs(db.groupContainers) do
-        if cid ~= containerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+        if cid ~= containerId and IsContainerVisibleInConfig(cid) then
             hasOtherContainer = true
             break
         end
@@ -329,7 +337,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                 local containers = db.groupContainers or {}
                 local folderContainers, looseContainers = {}, {}
                 for cid, ctr in pairs(containers) do
-                    if cid ~= containerId and CooldownCompanion:IsContainerVisibleToCurrentChar(cid) then
+                    if cid ~= containerId and IsContainerVisibleInConfig(cid) then
                         local name = ctr.name or ("Group " .. cid)
                         local fid = ctr.folderId
                         if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -34,6 +34,13 @@ local function CanAllPanelsMoveToContainer(panelIds, containerId)
     return true
 end
 
+local function CanMoveEntryToGroup(sourceGroupId, targetGroupId)
+    if CooldownCompanion.CanMoveEntryToGroup then
+        return CooldownCompanion:CanMoveEntryToGroup(sourceGroupId, targetGroupId) == true
+    end
+    return CooldownCompanion:IsGroupVisibleToCurrentChar(targetGroupId)
+end
+
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
@@ -113,7 +120,7 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
             local folderGroups, looseGroups = {}, {}
             for id, groupInfo in pairs(db.groups) do
                 if id ~= sourceGroupId
-                    and CooldownCompanion:IsGroupVisibleToCurrentChar(id)
+                    and CanMoveEntryToGroup(sourceGroupId, id)
                     and not GetManualMoveRejectMessage(groupInfo, multiCount) then
                     local groupName = groupInfo.name or ("Group " .. id)
                     local cid = groupInfo.parentContainerId
@@ -150,6 +157,9 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                     local info = UIDropDownMenu_CreateInfo()
                     info.text = groupEntry.name
                     info.func = function()
+                        if not CanMoveEntryToGroup(sourceGroupId, groupEntry.id) then
+                            return
+                        end
                         local targetGroup = db.groups[groupEntry.id]
                         local rejectMessage = GetManualMoveRejectMessage(targetGroup, multiCount)
                         if rejectMessage then
@@ -185,6 +195,9 @@ function ST._RefreshButtonSettingsMultiSelect(scroll, multiCount, multiIndices, 
                     local info = UIDropDownMenu_CreateInfo()
                     info.text = groupEntry.name
                     info.func = function()
+                        if not CanMoveEntryToGroup(sourceGroupId, groupEntry.id) then
+                            return
+                        end
                         local targetGroup = db.groups[groupEntry.id]
                         local rejectMessage = GetManualMoveRejectMessage(targetGroup, multiCount)
                         if rejectMessage then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsMultiSelect.lua
@@ -18,6 +18,22 @@ local function IsContainerVisibleInConfig(containerOrContainerId)
     return CooldownCompanion:IsContainerVisibleToCurrentChar(containerOrContainerId)
 end
 
+local function CanAllPanelsMoveToContainer(panelIds, containerId)
+    if not IsContainerVisibleInConfig(containerId) then
+        return false
+    end
+    if not CooldownCompanion.CanMovePanelToContainer then
+        return true
+    end
+    for _, panelId in ipairs(panelIds or {}) do
+        local ok = CooldownCompanion:CanMovePanelToContainer(panelId, containerId)
+        if not ok then
+            return false
+        end
+    end
+    return true
+end
+
 local function GroupUsesTriggerPanelEntries(group)
     return group and group.displayMode == "trigger"
 end
@@ -319,7 +335,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
 
     local hasOtherContainer = false
     for cid in pairs(db.groupContainers) do
-        if cid ~= containerId and IsContainerVisibleInConfig(cid) then
+        if cid ~= containerId and CanAllPanelsMoveToContainer(multiPanelIds, cid) then
             hasOtherContainer = true
             break
         end
@@ -337,7 +353,7 @@ function ST._RefreshPanelMultiSelect(scroll, multiCount, multiPanelIds)
                 local containers = db.groupContainers or {}
                 local folderContainers, looseContainers = {}, {}
                 for cid, ctr in pairs(containers) do
-                    if cid ~= containerId and IsContainerVisibleInConfig(cid) then
+                    if cid ~= containerId and CanAllPanelsMoveToContainer(multiPanelIds, cid) then
                         local name = ctr.name or ("Group " .. cid)
                         local fid = ctr.folderId
                         if fid and db.folders[fid] then

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3895,8 +3895,8 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
             clearBtn:SetText("Clear All Spec Filters")
             clearBtn:SetFullWidth(true)
             clearBtn:SetCallback("OnClick", function()
-                if folderSpecs then
-                    container.specs = CopyTable(folderSpecs)
+                if folder and type(folder.specs) == "table" and next(folder.specs) then
+                    container.specs = CopyTable(folder.specs)
                 else
                     container.specs = nil
                 end

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3929,10 +3929,14 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     local folder = db.folders and db.folders[folderId]
     if not folder then return end
 
-    local function RefreshFolderDependents()
-        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
+    local function RefreshFolderOnly()
         CooldownCompanion:RefreshAllGroups()
         CooldownCompanion:RefreshConfigPanel()
+    end
+
+    local function RefreshFolderSpecDependents()
+        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
+        RefreshFolderOnly()
     end
 
     AddScopedLoadConditionToggles(scroll, {
@@ -3958,7 +3962,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
         allowClassEligibility = folder.section == "global",
         ownerCharKey = folder.createdBy,
         characterCollapsedKey = "folder_loadconditions_character",
-        onChanged = RefreshFolderDependents,
+        onChanged = RefreshFolderOnly,
     })
 
     local specHeading = AceGUI:Create("Heading")
@@ -3980,7 +3984,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
             eligibilitySubjectLabel = "folder",
             allowClassEligibility = folder.section == "global",
             ownerCharKey = folder.createdBy,
-            onChanged = RefreshFolderDependents,
+            onChanged = RefreshFolderSpecDependents,
         })
 
         if folder.specs or folder.heroTalents then
@@ -3993,7 +3997,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
                 if type(folder.loadConditions) == "table" then
                     folder.loadConditions.specAllowlist = nil
                 end
-                RefreshFolderDependents()
+                RefreshFolderSpecDependents()
             end)
             scroll:AddChild(clearSpecsBtn)
         end

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -27,6 +27,8 @@ local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
+local AddCharacterEligibilityControls = ST._AddCharacterEligibilityControls
+local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
 
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -3776,11 +3778,15 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     local function RefreshPanels()
         CooldownCompanion:RefreshContainerPanels(containerId)
     end
+    local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container)
+    local folder = container.folderId and db.folders and db.folders[container.folderId]
+    local folderSpecs = folder and folder.specs
+    local folderHeroTalents = folder and folder.heroTalents
 
     AddScopedLoadConditionToggles(scroll, {
         target = container,
         defaults = CooldownCompanion:GetDefaultLoadConditions(),
-        inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container),
+        inheritedSources = inheritedSources,
         headingText = "Hide This Group In",
         headingTextWhenInherited = "Also Hide This Group In",
         inheritedCollapsedKey = "container_loadconditions_inherited",
@@ -3791,9 +3797,21 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         end,
     })
 
-    -- Spec filter section
+    AddCharacterEligibilityControls(scroll, {
+        target = container,
+        inheritedSources = inheritedSources,
+        allowClassEligibility = container.isGlobal == true,
+        ownerCharKey = container.createdBy,
+        characterCollapsedKey = "container_loadconditions_character",
+        onChanged = function()
+            RefreshPanels()
+            CooldownCompanion:RefreshConfigPanel()
+        end,
+    })
+
+    -- Class/spec eligibility section
     local specHeading = AceGUI:Create("Heading")
-    specHeading:SetText("Specialization Filter")
+    specHeading:SetText("Class & Specialization Eligibility")
     ColorHeading(specHeading)
     specHeading:SetFullWidth(true)
     scroll:AddChild(specHeading)
@@ -3805,119 +3823,66 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end)
 
     if not specCollapsed then
-    -- Folder spec inheritance: folder-level spec/hero filters are shown as
-    -- disabled (locked) on child containers, but children can still toggle
-    -- specs that the folder does NOT set.
-    local folder = container.folderId and db.folders and db.folders[container.folderId]
-    local folderSpecs = folder and folder.specs
-    local folderHeroTalents = folder and folder.heroTalents
-    local hasFolderSpecs = folderSpecs and next(folderSpecs)
+        local hasFolderSpecs = folderSpecs and next(folderSpecs)
 
-    -- Effective specs for hero talent rendering (union of folder + container specs)
-    local effectiveSpecs
-    if folderSpecs or container.specs then
-        effectiveSpecs = {}
-        if folderSpecs then for k in pairs(folderSpecs) do effectiveSpecs[k] = true end end
-        if container.specs then for k in pairs(container.specs) do effectiveSpecs[k] = true end end
-        if not next(effectiveSpecs) then effectiveSpecs = nil end
-    end
+        if hasFolderSpecs then
+            local inheritedLabel = AceGUI:Create("Label")
+            ST._ConfigureWrappedHelperLabel(inheritedLabel)
+            inheritedLabel:SetText("|cff888888Specs set by the parent folder cannot be changed here.|r")
+            inheritedLabel:SetFullWidth(true)
+            scroll:AddChild(inheritedLabel)
+        end
 
-    if hasFolderSpecs then
-        local inheritedLabel = AceGUI:Create("Label")
-        ST._ConfigureWrappedHelperLabel(inheritedLabel)
-        inheritedLabel:SetText("|cff888888Specs set by the parent folder cannot be changed here.|r")
-        inheritedLabel:SetFullWidth(true)
-        scroll:AddChild(inheritedLabel)
-    end
+        AddClassSpecEligibilityControls(scroll, {
+            target = container,
+            inheritedSources = inheritedSources,
+            allowClassEligibility = container.isGlobal == true,
+            ownerCharKey = container.createdBy,
+            useSpecAllowlist = hasFolderSpecs,
+            allowedSpecRestricted = hasFolderSpecs,
+            allowedSpecMap = folderSpecs,
+            effectiveSpecs = folderSpecs,
+            heroTalentsSource = folderHeroTalents,
+            useHeroTalentsSource = folderHeroTalents and next(folderHeroTalents) ~= nil,
+            disableHeroTalents = folderHeroTalents and next(folderHeroTalents) ~= nil,
+            onChanged = function()
+                RefreshPanels()
+                CooldownCompanion:RefreshConfigPanel()
+            end,
+        })
 
-    local numSpecs = GetNumSpecializations()
-    local configID = C_ClassTalents.GetActiveConfigID()
-    for i = 1, numSpecs do
-        local specId, name, _, icon = C_SpecializationInfo.GetSpecializationInfo(i)
-        if specId then
-            local lockedByFolder = folderSpecs and folderSpecs[specId]
-            local cb = AceGUI:Create("CheckBox")
-            cb:SetLabel(name)
-            if icon then cb:SetImage(icon, 0.08, 0.92, 0.08, 0.92) end
-            cb:SetFullWidth(true)
-            cb:SetValue(lockedByFolder or (container.specs and container.specs[specId]) or false)
-            if hasFolderSpecs then
-                cb:SetDisabled(true)
-            else
-                cb:SetCallback("OnValueChanged", function(widget, event, value)
-                    if value then
-                        if not container.specs then container.specs = {} end
-                        container.specs[specId] = true
-                    else
-                        if container.specs then
-                            container.specs[specId] = nil
-                            if not next(container.specs) then
-                                container.specs = nil
-                            end
-                        end
-                        CooldownCompanion:CleanHeroTalentsForSpec(container, specId)
-                    end
-                    RefreshPanels()
-                    CooldownCompanion:RefreshConfigPanel()
-                end)
-            end
-            scroll:AddChild(cb)
-
-            -- Hero talent sub-tree checkboxes
-            local specActive = lockedByFolder or (container.specs and container.specs[specId])
-            if configID and specActive then
-                local htOpts
-                if folderHeroTalents and next(folderHeroTalents) then
-                    htOpts = {
-                        heroTalentsSource = folderHeroTalents,
-                        useHeroTalentsSource = true,
-                        disableToggles = true,
-                        specsSource = effectiveSpecs,
-                    }
-                else
-                    htOpts = {
-                        heroTalentsSource = container.heroTalents,
-                        specsSource = effectiveSpecs,
-                        onChanged = function()
-                            RefreshPanels()
-                            CooldownCompanion:RefreshConfigPanel()
-                        end,
-                    }
+        -- Only show Clear All when container has specs/hero-talents beyond folder cascade
+        local hasOwnSpecs = false
+        if container.specs then
+            for specId in pairs(container.specs) do
+                if not (folderSpecs and folderSpecs[specId]) then
+                    hasOwnSpecs = true
+                    break
                 end
-                ST._BuildHeroTalentSubTreeCheckboxes(scroll, container, configID, specId, 20, containerId, htOpts)
             end
         end
-    end
-
-    -- Only show Clear All when container has specs/hero-talents beyond folder cascade
-    local hasOwnSpecs = false
-    if container.specs then
-        for specId in pairs(container.specs) do
-            if not (folderSpecs and folderSpecs[specId]) then
-                hasOwnSpecs = true
-                break
-            end
+        if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
+            hasOwnSpecs = true
         end
-    end
-    if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
-        hasOwnSpecs = true
-    end
-    if hasOwnSpecs then
-        local clearBtn = AceGUI:Create("Button")
-        clearBtn:SetText("Clear All Spec Filters")
-        clearBtn:SetFullWidth(true)
-        clearBtn:SetCallback("OnClick", function()
-            if folderSpecs then
-                container.specs = CopyTable(folderSpecs)
-            else
-                container.specs = nil
-            end
-            container.heroTalents = nil
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end)
-        scroll:AddChild(clearBtn)
-    end
+        if hasOwnSpecs then
+            local clearBtn = AceGUI:Create("Button")
+            clearBtn:SetText("Clear All Spec Filters")
+            clearBtn:SetFullWidth(true)
+            clearBtn:SetCallback("OnClick", function()
+                if folderSpecs then
+                    container.specs = CopyTable(folderSpecs)
+                else
+                    container.specs = nil
+                end
+                if type(container.loadConditions) == "table" then
+                    container.loadConditions.specAllowlist = nil
+                end
+                container.heroTalents = nil
+                RefreshPanels()
+                CooldownCompanion:RefreshConfigPanel()
+            end)
+            scroll:AddChild(clearBtn)
+        end
     end -- not specCollapsed
 end
 
@@ -3962,6 +3927,12 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     local folder = db.folders and db.folders[folderId]
     if not folder then return end
 
+    local function RefreshFolderDependents()
+        CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
+        CooldownCompanion:RefreshAllGroups()
+        CooldownCompanion:RefreshConfigPanel()
+    end
+
     AddScopedLoadConditionToggles(scroll, {
         target = folder,
         defaults = CooldownCompanion:GetLocalLoadConditionDefaults(),
@@ -3977,6 +3948,52 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
             CooldownCompanion:RefreshConfigPanel()
         end,
     })
+
+    AddCharacterEligibilityControls(scroll, {
+        target = folder,
+        inheritedSources = {},
+        allowClassEligibility = folder.section == "global",
+        ownerCharKey = folder.createdBy,
+        characterCollapsedKey = "folder_loadconditions_character",
+        onChanged = RefreshFolderDependents,
+    })
+
+    local specHeading = AceGUI:Create("Heading")
+    specHeading:SetText("Class & Specialization Eligibility")
+    ColorHeading(specHeading)
+    specHeading:SetFullWidth(true)
+    scroll:AddChild(specHeading)
+
+    local specCollapsed = CS.collapsedSections["folder_loadconditions_spec"]
+    AttachCollapseButton(specHeading, specCollapsed, function()
+        CS.collapsedSections["folder_loadconditions_spec"] = not CS.collapsedSections["folder_loadconditions_spec"]
+        CooldownCompanion:RefreshConfigPanel()
+    end)
+
+    if not specCollapsed then
+        AddClassSpecEligibilityControls(scroll, {
+            target = folder,
+            inheritedSources = {},
+            allowClassEligibility = folder.section == "global",
+            ownerCharKey = folder.createdBy,
+            onChanged = RefreshFolderDependents,
+        })
+
+        if folder.specs or folder.heroTalents then
+            local clearSpecsBtn = AceGUI:Create("Button")
+            clearSpecsBtn:SetText("Clear Folder Spec Filters")
+            clearSpecsBtn:SetFullWidth(true)
+            clearSpecsBtn:SetCallback("OnClick", function()
+                folder.specs = nil
+                folder.heroTalents = nil
+                if type(folder.loadConditions) == "table" then
+                    folder.loadConditions.specAllowlist = nil
+                end
+                RefreshFolderDependents()
+            end)
+            scroll:AddChild(clearSpecsBtn)
+        end
+    end
 
     if CooldownCompanion:HasLocalLoadConditions(folder) then
         local clearBtn = AceGUI:Create("Button")

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -27,6 +27,7 @@ local ApplyBorderEdgePositions = ST._ApplyBorderEdgePositions
 local ApplyIconTexCoord = ST._ApplyIconTexCoord
 local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
+local AddActiveEligibilitySummary = ST._AddActiveEligibilitySummary
 local AddCharacterEligibilityControls = ST._AddCharacterEligibilityControls
 local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
 local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
@@ -3786,6 +3787,12 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         folder.loadConditions and folder.loadConditions.specAllowlist
     )
     local folderHeroTalents = folder and folder.heroTalents
+    local hasFolderSpecs = folderSpecs and next(folderSpecs)
+    local hasFolderHeroTalents = folderHeroTalents and next(folderHeroTalents) ~= nil
+    local function RefreshContainerLoadConditions()
+        RefreshPanels()
+        CooldownCompanion:RefreshConfigPanel()
+    end
 
     AddScopedLoadConditionToggles(scroll, {
         target = container,
@@ -3795,10 +3802,23 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         headingTextWhenInherited = "Also Hide This Group In",
         inheritedCollapsedKey = "container_loadconditions_inherited",
         localCollapsedKey = "container_loadconditions_local",
-        onChanged = function()
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshContainerLoadConditions,
+    })
+
+    AddActiveEligibilitySummary(scroll, {
+        target = container,
+        inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "group",
+        allowClassEligibility = container.isGlobal == true,
+        ownerCharKey = container.createdBy,
+        useSpecAllowlist = hasFolderSpecs,
+        allowedSpecRestricted = hasFolderSpecs,
+        allowedSpecMap = folderSpecs,
+        effectiveSpecs = folderSpecs,
+        heroTalentsSource = folderHeroTalents,
+        useHeroTalentsSource = hasFolderHeroTalents,
+        disableHeroTalents = hasFolderHeroTalents,
+        onChanged = RefreshContainerLoadConditions,
     })
 
     AddCharacterEligibilityControls(scroll, {
@@ -3808,10 +3828,7 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         allowClassEligibility = container.isGlobal == true,
         ownerCharKey = container.createdBy,
         characterCollapsedKey = "container_loadconditions_character",
-        onChanged = function()
-            RefreshPanels()
-            CooldownCompanion:RefreshConfigPanel()
-        end,
+        onChanged = RefreshContainerLoadConditions,
     })
 
     -- Class/spec eligibility section
@@ -3828,8 +3845,6 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end)
 
     if not specCollapsed then
-        local hasFolderSpecs = folderSpecs and next(folderSpecs)
-
         if hasFolderSpecs then
             local inheritedLabel = AceGUI:Create("Label")
             ST._ConfigureWrappedHelperLabel(inheritedLabel)
@@ -3849,12 +3864,9 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
             allowedSpecMap = folderSpecs,
             effectiveSpecs = folderSpecs,
             heroTalentsSource = folderHeroTalents,
-            useHeroTalentsSource = folderHeroTalents and next(folderHeroTalents) ~= nil,
-            disableHeroTalents = folderHeroTalents and next(folderHeroTalents) ~= nil,
-            onChanged = function()
-                RefreshPanels()
-                CooldownCompanion:RefreshConfigPanel()
-            end,
+            useHeroTalentsSource = hasFolderHeroTalents,
+            disableHeroTalents = hasFolderHeroTalents,
+            onChanged = RefreshContainerLoadConditions,
         })
 
         -- Only show Clear All when container has specs/hero-talents beyond folder cascade
@@ -3965,6 +3977,16 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
             CooldownCompanion:RefreshAllGroups()
             CooldownCompanion:RefreshConfigPanel()
         end,
+    })
+
+    AddActiveEligibilitySummary(scroll, {
+        target = folder,
+        inheritedSources = {},
+        eligibilitySubjectLabel = "folder",
+        allowClassEligibility = folder.section == "global",
+        ownerCharKey = folder.createdBy,
+        characterOnChanged = RefreshFolderOnly,
+        specOnChanged = RefreshFolderSpecDependents,
     })
 
     AddCharacterEligibilityControls(scroll, {

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -29,6 +29,7 @@ local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local AddScopedLoadConditionToggles = ST._AddScopedLoadConditionToggles
 local AddCharacterEligibilityControls = ST._AddCharacterEligibilityControls
 local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
+local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
 
 -- Imports from SectionBuilders.lua
 local BuildCooldownTextControls = ST._BuildCooldownTextControls
@@ -3780,7 +3781,10 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end
     local inheritedSources = CooldownCompanion:GetInheritedLoadConditionSources(container)
     local folder = container.folderId and db.folders and db.folders[container.folderId]
-    local folderSpecs = folder and folder.specs
+    local folderSpecs = folder and BuildEligibilityBadgeMap(
+        folder.specs,
+        folder.loadConditions and folder.loadConditions.specAllowlist
+    )
     local folderHeroTalents = folder and folder.heroTalents
 
     AddScopedLoadConditionToggles(scroll, {
@@ -3855,13 +3859,21 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
 
         -- Only show Clear All when container has specs/hero-talents beyond folder cascade
         local hasOwnSpecs = false
-        if container.specs then
-            for specId in pairs(container.specs) do
-                if not (folderSpecs and folderSpecs[specId]) then
-                    hasOwnSpecs = true
-                    break
+        local function CheckOwnSpecs(specs)
+            if type(specs) ~= "table" then
+                return specs ~= nil
+            end
+            for specId in pairs(specs) do
+                if not (folderSpecs and folderSpecs[tonumber(specId) or specId]) then
+                    return true
                 end
             end
+            return false
+        end
+        if CheckOwnSpecs(container.specs)
+            or CheckOwnSpecs(container.loadConditions and container.loadConditions.specAllowlist)
+        then
+            hasOwnSpecs = true
         end
         if not hasOwnSpecs and container.heroTalents and next(container.heroTalents) then
             hasOwnSpecs = true

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3800,6 +3800,7 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     AddCharacterEligibilityControls(scroll, {
         target = container,
         inheritedSources = inheritedSources,
+        eligibilitySubjectLabel = "group",
         allowClassEligibility = container.isGlobal == true,
         ownerCharKey = container.createdBy,
         characterCollapsedKey = "container_loadconditions_character",
@@ -3836,6 +3837,7 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
         AddClassSpecEligibilityControls(scroll, {
             target = container,
             inheritedSources = inheritedSources,
+            eligibilitySubjectLabel = "group",
             allowClassEligibility = container.isGlobal == true,
             ownerCharKey = container.createdBy,
             useSpecAllowlist = hasFolderSpecs,
@@ -3952,6 +3954,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
     AddCharacterEligibilityControls(scroll, {
         target = folder,
         inheritedSources = {},
+        eligibilitySubjectLabel = "folder",
         allowClassEligibility = folder.section == "global",
         ownerCharKey = folder.createdBy,
         characterCollapsedKey = "folder_loadconditions_character",
@@ -3974,6 +3977,7 @@ local function BuildFolderLoadConditionsTab(scroll, folderId)
         AddClassSpecEligibilityControls(scroll, {
             target = folder,
             inheritedSources = {},
+            eligibilitySubjectLabel = "folder",
             allowClassEligibility = folder.section == "global",
             ownerCharKey = folder.createdBy,
             onChanged = RefreshFolderDependents,

--- a/CooldownCompanion_Config/ConfigSettings/Helpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/Helpers.lua
@@ -1027,19 +1027,6 @@ local CHARACTER_COPY_TOOLTIP_DETAILS = {
         "Copies: enable state, anchor/position mode, styling, icon, text, and cast effects.",
         "Does not copy: Resource Bars, Unit Frames, panels, or panel contents.",
     },
-    resourceBars = {
-        "Copies broad Resource Bar defaults from another character without replacing this character's spec-specific setup.",
-        "",
-        "What is copied:",
-        "- Enable state and panel anchor target",
-        "- Shared appearance defaults, like texture, text, and default colors",
-        "- Resource options that apply to this class",
-        "",
-        "What is not copied:",
-        "- The current spec's Layout tab or bar order",
-        "- Custom Bars",
-        "- Aura overlays and per-spec resource overrides",
-    },
 }
 
 local function CreateCharacterCopyButton(enableCb, systemKey, label, onCopied)

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -23,7 +23,6 @@ local PruneConfigCustomBarSelection = ST._PruneConfigCustomBarSelection
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
-local CreateCharacterCopyButton = ST._CreateCharacterCopyButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
@@ -51,6 +50,17 @@ local function RefreshLayoutOrderPreview()
         return
     end
     ST._RefreshColumn4(CS.col4Container)
+end
+
+local function BlockCustomBarExportForResourceBarConflict()
+    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
+        local message = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+        if message then
+            CooldownCompanion:Print(message)
+            return true
+        end
+    end
+    return false
 end
 
 -- Shared constants from ResourceBarConstants
@@ -164,6 +174,7 @@ local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForS
 local RBP = ST._RBP
 local resourceBarCollapsedSections = RBP.collapsedSections
 local BuildResourceAuraOverlaySection = RBP.BuildResourceAuraOverlaySection
+local BuildResourceBarConflictGate = RBP.BuildResourceBarConflictGate
 local GetConfigActiveResources = RBP.GetConfigActiveResources
 local GetCurrentConfigSpecID = RBP.GetCurrentConfigSpecID
 local ReadSpecOverrideKey = RBP.ReadSpecOverrideKey
@@ -659,6 +670,9 @@ local function OpenCustomBarRowMenu(customBars, specID, customBarId, entry)
         exportInfo.notCheckable = true
         exportInfo.func = function()
             CloseDropDownMenus()
+            if BlockCustomBarExportForResourceBarConflict() then
+                return
+            end
             local exportSettings = CooldownCompanion:GetResourceBarSettings()
             local payload = RB.BuildCustomBarsExportPayload and RB.BuildCustomBarsExportPayload(exportSettings, { entry })
             local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
@@ -1650,6 +1664,10 @@ ST._AddResourceSettingsListSection = function(container, settings)
 end
 
 local function BuildCustomBarsListPanel(container)
+    if BuildResourceBarConflictGate(container, "Custom Bars", false) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
     if not (settings and settings.enabled) then
         ST._AddResourceSettingsListSection(container, nil)
@@ -1842,6 +1860,9 @@ local function BuildCustomBarsListPanel(container)
     local exportAllBtn = AceGUI:Create("Button")
     exportAllBtn:SetText("Export All")
     exportAllBtn:SetCallback("OnClick", function()
+        if BlockCustomBarExportForResourceBarConflict() then
+            return
+        end
         local payload = RB.BuildCustomBarsExportPayload and RB.BuildCustomBarsExportPayload(settings, customBars)
         local exportString = payload and ST._EncodeExportData and ST._EncodeExportData(payload)
         if exportString then
@@ -2256,6 +2277,10 @@ local function BuildCustomBarIndicatorsTab(container, customBars, capturedIdx, c
 end
 
 local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
+    if BuildResourceBarConflictGate(container, "Custom Bars", false) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
     if not (settings and settings.enabled) then
         AddResourceBarsDisabledLabel(container, "Enable Resource Bars to configure Custom Bar settings.")

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -53,8 +53,8 @@ local function RefreshLayoutOrderPreview()
 end
 
 local function BlockCustomBarExportForResourceBarConflict()
-    if CooldownCompanion.GetPendingResourceBarConflictExportMessage then
-        local message = CooldownCompanion:GetPendingResourceBarConflictExportMessage()
+    if CooldownCompanion.GetCurrentResourceBarConflictExportMessage then
+        local message = CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
         if message then
             CooldownCompanion:Print(message)
             return true

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -1046,7 +1046,7 @@ local function BuildCustomBarTrackedAuraRowText(auraID, rowIndex)
 end
 
 local function ConfigureCustomBarTrackedAuraMoveButton(button, rotation, tooltipTitle, tooltipBody, disabled, onClick)
-    local isDisabled = disabled or CS.browseMode
+    local isDisabled = disabled
     button:SetSize(18, 18)
     if button.text then
         button.text:Hide()
@@ -1129,10 +1129,6 @@ local function EnsureCustomBarTrackedAuraMoveButtons(entry, cab, spellID, rowInd
 end
 
 local function ShowCustomBarTrackedAuraRowMenu(cab, spellID, rowIndex)
-    if CS.browseMode then
-        return
-    end
-
     if not CS.customBarTrackedAuraContextMenu then
         CS.customBarTrackedAuraContextMenu = CreateFrame("Frame", "CDCCustomBarTrackedAuraContextMenu", UIParent, "UIDropDownMenuTemplate")
     end
@@ -1157,9 +1153,6 @@ end
 
 local function InstallCustomBarTrackedAuraRowMenu(entry, cab, spellID, rowIndex)
     entry.frame:SetScript("OnMouseUp", function(_, button)
-        if CS.browseMode then
-            return
-        end
         if button == "RightButton" then
             ShowCustomBarTrackedAuraRowMenu(cab, spellID, rowIndex)
         end
@@ -1341,10 +1334,6 @@ local function BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUni
         RefreshCustomBarTrackedAuraEntry(cab, spellID)
     end
     auraEditBox:SetCallback("OnTextChanged", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if text and #text >= 1 and CS.SearchCDMAuraAutocomplete then
             CS.ShowAutocompleteResults(CS.SearchCDMAuraAutocomplete(text), widget, function(entry)
                 CommitCustomBarTrackedAuraEntry(widget, entry)
@@ -1354,10 +1343,6 @@ local function BuildCustomBarAuraTrackingSection(container, cab, resolvedAuraUni
         end
     end)
     auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
-        if CS.browseMode then
-            CS.HideAutocomplete()
-            return
-        end
         if CS.ConsumeAutocompleteEnter and CS.ConsumeAutocompleteEnter() then
             return
         end

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -337,9 +337,6 @@ local function ConfigureResourceAuraClearButton(button, onClear)
     button.icon:SetAtlas("common-icon-redx", false)
     button.icon:Show()
     button:SetScript("OnClick", function()
-        if CS.browseMode then
-            return
-        end
         if onClear then
             onClear()
         end
@@ -1011,7 +1008,7 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
     end
 
     auraEditBox:SetCallback("OnTextChanged", function(widget, _, text)
-        if spellID or CS.browseMode then
+        if spellID then
             CS.HideAutocomplete()
             return
         end
@@ -1024,7 +1021,7 @@ local function AddResourceAuraEntryFields(container, powerType, resourceName, en
         end
     end)
     auraEditBox:SetCallback("OnEnterPressed", function(widget, _, text)
-        if spellID or CS.browseMode then
+        if spellID then
             CS.HideAutocomplete()
             return
         end

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -1483,6 +1483,54 @@ local function GetResourceGapFieldConfig(settings, layout)
     return "yOffset", "Y Offset"
 end
 
+local function OpenResourceBarConflictChooser(force)
+    local classKey = CooldownCompanion.GetCurrentResourceBarClassKey and CooldownCompanion:GetCurrentResourceBarClassKey()
+    local showChooser = ST._ShowResourceBarConflictChooser
+    if showChooser then
+        return showChooser(classKey, { force = force })
+    end
+    CooldownCompanion:Print("Resource Bar conflict chooser is unavailable.")
+    return false
+end
+
+local function BuildResourceBarConflictGate(container, editSurface, autoOpen)
+    local conflict = CooldownCompanion.GetCurrentResourceBarConflict and CooldownCompanion:GetCurrentResourceBarConflict()
+    if not conflict then
+        return false
+    end
+
+    local classKey = CooldownCompanion.GetCurrentResourceBarClassKey and CooldownCompanion:GetCurrentResourceBarClassKey() or "current class"
+    local label = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(label)
+    label:SetText("Resource Bars for " .. tostring(classKey) .. " have multiple legacy setups. Choose one setup before editing " .. (editSurface or "Resource Bars") .. ".")
+    label:SetFullWidth(true)
+    container:AddChild(label)
+
+    local resolveBtn = AceGUI:Create("Button")
+    resolveBtn:SetText("Resolve Resource Bars")
+    resolveBtn:SetFullWidth(true)
+    resolveBtn:SetCallback("OnClick", function()
+        OpenResourceBarConflictChooser(true)
+    end)
+    container:AddChild(resolveBtn)
+    CS.resourceBarConflictResolveButton = resolveBtn
+
+    if autoOpen and not (CS.resourceBarConflictChooserDismissed and CS.resourceBarConflictChooserDismissed[classKey]) then
+        local function openIfStillPending()
+            if CooldownCompanion.GetCurrentResourceBarConflict and CooldownCompanion:GetCurrentResourceBarConflict() then
+                OpenResourceBarConflictChooser(false)
+            end
+        end
+        if C_Timer and C_Timer.After then
+            C_Timer.After(0, openIfStillPending)
+        else
+            openIfStillPending()
+        end
+    end
+
+    return true
+end
+
 ------------------------------------------------------------------------
 -- Export via ST._RBP
 ------------------------------------------------------------------------
@@ -1530,4 +1578,5 @@ ST._RBP = {
     IsResourceBarVerticalConfig = IsResourceBarVerticalConfig,
     GetResourceThicknessFieldConfig = GetResourceThicknessFieldConfig,
     GetResourceGapFieldConfig = GetResourceGapFieldConfig,
+    BuildResourceBarConflictGate = BuildResourceBarConflictGate,
 }

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -17,7 +17,6 @@ local ShowPopupAboveConfig = CS.ShowPopupAboveConfig
 local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
-local CreateCharacterCopyButton = ST._CreateCharacterCopyButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
@@ -167,6 +166,7 @@ local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForS
 local RBP = ST._RBP
 local resourceBarCollapsedSections = RBP.collapsedSections
 local BuildResourceAuraOverlaySection = RBP.BuildResourceAuraOverlaySection
+local BuildResourceBarConflictGate = RBP.BuildResourceBarConflictGate
 local AddResourceAuraOverrideControls = RBP.AddResourceAuraOverrideControls
 local GetConfigActiveResources = RBP.GetConfigActiveResources
 local GetCurrentConfigSpecID = RBP.GetCurrentConfigSpecID
@@ -993,7 +993,7 @@ end
 
 CS.healthResourceUI = HealthResource
 
-local function AddResourceSpecCopyButton(enableCb, characterCopyButton)
+local function AddResourceSpecCopyButton(enableCb)
     local _, initialSpecOrder, currentSpecID = CooldownCompanion:GetResourceBarSpecCopyOptions()
     if not currentSpecID or #initialSpecOrder == 0 then
         return
@@ -1018,11 +1018,7 @@ local function AddResourceSpecCopyButton(enableCb, characterCopyButton)
     end
 
     btn:ClearAllPoints()
-    if characterCopyButton then
-        btn:SetPoint("LEFT", characterCopyButton, "RIGHT", 2, 0)
-    else
-        btn:SetPoint("LEFT", enableCb.checkbg, "RIGHT", enableCb.text:GetStringWidth() + 4, 0)
-    end
+    btn:SetPoint("LEFT", enableCb.checkbg, "RIGHT", enableCb.text:GetStringWidth() + 4, 0)
     btn:Show()
 
     btn:SetScript("OnEnter", function(self)
@@ -1090,6 +1086,10 @@ local function AddResourceSpecCopyButton(enableCb, characterCopyButton)
 end
 
 local function BuildResourceBarAnchoringPanel(container)
+    if BuildResourceBarConflictGate(container, "Resource Bars", true) then
+        return
+    end
+
     local db = CooldownCompanion.db.profile
     local settings = CooldownCompanion:GetResourceBarSettings()
     local layout = CooldownCompanion:GetSpecLayoutOrder()
@@ -1108,12 +1108,7 @@ local function BuildResourceBarAnchoringPanel(container)
     end)
     container:AddChild(enableCb)
 
-    local characterCopyButton = CreateCharacterCopyButton(enableCb, "resourceBars", "Resource Bars", function()
-        CooldownCompanion:EvaluateResourceBars()
-        CooldownCompanion:UpdateAnchorStacking()
-        CooldownCompanion:RefreshConfigPanel()
-    end)
-    AddResourceSpecCopyButton(enableCb, characterCopyButton)
+    AddResourceSpecCopyButton(enableCb)
 
     if not settings.enabled then return end
     if not settings.resources then settings.resources = {} end
@@ -1220,6 +1215,10 @@ end
 ------------------------------------------------------------------------
 
 local function BuildResourceBarPositioningPanel(container)
+    if BuildResourceBarConflictGate(container, "Resource Bars", true) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
     local layout = CooldownCompanion:GetSpecLayoutOrder()
 
@@ -1983,6 +1982,10 @@ local function AddThresholdTickEntryEditor(panel, options)
 end
 
 local function BuildResourceBarStylingPanel(container, sectionMode, opts)
+    if BuildResourceBarConflictGate(container, "Resource Bars", true) then
+        return
+    end
+
     local settings = CooldownCompanion:GetResourceBarSettings()
 
     if not settings.enabled then


### PR DESCRIPTION
## What Players Will Notice
- Load Conditions now use consolidated dropdown filters for characters, classes, specializations, and hero talents, with active filters surfaced together.
- Group setup is organized around Global/current-class inventory plus Browse Other Classes, so same-class alts share class groups while off-class groups can be previewed without affecting runtime displays.
- Resource Bars, Resource Aura overlays, and Resource Bar Custom Bars now use class-wide setups, with a resolver for old profiles that had multiple same-class Resource Bar configurations.
- Import/export preserves portable class/spec/hero eligibility and class-scoped Resource Bars while keeping local character-only settings out of shared payloads.

## Why This Changed
- Character-scoped group and resource ownership made same-class alts expensive to maintain and hid profile-owned state behind per-character browsing.
- The new model keeps Column 1 as the profile's group control center while limiting runtime displays to groups that are actually loaded and eligible.
- Resource Bars needed safe migration before class-scoped profiles could feel trustworthy, especially for players with copied characters or backup setups.

## What Changed
- Merged #385: rebuilt Load Conditions eligibility with scope-aware class/spec/hero/character filtering and import/export sanitization.
- Merged #386: reworked Column 1 around Global/current-class groups plus Browse Other Classes, with class-scope guards for moves, copies, and previews.
- Merged #387: added `resourceBarsByClass`, class-aware normalization/import/export/migration, resolver UI, and Custom Bar preservation during same-class conflict resolution.
- Kept Cast Bar and Frame Anchoring character-scoped while Resource Bar data moved to class scope.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` over all changed Lua files in `origin/main...HEAD`
- `lua tests\eligibility-load-conditions.lua`
- `lua tests\eligibility-import-export.lua`
- `lua tests\character-eligibility-choices.lua`
- `lua tests\column1-profile-inventory.lua`
- `lua tests\resource-bars-class-scope.lua`
- PR #385 included user-reported in-game config validation for eligibility controls, including off-class hero talent dropdown behavior.
- PR #387 included manual in-game validation with restored pre-migration SavedVariables for the migration/resolver flow before the final Custom Bar preservation follow-up.
- `lua tests\rotation-assistant-panel.lua` failed on a stale source-text assertion looking for `GroupHasUsableButtons` in `Core/GroupManagement.lua`; the helper is now in `Core/GroupOperations.lua` and this test was not updated in this publish step.
- No new live in-game, DevBridge, combat, or restricted-content validation was performed for this `dev` -> `main` publish step.