### PR TITLE
Route transformed spell add notices through addon chat output

### DIFF
--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1616,7 +1616,7 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
             local baseName = C_Spell.GetSpellName(id) or name
             local overrideName = C_Spell.GetSpellName(overrideID)
             if overrideName and overrideName ~= baseName then
-                print("|cff00ccffCooldown Companion:|r Added " .. baseName
+                self:Print("Added " .. baseName
                     .. " (currently showing as " .. overrideName
                     .. ") - tracks all spell variants.")
                 transformNotified = true


### PR DESCRIPTION
## What Players Will Notice
- When a transformed spell is added, the explanatory chat notice now uses Cooldown Companion's normal addon message path. Tracking behavior is unchanged.

## Why This Changed
- This was the only raw `print()` call left in addon Lua, while the surrounding add-button messages use the addon `:Print` helper.

## What Changed
- Replaced the hand-built chat prefix in `CooldownCompanion: AddButtonToGroup`'s transformed-spell notification with `self:Print(...)`.
- Left the transform detection and duplicate "Added spell" suppression behavior unchanged.

## Validation
- `rg -n "\bprint\(" CooldownCompanion CooldownCompanion_Config -g '*.lua'` returned no Lua matches after the change.
- `luac -p CooldownCompanion/Core/GroupManagement.lua`
- `luac -p` across all tracked Lua files
- `git diff --check`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static message-routing cleanup with no intended tracking behavior change.