### PR TITLE
Remove unused UI return-value captures

### DIFF
--- a/CooldownCompanion/Core/Keybinds.lua
+++ b/CooldownCompanion/Core/Keybinds.lua
@@ -418,7 +418,7 @@ function CooldownCompanion:RebuildAddonSlotBindings()
     -- Strategy 1: Scan GetBinding() for CLICK commands.
     -- Covers Bartender4, Dominos, and any addon using CLICK binding format.
     for i = 1, GetNumBindings() do
-        local command, category, key1 = GetBinding(i)
+        local command, _, key1 = GetBinding(i)
         if key1 and command then
             local frameName = command:match("^CLICK (.+):LeftButton$")
             if frameName then

--- a/CooldownCompanion_Config/Config/Diagnostics.lua
+++ b/CooldownCompanion_Config/Config/Diagnostics.lua
@@ -313,7 +313,7 @@ local function BuildDiagnosticSnapshot()
 
     local loadedAddons = {}
     for i = 1, C_AddOns.GetNumAddOns() do
-        local name, title, _, loadable, reason, security = C_AddOns.GetAddOnInfo(i)
+        local name, title = C_AddOns.GetAddOnInfo(i)
         local isLoaded = C_AddOns.IsAddOnLoaded(i)
         if isLoaded then
             local version = C_AddOns.GetAddOnMetadata(i, "Version")

--- a/CooldownCompanion_Config/ConfigSettings/BarModeTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/BarModeTabs.lua
@@ -206,7 +206,7 @@ local function BuildBarAppearanceTab(container, group, style)
         end
     end
 
-    local iconAdvExpanded, iconAdvBtn = AddAdvancedToggle(showIconCb, "barIcon", tabInfoButtons, style.showBarIcon ~= false, {
+    local _, iconAdvBtn = AddAdvancedToggle(showIconCb, "barIcon", tabInfoButtons, style.showBarIcon ~= false, {
         title = "Bar Icon Advanced",
         build = BuildBarIconAdvanced,
     })
@@ -240,7 +240,7 @@ local function BuildBarAppearanceTab(container, group, style)
         AddOffsetSliders(panel, style, "barNameTextOffsetX", "barNameTextOffsetY", {range = 50}, refreshStyle)
     end
 
-    local nameAdvExpanded, nameAdvBtn = AddAdvancedToggle(showNameCbBasic, "barNameText", tabInfoButtons, style.showBarNameText ~= false, {
+    local _, nameAdvBtn = AddAdvancedToggle(showNameCbBasic, "barNameText", tabInfoButtons, style.showBarNameText ~= false, {
         title = "Name Text Advanced",
         build = BuildBarNameTextAdvanced,
     })
@@ -308,7 +308,7 @@ local function BuildBarAppearanceTab(container, group, style)
         AddOffsetSliders(panel, style, "chargeXOffset", "chargeYOffset", {x = -2, y = 2}, refreshStyle)
     end
 
-    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false, {
+    local _, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "barChargeText", tabInfoButtons, style.showChargeText ~= false, {
         title = "Count Text Advanced",
         build = BuildBarChargeTextAdvanced,
     })
@@ -396,7 +396,7 @@ local function BuildBarAppearanceTab(container, group, style)
         AddFontControls(panel, style, "barReady", {sizeMin = 6, sizeMax = 24}, refreshStyle)
     end
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(showReadyCb, "barReadyText", tabInfoButtons, style.showBarReadyText, {
+    local _, readyAdvBtn = AddAdvancedToggle(showReadyCb, "barReadyText", tabInfoButtons, style.showBarReadyText, {
         title = "Ready Text Advanced",
         build = BuildBarReadyTextAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonSettingsOverrides.lua
@@ -175,7 +175,7 @@ local function AddTextOverrideSection(scroll, buttonData, group, infoButtons)
         end
     end
 
-    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons, nil, {
+    local _, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "buttonTextFormatPreview", infoButtons, nil, {
         title = "Format Override Advanced",
         build = BuildFormatOverridePreviewAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -2677,7 +2677,7 @@ local function BuildEffectsTab(container)
         end
     end
 
-    local swipeAdvExpanded, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive, {
+    local _, swipeAdvBtn = AddAdvancedToggle(swipeCb, "cooldownSwipe", tabInfoButtons, style.showCooldownSwipe ~= false and not iconFillTimerActive, {
         title = "Cooldown Swipe Advanced",
         build = BuildCooldownSwipeAdvanced,
     })
@@ -3274,7 +3274,7 @@ local function BuildAppearanceTab(container)
 
     end
 
-    local cdTextAdvExpanded, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText, {
+    local _, cdTextAdvBtn = AddAdvancedToggle(cdTextCb, "cooldownText", tabInfoButtons, style.showCooldownText, {
         title = "Cooldown Text Advanced",
         build = BuildCooldownTextAdvanced,
     })
@@ -3302,7 +3302,7 @@ local function BuildAppearanceTab(container)
         AddOffsetSliders(panel, style, "chargeXOffset", "chargeYOffset", { x = -2, y = 2 }, refreshStyle)
     end
 
-    local chargeAdvExpanded, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false, {
+    local _, chargeAdvBtn = AddAdvancedToggle(chargeTextCb, "chargeText", tabInfoButtons, style.showChargeText ~= false, {
         title = "Count Text Advanced",
         build = BuildChargeTextAdvanced,
     })
@@ -3347,7 +3347,7 @@ local function BuildAppearanceTab(container)
 
     end
 
-    local auraTextAdvExpanded, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false, {
+    local _, auraTextAdvBtn = AddAdvancedToggle(auraTextCb, "auraText", tabInfoButtons, style.showAuraText ~= false, {
         title = "Aura Duration Text Advanced",
         build = BuildAuraDurationTextAdvanced,
     })
@@ -3383,7 +3383,7 @@ local function BuildAppearanceTab(container)
 
     end
 
-    local auraStackAdvExpanded, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
+    local _, auraStackAdvBtn = AddAdvancedToggle(auraStackCb, "auraStackText", tabInfoButtons, style.showAuraStackText ~= false, {
         title = "Aura Stack Text Advanced",
         build = BuildAuraStackTextAdvanced,
     })
@@ -3425,7 +3425,7 @@ local function BuildAppearanceTab(container)
         AddColorPicker(panel, style, "keybindFontColor", "Font Color", {1, 1, 1, 1}, true, refreshStyle, refreshStyle)
     end
 
-    local kbAdvExpanded, kbAdvBtn = AddAdvancedToggle(kbCb, "keybindText", tabInfoButtons, style.showKeybindText, {
+    local _, kbAdvBtn = AddAdvancedToggle(kbCb, "keybindText", tabInfoButtons, style.showKeybindText, {
         title = KEYBIND_CUSTOM_LABEL .. " Advanced",
         build = BuildKeybindTextAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/Helpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/Helpers.lua
@@ -856,7 +856,7 @@ local function BuildCompactModeControls(container, group, tabInfoButtons)
         }, tabInfoButtons)
     end
 
-    local compactAdvExpanded, compactAdvBtn = AddAdvancedToggle(compactCb, "compactLayout", tabInfoButtons, group.compactLayout, {
+    local _, compactAdvBtn = AddAdvancedToggle(compactCb, "compactLayout", tabInfoButtons, group.compactLayout, {
         title = "Compact Mode Advanced",
         build = BuildCompactAdvanced,
     })
@@ -1030,7 +1030,7 @@ local CHARACTER_COPY_TOOLTIP_DETAILS = {
 }
 
 local function CreateCharacterCopyButton(enableCb, systemKey, label, onCopied)
-    local copyValues, copyOrder = CooldownCompanion:GetCharacterScopedSettingsCopyOptions(systemKey)
+    local _, copyOrder = CooldownCompanion:GetCharacterScopedSettingsCopyOptions(systemKey)
     if #copyOrder == 0 then return end
 
     -- Pool one button per systemKey to avoid frame leaks across panel rebuilds

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -857,7 +857,7 @@ function HealthResource.BuildColorControls(container, settings, applyBars)
         CooldownCompanion:RefreshConfigPanel()
     end)
     container:AddChild(lowHealthAlertCb)
-    local lowHealthAlertAdvancedExpanded, lowHealthAlertAdvancedBtn = HealthResource.AddEffectStyleControls(container, lowHealthAlertCb, health, {
+    local _, lowHealthAlertAdvancedBtn = HealthResource.AddEffectStyleControls(container, lowHealthAlertCb, health, {
         enabledKey = "showLowHealthAlert",
         advancedKey = "healthLowHealthAlert",
         colorKey = "healthLowHealthAlertColor",

--- a/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
+++ b/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
@@ -1757,7 +1757,7 @@ local function BuildTextColorsControls(container, styleTable, refreshCallback)
         panel:AddChild(readyTextBox)
     end
 
-    local readyAdvExpanded, readyAdvBtn = AddAdvancedToggle(readyColorPicker, "textReadyText", tabInfoButtons, nil, {
+    local _, readyAdvBtn = AddAdvancedToggle(readyColorPicker, "textReadyText", tabInfoButtons, nil, {
         title = "Ready Color Advanced",
         build = BuildReadyTextAdvanced,
     })

--- a/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/TextModeTabs.lua
@@ -186,7 +186,7 @@ local function BuildTextAppearanceTab(container, group, style)
         end
     end
 
-    local fmtPreviewAdvExpanded, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons, nil, {
+    local _, fmtPreviewAdvBtn = AddAdvancedToggle(fmtHeading, "textFormatPreview", tabInfoButtons, nil, {
         title = "Format String Advanced",
         build = BuildFormatPreviewAdvanced,
     })


### PR DESCRIPTION
## What Changed
- Replaced unused first-return locals from advanced-toggle and copy-option helpers with `_`, matching the existing convention for intentionally ignored tuple values.
- Stopped naming unused add-on info tuple slots in the diagnostics snapshot loop.
- Preserved the companion return values that are still used for button anchoring, promote badges, keybind scanning, and copy-menu availability.

## Why This Changed
- These names implied expanded-state, copy-value, or add-on metadata was consumed when only later return values mattered.
- Keeping unused tuple captures named makes dense config UI builders harder to scan during maintenance.

## Developer Impact
- Future config and diagnostics maintenance has fewer misleading locals to chase.
- No player-facing behavior is intended to change.

## Validation
- Exact declaration scan for the cleaned-up locals found no remaining declaration-only candidates except the intentionally retained LibSharedMedia load assertion in `CooldownCompanion/Core/Init.lua`.
- `luac -p` passed for all 96 tracked Lua files.
- `git diff --check` passed; output only included the usual LF-to-CRLF working-copy warnings.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup.