### PR TITLE
Remove unused config helper return captures

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/BarModeTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/BarModeTabs.lua
@@ -206,7 +206,7 @@ local function BuildBarAppearanceTab(container, group, style)
         end
     end
 
-    local iconAdvExpanded, iconAdvBtn = AddAdvancedToggle(showIconCb, "barIcon", tabInfoButtons, style.showBarIcon ~= false, {
+    local _, iconAdvBtn = AddAdvancedToggle(showIconCb, "barIcon", tabInfoButtons, style.showBarIcon ~= false, {
         title = "Bar Icon Advanced",
         build = BuildBarIconAdvanced,
     })
@@ -240,7 +240,7 @@ local function BuildBarAppearanceTab(container, group, style)
         AddOffsetSliders(panel, style, "barNameTextOffsetX", "barNameTextOffsetY", {range = 50}, refreshStyle)
     end
 
-    local nameAdvExpanded, nameAdvBtn = AddAdvancedToggle(showNameCbBasic, "barNameText", tabInfoButtons, style.showBarNameText ~= false, {
+    local _, nameAdvBtn = AddAdvancedToggle(showNameCbBasic, "barNameText", tabInfoButtons, style.showBarNameText ~= false, {
         title = "Name Text Advanced",
         build = BuildBarNameTextAdvanced,
     })
@@ -308,7 +308,7 @@ local function BuildBarAppearanceTab(container, group, style)
         AddOffsetSliders(panel, style, "chargeXOffset", "chargeYOffset", {x = -2, y = 2}, refreshStyle)
     end
 
-    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false, {
+    local _, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false, {
         title = "Count Text Advanced",
         build = BuildBarChargeTextAdvanced,
     })
@@ -396,7 +396,7 @@ local function BuildBarAppearanceTab(container, group, style)
         AddFontControls(panel, style, "barReady", {sizeMin = 6, sizeMax = 24}, refreshStyle)
     end
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(showReadyCb, "barReadyText", tabInfoButtons, style.showBarReadyText, {
+    local _, readyAdvBtn = AddAdvancedToggle(showReadyCb, "barReadyText", tabInfoButtons, style.showBarReadyText, {
         title = "Ready Text Advanced",
         build = BuildBarReadyTextAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua
@@ -175,7 +175,7 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
         end
     end
 
-    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons, nil, {
+    local _, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons, nil, {
         title = "Format Override Advanced",
         build = BuildFormatOverridePreviewAdvanced,
     })
@@ -461,9 +461,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                 local revertBtn = CreateRevertButton(heading, buttonData, sectionId)
                 table.insert(infoButtons, revertBtn)
 
-                local previewAdvExpanded
                 if PREVIEWABLE_OVERRIDE_SECTIONS[sectionId] then
-                    local previewAdvBtn
                     local function BuildOverridePreviewAdvanced(panel)
                         if sectionId == "procGlow" and overrides.procGlowStyle ~= "none" then
                             AddSelectedButtonPreviewToggle(panel, "Preview Proc Glow", "_procGlowPreview", CooldownCompanion.SetProcGlowPreview)
@@ -503,7 +501,7 @@ function ST._BuildOverridesTab(scroll, buttonData, infoButtons)
                         end
                     end
 
-                    previewAdvExpanded, previewAdvBtn = AddAdvancedToggle(heading, "overridePreview_" .. sectionId, infoButtons, nil, {
+                    local _, previewAdvBtn = AddAdvancedToggle(heading, "overridePreview_" .. sectionId, infoButtons, nil, {
                         title = sectionDef.label .. " Advanced",
                         build = BuildOverridePreviewAdvanced,
                         isAvailable = function()

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -2677,7 +2677,7 @@ local function BuildEffectsTab(container)
         end
     end
 
-    local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive, {
+    local _, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive, {
         title = "Cooldown Swipe Advanced",
         build = BuildCooldownSwipeAdvanced,
     })
@@ -3274,7 +3274,7 @@ local function BuildAppearanceTab(container)
 
     end
 
-    local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText, {
+    local _, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText, {
         title = "Cooldown Text Advanced",
         build = BuildCooldownTextAdvanced,
     })
@@ -3302,7 +3302,7 @@ local function BuildAppearanceTab(container)
         AddOffsetSliders(panel, style, "chargeXOffset", "chargeYOffset", { x = -2, y = 2 }, refreshStyle)
     end
 
-    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false, {
+    local _, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false, {
         title = "Count Text Advanced",
         build = BuildChargeTextAdvanced,
     })
@@ -3347,7 +3347,7 @@ local function BuildAppearanceTab(container)
 
     end
 
-    local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false, {
+    local _, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false, {
         title = "Aura Duration Text Advanced",
         build = BuildAuraDurationTextAdvanced,
     })
@@ -3383,7 +3383,7 @@ local function BuildAppearanceTab(container)
 
     end
 
-    local auraStackAdvExpanded, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
+    local _, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
         title = "Aura Stack Text Advanced",
         build = BuildAuraStackTextAdvanced,
     })
@@ -3425,7 +3425,7 @@ local function BuildAppearanceTab(container)
         AddColorPicker(panel, style, "keybindFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
     end
 
-    local kbAdvExpanded, kbAdvBtn = AddAdvancedToggle(kbCb, "keybindText", tabInfoButtons, style.showKeybindText, {
+    local _, kbAdvBtn = AddAdvancedToggle(kbCb, "keybindText", tabInfoButtons, style.showKeybindText, {
         title = KEYBIND_CUSTOM_LABEL .. " Advanced",
         build = BuildKeybindTextAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/Helpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/Helpers.lua
@@ -856,7 +856,7 @@ local function BuildCompactModeControls(container, group, tabInfoButtons)
         }, tabInfoButtons)
     end
 
-    local compactAdvExpanded, compactAdvBtn = AddAdvancedToggle(compactCb, "compactLayout", tabInfoButtons, group.compactLayout, {
+    local _, compactAdvBtn = AddAdvancedToggle(compactCb, "compactLayout", tabInfoButtons, group.compactLayout, {
         title = "Compact Mode Advanced",
         build = BuildCompactAdvanced,
     })
@@ -1030,7 +1030,7 @@ local CHARACTER_COPY_TOOLTIP_DETAILS = {
 }
 
 local function CreateCharacterCopyButton(enableCb, systemKey, label, onCopied)
-    local copyValues, copyOrder = CooldownCompanion:GetCharacterScopedSettingsCopyOptions(systemKey)
+    local _, copyOrder = CooldownCompanion:GetCharacterScopedSettingsCopyOptions(systemKey)
     if #copyOrder == 0 then return end
 
     -- Pool one button per systemKey to avoid frame leaks across panel rebuilds

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -857,7 +857,7 @@ function HealthResource.BuildColorControls(container, settings, applyBars)
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(lowHealthAlertCb)
-    local lowHealthAlertAdvancedExpanded, lowHealthAlertAdvancedBtn = HealthResource.AddEffectStyleControls(container, lowHealthAlertCb, health, {
+    local _, lowHealthAlertAdvancedBtn = HealthResource.AddEffectStyleControls(container, lowHealthAlertCb, health, {
         enabledKey = "showLowHealthAlert",
         advancedKey = "healthLowHealthAlert",
         colorKey = "healthLowHealthAlertColor",

--- a/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
+++ b/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
@@ -1757,7 +1757,7 @@ local function BuildTextColorsControls(container, styleTable, refreshCallback)
         panel:AddChild(readyTextBox)
     end
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyColorPicker, "textReadyText", tabInfoButtons, nil, {
+    local _, readyAdvBtn = AddAdvancedToggle(readyColorPicker, "textReadyText", tabInfoButtons, nil, {
         title = "Ready Color Advanced",
         build = BuildReadyTextAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
@@ -186,7 +186,7 @@ local function BuildTextAppearanceTab(container, group, style)
         end
     end
 
-    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons, nil, {
+    local _, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons, nil, {
         title = "Format String Advanced",
         build = BuildFormatPreviewAdvanced,
     })


### PR DESCRIPTION
## What Changed
- Removed unused first-return captures from config advanced-toggle and helper calls while preserving the returned button/order values that are still used.
- Kept the existing `local _, value = ...` convention already used elsewhere in the config settings code.

## Why This Changed
- These locals captured expanded-state or copy-value returns that the surrounding code never reads, which made the config UI code look like it had extra state dependencies.

## Developer Impact
- Config settings code is a little easier to scan because each call now names only the return value the caller actually uses.
- No player-facing behavior is intended to change.

## Validation
- `luac -p CooldownCompanion_Config/ConfigSettings/BarModeTabs.lua CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua CooldownCompanion_Config/ConfigSettings/GroupTabs.lua CooldownCompanion_Config/ConfigSettings/Helpers.lua CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua`
- `luac -p` across all tracked Lua files
- `git diff --check origin/cleanup...HEAD`
- Exact-name scan confirmed the removed capture names have no remaining references.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.