### PR TITLE
Remove unused changelog entry helper

### DIFF
--- a/CooldownCompanion/Core/Changelog.lua
+++ b/CooldownCompanion/Core/Changelog.lua
@@ -275,13 +275,6 @@ function Changelog.GetNewestVersion()
     return orderedVersions[1]
 end
 
-function Changelog.GetEntry(version)
-    if not Changelog.HasEntry(version) then
-        return nil
-    end
-    return rawData.entries[version]
-end
-
 function Changelog.GetRenderTokens(version)
     if not Changelog.HasEntry(version) then
         return nil


### PR DESCRIPTION
## What Changed
- Removed the unused `Changelog.GetEntry` helper from the internal changelog module.

## Why This Changed
- The config changelog overlay renders entries through `GetRenderTokens`, while repo-wide exact-symbol checks showed `Changelog.GetEntry` had no callers.

## Developer Impact
- Keeps the changelog surface smaller after the recent navigation-helper cleanup and avoids carrying an unused entry accessor.

## Validation
- `rg -n "Changelog\.GetEntry|function Changelog\.GetEntry|GetEntry\(version\)" -g "*.lua" CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `luac -p CooldownCompanion\Core\Changelog.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is static-only dead-code cleanup with no intended behavior change.