### PR TITLE
Remove dead folder filter setters

### DIFF
--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -1194,69 +1194,6 @@ function CooldownCompanion:ApplyFolderSpecFilterToChildren(folderId)
     end
 end
 
-function CooldownCompanion:SetFolderSpecs(folderId, specs)
-    local db = self.db and self.db.profile
-    local folder = db and db.folders and db.folders[folderId]
-    if not folder then return false end
-    local oldSpecs = folder.specs and CopyTable(folder.specs) or nil
-
-    if specs and next(specs) then
-        local normalizedSpecs = {}
-        for specId, enabled in pairs(specs) do
-            local numSpecId = tonumber(specId)
-            if enabled and numSpecId then
-                normalizedSpecs[numSpecId] = true
-            end
-        end
-        folder.specs = next(normalizedSpecs) and normalizedSpecs or nil
-    else
-        folder.specs = nil
-    end
-
-    -- Hero filters must remain scoped to selected specs.
-    if folder.heroTalents and next(folder.heroTalents) then
-        if not (folder.specs and next(folder.specs)) then
-            folder.heroTalents = nil
-        elseif oldSpecs then
-            for specId in pairs(oldSpecs) do
-                if not folder.specs[specId] then
-                    -- Works for folders too; CleanHeroTalentsForSpec only mutates .heroTalents
-                    self:CleanHeroTalentsForSpec(folder, specId)
-                end
-            end
-        end
-    end
-
-    self:ApplyFolderSpecFilterToChildren(folderId)
-    self:RefreshAllGroups()
-    self:RefreshConfigPanel()
-    return true
-end
-
-function CooldownCompanion:SetFolderHeroTalent(folderId, subTreeID, enabled)
-    local db = self.db and self.db.profile
-    local folder = db and db.folders and db.folders[folderId]
-    if not folder then return false end
-    if not (folder.specs and next(folder.specs)) then return false end
-
-    if enabled then
-        if not folder.heroTalents then folder.heroTalents = {} end
-        folder.heroTalents[subTreeID] = true
-    else
-        if folder.heroTalents then
-            folder.heroTalents[subTreeID] = nil
-            if not next(folder.heroTalents) then
-                folder.heroTalents = nil
-            end
-        end
-    end
-
-    self:ApplyFolderSpecFilterToChildren(folderId)
-    self:RefreshAllGroups()
-    self:RefreshConfigPanel()
-    return true
-end
-
 function CooldownCompanion:IsHeroTalentAllowed(group)
     local effectiveHeroTalents, _, hasHeroTalentFilter = self:GetEffectiveHeroTalents(group)
     if not hasHeroTalentFilter then return true end


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion:SetFolderSpecs` and `CooldownCompanion:SetFolderHeroTalent` wrapper methods from `CooldownCompanion/Core/GroupOperations.lua`.

## Why This Changed
- Exact repo-wide scans showed both methods had no callers, while the live folder eligibility UI updates `folder.specs` / `folder.heroTalents` through the shared eligibility controls and refreshes child containers through `ApplyFolderSpecFilterToChildren`.

## Developer Impact
- Keeps folder load-condition maintenance focused on the active shared eligibility path instead of leaving stale duplicate setters around the same data.

## Validation
- `rg -n "SetFolderSpecs|SetFolderHeroTalent" .` returned no matches after removal.
- `luac -p CooldownCompanion\Core\GroupOperations.lua`
- `luac -p` passed across all tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.