### PR TITLE
Remove stale glow bar color imports

### DIFF
--- a/CooldownCompanion/ButtonFrame/Glows.lua
+++ b/CooldownCompanion/ButtonFrame/Glows.lua
@@ -21,9 +21,6 @@ local math_min = math.min
 -- Imports from Helpers
 local ApplyEdgePositions = ST._ApplyEdgePositions
 local FitHighlightFrame = ST._FitHighlightFrame
-local DEFAULT_BAR_AURA_COLOR = ST._DEFAULT_BAR_AURA_COLOR
-local DEFAULT_BAR_PANDEMIC_COLOR = ST._DEFAULT_BAR_PANDEMIC_COLOR
-local DEFAULT_BAR_CHARGE_COLOR = ST._DEFAULT_BAR_CHARGE_COLOR
 
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.


### PR DESCRIPTION
## What Changed
- Removed three unused bar-color helper aliases from `CooldownCompanion/ButtonFrame/Glows.lua`.

## Why This Changed
- These aliases were left behind after the glow module stopped reading the helper defaults directly; exact-name search showed each symbol was declaration-only in `Glows.lua`.

## Developer Impact
- Keeps the glow module's helper imports aligned with the code paths it actually uses, reducing stale state for future glow and bar-color maintenance.

## Validation
- `rg -n "DEFAULT_BAR_AURA_COLOR|DEFAULT_BAR_PANDEMIC_COLOR|DEFAULT_BAR_CHARGE_COLOR" CooldownCompanion\ButtonFrame\Glows.lua` returned no matches after removal.
- `luac -p CooldownCompanion\ButtonFrame\Glows.lua`
- `git ls-files '*.lua' | ForEach-Object { luac -p $_ }`
- `git diff --check` passed; Git emitted this checkout's normal LF-to-CRLF notice only.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.