### PR TITLE
Remove dead no-cooldown spell helpers

### DIFF
--- a/CooldownCompanion/Core/SpellQueries.lua
+++ b/CooldownCompanion/Core/SpellQueries.lua
@@ -311,15 +311,6 @@ function ST.HasPositiveResourceGateCost(spellId)
     return HasPositivePowerCost(spellId, IsResourceGatedNoCooldownPowerType)
 end
 
-function ST.HasPositiveRuneCost(spellId)
-    local runePowerType = Enum and Enum.PowerType and Enum.PowerType.Runes
-    if runePowerType == nil then return false end
-
-    return HasPositivePowerCost(spellId, function(powerType)
-        return powerType == runePowerType
-    end)
-end
-
 local function HasBaseCooldown(spellId)
     local baseCd = GetSpellBaseCooldown(spellId)
     return baseCd and baseCd > 0
@@ -335,14 +326,6 @@ end
 -- Returns true if the spell has no real cooldown surface (GCD-only).
 function ST.IsNoCooldownSpell(spellId)
     return not ST.HasSpellCooldownSurface(spellId)
-end
-
-function ST.IsRuneCostNoCooldownSpell(spellId)
-    return ST.HasPositiveRuneCost(spellId) and ST.IsNoCooldownSpell(spellId)
-end
-
-function ST.IsResourceGateNoCooldownSpell(spellId)
-    return ST.HasPositiveResourceGateCost(spellId) and ST.IsNoCooldownSpell(spellId)
 end
 
 -- Returns true if the spell tooltip contains a UsageRequirement line


### PR DESCRIPTION
## What Changed
- Removed unused shared helpers for rune-only and resource-gate no-cooldown spell classification from `CooldownCompanion/Core/SpellQueries.lua`.
- Left the live `ST.IsNoCooldownSpell` and `ST.HasPositiveResourceGateCost` paths unchanged.

## Why This Changed
- Exact repository scans showed `ST.HasPositiveRuneCost`, `ST.IsRuneCostNoCooldownSpell`, and `ST.IsResourceGateNoCooldownSpell` had no addon-owned call sites.
- Keeping stale spell-query exports around makes the cooldown helper surface harder to audit.

## Developer Impact
- Future cooldown-query maintenance has fewer redundant helper names to reason about.
- The active resource-gate no-cooldown behavior continues through the existing direct callers.

## Validation
- `rg -n "HasPositiveRuneCost|IsRuneCostNoCooldownSpell|IsResourceGateNoCooldownSpell" CooldownCompanion CooldownCompanion_Config -g '*.lua' -g '!CooldownCompanion/Libs/**'` returned no matches after removal.
- `luac -p CooldownCompanion/Core/SpellQueries.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only dead-helper cleanup with no intended runtime behavior change.