### PR TITLE
Remove stale config row badge helpers

### DIFF
--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -2058,19 +2058,6 @@ local function SetupGroupRowIndicators(entry, group)
         if r then badge.icon:SetVertexColor(r, g, b, a or 1) end
         badge:Show()
     end
-    local function AddIconBadge(texture, r, g, b, a)
-        badgeIndex = badgeIndex + 1
-        local badge = AcquireBadge(frame, badgeIndex)
-        badge.icon:SetTexture(texture)
-        if r then badge.icon:SetVertexColor(r, g, b, a or 1) end
-        badge:Show()
-    end
-    local function AddTextBadge(str)
-        badgeIndex = badgeIndex + 1
-        local badge = AcquireBadge(frame, badgeIndex)
-        badge.text:SetText(str)
-        badge:Show()
-    end
 
     -- Disabled
     if group.enabled == false then


### PR DESCRIPTION
## What Changed
- Removed two stale row-indicator badge helper functions from `CooldownCompanion_Config/Config/State.lua`.

## Why This Changed
- `AddIconBadge` and `AddTextBadge` were declaration-only inside `SetupGroupRowIndicators`; live row badge paths use `AddAtlasBadge` for simple atlas badges and direct `AcquireBadge` calls for spec and hero badges.

## Developer Impact
- Keeps the config row badge code easier to read by removing unused wrappers that no longer describe the active implementation.

## Validation
- Confirmed `AddIconBadge` and `AddTextBadge` no longer appear in `CooldownCompanion_Config/Config/State.lua` after removal.
- Ran `luac -p CooldownCompanion_Config/Config/State.lua`.
- Ran `luac -p` across all 96 tracked Lua files.
- Ran `git diff --check`; only the usual LF-to-CRLF checkout warning was emitted.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.