### PR TITLE
Remove unused changelog version index

### DIFF
--- a/CooldownCompanion/Core/Changelog.lua
+++ b/CooldownCompanion/Core/Changelog.lua
@@ -8,7 +8,6 @@ local CooldownCompanion = ST.Addon
 
 local rawData = ST._changelogData or {}
 local orderedVersions = {}
-local versionIndex = {}
 local parsedCache = {}
 local DEFAULT_FONT_SIZE = 13
 local MIN_FONT_SIZE = 11
@@ -102,14 +101,12 @@ end
 
 local function BuildOrderedIndex()
     orderedVersions = {}
-    versionIndex = {}
 
     local entries = rawData.entries or {}
     for _, version in ipairs(rawData.order or {}) do
         local entry = entries[version]
         if type(version) == "string" and type(entry) == "table" and type(entry.markdown) == "string" then
             orderedVersions[#orderedVersions + 1] = version
-            versionIndex[version] = #orderedVersions
         end
     end
 end


### PR DESCRIPTION
## What Changed
- Removed the write-only changelog `versionIndex` state from bundled changelog index building.

## Why This Changed
- The navigation and direct-entry helpers that consumed the index were already removed, leaving the table rebuilt but never read.

## Developer Impact
- Changelog data indexing now only keeps the ordered version list that current dropdown, render, and auto-open paths still use, reducing stale state that could mislead future maintenance.

## Validation
- `rg -n "versionIndex" CooldownCompanion CooldownCompanion_Config tests -g "*.lua"` returned no matches.
- `luac -p CooldownCompanion\Core\Changelog.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the recurring LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only dead-state cleanup with no intended runtime behavior change.