### PR TITLE
Improve bar timer performance with native duration text updates

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -83,6 +83,9 @@ local IsItemEquippable = CooldownCompanion.IsItemEquippable
 local IsEntryItemLike = CooldownCompanion.IsEntryItemLike
 local ResolveEffectiveItem = CooldownCompanion.ResolveEffectiveItem
 local FormatTime = CooldownCompanion.FormatTime
+local BindDurationText = CooldownCompanion.BindDurationText or function() return false end
+local UnbindDurationText = CooldownCompanion.UnbindDurationText or function() end
+local RecordDurationTextManualUpdate = CooldownCompanion.RecordDurationTextManualUpdate or function() end
 local ApplyFontStyle = CooldownCompanion.ApplyFontStyle
 
 -- Bar mode tooltip behavior: tooltip should come from hovering the icon area only.
@@ -1000,15 +1003,23 @@ local function ApplyBarAuraStackVisual(button, stackValue, stackValueAvailable)
     end
 end
 
--- Lightweight OnUpdate: keeps time text fresh while native StatusBar timers drive fill motion.
-local function SetBarTimeText(button, text)
+-- Manual text helpers unbind native duration text before writing fallback text.
+local function SetBarTimeText(button, text, countManualDurationText)
+    UnbindDurationText(button.timeText)
+    if countManualDurationText then
+        RecordDurationTextManualUpdate("bar")
+    end
     if button._lastBarTimeText ~= text then
         button._lastBarTimeText = text
         button.timeText:SetText(text)
     end
 end
 
-local function SetBarTimeFormattedText(button, fmt, value)
+local function SetBarTimeFormattedText(button, fmt, value, countManualDurationText)
+    UnbindDurationText(button.timeText)
+    if countManualDurationText then
+        RecordDurationTextManualUpdate("bar")
+    end
     button._lastBarTimeText = nil
     button.timeText:SetFormattedText(fmt, value)
 end
@@ -1134,23 +1145,25 @@ local function UpdateBarFill(button)
                     or (button.style.cooldownFontColor or DEFAULT_WHITE)
                 button.timeText:SetTextColor(cc[1], cc[2], cc[3], cc[4])
             end
-            -- Time text: HasSecretValues() returns a non-secret boolean.
-            -- Non-secret: full duration-format examples ("1:30", "45", "8.7", etc.)
-            -- Secret: pass the secret number through C++ SetFormattedText with the closest specifier.
+            -- Eligible DurationObjects use native text binding; other timer sources stay on the manual path.
             local durationStyle = button.style
             local secretFormatSpec = GetDurationSecretFormatSpec(durationStyle)
             if previewRemaining and previewRemaining > 0 then
-                SetBarTimeText(button, FormatTime(previewRemaining, durationStyle))
+                SetBarTimeText(button, FormatTime(previewRemaining, durationStyle), true)
             elseif button._durationObj then
-                local remaining = button._durationObj:GetRemainingDuration()
-                if not button._durationObj:HasSecretValues() then
-                    if remaining > 0 then
-                        SetBarTimeText(button, FormatTime(remaining, durationStyle))
-                    else
-                        SetBarTimeText(button, "")
-                    end
+                if BindDurationText(button.timeText, button._durationObj, durationStyle, "bar") then
+                    button._lastBarTimeText = nil
                 else
-                    SetBarTimeFormattedText(button, secretFormatSpec, remaining)
+                    local remaining = button._durationObj:GetRemainingDuration()
+                    if not button._durationObj:HasSecretValues() then
+                        if remaining > 0 then
+                            SetBarTimeText(button, FormatTime(remaining, durationStyle), true)
+                        else
+                            SetBarTimeText(button, "")
+                        end
+                    else
+                        SetBarTimeFormattedText(button, secretFormatSpec, remaining, true)
+                    end
                 end
             elseif button._viewerBar then
                 -- Totem: viewer bar values may be secret (set by Blizzard's internal totem tracking).
@@ -1158,14 +1171,16 @@ local function UpdateBarFill(button)
                 -- secure code sets it, so the widget reports plain — but the actual
                 -- number returned by GetValue() is a secret wrapper).
                 -- Always use SetFormattedText for secret-safe pass-through.
-                SetBarTimeFormattedText(button, secretFormatSpec, button._viewerBar:GetValue())
+                SetBarTimeFormattedText(button, secretFormatSpec, button._viewerBar:GetValue(), true)
             else
                 if itemRemaining > 0 then
-                    SetBarTimeText(button, FormatTime(itemRemaining, durationStyle))
+                    SetBarTimeText(button, FormatTime(itemRemaining, durationStyle), true)
                 else
                     SetBarTimeText(button, "")
                 end
             end
+        else
+            SetBarTimeText(button, "")
         end
     else
         ClearBarAuraStackVisual(button)

--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1147,30 +1147,18 @@ local function UpdateBarFill(button)
             end
             -- Eligible DurationObjects use native text binding; other timer sources stay on the manual path.
             local durationStyle = button.style
-            local secretFormatSpec = GetDurationSecretFormatSpec(durationStyle)
             if previewRemaining and previewRemaining > 0 then
                 SetBarTimeText(button, FormatTime(previewRemaining, durationStyle), true)
             elseif button._durationObj then
-                if BindDurationText(button.timeText, button._durationObj, durationStyle, "bar") then
-                    button._lastBarTimeText = nil
-                else
-                    local remaining = button._durationObj:GetRemainingDuration()
-                    if not button._durationObj:HasSecretValues() then
-                        if remaining > 0 then
-                            SetBarTimeText(button, FormatTime(remaining, durationStyle), true)
-                        else
-                            SetBarTimeText(button, "")
-                        end
-                    else
-                        SetBarTimeFormattedText(button, secretFormatSpec, remaining, true)
-                    end
-                end
+                button._lastBarTimeText = nil
+                BindDurationText(button.timeText, button._durationObj, durationStyle, "bar")
             elseif button._viewerBar then
                 -- Totem: viewer bar values may be secret (set by Blizzard's internal totem tracking).
                 -- HasSecretValues() on the viewer StatusBar is unreliable (Blizzard's
                 -- secure code sets it, so the widget reports plain — but the actual
                 -- number returned by GetValue() is a secret wrapper).
                 -- Always use SetFormattedText for secret-safe pass-through.
+                local secretFormatSpec = GetDurationSecretFormatSpec(durationStyle)
                 SetBarTimeFormattedText(button, secretFormatSpec, button._viewerBar:GetValue(), true)
             else
                 if itemRemaining > 0 then

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -400,7 +400,7 @@ local function IsDurationTextBindingSupported()
 end
 CooldownCompanion.IsDurationTextBindingSupported = IsDurationTextBindingSupported
 
-local function UnbindDurationText(fontString)
+local function UnbindDurationText(fontString, clearText)
     if not fontString then return end
 
     local binding = fontString._ccDurationTextBinding
@@ -413,7 +413,7 @@ local function UnbindDurationText(fontString)
     fontString._ccDurationTextBindingActive = nil
     fontString._ccDurationTextDuration = nil
     fontString._ccDurationTextFormatterKey = nil
-    if wasActive and fontString.SetText then
+    if (wasActive or clearText) and fontString.SetText then
         fontString:SetText("")
     end
 end
@@ -424,14 +424,14 @@ local function BindDurationText(fontString, durationObj, source, surface)
 
     if not (fontString and durationObj and IsDurationTextBindingSupported()) then
         IncrementDurationTextCounter("unsupported")
-        UnbindDurationText(fontString)
+        UnbindDurationText(fontString, true)
         return false
     end
 
     local formatter, formatKey = GetDurationTextFormatter(source)
     if not formatter then
         IncrementDurationTextCounter("unsupported")
-        UnbindDurationText(fontString)
+        UnbindDurationText(fontString, true)
         return false
     end
 
@@ -440,6 +440,7 @@ local function BindDurationText(fontString, durationObj, source, surface)
         binding = C_DurationUtil.CreateDurationTextBinding()
         if not DurationTextBindingHasMethods(binding) then
             IncrementDurationTextCounter("unsupported")
+            UnbindDurationText(fontString, true)
             return false
         end
 
@@ -452,6 +453,7 @@ local function BindDurationText(fontString, durationObj, source, surface)
         IncrementDurationTextCounter("bindingsCreated")
     elseif not fontString._ccDurationTextBindingReady and not DurationTextBindingHasMethods(binding) then
         IncrementDurationTextCounter("unsupported")
+        UnbindDurationText(fontString, true)
         return false
     else
         fontString._ccDurationTextBindingReady = true

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -110,6 +110,20 @@ CooldownCompanion.DURATION_FORMAT_DECIMAL_UNDER_10 = DURATION_FORMAT_DECIMAL_UND
 CooldownCompanion.DURATION_FORMAT_DECIMAL_UNDER_60 = DURATION_FORMAT_DECIMAL_UNDER_60
 
 local secondsFormatterCache = {}
+local durationTextFormatterCache = {}
+local durationTextBindingCounters = {
+    bindAttempts = 0,
+    bindSuccesses = 0,
+    bindingsCreated = 0,
+    bindingsReused = 0,
+    formatterUpdates = 0,
+    durationUpdates = 0,
+    unbinds = 0,
+    unsupported = 0,
+    manualUpdates = 0,
+    manualUpdatesBySurface = {},
+    nativeBindsBySurface = {},
+}
 
 local function NormalizeDurationFormat(value, decimalTimers)
     if DURATION_FORMAT_SET[value] then
@@ -219,6 +233,259 @@ local function GetDurationSecretFormatSpec(source)
     return "%.0f"
 end
 CooldownCompanion.GetDurationSecretFormatSpec = GetDurationSecretFormatSpec
+
+local function IncrementDurationTextCounter(key, surface)
+    durationTextBindingCounters[key] = (durationTextBindingCounters[key] or 0) + 1
+    if surface then
+        local bySurfaceKey = key == "manualUpdates" and "manualUpdatesBySurface" or "nativeBindsBySurface"
+        local bySurface = durationTextBindingCounters[bySurfaceKey]
+        bySurface[surface] = (bySurface[surface] or 0) + 1
+    end
+end
+
+function CooldownCompanion:GetDurationTextBindingDebugCounters()
+    return durationTextBindingCounters
+end
+
+function CooldownCompanion:ResetDurationTextBindingDebugCounters()
+    for key, value in pairs(durationTextBindingCounters) do
+        if type(value) == "table" then
+            for childKey in pairs(value) do
+                value[childKey] = nil
+            end
+        else
+            durationTextBindingCounters[key] = 0
+        end
+    end
+    for key in pairs(durationTextFormatterCache) do
+        durationTextFormatterCache[key] = nil
+    end
+end
+
+function CooldownCompanion.RecordDurationTextManualUpdate(surface)
+    IncrementDurationTextCounter("manualUpdates", surface)
+end
+
+local function GetDurationTextRoundingDown()
+    return GetEnumValue("NumericRuleFormatRounding", "Down", 2)
+end
+
+local function FloorComponent(divisor, modulo)
+    return {
+        div = divisor,
+        mod = modulo,
+        step = 1,
+        rounding = GetDurationTextRoundingDown(),
+    }
+end
+
+local function AddFloorBreakpoint(formatter, threshold, format)
+    formatter:AddBreakpoint({
+        threshold = threshold,
+        step = 1,
+        rounding = GetDurationTextRoundingDown(),
+        format = format,
+    })
+end
+
+local function AddClockBreakpoints(formatter, decimalThreshold)
+    if decimalThreshold and decimalThreshold > 0 then
+        formatter:AddBreakpoint({
+            threshold = 0,
+            format = "%.1f",
+        })
+    else
+        AddFloorBreakpoint(formatter, 0, "%.0f")
+    end
+
+    if decimalThreshold == 10 then
+        AddFloorBreakpoint(formatter, 10, "%.0f")
+    end
+
+    formatter:AddBreakpoint({
+        threshold = 60,
+        format = "%.0f:%02.0f",
+        components = {
+            FloorComponent(60),
+            FloorComponent(nil, 60),
+        },
+    })
+    formatter:AddBreakpoint({
+        threshold = 3600,
+        format = "%.0f:%02.0f:%02.0f",
+        components = {
+            FloorComponent(3600),
+            FloorComponent(60, 60),
+            FloorComponent(nil, 60),
+        },
+    })
+end
+
+local function AddUnitsBreakpoints(formatter)
+    AddFloorBreakpoint(formatter, 0, "%.0fs")
+    formatter:AddBreakpoint({
+        threshold = 60,
+        format = "%.0fm %.0fs",
+        components = {
+            FloorComponent(60),
+            FloorComponent(nil, 60),
+        },
+    })
+    formatter:AddBreakpoint({
+        threshold = 3600,
+        format = "%.0fh %.0fm",
+        components = {
+            FloorComponent(3600),
+            FloorComponent(60, 60),
+        },
+    })
+end
+
+local function CreateDurationTextFormatter(formatKey)
+    if not (C_StringUtil and C_StringUtil.CreateNumericRuleFormatter) then
+        return nil
+    end
+
+    local formatter = C_StringUtil.CreateNumericRuleFormatter()
+    if not (formatter and type(formatter.AddBreakpoint) == "function") then
+        return nil
+    end
+
+    if formatKey == DURATION_FORMAT_UNITS then
+        AddUnitsBreakpoints(formatter)
+    elseif formatKey == DURATION_FORMAT_DECIMAL_UNDER_10 then
+        AddClockBreakpoints(formatter, 10)
+    elseif formatKey == DURATION_FORMAT_DECIMAL_UNDER_60 then
+        AddClockBreakpoints(formatter, 60)
+    else
+        AddClockBreakpoints(formatter)
+    end
+
+    return formatter
+end
+
+local function GetDurationTextFormatter(source)
+    local formatKey = GetDurationFormat(source)
+    local cached = durationTextFormatterCache[formatKey]
+    if cached ~= nil then
+        if cached == false then
+            return nil, formatKey
+        end
+        return cached, formatKey
+    end
+
+    local formatter = CreateDurationTextFormatter(formatKey)
+    durationTextFormatterCache[formatKey] = formatter or false
+    return formatter, formatKey
+end
+
+local function DurationTextBindingHasMethods(binding)
+    return binding
+        and type(binding.SetFontString) == "function"
+        and type(binding.SetDuration) == "function"
+        and type(binding.SetFormatter) == "function"
+        and type(binding.SetUpdateInterval) == "function"
+        and type(binding.SetZeroDurationText) == "function"
+        and type(binding.SetExpiredText) == "function"
+        and type(binding.Enable) == "function"
+        and type(binding.Disable) == "function"
+end
+
+local function IsDurationTextBindingSupported()
+    return C_DurationUtil
+        and type(C_DurationUtil.CreateDurationTextBinding) == "function"
+        and C_StringUtil
+        and type(C_StringUtil.CreateNumericRuleFormatter) == "function"
+        or false
+end
+CooldownCompanion.IsDurationTextBindingSupported = IsDurationTextBindingSupported
+
+local function UnbindDurationText(fontString)
+    if not fontString then return end
+
+    local binding = fontString._ccDurationTextBinding
+    local wasActive = fontString._ccDurationTextBindingActive
+    if binding and wasActive and type(binding.Disable) == "function" then
+        binding:Disable()
+        IncrementDurationTextCounter("unbinds")
+    end
+
+    fontString._ccDurationTextBindingActive = nil
+    fontString._ccDurationTextDuration = nil
+    fontString._ccDurationTextFormatterKey = nil
+    if wasActive and fontString.SetText then
+        fontString:SetText("")
+    end
+end
+CooldownCompanion.UnbindDurationText = UnbindDurationText
+
+local function BindDurationText(fontString, durationObj, source, surface)
+    IncrementDurationTextCounter("bindAttempts")
+
+    if not (fontString and durationObj and IsDurationTextBindingSupported()) then
+        IncrementDurationTextCounter("unsupported")
+        UnbindDurationText(fontString)
+        return false
+    end
+
+    local formatter, formatKey = GetDurationTextFormatter(source)
+    if not formatter then
+        IncrementDurationTextCounter("unsupported")
+        UnbindDurationText(fontString)
+        return false
+    end
+
+    local binding = fontString._ccDurationTextBinding
+    if not binding then
+        binding = C_DurationUtil.CreateDurationTextBinding()
+        if not DurationTextBindingHasMethods(binding) then
+            IncrementDurationTextCounter("unsupported")
+            return false
+        end
+
+        binding:SetFontString(fontString)
+        binding:SetZeroDurationText("")
+        binding:SetExpiredText("")
+        binding:SetUpdateInterval(0.1)
+        fontString._ccDurationTextBinding = binding
+        fontString._ccDurationTextBindingReady = true
+        IncrementDurationTextCounter("bindingsCreated")
+    elseif not fontString._ccDurationTextBindingReady and not DurationTextBindingHasMethods(binding) then
+        IncrementDurationTextCounter("unsupported")
+        return false
+    else
+        fontString._ccDurationTextBindingReady = true
+        IncrementDurationTextCounter("bindingsReused")
+    end
+
+    local changed = false
+    if fontString._ccDurationTextFormatterKey ~= formatKey then
+        binding:SetFormatter(formatter)
+        fontString._ccDurationTextFormatterKey = formatKey
+        IncrementDurationTextCounter("formatterUpdates")
+        changed = true
+    end
+
+    local wasActive = fontString._ccDurationTextBindingActive
+    if fontString._ccDurationTextDuration ~= durationObj then
+        binding:SetDuration(durationObj)
+        fontString._ccDurationTextDuration = durationObj
+        IncrementDurationTextCounter("durationUpdates")
+        changed = true
+    end
+
+    if not wasActive then
+        binding:Enable()
+        changed = true
+    end
+    if changed and type(binding.UpdateFontString) == "function" then
+        binding:UpdateFontString()
+    end
+    fontString._ccDurationTextBindingActive = true
+    IncrementDurationTextCounter("bindSuccesses", surface)
+    return true
+end
+CooldownCompanion.BindDurationText = BindDurationText
 
 local function ApplyDurationFormatToCooldown(cooldown, source)
     if not cooldown then return end

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -25,6 +25,7 @@ local SetFrameClickThrough = ST.SetFrameClickThrough
 local SetFrameClickThroughRecursive = ST.SetFrameClickThroughRecursive
 local HideGlowStyles = ST._HideGlowStyles
 local EntryRuntime = ST.EntryRuntime
+local UnbindDurationText = CooldownCompanion.UnbindDurationText or function() end
 
 local function UnregisterKeyPressHighlightButton(button)
     local unregister = ST._UnregisterKeyPressHighlightButton
@@ -854,7 +855,10 @@ local function ClearReusableButtonRuntime(button)
         button.textString:SetAlpha(1)
     end
     if button.nameText then button.nameText:SetText("") end
-    if button.timeText then button.timeText:SetText("") end
+    if button.timeText then
+        UnbindDurationText(button.timeText)
+        button.timeText:SetText("")
+    end
     if button.statusBar then button.statusBar:SetAlpha(1.0) end
 end
 

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -22,6 +22,7 @@ local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
 local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
+local UnbindDurationText = CooldownCompanion.UnbindDurationText or function() end
 
 local math_floor = math.floor
 local math_min = math.min
@@ -31,6 +32,12 @@ local math_pi = math.pi
 local GetTime = GetTime
 local InCombatLockdown = InCombatLockdown
 local issecretvalue = issecretvalue
+
+local function UnbindFrameDurationText(frame)
+    if frame and frame.text then
+        UnbindDurationText(frame.text)
+    end
+end
 
 ------------------------------------------------------------------------
 -- Imports from ResourceBarConstants / ResourceBarHelpers / ResourceBarVisuals
@@ -391,6 +398,7 @@ local function UpdateCustomAuraBarIndicatorVisuals(barInfo, cabConfig, auraPrese
 end
 local function ClearStaleRecycledBarRuntimeState(frame)
     if not frame then return end
+    UnbindFrameDurationText(frame)
     ClearStatusBarMotion(frame)
     if frame._cdcCustomAuraAlphaModuleId then
         CooldownCompanion:UnregisterModuleAlpha(frame._cdcCustomAuraAlphaModuleId)
@@ -1969,6 +1977,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
         if powerType == RESOURCE_HEALTH then
             if not barInfo or barInfo.barType ~= "health_continuous" then
                 if barInfo and barInfo.frame then
+                    ClearStaleRecycledBarRuntimeState(barInfo.frame)
                     ClearResourceAuraVisuals(barInfo.frame)
                     barInfo.frame:Hide()
                 end
@@ -1986,6 +1995,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
             -- Stagger: continuous bar with dedicated update (health-based max, threshold colors)
             if not barInfo or barInfo.barType ~= "stagger_continuous" then
                 if barInfo and barInfo.frame then
+                    ClearStaleRecycledBarRuntimeState(barInfo.frame)
                     ClearResourceAuraVisuals(barInfo.frame)
                     barInfo.frame:Hide()
                 end
@@ -2006,6 +2016,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
             if not barInfo or barInfo.barType ~= "mw_segmented"
                 or #barInfo.frame.segments ~= halfSegments then
                 if barInfo and barInfo.frame then
+                    ClearStaleRecycledBarRuntimeState(barInfo.frame)
                     ClearResourceAuraVisuals(barInfo.frame)
                     barInfo.frame:Hide()
                 end
@@ -2051,6 +2062,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
             if not barInfo or barInfo.barType ~= "segmented"
                 or barInfo.frame._numSegments ~= max then
                 if barInfo and barInfo.frame then
+                    ClearStaleRecycledBarRuntimeState(barInfo.frame)
                     ClearResourceAuraVisuals(barInfo.frame)
                     barInfo.frame:Hide()
                 end
@@ -2071,6 +2083,7 @@ function CooldownCompanion:ApplyResourceBars(opts)
             -- Continuous bar
             if not barInfo or barInfo.barType ~= "continuous" then
                 if barInfo and barInfo.frame then
+                    ClearStaleRecycledBarRuntimeState(barInfo.frame)
                     ClearResourceAuraVisuals(barInfo.frame)
                     barInfo.frame:Hide()
                 end

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -60,7 +60,6 @@ local CreateOverlayBar = RB.CreateOverlayBar
 local LayoutOverlaySegments = RB.LayoutOverlaySegments
 
 local FormatTime = CooldownCompanion.FormatTime
-local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
 local BindDurationText = CooldownCompanion.BindDurationText or function() return false end
 local UnbindDurationText = CooldownCompanion.UnbindDurationText or function() end
 local RecordDurationTextManualUpdate = CooldownCompanion.RecordDurationTextManualUpdate or function() end
@@ -79,15 +78,6 @@ local function SetManualDurationText(fontString, text, countManualDurationText)
         RecordDurationTextManualUpdate("resource")
     end
     fontString:SetText(text)
-end
-
-local function SetManualDurationFormattedText(fontString, formatSpec, value, countManualDurationText)
-    if not fontString then return end
-    UnbindDurationText(fontString)
-    if countManualDurationText then
-        RecordDurationTextManualUpdate("resource")
-    end
-    fontString:SetFormattedText(formatSpec, value)
 end
 
 local function UnbindFrameDurationText(frame)
@@ -385,18 +375,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             -- Duration text (bar.text): driven by showDurationText, independent of drain
             if bar.text and bar.text:IsShown() then
                 if durationObj then
-                    if not BindDurationText(bar.text, durationObj, cabConfig, "resource") then
-                        local remaining = durationObj:GetRemainingDuration()
-                        if not durationObj:HasSecretValues() then
-                            if remaining > 0 then
-                                SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
-                            else
-                                SetManualDurationText(bar.text, "")
-                            end
-                        else
-                            SetManualDurationFormattedText(bar.text, GetDurationSecretFormatSpec(cabConfig), remaining, true)
-                        end
-                    end
+                    BindDurationText(bar.text, durationObj, cabConfig, "resource")
                 elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
                     local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
                     if remaining > 0 then
@@ -667,16 +646,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
             if bar.text and bar.text:IsShown() then
                 if auraDurationObj then
-                    if not BindDurationText(bar.text, auraDurationObj, cabConfig, "resource") then
-                        local remaining = auraDurationObj:GetRemainingDuration()
-                        if auraDurationObj:HasSecretValues() then
-                            SetManualDurationFormattedText(bar.text, GetDurationSecretFormatSpec(cabConfig), remaining, true)
-                        elseif remaining and remaining > 0 then
-                            SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
-                        else
-                            SetManualDurationText(bar.text, "")
-                        end
-                    end
+                    BindDurationText(bar.text, auraDurationObj, cabConfig, "resource")
                 elseif auraPreview or pandemicPreview then
                     SetManualDurationText(bar.text, FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig), true)
                 else
@@ -718,16 +688,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if bar.text and bar.text:IsShown() then
             if cooldownActive and durationObj then
-                if not BindDurationText(bar.text, durationObj, cabConfig, "resource") then
-                    local remaining = durationObj:GetRemainingDuration()
-                    if durationObj:HasSecretValues() then
-                        SetManualDurationFormattedText(bar.text, GetDurationSecretFormatSpec(cabConfig), remaining, true)
-                    elseif remaining and remaining > 0 then
-                        SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
-                    else
-                        SetManualDurationText(bar.text, "")
-                    end
-                end
+                BindDurationText(bar.text, durationObj, cabConfig, "resource")
             else
                 SetManualDurationText(bar.text, "")
             end

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -61,6 +61,9 @@ local LayoutOverlaySegments = RB.LayoutOverlaySegments
 
 local FormatTime = CooldownCompanion.FormatTime
 local GetDurationSecretFormatSpec = CooldownCompanion.GetDurationSecretFormatSpec
+local BindDurationText = CooldownCompanion.BindDurationText or function() return false end
+local UnbindDurationText = CooldownCompanion.UnbindDurationText or function() end
+local RecordDurationTextManualUpdate = CooldownCompanion.RecordDurationTextManualUpdate or function() end
 local SetAuraStackCountText = EntryRuntime.SetAuraStackCountText
 local SetStatusBarImmediateValue = ST.SetStatusBarImmediateValue
 local SetStatusBarSmoothRange = ST.SetStatusBarSmoothRange
@@ -68,6 +71,30 @@ local SetStatusBarSmoothValue = ST.SetStatusBarSmoothValue
 local SetStatusBarSegmentedValue = ST.SetStatusBarSegmentedValue
 local SetStatusBarElapsedDuration = ST.SetStatusBarElapsedDuration
 local SetStatusBarRemainingDuration = ST.SetStatusBarRemainingDuration
+
+local function SetManualDurationText(fontString, text, countManualDurationText)
+    if not fontString then return end
+    UnbindDurationText(fontString)
+    if countManualDurationText then
+        RecordDurationTextManualUpdate("resource")
+    end
+    fontString:SetText(text)
+end
+
+local function SetManualDurationFormattedText(fontString, formatSpec, value, countManualDurationText)
+    if not fontString then return end
+    UnbindDurationText(fontString)
+    if countManualDurationText then
+        RecordDurationTextManualUpdate("resource")
+    end
+    fontString:SetFormattedText(formatSpec, value)
+end
+
+local function UnbindFrameDurationText(frame)
+    if frame and frame.text then
+        UnbindDurationText(frame.text)
+    end
+end
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -301,6 +328,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 MarkLayoutDirty()
             end
             if not shouldShow then
+                UnbindFrameDurationText(barInfo.frame)
                 if barInfo.frame then
                     if not auraPresent then
                         barInfo.frame._customAuraStackValue = nil
@@ -357,28 +385,32 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             -- Duration text (bar.text): driven by showDurationText, independent of drain
             if bar.text and bar.text:IsShown() then
                 if durationObj then
-                    local remaining = durationObj:GetRemainingDuration()
-                    if not durationObj:HasSecretValues() then
-                        if remaining > 0 then
-                            bar.text:SetText(FormatTime(remaining, cabConfig))
+                    if not BindDurationText(bar.text, durationObj, cabConfig, "resource") then
+                        local remaining = durationObj:GetRemainingDuration()
+                        if not durationObj:HasSecretValues() then
+                            if remaining > 0 then
+                                SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
+                            else
+                                SetManualDurationText(bar.text, "")
+                            end
                         else
-                            bar.text:SetText("")
+                            SetManualDurationFormattedText(bar.text, GetDurationSecretFormatSpec(cabConfig), remaining, true)
                         end
-                    else
-                        bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
                     end
                 elseif auraCooldownStart and auraCooldownDuration and auraCooldownDuration > 0 then
                     local remaining = auraCooldownStart + auraCooldownDuration - GetTime()
                     if remaining > 0 then
-                        bar.text:SetText(FormatTime(remaining, cabConfig))
+                        SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
                     else
-                        bar.text:SetText("")
+                        SetManualDurationText(bar.text, "")
                     end
                 elseif indicatorPreview then
-                    bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig))
+                    SetManualDurationText(bar.text, FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig), true)
                 else
-                    bar.text:SetText("")
+                    SetManualDurationText(bar.text, "")
                 end
+            elseif bar.text then
+                UnbindDurationText(bar.text)
             end
 
             -- Stack text (bar.stackText): driven by showStackText
@@ -586,6 +618,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 MarkLayoutDirty()
             end
             if not shouldShow then
+                UnbindFrameDurationText(barInfo.frame)
                 ClearCustomAuraBarIndicatorState(barInfo, false)
                 UpdateSpellCustomBarSounds(auraPresent)
                 return
@@ -634,19 +667,23 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
             if bar.text and bar.text:IsShown() then
                 if auraDurationObj then
-                    local remaining = auraDurationObj:GetRemainingDuration()
-                    if auraDurationObj:HasSecretValues() then
-                        bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
-                    elseif remaining and remaining > 0 then
-                        bar.text:SetText(FormatTime(remaining, cabConfig))
-                    else
-                        bar.text:SetText("")
+                    if not BindDurationText(bar.text, auraDurationObj, cabConfig, "resource") then
+                        local remaining = auraDurationObj:GetRemainingDuration()
+                        if auraDurationObj:HasSecretValues() then
+                            SetManualDurationFormattedText(bar.text, GetDurationSecretFormatSpec(cabConfig), remaining, true)
+                        elseif remaining and remaining > 0 then
+                            SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
+                        else
+                            SetManualDurationText(bar.text, "")
+                        end
                     end
                 elseif auraPreview or pandemicPreview then
-                    bar.text:SetText(FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig))
+                    SetManualDurationText(bar.text, FormatTime(CUSTOM_AURA_BAR_EFFECT_PREVIEW_DURATION, cabConfig), true)
                 else
-                    bar.text:SetText("")
+                    SetManualDurationText(bar.text, "")
                 end
+            elseif bar.text then
+                UnbindDurationText(bar.text)
             end
 
             UpdateSpellCustomBarChargeText(bar, cooldownResult)
@@ -681,17 +718,21 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if bar.text and bar.text:IsShown() then
             if cooldownActive and durationObj then
-                local remaining = durationObj:GetRemainingDuration()
-                if durationObj:HasSecretValues() then
-                    bar.text:SetFormattedText(GetDurationSecretFormatSpec(cabConfig), remaining)
-                elseif remaining and remaining > 0 then
-                    bar.text:SetText(FormatTime(remaining, cabConfig))
-                else
-                    bar.text:SetText("")
+                if not BindDurationText(bar.text, durationObj, cabConfig, "resource") then
+                    local remaining = durationObj:GetRemainingDuration()
+                    if durationObj:HasSecretValues() then
+                        SetManualDurationFormattedText(bar.text, GetDurationSecretFormatSpec(cabConfig), remaining, true)
+                    elseif remaining and remaining > 0 then
+                        SetManualDurationText(bar.text, FormatTime(remaining, cabConfig), true)
+                    else
+                        SetManualDurationText(bar.text, "")
+                    end
                 end
             else
-                bar.text:SetText("")
+                SetManualDurationText(bar.text, "")
             end
+        elseif bar.text then
+            UnbindDurationText(bar.text)
         end
 
         UpdateSpellCustomBarChargeText(bar, cooldownResult)
@@ -968,6 +1009,8 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                     else
                         bar.text:SetPoint("CENTER")
                     end
+                else
+                    UnbindDurationText(bar.text)
                 end
             end
 
@@ -1059,6 +1102,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         for i = firstHiddenIndex, #resourceBarFrames do
             local barInfo = resourceBarFrames[i]
             if barInfo and barInfo.frame then
+                UnbindFrameDurationText(barInfo.frame)
                 ClearStaleRecycledBarRuntimeState(barInfo.frame)
                 ClearCustomAuraBarIndicatorState(barInfo, true)
                 ClearResourceAuraVisuals(barInfo.frame)
@@ -1150,6 +1194,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         if needsRecreate then
             if barInfo and barInfo.frame then
+                UnbindFrameDurationText(barInfo.frame)
                 ClearCustomAuraBarIndicatorState(barInfo, true)
                 ClearResourceAuraVisuals(barInfo.frame)
                 ClearMaxStacksIndicator(barInfo)


### PR DESCRIPTION
## What Players Will Notice
- Bar-mode cooldown and aura timers, plus custom resource bar duration text, should keep the same selected duration formatting while the addon does less Lua-side timer text work.
- Timer labels now clear cleanly when native-bound bar/resource frames are hidden, recycled, or switch back to manual text paths, reducing the chance of stale timer text.

## Why This Changed
- Bar and custom resource timer labels were still doing recurring Lua-side duration sampling and formatting in places where the game can drive the duration text natively.
- Eligible `DurationObject` labels still had Lua fallback branches that sampled and formatted remaining duration after native binding was introduced.

## What Changed
- Added shared native duration text binding helpers using `C_DurationUtil`/`C_StringUtil`, including formatter mapping for the addon's existing duration formats and debug counters for native/manual text updates.
- Wired eligible bar-mode and custom resource bar `DurationObject` labels to native duration text binding only.
- Kept manual duration text for text mode, previews, viewer/statusbar pass-through, item/numeric fallback timers, ready/hidden states, and blanks.
- Added cleanup so native duration bindings are disabled when button/resource bar frames are recycled, hidden, or reused for another bar type.

## Validation
- `lua tests\duration-text-binding.lua`
- `lua tests\durationless-aura-cooldown-swipe.lua`
- `lua tests\resource-bars-class-scope.lua`
- `lua tests\max-stack-indicator-parity.lua`
- `lua tests\group-style-update-fast-path.lua`
- `luac -p` over shipped addon Lua
- `git diff --check origin/main...HEAD`
- `parallel-review-recommendations`: five reviewers, no actionable findings
- User-reported in-game/combat smoke: timer text appeared fine after the native binding change
- Not independently validated by this agent in game; additional restricted/secret/hide-recycle runtime proof can be captured before marking the PR ready if desired
