### PR TITLE
Remove stale visibility helper code

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -2079,20 +2079,6 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         return false
     end
 
-    local function AllSelectedMatch(predicate)
-        local anySelected = false
-        for idx in pairs(CS.selectedButtons) do
-            local bd = group.buttons[idx]
-            if bd then
-                anySelected = true
-                if not predicate(bd) then
-                    return false
-                end
-            end
-        end
-        return anySelected
-    end
-
     local function AllSelectedMatchFiltered(filterFn, predicate)
         local anyMatched = false
         for idx in pairs(CS.selectedButtons) do
@@ -2130,7 +2116,7 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         and (CS.selectedGroup .. "_batch_visibility")
         or  (CS.selectedGroup .. "_" .. CS.selectedButton .. "_visibility")
     local visCollapsed = CS.collapsedSections[visKey]
-    local visCollapseBtn = AttachCollapseButton(heading, visCollapsed, function()
+    AttachCollapseButton(heading, visCollapsed, function()
         CS.collapsedSections[visKey] = not CS.collapsedSections[visKey]
         CooldownCompanion:RefreshConfigPanel()
     end)


### PR DESCRIPTION
## What Changed
- Removed the unused `AllSelectedMatch` helper from the button visibility settings builder.
- Stopped storing the unused return value from the visibility section collapse-button setup.

## Why This Changed
- The visibility settings code kept a stale all-selected helper even though the live paths use `AnySelectedMatch` and `AllSelectedMatchFiltered`.
- The collapse button call still matters, but naming its unused return value made the section look like later code depended on it.

## Developer Impact
- The visibility settings builder is a little easier to scan because only live helper paths remain in that block.
- No player-facing behavior is intended to change.

## Validation
- Exact-name search confirmed `AllSelectedMatch` and `visCollapseBtn` no longer appear in `CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua`.
- `luac -p CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the existing LF-to-CRLF checkout warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup.