### PR TITLE
Fix deferred cooldown swipe flicker

### DIFF
--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1194,7 +1194,9 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
 
         local timedAuraPrimarySwipeActive = button._auraPrimarySwipeActive == true
             and button._auraHasTimer ~= false
-        local cooldownVisualActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+        local realCooldownSwipeActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN
+            and button._cooldownDeferred ~= true
+        local cooldownVisualActive = realCooldownSwipeActive
             or timedAuraPrimarySwipeActive
             or button._conditionalAuraDurationTextPreview == true
             or button._conditionalPreviewDomain == "cooldown"


### PR DESCRIPTION
## What Players Will Notice
- Cooldown buttons for spells that enter a deferred cooldown state, such as Nature's Swiftness or Tip the Scales, should no longer flash an empty radial cooldown swipe while the spell is active and waiting for the real timer to begin.

## Why This Changed
- Blizzard exposes these hold-style cooldowns as unavailable before a renderable cooldown duration exists. Cooldown Companion kept the cooldown truth correctly, but icon-mode visibility could still re-show the main cooldown frame during that deferred window, producing a flickering swipe artifact during combat refreshes.

## What Changed
- Icon-mode cooldown visibility now separates real swipe presentation from deferred cooldown truth.
- `_cooldownDeferred` still keeps the button unavailable/desaturated, but it no longer counts as a reason to show the main radial cooldown widget until a real timer is available.

## Validation
- `lua tests/durationless-aura-cooldown-swipe.lua`
- `luac -p` over all shipped Lua files under `CooldownCompanion` and `CooldownCompanion_Config`
- `git diff --check origin/main...HEAD`
- DevBridge showed no Cooldown Companion errors and confirmed a Nature's Swiftness button in the saved runtime snapshot, but this was a logout-flush snapshot rather than fresh in-combat proof.
- Fresh in-game combat and restricted-content validation is still pending.