### PR TITLE
Remove unused Bars & Frames runtime helper

### DIFF
--- a/CooldownCompanion/Core/BarsAndFramesRuntime.lua
+++ b/CooldownCompanion/Core/BarsAndFramesRuntime.lua
@@ -113,10 +113,6 @@ function CooldownCompanion:RefreshBarsAndFramesRuntimeFeatureGate(feature, reaso
     return enabled == true and flags and flags[feature] == true, flags
 end
 
-function CooldownCompanion:IsBarsAndFramesRuntimeEnabled()
-    return runtime.enabled == true
-end
-
 function CooldownCompanion:IsBarsAndFramesRuntimeFeatureEnabled(feature)
     return runtime.enabled == true and runtime.flags and runtime.flags[feature] == true
 end


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion:IsBarsAndFramesRuntimeEnabled` wrapper from `Core/BarsAndFramesRuntime.lua`.

## Why This Changed
- Repo-wide exact-symbol scans showed the wrapper had no callers; the live runtime checks use `IsBarsAndFramesRuntimeFeatureEnabled`, `RefreshBarsAndFramesRuntimeFeatureGate`, and the diagnostics debug snapshot instead.

## Developer Impact
- Keeps the Bars & Frames runtime gate surface smaller and reduces stale helper noise around the feature-specific gate that the addon actually uses.

## Validation
- `rg -n "IsBarsAndFramesRuntimeEnabled" .` returned no matches after removal.
- `luac -p CooldownCompanion\Core\BarsAndFramesRuntime.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the existing LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only dead-helper cleanup with no intended runtime behavior change.