### PR TITLE
Fix Zenith display while Zenith Stomp is active

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1260,10 +1260,12 @@ local function UpdateBarDisplay(button)
     if itemUsesResolvedCooldownState then
         onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif isChargeButton then
-        onCooldown = chargeState == CHARGE_STATE_MISSING
-            or chargeState == CHARGE_STATE_ZERO
+        onCooldown = button._chargePresentationSuppressed ~= true
+            and (chargeState == CHARGE_STATE_MISSING
+                or chargeState == CHARGE_STATE_ZERO)
     else
-        onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        onCooldown = button._cooldownPresentationSuppressed ~= true
+            and button._cooldownState == COOLDOWN_STATE_COOLDOWN
     end
 
     -- Time text color: switch between cooldown and ready colors
@@ -1930,6 +1932,8 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._lastReadableCharges = nil
     button._chargeSpellId = nil
     button._chargeInfoFromFallback = nil
+    button._chargePresentationSuppressed = nil
+    button._cooldownPresentationSuppressed = nil
     button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._displaySpellId = nil

--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1927,6 +1927,9 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._vertexA = nil
     button._chargeText = nil
     button._chargeCountReadable = nil
+    button._lastReadableCharges = nil
+    button._chargeSpellId = nil
+    button._chargeInfoFromFallback = nil
     button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._displaySpellId = nil

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1458,7 +1458,17 @@ function CooldownCompanion:UpdateButtonCooldown(button)
            and button._lastReadableCharges ~= nil then
             if button._chargeRecharging == true then
                 if button._lastReadableCharges <= 0 then
-                    button._mainCDShown = true
+                    if button._chargePresentationSuppressed == true then
+                        button._mainCDShown = true
+                    else
+                        local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
+                            or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+                        if slotProbe.shown ~= nil then
+                            button._mainCDShown = slotProbe.realShown == true
+                        else
+                            button._mainCDShown = true
+                        end
+                    end
                 else
                     local maxCharges = buttonData.maxCharges
                     local spent = button._chargesSpent

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1313,6 +1313,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._lastReadableCharges = nil
         button._chargeSpellId = nil
         button._chargeInfoFromFallback = nil
+        button._chargePresentationSuppressed = nil
+        button._cooldownPresentationSuppressed = nil
         if buttonData.type == "spell" then
             button.count:SetText("")
         end
@@ -1380,6 +1382,19 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._chargeText = nil
             button.count:SetText("")
         end
+    end
+
+    if button._chargePresentationSuppressed == true and not auraOwnsPrimarySwipe then
+        button._cooldownPresentationSuppressed = true
+        button._cooldownState = COOLDOWN_STATE_READY
+        button._cooldownDeferred = nil
+        button._durationObj = nil
+        if not button._isBar and not button._isText then
+            button.cooldown:SetCooldown(0, 0)
+            button.cooldown:Hide()
+        end
+    else
+        button._cooldownPresentationSuppressed = nil
     end
 
     button._isOnGCD = isOnGCD or false
@@ -1516,7 +1531,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if IsEntryItemLike(buttonData) then
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then
-        button._desatCooldownActive = button._chargeState == CHARGE_STATE_ZERO
+        button._desatCooldownActive = button._chargePresentationSuppressed ~= true
+            and button._chargeState == CHARGE_STATE_ZERO
     elseif auraOwnsPrimarySwipe and auraProbeInfo then
         button._desatCooldownActive = (auraProbeRealCooldownShown and not auraProbeIsGCDOnly) or false
     else
@@ -1533,16 +1549,17 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if usesChargeBehavior then
       if buttonData.type == "spell" and buttonData.hasCharges then
+        local showChargePresentation = button._chargePresentationSuppressed ~= true
         -- Bar/text mode: charge bars are driven by the recharge DurationObject, not
         -- the main spell CD or GCD. Save and clear the main CD so recharge
         -- timing fully controls bar fill for charge spells.
-        if (button._isBar or button._isText) and not auraOwnsPrimarySwipe and button._chargeDurationObj then
+        if showChargePresentation and (button._isBar or button._isText) and not auraOwnsPrimarySwipe and button._chargeDurationObj then
             button._durationObj = nil
         end
 
         local normalCooldownDisplayActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
             or (isGCDOnly and style.showGCDSwipe == true)
-        if not auraOwnsPrimarySwipe and button._chargeDurationObj then
+        if showChargePresentation and not auraOwnsPrimarySwipe and button._chargeDurationObj then
             if not button._isBar and not button._isText then
                 if button._chargeCooldownVisualActive then
                     -- Icon mode: active recharge owns the shared cooldown frame.
@@ -1555,7 +1572,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 -- Bar/text mode: only set _durationObj if actually recharging
                 button._durationObj = button._chargeDurationObj
             end
-        elseif not button._isBar and not button._isText and not auraOwnsPrimarySwipe then
+        elseif showChargePresentation and not button._isBar and not button._isText and not auraOwnsPrimarySwipe then
             -- Icon mode fallback: no chargeDurationObj, try fetching one.
             -- Only an active charge DurationObject may replace an existing GCD display.
             local chargeSpellID = cooldownSpellId or buttonData.id
@@ -1676,7 +1693,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local cooldownActive
             if usesChargeBehavior then
                 -- Charge spells: cooldown-active means zero available charges.
-                cooldownActive = button._chargeState == CHARGE_STATE_ZERO
+                cooldownActive = button._chargePresentationSuppressed ~= true
+                    and button._chargeState == CHARGE_STATE_ZERO
             elseif auraOwnsPrimarySwipe then
                 -- Aura visuals replace button.cooldown; reuse the shared
                 -- probe computed above (same spell, same tick).

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1441,12 +1441,17 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._mainCDShown = false
         elseif buttonData.type == "spell"
            and button._lastReadableCharges ~= nil then
-            if button._lastReadableCharges <= 0 then
-                button._mainCDShown = true
-            else
-                local maxCharges = buttonData.maxCharges
-                local spent = button._chargesSpent
-                button._mainCDShown = maxCharges and maxCharges > 1 and spent and spent >= maxCharges or false
+            if button._chargeRecharging == true then
+                if button._lastReadableCharges <= 0 then
+                    button._mainCDShown = true
+                else
+                    local maxCharges = buttonData.maxCharges
+                    local spent = button._chargesSpent
+                    button._mainCDShown = maxCharges and maxCharges > 1 and spent and spent >= maxCharges or false
+                end
+            elseif button._chargeRecharging == false then
+                button._lastReadableCharges = nil
+                button._chargesSpent = nil
             end
         elseif buttonData.type == "spell" and usesChargeBehavior and buttonData.hasCharges then
             -- Restricted mode: charges unreadable (secret values).

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -600,6 +600,9 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
     if not (button and IsReadyGlowMaxChargeEligible(buttonData)) then
         return false
     end
+    if button._chargePresentationSuppressed == true then
+        return false
+    end
 
     return button._chargeState == CHARGE_STATE_FULL
 end
@@ -1411,6 +1414,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             and style.showGCDSwipe == true
             and buttonData.type == "spell"
             and isOnGCD == true
+            and button._chargePresentationSuppressed ~= true
+            and button._cooldownPresentationSuppressed ~= true
         if showBarGCDSwipe then
             local gcdDurationObj = CooldownCompanion._gcdDurationObj
             if not gcdDurationObj and spellCooldownDuration then
@@ -1679,7 +1684,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local maxCharges
             local chargeRecharging = false
             local chargeCooldownStartTime
-            if usesChargeBehavior then
+            local chargePresentationSuppressed = usesChargeBehavior
+                and button._chargePresentationSuppressed == true
+            if usesChargeBehavior and not chargePresentationSuppressed then
                 if button._currentReadableCharges ~= nil then
                     currentCharges = button._currentReadableCharges
                 elseif charges and charges.currentCharges ~= nil
@@ -1698,6 +1705,8 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                    and not issecretvalue(charges.cooldownStartTime) then
                     chargeCooldownStartTime = charges.cooldownStartTime
                 end
+            elseif chargePresentationSuppressed then
+                button._sndInitialized = nil
             end
 
             local cooldownActive

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1310,6 +1310,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._chargesSpent = nil
         button._chargeText = nil
         button._displayCountZeroUsabilityFallback = nil
+        button._lastReadableCharges = nil
+        button._chargeSpellId = nil
+        button._chargeInfoFromFallback = nil
         if buttonData.type == "spell" then
             button.count:SetText("")
         end
@@ -1436,6 +1439,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- some use-count spells. Do not guess zero-state from unrelated
             -- usability signals; leave the zero-state unknown instead.
             button._mainCDShown = false
+        elseif buttonData.type == "spell"
+           and button._lastReadableCharges ~= nil then
+            if button._lastReadableCharges <= 0 then
+                button._mainCDShown = true
+            else
+                local maxCharges = buttonData.maxCharges
+                local spent = button._chargesSpent
+                button._mainCDShown = maxCharges and maxCharges > 1 and spent and spent >= maxCharges or false
+            end
         elseif buttonData.type == "spell" and usesChargeBehavior and buttonData.hasCharges then
             -- Restricted mode: charges unreadable (secret values).
             -- Action bar probe reflects the regular-cooldown DurationObject

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1195,11 +1195,13 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
 
         local timedAuraPrimarySwipeActive = button._auraPrimarySwipeActive == true
             and button._auraHasTimer ~= false
-        local cooldownVisualActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        local cooldownPresentationSuppressed = button._cooldownPresentationSuppressed == true
+        local cooldownVisualActive = (button._cooldownState == COOLDOWN_STATE_COOLDOWN
+                and not cooldownPresentationSuppressed)
             or timedAuraPrimarySwipeActive
             or button._conditionalAuraDurationTextPreview == true
             or button._conditionalPreviewDomain == "cooldown"
-            or button._chargeCooldownVisualActive == true
+            or (button._chargeCooldownVisualActive == true and button._chargePresentationSuppressed ~= true)
             or (isGCDOnly and style.showGCDSwipe == true)
 
         if suppressGCD or not cooldownVisualActive then
@@ -1439,6 +1441,8 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._lastReadableCharges = nil
     button._chargeSpellId = nil
     button._chargeInfoFromFallback = nil
+    button._chargePresentationSuppressed = nil
+    button._cooldownPresentationSuppressed = nil
     button._zeroChargesConfirmed = nil
     button._hideCooldownChargesActive = nil
     button._nilConfirmPending = nil

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1436,6 +1436,9 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._vertexA = nil
     button._chargeText = nil
     button._chargeCountReadable = nil
+    button._lastReadableCharges = nil
+    button._chargeSpellId = nil
+    button._chargeInfoFromFallback = nil
     button._zeroChargesConfirmed = nil
     button._hideCooldownChargesActive = nil
     button._nilConfirmPending = nil

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1195,14 +1195,17 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
 
         local timedAuraPrimarySwipeActive = button._auraPrimarySwipeActive == true
             and button._auraHasTimer ~= false
+        local chargePresentationSuppressed = button._chargePresentationSuppressed == true
         local cooldownPresentationSuppressed = button._cooldownPresentationSuppressed == true
         local cooldownVisualActive = (button._cooldownState == COOLDOWN_STATE_COOLDOWN
                 and not cooldownPresentationSuppressed)
             or timedAuraPrimarySwipeActive
             or button._conditionalAuraDurationTextPreview == true
             or button._conditionalPreviewDomain == "cooldown"
-            or (button._chargeCooldownVisualActive == true and button._chargePresentationSuppressed ~= true)
-            or (isGCDOnly and style.showGCDSwipe == true)
+            or (button._chargeCooldownVisualActive == true and not chargePresentationSuppressed)
+            or (isGCDOnly and style.showGCDSwipe == true
+                and not chargePresentationSuppressed
+                and not cooldownPresentationSuppressed)
 
         if suppressGCD or not cooldownVisualActive then
             button.cooldown:Hide()

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -60,6 +60,10 @@ local function IsAuraOnlyEntry(buttonData)
         and buttonData.auraTracking == true
 end
 
+local function IsChargePresentationVisible(button)
+    return button and button._chargePresentationSuppressed ~= true
+end
+
 ------------------------------------------------------------------------
 -- FORMAT STRING PARSER
 -- Parses "{name}  {status}" into a list of segments:
@@ -369,14 +373,17 @@ local function EvaluateTokenPresence(button, tokenName, timeRemaining, timeIsSec
     if tokenName == "time" then
         return timeIsSecret or (timeRemaining and timeRemaining > 0)
     elseif tokenName == "charges" then
-        return UsesChargeBehavior(button.buttonData)
+        return IsChargePresentationVisible(button) and UsesChargeBehavior(button.buttonData)
     elseif tokenName == "maxcharges" then
+        if not IsChargePresentationVisible(button) then return false end
         if not UsesChargeBehavior(button.buttonData) then return false end
         return button._chargeState == CHARGE_STATE_FULL
     elseif tokenName == "missingcharges" then
+        if not IsChargePresentationVisible(button) then return false end
         if not UsesChargeBehavior(button.buttonData) then return false end
         return button._chargeState == CHARGE_STATE_MISSING
     elseif tokenName == "zerocharges" then
+        if not IsChargePresentationVisible(button) then return false end
         if not UsesChargeBehavior(button.buttonData) then return false end
         return button._chargeState == CHARGE_STATE_ZERO
     elseif tokenName == "stacks" then
@@ -446,8 +453,9 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
 
     -- Gather live state
     local auraOnlyEntry = IsAuraOnlyEntry(buttonData)
-    local currentCharges = button._currentReadableCharges
-    local maxCharges = button.buttonData.maxCharges
+    local chargePresentationVisible = IsChargePresentationVisible(button)
+    local currentCharges = chargePresentationVisible and button._currentReadableCharges or nil
+    local maxCharges = chargePresentationVisible and buttonData.maxCharges or nil
     local stackDisplayText, stackDisplayKind = ResolveTextModeStackDisplay(button)
     local auraDurationTextPreview = button._conditionalAuraDurationTextPreview == true
     local auraActive = button._auraActive or auraDurationTextPreview

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -24,12 +24,41 @@ local IsEntryItemLike = CooldownCompanion.IsEntryItemLike or function(buttonData
                 and (buttonData.itemSlot == 13 or buttonData.itemSlot == 14)))
 end
 
+local function GetReadableMaxCharges(charges)
+    local maxCharges = charges and charges.maxCharges
+    if maxCharges and not issecretvalue(maxCharges) then
+        return tonumber(maxCharges)
+    end
+    return nil
+end
+
+local function ResolveRuntimeChargeInfo(buttonData, chargeSpellID)
+    local spellID = chargeSpellID or buttonData.id
+    local charges = C_Spell.GetSpellCharges(spellID)
+    local maxCharges = GetReadableMaxCharges(charges)
+
+    if (not maxCharges or maxCharges <= 1)
+        and ST.ResolveSpellChargeInfo
+        and buttonData.id then
+        local resolvedCharges, resolvedSpellID, resolvedMaxCharges = ST.ResolveSpellChargeInfo(buttonData.id)
+        if resolvedCharges and (resolvedMaxCharges or 0) > 1 then
+            return resolvedCharges, resolvedSpellID or buttonData.id, true, resolvedMaxCharges
+        end
+    end
+
+    return charges, spellID, false, maxCharges
+end
+
 -- Update charge count state for a spell with hasCharges enabled.
 -- chargeSpellID should be the effective runtime spell ID (override-aware).
 -- Returns the raw charges API table (may be nil) for use by callers.
 local function UpdateChargeTracking(button, buttonData, chargeSpellID)
-    local spellID = chargeSpellID or buttonData.id
-    local charges = C_Spell.GetSpellCharges(spellID)
+    local previousReadableCharges = button._chargeCountReadable == true
+        and button._currentReadableCharges
+        or nil
+    local charges, spellID, usedChargeFallback, maxCharges = ResolveRuntimeChargeInfo(buttonData, chargeSpellID)
+    button._chargeSpellId = spellID
+    button._chargeInfoFromFallback = usedChargeFallback or nil
 
     -- Read current charges only from the authoritative charge API field.
     -- Display-count APIs are UI-oriented and can transiently read 0 during
@@ -37,6 +66,10 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
     local cur
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
         cur = charges.currentCharges
+        button._lastReadableCharges = cur
+    elseif (usedChargeFallback or (maxCharges or 0) > 1)
+        and previousReadableCharges ~= nil then
+        button._lastReadableCharges = previousReadableCharges
     end
     button._currentReadableCharges = cur
     button._chargeCountReadable = (cur ~= nil)
@@ -63,6 +96,9 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
         button._chargeDurationObj = nil
         button._chargeRecharging = false
         button._chargeState = nil
+        button._lastReadableCharges = nil
+        button._chargeSpellId = nil
+        button._chargeInfoFromFallback = nil
         return nil
     end
 

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -82,6 +82,10 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
     local charges, spellID, usedChargeFallback, maxCharges = ResolveRuntimeChargeInfo(buttonData, chargeSpellID)
     button._chargeSpellId = spellID
     button._chargeInfoFromFallback = usedChargeFallback or nil
+    button._chargePresentationSuppressed = usedChargeFallback == true
+        and chargeSpellID ~= nil
+        and tonumber(spellID) ~= tonumber(chargeSpellID)
+        or nil
 
     -- Read current charges only from the authoritative charge API field.
     -- Display-count APIs are UI-oriented and can transiently read 0 during
@@ -122,6 +126,8 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
         button._lastReadableCharges = nil
         button._chargeSpellId = nil
         button._chargeInfoFromFallback = nil
+        button._chargePresentationSuppressed = nil
+        button._cooldownPresentationSuppressed = nil
         button._chargesSpent = nil
         return nil
     end
@@ -138,7 +144,10 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
 
     -- Display charge text via secret-safe widget methods
     local showChargeText = button.style and button.style.showChargeText
-    if not showChargeText then
+    if button._chargePresentationSuppressed == true then
+        button._chargeText = nil
+        button.count:SetText("")
+    elseif not showChargeText then
         button.count:SetText("")
     else
         if cur then

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -32,6 +32,29 @@ local function GetReadableMaxCharges(charges)
     return nil
 end
 
+local function SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
+    if not owner or currentCharges == nil then
+        return
+    end
+    if issecretvalue and (issecretvalue(maxCharges) or issecretvalue(currentCharges)) then
+        return
+    end
+
+    maxCharges = tonumber(maxCharges)
+    currentCharges = tonumber(currentCharges)
+    if not maxCharges or maxCharges <= 1 or not currentCharges then
+        return
+    end
+
+    local spent = maxCharges - currentCharges
+    if spent < 0 then
+        spent = 0
+    elseif spent > maxCharges then
+        spent = maxCharges
+    end
+    owner._chargesSpent = spent
+end
+
 local function ResolveRuntimeChargeInfo(buttonData, chargeSpellID)
     local spellID = chargeSpellID or buttonData.id
     local charges = C_Spell.GetSpellCharges(spellID)
@@ -99,10 +122,12 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
         button._lastReadableCharges = nil
         button._chargeSpellId = nil
         button._chargeInfoFromFallback = nil
+        button._chargesSpent = nil
         return nil
     end
 
     local mx = buttonData.maxCharges
+    SyncSpentChargesFromReadableCount(button, mx, cur)
 
     -- Recharge DurationObject for multi-charge spells.
     -- GetSpellChargeDuration returns nil for maxCharges=1 (Blizzard doesn't treat

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -432,6 +432,7 @@ local function ResolveDesaturationIntent(button, buttonData, style, target)
         end
         if not target.active and buttonData.desaturateWhileZeroCharges
                 and not CooldownCompanion.HasItemFallbacks(buttonData)
+                and button._chargePresentationSuppressed ~= true
                 and button._chargeState == CHARGE_STATE_ZERO then
             target.active = true
             target.reason = "zero-charges"

--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -139,6 +139,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local itemUsesResolvedCooldownState = IsEntryItemLike(buttonData)
         and button._resolvedItemQuantityKind == "stacks"
     local noCooldownForVisibility = IsNoCooldownForVisibility(button)
+    local chargePresentationSuppressed = button._chargePresentationSuppressed == true
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
     if buttonData.hideWhileOnCooldown and not noCooldownForVisibility and not barAuraStackDisplay then
@@ -147,7 +148,11 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if button._chargeState == CHARGE_STATE_ZERO
+            if chargePresentationSuppressed then
+                if button._cooldownState == COOLDOWN_STATE_COOLDOWN and not auraOwnsPrimarySwipe then
+                    hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
+                end
+            elseif button._chargeState == CHARGE_STATE_ZERO
                     or button._chargeState == CHARGE_STATE_MISSING then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
@@ -169,7 +174,11 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if button._chargeState == CHARGE_STATE_FULL then
+            if chargePresentationSuppressed then
+                if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN and not auraOwnsPrimarySwipe then
+                    hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
+                end
+            elseif button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif IsEntryItemLike(buttonData) then

--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -148,12 +148,9 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if chargePresentationSuppressed then
-                if button._cooldownState == COOLDOWN_STATE_COOLDOWN and not auraOwnsPrimarySwipe then
-                    hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
-                end
-            elseif button._chargeState == CHARGE_STATE_ZERO
-                    or button._chargeState == CHARGE_STATE_MISSING then
+            if not chargePresentationSuppressed
+                    and (button._chargeState == CHARGE_STATE_ZERO
+                    or button._chargeState == CHARGE_STATE_MISSING) then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         elseif IsEntryItemLike(buttonData) then
@@ -174,11 +171,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if chargePresentationSuppressed then
-                if button._cooldownState ~= COOLDOWN_STATE_COOLDOWN and not auraOwnsPrimarySwipe then
-                    hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
-                end
-            elseif button._chargeState == CHARGE_STATE_FULL then
+            if not chargePresentationSuppressed and button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif IsEntryItemLike(buttonData) then

--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -210,6 +210,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     if buttonData.hideWhileZeroCharges
             and not barAuraStackDisplay
             and not CooldownCompanion.HasItemFallbacks(buttonData)
+            and button._chargePresentationSuppressed ~= true
             and button._chargeState == CHARGE_STATE_ZERO then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_CHARGES)
     end

--- a/CooldownCompanion/ButtonFrame/VisualState.lua
+++ b/CooldownCompanion/ButtonFrame/VisualState.lua
@@ -386,6 +386,8 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
 
     local procSuppressesReady = procOverlayShown and style.procGlowStyle ~= "none"
     local auraSuppressesReady = button._auraTrackingReady == true and button._auraActive == true
+    local cooldownPresentationSuppressed = button._cooldownPresentationSuppressed == true
+        or button._chargePresentationSuppressed == true
     if not button.readyGlow then
         SetGlowIntent(ready, false, false, "missing-widget")
     elseif button._readyGlowPreview == true then
@@ -397,6 +399,9 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
         SetGlowIntent(ready, true, false, "passive")
     elseif button._noCooldown then
         SetGlowIntent(ready, true, false, "no-cooldown")
+    elseif cooldownPresentationSuppressed then
+        SetGlowIntent(ready, true, false, "presentation-suppressed")
+        ready.cooldownSuppressed = true
     elseif style.readyGlowCombatOnly and not inCombat then
         SetGlowIntent(ready, true, false, "combat-only")
         ready.combatOnly = true

--- a/CooldownCompanion/ButtonFrame/VisualState.lua
+++ b/CooldownCompanion/ButtonFrame/VisualState.lua
@@ -505,6 +505,7 @@ local function ResolveIconFillIntent(button, buttonData, style, target)
         cooldownReason = "cooldown"
     elseif UsesIconFillChargeBehavior(buttonData)
         and button._chargeRecharging == true
+        and button._chargePresentationSuppressed ~= true
         and button._hideCooldownChargesActive ~= true then
         cooldownReason = "charge-recharge"
     end

--- a/CooldownCompanion/ButtonFrame/VisualState.lua
+++ b/CooldownCompanion/ButtonFrame/VisualState.lua
@@ -192,6 +192,9 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
     if not (button and IsReadyGlowMaxChargeEligible(buttonData)) then
         return false
     end
+    if button._chargePresentationSuppressed == true then
+        return false
+    end
 
     return button._chargeState == CHARGE_STATE_FULL
 end

--- a/CooldownCompanion/Core/AuraTexturesEffects.lua
+++ b/CooldownCompanion/Core/AuraTexturesEffects.lua
@@ -608,6 +608,10 @@ local function ResolveTextureIndicatorSectionState(button, sectionKey, config, t
                 or "no-cooldown"
             return FinishTextureIndicatorSectionState(target, false, reason, nil, effectType)
         end
+        if button._chargePresentationSuppressed == true
+                or button._cooldownPresentationSuppressed == true then
+            return FinishTextureIndicatorSectionState(target, false, "presentation-suppressed", nil, effectType)
+        end
         local active = button._desatCooldownActive == false
         return FinishTextureIndicatorSectionState(target, active, active and "ready" or "not-ready", nil, effectType)
     end
@@ -642,6 +646,10 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
     end
 
     if conditionKey == "cooldownActive" then
+        if button._chargePresentationSuppressed == true
+                or button._cooldownPresentationSuppressed == true then
+            return nil
+        end
         return button._desatCooldownActive == true
     end
 

--- a/CooldownCompanion/Core/AuraTexturesEffects.lua
+++ b/CooldownCompanion/Core/AuraTexturesEffects.lua
@@ -698,12 +698,18 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
     end
 
     if conditionKey == "chargesRecharging" then
+        if button._chargePresentationSuppressed == true then
+            return false
+        end
         return button._chargeRecharging == true
     end
 
     if conditionKey == "chargeState" then
         local buttonData = button.buttonData
         if not buttonData or buttonData.hasCharges ~= true then
+            return nil
+        end
+        if button._chargePresentationSuppressed == true then
             return nil
         end
 

--- a/CooldownCompanion/Core/AuraTexturesEffects.lua
+++ b/CooldownCompanion/Core/AuraTexturesEffects.lua
@@ -645,11 +645,12 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
         return false
     end
 
+    if button._chargePresentationSuppressed == true
+            or button._cooldownPresentationSuppressed == true then
+        return nil
+    end
+
     if conditionKey == "cooldownActive" then
-        if button._chargePresentationSuppressed == true
-                or button._cooldownPresentationSuppressed == true then
-            return nil
-        end
         return button._desatCooldownActive == true
     end
 

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1423,6 +1423,8 @@ local function ClearOwnerChargeState(owner)
     owner._lastReadableCharges = nil
     owner._chargeSpellId = nil
     owner._chargeInfoFromFallback = nil
+    owner._chargePresentationSuppressed = nil
+    owner._cooldownPresentationSuppressed = nil
 end
 
 function EntryRuntime.RecordChargeSpent(owner)
@@ -1516,8 +1518,11 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
 
     local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
     local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+    local chargePresentationSuppressed = result.preserveReadableCharges == true
+        and tonumber(cooldownSpellID) ~= tonumber(result.cooldownSpellID)
     result.chargeDurationObj = chargeDurationObj
     result.chargeRecharging = chargeRecharging or false
+    result.chargePresentationSuppressed = chargePresentationSuppressed or nil
 
     local currentCharges
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
@@ -1543,6 +1548,7 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._chargeRecharging = result.chargeRecharging
         owner._chargeSpellId = cooldownSpellID
         owner._chargeInfoFromFallback = result.preserveReadableCharges or nil
+        owner._chargePresentationSuppressed = chargePresentationSuppressed or nil
         SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
     end
 
@@ -1599,7 +1605,7 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._chargeState = result.chargeState
     end
 
-    if result.chargeRecharging then
+    if result.chargeRecharging and not chargePresentationSuppressed then
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-charge-recharge"
         result.renderDurationObj = chargeDurationObj

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1420,6 +1420,9 @@ local function ClearOwnerChargeState(owner)
     owner._mainCDShown = nil
     owner._chargeState = nil
     owner._chargesSpent = nil
+    owner._lastReadableCharges = nil
+    owner._chargeSpellId = nil
+    owner._chargeInfoFromFallback = nil
 end
 
 function EntryRuntime.RecordChargeSpent(owner)
@@ -1467,6 +1470,12 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
         currentCharges = charges.currentCharges
         result.currentCharges = currentCharges
+    elseif result.preserveReadableCharges == true
+        and owner
+        and owner._chargeCountReadable == true
+        and owner._currentReadableCharges ~= nil then
+        currentCharges = owner._currentReadableCharges
+        result.currentCharges = currentCharges
     elseif C_Spell.GetSpellDisplayCount then
         result.chargeDisplayCount = C_Spell.GetSpellDisplayCount(cooldownSpellID)
     end
@@ -1482,6 +1491,8 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._chargeCountReadable = currentCharges ~= nil
         owner._chargeDurationObj = chargeDurationObj
         owner._chargeRecharging = result.chargeRecharging
+        owner._chargeSpellId = cooldownSpellID
+        owner._chargeInfoFromFallback = result.preserveReadableCharges or nil
     end
 
     local mainCDShown = false
@@ -1634,8 +1645,19 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
         owner._customCooldownSpellID = cooldownSpellID
     end
 
+    local chargeSpellID = cooldownSpellID
     local charges = C_Spell.GetSpellCharges(cooldownSpellID)
     local maxCharges = charges and tonumber(charges.maxCharges)
+    local preserveReadableCharges = false
+    if (not maxCharges or maxCharges <= 1) and ST.ResolveSpellChargeInfo then
+        local resolvedCharges, resolvedChargeSpellID, resolvedMaxCharges = ST.ResolveSpellChargeInfo(spellID)
+        if resolvedCharges and (resolvedMaxCharges or 0) > 1 then
+            charges = resolvedCharges
+            chargeSpellID = resolvedChargeSpellID or spellID
+            maxCharges = resolvedMaxCharges
+            preserveReadableCharges = true
+        end
+    end
     SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
     local hasCharges = (maxCharges or 0) > 1
     local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
@@ -1666,10 +1688,12 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     })
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
+    result.chargeSpellID = chargeSpellID
+    result.preserveReadableCharges = preserveReadableCharges or nil
     result.noCooldown = noCooldown or nil
 
     if hasCharges then
-        ApplyCustomBarChargeState(owner, result, spellID, cooldownSpellID, charges, maxCharges)
+        ApplyCustomBarChargeState(owner, result, spellID, chargeSpellID, charges, maxCharges)
     else
         ClearOwnerChargeState(owner)
     end

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1434,6 +1434,30 @@ function EntryRuntime.RecordChargeSpent(owner)
     end
 end
 
+local function InferCurrentChargesFromSpent(maxCharges, spent)
+    if maxCharges == nil or (issecretvalue and issecretvalue(maxCharges)) then
+        return nil
+    end
+    if spent == nil or (issecretvalue and issecretvalue(spent)) then
+        return nil
+    end
+
+    maxCharges = tonumber(maxCharges)
+    spent = tonumber(spent)
+    if not maxCharges or maxCharges <= 0 or not spent then
+        return nil
+    end
+
+    local current = maxCharges - spent
+    if current < 0 then
+        return 0
+    end
+    if current > maxCharges then
+        return maxCharges
+    end
+    return current
+end
+
 local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
     if not customBar then return end
 
@@ -1466,24 +1490,26 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
     result.maxCharges = maxCharges
     result.charges = charges
 
+    local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+    local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+    result.chargeDurationObj = chargeDurationObj
+    result.chargeRecharging = chargeRecharging or false
+
     local currentCharges
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
         currentCharges = charges.currentCharges
         result.currentCharges = currentCharges
     elseif result.preserveReadableCharges == true
+        and chargeRecharging == true
         and owner
         and owner._chargeCountReadable == true
         and owner._currentReadableCharges ~= nil then
-        currentCharges = owner._currentReadableCharges
+        currentCharges = InferCurrentChargesFromSpent(maxCharges, owner._chargesSpent)
+            or owner._currentReadableCharges
         result.currentCharges = currentCharges
     elseif C_Spell.GetSpellDisplayCount then
         result.chargeDisplayCount = C_Spell.GetSpellDisplayCount(cooldownSpellID)
     end
-
-    local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
-    local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
-    result.chargeDurationObj = chargeDurationObj
-    result.chargeRecharging = chargeRecharging or false
 
     if owner then
         owner._customCooldownHasCharges = true
@@ -1512,6 +1538,8 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._mainCDShown = mainCDShown
         if result.chargeRecharging and not owner._chargesSpent then
             owner._chargesSpent = maxCharges or 0
+        elseif result.chargeRecharging == false then
+            owner._chargesSpent = nil
         end
     end
 

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1458,6 +1458,30 @@ local function InferCurrentChargesFromSpent(maxCharges, spent)
     return current
 end
 
+local function SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
+    if not owner or currentCharges == nil then
+        return
+    end
+    if (issecretvalue and issecretvalue(maxCharges))
+        or (issecretvalue and issecretvalue(currentCharges)) then
+        return
+    end
+
+    maxCharges = tonumber(maxCharges)
+    currentCharges = tonumber(currentCharges)
+    if not maxCharges or maxCharges <= 1 or not currentCharges then
+        return
+    end
+
+    local spent = maxCharges - currentCharges
+    if spent < 0 then
+        spent = 0
+    elseif spent > maxCharges then
+        spent = maxCharges
+    end
+    owner._chargesSpent = spent
+end
+
 local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
     if not customBar then return end
 
@@ -1519,6 +1543,7 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._chargeRecharging = result.chargeRecharging
         owner._chargeSpellId = cooldownSpellID
         owner._chargeInfoFromFallback = result.preserveReadableCharges or nil
+        SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
     end
 
     local mainCDShown = false
@@ -1536,7 +1561,9 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
 
     if owner then
         owner._mainCDShown = mainCDShown
-        if result.chargeRecharging and not owner._chargesSpent then
+        if currentCharges ~= nil then
+            -- Readable charge counts already synced _chargesSpent above.
+        elseif result.chargeRecharging and not owner._chargesSpent then
             owner._chargesSpent = maxCharges or 0
         elseif result.chargeRecharging == false then
             owner._chargesSpent = nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -740,6 +740,9 @@ local function ClearReusableButtonRuntime(button)
     button._chargeState = nil
     button._currentReadableCharges = nil
     button._chargeCountReadable = nil
+    button._lastReadableCharges = nil
+    button._chargeSpellId = nil
+    button._chargeInfoFromFallback = nil
     button._chargeText = nil
     button._chargesSpent = nil
     button._sndInitialized = nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -743,6 +743,8 @@ local function ClearReusableButtonRuntime(button)
     button._lastReadableCharges = nil
     button._chargeSpellId = nil
     button._chargeInfoFromFallback = nil
+    button._chargePresentationSuppressed = nil
+    button._cooldownPresentationSuppressed = nil
     button._chargeText = nil
     button._chargesSpent = nil
     button._sndInitialized = nil

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2646,6 +2646,9 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._chargeState = nil
                 button._currentReadableCharges = nil
                 button._chargeCountReadable = nil
+                button._lastReadableCharges = nil
+                button._chargeSpellId = nil
+                button._chargeInfoFromFallback = nil
                 button._zeroChargesConfirmed = nil
                 button._displayCountZeroUsabilityFallback = nil
                 ClearButtonVisualState(button)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2649,6 +2649,8 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._lastReadableCharges = nil
                 button._chargeSpellId = nil
                 button._chargeInfoFromFallback = nil
+                button._chargePresentationSuppressed = nil
+                button._cooldownPresentationSuppressed = nil
                 button._zeroChargesConfirmed = nil
                 button._displayCountZeroUsabilityFallback = nil
                 ClearButtonVisualState(button)

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -13,6 +13,9 @@ local pairs = pairs
 local wipe = wipe
 local ipairs = ipairs
 local select = select
+local tonumber = tonumber
+local issecretvalue = issecretvalue
+local C_Spell_GetSpellCharges = C_Spell.GetSpellCharges
 
 -- Import cross-file variables
 local defaults = ST._defaults
@@ -47,6 +50,37 @@ ST._BUFF_VIEWER_SET = BUFF_VIEWER_SET
 
 local cdmAlphaGuard = {}
 ST._cdmAlphaGuard = cdmAlphaGuard
+
+local function GetReadableMaxCharges(charges)
+    local maxCharges = charges and charges.maxCharges
+    if maxCharges and not issecretvalue(maxCharges) then
+        return tonumber(maxCharges)
+    end
+    return nil
+end
+
+local function SpellHasDirectMultiChargeInfo(spellID)
+    if not (spellID and C_Spell_GetSpellCharges) then return false end
+    local charges = C_Spell_GetSpellCharges(spellID)
+    return (GetReadableMaxCharges(charges) or 0) > 1
+end
+
+local function CastConsumesTrackedCharge(button, buttonData, spellID, displaySpellID)
+    if spellID == buttonData.id then
+        return true
+    end
+
+    local chargeSpellID = button and button._chargeSpellId
+    if chargeSpellID and spellID == chargeSpellID then
+        return true
+    end
+
+    if displaySpellID and spellID == displaySpellID and displaySpellID ~= buttonData.id then
+        return SpellHasDirectMultiChargeInfo(spellID)
+    end
+
+    return false
+end
 
 function CooldownCompanion:OnInitialize()
     self._hadSavedVariables = type(_G.CooldownCompanionDB) == "table"
@@ -419,8 +453,11 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
             if buttonData.type == "spell"
                 and not buttonData.isPassive then
                 local displaySpellID = button._displaySpellId or buttonData.id
-                if spellID == buttonData.id or spellID == displaySpellID then
-                    if self.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
+                local chargeSpellID = button._chargeSpellId
+                if spellID == buttonData.id or spellID == displaySpellID or spellID == chargeSpellID then
+                    if self.UsesChargeBehavior(buttonData)
+                        and buttonData.hasCharges
+                        and CastConsumesTrackedCharge(button, buttonData, spellID, displaySpellID) then
                         -- Track charge consumption for restricted-mode color heuristic.
                         -- _chargeRecharging at event time reflects the PRE-cast state:
                         --   false = casting from full charges → reset to 1

--- a/CooldownCompanion/Core/SoundAlerts.lua
+++ b/CooldownCompanion/Core/SoundAlerts.lua
@@ -895,6 +895,7 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
     local chargeRecharging = opts.chargeRecharging and true or false
     local currentCharges = opts.currentCharges
     local chargeCooldownStartTime = opts.chargeCooldownStartTime
+    local suppressChargeAvailable = opts.suppressChargeAvailable == true
 
     if not state._sndInitialized then
         state._sndInitialized = true
@@ -922,7 +923,7 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
         opts.play(opts.playContext, "onCooldown")
     end
 
-    if enabledEvents.available then
+    if enabledEvents.available and not suppressChargeAvailable then
         if opts.usesChargeBehavior then
             if DidGainChargeSincePreviousState(state, cooldownActive, currentCharges, chargeRecharging, chargeCooldownStartTime) then
                 opts.play(opts.playContext, "available")
@@ -956,11 +957,21 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, coold
     end
 
     if customBar and customBar.entryType == "spell" then
-        local chargeRecharging = cooldownResult and cooldownResult.chargeRecharging == true
-        local currentCharges = cooldownResult and cooldownResult.currentCharges
+        local chargePresentationSuppressed = cooldownResult
+            and cooldownResult.chargePresentationSuppressed == true
+        if chargePresentationSuppressed and barInfo then
+            barInfo._sndInitialized = nil
+        end
+        local chargeRecharging = (not chargePresentationSuppressed)
+            and cooldownResult and cooldownResult.chargeRecharging == true
+            or false
+        local currentCharges = (not chargePresentationSuppressed)
+            and cooldownResult and cooldownResult.currentCharges
+            or nil
         local chargeCooldownStartTime
         local charges = cooldownResult and cooldownResult.charges
-        if charges and charges.cooldownStartTime ~= nil and not issecretvalue(charges.cooldownStartTime) then
+        if not chargePresentationSuppressed
+                and charges and charges.cooldownStartTime ~= nil and not issecretvalue(charges.cooldownStartTime) then
             chargeCooldownStartTime = charges.cooldownStartTime
         end
 
@@ -976,6 +987,7 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, coold
         opts.chargeCooldownStartTime = chargeCooldownStartTime
         opts.includeAuraEvents = customBar.auraTracking == true
         opts.usesChargeBehavior = cooldownResult and cooldownResult.hasCharges == true
+        opts.suppressChargeAvailable = chargePresentationSuppressed
         opts.play = PlayCustomBarTransitionSound
         opts.playContext = customBar
         UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, opts)
@@ -1018,6 +1030,11 @@ function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isO
         return
     end
 
+    local chargePresentationSuppressed = button._chargePresentationSuppressed == true
+    if chargePresentationSuppressed then
+        button._sndInitialized = nil
+    end
+
     local opts = button._sndTransitionOptions
     if not opts then
         opts = {}
@@ -1025,11 +1042,12 @@ function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isO
     end
     opts.cooldownActive = cooldownActive
     opts.auraActive = auraActive
-    opts.currentCharges = currentCharges
-    opts.chargeRecharging = chargeRecharging
-    opts.chargeCooldownStartTime = chargeCooldownStartTime
+    opts.currentCharges = chargePresentationSuppressed and nil or currentCharges
+    opts.chargeRecharging = chargePresentationSuppressed and false or chargeRecharging
+    opts.chargeCooldownStartTime = chargePresentationSuppressed and nil or chargeCooldownStartTime
     opts.includeAuraEvents = true
     opts.usesChargeBehavior = UsesChargeBehavior(buttonData)
+    opts.suppressChargeAvailable = chargePresentationSuppressed
     opts.play = PlayButtonTransitionSound
     opts.playContext = buttonData
     UpdateCooldownSoundAlertTransitions(button, enabledEvents, opts)

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -481,6 +481,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if not (bar and bar.stackText and bar.stackText:IsShown()) then
             return
         end
+        if cooldownResult and cooldownResult.chargePresentationSuppressed == true then
+            bar.stackText:SetText("")
+            return
+        end
 
         local currentCharges = cooldownResult and cooldownResult.currentCharges
         local maxCharges = cooldownResult and cooldownResult.maxCharges
@@ -545,8 +549,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local cooldownColor = cabConfig.barCooldownColor or {0.6, 0.13, 0.18, 1}
         local rechargeColor = cabConfig.barChargeColor or {1.0, 0.82, 0.0, 1}
         local chargeState = cooldownResult and cooldownResult.chargeState
+        local chargePresentationSuppressed = cooldownResult and cooldownResult.chargePresentationSuppressed == true
         local fillColor = barColor
-        if cooldownResult and cooldownResult.hasCharges == true then
+        if cooldownResult and cooldownResult.hasCharges == true and not chargePresentationSuppressed then
             if chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO then
                 fillColor = cooldownColor
             elseif cooldownActive then
@@ -559,7 +564,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local function UpdateSpellCustomBarSounds(soundAuraActive)
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 local soundCooldownActive = cooldownActive
-                if cooldownResult and cooldownResult.hasCharges == true then
+                if cooldownResult and cooldownResult.hasCharges == true and not chargePresentationSuppressed then
                     soundCooldownActive = cooldownResult.chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO
                         or (cooldownResult.chargeState == nil and cooldownActive)
                 end

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -703,6 +703,75 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         UpdateSpellCustomBarSounds(false)
     end
 
+    local function GetReadableMaxCharges(spellID)
+        if not spellID or not C_Spell.GetSpellCharges then
+            return nil
+        end
+
+        local charges = C_Spell.GetSpellCharges(spellID)
+        local maxCharges = charges and charges.maxCharges
+        if maxCharges == nil or (issecretvalue and issecretvalue(maxCharges)) then
+            return nil
+        end
+        return tonumber(maxCharges)
+    end
+
+    local function SpellHasDirectMultiChargeInfo(spellID)
+        local maxCharges = GetReadableMaxCharges(spellID)
+        return maxCharges ~= nil and maxCharges > 1
+    end
+
+    local function CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID)
+        if bar and bar._customCooldownHasCharges == true then
+            return true
+        end
+        if cabConfig and cabConfig.hasCharges == true then
+            return true
+        end
+
+        local configMaxCharges = cabConfig and cabConfig.maxCharges
+        if configMaxCharges ~= nil
+            and not (issecretvalue and issecretvalue(configMaxCharges))
+            and (tonumber(configMaxCharges) or 0) > 1 then
+            return true
+        end
+
+        if bar and SpellHasDirectMultiChargeInfo(bar._chargeSpellId) then
+            return true
+        end
+        return SpellHasDirectMultiChargeInfo(baseSpellID)
+    end
+
+    local function CustomBarCastConsumesTrackedCharge(bar, cabConfig, spellID)
+        local castSpellID = tonumber(spellID)
+        local baseSpellID = tonumber(cabConfig and cabConfig.spellID)
+        if not castSpellID or not baseSpellID then
+            return false
+        end
+        if not CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID) then
+            return false
+        end
+
+        if castSpellID == baseSpellID then
+            return true
+        end
+
+        local chargeSpellID = tonumber(bar and bar._chargeSpellId)
+        if chargeSpellID and castSpellID == chargeSpellID then
+            return true
+        end
+
+        local runtimeSpellID = C_Spell.GetOverrideSpell and C_Spell.GetOverrideSpell(baseSpellID)
+        if not runtimeSpellID or runtimeSpellID == 0 then
+            runtimeSpellID = baseSpellID
+        end
+        runtimeSpellID = tonumber(runtimeSpellID)
+        return runtimeSpellID
+            and runtimeSpellID ~= baseSpellID
+            and castSpellID == runtimeSpellID
+            and SpellHasDirectMultiChargeInfo(runtimeSpellID)
+    end
+
     function CooldownCompanion:RecordCustomBarSpellCast(spellID)
         if not spellID then return end
 
@@ -715,16 +784,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 and cabConfig
                 and cabConfig.entryType == "spell"
             then
-                local baseSpellID = tonumber(cabConfig.spellID)
-                local runtimeSpellID = baseSpellID and C_Spell.GetOverrideSpell(baseSpellID)
-                if not runtimeSpellID or runtimeSpellID == 0 then
-                    runtimeSpellID = baseSpellID
-                end
-
-                local charges = runtimeSpellID and C_Spell.GetSpellCharges(runtimeSpellID)
-                local maxCharges = charges and tonumber(charges.maxCharges)
-                if (maxCharges or 0) > 1
-                    and (spellID == baseSpellID or spellID == runtimeSpellID) then
+                if CustomBarCastConsumesTrackedCharge(bar, cabConfig, spellID) then
                     EntryRuntime.RecordChargeSpent(bar)
                 end
             end

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -565,11 +565,17 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local function UpdateSpellCustomBarSounds(soundAuraActive)
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 local soundCooldownActive = cooldownActive
+                local soundCooldownResult = cooldownResult
+                if chargePresentationSuppressed then
+                    soundCooldownActive = false
+                    soundCooldownResult = nil
+                    barInfo._sndInitialized = nil
+                end
                 if cooldownResult and cooldownResult.hasCharges == true and not chargePresentationSuppressed then
                     soundCooldownActive = cooldownResult.chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO
                         or (cooldownResult.chargeState == nil and cooldownActive)
                 end
-                CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, soundAuraActive, soundCooldownActive, cooldownResult)
+                CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, soundAuraActive, soundCooldownActive, soundCooldownResult)
             end
         end
 

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -534,8 +534,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local cooldownResult = EntryRuntime.EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
+        local chargePresentationSuppressed = cooldownResult and cooldownResult.chargePresentationSuppressed == true
         local cooldownActive = cooldownResult
             and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
+            and not chargePresentationSuppressed
         local auraState = ResolveSpellCustomBarAuraState(barInfo)
         local auraPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         local auraPreview = bar._barAuraActivePreview == true
@@ -549,7 +551,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local cooldownColor = cabConfig.barCooldownColor or {0.6, 0.13, 0.18, 1}
         local rechargeColor = cabConfig.barChargeColor or {1.0, 0.82, 0.0, 1}
         local chargeState = cooldownResult and cooldownResult.chargeState
-        local chargePresentationSuppressed = cooldownResult and cooldownResult.chargePresentationSuppressed == true
         local fillColor = barColor
         if cooldownResult and cooldownResult.hasCharges == true and not chargePresentationSuppressed then
             if chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO then

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -721,7 +721,15 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         return maxCharges ~= nil and maxCharges > 1
     end
 
-    local function CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID)
+    local function GetRuntimeSpellID(baseSpellID)
+        local runtimeSpellID = C_Spell.GetOverrideSpell and C_Spell.GetOverrideSpell(baseSpellID)
+        if not runtimeSpellID or runtimeSpellID == 0 then
+            runtimeSpellID = baseSpellID
+        end
+        return tonumber(runtimeSpellID)
+    end
+
+    local function CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID, runtimeSpellID)
         if bar and bar._customCooldownHasCharges == true then
             return true
         end
@@ -739,7 +747,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if bar and SpellHasDirectMultiChargeInfo(bar._chargeSpellId) then
             return true
         end
-        return SpellHasDirectMultiChargeInfo(baseSpellID)
+        if SpellHasDirectMultiChargeInfo(baseSpellID) then
+            return true
+        end
+        return runtimeSpellID
+            and runtimeSpellID ~= baseSpellID
+            and SpellHasDirectMultiChargeInfo(runtimeSpellID)
     end
 
     local function CustomBarCastConsumesTrackedCharge(bar, cabConfig, spellID)
@@ -748,7 +761,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if not castSpellID or not baseSpellID then
             return false
         end
-        if not CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID) then
+
+        local runtimeSpellID = GetRuntimeSpellID(baseSpellID)
+        if not CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID, runtimeSpellID) then
             return false
         end
 
@@ -761,11 +776,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return true
         end
 
-        local runtimeSpellID = C_Spell.GetOverrideSpell and C_Spell.GetOverrideSpell(baseSpellID)
-        if not runtimeSpellID or runtimeSpellID == 0 then
-            runtimeSpellID = baseSpellID
-        end
-        runtimeSpellID = tonumber(runtimeSpellID)
         return runtimeSpellID
             and runtimeSpellID ~= baseSpellID
             and castSpellID == runtimeSpellID


### PR DESCRIPTION
## What Players Will Notice
- Windwalker Monk Zenith entries now respect hidden/suppressed cooldown and charge presentation while Zenith Stomp temporarily replaces Zenith.
- Zenith's base cooldown swipe, charge count, ready glow, trigger effects, texture indicators, and sound alerts no longer leak through during the Zenith Stomp window.
- When Zenith Stomp is no longer overriding Zenith, the normal Zenith charge/cooldown display resumes from the preserved charge state.

## Why This Changed
- Zenith behaves like a charge-based base spell that is temporarily replaced by Zenith Stomp. The addon was preserving the underlying Zenith charge state, but several presentation paths still treated the hidden base spell as ready, recharging, or available while Zenith Stomp was active.
- The fix follows the same shape as the prior replacement-spell issue: preserve the tracked base state internally, but suppress the base spell's visible cooldown/charge presentation until the override ends.

## What Changed
- Added replacement-aware charge fallback tracking so Zenith can keep its underlying charge state without treating Zenith Stomp as another Zenith charge spend.
- Suppressed Zenith cooldown/charge presentation across icon, bar, text, visibility, ready glow, desaturation, texture trigger, custom bar charge detail, and sound-alert paths while Zenith Stomp overrides Zenith.
- Kept custom cooldown bars in a neutral ready/full state during suppression while clearing replacement cooldown text, charge text, recharge state, and charge sound transitions.
- Added cleanup for suppression state when button styles, groups, or cooldown tracking state are refreshed.

## Validation
- `lua tests\zenith-stomp-charge-override.lua`
- `lua tests\surging-totem-override-cooldown.lua`
- `lua tests\soul-immolation-charge-override.lua`
- `lua tests\group-button-frame-pooling.lua`
- `luac -p` on the changed shipped Lua files and the local Zenith harness
- `git diff --check origin/main...HEAD`
- Five-agent static review reported no actionable findings after the final suppression pass.
- User-reported in-game testing covered the main Zenith/Stomp behavior during the investigation, but I did not independently run live WoW, combat, arena, battleground, or restricted-content validation from Codex after the final static trigger cleanup.