### PR TITLE
Remove unused talent picker status helper

### DIFF
--- a/CooldownCompanion_Config/Config/TalentPicker.lua
+++ b/CooldownCompanion_Config/Config/TalentPicker.lua
@@ -1766,7 +1766,3 @@ end
 function CooldownCompanion:CloseTalentPicker()
     HideTalentPicker()
 end
-
-function CooldownCompanion:IsTalentPickerOpen()
-    return CS.talentPickerMode
-end


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion:IsTalentPickerOpen` helper from the config talent picker.

## Why This Changed
- Source-wide checks showed no addon code, TOCs, docs, or local tests call the helper. Active config paths already read `CS.talentPickerMode` directly and continue to use `OpenTalentPicker` / `CloseTalentPicker` for picker control.

## Developer Impact
- Keeps the talent picker API surface smaller by dropping a stale status wrapper with no current consumer.

## Validation
- `rg -n "IsTalentPickerOpen" --glob "*.lua" --glob "*.md" --glob "*.toc" tests .` returned no matches after removal.
- `luac -p CooldownCompanion_Config/Config/TalentPicker.lua`
- `luac -p` across all tracked Lua files
- `git diff --check HEAD^ HEAD`
- `lua tests\duration-text-binding.lua`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only maintenance cleanup with no intended behavior change.
