### PR TITLE
Show live aura values in tracked aura tooltips

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -50,6 +50,7 @@ local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
 local CreateGlowContainer = ST._CreateGlowContainer
 local SetBarAuraEffect = ST._SetBarAuraEffect
 local IsBarAuraIndicatorEnabled = ST.IsBarAuraIndicatorEnabled
+local ShowButtonTooltip = ST._ShowButtonTooltip
 
 -- Imports from Visibility
 local UpdateLossOfControl = ST._UpdateLossOfControl
@@ -98,14 +99,7 @@ local function SetBarIconTooltipScripts(button, enable)
             local bd = button.buttonData
             if not bd then return end
             GameTooltip_SetDefaultAnchor(GameTooltip, UIParent)
-            if bd.type == "spell" then
-                GameTooltip:SetSpellByID(button._displaySpellId or bd.id)
-            elseif IsEntryItemLike(bd) then
-                local itemID = button._resolvedItemId or bd.id
-                if itemID then
-                    GameTooltip:SetItemByID(itemID)
-                end
-            end
+            ShowButtonTooltip(button, GameTooltip)
             GameTooltip:Show()
         end)
         iconBounds:SetScript("OnLeave", function()

--- a/CooldownCompanion/ButtonFrame/Glows.lua
+++ b/CooldownCompanion/ButtonFrame/Glows.lua
@@ -866,19 +866,44 @@ local function GetViewerAuraStackText(viewerFrame)
     return ""
 end
 
+local function IsTooltipAuraUnit(unit)
+    return unit == "player" or unit == "target"
+end
+
+local function ShowButtonTooltip(button, tooltip)
+    if not (button and tooltip and button.buttonData) then return false end
+
+    local buttonData = button.buttonData
+    local auraUnit = button._auraUnit
+    local auraInstanceID = button._auraInstanceID
+    if button._auraActive == true
+        and type(auraInstanceID) == "number"
+        and IsTooltipAuraUnit(auraUnit)
+        and tooltip.SetUnitAuraByAuraInstanceID then
+        tooltip:SetUnitAuraByAuraInstanceID(auraUnit, auraInstanceID, "INCLUDE_NAME_PLATE_ONLY")
+        return true
+    end
+
+    if buttonData.type == "spell" then
+        tooltip:SetSpellByID(button._displaySpellId or buttonData.id)
+        return true
+    elseif IsEntryItemLike(buttonData) then
+        local itemID = button._resolvedItemId or buttonData.id
+        if itemID then
+            tooltip:SetItemByID(itemID)
+            return true
+        end
+    end
+
+    return false
+end
+
 -- Setup tooltip OnEnter/OnLeave scripts on a button frame.
 -- Shared between icon-mode (CreateButtonFrame) and style refreshes.
 local function SetupTooltipScripts(button)
     button:SetScript("OnEnter", function(self)
         GameTooltip_SetDefaultAnchor(GameTooltip, UIParent)
-        if self.buttonData.type == "spell" then
-            GameTooltip:SetSpellByID(self._displaySpellId or self.buttonData.id)
-        elseif IsEntryItemLike(self.buttonData) then
-            local itemID = self._resolvedItemId or self.buttonData.id
-            if itemID then
-                GameTooltip:SetItemByID(itemID)
-            end
-        end
+        ShowButtonTooltip(self, GameTooltip)
         GameTooltip:Show()
     end)
     button:SetScript("OnLeave", function(self)
@@ -967,6 +992,7 @@ ST._ShowGlowStyle = ShowGlowStyle
 ST._CreateGlowContainer = CreateGlowContainer
 ST._CreateAssistedHighlight = CreateAssistedHighlight
 ST._GetViewerAuraStackText = GetViewerAuraStackText
+ST._ShowButtonTooltip = ShowButtonTooltip
 ST._SetupTooltipScripts = SetupTooltipScripts
 ST.IsBarAuraIndicatorEnabled = IsBarAuraIndicatorEnabled
 ST._SetBarAuraEffect = SetBarAuraEffect

--- a/CooldownCompanion/ButtonFrame/Glows.lua
+++ b/CooldownCompanion/ButtonFrame/Glows.lua
@@ -880,8 +880,9 @@ local function ShowButtonTooltip(button, tooltip)
         and type(auraInstanceID) == "number"
         and IsTooltipAuraUnit(auraUnit)
         and tooltip.SetUnitAuraByAuraInstanceID then
-        tooltip:SetUnitAuraByAuraInstanceID(auraUnit, auraInstanceID, "INCLUDE_NAME_PLATE_ONLY")
-        return true
+        if tooltip:SetUnitAuraByAuraInstanceID(auraUnit, auraInstanceID, "INCLUDE_NAME_PLATE_ONLY") then
+            return true
+        end
     end
 
     if buttonData.type == "spell" then


### PR DESCRIPTION
## What Players Will Notice
- With Show Tooltips enabled, active tracked aura entries can now show Blizzard's live aura tooltip values, matching the Cooldown Manager for effects like Ignite damage over time and Blazing Barrier absorb amount.
- Bar-mode icon hovers use the same aura-aware tooltip behavior as icon mode.
- Inactive, unavailable, stale, unsupported-unit, and item-like entries still fall back to the normal static spell or item tooltip.

## Why This Changed
- CC's tracked aura entries were still showing static spell descriptions while Blizzard's Cooldown Manager showed active aura-specific values.
- Those live values belong to Blizzard's aura tooltip renderer, so CC now points the tooltip at the active aura instance instead of trying to rebuild tooltip text itself.

## What Changed
- Added a shared button tooltip helper that prefers `SetUnitAuraByAuraInstanceID` for active `player` or `target` auras with a current aura instance ID.
- Kept the existing spell and item tooltip fallback path for inactive, missing, stale, unsupported, or item-like entries.
- Reused the shared helper from bar mode while preserving icon-only hover behavior.
- Checked Blizzard's tooltip setter return value so stale or restricted aura instances fall through to the static fallback instead of suppressing the tooltip.

## Validation
- Passed: `lua tests\button-tooltip-active-aura.lua`
- Passed: `lua tests\aura-instance-membership.lua`
- Passed: `lua tests\durationless-aura-cooldown-swipe.lua`
- Passed: `luac -p CooldownCompanion\ButtonFrame\Glows.lua CooldownCompanion\ButtonFrame\BarMode.lua tests\button-tooltip-active-aura.lua`
- Passed: `git diff --check origin/main...HEAD`
- Passed: `$parallel-review-recommendations` with five reviewers reporting no actionable static findings.
- Known current unrelated failure: `lua tests\aura-viewer-identity.lua` still fails at line 165 in the `EntryRuntime.lua` identity/grace path, which this branch does not change.

## Runtime Proof
- Not yet verified in-game.
- Still needs live hover checks for active Blazing Barrier and Ignite, inactive/missing aura fallback, bar-mode icon hover, target aura switch/removal, and combat or restricted-content hover behavior with no Lua errors.
