### PR TITLE
Remove unused load-condition wrapper

### DIFF
--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2422,10 +2422,6 @@ function CooldownCompanion:GetCurrentEligibilityIdentity()
     }
 end
 
-function CooldownCompanion:CheckLoadConditions(group)
-    return self:EvaluateLoadConditions(group and group.loadConditions)
-end
-
 local function AddLoadConditionSource(sources, label, entity, defaults, allowClassEligibility)
     if type(entity) == "table" and type(entity.loadConditions) == "table" then
         sources[#sources + 1] = {


### PR DESCRIPTION
## What Changed
- Removed the unused `CooldownCompanion:CheckLoadConditions` wrapper from `CooldownCompanion/Core/GroupOperations.lua`.

## Why This Changed
- Exact-symbol scans showed `CheckLoadConditions` had no callers, while the active load-condition paths use `EvaluateLoadConditions`, `GetLoadConditionSourcesForGroup`, `EvaluateLoadConditionSources`, and `IsButtonLoadConditionMet` directly.

## Developer Impact
- Keeps the group load-condition API surface smaller and avoids preserving an obsolete wrapper beside the newer source-based evaluation helpers.

## Validation
- `rg -n '\bCheckLoadConditions\b' . -g '!CooldownCompanion/Libs/**' -g '!CooldownCompanion_Config/Libs/**' -g '!.git/**'` returned no matches after removal.
- `luac -p CooldownCompanion\Core\GroupOperations.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- `lua tests\eligibility-load-conditions.lua`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is static-only dead-wrapper cleanup with no intended behavior change.