### PR TITLE
Remove dead tracking resolver exports

### DIFF
--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -417,7 +417,5 @@ ST._UpdateChargeTracking = UpdateChargeTracking
 ST._UpdateDisplayCountTracking = UpdateDisplayCountTracking
 ST._UpdateItemChargeTracking = UpdateItemChargeTracking
 ST._UpdateIconTint = UpdateIconTint
-ST._ResolveIconTintIntent = ResolveIconTintIntent
-ST._ResolveDesaturationIntent = ResolveDesaturationIntent
 ST._ResolveIconDesaturationIntent = ResolveDesaturationIntent
 ST._EvaluateDesaturation = EvaluateDesaturation


### PR DESCRIPTION
## What Changed
- Removed two stale internal exports from `CooldownCompanion/ButtonFrame/Tracking.lua`: `ST._ResolveIconTintIntent` and `ST._ResolveDesaturationIntent`.
- Kept the local resolver functions and the live `ST._ResolveIconDesaturationIntent` export used by icon mode and visual state.

## Why This Changed
- Exact-symbol scans showed both removed `ST._...` exports had no consumers, so they only widened the internal button tracking surface without serving a caller.

## Developer Impact
- Maintainers have less duplicate/internal tracking API surface to reason about when following icon tint and desaturation behavior.
- The runtime paths are unchanged because the resolvers still run through their existing local callers and the active shared desaturation export remains intact.

## Validation
- `rg -n -F "ST._ResolveIconTintIntent" -g '*.lua'` returned no matches after removal.
- `rg -n -F "ST._ResolveDesaturationIntent" -g '*.lua'` returned no matches after removal.
- `rg -n -F "ST._ResolveIconDesaturationIntent" -g '*.lua'` confirmed the live export still has its two consumers.
- `luac -p CooldownCompanion\\ButtonFrame\\Tracking.lua` passed.
- `luac -p` passed for all 96 tracked Lua files.
- `git diff --check` passed, with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only export cleanup with no intended runtime behavior change.