### PR TITLE
Preview other-class panels while configuring

### DIFF
--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -1781,6 +1781,26 @@ function CooldownCompanion:RefreshCursorAnchorTicker()
     end
 end
 
+local function ShouldShowGroupFrameForRuntimeOrPreview(addon, groupId, group)
+    if addon:IsGroupEligibleForConfigPreview(groupId, {
+        group = group,
+    }) then
+        return true
+    end
+
+    if addon.IsGroupSuppressedForOtherClassBrowse
+        and addon:IsGroupSuppressedForOtherClassBrowse(groupId, group) then
+        return false
+    end
+
+    return addon:IsGroupActive(groupId, {
+        group = group,
+        checkCharVisibility = true,
+        checkLoadConditions = true,
+        requireButtons = true,
+    })
+end
+
 function CooldownCompanion:CreateGroupFrame(groupId)
     -- Return existing frame to prevent duplicates (SharedMedia callbacks
     -- can trigger RefreshAllMedia before OnEnable's CreateAllGroupFrames)
@@ -1982,20 +2002,7 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     self:PopulateGroupButtons(groupId)
     
     -- Show/hide based on runtime activity, plus selected config previews.
-    local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
-        group = group,
-    })
-    local suppressedForOtherClassBrowse = self.IsGroupSuppressedForOtherClassBrowse
-        and self:IsGroupSuppressedForOtherClassBrowse(groupId, group)
-    if previewEligible or (
-        not suppressedForOtherClassBrowse
-        and self:IsGroupActive(groupId, {
-            group = group,
-            checkCharVisibility = true,
-            checkLoadConditions = true,
-            requireButtons = true,
-        })
-    ) then
+    if ShouldShowGroupFrameForRuntimeOrPreview(self, groupId, group) then
         frame:Show()
         -- Apply current alpha from the alpha fade system so frame doesn't flash at 1.0
         ApplyCurrentAlphaIfPresent(self, frame, groupId, group)
@@ -2845,20 +2852,7 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
 
     -- Update visibility: runtime-active groups show normally; selected config
     -- previews can also show without becoming runtime-visible.
-    local previewEligible = CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, {
-        group = group,
-    })
-    local suppressedForOtherClassBrowse = CooldownCompanion.IsGroupSuppressedForOtherClassBrowse
-        and CooldownCompanion:IsGroupSuppressedForOtherClassBrowse(groupId, group)
-    local isActive = previewEligible or (
-        not suppressedForOtherClassBrowse
-        and CooldownCompanion:IsGroupActive(groupId, {
-            group = group,
-            checkCharVisibility = true,
-            checkLoadConditions = true,
-            requireButtons = true,
-        })
-    )
+    local isActive = ShouldShowGroupFrameForRuntimeOrPreview(CooldownCompanion, groupId, group)
     if isActive then
         if InCombatLockdown() and frame:IsProtected() then
             if not frame:IsShown() then

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -3718,7 +3718,13 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
     HideContainerPanelLabels(frame)
     UpdateContainerWrapperLevels(frame)
 
-    if self._combatForcedLock or container.locked ~= false or not self:IsContainerVisibleToCurrentChar(containerId) then
+    local allPanels = self.GetPanels and self:GetPanels(containerId) or nil
+    local suppressedForOtherClassBrowse = self.IsContainerSuppressedForOtherClassBrowse
+        and self:IsContainerSuppressedForOtherClassBrowse(containerId, allPanels)
+    if self._combatForcedLock
+        or container.locked ~= false
+        or not self:IsContainerVisibleToCurrentChar(containerId)
+        or suppressedForOtherClassBrowse then
         if self.UpdateContainerDragHandle then
             self:UpdateContainerDragHandle(containerId, true)
         else
@@ -3738,8 +3744,8 @@ function CooldownCompanion:RefreshContainerWrapper(containerId)
         return
     end
 
-    local previewPanels = self.GetContainerUnlockPreviewPanels and self:GetContainerUnlockPreviewPanels(containerId) or {}
-    local allPanels = self.GetPanels and self:GetPanels(containerId) or previewPanels
+    local previewPanels = self.GetContainerUnlockPreviewPanels and self:GetContainerUnlockPreviewPanels(containerId, allPanels) or {}
+    allPanels = allPanels or previewPanels
     local previewRects = {}
     local previewedGroupIds = {}
     local minLeft, maxRight, minBottom, maxTop = nil, nil, nil, nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -1981,15 +1981,21 @@ function CooldownCompanion:CreateGroupFrame(groupId)
     -- Create buttons
     self:PopulateGroupButtons(groupId)
     
-    -- Show/hide based on runtime activity, plus selected off-class config previews.
-    if self:IsGroupActive(groupId, {
+    -- Show/hide based on runtime activity, plus selected config previews.
+    local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
         group = group,
-        checkCharVisibility = true,
-        checkLoadConditions = true,
-        requireButtons = true,
-    }) or self:IsGroupEligibleForConfigPreview(groupId, {
-        group = group,
-    }) then
+    })
+    local suppressedForOtherClassBrowse = self.IsGroupSuppressedForOtherClassBrowse
+        and self:IsGroupSuppressedForOtherClassBrowse(groupId, group)
+    if previewEligible or (
+        not suppressedForOtherClassBrowse
+        and self:IsGroupActive(groupId, {
+            group = group,
+            checkCharVisibility = true,
+            checkLoadConditions = true,
+            requireButtons = true,
+        })
+    ) then
         frame:Show()
         -- Apply current alpha from the alpha fade system so frame doesn't flash at 1.0
         ApplyCurrentAlphaIfPresent(self, frame, groupId, group)
@@ -2837,16 +2843,22 @@ function CooldownCompanion:RefreshGroupFrame(groupId)
     )
     self:UpdateGroupClickthrough(groupId)
 
-    -- Update visibility: runtime-active groups show normally; selected off-class
-    -- groups can also show as config previews without becoming runtime-visible.
-    local isActive = CooldownCompanion:IsGroupActive(groupId, {
-        group = group,
-        checkCharVisibility = true,
-        checkLoadConditions = true,
-        requireButtons = true,
-    }) or CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, {
+    -- Update visibility: runtime-active groups show normally; selected config
+    -- previews can also show without becoming runtime-visible.
+    local previewEligible = CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, {
         group = group,
     })
+    local suppressedForOtherClassBrowse = CooldownCompanion.IsGroupSuppressedForOtherClassBrowse
+        and CooldownCompanion:IsGroupSuppressedForOtherClassBrowse(groupId, group)
+    local isActive = previewEligible or (
+        not suppressedForOtherClassBrowse
+        and CooldownCompanion:IsGroupActive(groupId, {
+            group = group,
+            checkCharVisibility = true,
+            checkLoadConditions = true,
+            requireButtons = true,
+        })
+    )
     if isActive then
         if InCombatLockdown() and frame:IsProtected() then
             if not frame:IsShown() then

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -287,6 +287,13 @@ local function GetGroupButtonSizingOptions(self, groupId, group, buttonUsability
     return nil
 end
 
+local function IsSourceButtonInPreviewScope(self, groupId, sourceIndex, opts)
+    if self.IsButtonInConfigPreviewScope then
+        return self:IsButtonInConfigPreviewScope(groupId, sourceIndex, opts)
+    end
+    return true
+end
+
 local function GetContainerPreviewSelectionState(groupId)
     local profile = CooldownCompanion.db and CooldownCompanion.db.profile
     local group = profile and profile.groups and profile.groups[groupId]
@@ -2261,7 +2268,7 @@ end
 
 -- Compute button width/height from group style (bar mode vs square vs non-square).
 -- Returns width, height, isBarMode.
-local function GetButtonDimensions(group, buttonUsabilityOptions)
+local function GetButtonDimensions(group, buttonUsabilityOptions, groupId)
     local style = group.style or {}
     local isBarMode = group.displayMode == "bars"
     local isTextMode = group.displayMode == "text"
@@ -2273,8 +2280,9 @@ local function GetButtonDimensions(group, buttonUsabilityOptions)
         w = style.textWidth or 200
         if GetEffectiveTextHeight then
             local maxHeight = GetEffectiveTextHeight(style, style.textFormat or "{name}  {status}")
-            for _, buttonData in ipairs(group.buttons or {}) do
-                if CooldownCompanion:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
+            for sourceIndex, buttonData in ipairs(group.buttons or {}) do
+                if IsSourceButtonInPreviewScope(CooldownCompanion, groupId, sourceIndex, buttonUsabilityOptions)
+                    and CooldownCompanion:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
                     local effectiveStyle = CooldownCompanion:GetEffectiveStyle(style, buttonData)
                     local fmt = buttonData.textFormat or effectiveStyle.textFormat or "{name}  {status}"
                     local buttonHeight = GetEffectiveTextHeight(effectiveStyle, fmt)
@@ -2345,7 +2353,7 @@ local function ApplyTextGroupHeader(self, frame, group, style, isTextMode)
 end
 
 local function ApplyActiveButtonLayout(self, groupId, frame, group, buttonSizingOptions, headerHeight)
-    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions)
+    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions, groupId)
     local style = group.style or {}
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")
@@ -2375,7 +2383,9 @@ local function ApplyActiveButtonLayout(self, groupId, frame, group, buttonSizing
 
     frame.visibleButtonCount = isTriggerMode and (visibleIndex > 0 and 1 or 0) or visibleIndex
     if group.parentContainerId and not group.compactLayout and self.GetGroupLayoutButtonCount then
-        frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+        frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group, {
+            buttonUsabilityOptions = buttonSizingOptions,
+        })
     else
         frame.layoutButtonCount = nil
     end
@@ -2460,7 +2470,8 @@ local function GetStyleUpdateEntries(self, groupId, frame, group)
     local previousCount = entries.count or 0
     local visibleIndex = 0
     for sourceIndex, buttonData in ipairs(sourceButtons) do
-        if IsRuntimeButtonUsable(self, buttonData, group, buttonUsabilityOptions) then
+        if IsSourceButtonInPreviewScope(self, groupId, sourceIndex, buttonUsabilityOptions)
+            and IsRuntimeButtonUsable(self, buttonData, group, buttonUsabilityOptions) then
             visibleIndex = visibleIndex + 1
             local button = frame.buttons and frame.buttons[visibleIndex]
             if not button then
@@ -2524,7 +2535,8 @@ function CooldownCompanion:PopulateGroupButtons(groupId)
 
     -- Create new buttons (skip untalented spells)
     for i, buttonData in ipairs(sourceButtons) do
-        if IsRuntimeButtonUsable(self, buttonData, group, buttonUsabilityOptions) then
+        if IsSourceButtonInPreviewScope(self, groupId, i, buttonUsabilityOptions)
+            and IsRuntimeButtonUsable(self, buttonData, group, buttonUsabilityOptions) then
             local effectiveStyle = self:GetEffectiveStyle(style, buttonData)
             local poolKey = GetButtonPoolKey(group, buttonData, effectiveStyle)
             local button = AcquireButtonFromPool(frame, poolKey)
@@ -2582,7 +2594,7 @@ function CooldownCompanion:ResizeGroupFrame(groupId)
         and self:GetGroupButtonUsabilityOptions(groupId, group)
         or nil
     local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
-    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions)
+    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions, groupId)
     local style = group.style or {}
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")
@@ -2670,7 +2682,7 @@ function CooldownCompanion:UpdateGroupLayout(groupId)
         and self:GetGroupButtonUsabilityOptions(groupId, group)
         or nil
     local buttonSizingOptions = GetGroupButtonSizingOptions(self, groupId, group, buttonUsabilityOptions)
-    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions)
+    local buttonWidth, buttonHeight, isBarMode = GetButtonDimensions(group, buttonSizingOptions, groupId)
     local style = group.style or {}
     local spacing = style.buttonSpacing or ST.BUTTON_SPACING
     local orientation = style.orientation or (isBarMode and "vertical" or "horizontal")

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1316,6 +1316,7 @@ local CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS = {
     ignoreSpellAvailability = true,
     ignoreTalentConditions = true,
     configPreview = true,
+    selectionDrivenConfigPreview = true,
 }
 
 local function IsGroupEnabledForConfigPreview(addon, group)
@@ -1341,9 +1342,56 @@ local function IsGroupEnabledForConfigPreview(addon, group)
     return true
 end
 
+local function IsConfigSelectionPreviewShown()
+    local CS = ST and ST._configState
+    local configFrame = CS and CS.configFrame
+    local frame = configFrame and configFrame.frame
+    if not (frame and frame.IsShown and frame:IsShown()) then
+        return nil
+    end
+    return CS
+end
+
+local function IsSelectionDrivenConfigPreviewScope(addon, groupId, sourceIndex)
+    local CS = IsConfigSelectionPreviewShown()
+    if not CS then
+        return false
+    end
+
+    if CS.selectedGroup == groupId then
+        if not sourceIndex then
+            return true
+        end
+        if CS.selectedButton then
+            return CS.selectedButton == sourceIndex
+        end
+        if CS.selectedButtons and next(CS.selectedButtons) then
+            return CS.selectedButtons[sourceIndex] or false
+        end
+        return true
+    end
+
+    if CS.selectedPanels and CS.selectedPanels[groupId] then
+        return true
+    end
+
+    if CS.selectedContainer and not CS.selectedGroup then
+        local db = addon.db
+        local group = db and db.profile and db.profile.groups and db.profile.groups[groupId]
+        if group and group.parentContainerId == CS.selectedContainer then
+            return true
+        end
+    end
+
+    return false
+end
+
 function CooldownCompanion:IsButtonInConfigPreviewScope(groupId, sourceIndex, opts)
     if not (opts and opts.configPreview) then
         return true
+    end
+    if opts.selectionDrivenConfigPreview then
+        return IsSelectionDrivenConfigPreviewScope(self, groupId, sourceIndex) == true
     end
     if not ST.IsConfigButtonForceVisible then
         return true
@@ -1363,7 +1411,7 @@ local function GroupHasConfigPreviewButtons(addon, groupId, group)
 end
 
 function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
-    if not (groupId and ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(groupId)) then
+    if not (groupId and IsSelectionDrivenConfigPreviewScope(self, groupId)) then
         return nil
     end
 
@@ -1450,7 +1498,7 @@ end
 
 function CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, opts)
     opts = opts or {}
-    if not (groupId and ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(groupId)) then
+    if not (groupId and IsSelectionDrivenConfigPreviewScope(self, groupId)) then
         return false
     end
 

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2969,7 +2969,7 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
         end
         return
     end
-    if not (ST.IsGroupConfigSelected and self.db and self.db.profile and self.db.profile.groups) then
+    if not (self.db and self.db.profile and self.db.profile.groups) then
         return
     end
 
@@ -2980,7 +2980,7 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
     local candidates = {}
 
     for groupId in pairs(groups) do
-        if ST.IsGroupConfigSelected(groupId) then
+        if IsSelectionDrivenConfigPreviewScope(self, groupId) then
             currentPreviewed = currentPreviewed or {}
             currentPreviewed[groupId] = true
             candidates[groupId] = true

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -897,14 +897,15 @@ function CooldownCompanion:IsGroupVisibleInUnlockPreview(groupId, opts)
     return true
 end
 
-function CooldownCompanion:GetContainerUnlockPreviewPanels(containerId)
+function CooldownCompanion:GetContainerUnlockPreviewPanels(containerId, panels)
     local previewPanels = {}
-    local panels = self:GetPanels(containerId)
-    for _, panelInfo in ipairs(panels) do
-        if self:IsGroupVisibleInUnlockPreview(panelInfo.groupId, {
-            group = panelInfo.group,
-            checkCharVisibility = true,
-        }) then
+    local panelList = panels or self:GetPanels(containerId)
+    for _, panelInfo in ipairs(panelList) do
+        if not self:IsGroupSuppressedForOtherClassBrowse(panelInfo.groupId, panelInfo.group)
+            and self:IsGroupVisibleInUnlockPreview(panelInfo.groupId, {
+                group = panelInfo.group,
+                checkCharVisibility = true,
+            }) then
             previewPanels[#previewPanels + 1] = panelInfo
         end
     end
@@ -1553,6 +1554,32 @@ local function EnsureConfigPreviewContainerFrame(addon, group, previewEligible)
     end
 end
 
+local function CleanupInactiveConfigPreviewContainerFrames(addon)
+    if not addon.containerFrames then
+        return false
+    end
+
+    local previewContainerIds = BuildConfigPreviewEligibility(addon)
+    local cleaned = false
+    for containerId, frame in pairs(addon.containerFrames) do
+        if frame
+            and not addon:IsContainerVisibleToCurrentChar(containerId)
+            and not (previewContainerIds and previewContainerIds[containerId]) then
+            if InCombatLockdown() and frame.IsProtected and frame:IsProtected() then
+                addon._pendingVisibilityRefresh = true
+            else
+                if addon.ClearContainerUnlockState then
+                    addon:ClearContainerUnlockState(containerId)
+                end
+                local wasShown = not frame.IsShown or frame:IsShown()
+                frame:Hide()
+                cleaned = cleaned or wasShown
+            end
+        end
+    end
+    return cleaned
+end
+
 local function IsConfigFrameShown()
     local configState = ST and ST._configState
     local frame = configState and configState.configFrame and configState.configFrame.frame
@@ -1590,6 +1617,29 @@ function CooldownCompanion:IsGroupSuppressedForOtherClassBrowse(groupId, group)
         checkLoadConditions = true,
         requireButtons = true,
     }) == true
+end
+
+function CooldownCompanion:IsContainerSuppressedForOtherClassBrowse(containerId, panels)
+    if not containerId then
+        return false
+    end
+
+    local panelList = panels or (self.GetPanels and self:GetPanels(containerId)) or nil
+    local hasSuppressedPanel = false
+    for _, panelInfo in ipairs(panelList or {}) do
+        local groupId = panelInfo.groupId
+        local group = panelInfo.group
+        if self:IsGroupSuppressedForOtherClassBrowse(groupId, group) then
+            hasSuppressedPanel = true
+        elseif self:IsGroupVisibleInUnlockPreview(groupId, {
+            group = group,
+            checkCharVisibility = true,
+        }) then
+            return false
+        end
+    end
+
+    return hasSuppressedPanel
 end
 
 function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
@@ -2972,8 +3022,9 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
         end
     end
     self._refreshingConfigSelectedGroupFrames = nil
+    local containersCleaned = CleanupInactiveConfigPreviewContainerFrames(self)
 
-    if refreshed then
+    if refreshed or containersCleaned then
         self:FinalizePanelAnchors()
         if self.RefreshAllContainerWrappers then
             self:RefreshAllContainerWrappers()

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1473,6 +1473,45 @@ function CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, opts)
     return GroupHasConfigPreviewButtons(self, groupId, group)
 end
 
+local function IsConfigFrameShown()
+    local configState = ST and ST._configState
+    local frame = configState and configState.configFrame and configState.configFrame.frame
+    return frame and frame.IsShown and frame:IsShown()
+end
+
+function CooldownCompanion:IsGroupSuppressedForOtherClassBrowse(groupId, group)
+    local configState = ST and ST._configState
+    if not (configState
+        and configState.otherClassLibraryActive == true
+        and configState.hideActiveCurrentClassPanels == true
+        and IsConfigFrameShown()) then
+        return false
+    end
+
+    local db = self.db and self.db.profile
+    group = group or (db and db.groups and db.groups[groupId])
+    if not group then
+        return false
+    end
+
+    local visibleToCurrentChar = self:IsGroupVisibleToCurrentChar(groupId)
+    if not visibleToCurrentChar then
+        return false
+    end
+
+    local frame = self.groupFrames and self.groupFrames[groupId]
+    if frame and frame.IsShown and frame:IsShown() then
+        return true
+    end
+
+    return self:IsGroupActive(groupId, {
+        group = group,
+        checkCharVisibility = false,
+        checkLoadConditions = true,
+        requireButtons = true,
+    }) == true
+end
+
 function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
     if not group.heroTalents or not next(group.heroTalents) then return end
     local subTreeIDs = C_ClassTalents.GetHeroTalentSpecsForClassSpec(nil, specId)
@@ -2980,6 +3019,8 @@ function CooldownCompanion:RefreshAllGroups()
     for groupId, group in pairs(self.db.profile.groups) do
         if not self:IsGroupVisibleToCurrentChar(groupId) then
             self:UnloadGroup(groupId)
+        elseif self:IsGroupSuppressedForOtherClassBrowse(groupId, group) then
+            self:UnloadGroup(groupId)
         elseif self:IsGroupActive(groupId, {
             group = group,
             checkCharVisibility = false,
@@ -3036,6 +3077,8 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
             group = group,
         })
         if not visible and not previewEligible then
+            self:UnloadGroup(groupId)
+        elseif self:IsGroupSuppressedForOtherClassBrowse(groupId, group) then
             self:UnloadGroup(groupId)
         else
             local active = self:IsGroupActive(groupId, {

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1514,6 +1514,45 @@ function CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, opts)
     return GroupHasConfigPreviewButtons(self, groupId, group)
 end
 
+local function BuildConfigPreviewEligibility(addon)
+    local groups = addon.db and addon.db.profile and addon.db.profile.groups
+    if not groups then
+        return nil, nil
+    end
+
+    local containerIds
+    local groupIds
+    for groupId, group in pairs(groups) do
+        local containerId = group and group.parentContainerId
+        if containerId and addon:IsGroupEligibleForConfigPreview(groupId, {
+            group = group,
+        }) then
+            containerIds = containerIds or {}
+            containerIds[containerId] = true
+            groupIds = groupIds or {}
+            groupIds[groupId] = true
+        end
+    end
+    return containerIds, groupIds
+end
+
+local function EnsureConfigPreviewContainerFrame(addon, group, previewEligible)
+    if not (previewEligible and group and group.parentContainerId and addon.containerFrames) then
+        return
+    end
+    if InCombatLockdown() then
+        addon._pendingVisibilityRefresh = true
+        return
+    end
+
+    local containerFrame = addon.containerFrames[group.parentContainerId]
+    if containerFrame then
+        containerFrame:Show()
+    elseif addon.CreateContainerFrame then
+        addon:CreateContainerFrame(group.parentContainerId)
+    end
+end
+
 local function IsConfigFrameShown()
     local configState = ST and ST._configState
     local frame = configState and configState.configFrame and configState.configFrame.frame
@@ -2911,20 +2950,22 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
             local frame = self.groupFrames and self.groupFrames[groupId]
             local wasPreviewed = previousPreviewed and previousPreviewed[groupId]
             local isPreviewed = currentPreviewed and currentPreviewed[groupId]
+            local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
+                group = group,
+            })
             local active = self:IsGroupActive(groupId, {
                 group = group,
                 checkCharVisibility = true,
                 checkLoadConditions = true,
                 requireButtons = true,
-            }) or self:IsGroupEligibleForConfigPreview(groupId, {
-                group = group,
-            })
+            }) or previewEligible
             if (active or (wasPreviewed and frame))
                 and (not frame
                     or (wasPreviewed and not isPreviewed)
                     or self:GroupButtonSetNeedsRebuild(groupId, group, {
                         allowConfigPreviewButtonUsability = isPreviewed,
                     })) then
+                EnsureConfigPreviewContainerFrame(self, group, previewEligible)
                 self:RefreshGroupFrame(groupId)
                 refreshed = true
             end
@@ -3024,6 +3065,7 @@ function CooldownCompanion:RefreshAllGroups()
         return
     end
     -- Clean up stale container frames (e.g. after profile switch)
+    local previewContainerIds, previewGroupIds = BuildConfigPreviewEligibility(self)
     if self.containerFrames then
         local containers = self.db.profile.groupContainers or {}
         for containerId, frame in pairs(self.containerFrames) do
@@ -3034,9 +3076,12 @@ function CooldownCompanion:RefreshAllGroups()
         end
         -- Ensure all current-profile containers have frames
         for containerId, _ in pairs(containers) do
-            if self:IsContainerVisibleToCurrentChar(containerId) then
+            if self:IsContainerVisibleToCurrentChar(containerId)
+                or (previewContainerIds and previewContainerIds[containerId]) then
                 if not self.containerFrames[containerId] then
                     self:CreateContainerFrame(containerId)
+                else
+                    self.containerFrames[containerId]:Show()
                 end
             else
                 if self.containerFrames[containerId] then
@@ -3066,9 +3111,7 @@ function CooldownCompanion:RefreshAllGroups()
     -- Refresh current profile's groups: load active ones, unload inactive ones
     for groupId, group in pairs(self.db.profile.groups) do
         local visible = self:IsGroupVisibleToCurrentChar(groupId)
-        local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
-            group = group,
-        })
+        local previewEligible = previewGroupIds and previewGroupIds[groupId] == true
         if not visible and not previewEligible then
             self:UnloadGroup(groupId)
         elseif self:IsGroupSuppressedForOtherClassBrowse(groupId, group) then
@@ -3128,6 +3171,7 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
         local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
             group = group,
         })
+        EnsureConfigPreviewContainerFrame(self, group, previewEligible)
         if not visible and not previewEligible then
             self:UnloadGroup(groupId)
         elseif self:IsGroupSuppressedForOtherClassBrowse(groupId, group) then

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1314,6 +1314,7 @@ end
 local CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS = {
     checkLoadConditions = false,
     ignoreSpellAvailability = true,
+    ignoreItemAvailability = true,
     ignoreTalentConditions = true,
     configPreview = true,
     selectionDrivenConfigPreview = true,
@@ -1375,7 +1376,8 @@ local function IsSelectionDrivenConfigPreviewScope(addon, groupId, sourceIndex)
         return true
     end
 
-    if CS.selectedContainer and not CS.selectedGroup then
+    if CS.selectedContainer and not CS.selectedGroup
+        and not (CS.selectedPanels and next(CS.selectedPanels)) then
         local db = addon.db
         local group = db and db.profile and db.profile.groups and db.profile.groups[groupId]
         if group and group.parentContainerId == CS.selectedContainer then
@@ -1488,6 +1490,7 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
     if opts.requireButtons and not self:GroupHasUsableButtons(group, {
         checkLoadConditions = opts.checkLoadConditions,
         ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
+        ignoreItemAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreItemAvailability,
         ignoreTalentConditions = buttonUsabilityOptions and buttonUsabilityOptions.ignoreTalentConditions,
     }) then
         return false
@@ -2631,6 +2634,13 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
     if opts.ignoreSpellAvailability and buttonData.type == "spell" then
         return true
     end
+    if opts.ignoreItemAvailability
+        and (
+            buttonData.type == "item"
+            or (CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData))
+        ) then
+        return true
+    end
 
     -- Passive/proc spells are tracked via aura, not spellbook presence.
     -- Multi-CDM-child buttons: verify their specific slot still exists in the CDM
@@ -3055,7 +3065,11 @@ function CooldownCompanion:RefreshAllGroups()
 
     -- Refresh current profile's groups: load active ones, unload inactive ones
     for groupId, group in pairs(self.db.profile.groups) do
-        if not self:IsGroupVisibleToCurrentChar(groupId) then
+        local visible = self:IsGroupVisibleToCurrentChar(groupId)
+        local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
+            group = group,
+        })
+        if not visible and not previewEligible then
             self:UnloadGroup(groupId)
         elseif self:IsGroupSuppressedForOtherClassBrowse(groupId, group) then
             self:UnloadGroup(groupId)
@@ -3064,7 +3078,7 @@ function CooldownCompanion:RefreshAllGroups()
             checkCharVisibility = false,
             checkLoadConditions = true,
             requireButtons = false,
-        }) then
+        }) or previewEligible then
             self:RefreshGroupFrame(groupId)
         else
             self:UnloadGroup(groupId)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1284,7 +1284,8 @@ function CooldownCompanion:GroupHasUsableButtons(group, opts)
     return false
 end
 
-function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)
+function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group, opts)
+    opts = opts or {}
     if self:IsRotationAssistantGroup(group) then
         return 1
     end
@@ -1293,17 +1294,104 @@ function CooldownCompanion:GetGroupLayoutButtonCount(groupId, group)
         return 0
     end
 
-    local opts = self.GetGroupLayoutButtonUsabilityOptions
-        and self:GetGroupLayoutButtonUsabilityOptions(groupId, group)
-        or nil
+    local buttonUsabilityOptions = opts.buttonUsabilityOptions
+    if not buttonUsabilityOptions
+        and opts.allowConfigPreviewButtonUsability
+        and self.GetGroupLayoutButtonUsabilityOptions then
+        buttonUsabilityOptions = self:GetGroupLayoutButtonUsabilityOptions(groupId, group)
+    end
 
     local count = 0
-    for _, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group, opts) then
+    for sourceIndex, buttonData in ipairs(group.buttons) do
+        if self:IsButtonInConfigPreviewScope(groupId, sourceIndex, buttonUsabilityOptions)
+            and self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
             count = count + 1
         end
     end
     return count
+end
+
+local CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS = {
+    checkLoadConditions = false,
+    ignoreSpellAvailability = true,
+    ignoreTalentConditions = true,
+    configPreview = true,
+}
+
+local function IsGroupEnabledForConfigPreview(addon, group)
+    if not group then return false end
+
+    local container = addon:GetParentContainer(group)
+    if container then
+        if container.enabled == false or group.enabled == false then return false end
+    elseif group.enabled == false then
+        return false
+    end
+
+    if group.parentContainerId then
+        if not addon.ResolveContainerClassScope then
+            return false
+        end
+        local scope = addon:ResolveContainerClassScope(group.parentContainerId)
+        if not scope or scope.isInvalid == true then
+            return false
+        end
+    end
+
+    return true
+end
+
+function CooldownCompanion:IsButtonInConfigPreviewScope(groupId, sourceIndex, opts)
+    if not (opts and opts.configPreview) then
+        return true
+    end
+    if not ST.IsConfigButtonForceVisible then
+        return true
+    end
+
+    local previewButton = {
+        _groupId = groupId,
+        index = sourceIndex,
+    }
+    return ST.IsConfigButtonForceVisible(previewButton) == true
+end
+
+local function GroupHasConfigPreviewButtons(addon, groupId, group)
+    if addon:IsRotationAssistantGroup(group) then
+        return true
+    end
+    if not (group and group.buttons and #group.buttons > 0) then
+        return false
+    end
+    for sourceIndex, buttonData in ipairs(group.buttons) do
+        if addon:IsButtonInConfigPreviewScope(groupId, sourceIndex, CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS)
+            and addon:IsButtonUsable(buttonData, group, CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS) then
+            return true
+        end
+    end
+    return false
+end
+
+function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)
+    if not (groupId and ST.IsGroupConfigSelected and ST.IsGroupConfigSelected(groupId)) then
+        return nil
+    end
+
+    local db = self.db and self.db.profile
+    group = group or (db and db.groups and db.groups[groupId])
+    if not IsGroupEnabledForConfigPreview(self, group) then
+        return nil
+    end
+
+    if not GroupHasConfigPreviewButtons(self, groupId, group) then
+        return nil
+    end
+
+    return CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS
+end
+
+function CooldownCompanion:GetGroupLayoutButtonUsabilityOptions(groupId, group)
+    return self:GetGroupButtonUsabilityOptions(groupId, group)
 end
 
 function CooldownCompanion:IsGroupActive(groupId, opts)
@@ -1353,11 +1441,16 @@ function CooldownCompanion:IsGroupActive(groupId, opts)
     end
 
     local buttonUsabilityOptions = opts.buttonUsabilityOptions
-        or (self.GetGroupButtonUsabilityOptions and self:GetGroupButtonUsabilityOptions(groupId, group))
+    if not buttonUsabilityOptions
+        and opts.allowConfigPreviewButtonUsability
+        and self.GetGroupButtonUsabilityOptions then
+        buttonUsabilityOptions = self:GetGroupButtonUsabilityOptions(groupId, group)
+    end
 
     if opts.requireButtons and not self:GroupHasUsableButtons(group, {
         checkLoadConditions = opts.checkLoadConditions,
         ignoreSpellAvailability = buttonUsabilityOptions and buttonUsabilityOptions.ignoreSpellAvailability,
+        ignoreTalentConditions = buttonUsabilityOptions and buttonUsabilityOptions.ignoreTalentConditions,
     }) then
         return false
     end
@@ -1373,28 +1466,11 @@ function CooldownCompanion:IsGroupEligibleForConfigPreview(groupId, opts)
 
     local db = self.db and self.db.profile
     local group = opts.group or (db and db.groups and db.groups[groupId])
-    if not group then return false end
-
-    local container = self:GetParentContainer(group)
-    if container then
-        if container.enabled == false or group.enabled == false then return false end
-    elseif group.enabled == false then
+    if not IsGroupEnabledForConfigPreview(self, group) then
         return false
     end
 
-    if not self:IsRotationAssistantGroup(group) and not (group.buttons and #group.buttons > 0) then
-        return false
-    end
-
-    if not self.ResolveContainerClassScope then
-        return false
-    end
-    if not group.parentContainerId then
-        return false
-    end
-
-    local scope = self:ResolveContainerClassScope(group.parentContainerId)
-    return scope and scope.isOtherClass == true and scope.isInvalid ~= true
+    return GroupHasConfigPreviewButtons(self, groupId, group)
 end
 
 function CooldownCompanion:CleanHeroTalentsForSpec(group, specId)
@@ -2473,7 +2549,7 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
     if opts.checkLoadConditions ~= false and not self:IsButtonLoadConditionMet(buttonData, group) then return false end
 
     -- Per-button talent condition: gate visibility on a specific talent node.
-    if not self:IsTalentConditionMet(buttonData) then return false end
+    if not opts.ignoreTalentConditions and not self:IsTalentConditionMet(buttonData) then return false end
 
     if opts.ignoreSpellAvailability and buttonData.type == "spell" then
         return true
@@ -2554,7 +2630,8 @@ local function GetFrameForButtonSetComparison(addon, groupId)
     return addon._dormantFrames and addon._dormantFrames[groupId] or nil
 end
 
-function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
+function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group, opts)
+    opts = opts or {}
     local frame = GetFrameForButtonSetComparison(self, groupId)
     if not frame or not frame.buttons then
         return false
@@ -2571,11 +2648,15 @@ function CooldownCompanion:GroupButtonSetNeedsRebuild(groupId, group)
 
     local usableButtons = {}
     local usableCount = 0
-    local buttonUsabilityOptions = self.GetGroupButtonUsabilityOptions
-        and self:GetGroupButtonUsabilityOptions(groupId, group)
-        or nil
-    for _, buttonData in ipairs(group.buttons) do
-        if self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
+    local buttonUsabilityOptions = opts.buttonUsabilityOptions
+    if not buttonUsabilityOptions
+        and opts.allowConfigPreviewButtonUsability
+        and self.GetGroupButtonUsabilityOptions then
+        buttonUsabilityOptions = self:GetGroupButtonUsabilityOptions(groupId, group)
+    end
+    for sourceIndex, buttonData in ipairs(group.buttons) do
+        if self:IsButtonInConfigPreviewScope(groupId, sourceIndex, buttonUsabilityOptions)
+            and self:IsButtonUsable(buttonData, group, buttonUsabilityOptions) then
             usableCount = usableCount + 1
             usableButtons[usableCount] = buttonData
         end
@@ -2754,7 +2835,9 @@ function CooldownCompanion:RefreshConfigSelectedGroupFrames()
             if (active or (wasPreviewed and frame))
                 and (not frame
                     or (wasPreviewed and not isPreviewed)
-                    or self:GroupButtonSetNeedsRebuild(groupId, group)) then
+                    or self:GroupButtonSetNeedsRebuild(groupId, group, {
+                        allowConfigPreviewButtonUsability = isPreviewed,
+                    })) then
                 self:RefreshGroupFrame(groupId)
                 refreshed = true
             end
@@ -2783,7 +2866,11 @@ function CooldownCompanion:FinalizePanelAnchors()
         local frame = self.groupFrames[groupId]
         if group and group.parentContainerId and group.anchor and frame then
             if not group.compactLayout then
-                frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group)
+                frame.layoutButtonCount = self:GetGroupLayoutButtonCount(groupId, group, {
+                    allowConfigPreviewButtonUsability = self:IsGroupEligibleForConfigPreview(groupId, {
+                        group = group,
+                    }),
+                })
             else
                 frame.layoutButtonCount = nil
             end
@@ -2945,12 +3032,9 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
 
     for groupId, group in pairs(self.db.profile.groups) do
         local visible = self:IsGroupVisibleToCurrentChar(groupId)
-        local previewEligible = false
-        if not visible then
-            previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
-                group = group,
-            })
-        end
+        local previewEligible = self:IsGroupEligibleForConfigPreview(groupId, {
+            group = group,
+        })
         if not visible and not previewEligible then
             self:UnloadGroup(groupId)
         else
@@ -2965,11 +3049,15 @@ function CooldownCompanion:RefreshAllGroupsVisibilityOnly()
                 self:UnloadGroup(groupId)
             else
                 local frame = self.groupFrames[groupId]
-                if frame and self:GroupButtonSetNeedsRebuild(groupId, group) then
+                if frame and self:GroupButtonSetNeedsRebuild(groupId, group, {
+                    allowConfigPreviewButtonUsability = previewEligible,
+                }) then
                     self:RefreshGroupFrame(groupId)
                     frame = self.groupFrames[groupId]
                 elseif not frame then
-                    if self:GroupButtonSetNeedsRebuild(groupId, group) then
+                    if self:GroupButtonSetNeedsRebuild(groupId, group, {
+                        allowConfigPreviewButtonUsability = previewEligible,
+                    }) then
                         self:DiscardDormantFrame(groupId)
                     end
                     -- Recover dormant frame with buttons intact (no repopulation needed)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1357,19 +1357,9 @@ function CooldownCompanion:IsButtonInConfigPreviewScope(groupId, sourceIndex, op
 end
 
 local function GroupHasConfigPreviewButtons(addon, groupId, group)
-    if addon:IsRotationAssistantGroup(group) then
-        return true
-    end
-    if not (group and group.buttons and #group.buttons > 0) then
-        return false
-    end
-    for sourceIndex, buttonData in ipairs(group.buttons) do
-        if addon:IsButtonInConfigPreviewScope(groupId, sourceIndex, CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS)
-            and addon:IsButtonUsable(buttonData, group, CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS) then
-            return true
-        end
-    end
-    return false
+    return addon:GetGroupLayoutButtonCount(groupId, group, {
+        buttonUsabilityOptions = CONFIG_PREVIEW_BUTTON_USABILITY_OPTIONS,
+    }) > 0
 end
 
 function CooldownCompanion:GetGroupButtonUsabilityOptions(groupId, group)

--- a/CooldownCompanion/Core/Utils.lua
+++ b/CooldownCompanion/Core/Utils.lua
@@ -614,8 +614,9 @@ function ST.IsGroupConfigSelected(groupId)
     -- Multi-panel selection
     if CS.selectedPanels and CS.selectedPanels[groupId] then return true end
 
-    -- Container selected, no specific panel → all panels in that container
-    if CS.selectedContainer and not CS.selectedGroup then
+    -- Container selected, no specific panel multi-select → all panels in that container
+    if CS.selectedContainer and not CS.selectedGroup
+        and not (CS.selectedPanels and next(CS.selectedPanels)) then
         local db = ST.Addon.db
         local group = db and db.profile.groups[groupId]
         if group and group.parentContainerId == CS.selectedContainer then
@@ -674,8 +675,9 @@ function ST.IsConfigButtonForceVisible(button)
         return true
     end
 
-    -- Container selected, no specific panel → all buttons in all panels
-    if CS.selectedContainer and not CS.selectedGroup then
+    -- Container selected, no specific panel multi-select → all buttons in all panels
+    if CS.selectedContainer and not CS.selectedGroup
+        and not (CS.selectedPanels and next(CS.selectedPanels)) then
         local db = ST.Addon.db
         local group = db and db.profile.groups[groupId]
         if group and group.parentContainerId == CS.selectedContainer then

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -678,6 +678,13 @@ end
 
 local function ClearColumn1ButtonBar()
     for _, widget in ipairs(CS.col1BarWidgets) do
+        local frame = widget and widget.frame
+        if frame and frame._cdcHideActiveOtherClassBrowse then
+            frame:SetScript("OnEnter", nil)
+            frame:SetScript("OnLeave", nil)
+            frame._cdcHideActiveOtherClassBrowse = nil
+            GameTooltip:Hide()
+        end
         widget:Release()
     end
     wipe(CS.col1BarWidgets)

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -41,8 +41,24 @@ local SelectConfigFolder = ST._SelectConfigFolder
 local SelectConfigContainer = ST._SelectConfigContainer
 local ToggleConfigContainerMultiSelect = ST._ToggleConfigContainerMultiSelect
 local SelectConfigPanel = ST._SelectConfigPanel
+local ClearOtherClassHideActive = ST._ClearOtherClassHideActive
+local SetHideActiveCurrentClassPanels = ST._SetHideActiveCurrentClassPanels
 
 local GenerateGroupName
+
+local function ClearOtherClassBrowseState(opts)
+    CS.otherClassLibraryActive = false
+    CS.otherClassLibraryClassKey = nil
+    if ClearOtherClassHideActive then
+        ClearOtherClassHideActive(opts)
+    else
+        local changed = CS.hideActiveCurrentClassPanels == true
+        CS.hideActiveCurrentClassPanels = false
+        if changed and not (opts and opts.skipRefresh) and CooldownCompanion.RefreshAllGroupsVisibilityOnly then
+            CooldownCompanion:RefreshAllGroupsVisibilityOnly()
+        end
+    end
+end
 
 local function OpenContainerLoadConditions(containerId)
     SelectConfigContainer(containerId)
@@ -674,15 +690,23 @@ local function ShowFolderContextMenu(db, folderId, folder)
     ToggleDropDownMenu(1, nil, CS.folderContextMenu, "cursor", 0, 0)
 end
 
+local function ClearColumn1ButtonBar()
+    for _, widget in ipairs(CS.col1BarWidgets) do
+        widget:Release()
+    end
+    wipe(CS.col1BarWidgets)
+    if CS.col1ButtonBar then
+        CS.col1ButtonBar._topRowBtns = nil
+        CS.col1ButtonBar:SetScript("OnSizeChanged", nil)
+    end
+end
+
 local function PopulateColumn1ButtonBar()
     if not CS.col1ButtonBar then
         return
     end
 
-    for _, widget in ipairs(CS.col1BarWidgets) do
-        widget:Release()
-    end
-    wipe(CS.col1BarWidgets)
+    ClearColumn1ButtonBar()
 
     local barW = CS.col1ButtonBar:GetWidth() or 300
     local thirdW = (barW - 6) / 3
@@ -749,6 +773,60 @@ local function PopulateColumn1ButtonBar()
     end)
 end
 
+local function PopulateOtherClassBrowseButtonBar()
+    if not CS.col1ButtonBar then
+        return
+    end
+
+    ClearColumn1ButtonBar()
+
+    local toggleBtn = AceGUI:Create("Button")
+    local function UpdateToggleText()
+        toggleBtn:SetText(CS.hideActiveCurrentClassPanels == true and "Show Active" or "Hide Active")
+    end
+    UpdateToggleText()
+    toggleBtn:SetCallback("OnClick", function()
+        local hideActive = not (CS.hideActiveCurrentClassPanels == true)
+        if SetHideActiveCurrentClassPanels then
+            SetHideActiveCurrentClassPanels(hideActive)
+        else
+            CS.hideActiveCurrentClassPanels = hideActive and CS.otherClassLibraryActive == true
+            if CooldownCompanion.RefreshAllGroupsVisibilityOnly then
+                CooldownCompanion:RefreshAllGroupsVisibilityOnly()
+            end
+        end
+        UpdateToggleText()
+    end)
+    toggleBtn.frame:SetParent(CS.col1ButtonBar)
+    toggleBtn.frame:ClearAllPoints()
+    toggleBtn.frame:SetPoint("TOPLEFT", CS.col1ButtonBar, "TOPLEFT", 0, -1)
+    toggleBtn.frame:SetPoint("TOPRIGHT", CS.col1ButtonBar, "TOPRIGHT", 0, -1)
+    toggleBtn.frame:SetHeight(28)
+    toggleBtn.frame._cdcHideActiveOtherClassBrowse = true
+    toggleBtn.frame:SetScript("OnEnter", function(self)
+        local hidden = CS.hideActiveCurrentClassPanels == true
+        GameTooltip:SetOwner(self, "ANCHOR_TOP")
+        GameTooltip:AddLine(hidden and "Show Active" or "Hide Active")
+        GameTooltip:AddLine(hidden and "Show your current character's panels again." or "Hide your current character's panels.", 1, 1, 1, true)
+        GameTooltip:AddLine(" ")
+        GameTooltip:AddLine("Other-class previews stay visible.", 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    toggleBtn.frame:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    toggleBtn.frame:Show()
+    table.insert(CS.col1BarWidgets, toggleBtn)
+
+    CS.col1ButtonBar._topRowBtns = { toggleBtn.frame }
+    CS.col1ButtonBar:SetScript("OnSizeChanged", function(self, w)
+        if self._topRowBtns and self._topRowBtns[1] then
+            self._topRowBtns[1]:SetWidth(w)
+        end
+    end)
+    CS.col1ButtonBar:Show()
+end
+
 ------------------------------------------------------------------------
 -- COLUMN 1: Groups
 ------------------------------------------------------------------------
@@ -757,8 +835,7 @@ local function RefreshColumn1(preserveDrag)
 
     -- Bars & Frames panel mode: take over col1 with the bar/frame tab group
     if CS.resourceBarPanelActive then
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassBrowseState()
         CancelDrag()
         CS.HideAutocomplete()
         CS.col1Scroll.frame:Hide()
@@ -838,8 +915,7 @@ local function RefreshColumn1(preserveDrag)
     if not db.folders then db.folders = {} end
 
     if CooldownCompanion._unsupportedLegacyProfile then
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassBrowseState()
         if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
 
         local spacer = AceGUI:Create("SimpleGroup")
@@ -1742,8 +1818,7 @@ local function RefreshColumn1(preserveDrag)
     local function RenderOtherClassLibrary(otherSectionOrder)
         local totalCount, classCount = GetOtherClassSummary(otherSectionOrder)
         if totalCount <= 0 or classCount <= 0 then
-            CS.otherClassLibraryActive = false
-            CS.otherClassLibraryClassKey = nil
+            ClearOtherClassBrowseState()
             return false
         end
 
@@ -1781,8 +1856,7 @@ local function RefreshColumn1(preserveDrag)
                 if ClearConfigPrimarySelection then
                     ClearConfigPrimarySelection()
                 end
-                CS.otherClassLibraryActive = false
-                CS.otherClassLibraryClassKey = nil
+                ClearOtherClassBrowseState()
                 CooldownCompanion:RefreshConfigPanel()
             end,
         })
@@ -1849,7 +1923,7 @@ local function RefreshColumn1(preserveDrag)
         CS.col1Scroll:AddChild(label)
         CS.lastCol1RenderedRows = col1RenderedRows
         if CS.otherClassLibraryActive then
-            if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
+            PopulateOtherClassBrowseButtonBar()
         else
             PopulateColumn1ButtonBar()
         end
@@ -1857,8 +1931,7 @@ local function RefreshColumn1(preserveDrag)
     end
 
     if showNewUserEmptyState then
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
+        ClearOtherClassBrowseState()
 
         local spacer = AceGUI:Create("SimpleGroup")
         spacer:SetFullWidth(true)
@@ -1972,7 +2045,7 @@ local function RefreshColumn1(preserveDrag)
     CS.lastCol1RenderedRows = col1RenderedRows
 
     if CS.otherClassLibraryActive then
-        if CS.col1ButtonBar then CS.col1ButtonBar:Hide() end
+        PopulateOtherClassBrowseButtonBar()
     else
         PopulateColumn1ButtonBar()
     end

--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -41,24 +41,10 @@ local SelectConfigFolder = ST._SelectConfigFolder
 local SelectConfigContainer = ST._SelectConfigContainer
 local ToggleConfigContainerMultiSelect = ST._ToggleConfigContainerMultiSelect
 local SelectConfigPanel = ST._SelectConfigPanel
-local ClearOtherClassHideActive = ST._ClearOtherClassHideActive
 local SetHideActiveCurrentClassPanels = ST._SetHideActiveCurrentClassPanels
+local ClearOtherClassBrowseState = ST._ResetOtherClassLibraryState
 
 local GenerateGroupName
-
-local function ClearOtherClassBrowseState(opts)
-    CS.otherClassLibraryActive = false
-    CS.otherClassLibraryClassKey = nil
-    if ClearOtherClassHideActive then
-        ClearOtherClassHideActive(opts)
-    else
-        local changed = CS.hideActiveCurrentClassPanels == true
-        CS.hideActiveCurrentClassPanels = false
-        if changed and not (opts and opts.skipRefresh) and CooldownCompanion.RefreshAllGroupsVisibilityOnly then
-            CooldownCompanion:RefreshAllGroupsVisibilityOnly()
-        end
-    end
-end
 
 local function OpenContainerLoadConditions(containerId)
     SelectConfigContainer(containerId)
@@ -787,14 +773,7 @@ local function PopulateOtherClassBrowseButtonBar()
     UpdateToggleText()
     toggleBtn:SetCallback("OnClick", function()
         local hideActive = not (CS.hideActiveCurrentClassPanels == true)
-        if SetHideActiveCurrentClassPanels then
-            SetHideActiveCurrentClassPanels(hideActive)
-        else
-            CS.hideActiveCurrentClassPanels = hideActive and CS.otherClassLibraryActive == true
-            if CooldownCompanion.RefreshAllGroupsVisibilityOnly then
-                CooldownCompanion:RefreshAllGroupsVisibilityOnly()
-            end
-        end
+        SetHideActiveCurrentClassPanels(hideActive)
         UpdateToggleText()
     end)
     toggleBtn.frame:SetParent(CS.col1ButtonBar)

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1608,7 +1608,6 @@ local function CreateConfigPanel()
             if CS.CloseAdvancedSettingsPanel then
                 CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
             end
-            ClearTransientConfigPreviewState()
 
             savedFrameRight = content:GetRight()
             savedFrameTop = content:GetTop()
@@ -1619,6 +1618,7 @@ local function CreateConfigPanel()
             isCollapsing = true
             content:Hide()
             isCollapsing = false
+            ClearTransientConfigPreviewState()
 
             ApplyMiniFrameBackdrop()
             miniFrame:ClearAllPoints()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1562,6 +1562,7 @@ local function CreateConfigPanel()
             if frame.HideChangelogOverlay then
                 frame.HideChangelogOverlay()
             end
+            ClearHideActiveCurrentClassPanels()
             self:Hide()
         elseif not InCombatLockdown() then
             self:SetPropagateKeyboardInput(true)

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -28,6 +28,7 @@ local IsConfigFinderAvailable = ST._IsConfigFinderAvailable
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local SetConfigFinderText = ST._SetConfigFinderText
 local ClearConfigFinderText = ST._ClearConfigFinderText
+local ClearOtherClassHideActive = ST._ClearOtherClassHideActive
 local InvalidateConfigFinderResults = ST._InvalidateConfigFinderResults
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
@@ -38,11 +39,41 @@ local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
 local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
 
+local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
+local CONFIG_FINDER_BOX_HEIGHT = 28
+local CONFIG_FINDER_BUTTON_GAP = 3
+local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
+local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
+local CONFIG_NESTED_INLINE_GROUP_INSET = 20
+local CONFIG_DRAG_ALPHA = 0.40
+local PROFILE_WIDE_FONT_WINDOW_FALLBACK_WIDTH = 330
+local PROFILE_WIDE_FONT_WINDOW_HEIGHT = 168
+local PROFILE_WIDE_BAR_TEXTURE_WINDOW_HEIGHT = 106
+
 local function GetAddonVersionText()
     if ST._GetAddonVersion then
         return ST._GetAddonVersion()
     end
     return "unknown"
+end
+
+local function ClearHideActiveCurrentClassPanels(opts)
+    if ClearOtherClassHideActive then
+        return ClearOtherClassHideActive(opts)
+    end
+
+    local changed = CS.hideActiveCurrentClassPanels == true
+    CS.hideActiveCurrentClassPanels = false
+    if changed and not (opts and opts.skipRefresh) and CooldownCompanion.RefreshAllGroupsVisibilityOnly then
+        CooldownCompanion:RefreshAllGroupsVisibilityOnly()
+    end
+    return changed
+end
+
+local function ResetOtherClassBrowseState(opts)
+    CS.otherClassLibraryActive = false
+    CS.otherClassLibraryClassKey = nil
+    ClearHideActiveCurrentClassPanels(opts)
 end
 
 local function GetVersionFooterText()
@@ -60,17 +91,6 @@ local function GetVersionFooterText()
     end
     return footer
 end
-
-local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
-local CONFIG_FINDER_BOX_HEIGHT = 28
-local CONFIG_FINDER_BUTTON_GAP = 3
-local CONFIG_FINDER_RESERVED_HEIGHT = CONFIG_FINDER_BOX_HEIGHT + CONFIG_FINDER_BUTTON_GAP
-local CONFIG_COMPACT_ROW_MIN_WIDTH = 236
-local CONFIG_NESTED_INLINE_GROUP_INSET = 20
-local CONFIG_DRAG_ALPHA = 0.40
-local PROFILE_WIDE_FONT_WINDOW_FALLBACK_WIDTH = 330
-local PROFILE_WIDE_FONT_WINDOW_HEIGHT = 168
-local PROFILE_WIDE_BAR_TEXTURE_WINDOW_HEIGHT = 106
 
 local function GetProfileWideSideWindowWidth()
     local configFrame = CS.configFrame
@@ -1234,8 +1254,7 @@ local function CreateConfigPanel()
             if ClearConfigPrimarySelection then
                 ClearConfigPrimarySelection()
             end
-            CS.otherClassLibraryActive = false
-            CS.otherClassLibraryClassKey = nil
+            ResetOtherClassBrowseState()
             CooldownCompanion:RefreshConfigPanel()
             return
         end
@@ -1248,6 +1267,7 @@ local function CreateConfigPanel()
         if ClearConfigPrimarySelection then
             ClearConfigPrimarySelection()
         end
+        ClearHideActiveCurrentClassPanels()
         CS.otherClassLibraryActive = true
         CS.otherClassLibraryClassKey = nil
         CooldownCompanion:RefreshConfigPanel()
@@ -2556,11 +2576,13 @@ function CooldownCompanion:_configToggleImpl()
         if CS.CloseAdvancedSettingsPanel then
             CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
         end
+        ClearHideActiveCurrentClassPanels()
         CS.configFrame._miniFrame:Hide()
         return
     end
 
     if CS.configFrame.frame:IsShown() then
+        ClearHideActiveCurrentClassPanels()
         CS.configFrame.frame:Hide()
     else
         SetPrimaryMode("buttons", { skipRefresh = true })

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -932,6 +932,7 @@ local function CreateConfigPanel()
         if CS.CloseAdvancedSettingsPanel then
             CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
         end
+        ClearHideActiveCurrentClassPanels()
         if not CS.previewToggleRefreshActive then
             CooldownCompanion:ClearAllConfigPreviews()
             if CooldownCompanion.RefreshConfigSelectedGroupFrames then

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -28,7 +28,8 @@ local IsConfigFinderAvailable = ST._IsConfigFinderAvailable
 local IsConfigFinderActive = ST._IsConfigFinderActive
 local SetConfigFinderText = ST._SetConfigFinderText
 local ClearConfigFinderText = ST._ClearConfigFinderText
-local ClearOtherClassHideActive = ST._ClearOtherClassHideActive
+local ClearHideActiveCurrentClassPanels = ST._ClearOtherClassHideActive
+local ResetOtherClassBrowseState = ST._ResetOtherClassLibraryState
 local InvalidateConfigFinderResults = ST._InvalidateConfigFinderResults
 local BuildConfigFinderResults = ST._BuildConfigFinderResults
 local MaybeAutoStartFirstIconPanelTutorial = ST._MaybeAutoStartFirstIconPanelTutorial
@@ -55,25 +56,6 @@ local function GetAddonVersionText()
         return ST._GetAddonVersion()
     end
     return "unknown"
-end
-
-local function ClearHideActiveCurrentClassPanels(opts)
-    if ClearOtherClassHideActive then
-        return ClearOtherClassHideActive(opts)
-    end
-
-    local changed = CS.hideActiveCurrentClassPanels == true
-    CS.hideActiveCurrentClassPanels = false
-    if changed and not (opts and opts.skipRefresh) and CooldownCompanion.RefreshAllGroupsVisibilityOnly then
-        CooldownCompanion:RefreshAllGroupsVisibilityOnly()
-    end
-    return changed
-end
-
-local function ResetOtherClassBrowseState(opts)
-    CS.otherClassLibraryActive = false
-    CS.otherClassLibraryClassKey = nil
-    ClearHideActiveCurrentClassPanels(opts)
 end
 
 local function GetVersionFooterText()

--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -40,6 +40,19 @@ local RefreshTutorialPlacement = ST._RefreshTutorialPlacement
 local SetupChangelogOverlay = ST._SetupChangelogOverlay
 local RefreshVisibleConfigCompactRows = ST._RefreshVisibleConfigCompactRows
 
+local function ClearTransientConfigPreviewState()
+    ClearHideActiveCurrentClassPanels()
+    if CS.previewToggleRefreshActive then
+        return
+    end
+    if CooldownCompanion.ClearAllConfigPreviews then
+        CooldownCompanion:ClearAllConfigPreviews()
+    end
+    if CooldownCompanion.RefreshConfigSelectedGroupFrames then
+        CooldownCompanion:RefreshConfigSelectedGroupFrames()
+    end
+end
+
 local MANUAL_COLUMN_LAYOUT = "CDC_MANUAL"
 local CONFIG_FINDER_BOX_HEIGHT = 28
 local CONFIG_FINDER_BUTTON_GAP = 3
@@ -932,13 +945,7 @@ local function CreateConfigPanel()
         if CS.CloseAdvancedSettingsPanel then
             CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
         end
-        ClearHideActiveCurrentClassPanels()
-        if not CS.previewToggleRefreshActive then
-            CooldownCompanion:ClearAllConfigPreviews()
-            if CooldownCompanion.RefreshConfigSelectedGroupFrames then
-                CooldownCompanion:RefreshConfigSelectedGroupFrames()
-            end
-        end
+        ClearTransientConfigPreviewState()
         if ClearConfigShiftTooltipHover then
             ClearConfigShiftTooltipHover()
         end
@@ -1562,7 +1569,7 @@ local function CreateConfigPanel()
             if frame.HideChangelogOverlay then
                 frame.HideChangelogOverlay()
             end
-            ClearHideActiveCurrentClassPanels()
+            ClearTransientConfigPreviewState()
             self:Hide()
         elseif not InCombatLockdown() then
             self:SetPropagateKeyboardInput(true)
@@ -1601,6 +1608,7 @@ local function CreateConfigPanel()
             if CS.CloseAdvancedSettingsPanel then
                 CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
             end
+            ClearTransientConfigPreviewState()
 
             savedFrameRight = content:GetRight()
             savedFrameTop = content:GetTop()
@@ -2560,7 +2568,7 @@ function CooldownCompanion:_configToggleImpl()
         if CS.CloseAdvancedSettingsPanel then
             CS.CloseAdvancedSettingsPanel({ skipRefresh = true })
         end
-        ClearHideActiveCurrentClassPanels()
+        ClearTransientConfigPreviewState()
         CS.configFrame._miniFrame:Hide()
         return
     end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -596,6 +596,12 @@ local function ClearOtherClassHideActive(opts)
     return SetHideActiveCurrentClassPanels(false, opts)
 end
 
+local function ResetOtherClassLibraryState(opts)
+    CS.otherClassLibraryActive = false
+    CS.otherClassLibraryClassKey = nil
+    return ClearOtherClassHideActive(opts)
+end
+
 local ClearConfigPrimarySelection
 
 local function SetConfigFinderText(text, opts)
@@ -613,9 +619,7 @@ local function SetConfigFinderText(text, opts)
         if not (opts and opts.preservePrimarySelection) and ClearConfigPrimarySelection then
             ClearConfigPrimarySelection()
         end
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
-        ClearOtherClassHideActive()
+        ResetOtherClassLibraryState()
     end
 
     if opts and opts.syncWidget == false then
@@ -3073,9 +3077,7 @@ local function ResetConfigSelection(full)
         wipe(CS.selectedGroups)
         wipe(CS.selectedCustomBars)
         CS.addingToPanelId = nil
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
-        ClearOtherClassHideActive()
+        ResetOtherClassLibraryState()
     end
     RefreshAlphaDriverForConfigSelection()
 end
@@ -3094,18 +3096,13 @@ local function SetConfigPrimaryMode(mode, opts)
     if toBars and not wasBars then
         -- Preserve existing behavior when entering Bars & Frames mode.
         ResetConfigSelection(true)
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
-        ClearOtherClassHideActive()
     elseif (not toBars) and wasBars then
         -- Stop preview loops when returning to button settings mode.
         CooldownCompanion:ClearAllConfigPreviews()
         CS.selectedCustomBarId = nil
         CS.customBarSettingsTab = "appearance"
         ClearConfigResourceSelection()
-        CS.otherClassLibraryActive = false
-        CS.otherClassLibraryClassKey = nil
-        ClearOtherClassHideActive()
+        ResetOtherClassLibraryState()
     end
 
     CS.resourceBarPanelActive = toBars
@@ -3440,6 +3437,7 @@ ST._SetConfigFinderText = SetConfigFinderText
 ST._ClearConfigFinderText = ClearConfigFinderText
 ST._SetHideActiveCurrentClassPanels = SetHideActiveCurrentClassPanels
 ST._ClearOtherClassHideActive = ClearOtherClassHideActive
+ST._ResetOtherClassLibraryState = ResetOtherClassLibraryState
 ST._BuildConfigFinderResults = BuildConfigFinderResults
 ST._InvalidateConfigFinderResults = InvalidateConfigFinderResults
 ST._SelectConfigFinderResult = SelectConfigFinderResult

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -277,6 +277,7 @@ ST._configState = {
     collapsedPanels = {},
     otherClassLibraryActive = false,
     otherClassLibraryClassKey = nil,
+    hideActiveCurrentClassPanels = false,
     panelClickTimes = {},
     addingToPanelId = nil,
     folderAccentBars = {},
@@ -578,6 +579,23 @@ local function IsConfigFinderActive()
     return IsConfigFinderAvailable() and IsConfigFinderQueryUsable(CS.configSearchText)
 end
 
+local function SetHideActiveCurrentClassPanels(active, opts)
+    local enabled = active == true and CS.otherClassLibraryActive == true
+    if CS.hideActiveCurrentClassPanels == enabled then
+        return false
+    end
+
+    CS.hideActiveCurrentClassPanels = enabled
+    if not (opts and opts.skipRefresh) and CooldownCompanion.RefreshAllGroupsVisibilityOnly then
+        CooldownCompanion:RefreshAllGroupsVisibilityOnly()
+    end
+    return true
+end
+
+local function ClearOtherClassHideActive(opts)
+    return SetHideActiveCurrentClassPanels(false, opts)
+end
+
 local ClearConfigPrimarySelection
 
 local function SetConfigFinderText(text, opts)
@@ -597,6 +615,7 @@ local function SetConfigFinderText(text, opts)
         end
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
+        ClearOtherClassHideActive()
     end
 
     if opts and opts.syncWidget == false then
@@ -865,6 +884,7 @@ end
 
 local function RestoreOtherClassLibraryForScope(scope)
     if scope and scope.isOtherClass then
+        ClearOtherClassHideActive()
         CS.otherClassLibraryActive = true
         CS.otherClassLibraryClassKey = scope.ownerClassKey
         return true
@@ -3055,6 +3075,7 @@ local function ResetConfigSelection(full)
         CS.addingToPanelId = nil
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
+        ClearOtherClassHideActive()
     end
     RefreshAlphaDriverForConfigSelection()
 end
@@ -3075,6 +3096,7 @@ local function SetConfigPrimaryMode(mode, opts)
         ResetConfigSelection(true)
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
+        ClearOtherClassHideActive()
     elseif (not toBars) and wasBars then
         -- Stop preview loops when returning to button settings mode.
         CooldownCompanion:ClearAllConfigPreviews()
@@ -3083,6 +3105,7 @@ local function SetConfigPrimaryMode(mode, opts)
         ClearConfigResourceSelection()
         CS.otherClassLibraryActive = false
         CS.otherClassLibraryClassKey = nil
+        ClearOtherClassHideActive()
     end
 
     CS.resourceBarPanelActive = toBars
@@ -3415,6 +3438,8 @@ ST._IsConfigFinderAvailable = IsConfigFinderAvailable
 ST._IsConfigFinderActive = IsConfigFinderActive
 ST._SetConfigFinderText = SetConfigFinderText
 ST._ClearConfigFinderText = ClearConfigFinderText
+ST._SetHideActiveCurrentClassPanels = SetHideActiveCurrentClassPanels
+ST._ClearOtherClassHideActive = ClearOtherClassHideActive
 ST._BuildConfigFinderResults = BuildConfigFinderResults
 ST._InvalidateConfigFinderResults = InvalidateConfigFinderResults
 ST._SelectConfigFinderResult = SelectConfigFinderResult


### PR DESCRIPTION
## What Players Will Notice
- Browse Other Classes previews are more useful while the config is open: selected other-class panels can now appear even when their spells, items, equipment slots, or trinket entries are unavailable to the current character.
- The new Hide Active button in Browse Other Classes can temporarily hide panels from the currently played character, making overlapping other-class layouts easier to inspect.
- Closing, collapsing, or leaving Browse Other Classes restores the normal runtime view so unavailable displays remain pruned outside config previewing.

## Why This Changed
- Previously, unavailable entries could not be previewed, which made Browse Other Classes much less useful for comparing layouts across characters or classes.
- Current-character panels could also overlap the other-class previews the user was trying to inspect.

## What Changed
- Added selection-driven config preview rules so only the panels, buttons, and containers selected in config can materialize unavailable spell/item/equipment/trinket entries.
- Added transient Hide Active state and a Browse Other Classes button-bar control that never persists to profile data.
- Updated group, container, frame, and alpha/force-visible paths so selected previews stay visible while normal runtime pruning remains unchanged outside config.
- Cleaned up preview state across normal close, collapse, minimized close, Bars & Frames transitions, and panel multi-select changes.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` on the six changed Lua files
- `lua tests\column1-profile-inventory.lua`
- `lua tests\spell-availability-runtime-pruning.lua`
- `lua tests\group-button-frame-pooling.lua`
- `lua tests\group-style-update-fast-path.lua`
- `lua tests\eligibility-load-conditions.lua`
- Five-agent static review pass reported no actionable findings after the final fixes.
- In-game validation is still pending for Browse Other Classes preview behavior, Hide Active restoration, close/collapse/minimized close cleanup, and runtime pruning outside config.