### PR TITLE
Restore charge display reliability by reverting Zenith Stomp suppression

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1260,12 +1260,10 @@ local function UpdateBarDisplay(button)
     if itemUsesResolvedCooldownState then
         onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif isChargeButton then
-        onCooldown = button._chargePresentationSuppressed ~= true
-            and (chargeState == CHARGE_STATE_MISSING
-                or chargeState == CHARGE_STATE_ZERO)
+        onCooldown = chargeState == CHARGE_STATE_MISSING
+            or chargeState == CHARGE_STATE_ZERO
     else
-        onCooldown = button._cooldownPresentationSuppressed ~= true
-            and button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        onCooldown = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     end
 
     -- Time text color: switch between cooldown and ready colors
@@ -1929,11 +1927,6 @@ function CooldownCompanion:UpdateBarStyle(button, newStyle)
     button._vertexA = nil
     button._chargeText = nil
     button._chargeCountReadable = nil
-    button._lastReadableCharges = nil
-    button._chargeSpellId = nil
-    button._chargeInfoFromFallback = nil
-    button._chargePresentationSuppressed = nil
-    button._cooldownPresentationSuppressed = nil
     button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._displaySpellId = nil

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -600,9 +600,6 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
     if not (button and IsReadyGlowMaxChargeEligible(buttonData)) then
         return false
     end
-    if button._chargePresentationSuppressed == true then
-        return false
-    end
 
     return button._chargeState == CHARGE_STATE_FULL
 end
@@ -1313,11 +1310,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         button._chargesSpent = nil
         button._chargeText = nil
         button._displayCountZeroUsabilityFallback = nil
-        button._lastReadableCharges = nil
-        button._chargeSpellId = nil
-        button._chargeInfoFromFallback = nil
-        button._chargePresentationSuppressed = nil
-        button._cooldownPresentationSuppressed = nil
         if buttonData.type == "spell" then
             button.count:SetText("")
         end
@@ -1387,19 +1379,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
     end
 
-    if button._chargePresentationSuppressed == true and not auraOwnsPrimarySwipe then
-        button._cooldownPresentationSuppressed = true
-        button._cooldownState = COOLDOWN_STATE_READY
-        button._cooldownDeferred = nil
-        button._durationObj = nil
-        if not button._isBar and not button._isText then
-            button.cooldown:SetCooldown(0, 0)
-            button.cooldown:Hide()
-        end
-    else
-        button._cooldownPresentationSuppressed = nil
-    end
-
     button._isOnGCD = isOnGCD or false
     -- Bar mode: suppress GCD-only display in bars (checked by UpdateBarFill OnUpdate).
     -- Skip for charge spells: their _durationObj is the recharge cycle, never the GCD.
@@ -1414,8 +1393,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             and style.showGCDSwipe == true
             and buttonData.type == "spell"
             and isOnGCD == true
-            and button._chargePresentationSuppressed ~= true
-            and button._cooldownPresentationSuppressed ~= true
         if showBarGCDSwipe then
             local gcdDurationObj = CooldownCompanion._gcdDurationObj
             if not gcdDurationObj and spellCooldownDuration then
@@ -1459,30 +1436,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- some use-count spells. Do not guess zero-state from unrelated
             -- usability signals; leave the zero-state unknown instead.
             button._mainCDShown = false
-        elseif buttonData.type == "spell"
-           and button._lastReadableCharges ~= nil then
-            if button._chargeRecharging == true then
-                if button._lastReadableCharges <= 0 then
-                    if button._chargePresentationSuppressed == true then
-                        button._mainCDShown = true
-                    else
-                        local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
-                            or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-                        if slotProbe.shown ~= nil then
-                            button._mainCDShown = slotProbe.realShown == true
-                        else
-                            button._mainCDShown = true
-                        end
-                    end
-                else
-                    local maxCharges = buttonData.maxCharges
-                    local spent = button._chargesSpent
-                    button._mainCDShown = maxCharges and maxCharges > 1 and spent and spent >= maxCharges or false
-                end
-            elseif button._chargeRecharging == false then
-                button._lastReadableCharges = nil
-                button._chargesSpent = nil
-            end
         elseif buttonData.type == "spell" and usesChargeBehavior and buttonData.hasCharges then
             -- Restricted mode: charges unreadable (secret values).
             -- Action bar probe reflects the regular-cooldown DurationObject
@@ -1546,8 +1499,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if IsEntryItemLike(buttonData) then
         button._desatCooldownActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
     elseif usesChargeBehavior then
-        button._desatCooldownActive = button._chargePresentationSuppressed ~= true
-            and button._chargeState == CHARGE_STATE_ZERO
+        button._desatCooldownActive = button._chargeState == CHARGE_STATE_ZERO
     elseif auraOwnsPrimarySwipe and auraProbeInfo then
         button._desatCooldownActive = (auraProbeRealCooldownShown and not auraProbeIsGCDOnly) or false
     else
@@ -1564,17 +1516,16 @@ function CooldownCompanion:UpdateButtonCooldown(button)
 
     if usesChargeBehavior then
       if buttonData.type == "spell" and buttonData.hasCharges then
-        local showChargePresentation = button._chargePresentationSuppressed ~= true
         -- Bar/text mode: charge bars are driven by the recharge DurationObject, not
         -- the main spell CD or GCD. Save and clear the main CD so recharge
         -- timing fully controls bar fill for charge spells.
-        if showChargePresentation and (button._isBar or button._isText) and not auraOwnsPrimarySwipe and button._chargeDurationObj then
+        if (button._isBar or button._isText) and not auraOwnsPrimarySwipe and button._chargeDurationObj then
             button._durationObj = nil
         end
 
         local normalCooldownDisplayActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
             or (isGCDOnly and style.showGCDSwipe == true)
-        if showChargePresentation and not auraOwnsPrimarySwipe and button._chargeDurationObj then
+        if not auraOwnsPrimarySwipe and button._chargeDurationObj then
             if not button._isBar and not button._isText then
                 if button._chargeCooldownVisualActive then
                     -- Icon mode: active recharge owns the shared cooldown frame.
@@ -1587,7 +1538,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 -- Bar/text mode: only set _durationObj if actually recharging
                 button._durationObj = button._chargeDurationObj
             end
-        elseif showChargePresentation and not button._isBar and not button._isText and not auraOwnsPrimarySwipe then
+        elseif not button._isBar and not button._isText and not auraOwnsPrimarySwipe then
             -- Icon mode fallback: no chargeDurationObj, try fetching one.
             -- Only an active charge DurationObject may replace an existing GCD display.
             local chargeSpellID = cooldownSpellId or buttonData.id
@@ -1684,9 +1635,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             local maxCharges
             local chargeRecharging = false
             local chargeCooldownStartTime
-            local chargePresentationSuppressed = usesChargeBehavior
-                and button._chargePresentationSuppressed == true
-            if usesChargeBehavior and not chargePresentationSuppressed then
+            if usesChargeBehavior then
                 if button._currentReadableCharges ~= nil then
                     currentCharges = button._currentReadableCharges
                 elseif charges and charges.currentCharges ~= nil
@@ -1705,15 +1654,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                    and not issecretvalue(charges.cooldownStartTime) then
                     chargeCooldownStartTime = charges.cooldownStartTime
                 end
-            elseif chargePresentationSuppressed then
-                button._sndInitialized = nil
             end
 
             local cooldownActive
             if usesChargeBehavior then
                 -- Charge spells: cooldown-active means zero available charges.
-                cooldownActive = button._chargePresentationSuppressed ~= true
-                    and button._chargeState == CHARGE_STATE_ZERO
+                cooldownActive = button._chargeState == CHARGE_STATE_ZERO
             elseif auraOwnsPrimarySwipe then
                 -- Aura visuals replace button.cooldown; reuse the shared
                 -- probe computed above (same spell, same tick).

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1195,17 +1195,12 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
 
         local timedAuraPrimarySwipeActive = button._auraPrimarySwipeActive == true
             and button._auraHasTimer ~= false
-        local chargePresentationSuppressed = button._chargePresentationSuppressed == true
-        local cooldownPresentationSuppressed = button._cooldownPresentationSuppressed == true
-        local cooldownVisualActive = (button._cooldownState == COOLDOWN_STATE_COOLDOWN
-                and not cooldownPresentationSuppressed)
+        local cooldownVisualActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
             or timedAuraPrimarySwipeActive
             or button._conditionalAuraDurationTextPreview == true
             or button._conditionalPreviewDomain == "cooldown"
-            or (button._chargeCooldownVisualActive == true and not chargePresentationSuppressed)
-            or (isGCDOnly and style.showGCDSwipe == true
-                and not chargePresentationSuppressed
-                and not cooldownPresentationSuppressed)
+            or button._chargeCooldownVisualActive == true
+            or (isGCDOnly and style.showGCDSwipe == true)
 
         if suppressGCD or not cooldownVisualActive then
             button.cooldown:Hide()
@@ -1441,11 +1436,6 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._vertexA = nil
     button._chargeText = nil
     button._chargeCountReadable = nil
-    button._lastReadableCharges = nil
-    button._chargeSpellId = nil
-    button._chargeInfoFromFallback = nil
-    button._chargePresentationSuppressed = nil
-    button._cooldownPresentationSuppressed = nil
     button._zeroChargesConfirmed = nil
     button._hideCooldownChargesActive = nil
     button._nilConfirmPending = nil

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -60,10 +60,6 @@ local function IsAuraOnlyEntry(buttonData)
         and buttonData.auraTracking == true
 end
 
-local function IsChargePresentationVisible(button)
-    return button and button._chargePresentationSuppressed ~= true
-end
-
 ------------------------------------------------------------------------
 -- FORMAT STRING PARSER
 -- Parses "{name}  {status}" into a list of segments:
@@ -373,17 +369,14 @@ local function EvaluateTokenPresence(button, tokenName, timeRemaining, timeIsSec
     if tokenName == "time" then
         return timeIsSecret or (timeRemaining and timeRemaining > 0)
     elseif tokenName == "charges" then
-        return IsChargePresentationVisible(button) and UsesChargeBehavior(button.buttonData)
+        return UsesChargeBehavior(button.buttonData)
     elseif tokenName == "maxcharges" then
-        if not IsChargePresentationVisible(button) then return false end
         if not UsesChargeBehavior(button.buttonData) then return false end
         return button._chargeState == CHARGE_STATE_FULL
     elseif tokenName == "missingcharges" then
-        if not IsChargePresentationVisible(button) then return false end
         if not UsesChargeBehavior(button.buttonData) then return false end
         return button._chargeState == CHARGE_STATE_MISSING
     elseif tokenName == "zerocharges" then
-        if not IsChargePresentationVisible(button) then return false end
         if not UsesChargeBehavior(button.buttonData) then return false end
         return button._chargeState == CHARGE_STATE_ZERO
     elseif tokenName == "stacks" then
@@ -453,9 +446,8 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
 
     -- Gather live state
     local auraOnlyEntry = IsAuraOnlyEntry(buttonData)
-    local chargePresentationVisible = IsChargePresentationVisible(button)
-    local currentCharges = chargePresentationVisible and button._currentReadableCharges or nil
-    local maxCharges = chargePresentationVisible and buttonData.maxCharges or nil
+    local currentCharges = button._currentReadableCharges
+    local maxCharges = button.buttonData.maxCharges
     local stackDisplayText, stackDisplayKind = ResolveTextModeStackDisplay(button)
     local auraDurationTextPreview = button._conditionalAuraDurationTextPreview == true
     local auraActive = button._auraActive or auraDurationTextPreview

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -24,68 +24,12 @@ local IsEntryItemLike = CooldownCompanion.IsEntryItemLike or function(buttonData
                 and (buttonData.itemSlot == 13 or buttonData.itemSlot == 14)))
 end
 
-local function GetReadableMaxCharges(charges)
-    local maxCharges = charges and charges.maxCharges
-    if maxCharges and not issecretvalue(maxCharges) then
-        return tonumber(maxCharges)
-    end
-    return nil
-end
-
-local function SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
-    if not owner or currentCharges == nil then
-        return
-    end
-    if issecretvalue and (issecretvalue(maxCharges) or issecretvalue(currentCharges)) then
-        return
-    end
-
-    maxCharges = tonumber(maxCharges)
-    currentCharges = tonumber(currentCharges)
-    if not maxCharges or maxCharges <= 1 or not currentCharges then
-        return
-    end
-
-    local spent = maxCharges - currentCharges
-    if spent < 0 then
-        spent = 0
-    elseif spent > maxCharges then
-        spent = maxCharges
-    end
-    owner._chargesSpent = spent
-end
-
-local function ResolveRuntimeChargeInfo(buttonData, chargeSpellID)
-    local spellID = chargeSpellID or buttonData.id
-    local charges = C_Spell.GetSpellCharges(spellID)
-    local maxCharges = GetReadableMaxCharges(charges)
-
-    if (not maxCharges or maxCharges <= 1)
-        and ST.ResolveSpellChargeInfo
-        and buttonData.id then
-        local resolvedCharges, resolvedSpellID, resolvedMaxCharges = ST.ResolveSpellChargeInfo(buttonData.id)
-        if resolvedCharges and (resolvedMaxCharges or 0) > 1 then
-            return resolvedCharges, resolvedSpellID or buttonData.id, true, resolvedMaxCharges
-        end
-    end
-
-    return charges, spellID, false, maxCharges
-end
-
 -- Update charge count state for a spell with hasCharges enabled.
 -- chargeSpellID should be the effective runtime spell ID (override-aware).
 -- Returns the raw charges API table (may be nil) for use by callers.
 local function UpdateChargeTracking(button, buttonData, chargeSpellID)
-    local previousReadableCharges = button._chargeCountReadable == true
-        and button._currentReadableCharges
-        or nil
-    local charges, spellID, usedChargeFallback, maxCharges = ResolveRuntimeChargeInfo(buttonData, chargeSpellID)
-    button._chargeSpellId = spellID
-    button._chargeInfoFromFallback = usedChargeFallback or nil
-    button._chargePresentationSuppressed = usedChargeFallback == true
-        and chargeSpellID ~= nil
-        and tonumber(spellID) ~= tonumber(chargeSpellID)
-        or nil
+    local spellID = chargeSpellID or buttonData.id
+    local charges = C_Spell.GetSpellCharges(spellID)
 
     -- Read current charges only from the authoritative charge API field.
     -- Display-count APIs are UI-oriented and can transiently read 0 during
@@ -93,10 +37,6 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
     local cur
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
         cur = charges.currentCharges
-        button._lastReadableCharges = cur
-    elseif (usedChargeFallback or (maxCharges or 0) > 1)
-        and previousReadableCharges ~= nil then
-        button._lastReadableCharges = previousReadableCharges
     end
     button._currentReadableCharges = cur
     button._chargeCountReadable = (cur ~= nil)
@@ -123,17 +63,10 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
         button._chargeDurationObj = nil
         button._chargeRecharging = false
         button._chargeState = nil
-        button._lastReadableCharges = nil
-        button._chargeSpellId = nil
-        button._chargeInfoFromFallback = nil
-        button._chargePresentationSuppressed = nil
-        button._cooldownPresentationSuppressed = nil
-        button._chargesSpent = nil
         return nil
     end
 
     local mx = buttonData.maxCharges
-    SyncSpentChargesFromReadableCount(button, mx, cur)
 
     -- Recharge DurationObject for multi-charge spells.
     -- GetSpellChargeDuration returns nil for maxCharges=1 (Blizzard doesn't treat
@@ -144,10 +77,7 @@ local function UpdateChargeTracking(button, buttonData, chargeSpellID)
 
     -- Display charge text via secret-safe widget methods
     local showChargeText = button.style and button.style.showChargeText
-    if button._chargePresentationSuppressed == true then
-        button._chargeText = nil
-        button.count:SetText("")
-    elseif not showChargeText then
+    if not showChargeText then
         button.count:SetText("")
     else
         if cur then
@@ -432,7 +362,6 @@ local function ResolveDesaturationIntent(button, buttonData, style, target)
         end
         if not target.active and buttonData.desaturateWhileZeroCharges
                 and not CooldownCompanion.HasItemFallbacks(buttonData)
-                and button._chargePresentationSuppressed ~= true
                 and button._chargeState == CHARGE_STATE_ZERO then
             target.active = true
             target.reason = "zero-charges"

--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -139,7 +139,6 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     local itemUsesResolvedCooldownState = IsEntryItemLike(buttonData)
         and button._resolvedItemQuantityKind == "stacks"
     local noCooldownForVisibility = IsNoCooldownForVisibility(button)
-    local chargePresentationSuppressed = button._chargePresentationSuppressed == true
 
     -- Check hideWhileOnCooldown (skip for no-CD spells — always "not on CD")
     if buttonData.hideWhileOnCooldown and not noCooldownForVisibility and not barAuraStackDisplay then
@@ -148,9 +147,8 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if not chargePresentationSuppressed
-                    and (button._chargeState == CHARGE_STATE_ZERO
-                    or button._chargeState == CHARGE_STATE_MISSING) then
+            if button._chargeState == CHARGE_STATE_ZERO
+                    or button._chargeState == CHARGE_STATE_MISSING then
                 hideReasons = bit_bor(hideReasons, HIDE_ON_COOLDOWN)
             end
         elseif IsEntryItemLike(buttonData) then
@@ -171,7 +169,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if not chargePresentationSuppressed and button._chargeState == CHARGE_STATE_FULL then
+            if button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif IsEntryItemLike(buttonData) then
@@ -212,7 +210,6 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     if buttonData.hideWhileZeroCharges
             and not barAuraStackDisplay
             and not CooldownCompanion.HasItemFallbacks(buttonData)
-            and button._chargePresentationSuppressed ~= true
             and button._chargeState == CHARGE_STATE_ZERO then
         hideReasons = bit_bor(hideReasons, HIDE_ZERO_CHARGES)
     end

--- a/CooldownCompanion/ButtonFrame/VisualState.lua
+++ b/CooldownCompanion/ButtonFrame/VisualState.lua
@@ -192,9 +192,6 @@ local function IsReadyGlowAtMaxCharges(button, buttonData)
     if not (button and IsReadyGlowMaxChargeEligible(buttonData)) then
         return false
     end
-    if button._chargePresentationSuppressed == true then
-        return false
-    end
 
     return button._chargeState == CHARGE_STATE_FULL
 end
@@ -386,8 +383,6 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
 
     local procSuppressesReady = procOverlayShown and style.procGlowStyle ~= "none"
     local auraSuppressesReady = button._auraTrackingReady == true and button._auraActive == true
-    local cooldownPresentationSuppressed = button._cooldownPresentationSuppressed == true
-        or button._chargePresentationSuppressed == true
     if not button.readyGlow then
         SetGlowIntent(ready, false, false, "missing-widget")
     elseif button._readyGlowPreview == true then
@@ -399,9 +394,6 @@ local function ResolveIconGlowIntent(button, buttonData, style, procOverlayActiv
         SetGlowIntent(ready, true, false, "passive")
     elseif button._noCooldown then
         SetGlowIntent(ready, true, false, "no-cooldown")
-    elseif cooldownPresentationSuppressed then
-        SetGlowIntent(ready, true, false, "presentation-suppressed")
-        ready.cooldownSuppressed = true
     elseif style.readyGlowCombatOnly and not inCombat then
         SetGlowIntent(ready, true, false, "combat-only")
         ready.combatOnly = true
@@ -513,7 +505,6 @@ local function ResolveIconFillIntent(button, buttonData, style, target)
         cooldownReason = "cooldown"
     elseif UsesIconFillChargeBehavior(buttonData)
         and button._chargeRecharging == true
-        and button._chargePresentationSuppressed ~= true
         and button._hideCooldownChargesActive ~= true then
         cooldownReason = "charge-recharge"
     end

--- a/CooldownCompanion/Core/AuraTexturesEffects.lua
+++ b/CooldownCompanion/Core/AuraTexturesEffects.lua
@@ -608,10 +608,6 @@ local function ResolveTextureIndicatorSectionState(button, sectionKey, config, t
                 or "no-cooldown"
             return FinishTextureIndicatorSectionState(target, false, reason, nil, effectType)
         end
-        if button._chargePresentationSuppressed == true
-                or button._cooldownPresentationSuppressed == true then
-            return FinishTextureIndicatorSectionState(target, false, "presentation-suppressed", nil, effectType)
-        end
         local active = button._desatCooldownActive == false
         return FinishTextureIndicatorSectionState(target, active, active and "ready" or "not-ready", nil, effectType)
     end
@@ -643,11 +639,6 @@ end
 local function EvaluateTriggerRowCondition(button, conditionKey)
     if not button then
         return false
-    end
-
-    if button._chargePresentationSuppressed == true
-            or button._cooldownPresentationSuppressed == true then
-        return nil
     end
 
     if conditionKey == "cooldownActive" then
@@ -707,18 +698,12 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
     end
 
     if conditionKey == "chargesRecharging" then
-        if button._chargePresentationSuppressed == true then
-            return false
-        end
         return button._chargeRecharging == true
     end
 
     if conditionKey == "chargeState" then
         local buttonData = button.buttonData
         if not buttonData or buttonData.hasCharges ~= true then
-            return nil
-        end
-        if button._chargePresentationSuppressed == true then
             return nil
         end
 

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1420,11 +1420,6 @@ local function ClearOwnerChargeState(owner)
     owner._mainCDShown = nil
     owner._chargeState = nil
     owner._chargesSpent = nil
-    owner._lastReadableCharges = nil
-    owner._chargeSpellId = nil
-    owner._chargeInfoFromFallback = nil
-    owner._chargePresentationSuppressed = nil
-    owner._cooldownPresentationSuppressed = nil
 end
 
 function EntryRuntime.RecordChargeSpent(owner)
@@ -1434,54 +1429,6 @@ function EntryRuntime.RecordChargeSpent(owner)
     else
         owner._chargesSpent = (owner._chargesSpent or 0) + 1
     end
-end
-
-local function InferCurrentChargesFromSpent(maxCharges, spent)
-    if maxCharges == nil or (issecretvalue and issecretvalue(maxCharges)) then
-        return nil
-    end
-    if spent == nil or (issecretvalue and issecretvalue(spent)) then
-        return nil
-    end
-
-    maxCharges = tonumber(maxCharges)
-    spent = tonumber(spent)
-    if not maxCharges or maxCharges <= 0 or not spent then
-        return nil
-    end
-
-    local current = maxCharges - spent
-    if current < 0 then
-        return 0
-    end
-    if current > maxCharges then
-        return maxCharges
-    end
-    return current
-end
-
-local function SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
-    if not owner or currentCharges == nil then
-        return
-    end
-    if (issecretvalue and issecretvalue(maxCharges))
-        or (issecretvalue and issecretvalue(currentCharges)) then
-        return
-    end
-
-    maxCharges = tonumber(maxCharges)
-    currentCharges = tonumber(currentCharges)
-    if not maxCharges or maxCharges <= 1 or not currentCharges then
-        return
-    end
-
-    local spent = maxCharges - currentCharges
-    if spent < 0 then
-        spent = 0
-    elseif spent > maxCharges then
-        spent = maxCharges
-    end
-    owner._chargesSpent = spent
 end
 
 local function SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
@@ -1516,29 +1463,18 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
     result.maxCharges = maxCharges
     result.charges = charges
 
-    local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
-    local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
-    local chargePresentationSuppressed = result.preserveReadableCharges == true
-        and tonumber(cooldownSpellID) ~= tonumber(result.cooldownSpellID)
-    result.chargeDurationObj = chargeDurationObj
-    result.chargeRecharging = chargeRecharging or false
-    result.chargePresentationSuppressed = chargePresentationSuppressed or nil
-
     local currentCharges
     if charges and charges.currentCharges ~= nil and not issecretvalue(charges.currentCharges) then
         currentCharges = charges.currentCharges
         result.currentCharges = currentCharges
-    elseif result.preserveReadableCharges == true
-        and chargeRecharging == true
-        and owner
-        and owner._chargeCountReadable == true
-        and owner._currentReadableCharges ~= nil then
-        currentCharges = InferCurrentChargesFromSpent(maxCharges, owner._chargesSpent)
-            or owner._currentReadableCharges
-        result.currentCharges = currentCharges
     elseif C_Spell.GetSpellDisplayCount then
         result.chargeDisplayCount = C_Spell.GetSpellDisplayCount(cooldownSpellID)
     end
+
+    local chargeDurationObj = C_Spell.GetSpellChargeDuration(cooldownSpellID)
+    local chargeRecharging = DurationObjectShowsCooldown(chargeDurationObj)
+    result.chargeDurationObj = chargeDurationObj
+    result.chargeRecharging = chargeRecharging or false
 
     if owner then
         owner._customCooldownHasCharges = true
@@ -1546,10 +1482,6 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._chargeCountReadable = currentCharges ~= nil
         owner._chargeDurationObj = chargeDurationObj
         owner._chargeRecharging = result.chargeRecharging
-        owner._chargeSpellId = cooldownSpellID
-        owner._chargeInfoFromFallback = result.preserveReadableCharges or nil
-        owner._chargePresentationSuppressed = chargePresentationSuppressed or nil
-        SyncSpentChargesFromReadableCount(owner, maxCharges, currentCharges)
     end
 
     local mainCDShown = false
@@ -1567,12 +1499,8 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
 
     if owner then
         owner._mainCDShown = mainCDShown
-        if currentCharges ~= nil then
-            -- Readable charge counts already synced _chargesSpent above.
-        elseif result.chargeRecharging and not owner._chargesSpent then
+        if result.chargeRecharging and not owner._chargesSpent then
             owner._chargesSpent = maxCharges or 0
-        elseif result.chargeRecharging == false then
-            owner._chargesSpent = nil
         end
     end
 
@@ -1605,7 +1533,7 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
         owner._chargeState = result.chargeState
     end
 
-    if result.chargeRecharging and not chargePresentationSuppressed then
+    if result.chargeRecharging then
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-charge-recharge"
         result.renderDurationObj = chargeDurationObj
@@ -1706,19 +1634,8 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
         owner._customCooldownSpellID = cooldownSpellID
     end
 
-    local chargeSpellID = cooldownSpellID
     local charges = C_Spell.GetSpellCharges(cooldownSpellID)
     local maxCharges = charges and tonumber(charges.maxCharges)
-    local preserveReadableCharges = false
-    if (not maxCharges or maxCharges <= 1) and ST.ResolveSpellChargeInfo then
-        local resolvedCharges, resolvedChargeSpellID, resolvedMaxCharges = ST.ResolveSpellChargeInfo(spellID)
-        if resolvedCharges and (resolvedMaxCharges or 0) > 1 then
-            charges = resolvedCharges
-            chargeSpellID = resolvedChargeSpellID or spellID
-            maxCharges = resolvedMaxCharges
-            preserveReadableCharges = true
-        end
-    end
     SyncCustomBarChargeMetadata(customBar, charges, maxCharges)
     local hasCharges = (maxCharges or 0) > 1
     local secrecy = ResolveSpellCooldownSecrecy(owner, cooldownSpellID)
@@ -1749,12 +1666,10 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     })
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
-    result.chargeSpellID = chargeSpellID
-    result.preserveReadableCharges = preserveReadableCharges or nil
     result.noCooldown = noCooldown or nil
 
     if hasCharges then
-        ApplyCustomBarChargeState(owner, result, spellID, chargeSpellID, charges, maxCharges)
+        ApplyCustomBarChargeState(owner, result, spellID, cooldownSpellID, charges, maxCharges)
     else
         ClearOwnerChargeState(owner)
     end

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -747,11 +747,6 @@ local function ClearReusableButtonRuntime(button)
     button._chargeState = nil
     button._currentReadableCharges = nil
     button._chargeCountReadable = nil
-    button._lastReadableCharges = nil
-    button._chargeSpellId = nil
-    button._chargeInfoFromFallback = nil
-    button._chargePresentationSuppressed = nil
-    button._cooldownPresentationSuppressed = nil
     button._chargeText = nil
     button._chargesSpent = nil
     button._sndInitialized = nil

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2903,11 +2903,6 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._chargeState = nil
                 button._currentReadableCharges = nil
                 button._chargeCountReadable = nil
-                button._lastReadableCharges = nil
-                button._chargeSpellId = nil
-                button._chargeInfoFromFallback = nil
-                button._chargePresentationSuppressed = nil
-                button._cooldownPresentationSuppressed = nil
                 button._zeroChargesConfirmed = nil
                 button._displayCountZeroUsabilityFallback = nil
                 ClearButtonVisualState(button)

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -13,9 +13,6 @@ local pairs = pairs
 local wipe = wipe
 local ipairs = ipairs
 local select = select
-local tonumber = tonumber
-local issecretvalue = issecretvalue
-local C_Spell_GetSpellCharges = C_Spell.GetSpellCharges
 
 -- Import cross-file variables
 local defaults = ST._defaults
@@ -50,37 +47,6 @@ ST._BUFF_VIEWER_SET = BUFF_VIEWER_SET
 
 local cdmAlphaGuard = {}
 ST._cdmAlphaGuard = cdmAlphaGuard
-
-local function GetReadableMaxCharges(charges)
-    local maxCharges = charges and charges.maxCharges
-    if maxCharges and not issecretvalue(maxCharges) then
-        return tonumber(maxCharges)
-    end
-    return nil
-end
-
-local function SpellHasDirectMultiChargeInfo(spellID)
-    if not (spellID and C_Spell_GetSpellCharges) then return false end
-    local charges = C_Spell_GetSpellCharges(spellID)
-    return (GetReadableMaxCharges(charges) or 0) > 1
-end
-
-local function CastConsumesTrackedCharge(button, buttonData, spellID, displaySpellID)
-    if spellID == buttonData.id then
-        return true
-    end
-
-    local chargeSpellID = button and button._chargeSpellId
-    if chargeSpellID and spellID == chargeSpellID then
-        return true
-    end
-
-    if displaySpellID and spellID == displaySpellID and displaySpellID ~= buttonData.id then
-        return SpellHasDirectMultiChargeInfo(spellID)
-    end
-
-    return false
-end
 
 function CooldownCompanion:OnInitialize()
     self._hadSavedVariables = type(_G.CooldownCompanionDB) == "table"
@@ -453,11 +419,8 @@ function CooldownCompanion:OnSpellCast(event, unit, castGUID, spellID)
             if buttonData.type == "spell"
                 and not buttonData.isPassive then
                 local displaySpellID = button._displaySpellId or buttonData.id
-                local chargeSpellID = button._chargeSpellId
-                if spellID == buttonData.id or spellID == displaySpellID or spellID == chargeSpellID then
-                    if self.UsesChargeBehavior(buttonData)
-                        and buttonData.hasCharges
-                        and CastConsumesTrackedCharge(button, buttonData, spellID, displaySpellID) then
+                if spellID == buttonData.id or spellID == displaySpellID then
+                    if self.UsesChargeBehavior(buttonData) and buttonData.hasCharges then
                         -- Track charge consumption for restricted-mode color heuristic.
                         -- _chargeRecharging at event time reflects the PRE-cast state:
                         --   false = casting from full charges → reset to 1

--- a/CooldownCompanion/Core/SoundAlerts.lua
+++ b/CooldownCompanion/Core/SoundAlerts.lua
@@ -895,7 +895,6 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
     local chargeRecharging = opts.chargeRecharging and true or false
     local currentCharges = opts.currentCharges
     local chargeCooldownStartTime = opts.chargeCooldownStartTime
-    local suppressChargeAvailable = opts.suppressChargeAvailable == true
 
     if not state._sndInitialized then
         state._sndInitialized = true
@@ -923,7 +922,7 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
         opts.play(opts.playContext, "onCooldown")
     end
 
-    if enabledEvents.available and not suppressChargeAvailable then
+    if enabledEvents.available then
         if opts.usesChargeBehavior then
             if DidGainChargeSincePreviousState(state, cooldownActive, currentCharges, chargeRecharging, chargeCooldownStartTime) then
                 opts.play(opts.playContext, "available")
@@ -957,21 +956,11 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, coold
     end
 
     if customBar and customBar.entryType == "spell" then
-        local chargePresentationSuppressed = cooldownResult
-            and cooldownResult.chargePresentationSuppressed == true
-        if chargePresentationSuppressed and barInfo then
-            barInfo._sndInitialized = nil
-        end
-        local chargeRecharging = (not chargePresentationSuppressed)
-            and cooldownResult and cooldownResult.chargeRecharging == true
-            or false
-        local currentCharges = (not chargePresentationSuppressed)
-            and cooldownResult and cooldownResult.currentCharges
-            or nil
+        local chargeRecharging = cooldownResult and cooldownResult.chargeRecharging == true
+        local currentCharges = cooldownResult and cooldownResult.currentCharges
         local chargeCooldownStartTime
         local charges = cooldownResult and cooldownResult.charges
-        if not chargePresentationSuppressed
-                and charges and charges.cooldownStartTime ~= nil and not issecretvalue(charges.cooldownStartTime) then
+        if charges and charges.cooldownStartTime ~= nil and not issecretvalue(charges.cooldownStartTime) then
             chargeCooldownStartTime = charges.cooldownStartTime
         end
 
@@ -987,7 +976,6 @@ function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, coold
         opts.chargeCooldownStartTime = chargeCooldownStartTime
         opts.includeAuraEvents = customBar.auraTracking == true
         opts.usesChargeBehavior = cooldownResult and cooldownResult.hasCharges == true
-        opts.suppressChargeAvailable = chargePresentationSuppressed
         opts.play = PlayCustomBarTransitionSound
         opts.playContext = customBar
         UpdateCooldownSoundAlertTransitions(barInfo, enabledEvents, opts)
@@ -1030,11 +1018,6 @@ function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isO
         return
     end
 
-    local chargePresentationSuppressed = button._chargePresentationSuppressed == true
-    if chargePresentationSuppressed then
-        button._sndInitialized = nil
-    end
-
     local opts = button._sndTransitionOptions
     if not opts then
         opts = {}
@@ -1042,12 +1025,11 @@ function CooldownCompanion:UpdateButtonSoundAlerts(button, cooldownSpellID, _isO
     end
     opts.cooldownActive = cooldownActive
     opts.auraActive = auraActive
-    opts.currentCharges = chargePresentationSuppressed and nil or currentCharges
-    opts.chargeRecharging = chargePresentationSuppressed and false or chargeRecharging
-    opts.chargeCooldownStartTime = chargePresentationSuppressed and nil or chargeCooldownStartTime
+    opts.currentCharges = currentCharges
+    opts.chargeRecharging = chargeRecharging
+    opts.chargeCooldownStartTime = chargeCooldownStartTime
     opts.includeAuraEvents = true
     opts.usesChargeBehavior = UsesChargeBehavior(buttonData)
-    opts.suppressChargeAvailable = chargePresentationSuppressed
     opts.play = PlayButtonTransitionSound
     opts.playContext = buttonData
     UpdateCooldownSoundAlertTransitions(button, enabledEvents, opts)

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -481,10 +481,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         if not (bar and bar.stackText and bar.stackText:IsShown()) then
             return
         end
-        if cooldownResult and cooldownResult.chargePresentationSuppressed == true then
-            bar.stackText:SetText("")
-            return
-        end
 
         local currentCharges = cooldownResult and cooldownResult.currentCharges
         local maxCharges = cooldownResult and cooldownResult.maxCharges
@@ -534,10 +530,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local cooldownResult = EntryRuntime.EvaluateSpellCooldownStateForCustomBar(cabConfig, bar)
         local durationObj = cooldownResult and cooldownResult.renderDurationObj
-        local chargePresentationSuppressed = cooldownResult and cooldownResult.chargePresentationSuppressed == true
         local cooldownActive = cooldownResult
             and cooldownResult.state == ST.CooldownLogic.STATE_COOLDOWN
-            and not chargePresentationSuppressed
         local auraState = ResolveSpellCustomBarAuraState(barInfo)
         local auraPresent = auraState and auraState.ready == true and auraState.auraPresent == true
         local auraPreview = bar._barAuraActivePreview == true
@@ -552,7 +546,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local rechargeColor = cabConfig.barChargeColor or {1.0, 0.82, 0.0, 1}
         local chargeState = cooldownResult and cooldownResult.chargeState
         local fillColor = barColor
-        if cooldownResult and cooldownResult.hasCharges == true and not chargePresentationSuppressed then
+        if cooldownResult and cooldownResult.hasCharges == true then
             if chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO then
                 fillColor = cooldownColor
             elseif cooldownActive then
@@ -565,17 +559,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         local function UpdateSpellCustomBarSounds(soundAuraActive)
             if CooldownCompanion.UpdateCustomBarSoundAlerts then
                 local soundCooldownActive = cooldownActive
-                local soundCooldownResult = cooldownResult
-                if chargePresentationSuppressed then
-                    soundCooldownActive = false
-                    soundCooldownResult = nil
-                    barInfo._sndInitialized = nil
-                end
-                if cooldownResult and cooldownResult.hasCharges == true and not chargePresentationSuppressed then
+                if cooldownResult and cooldownResult.hasCharges == true then
                     soundCooldownActive = cooldownResult.chargeState == ST.CooldownLogic.CHARGE_STATE_ZERO
                         or (cooldownResult.chargeState == nil and cooldownActive)
                 end
-                CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, soundAuraActive, soundCooldownActive, soundCooldownResult)
+                CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, soundAuraActive, soundCooldownActive, cooldownResult)
             end
         end
 
@@ -715,85 +703,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         UpdateSpellCustomBarSounds(false)
     end
 
-    local function GetReadableMaxCharges(spellID)
-        if not spellID or not C_Spell.GetSpellCharges then
-            return nil
-        end
-
-        local charges = C_Spell.GetSpellCharges(spellID)
-        local maxCharges = charges and charges.maxCharges
-        if maxCharges == nil or (issecretvalue and issecretvalue(maxCharges)) then
-            return nil
-        end
-        return tonumber(maxCharges)
-    end
-
-    local function SpellHasDirectMultiChargeInfo(spellID)
-        local maxCharges = GetReadableMaxCharges(spellID)
-        return maxCharges ~= nil and maxCharges > 1
-    end
-
-    local function GetRuntimeSpellID(baseSpellID)
-        local runtimeSpellID = C_Spell.GetOverrideSpell and C_Spell.GetOverrideSpell(baseSpellID)
-        if not runtimeSpellID or runtimeSpellID == 0 then
-            runtimeSpellID = baseSpellID
-        end
-        return tonumber(runtimeSpellID)
-    end
-
-    local function CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID, runtimeSpellID)
-        if bar and bar._customCooldownHasCharges == true then
-            return true
-        end
-        if cabConfig and cabConfig.hasCharges == true then
-            return true
-        end
-
-        local configMaxCharges = cabConfig and cabConfig.maxCharges
-        if configMaxCharges ~= nil
-            and not (issecretvalue and issecretvalue(configMaxCharges))
-            and (tonumber(configMaxCharges) or 0) > 1 then
-            return true
-        end
-
-        if bar and SpellHasDirectMultiChargeInfo(bar._chargeSpellId) then
-            return true
-        end
-        if SpellHasDirectMultiChargeInfo(baseSpellID) then
-            return true
-        end
-        return runtimeSpellID
-            and runtimeSpellID ~= baseSpellID
-            and SpellHasDirectMultiChargeInfo(runtimeSpellID)
-    end
-
-    local function CustomBarCastConsumesTrackedCharge(bar, cabConfig, spellID)
-        local castSpellID = tonumber(spellID)
-        local baseSpellID = tonumber(cabConfig and cabConfig.spellID)
-        if not castSpellID or not baseSpellID then
-            return false
-        end
-
-        local runtimeSpellID = GetRuntimeSpellID(baseSpellID)
-        if not CustomBarHasChargeBehavior(bar, cabConfig, baseSpellID, runtimeSpellID) then
-            return false
-        end
-
-        if castSpellID == baseSpellID then
-            return true
-        end
-
-        local chargeSpellID = tonumber(bar and bar._chargeSpellId)
-        if chargeSpellID and castSpellID == chargeSpellID then
-            return true
-        end
-
-        return runtimeSpellID
-            and runtimeSpellID ~= baseSpellID
-            and castSpellID == runtimeSpellID
-            and SpellHasDirectMultiChargeInfo(runtimeSpellID)
-    end
-
     function CooldownCompanion:RecordCustomBarSpellCast(spellID)
         if not spellID then return end
 
@@ -806,7 +715,16 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 and cabConfig
                 and cabConfig.entryType == "spell"
             then
-                if CustomBarCastConsumesTrackedCharge(bar, cabConfig, spellID) then
+                local baseSpellID = tonumber(cabConfig.spellID)
+                local runtimeSpellID = baseSpellID and C_Spell.GetOverrideSpell(baseSpellID)
+                if not runtimeSpellID or runtimeSpellID == 0 then
+                    runtimeSpellID = baseSpellID
+                end
+
+                local charges = runtimeSpellID and C_Spell.GetSpellCharges(runtimeSpellID)
+                local maxCharges = charges and tonumber(charges.maxCharges)
+                if (maxCharges or 0) > 1
+                    and (spellID == baseSpellID or spellID == runtimeSpellID) then
                     EntryRuntime.RecordChargeSpent(bar)
                 end
             end


### PR DESCRIPTION
## What Players Will Notice
- Charge text color and icon desaturation should return to the simpler pre-Zenith-suppression behavior path for charge-based abilities.
- The Zenith/Stomp-specific suppression introduced in 1.20 is backed out for now, so Zenith entries may no longer hide all base Zenith presentation while Zenith Stomp is active.

## Why This Changed
- The Zenith Stomp display fix tried to preserve replacement-spell behavior while suppressing base Zenith charge, cooldown, glow, texture, and sound presentation.
- Follow-up live repros showed that this approach was destabilizing normal charge text color and icon saturation, even after multiple attempted fixes.
- Charge text and saturation are core display behavior across classes; the Zenith/Stomp replacement behavior is narrower, so this PR intentionally restores the safer baseline first.

## What Changed
- Reverts PR #389 / merge commit `ee4e895d` (`Fix Zenith display while Zenith Stomp is active`) across the button, custom bar, visibility, visual state, texture effect, sound alert, and lifecycle paths.
- Removes the replacement-spell charge presentation suppression fields and charge-spend filtering that were introduced for Zenith/Stomp.
- Leaves the existing 1.20 changelog entry intact; the 1.20.1 changelog can describe this reversion separately.

## Validation
- Ran `luac -p` on all addon Lua files touched by the revert.
- Ran `git diff --check origin/main...HEAD`.
- Searched the tracked addon code for leftover Zenith/Stomp suppression symbols; only the intentionally retained 1.20 changelog text still mentions Zenith Stomp.
- Post-revert in-game combat validation is still pending.
