### PR TITLE
Remove dead custom bar sound preview helper

### DIFF
--- a/CooldownCompanion/Core/SoundAlerts.lua
+++ b/CooldownCompanion/Core/SoundAlerts.lua
@@ -759,10 +759,6 @@ function CooldownCompanion:PreviewSoundAlertSelection(buttonData, soundName)
     return PlaySharedMediaSound(soundName, self:GetButtonSoundAlertChannel(buttonData), GetButtonSpeechText(buttonData))
 end
 
-function CooldownCompanion:PreviewCustomBarSoundAlertSelection(customBar, soundName)
-    return PlaySharedMediaSound(soundName, self:GetCustomBarSoundAlertChannel(customBar), GetCustomBarSpeechText(customBar))
-end
-
 function CooldownCompanion:PreviewTriggerPanelSoundAlertSelection(groupOrId, soundName)
     local group = ResolveGroup(groupOrId)
     return PlaySharedMediaSound(soundName, DEFAULT_SOUND_CHANNEL, GetTriggerPanelSpeechText(group))


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion:PreviewCustomBarSoundAlertSelection` helper from `CooldownCompanion/Core/SoundAlerts.lua`.

## Why This Changed
- Exact source scans showed the helper had no in-repo callers, while custom bar sound alert configuration and runtime playback still use the active `Get/Set/PlayCustomBarSoundAlertEvent` path.

## Developer Impact
- Keeps the sound-alert API surface smaller and avoids carrying a custom-bar preview wrapper that is not wired into the config UI.

## Validation
- `rg -n "PreviewCustomBarSoundAlertSelection" . -g '*.lua'` returned no matches after removal.
- `luac -p CooldownCompanion\Core\SoundAlerts.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.