### PR TITLE
Remove dead text mode exports

### DIFF
--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -1094,7 +1094,5 @@ end
 -- EXPORTS
 ------------------------------------------------------------------------
 ST._UpdateTextDisplay = UpdateTextDisplay
-ST._UpdateTextStyle = UpdateTextStyle
 ST._ParseFormatString = ParseFormatString
-ST._HasAnyEffects = HasAnyEffects
 ST._GetEffectiveTextHeight = GetEffectiveTextHeight


### PR DESCRIPTION
## What Changed
- Removed two unused internal `ST._...` exports from `CooldownCompanion/ButtonFrame/TextMode.lua`.
- Kept the underlying local `UpdateTextStyle` and `HasAnyEffects` functions intact because `TextMode.lua` still calls them directly.

## Why This Changed
- Exact-symbol scans showed `ST._UpdateTextStyle` and `ST._HasAnyEffects` had no tracked production or test consumers, so the export table carried stale cross-module API surface.

## Developer Impact
- Text mode now exposes less dead internal surface, making future button-frame maintenance easier to reason about without changing runtime behavior.

## Validation
- `rg -n "ST\._UpdateTextStyle|ST\._HasAnyEffects" CooldownCompanion CooldownCompanion_Config tests -g '*.lua'` returned no matches after removal.
- `luac -p CooldownCompanion\ButtonFrame\TextMode.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the repo's usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only dead-export cleanup with no intended behavior change.