### PR TITLE
Remove dead resource display helper exports

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -163,8 +163,6 @@ local function ReadDisplaySetting(baseSettings, specSettings, key, fallback)
     return fallback
 end
 
-CS._SeedSpecResourceDisplaySettings = SeedSpecResourceDisplaySettings
-CS._ReadResourceDisplaySetting = ReadDisplaySetting
 CS._GetCurrentConfigSpecID = GetCurrentConfigSpecID
 CS._GetSpecResourceDisplayProfile = RB.GetSpecResourceDisplayProfile
 CS._ResourceTextDisplayKeys = RB.RESOURCE_TEXT_DISPLAY_KEYS


### PR DESCRIPTION
## What Changed
- Removed the stale `CS._SeedSpecResourceDisplaySettings` and `CS._ReadResourceDisplaySetting` export assignments from `ResourceBarPanelsResource.lua`.
- Kept the underlying local helpers in place because the resource panel still calls them directly.

## Why This Changed
- Exact repo scans showed the `CS._...` exports had no production or test consumers, so they were leftover module surface rather than active integration points.

## Developer Impact
- The resource bar config panel exposes fewer dead internal hooks, making future maintenance around resource display settings easier to reason about.

## Validation
- `rg -n "CS\\._SeedSpecResourceDisplaySettings|CS\\._ReadResourceDisplaySetting" -g '*.lua' CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `rg -n "SeedSpecResourceDisplaySettings|ReadDisplaySetting"` confirmed the local helpers still have in-file callers.
- `luac -p CooldownCompanion_Config\\ConfigSettings\\ResourceBarPanelsResource.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- `lua tests\\resource-bars-class-scope.lua` passed.
- `lua tests\\eligibility-import-export.lua` passed.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only config cleanup with no intended behavior change.