### PR TITLE
Remove dead texture selection label helper

### DIFF
--- a/CooldownCompanion/Core/AuraTexturesPicker.lua
+++ b/CooldownCompanion/Core/AuraTexturesPicker.lua
@@ -485,14 +485,6 @@ function CooldownCompanion:CreateTexturePanelSelection(entry, baseSettings)
     return NormalizeAuraTextureSettings(selection)
 end
 
-function CooldownCompanion:GetTexturePanelSelectionLabel(groupOrId)
-    local settings = self:GetTexturePanelSettings(groupOrId)
-    if not settings or not settings.sourceType then
-        return nil
-    end
-    return settings.label or tostring(settings.sourceValue)
-end
-
 function CooldownCompanion:EnsureAuraTextureLibraryStore()
     local profile = self.db and self.db.profile
     if not profile then


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion:GetTexturePanelSelectionLabel` helper from the aura texture picker code.

## Why This Changed
- Exact repo-wide search showed the helper was only referenced by its own definition, leaving a stale exported texture-picker surface after the current selection/apply path moved elsewhere.

## Developer Impact
- Keeps the aura texture picker API smaller and avoids future maintainers chasing an unused label accessor.

## Validation
- `rg -n "GetTexturePanelSelectionLabel" .` returned no matches after removal.
- `luac -p CooldownCompanion/Core/AuraTexturesPicker.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- In-game, DevBridge, combat, and restricted-content validation were not run; this is a static-only dead-helper removal with no intended runtime behavior change.