### PR TITLE
Remove dead trigger panel line counter

### DIFF
--- a/CooldownCompanion/Core/AuraTextures.lua
+++ b/CooldownCompanion/Core/AuraTextures.lua
@@ -954,22 +954,6 @@ function CooldownCompanion.SanitizeTriggerPanelTextValue(value)
     return value
 end
 
-function CooldownCompanion.CountTriggerPanelTextLines(value)
-    value = CooldownCompanion.NormalizeTriggerPanelTextLineEndings(value)
-    if value == "" then
-        return 1
-    end
-
-    local lineCount = 1
-    for index = 1, #value do
-        if value:sub(index, index) == "\n" then
-            lineCount = lineCount + 1
-        end
-    end
-
-    return lineCount
-end
-
 function CooldownCompanion:GetTriggerPanelDisplayType(groupOrId, createIfMissing)
     local group = ResolveGroup(groupOrId)
     if type(group) ~= "table" then


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion.CountTriggerPanelTextLines` helper from trigger panel text settings code.

## Why This Changed
- Exact reference scans showed the helper had no call sites, while the active trigger text path already normalizes line endings and enforces text limits through `SanitizeTriggerPanelTextValue` plus the config UI counters.

## Developer Impact
- Keeps trigger panel text maintenance focused on the live sanitizer/normalizer path instead of carrying a duplicate dead line-count helper.

## Validation
- `rg -n "CountTriggerPanelTextLines" .` returned no matches after removal.
- `luac -p CooldownCompanion\Core\AuraTextures.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the repo's usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.