### PR TITLE
Remove stale ready glow helpers

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -247,40 +247,6 @@ local function GetDefaultAuraUnit(isHarmful)
     return isHarmful and "target" or "player"
 end
 
-local function PrimeSelectedReadyGlowCappedChargeTransition(groupId, buttonIndex)
-    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
-    local button = frame and frame.buttons and frame.buttons[buttonIndex]
-    local buttonData = button and button.buttonData
-    if not (button and buttonData) then
-        return
-    end
-
-    if buttonData.type ~= "spell"
-       or buttonData.hasCharges ~= true
-       or buttonData._hasDisplayCount then
-        return
-    end
-
-    button._readyGlowMaxChargesSpellID = button._displaySpellId or buttonData.id
-    button._readyGlowMaxChargesStartTime = nil
-    button._readyGlowMaxChargesActive = false
-end
-
-local function PrimeSelectedReadyGlowNormalTransition(groupId, buttonIndex)
-    local frame = CooldownCompanion.groupFrames and CooldownCompanion.groupFrames[groupId]
-    local button = frame and frame.buttons and frame.buttons[buttonIndex]
-    local buttonData = button and button.buttonData
-    if not (button and buttonData) then
-        return
-    end
-
-    if buttonData.isPassive or button._noCooldown == true or button._desatCooldownActive == true then
-        return
-    end
-
-    button._readyGlowStartTime = GetTime()
-end
-
 local function EnsureAuraUnitChoice(buttonData, isHarmful, unit)
     if IsValidAuraUnit(unit) then
         buttonData.auraUnit = unit


### PR DESCRIPTION
## What Changed
- Removed the unused ready-glow transition helper pair from `CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua`.
- Left the active ready-glow override helpers in `CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua`, where the callers still live.

## Why This Changed
- After override controls moved into `ButtonSettingsOverrides.lua`, the old `ButtonSettings.lua` helpers had no remaining callers. Exact-name search showed the removed functions only appeared at their own definitions in `ButtonSettings.lua`.

## Developer Impact
- Reduces duplicated ready-glow helper logic and keeps `ButtonSettings.lua` focused on active selected-button settings paths.

## Validation
- `rg "PrimeSelectedReadyGlowCappedChargeTransition|PrimeSelectedReadyGlowNormalTransition" CooldownCompanion_Config\\ConfigSettings\\ButtonSettings.lua CooldownCompanion_Config\\ConfigSettings\\ButtonSettingsOverrides.lua` confirmed the removed names are absent from `ButtonSettings.lua` and still defined/called in `ButtonSettingsOverrides.lua`.
- `luac -p CooldownCompanion_Config\\ConfigSettings\\ButtonSettings.lua`
- `luac -p` across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF checkout warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.