### PR TITLE
Remove stale ConfigSettings imports

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/CastBarPanels.lua
+++ b/CooldownCompanion_Config/ConfigSettings/CastBarPanels.lua
@@ -5,7 +5,6 @@ local CS = ST._configState
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
-local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateCharacterCopyButton = ST._CreateCharacterCopyButton
 local AddColorPicker = ST._AddColorPicker

--- a/CooldownCompanion_Config/ConfigSettings/FormatEditor.lua
+++ b/CooldownCompanion_Config/ConfigSettings/FormatEditor.lua
@@ -9,7 +9,6 @@ local AceGUI = LibStub("AceGUI-3.0")
 local CS = ST._configState
 
 local ParseFormatString = ST._ParseFormatString
-local HasAnyEffects = ST._HasAnyEffects
 local CreateInfoButton = ST._CreateInfoButton
 local FormatTime = CooldownCompanion.FormatTime
 local AddColorPicker = ST._AddColorPicker

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -33,11 +33,7 @@ local AddClassSpecEligibilityControls = ST._AddClassSpecEligibilityControls
 local BuildEligibilityBadgeMap = ST._BuildEligibilityBadgeMap
 
 -- Imports from SectionBuilders.lua
-local BuildCooldownTextControls = ST._BuildCooldownTextControls
-local BuildAuraTextControls = ST._BuildAuraTextControls
-local BuildAuraStackTextControls = ST._BuildAuraStackTextControls
 local BuildKeybindTextControls = ST._BuildKeybindTextControls
-local BuildChargeTextControls = ST._BuildChargeTextControls
 local BuildBorderControls = ST._BuildBorderControls
 local BuildBackgroundColorControls = ST._BuildBackgroundColorControls
 local BuildDesaturationControls = ST._BuildDesaturationControls
@@ -53,7 +49,6 @@ local BuildIconTintControls = ST._BuildIconTintControls
 local BuildAssistedHighlightControls = ST._BuildAssistedHighlightControls
 local BuildProcGlowControls = ST._BuildProcGlowControls
 local BuildPandemicGlowControls = ST._BuildPandemicGlowControls
-local BuildPandemicBarControls = ST._BuildPandemicBarControls
 local BuildAuraIndicatorControls = ST._BuildAuraIndicatorControls
 local AddConditionalPreviewButton = ST._AddConditionalPreviewButton
 local AddPreviewBadge = ST._AddPreviewBadge
@@ -62,10 +57,6 @@ local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 local BuildAuraDurationSwipeControls = ST._BuildAuraDurationSwipeControls
 local BuildReadyGlowControls = ST._BuildReadyGlowControls
 local BuildKeyPressHighlightControls = ST._BuildKeyPressHighlightControls
-local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
-local BuildBarColorsControls = ST._BuildBarColorsControls
-local BuildBarNameTextControls = ST._BuildBarNameTextControls
-local BuildBarReadyTextControls = ST._BuildBarReadyTextControls
 
 local function PrimeReadyGlowCappedChargeTransitions(groupId)
     local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -10,7 +10,6 @@ local CooldownCompanion = ST.Addon
 local AceGUI = LibStub("AceGUI-3.0")
 local LSM = LibStub("LibSharedMedia-3.0")
 local CS = ST._configState
-local IsPassiveOrProc = ST._IsPassiveOrProc
 local ShowPopupAboveConfig = CS.ShowPopupAboveConfig
 
 -- Imports from Helpers.lua
@@ -18,23 +17,13 @@ local ColorHeading = ST._ColorHeading
 local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateInfoButton = ST._CreateInfoButton
-local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker
 local AddAnchorDropdown = ST._AddAnchorDropdown
 local HookSliderEditBox = ST._HookSliderEditBox
 local BuildAlphaControls = ST._BuildAlphaControls
 local BuildIndependentAnchorTargetRow = ST._BuildIndependentAnchorTargetRow
-local BuildPandemicBarControls = ST._BuildPandemicBarControls
-local BuildBarActiveAuraControls = ST._BuildBarActiveAuraControls
-local BuildBarAuraPulseControls = ST._BuildBarAuraPulseControls
-local BuildPandemicBarPulseControls = ST._BuildPandemicBarPulseControls
 local AddPreviewToggleButton = ST._AddPreviewToggleButton
-local AddPreviewBadge = ST._AddPreviewBadge
 local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
-local CleanRecycledEntry = ST._CleanRecycledEntry
-local ApplyConfigRowIcon = ST._ApplyConfigRowIcon
-local BindConfigShiftTooltip = ST._BindConfigShiftTooltip
-local AddDurationFormatDropdown = ST._AddDurationFormatDropdown
 local tabInfoButtons = CS.tabInfoButtons
 
 local function RefreshLayoutOrderPreview()
@@ -205,12 +194,6 @@ local function EnsureResourceLayoutAnchor(settings, layout)
         layout.independentWidth = settings.independentWidth
     end
 end
-
-local ResolveSpecOverrideKey = ST._ResolveSpecOverrideKey
-local StartDragTracking = ST._StartDragTracking
-local GetDragIndicator = ST._GetDragIndicator
-local HideDragIndicator = ST._HideDragIndicator
-local ResetDragIndicatorStyle = ST._ResetDragIndicatorStyle
 
 local function CopyTableValue(value)
     return type(value) == "table" and CopyTable(value) or value

--- a/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
+++ b/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
@@ -6,11 +6,7 @@ local RB = ST._RB
 
 -- Imports from Helpers.lua
 local ColorHeading = ST._ColorHeading
-local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
-local CreatePromoteButton = ST._CreatePromoteButton
-local CreateRevertButton = ST._CreateRevertButton
-local CreateCheckboxPromoteButton = ST._CreateCheckboxPromoteButton
 local CreateInfoButton = ST._CreateInfoButton
 local ApplyCheckboxIndent = ST._ApplyCheckboxIndent
 local AddColorPicker = ST._AddColorPicker

--- a/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
@@ -13,7 +13,6 @@ local AttachCollapseButton = ST._AttachCollapseButton
 local AddAdvancedToggle = ST._AddAdvancedToggle
 local CreateInfoButton = ST._CreateInfoButton
 local BuildCompactModeControls = ST._BuildCompactModeControls
-local BuildGroupSettingPresetControls = ST._BuildGroupSettingPresetControls
 local CreatePromoteButton = ST._CreatePromoteButton
 local BuildTextColorsControls = ST._BuildTextColorsControls
 local OpenFormatEditor = ST._OpenFormatEditor


### PR DESCRIPTION
## What Players Will Notice
- No player-facing behavior change.

## Why This Changed
- Several `ConfigSettings` files still had top-level helper aliases left behind after builder responsibilities moved.
- Exact-name scans showed those aliases were only referenced on their own declaration lines, which made import blocks harder to trust during maintenance.

## What Changed
- Removed 33 unused top-level helper aliases from `CastBarPanels`, `FormatEditor`, `GroupTabs`, `ResourceBarPanelsResource`, `SectionBuilders`, and `TextModeTabs`.
- Left active builder imports and runtime code untouched.

## Validation
- Exact-name one-hit import scan on the touched files returned no remaining unused `ST` / `CS` / `RB` / `RBP` aliases.
- `luac -p` across tracked Lua files passed.
- `git diff --check` passed.

## Runtime Proof
- Not run in-game, through DevBridge, in combat, or against restricted content.
- This is a static-only cleanup with no intended behavior change.