### PR TITLE
Remove dead bar colors controls

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
+++ b/CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua
@@ -1619,13 +1619,6 @@ local function BuildMaxStacksIndicatorAdvancedControls(container, styleTable, re
     })
 end
 
-local function BuildBarColorsControls(container, styleTable, refreshCallback)
-    AddColorPicker(container, styleTable, "barColor", "Bar Color", {0.2, 0.6, 1.0, 1.0}, true, refreshCallback, refreshCallback)
-    AddColorPicker(container, styleTable, "barCooldownColor", "Bar Cooldown Color", {0.6, 0.6, 0.6, 1.0}, true, refreshCallback, refreshCallback)
-    AddColorPicker(container, styleTable, "barChargeColor", "Bar Recharging Color", {1.0, 0.82, 0.0, 1.0}, true, refreshCallback, refreshCallback)
-    AddColorPicker(container, styleTable, "barBgColor", "Bar Background Color", {0.1, 0.1, 0.1, 0.8}, true, refreshCallback, refreshCallback)
-end
-
 local function BuildBarNameTextControls(container, styleTable, refreshCallback)
     local showNameCb = AceGUI:Create("CheckBox")
     showNameCb:SetLabel("Show Name Text")
@@ -1806,7 +1799,6 @@ ST._BuildBarActiveAuraControls = BuildBarActiveAuraControls
 ST._BuildBarAuraPulseControls = BuildBarAuraPulseControls
 ST._BuildPandemicBarPulseControls = BuildPandemicBarPulseControls
 ST._BuildMaxStacksIndicatorAdvancedControls = BuildMaxStacksIndicatorAdvancedControls
-ST._BuildBarColorsControls = BuildBarColorsControls
 ST._BuildBarNameTextControls = BuildBarNameTextControls
 ST._BuildBarReadyTextControls = BuildBarReadyTextControls
 ST._BuildTextFontControls = BuildTextFontControls


### PR DESCRIPTION
## What Changed
- Removed the unused `BuildBarColorsControls` config builder and its stale `ST._BuildBarColorsControls` export from `SectionBuilders.lua`.

## Why This Changed
- Exact-symbol scans showed the helper had no first-party or test consumers; it only existed as a local declaration plus an exported private helper.

## Developer Impact
- Keeps the shared settings builder export list aligned with live code and trims another dead config-maintenance surface.

## Validation
- Exact-symbol scan for `BuildBarColorsControls` / `_BuildBarColorsControls` returned no matches after removal.
- `luac -p CooldownCompanion_Config/ConfigSettings/SectionBuilders.lua`
- `luac -p` across 96 tracked first-party/test Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.
