### PR TITLE
Remove dead resource bar migration helpers

### DIFF
--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -1782,18 +1782,6 @@ local function GetFallbackResourceBarSettings(addon, classKey)
     return settings
 end
 
-function CooldownCompanion:CaptureLegacyScopedBarSettingsSeeds()
-    local profile = self.db and self.db.profile
-    if not profile then
-        return
-    end
-
-    CaptureLegacyScopedBarSystemSeed(profile, RESOURCE_BAR_SYSTEM_SPEC)
-    for _, systemSpec in pairs(SCOPED_BAR_SYSTEMS) do
-        CaptureLegacyScopedBarSystemSeed(profile, systemSpec)
-    end
-end
-
 function CooldownCompanion:EnsureLegacyScopedBarSeenCharacters()
     local profile = self.db and self.db.profile
     if not profile then
@@ -1935,22 +1923,8 @@ function CooldownCompanion:RunResourceBarClassScopeMigration()
     end
 end
 
-function CooldownCompanion:GetResourceBarClassSettingsStore()
-    local profile = self.db and self.db.profile
-    if type(profile) ~= "table" then
-        return nil
-    end
-    return EnsureResourceBarClassStore(profile)
-end
-
 function CooldownCompanion:GetCurrentResourceBarClassKey()
     return GetCurrentResourceBarClassKey(self)
-end
-
-function CooldownCompanion:EnsureCurrentCharacterScopedBarSettings()
-    self:GetResourceBarSettings()
-    self:GetCharacterScopedSettings("castBar")
-    self:GetCharacterScopedSettings("frameAnchoring")
 end
 
 function CooldownCompanion:GetResourceBarSettings()
@@ -1998,14 +1972,6 @@ end
 
 function CooldownCompanion:GetFrameAnchoringSettings()
     return self:GetCharacterScopedSettings("frameAnchoring")
-end
-
-function CooldownCompanion:GetResourceBarMigrationState()
-    local profile = self.db and self.db.profile
-    if type(profile) ~= "table" then
-        return nil
-    end
-    return EnsureResourceBarMigrationState(profile)
 end
 
 function CooldownCompanion:GetResourceBarConflict(classKey)
@@ -2060,14 +2026,6 @@ end
 
 function CooldownCompanion:GetCurrentResourceBarConflictExportMessage()
     return self:GetResourceBarConflictExportMessage(GetCurrentResourceBarClassKey(self))
-end
-
-function CooldownCompanion:GetResourceBarUnsafeLegacySummary()
-    local profile = self.db and self.db.profile
-    local state = type(profile) == "table" and rawget(profile, RESOURCE_BAR_MIGRATION_KEY) or nil
-    local unsafe = type(state) == "table" and state.unsafeCharKeys or nil
-    local keys = SortedMapKeys(unsafe)
-    return keys
 end
 
 function CooldownCompanion:ResolveResourceBarConflict(classKey, sourceCharKey, options)


### PR DESCRIPTION
## What Changed
- Removed five unreferenced resource-bar migration/inspection helper methods from `CooldownCompanion/Core/ScopedSettings.lua`.
- Left the active resource-bar class migration, conflict detection/resolution, conflict export messages, and settings getters untouched.

## Why This Changed
- Exact repo-wide scans showed these helper methods were declaration-only, so they made the migration surface look larger than the code actually uses.

## Developer Impact
- Resource-bar migration code is smaller and easier to audit without changing the live migration or conflict-resolution paths.

## Validation
- `rg -n "CaptureLegacyScopedBarSettingsSeeds|GetResourceBarClassSettingsStore|EnsureCurrentCharacterScopedBarSettings|GetResourceBarMigrationState|GetResourceBarUnsafeLegacySummary" .` returned no matches after removal.
- `luac -p CooldownCompanion\Core\ScopedSettings.lua`
- `luac -p` across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- `lua tests\resource-bars-class-scope.lua`
- `lua tests\eligibility-import-export.lua`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended player-facing behavior change.