### PR TITLE
Remove dead Import Review adapter exports

### DIFF
--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -1011,6 +1011,4 @@ function CooldownCompanion:OpenImportReviewWindow(context)
     ShowImportReviewWindow(context)
 end
 
-ST._ClassifyImportReviewText = function(text) return CooldownCompanion:ClassifyImportReviewText(text) end
-ST._ApplyReviewedImport = function(review) return CooldownCompanion:ApplyReviewedImport(review) end
 ST._OpenImportReviewWindow = function(context) return CooldownCompanion:OpenImportReviewWindow(context) end


### PR DESCRIPTION
## What Changed
- Removed the unused `ST._ClassifyImportReviewText` and `ST._ApplyReviewedImport` adapter exports from `CooldownCompanion_Config/Config/ImportReview.lua`.
- Left the live `ST._OpenImportReviewWindow` adapter and the direct `CooldownCompanion:ClassifyImportReviewText` / `CooldownCompanion:ApplyReviewedImport` methods intact.

## Why This Changed
- Exact-symbol scans showed the two adapter exports were definition-only; the Import Review window already calls the main methods directly.

## Developer Impact
- Keeps the config import surface smaller and prevents future maintenance from chasing stale adapter hooks.

## Validation
- `rg -n "_ClassifyImportReviewText|_ApplyReviewedImport|_OpenImportReviewWindow|ClassifyImportReviewText|ApplyReviewedImport|OpenImportReviewWindow" CooldownCompanion CooldownCompanion_Config -g '*.lua'`
- `luac -p CooldownCompanion_Config\Config\ImportReview.lua`
- `luac -p` across all tracked Lua files
- `git diff --check`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is static-only cleanup with no intended player-facing behavior change.