### PR TITLE
Remove dead utils constants

### DIFF
--- a/CooldownCompanion/Core/Utils.lua
+++ b/CooldownCompanion/Core/Utils.lua
@@ -18,10 +18,6 @@ local issecretvalue = issecretvalue
 -- Constants
 --------------------------------------------------------------------------------
 
-ST.DEFAULT_OVERHANG_PCT = 32
-ST.DEFAULT_GLOW_COLOR = {1, 1, 1, 1}
-ST.DEFAULT_BG_COLOR = {0.2, 0.2, 0.2, 0.8}
-ST.NUM_GLOW_STYLES = 3
 ST.BORDER_RENDER_MODE_CUSTOM = "custom"
 ST.BORDER_RENDER_MODE_CRISP = "crisp"
 ST.DEFAULT_FONT_NAME = ST.DEFAULT_FONT_NAME or "Friz Quadrata TT"


### PR DESCRIPTION
## What Changed
- Removed four unused shared-table constants from `CooldownCompanion/Core/Utils.lua`: `ST.DEFAULT_OVERHANG_PCT`, `ST.DEFAULT_GLOW_COLOR`, `ST.DEFAULT_BG_COLOR`, and `ST.NUM_GLOW_STYLES`.

## Why This Changed
- Repo-wide exact-symbol searches showed these constants were assignment-only, while the neighboring shared constants in `Utils.lua` are still actively consumed.

## Developer Impact
- Keeps the shared `ST` constants surface limited to values that the addon actually uses, making future utility work a little easier to audit.

## Validation
- `rg -n "DEFAULT_OVERHANG_PCT|DEFAULT_GLOW_COLOR|DEFAULT_BG_COLOR|NUM_GLOW_STYLES"` returned no remaining matches after removal.
- `luac -p CooldownCompanion\Core\Utils.lua` passed.
- `luac -p` passed for all 96 tracked Lua files.
- `git diff --check` passed with only the existing LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.