### PR TITLE
Remove dead eligibility strip helper exports

### DIFF
--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -1321,8 +1321,6 @@ local function DecodeSharedPayload(text)
     return true, data
 end
 
-ST._StripCharacterEligibilityFromLoadConditions = StripCharacterEligibilityFromLoadConditions
-ST._StripCharacterEligibilityFromEntity = StripCharacterEligibilityFromEntity
 ST._StripCharacterEligibilityFromProfile = StripCharacterEligibilityFromProfile
 ST._StripCharacterEligibilityFromPayload = StripCharacterEligibilityFromPayload
 ST._EncodeSharedPayload = EncodeSharedPayload


### PR DESCRIPTION
## What Changed
- Removed two unused `ST` exports for lower-level character-eligibility strip helpers in `ExportCodec.lua`.
- Kept the internal helper functions and the live profile/payload exports that import and export flows still use.

## Why This Changed
- Exact-symbol scans showed `ST._StripCharacterEligibilityFromLoadConditions` and `ST._StripCharacterEligibilityFromEntity` had no local callers, while their private functions are still used through the profile and payload wrappers.

## Developer Impact
- The import/export codec exposes a smaller helper surface, which makes future config maintenance easier without changing player-facing behavior.

## Validation
- `rg -u -n "ST\._StripCharacterEligibilityFromLoadConditions|ST\._StripCharacterEligibilityFromEntity" . -g "*.lua" -g "*.md" -g "*.toc"` returned no matches after removal.
- `luac -p CooldownCompanion_Config\Config\ExportCodec.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the existing LF-to-CRLF working-copy warning.
- `lua tests\eligibility-import-export.lua`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only export cleanup with no intended runtime behavior change.