### PR TITLE
Remove unused cooldown state helpers

### DIFF
--- a/CooldownCompanion/Core/CooldownLogic.lua
+++ b/CooldownCompanion/Core/CooldownLogic.lua
@@ -17,28 +17,6 @@ CooldownLogic.CHARGE_STATE_FULL = "full"
 CooldownLogic.CHARGE_STATE_MISSING = "missing"
 CooldownLogic.CHARGE_STATE_ZERO = "zero"
 
-local COOLDOWN_STATE_PRIORITY = {
-    [CooldownLogic.STATE_READY] = 1,
-    [CooldownLogic.STATE_GCD] = 1,
-    [CooldownLogic.STATE_COOLDOWN] = 3,
-}
-
-function CooldownLogic.GetCooldownStatePriority(state)
-    return COOLDOWN_STATE_PRIORITY[state] or 0
-end
-
-function CooldownLogic.SelectStrongerCooldownState(a, b)
-    if CooldownLogic.GetCooldownStatePriority(b and b.state) >
-            CooldownLogic.GetCooldownStatePriority(a and a.state) then
-        return b
-    end
-    return a
-end
-
-function CooldownLogic.IsRealCooldownState(state)
-    return state == CooldownLogic.STATE_COOLDOWN
-end
-
 function CooldownLogic.IsSpellGCDOnly(info, options)
     if not info then
         return false


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownLogic.GetCooldownStatePriority`, `CooldownLogic.SelectStrongerCooldownState`, and `CooldownLogic.IsRealCooldownState` helpers, plus the private priority table that only supported the unused selector.

## Why This Changed
- Exact source-wide scans showed the selector and predicate had no runtime or config callers; the priority helper was only referenced by the unused selector.

## Developer Impact
- Keeps the cooldown logic module focused on the state constants and GCD helper paths that are still actively consumed.

## Validation
- `rg -n "GetCooldownStatePriority|SelectStrongerCooldownState|IsRealCooldownState|COOLDOWN_STATE_PRIORITY" CooldownCompanion CooldownCompanion_Config -g '*.lua'` returned no matches after removal.
- `luac -p CooldownCompanion\Core\CooldownLogic.lua`
- `luac -p` across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- In-game, DevBridge, combat, and restricted-content validation were not run; this is a static-only cleanup with no intended behavior change.