### PR TITLE
Remove unused media setup from initialization

### DIFF
--- a/CooldownCompanion/Core/Init.lua
+++ b/CooldownCompanion/Core/Init.lua
@@ -41,9 +41,6 @@ local LDB = LibStub("LibDataBroker-1.1")
 local LDBIcon = LibStub("LibDBIcon-1.0")
 ST._LDBIcon = LDBIcon
 
--- LibSharedMedia for font/texture selection
-local LSM = LibStub("LibSharedMedia-3.0")
-
 -- Masque skinning support (optional)
 local Masque = LibStub("Masque", true)
 local MasqueGroups = {} -- Maps groupId -> Masque Group object


### PR DESCRIPTION
## What Changed
- Removed the unused `LSM` LibSharedMedia binding and stale setup comment from `CooldownCompanion/Core/Init.lua`.

## Why This Changed
- `Init.lua` no longer uses LibSharedMedia directly; the live media callback setup is owned by `Core/Lifecycle.lua`, so the extra binding was stale initialization code.

## Developer Impact
- Addon initialization is slightly easier to read because media setup now has one clear owner instead of an unused early binding.

## Validation
- `rg -n "\bLSM\b|LibSharedMedia for font/texture selection|LibSharedMedia-3.0" CooldownCompanion/Core/Init.lua CooldownCompanion/Core/Lifecycle.lua CooldownCompanion -g "*.lua" -g "*.toc"`
- `luac -p CooldownCompanion/Core/Init.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` (only the usual LF-to-CRLF working-copy warning)
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is static-only initialization cleanup with no intended behavior change.