### PR TITLE
Remove dead runtime helpers

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -332,22 +332,6 @@ local function ApplyConditionalVisualPreview(button, buttonData, style, preview,
     end
 end
 
-local function AuraDataHasTimer(auraData)
-    if not auraData then return false end
-    local duration = auraData.duration
-    if duration == nil then return false end
-    if issecretvalue(duration) then return nil end
-    return duration > 0
-end
-
-local function MergeAuraTimerState(currentHasTimer, auraData)
-    local hasTimer = AuraDataHasTimer(auraData)
-    if hasTimer ~= nil then
-        return hasTimer
-    end
-    return currentHasTimer
-end
-
 local function GetViewerNameFontString(viewerFrame)
     -- BuffBar viewer items render name text on Bar.Name. BuffIcon entries have no name text.
     local bar = viewerFrame and viewerFrame.Bar

--- a/CooldownCompanion/Core/AlphaFade.lua
+++ b/CooldownCompanion/Core/AlphaFade.lua
@@ -649,17 +649,6 @@ function CooldownCompanion:UpdateGroupAlpha(groupId, group, locked, frame, now, 
     end
 end
 
-local function ResetAlphaState(state)
-    if not state then
-        return
-    end
-    state.currentAlpha = 1
-    state.desiredAlpha = 1
-    state.fadeDuration = 0
-    state.lastAlpha = 1
-    state.hoverExpire = nil
-end
-
 local function ResetOwnedGroupAlphaState(self, groupId)
     if self.alphaState then
         self.alphaState[groupId] = nil

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -133,15 +133,6 @@ local function AddAuraCandidateID(candidateSet, spellID)
     end
 end
 
-local function AddAuraCandidateIDsFromString(candidateSet, rawIDs)
-    if not rawIDs then
-        return
-    end
-    for id in tostring(rawIDs):gmatch("%d+") do
-        AddAuraCandidateID(candidateSet, id)
-    end
-end
-
 local function AppendOrderedAuraCandidateID(candidateSet, orderedSet, orderedIDs, spellID)
     local numericID = tonumber(spellID)
     if not numericID or numericID == 0 then


### PR DESCRIPTION
## What Changed
- Removed unused file-local helper functions from alpha fade, aura candidate, and cooldown update runtime files.
- The deleted helpers were `ResetAlphaState`, `AddAuraCandidateIDsFromString`, `AuraDataHasTimer`, and `MergeAuraTimerState`.

## Why This Changed
- Exact-name scans showed these helpers were declaration-only after earlier runtime refactors, leaving stale paths for future maintainers to audit.

## Developer Impact
- Runtime maintenance gets a little cleaner: alpha, aura, and cooldown update files no longer suggest obsolete helper paths are active.

## Validation
- Exact-name scan for the removed symbols returned no matches.
- `luac -p` passed for the three changed Lua files.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed, with only the repository's usual LF-to-CRLF working-copy warnings.

## Runtime Proof
- No in-game, DevBridge, combat, or restricted-content validation was performed. This is a static-only removal of unreachable local functions with no intended behavior change.