### PR TITLE
Remove dead resource bar anchor frame helper

### DIFF
--- a/CooldownCompanion/OtherBars/ResourceBarHelpers.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarHelpers.lua
@@ -183,12 +183,6 @@ local function GetEffectiveAnchorGroupId(settings)
     return CooldownCompanion:GetFirstAvailableAnchorGroup()
 end
 
-local function GetAnchorGroupFrame(settings)
-    local groupId = GetEffectiveAnchorGroupId(settings)
-    if not groupId then return nil end
-    return CooldownCompanion.groupFrames[groupId]
-end
-
 local function GetCurrentSpecID()
     local specIdx = C_SpecializationInfo.GetSpecialization()
     if specIdx then
@@ -2078,7 +2072,6 @@ RB.GetResourceGlobalThickness = GetResourceGlobalThickness
 RB.GetResourceAnchorGap = GetResourceAnchorGap
 RB.GetVerticalSideFallback = GetVerticalSideFallback
 RB.GetEffectiveAnchorGroupId = GetEffectiveAnchorGroupId
-RB.GetAnchorGroupFrame = GetAnchorGroupFrame
 RB.GetCurrentSpecID = GetCurrentSpecID
 RB.GetPlayerClassID = GetPlayerClassID
 RB.GetSpecCustomAuraBars = GetSpecCustomAuraBars


### PR DESCRIPTION
## What Changed
- Removed the unused resource-bar `GetAnchorGroupFrame` helper and its `RB.GetAnchorGroupFrame` export from `CooldownCompanion/OtherBars/ResourceBarHelpers.lua`.

## Why This Changed
- Exact tracked-source scans showed `RB.GetAnchorGroupFrame` was assignment-only; resource bars still use `RB.GetEffectiveAnchorGroupId`, while cast bar and frame anchoring keep their own separate local anchor-frame helpers.

## Developer Impact
- Narrows the internal resource-bar helper surface and removes one stale helper that could otherwise look like a supported dependency.

## Validation
- `rg -n --fixed-strings "GetAnchorGroupFrame" CooldownCompanion CooldownCompanion_Config`
- `rg -n --fixed-strings "RB.GetAnchorGroupFrame" CooldownCompanion CooldownCompanion_Config`
- `rg -n --fixed-strings "rb.GetAnchorGroupFrame" CooldownCompanion CooldownCompanion_Config`
- `luac -p CooldownCompanion\OtherBars\ResourceBarHelpers.lua`
- all tracked Lua files with `luac -p`
- `git diff --check`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.