### PR TITLE
Remove stale resource bar imports

### DIFF
--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -26,13 +26,11 @@ local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 local math_floor = math.floor
 local math_min = math.min
 local math_max = math.max
-local math_abs = math.abs
 local math_sin = math.sin
 local math_pi = math.pi
 local GetTime = GetTime
 local InCombatLockdown = InCombatLockdown
 local issecretvalue = issecretvalue
-local string_format = string.format
 
 ------------------------------------------------------------------------
 -- Imports from ResourceBarConstants / ResourceBarHelpers / ResourceBarVisuals
@@ -124,8 +122,6 @@ local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 -- Other ST imports
 local CreateGlowContainer = ST._CreateGlowContainer
-local ShowGlowStyle = ST._ShowGlowStyle
-local HideGlowStyles = ST._HideGlowStyles
 local SetBarAuraEffect = ST._SetBarAuraEffect
 local IsBarAuraIndicatorEnabled = ST.IsBarAuraIndicatorEnabled
 local DEFAULT_BAR_PANDEMIC_COLOR = ST._DEFAULT_BAR_PANDEMIC_COLOR


### PR DESCRIPTION
## What Players Will Notice

No player-facing behavior changes. Resource bars should work the same as before.

## Why This Changed

`CooldownCompanion/OtherBars/ResourceBar.lua` still declared several top-level helper aliases that were no longer referenced after earlier resource bar visual work. Keeping stale imports around makes the module harder to scan and can mislead future changes about which glow helpers are still used directly in this file.

## What Changed

- Removed unused `math_abs` and `string_format` aliases from `ResourceBar.lua`.
- Removed unused `ShowGlowStyle` and `HideGlowStyles` aliases from `ResourceBar.lua`; the glow helpers remain defined and used by their owning modules.

## Validation

- Confirmed the removed aliases have zero remaining exact-name references in `CooldownCompanion/OtherBars/ResourceBar.lua`.
- `luac -p` passed for all 96 tracked Lua files.
- `git diff --check` passed.

## Runtime Proof

No in-game, DevBridge, combat, or restricted-content validation was run. This is a static-only cleanup with no intended behavior change.