### PR TITLE
Remove stale column render helpers

### DIFF
--- a/CooldownCompanion_Config/Config/Column1.lua
+++ b/CooldownCompanion_Config/Config/Column1.lua
@@ -941,34 +941,12 @@ local function RefreshColumn1(preserveDrag)
 
     local containerStats = {}
 
-    -- Count current children in scroll widget
-    local function CountScrollChildren()
-        local children = { CS.col1Scroll.content:GetChildren() }
-        return #children
-    end
-
     -- Track all rendered rows for drag system: sequential index -> metadata
     local col1RenderedRows = {}
 
     local function TrackRenderedRow(meta)
         col1RenderedRows[#col1RenderedRows + 1] = meta
         return meta
-    end
-
-    local function AddAuxWidget(widget, sectionTag, ownerKind, ownerId, ownerFolderId)
-        CS.col1Scroll:AddChild(widget)
-        TrackRenderedRow({
-            kind = "aux-block",
-            widget = widget,
-            section = sectionTag,
-            loadBucket = "aux",
-            acceptsDrop = false,
-            previewProxy = false,
-            layoutOnly = true,
-            ownerKind = ownerKind,
-            ownerId = ownerId,
-            ownerFolderId = ownerFolderId,
-        })
     end
 
     local function ResolveContainerScope(containerId, container)
@@ -1446,27 +1424,6 @@ local function RefreshColumn1(preserveDrag)
             end
         end)
 
-    end
-
-    local function RenderSectionMarker(section, headingText, headingColor)
-        local heading = AceGUI:Create("Label")
-        heading:SetFullWidth(true)
-        heading:SetHeight(18)
-        CS.col1Scroll:AddChild(heading)
-        SetupColumn1MarkerRow(heading, {
-            text = headingText,
-            color = headingColor,
-        })
-        TrackRenderedRow({
-            kind = "section-title",
-            widget = heading,
-            section = section,
-            loadBucket = "marker",
-            acceptsDrop = false,
-            keepVisibleDuringPreview = true,
-            previewProxy = true,
-            isMarker = true,
-        })
     end
 
     -- Render a section (global, current class, or another class)


### PR DESCRIPTION
## What Changed
- Removed three declaration-only helpers from `CooldownCompanion_Config/Config/Column1.lua`: `CountScrollChildren`, `AddAuxWidget`, and `RenderSectionMarker`.
- Left the live column row tracking, section header rendering, and drag metadata paths unchanged.

## Why This Changed
- These helpers were remnants of earlier column rendering paths. Exact-name scans showed each symbol only existed at its own declaration, so the code added maintenance noise without participating in the current config UI.

## Developer Impact
- The column rebuild path is a little easier to inspect because stale helper branches and unused drag-row metadata shapes are gone.
- No player-facing behavior is intended to change.

## Validation
- `rg -n "CountScrollChildren|AddAuxWidget|RenderSectionMarker|aux-block|section-title" CooldownCompanion_Config\Config\Column1.lua` returned no matches after removal.
- `luac -p CooldownCompanion_Config\Config\Column1.lua` passed.
- `luac -p` across all 96 tracked Lua files passed.
- `git diff --check` passed, with only the repo's normal LF-to-CRLF checkout warning.

## Runtime Proof
- No in-game, DevBridge, combat, or restricted-content validation was performed. This is a static-only removal of unused local helpers with no intended runtime behavior change.