### PR TITLE
Remove stale drag reorder target helpers

### DIFF
--- a/CooldownCompanion_Config/Config/DragReorderTargets.lua
+++ b/CooldownCompanion_Config/Config/DragReorderTargets.lua
@@ -134,18 +134,6 @@ local function GetDropIndex(scrollWidget, cursorY, childOffset, totalDraggable)
     return dropIndex, anchorFrame, anchorAbove
 end
 
-------------------------------------------------------------------------
--- Column 2 cross-panel drop target detection
-------------------------------------------------------------------------
-local function FindPreviousPanelId(renderedRows, currentIndex)
-    for i = currentIndex - 1, 1, -1 do
-        if renderedRows[i].kind == "header" then
-            return renderedRows[i].panelId
-        end
-    end
-    return nil
-end
-
 local function BuildCol2EntryDropTarget(action, targetPanelId, targetIndex, anchorFrame, anchorAbove)
     local groups = CooldownCompanion.db and CooldownCompanion.db.profile and CooldownCompanion.db.profile.groups
     local group = targetPanelId and groups and groups[targetPanelId]
@@ -851,20 +839,6 @@ local function BuildCol1FolderReorderBlockTarget(renderedRows, folderId, action,
         end
     end
     return result
-end
-
-local function FindCol1FolderDropTarget(renderedRows, section, folderId)
-    if not folderId then
-        return nil
-    end
-
-    for _, candidate in ipairs(renderedRows or {}) do
-        if candidate.section == section and candidate.kind == "folder" and candidate.id == folderId then
-            return BuildCol1FolderBlockDropResult(renderedRows, folderId, "into-folder")
-        end
-    end
-
-    return nil
 end
 
 local function ResolveCol1FolderBlockDropTarget(renderedRows, rowMeta, sourceKind, action, extra)


### PR DESCRIPTION
## What Changed
- Removed two unused file-local helper functions from `CooldownCompanion_Config/Config/DragReorderTargets.lua`.
- The remaining drag target code continues to use the active column 2 entry target builder and column 1 folder block target helpers directly.

## Why This Changed
- `FindPreviousPanelId` and `FindCol1FolderDropTarget` had no callers, which made the drag-reorder target module carry stale paths that no longer participate in drop resolution.

## Developer Impact
- Keeps the config drag-and-drop target resolver easier to scan by removing dead helper code from a high-traffic maintenance file.

## Validation
- `rg -n "FindPreviousPanelId|FindCol1FolderDropTarget" CooldownCompanion_Config\\Config\\DragReorderTargets.lua` returned no matches after removal.
- `luac -p CooldownCompanion_Config\\Config\\DragReorderTargets.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the existing LF-to-CRLF checkout warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.