### PR TITLE
Remove unused UI helper return locals

### DIFF
--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -657,7 +657,6 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Create main button frame
     local button = CreateFrame("Frame", parent:GetName() .. "Button" .. index, parent)
     button:SetSize(width, height)
-    local baseLevel = button:GetFrameLevel()
 
     -- Background
     button.bg = button:CreateTexture(nil, "BACKGROUND")

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettings.lua
@@ -1583,7 +1583,7 @@ local function BuildItemSettings(scroll, buttonData, infoButtons)
 
     local itemKey = CS.selectedGroup .. "_" .. CS.selectedButton .. "_itemsettings"
     local itemCollapsed = CS.collapsedSections[itemKey]
-    local itemCollapseBtn = AttachCollapseButton(itemHeading, itemCollapsed, function()
+    AttachCollapseButton(itemHeading, itemCollapsed, function()
         CS.collapsedSections[itemKey] = not CS.collapsedSections[itemKey]
         CooldownCompanion:RefreshConfigPanel()
     end)

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -2550,7 +2550,7 @@ local function BuildEffectsTab(container)
         end)
     end
 
-    local assistedAdvExpanded = AddAdvancedToggle(assistedCb, "assistedHighlight", tabInfoButtons, style.showAssistedHighlight or false, {
+    AddAdvancedToggle(assistedCb, "assistedHighlight", tabInfoButtons, style.showAssistedHighlight or false, {
         title = "Assisted Highlight Advanced",
         build = BuildAssistedHighlightAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -2517,11 +2517,12 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         AddDurationFormatDropdown(panel, customBars[cabIdx], cabApplyBars)
                     end
 
-                    local durationAdvExpanded = showDurationControls
-                        and AddAdvancedToggle(durationTextCb, "rbCabDurationText_" .. capturedKey, rbCabTextAdvBtns, showDuration, {
+                    if showDurationControls then
+                        AddAdvancedToggle(durationTextCb, "rbCabDurationText_" .. capturedKey, rbCabTextAdvBtns, showDuration, {
                             title = "Duration Text Advanced",
                             build = BuildDurationTextAdvanced,
                         })
+                    end
 
                     local function BuildStackTextAdvanced(panel)
                         if not isActive then
@@ -2589,7 +2590,7 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
                         AddColorPicker(panel, customBars[cabIdx], "stackTextFontColor", "Stack Text Color", DEFAULT_RESOURCE_TEXT_COLOR, true, cabApplyBars)
                     end
 
-                    local stackAdvExpanded = AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack, {
+                    AddAdvancedToggle(stackTextCb, "rbCabStackText_" .. capturedKey, rbCabTextAdvBtns, showStack, {
                         title = stackTextLabel .. " Advanced",
                         build = BuildStackTextAdvanced,
                     })


### PR DESCRIPTION
## What Changed
- Removed unused local variables that only captured return values from UI helper calls in button settings, group effects, custom resource bar text settings, and icon button creation.
- Kept the `AttachCollapseButton` and `AddAdvancedToggle` calls in place so the existing UI setup side effects are unchanged.

## Why This Changed
- Exact-symbol scans showed these locals were declaration-only, making the surrounding UI code harder to read and suggesting false dependencies on return values that are not used.

## Developer Impact
- Future config and button-frame maintenance can read these sections without chasing unused return values or stale frame-level snapshots.

## Validation
- Exact-symbol scan confirmed `itemCollapseBtn`, `assistedAdvExpanded`, `durationAdvExpanded`, `stackAdvExpanded`, and the removed `IconMode.lua` `baseLevel` declaration no longer appear in the touched files.
- `luac -p` passed for all touched Lua files.
- `luac -p` passed across all tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF checkout warnings.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is static-only cleanup with no intended behavior change.