### PR TITLE
Remove unused aura and resource bar helpers

### DIFF
--- a/CooldownCompanion/Core/AuraTextures.lua
+++ b/CooldownCompanion/Core/AuraTextures.lua
@@ -17,35 +17,21 @@ CooldownCompanion.TRIGGER_PANEL_TEXT_INSET_Y = 2
 CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_X = 6
 CooldownCompanion.TRIGGER_PANEL_TEXT_OVERFLOW_Y = 4
 
-local C_Item_IsUsableItem = C_Item.IsUsableItem
-local C_Spell_GetSpellName = C_Spell.GetSpellName
-local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
 local GetTime = GetTime
 local ipairs = ipairs
 local issecretvalue = issecretvalue
-local math_abs = math.abs
 local math_cos = math.cos
-local math_floor = math.floor
 local math_max = math.max
-local math_min = math.min
-local math_pi = math.pi
-local math_rad = math.rad
 local math_sin = math.sin
 local pairs = pairs
-local string_find = string.find
 
 local function IsRuntimeItemLike(buttonData)
     return buttonData
         and (buttonData.type == "item" or buttonData.type == "equipmentSlot" or buttonData.type == "equipitem")
 end
-local string_format = string.format
 local string_gsub = string.gsub
-local string_lower = string.lower
-local string_trim = strtrim
 local string_upper = string.upper
 local table_concat = table.concat
-local table_insert = table.insert
-local table_sort = table.sort
 local tonumber = tonumber
 local type = type
 

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -26,13 +26,11 @@ local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 local math_floor = math.floor
 local math_min = math.min
 local math_max = math.max
-local math_abs = math.abs
 local math_sin = math.sin
 local math_pi = math.pi
 local GetTime = GetTime
 local InCombatLockdown = InCombatLockdown
 local issecretvalue = issecretvalue
-local string_format = string.format
 
 ------------------------------------------------------------------------
 -- Imports from ResourceBarConstants / ResourceBarHelpers / ResourceBarVisuals
@@ -124,8 +122,6 @@ local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 -- Other ST imports
 local CreateGlowContainer = ST._CreateGlowContainer
-local ShowGlowStyle = ST._ShowGlowStyle
-local HideGlowStyles = ST._HideGlowStyles
 local SetBarAuraEffect = ST._SetBarAuraEffect
 local IsBarAuraIndicatorEnabled = ST.IsBarAuraIndicatorEnabled
 local DEFAULT_BAR_PANDEMIC_COLOR = ST._DEFAULT_BAR_PANDEMIC_COLOR

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -26,13 +26,6 @@ local AddPreviewToggleButton = ST._AddPreviewToggleButton
 local RefreshConfigPanelForPreviewToggle = ST._RefreshConfigPanelForPreviewToggle
 local tabInfoButtons = CS.tabInfoButtons
 
-local function RefreshLayoutOrderPreview()
-    if not (CS.resourceBarPanelActive and CS.col4Container and ST._RefreshColumn4) then
-        return
-    end
-    ST._RefreshColumn4(CS.col4Container)
-end
-
 -- Shared constants from ResourceBarConstants
 local RB = ST._RB
 local POWER_NAMES = RB.POWER_NAMES
@@ -101,7 +94,6 @@ local DEFAULT_ESSENCE_RECHARGING_COLOR = RB.DEFAULT_ESSENCE_RECHARGING_COLOR
 local DEFAULT_ESSENCE_MAX_COLOR = RB.DEFAULT_ESSENCE_MAX_COLOR
 local GetResolvedCustomAuraBarAuraUnit = RB.GetResolvedCustomAuraBarAuraUnit
 local EnsureCustomAuraBarAuraUnit = RB.EnsureCustomAuraBarAuraUnit
-local GetCustomBarEntryType = RB.GetCustomBarEntryType
 local EnsureCustomBarId = RB.EnsureCustomBarId
 local EnsureCustomBarLayout = RB.EnsureCustomBarLayout
 local GetCustomBarLayout = RB.GetCustomBarLayout
@@ -112,42 +104,6 @@ local resourceSpecCopyButton
 local resourceSpecCopyMenu
 local thresholdTickDraftRows = {}
 local thresholdTickEditorErrors = {}
-
-local function IsHeroSpecProxyCondition(cond)
-    return type(cond) == "table"
-        and cond.nodeID ~= nil
-        and cond.heroSubTreeID ~= nil
-        and cond.entryID == nil
-        and type(cond.name) == "string"
-        and type(cond.heroName) == "string"
-        and cond.name == cond.heroName
-end
-local function IsSpellCustomBarConfig(cab)
-    if RB.IsSpellCustomBarConfig then
-        return RB.IsSpellCustomBarConfig(cab)
-    end
-    return GetCustomBarEntryType and GetCustomBarEntryType(cab) == "spell"
-end
-
-local function IsCustomBarAuraDisplayConfig(cab, isSpellCustomBar)
-    if isSpellCustomBar == nil then
-        isSpellCustomBar = IsSpellCustomBarConfig(cab)
-    end
-
-    return (not isSpellCustomBar) or (cab and cab.auraTracking == true)
-end
-
-local function GetCustomBarTrackingModeConfig(cab, isSpellCustomBar)
-    if RB.GetCustomBarTrackingMode then
-        return RB.GetCustomBarTrackingMode(cab, isSpellCustomBar)
-    end
-
-    local mode = cab and cab.trackingMode
-    if mode == "active" or mode == "stacks" then
-        return mode
-    end
-    return isSpellCustomBar and "active" or "stacks"
-end
 
 local RefreshCustomAuraBarAuraUnitForSpell = RB.RefreshCustomAuraBarAuraUnitForSpell
 

--- a/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
@@ -26,38 +26,6 @@ local AddBorderRenderModeDropdown = ST._AddBorderRenderModeDropdown
 local tabInfoButtons = CS.tabInfoButtons
 local appearanceTabElements = CS.appearanceTabElements
 
-local TOKEN_HELP_TEXT = table.concat({
-    "|cffffffffAvailable Tokens:|r",
-    "",
-    "|cff00ff00{name}|r  Spell/item display name",
-    "|cff00ff00{time}|r  Cooldown time remaining",
-    "|cff00ff00{charges}|r  Current charges (if spell has charges)",
-    "|cff00ff00{maxcharges}|r  Maximum charges (if spell has charges)",
-    "|cff00ff00{stacks}|r  Aura stacks or item count",
-    "|cff00ff00{aura}|r  Aura duration remaining",
-    "|cff00ff00{keybind}|r  Keybind text",
-    "|cff00ff00{status}|r  Shows ready/cooldown/aura, or aura-only state for aura entries",
-    "|cff00ff00{icon}|r  Inline spell icon texture",
-    "|cff00ff00{br}|r  Manual line break",
-    "  |cff888888{?aura} checks whether the aura is active, even if it has no timer|r",
-    "",
-    "|cffffffffConditional-Only Tokens:|r",
-    "",
-    "|cff00ff00{missingcharges}|r  |cff888888(conditional only)|r Recharging with charges left",
-    "|cff00ff00{zerocharges}|r  |cff888888(conditional only)|r All charges spent",
-    "|cff00ff00{pandemic}|r  |cff888888(conditional only)|r Aura in pandemic window",
-    "|cff00ff00{proc}|r  |cff888888(conditional only)|r Spell proc overlay active",
-    "|cff00ff00{available}|r  |cff888888(conditional only)|r Off cooldown / has charges",
-    "|cff00ff00{unusable}|r  |cff888888(conditional only)|r Spell/item not usable",
-    "|cff00ff00{oor}|r  |cff888888(conditional only)|r Target out of range",
-    "",
-    "{status} resolves to:",
-    "  Ready (green) when off CD",
-    "  Cooldown time (red) when on CD",
-    "  Aura time (cyan) when aura active",
-    "  Aura entries stay blank when inactive instead of showing Ready",
-}, "\n")
-
 -- Syntax colors for summary (matching FormatEditor.lua)
 local SUM_TOKEN  = "ff00ff00"
 local SUM_COND_P = "ffffff00"
@@ -65,7 +33,6 @@ local SUM_COND_N = "ffff8844"
 local SUM_EFFECT = "ffcc44ff"
 local SUM_COLOR  = "ff44bbff"
 local SUM_GRAY   = "ff888888"
-local SUM_SEP    = "  |cff666666\194\183|r  "
 
 local function BuildFormatSummary(formatString)
     local segments = ParseFormatString(formatString)


### PR DESCRIPTION
## What Changed
- Removed stale local API aliases and imports from the aura texture and resource bar runtime modules.
- Removed dead resource bar config panel helpers and the old text-mode token help constant.

## Why This Changed
- The `dev` branch contains narrow mainline cleanup sweeps for code left unused after recent config, resource bar, and text-mode refactors.
- Keeping those stale locals around made the affected modules harder to audit without providing runtime behavior.

## Developer Impact
- Reduces noise in core, resource bar, and config settings files so future changes are easier to review.
- Does not intentionally change player-facing behavior.

## Validation
- `luac -p CooldownCompanion/Core/AuraTextures.lua CooldownCompanion/OtherBars/ResourceBar.lua CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua`
- `git diff --check origin/main...HEAD`

## Runtime Proof
- Not run in-game; this is static maintenance cleanup only.
- Combat and restricted-content behavior were not verified.