### PR TITLE
Remove dead trigger summary helpers

### DIFF
--- a/CooldownCompanion/Core/AuraTextures.lua
+++ b/CooldownCompanion/Core/AuraTextures.lua
@@ -31,7 +31,6 @@ local function IsRuntimeItemLike(buttonData)
 end
 local string_gsub = string.gsub
 local string_upper = string.upper
-local table_concat = table.concat
 local tonumber = tonumber
 local type = type
 
@@ -697,12 +696,6 @@ local function NormalizeAuraTextureSettings(settings)
     return settings
 end
 
-function CooldownCompanion:IsAuraTextureButtonSupported(buttonData)
-    return type(buttonData) == "table"
-        and buttonData.type == "spell"
-        and (buttonData.auraTracking == true or buttonData.isPassive == true)
-end
-
 function CooldownCompanion:IsTexturePanelGroup(group)
     return type(group) == "table" and group.displayMode == "textures"
 end
@@ -1335,34 +1328,6 @@ function CooldownCompanion:RemoveTriggerConditionClause(buttonData, clauseIndex)
     table.remove(clauses, clauseIndex)
     self:SetTriggerConditionClauses(buttonData, clauses)
     return true
-end
-
-function CooldownCompanion:GetTriggerConditionSummary(buttonData)
-    if type(buttonData) ~= "table" then
-        return nil
-    end
-
-    local summaries = {}
-    for _, clause in ipairs(self:GetTriggerConditionClauses(buttonData)) do
-        local conditionKey = NormalizeTriggerConditionKey(buttonData, clause.key)
-        local conditionLabel = TRIGGER_CONDITION_LABELS[conditionKey]
-        local stateLabel
-        if TRIGGER_EXPECTED_LABELS[conditionKey] ~= nil then
-            stateLabel = (TRIGGER_EXPECTED_LABELS[conditionKey] or TRIGGER_EXPECTED_LABELS.cooldownActive)[clause.expected == false and "false" or "true"]
-        else
-            local stateKey = NormalizeTriggerStateKey(conditionKey, clause.state)
-            stateLabel = TRIGGER_STATE_LABELS[conditionKey] and TRIGGER_STATE_LABELS[conditionKey][stateKey]
-        end
-        if conditionLabel and stateLabel then
-            summaries[#summaries + 1] = conditionLabel .. " " .. stateLabel
-        end
-    end
-
-    if #summaries == 0 then
-        return nil
-    end
-
-    return table_concat(summaries, " AND ")
 end
 
 function CooldownCompanion:GetCompactTriggerConditionSummary(buttonData, maxVisibleClauses)


### PR DESCRIPTION
## What Changed
- Removed two definition-only helpers from `CooldownCompanion/Core/AuraTextures.lua`: `IsAuraTextureButtonSupported` and the older full `GetTriggerConditionSummary`.
- Removed the `table.concat` alias that only served the deleted full-summary helper.

## Why This Changed
- Exact-name scans showed both helpers had no in-repo call sites; the live trigger panel UI uses `GetCompactTriggerConditionSummary` for condition rows.

## Developer Impact
- Keeps the texture/trigger-panel helper surface smaller and removes stale summary logic that future changes could mistake for live behavior.

## Validation
- `rg -n "IsAuraTextureButtonSupported|GetTriggerConditionSummary|table_concat" CooldownCompanion\Core\AuraTextures.lua` returned no matches.
- `rg -n "GetCompactTriggerConditionSummary|IsTexturePanelGroup|IsTriggerPanelGroup|IsStandaloneTexturePanelGroup" CooldownCompanion CooldownCompanion_Config -g '*.lua'` confirmed the live related helpers remain.
- `luac -p CooldownCompanion\Core\AuraTextures.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed, with only the usual LF-to-CRLF checkout warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is static-only dead-code cleanup.