### PR TITLE
Remove unused internal addon helpers

### DIFF
--- a/CooldownCompanion/Core/Changelog.lua
+++ b/CooldownCompanion/Core/Changelog.lua
@@ -275,13 +275,6 @@ function Changelog.GetNewestVersion()
     return orderedVersions[1]
 end
 
-function Changelog.GetEntry(version)
-    if not Changelog.HasEntry(version) then
-        return nil
-    end
-    return rawData.entries[version]
-end
-
 function Changelog.GetRenderTokens(version)
     if not Changelog.HasEntry(version) then
         return nil

--- a/CooldownCompanion/Core/Changelog.lua
+++ b/CooldownCompanion/Core/Changelog.lua
@@ -292,22 +292,6 @@ function Changelog.GetRenderTokens(version)
     return parsedCache[version]
 end
 
-function Changelog.GetPreviousVersion(version)
-    local idx = versionIndex[version]
-    if not idx then
-        return nil
-    end
-    return orderedVersions[idx + 1]
-end
-
-function Changelog.GetNextVersion(version)
-    local idx = versionIndex[version]
-    if not idx or idx <= 1 then
-        return nil
-    end
-    return orderedVersions[idx - 1]
-end
-
 function Changelog.ShouldAutoOpen()
     local version = GetAddonVersion()
     if not Changelog.HasEntry(version) then

--- a/CooldownCompanion/Core/Changelog.lua
+++ b/CooldownCompanion/Core/Changelog.lua
@@ -8,7 +8,6 @@ local CooldownCompanion = ST.Addon
 
 local rawData = ST._changelogData or {}
 local orderedVersions = {}
-local versionIndex = {}
 local parsedCache = {}
 local DEFAULT_FONT_SIZE = 13
 local MIN_FONT_SIZE = 11
@@ -102,14 +101,12 @@ end
 
 local function BuildOrderedIndex()
     orderedVersions = {}
-    versionIndex = {}
 
     local entries = rawData.entries or {}
     for _, version in ipairs(rawData.order or {}) do
         local entry = entries[version]
         if type(version) == "string" and type(entry) == "table" and type(entry.markdown) == "string" then
             orderedVersions[#orderedVersions + 1] = version
-            versionIndex[version] = #orderedVersions
         end
     end
 end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2422,10 +2422,6 @@ function CooldownCompanion:GetCurrentEligibilityIdentity()
     }
 end
 
-function CooldownCompanion:CheckLoadConditions(group)
-    return self:EvaluateLoadConditions(group and group.loadConditions)
-end
-
 local function AddLoadConditionSource(sources, label, entity, defaults, allowClassEligibility)
     if type(entity) == "table" and type(entity.loadConditions) == "table" then
         sources[#sources + 1] = {

--- a/CooldownCompanion/Core/Init.lua
+++ b/CooldownCompanion/Core/Init.lua
@@ -41,9 +41,6 @@ local LDB = LibStub("LibDataBroker-1.1")
 local LDBIcon = LibStub("LibDBIcon-1.0")
 ST._LDBIcon = LDBIcon
 
--- LibSharedMedia for font/texture selection
-local LSM = LibStub("LibSharedMedia-3.0")
-
 -- Masque skinning support (optional)
 local Masque = LibStub("Masque", true)
 local MasqueGroups = {} -- Maps groupId -> Masque Group object

--- a/CooldownCompanion_Config/Config/ImportReview.lua
+++ b/CooldownCompanion_Config/Config/ImportReview.lua
@@ -1011,6 +1011,4 @@ function CooldownCompanion:OpenImportReviewWindow(context)
     ShowImportReviewWindow(context)
 end
 
-ST._ClassifyImportReviewText = function(text) return CooldownCompanion:ClassifyImportReviewText(text) end
-ST._ApplyReviewedImport = function(review) return CooldownCompanion:ApplyReviewedImport(review) end
 ST._OpenImportReviewWindow = function(context) return CooldownCompanion:OpenImportReviewWindow(context) end

--- a/CooldownCompanion_Config/Config/TalentPicker.lua
+++ b/CooldownCompanion_Config/Config/TalentPicker.lua
@@ -1766,7 +1766,3 @@ end
 function CooldownCompanion:CloseTalentPicker()
     HideTalentPicker()
 end
-
-function CooldownCompanion:IsTalentPickerOpen()
-    return CS.talentPickerMode
-end


### PR DESCRIPTION
## What Changed
- Removed unused changelog entry/navigation helpers and the supporting version index.
- Removed unused load-condition, import-review, talent picker, and init media helper bindings.

## Why This Changed
- These symbols had no live callers after the cleanup sweeps, leaving extra internal API surface that made the addon/config code harder to audit.

## Developer Impact
- Keeps the changelog, load-condition, import-review, talent-picker, and initialization paths smaller without changing intended player-facing behavior.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` across 96 tracked Lua files
- Exact-symbol scan for `Changelog.GetEntry`, `Changelog.GetPreviousVersion`, `Changelog.GetNextVersion`, `versionIndex`, `CheckLoadConditions`, `IsTalentPickerOpen`, `_ClassifyImportReviewText`, and `_ApplyReviewedImport`
- No in-game, combat, or restricted-content validation was performed; this is static-only dead-code removal with no intended runtime behavior change.