### PR TITLE
Remove dead folder general tab builder

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
+++ b/CooldownCompanion_Config/ConfigSettings/GroupTabs.lua
@@ -3902,42 +3902,6 @@ local function BuildContainerLoadConditionsTab(scroll, containerId)
     end -- not specCollapsed
 end
 
-local function BuildFolderGeneralTab(scroll, folderId)
-    local db = CooldownCompanion.db.profile
-    local folder = db.folders and db.folders[folderId]
-    if not folder then return end
-
-    local heading = AceGUI:Create("Heading")
-    heading:SetText("Folder")
-    ColorHeading(heading)
-    heading:SetFullWidth(true)
-    scroll:AddChild(heading)
-
-    local nameBox = AceGUI:Create("EditBox")
-    nameBox:SetLabel("Name")
-    nameBox:SetText(folder.name or "")
-    nameBox:SetFullWidth(true)
-    local function CommitFolderName(widget, text)
-        if CooldownCompanion:RenameFolder(folderId, text) then
-            CooldownCompanion:RefreshConfigPanel()
-        elseif widget and widget.SetText then
-            widget:SetText(folder.name or "")
-        end
-    end
-    nameBox:SetCallback("OnEnterPressed", function(widget, event, text)
-        CommitFolderName(widget, text)
-    end)
-    nameBox:SetCallback("OnEditFocusLost", function(widget)
-        CommitFolderName(widget, widget:GetText())
-    end)
-    scroll:AddChild(nameBox)
-
-    local section = AceGUI:Create("Label")
-    section:SetText("|cff888888Section:|r " .. tostring(folder.section or "character"))
-    section:SetFullWidth(true)
-    scroll:AddChild(section)
-end
-
 local function BuildFolderLoadConditionsTab(scroll, folderId)
     local db = CooldownCompanion.db.profile
     local folder = db.folders and db.folders[folderId]
@@ -4046,5 +4010,4 @@ ST._BuildAppearanceTab = BuildAppearanceTab
 ST._BuildEffectsTab = BuildEffectsTab
 ST._BuildContainerGeneralTab = BuildContainerGeneralTab
 ST._BuildContainerLoadConditionsTab = BuildContainerLoadConditionsTab
-ST._BuildFolderGeneralTab = BuildFolderGeneralTab
 ST._BuildFolderLoadConditionsTab = BuildFolderLoadConditionsTab


### PR DESCRIPTION
## What Changed
- Removed the orphaned `BuildFolderGeneralTab` helper from `CooldownCompanion_Config/ConfigSettings/GroupTabs.lua`.
- Removed the stale `ST._BuildFolderGeneralTab` export while leaving the live folder load-conditions tab export intact.

## Why This Changed
- The folder settings surface in `Column4.lua` only wires `ST._BuildFolderLoadConditionsTab`; tracked Lua had no caller for `BuildFolderGeneralTab` or `ST._BuildFolderGeneralTab`.

## Developer Impact
- Keeps the config tab builder exports aligned with the UI that actually exists, reducing dead code around folder settings.

## Validation
- `rg -n "BuildFolderGeneralTab|_BuildFolderGeneralTab" --glob '*.lua' --glob '!tests/**'` returned no tracked Lua matches after removal.
- `luac -p CooldownCompanion_Config/ConfigSettings/GroupTabs.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed, with only the existing LF-to-CRLF working-copy warning.
- In-game, DevBridge, combat, and restricted-content validation were not run; this is a static-only cleanup with no intended behavior change.