### PR TITLE
Remove dead private exports

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -469,8 +469,6 @@ local function ActiveAuraIconNeedsRefresh(button, auraState, previousIcon, previ
 
     return false
 end
-ST._ActiveAuraIconNeedsRefresh = ActiveAuraIconNeedsRefresh
-
 local function ShouldUseActiveAuraIcon(buttonData)
     return buttonData
         and (buttonData.auraShowAuraIcon == true

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -356,7 +356,6 @@ local function ShowResourceBarConflictChooser(classKey, opts)
 end
 
 ST._ShowResourceBarConflictChooser = ShowResourceBarConflictChooser
-ST._HideResourceBarConflictChooser = HideResourceBarConflictChooser
 
 local function PruneDeletedFolderSelection(folderId)
     local db = CooldownCompanion.db and CooldownCompanion.db.profile

--- a/CooldownCompanion_Config/Config/SpellItemAdd.lua
+++ b/CooldownCompanion_Config/Config/SpellItemAdd.lua
@@ -1273,7 +1273,6 @@ end
 -- ST._ exports (consumed by later Config/ files)
 ------------------------------------------------------------------------
 ST._TryAdd = TryAdd
-ST._TryAddEquipmentSlot = TryAddEquipmentSlot
 ST._TryReceiveCursorDrop = TryReceiveCursorDrop
 ST._BuildAutocompleteCache = BuildAutocompleteCache
 ST._OnAutocompleteSelect = OnAutocompleteSelect


### PR DESCRIPTION
## What Changed
- Removed three `_`-prefixed internal exports that no tracked source or Lua test still references: `ST._ActiveAuraIconNeedsRefresh`, `ST._HideResourceBarConflictChooser`, and `ST._TryAddEquipmentSlot`.
- Left the underlying local helpers intact because they still have direct in-file callers.

## Why This Changed
- These exports had drifted into assignment-only maintenance surface after callers moved to local helper paths. Keeping them exported made the private `ST._` surface look broader than it is.

## Developer Impact
- Maintainers have fewer stale internal hooks to consider when reading cooldown icon refresh, resource bar conflict popup, and spell/item add code.
- No player-facing behavior is intended to change.

## Validation
- Exact scans over `CooldownCompanion`, `CooldownCompanion_Config`, and `tests` found no remaining references to the three removed exports.
- Exact scans confirmed the underlying local helpers still have direct in-file callers.
- `luac -p` passed for all tracked Lua files.
- `git diff --check` passed, with only the usual Windows LF-to-CRLF working-copy warnings.
- Passing focused Lua tests: `tests\column1-profile-inventory.lua`, `tests\durationless-aura-cooldown-swipe.lua`, and `tests\eligibility-import-export.lua`.
- Additional nearby tests were attempted but failed on assertions outside the removed-export surface: `tests\assisted-rotation-entry.lua` (`assisted type constant expected assistedRotation, got nil`), `tests\config-loader.lua` (`/cdc should toggle native config after load`), and `tests\zenith-stomp-charge-override.lua` (`ST._ResolveDesaturationIntent` nil). These were not treated as gating proof for this static-only cleanup.
- One five-reviewer `parallel-review-recommendations` pass against `origin/cleanup` completed with all five reviewers reporting `Findings: NO ACTIONABLE FINDINGS`.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup.