### PR TITLE
Remove dead config widget helper

### DIFF
--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -3321,18 +3321,6 @@ ST._ContainersHaveForeignSpecs = ContainersHaveForeignSpecs
 ST._FolderHasForeignSpecs = FolderHasForeignSpecs
 
 ------------------------------------------------------------------------
--- Helper: Recursively disable all interactive AceGUI widgets
-------------------------------------------------------------------------
-local function DisableAllWidgets(container)
-    if container.children then
-        for _, child in ipairs(container.children) do
-            if child.SetDisabled then child:SetDisabled(true) end
-            DisableAllWidgets(child)
-        end
-    end
-end
-
-------------------------------------------------------------------------
 -- Helper: Get class-colored text for current player
 ------------------------------------------------------------------------
 local function GetClassColoredText(text)
@@ -3350,5 +3338,3 @@ local function GetClassColoredText(text)
     return safeText
 end
 ST._GetClassColoredText = GetClassColoredText
-
-ST._DisableAllWidgets = DisableAllWidgets


### PR DESCRIPTION
## What Changed
- Removed the unused `DisableAllWidgets` helper from `CooldownCompanion_Config/Config/State.lua`.
- Removed the stale `ST._DisableAllWidgets` export that had no production or test consumers.

## Why This Changed
- Exact-symbol scans showed the helper was only referenced by its own recursive call and dead export, so keeping it made the config state module look like it still had a live disable-all-widgets path.

## Developer Impact
- Config state is a little easier to audit because the exported helper list no longer includes an orphaned AceGUI utility.
- No player-facing behavior is intended to change.

## Validation
- `rg -n "DisableAllWidgets|ST\\._DisableAllWidgets" .` returned no matches after removal.
- `luac -p CooldownCompanion_Config\\Config\\State.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- `lua tests\\character-eligibility-choices.lua`
- `lua tests\\column1-profile-inventory.lua`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.