### PR TITLE
Remove unused changelog navigation helpers

### DIFF
--- a/CooldownCompanion/Core/Changelog.lua
+++ b/CooldownCompanion/Core/Changelog.lua
@@ -292,22 +292,6 @@ function Changelog.GetRenderTokens(version)
     return parsedCache[version]
 end
 
-function Changelog.GetPreviousVersion(version)
-    local idx = versionIndex[version]
-    if not idx then
-        return nil
-    end
-    return orderedVersions[idx + 1]
-end
-
-function Changelog.GetNextVersion(version)
-    local idx = versionIndex[version]
-    if not idx or idx <= 1 then
-        return nil
-    end
-    return orderedVersions[idx - 1]
-end
-
 function Changelog.ShouldAutoOpen()
     local version = GetAddonVersion()
     if not Changelog.HasEntry(version) then


### PR DESCRIPTION
## What Changed
- Removed the unused `Changelog.GetPreviousVersion` and `Changelog.GetNextVersion` helpers from the bundled changelog service.

## Why This Changed
- Exact-symbol scans showed both navigation helpers were definition-only, while the active changelog overlay uses the dropdown, newest-version, entry, render-token, seen-state, and font-size APIs.

## Developer Impact
- The changelog service has a smaller internal API surface, so future changelog UI work has fewer stale helpers to reason about.

## Validation
- `rg -n "GetPreviousVersion|GetNextVersion" CooldownCompanion CooldownCompanion_Config -g "*.lua"` returned no Lua matches after removal.
- `luac -p CooldownCompanion\Core\Changelog.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only dead-code cleanup with no intended runtime behavior change.