### PR TITLE
Add one-click Cooldown Manager starter panels

### DIFF
--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1583,7 +1583,7 @@ function CooldownCompanion:ToggleGroupGlobal(containerId)
     self:RefreshAllGroups()
 end
 
-function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPetSpell, isPassive, forceAura, cdmChildSlot)
+function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPetSpell, isPassive, forceAura, cdmChildSlot, preserveSpellID)
     local group = self.db.profile.groups[groupId]
     if not group then return end
 
@@ -1596,10 +1596,15 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
     -- Resolve spell transforms to base spell ID so the override chain can
     -- freely reach all variant forms at runtime.  Skip for items (no spell
     -- transform system), pet spells (may not resolve through GetBaseSpell),
-    -- forced aura entries, and CDM child-slot buttons (viewer-frame mapping
-    -- uses specific IDs).
+    -- forced aura entries, CDM child-slot buttons (viewer-frame mapping
+    -- uses specific IDs), and CDM starter entries whose display metadata
+    -- already selected the intended spell ID.
     local transformNotified
-    if buttonType == "spell" and not isPetSpell and forceAura ~= true and not cdmChildSlot then
+    if buttonType == "spell"
+        and not isPetSpell
+        and forceAura ~= true
+        and not cdmChildSlot
+        and preserveSpellID ~= true then
         local baseID = ST.ResolveToBaseSpell(id)
         if baseID ~= id then
             id = baseID

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -33,6 +33,20 @@ local function IsValidDirectStyleCopyMode(mode)
     return DIRECT_STYLE_COPY_MODES[mode] == true
 end
 
+local function ShouldClearCDMPanelSourceForDisplayMode(group, displayMode)
+    if not (group and group.cdmPanelSource) then
+        return false
+    end
+
+    local getSourceDisplayMode = ST._GetCDMPanelSourceDisplayMode
+    if not getSourceDisplayMode then
+        return false
+    end
+
+    local expectedMode = getSourceDisplayMode(group.cdmPanelSource)
+    return expectedMode == nil or expectedMode ~= displayMode
+end
+
 local function GetAnchorOffset(point, width, height)
     local halfW = (width or 0) / 2
     local halfH = (height or 0) / 2
@@ -1325,6 +1339,9 @@ function CooldownCompanion:ChangePanelDisplayMode(groupId, newMode)
     end
 
     group.displayMode = newMode
+    if oldMode ~= newMode and ShouldClearCDMPanelSourceForDisplayMode(group, newMode) then
+        group.cdmPanelSource = nil
+    end
     if newMode == "bars" or newMode == "text" then
         group.style.orientation = "vertical"
     end

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1053,6 +1053,7 @@ function CooldownCompanion:DuplicateContainer(containerId)
             db.nextGroupId = newGroupId + 1
 
             local newPanel = CopyTable(group)
+            newPanel.cdmPanelSource = nil
             newPanel.parentContainerId = newContainerId
             newPanel.anchor = {
                 point = "CENTER",
@@ -1227,6 +1228,7 @@ function CooldownCompanion:DuplicatePanel(containerId, groupId)
     local newPanel = CopyTable(sourcePanel)
     newPanel.name = sourcePanel.name .. " (Copy)"
     newPanel.order = self:GetPanelCount(containerId) + 1
+    newPanel.cdmPanelSource = nil
     ResetCopiedStandalonePanelAnchor(newPanel, db.groups, groupId, containerId, containerId)
     NormalizeCopiedEntityForContainerScope(self, newPanel, container)
 
@@ -1426,6 +1428,7 @@ function CooldownCompanion:DuplicateGroup(id)
     local newGroup = CopyTable(sourceGroup)
     newGroup.name = sourceGroup.name .. " (Copy)"
     newGroup.order = newGroupId
+    newGroup.cdmPanelSource = nil
     newGroup.createdBy = self.db.keys.char
     newGroup.isGlobal = false
     NormalizeCopiedEntityForContainerScope(self, newGroup, newGroup)

--- a/CooldownCompanion/Core/SpellQueries.lua
+++ b/CooldownCompanion/Core/SpellQueries.lua
@@ -17,6 +17,25 @@ local function IsConcreteSpellID(spellID)
 end
 ST.IsConcreteSpellID = IsConcreteSpellID
 
+function ST.ResolveCDMDisplaySpellID(cooldownInfo)
+    if type(cooldownInfo) ~= "table" then
+        return nil
+    end
+    if IsConcreteSpellID(cooldownInfo.linkedSpellID) then
+        return cooldownInfo.linkedSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
+        return cooldownInfo.overrideTooltipSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.overrideSpellID) then
+        return cooldownInfo.overrideSpellID
+    end
+    if IsConcreteSpellID(cooldownInfo.spellID) then
+        return cooldownInfo.spellID
+    end
+    return nil
+end
+
 function ST.ResolveCDMAuraSpellID(cooldownInfo)
     if type(cooldownInfo) ~= "table" then
         return nil

--- a/CooldownCompanion/Core/SpellQueries.lua
+++ b/CooldownCompanion/Core/SpellQueries.lua
@@ -21,9 +21,8 @@ function ST.ResolveCDMDisplaySpellID(cooldownInfo)
     if type(cooldownInfo) ~= "table" then
         return nil
     end
-    if IsConcreteSpellID(cooldownInfo.linkedSpellID) then
-        return cooldownInfo.linkedSpellID
-    end
+    -- linkedSpellID is live aura state on Blizzard item data; starter setup
+    -- needs stable CDM metadata so cooldown panels do not capture an aura stage.
     if IsConcreteSpellID(cooldownInfo.overrideTooltipSpellID) then
         return cooldownInfo.overrideTooltipSpellID
     end

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -43,8 +43,16 @@ local ToggleConfigPanelMultiSelect = ST._ToggleConfigPanelMultiSelect
 local SelectConfigButton = ST._SelectConfigButton
 local SelectConfigButtonPanel = ST._SelectConfigButtonPanel
 local SelectConfigRotationAssistantEntry = ST._SelectConfigRotationAssistantEntry
+local ClearConfigButtonSelection = ST._ClearConfigButtonSelection
+local ClearConfigPanelSelection = ST._ClearConfigPanelSelection
+local BuildCDMPanelSourceData = ST._BuildCDMPanelSourceData
+local GetCDMPanelSourceData = ST._GetCDMPanelSourceData
+local PopulateCDMPanelFromSource = ST._PopulateCDMPanelFromSource
+local ApplyCDMStarterPanelLayout = ST._ApplyCDMStarterPanelLayout
+local IsCDMPanelSourceKey = ST._IsCDMPanelSourceKey
 
 local IsTriggerPanelGroup
+local RefreshCDMPanelFromSource
 
 local function IsContainerVisibleInConfig(containerOrContainerId)
     if CooldownCompanion.ResolveContainerClassScope then
@@ -108,6 +116,7 @@ local ROW_BADGE_SPACING = 2
 local ROW_BADGE_RIGHT_PAD = 4
 local TEXTURE_PANEL_HEADER_BADGE_ATLAS = "UI-HUD-MicroMenu-Communities-Icon-Notification"
 local CURSOR_PANEL_HEADER_BADGE_ATLAS = "cursor_cast_32"
+local CDM_PANEL_HEADER_BADGE_ATLAS = "common-icon-rotateleft"
 local PANEL_HEADER_TYPE_BADGE_GAP = 2
 local TRIGGER_PANEL_BADGE_COLOR = { 1.0, 0.18, 0.78 }
 local PANEL_TYPE_TOOLTIPS = {
@@ -161,6 +170,20 @@ local function AddPanelTypeMenuTooltip(info, displayMode)
 
     info.tooltipTitle = tooltip.title
     info.tooltipText = tooltip.description
+    info.tooltipOnButton = true
+end
+
+local function ShowCDMStarterTooltip(owner)
+    GameTooltip:SetOwner(owner, "ANCHOR_TOP")
+    GameTooltip:AddLine("Build from Cooldown Manager", 1, 0.82, 0, true)
+    GameTooltip:AddLine("Creates editable panels from displayed Essential, Utility, Tracked Buffs, and Tracked Bars sections.", 1, 1, 1, true)
+    GameTooltip:AddLine("Not Displayed entries are ignored.", 0.75, 0.75, 0.75, true)
+    GameTooltip:Show()
+end
+
+local function AddCDMStarterMenuTooltip(info)
+    info.tooltipTitle = "Add Missing CDM Panels"
+    info.tooltipText = "Creates any missing Cooldown Manager starter panels without duplicating existing CDM panels."
     info.tooltipOnButton = true
 end
 
@@ -317,6 +340,57 @@ local function ConfigureCursorAnchorBadge(header, panel)
     badge:Hide()
 end
 
+local function ConfigureCDMRefreshBadge(header, panel, panelId, containerId, cursorBadgeShown)
+    local badge = header.frame._cdcCDMRefreshBadge
+    if not badge then
+        badge = CreateFrame("Button", nil, header.frame)
+        badge:SetSize(16, 16)
+        badge:RegisterForClicks("LeftButtonUp")
+        badge:SetPropagateMouseClicks(false)
+        badge:SetPropagateMouseMotion(false)
+        badge.icon = badge:CreateTexture(nil, "OVERLAY")
+        badge.icon:SetAllPoints()
+        badge:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:AddLine("Refresh from Cooldown Manager", 1, 0.82, 0, true)
+            GameTooltip:AddLine("Replace this panel's entries from its linked CDM section.", 1, 1, 1, true)
+            GameTooltip:Show()
+        end)
+        badge:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+        end)
+        header.frame._cdcCDMRefreshBadge = badge
+    end
+
+    badge:SetFrameLevel(header.frame:GetFrameLevel() + 25)
+    badge:ClearAllPoints()
+
+    if not (panel
+        and panel.cdmPanelSource
+        and IsCDMPanelSourceKey
+        and IsCDMPanelSourceKey(panel.cdmPanelSource)) then
+        badge:Hide()
+        return
+    end
+
+    local leftOffset = 4
+    if cursorBadgeShown then
+        leftOffset = leftOffset + ROW_BADGE_SIZE + ROW_BADGE_SPACING
+    end
+    badge:SetPoint("LEFT", header.frame, "LEFT", leftOffset, 0)
+    badge.icon:SetAtlas(CDM_PANEL_HEADER_BADGE_ATLAS, false)
+    badge.icon:SetVertexColor(0.35, 0.8, 1, 0.95)
+    if badge.icon.SetDesaturated then
+        badge.icon:SetDesaturated(false)
+    end
+    badge:SetScript("OnClick", function(_, button)
+        if button ~= "LeftButton" then return end
+        GameTooltip:Hide()
+        RefreshCDMPanelFromSource(panelId, panel, containerId)
+    end)
+    badge:Show()
+end
+
 local function ConfigurePanelTypeBadge(header, displayMode, textWidth)
     local modeBadge = header._cdcModeBadge
     if not modeBadge then
@@ -417,6 +491,168 @@ local function CreatePanelInSelectedContainer(displayMode, opts)
     FinalizeCreatedPanel(newPanelId, displayMode, opts)
 end
 
+local function PrintCooldownManagerUnavailable(sourceData)
+    local reason = sourceData and sourceData.failureReason
+    if type(reason) ~= "string" or reason == "" then
+        reason = "Unknown reason"
+    end
+    CooldownCompanion:Print("Cooldown Manager unavailable: " .. reason)
+end
+
+local function GetExistingCDMPanelSources(containerId)
+    local existing = {}
+    for _, panelInfo in ipairs(CooldownCompanion:GetPanels(containerId) or {}) do
+        local panel = panelInfo.group
+        if panel and panel.cdmPanelSource and IsCDMPanelSourceKey and IsCDMPanelSourceKey(panel.cdmPanelSource) then
+            existing[panel.cdmPanelSource] = true
+        end
+    end
+    return existing
+end
+
+local function CreateCDMPanelFromSource(containerId, sourceData)
+    local panelId = CooldownCompanion:CreatePanel(containerId, sourceData.displayMode)
+    if not panelId then
+        return nil, 0
+    end
+
+    local group = CooldownCompanion.db.profile.groups[panelId]
+    if group then
+        group.name = sourceData.panelName
+        group.cdmPanelSource = sourceData.key
+        if ApplyCDMStarterPanelLayout then
+            ApplyCDMStarterPanelLayout(group, sourceData.key, containerId)
+        end
+    end
+
+    local added = PopulateCDMPanelFromSource and PopulateCDMPanelFromSource(panelId, sourceData) or 0
+    return panelId, added
+end
+
+local function CreateMissingCDMPanelsInSelectedContainer()
+    local containerId = CS.selectedContainer
+    if not containerId then
+        return
+    end
+
+    if not BuildCDMPanelSourceData then
+        CooldownCompanion:Print("Cooldown Manager panel setup is unavailable.")
+        return
+    end
+
+    local sourceData = BuildCDMPanelSourceData()
+    if not (sourceData and sourceData.available) then
+        PrintCooldownManagerUnavailable(sourceData)
+        return
+    end
+
+    if (sourceData.totalEntries or 0) == 0 then
+        CooldownCompanion:Print("No displayed Cooldown Manager entries found.")
+        return
+    end
+
+    local existingSources = GetExistingCDMPanelSources(containerId)
+    local createdPanelIds = {}
+    local createdBySource = {}
+    local createdEntryCount = 0
+
+    for _, source in ipairs(sourceData.sources or {}) do
+        if not existingSources[source.key] and source.entries and #source.entries > 0 then
+            local panelId, added = CreateCDMPanelFromSource(containerId, source)
+            if panelId then
+                createdPanelIds[#createdPanelIds + 1] = panelId
+                createdBySource[source.key] = panelId
+                createdEntryCount = createdEntryCount + (added or 0)
+                existingSources[source.key] = true
+            end
+        end
+    end
+
+    if #createdPanelIds == 0 then
+        CooldownCompanion:Print("No missing Cooldown Manager panels to add.")
+        return
+    end
+
+    local selectPanelId = createdBySource.essential or createdPanelIds[1]
+    SelectConfigPanel(selectPanelId, { containerId = containerId })
+    CS.addingToPanelId = nil
+    CS.pendingEditBoxFocus = false
+    CooldownCompanion:RefreshConfigPanel()
+    CooldownCompanion:Print(("Created %d Cooldown Manager panel%s with %d entr%s."):format(
+        #createdPanelIds,
+        #createdPanelIds == 1 and "" or "s",
+        createdEntryCount,
+        createdEntryCount == 1 and "y" or "ies"
+    ))
+end
+
+local function DeleteEmptyCDMPanel(data)
+    if type(data) ~= "table" then
+        return
+    end
+
+    local containerId = data.containerId
+    local panelId = data.panelId
+    local panel = CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[panelId]
+        or nil
+    if not panel or panel.parentContainerId ~= containerId or panel.cdmPanelSource ~= data.sourceKey then
+        return
+    end
+
+    local panelName = panel.name or "Panel"
+    CooldownCompanion:ClearAllConfigPreviews()
+    if CooldownCompanion:DeletePanel(containerId, panelId) then
+        if CS.selectedGroup == panelId and ClearConfigPanelSelection then
+            ClearConfigPanelSelection()
+        end
+        if CS.selectedPanels then
+            CS.selectedPanels[panelId] = nil
+        end
+        if CS.addingToPanelId == panelId then
+            CS.addingToPanelId = nil
+        end
+        CooldownCompanion:RefreshConfigPanel()
+        CooldownCompanion:Print("Deleted " .. panelName .. ": Cooldown Manager section is empty.")
+    end
+end
+ST._DeleteEmptyCDMPanel = DeleteEmptyCDMPanel
+
+RefreshCDMPanelFromSource = function(panelId, panel, containerId)
+    if not (panel and panel.cdmPanelSource and IsCDMPanelSourceKey and IsCDMPanelSourceKey(panel.cdmPanelSource)) then
+        return
+    end
+
+    local sourceData = BuildCDMPanelSourceData and BuildCDMPanelSourceData() or nil
+    if not (sourceData and sourceData.available) then
+        PrintCooldownManagerUnavailable(sourceData)
+        return
+    end
+
+    local source = GetCDMPanelSourceData and GetCDMPanelSourceData(sourceData, panel.cdmPanelSource) or nil
+    if not source or not source.entries or #source.entries == 0 then
+        ShowPopupAboveConfig("CDC_DELETE_EMPTY_CDM_PANEL", panel.name or "Panel", {
+            containerId = containerId,
+            panelId = panelId,
+            sourceKey = panel.cdmPanelSource,
+        })
+        return
+    end
+
+    local added = PopulateCDMPanelFromSource and PopulateCDMPanelFromSource(panelId, source) or 0
+    if CS.selectedGroup == panelId and ClearConfigButtonSelection then
+        ClearConfigButtonSelection()
+    end
+    CooldownCompanion:RefreshConfigPanel()
+    CooldownCompanion:Print(("Refreshed %s from Cooldown Manager (%d entr%s)."):format(
+        panel.name or "Panel",
+        added,
+        added == 1 and "y" or "ies"
+    ))
+end
+
 local function EnsureCol2PanelTypeMenu()
     if not CS.col2PanelTypeMenu then
         CS.col2PanelTypeMenu = CreateFrame("Frame", "CDCCol2PanelTypeMenu", UIParent, "UIDropDownMenuTemplate")
@@ -487,6 +723,16 @@ local function PopulateCol2PanelCreationBar(panelBtnWidth)
             if level ~= 1 then return end
 
             local info = UIDropDownMenu_CreateInfo()
+            info.text = "Add Missing CDM Panels"
+            info.notCheckable = true
+            AddCDMStarterMenuTooltip(info)
+            info.func = function()
+                CloseDropDownMenus()
+                CreateMissingCDMPanelsInSelectedContainer()
+            end
+            UIDropDownMenu_AddButton(info, level)
+
+            info = UIDropDownMenu_CreateInfo()
             info.text = "Text Panel"
             info.notCheckable = true
             AddPanelTypeMenuTooltip(info, "text")
@@ -583,6 +829,35 @@ local function RenderColumn2NoPanelsState(classColor)
     desc:SetFont((GameFontNormal:GetFont()), 12, "")
     desc:SetColor(0.7, 0.7, 0.7)
     CS.col2Scroll:AddChild(desc)
+
+    local cdmButtonSpacer = AceGUI:Create("SimpleGroup")
+    cdmButtonSpacer:SetFullWidth(true)
+    cdmButtonSpacer:SetHeight(12)
+    cdmButtonSpacer.noAutoHeight = true
+    CS.col2Scroll:AddChild(cdmButtonSpacer)
+
+    local cdmButton = AceGUI:Create("Button")
+    cdmButton:SetText("Build from Cooldown Manager")
+    cdmButton:SetFullWidth(true)
+    cdmButton:SetCallback("OnClick", function()
+        CreateMissingCDMPanelsInSelectedContainer()
+    end)
+    cdmButton:SetCallback("OnEnter", function(widget)
+        ShowCDMStarterTooltip(widget.frame)
+    end)
+    cdmButton:SetCallback("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    CS.col2Scroll:AddChild(cdmButton)
+
+    local cdmHelp = AceGUI:Create("Label")
+    ST._ConfigureWrappedHelperLabel(cdmHelp)
+    cdmHelp:SetText("Uses displayed CDM sections only. Not Displayed entries are ignored.")
+    cdmHelp:SetFullWidth(true)
+    cdmHelp:SetJustifyH("CENTER")
+    cdmHelp:SetFont((GameFontNormal:GetFont()), 11, "")
+    cdmHelp:SetColor(0.7, 0.7, 0.7)
+    CS.col2Scroll:AddChild(cdmHelp)
 
     local helpSpacer = AceGUI:Create("SimpleGroup")
     helpSpacer:SetFullWidth(true)
@@ -1846,6 +2121,7 @@ local function RefreshColumn2()
                     and CooldownCompanion:IsGroupCursorAnchored(panel)
                     or false
                 ConfigureCursorAnchorBadge(header, panel)
+                ConfigureCDMRefreshBadge(header, panel, panelId, CS.selectedContainer, isCursorAnchoredPanel)
                 rightOffset = ConfigureGenericRenameBadge(header, panel, panelId, rightOffset)
 
                 -- Anchor unlock badge (shown when panel is individually unlocked)

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -50,6 +50,7 @@ local GetCDMPanelSourceData = ST._GetCDMPanelSourceData
 local PopulateCDMPanelFromSource = ST._PopulateCDMPanelFromSource
 local ApplyCDMStarterPanelLayout = ST._ApplyCDMStarterPanelLayout
 local IsCDMPanelSourceKey = ST._IsCDMPanelSourceKey
+local GetCDMPanelSourceDisplayMode = ST._GetCDMPanelSourceDisplayMode
 
 local IsTriggerPanelGroup
 local RefreshCDMPanelFromSource
@@ -185,6 +186,18 @@ local function AddCDMStarterMenuTooltip(info)
     info.tooltipTitle = "Add Missing CDM Panels"
     info.tooltipText = "Creates any missing Cooldown Manager starter panels without duplicating existing CDM panels."
     info.tooltipOnButton = true
+end
+
+local function IsActiveCDMPanelSource(panel)
+    if not (panel
+        and panel.cdmPanelSource
+        and IsCDMPanelSourceKey
+        and IsCDMPanelSourceKey(panel.cdmPanelSource)) then
+        return false
+    end
+
+    local expectedMode = GetCDMPanelSourceDisplayMode and GetCDMPanelSourceDisplayMode(panel.cdmPanelSource) or nil
+    return expectedMode == nil or panel.displayMode == expectedMode
 end
 
 local function GetPanelTypeBadgeAtlas(displayMode)
@@ -365,10 +378,7 @@ local function ConfigureCDMRefreshBadge(header, panel, panelId, containerId, cur
     badge:SetFrameLevel(header.frame:GetFrameLevel() + 25)
     badge:ClearAllPoints()
 
-    if not (panel
-        and panel.cdmPanelSource
-        and IsCDMPanelSourceKey
-        and IsCDMPanelSourceKey(panel.cdmPanelSource)) then
+    if not IsActiveCDMPanelSource(panel) then
         badge:Hide()
         return
     end
@@ -503,7 +513,7 @@ local function GetExistingCDMPanelSources(containerId)
     local existing = {}
     for _, panelInfo in ipairs(CooldownCompanion:GetPanels(containerId) or {}) do
         local panel = panelInfo.group
-        if panel and panel.cdmPanelSource and IsCDMPanelSourceKey and IsCDMPanelSourceKey(panel.cdmPanelSource) then
+        if IsActiveCDMPanelSource(panel) then
             existing[panel.cdmPanelSource] = true
         end
     end
@@ -621,7 +631,7 @@ end
 ST._DeleteEmptyCDMPanel = DeleteEmptyCDMPanel
 
 RefreshCDMPanelFromSource = function(panelId, panel, containerId)
-    if not (panel and panel.cdmPanelSource and IsCDMPanelSourceKey and IsCDMPanelSourceKey(panel.cdmPanelSource)) then
+    if not IsActiveCDMPanelSource(panel) then
         return
     end
 

--- a/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
+++ b/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
@@ -12,6 +12,7 @@ local math_max = math.max
 local tonumber = tonumber
 
 local IsConcreteSpellID = ST.IsConcreteSpellID
+local ResolveCDMDisplaySpellID = ST.ResolveCDMDisplaySpellID
 local ResolveCDMAuraSpellID = ST.ResolveCDMAuraSpellID
 local bit_band = bit and bit.band
 
@@ -57,6 +58,11 @@ end
 
 local function IsKnownSourceKey(sourceKey)
     return CDM_PANEL_SOURCE_BY_KEY[sourceKey] ~= nil
+end
+
+local function GetSourceDisplayMode(sourceKey)
+    local source = CDM_PANEL_SOURCE_BY_KEY[sourceKey]
+    return source and source.displayMode or nil
 end
 
 local function CheckCooldownViewerAvailable()
@@ -157,7 +163,9 @@ local function ResolveEntrySpellID(source, cooldownInfo)
         return ResolveCDMAuraSpellID and ResolveCDMAuraSpellID(cooldownInfo) or nil
     end
 
-    return cooldownInfo and cooldownInfo.spellID or nil
+    return ResolveCDMDisplaySpellID and ResolveCDMDisplaySpellID(cooldownInfo)
+        or cooldownInfo and cooldownInfo.spellID
+        or nil
 end
 
 local function BuildSourceEntries(source, dataProvider)
@@ -276,6 +284,9 @@ local function PopulateCDMPanelFromSource(panelId, sourceData)
             entry.forceAura
         )
         if index then
+            if sourceData.entryKind == "spell" and group.buttons and group.buttons[index] then
+                group.buttons[index].name = entry.name
+            end
             added = added + 1
         end
     end
@@ -345,4 +356,5 @@ ST._GetCDMPanelSourceData = GetSourceData
 ST._PopulateCDMPanelFromSource = PopulateCDMPanelFromSource
 ST._ApplyCDMStarterPanelLayout = ApplyCDMStarterPanelLayout
 ST._IsCDMPanelSourceKey = IsKnownSourceKey
+ST._GetCDMPanelSourceDisplayMode = GetSourceDisplayMode
 ST._CDMPanelSources = CDM_PANEL_SOURCES

--- a/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
+++ b/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
@@ -281,7 +281,9 @@ local function PopulateCDMPanelFromSource(panelId, sourceData)
             entry.name,
             nil,
             entry.isPassive,
-            entry.forceAura
+            entry.forceAura,
+            nil,
+            sourceData.entryKind == "spell"
         )
         if index then
             if sourceData.entryKind == "spell" and group.buttons and group.buttons[index] then

--- a/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
+++ b/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
@@ -81,6 +81,29 @@ local function CheckCooldownViewerAvailable()
     return true, nil
 end
 
+local function GetCooldownViewerSettingsDataProvider()
+    local settings = CooldownViewerSettings
+    if not settings and C_AddOns and C_AddOns.LoadAddOn then
+        C_AddOns.LoadAddOn("Blizzard_CooldownViewer")
+        settings = CooldownViewerSettings
+    end
+
+    local dataProvider = settings
+        and settings.GetDataProvider
+        and settings:GetDataProvider()
+        or nil
+    if not (dataProvider
+        and dataProvider.CheckBuildDisplayData
+        and dataProvider.GetOrderedCooldownIDsForCategory
+        and dataProvider.GetCooldownInfoForID) then
+        return nil
+    end
+
+    -- Raw category sets include entries Blizzard shows under Not Displayed.
+    dataProvider:CheckBuildDisplayData()
+    return dataProvider
+end
+
 local function GetCooldownCategory(source)
     local categories = Enum and Enum.CooldownViewerCategory
     return categories and categories[source.categoryKey] or nil
@@ -137,14 +160,14 @@ local function ResolveEntrySpellID(source, cooldownInfo)
     return cooldownInfo and cooldownInfo.spellID or nil
 end
 
-local function BuildSourceEntries(source)
+local function BuildSourceEntries(source, dataProvider)
     local entries = {}
     local category = GetCooldownCategory(source)
     if category == nil then
         return entries
     end
 
-    local cooldownIDs = C_CooldownViewer.GetCooldownViewerCategorySet(category, false)
+    local cooldownIDs = dataProvider:GetOrderedCooldownIDsForCategory(category, false)
     if type(cooldownIDs) ~= "table" then
         return entries
     end
@@ -152,7 +175,7 @@ local function BuildSourceEntries(source)
     local seen = {}
     for _, cooldownID in ipairs(cooldownIDs) do
         if type(cooldownID) == "number" then
-            local cooldownInfo = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
+            local cooldownInfo = dataProvider:GetCooldownInfoForID(cooldownID)
             if type(cooldownInfo) == "table"
                 and cooldownInfo.isKnown ~= false
                 and (source.entryKind ~= "aura" or ShouldIncludeAuraCooldownInfo(cooldownInfo)) then
@@ -203,9 +226,16 @@ local function BuildCDMPanelSourceData()
         return result
     end
 
+    local dataProvider = GetCooldownViewerSettingsDataProvider()
+    if not dataProvider then
+        result.available = false
+        result.failureReason = "Cooldown Manager display data is unavailable."
+        return result
+    end
+
     for _, sourceSpec in ipairs(CDM_PANEL_SOURCES) do
         local source = CopySourceSpec(sourceSpec)
-        source.entries = BuildSourceEntries(sourceSpec)
+        source.entries = BuildSourceEntries(sourceSpec, dataProvider)
         result.totalEntries = result.totalEntries + #source.entries
         result.sources[#result.sources + 1] = source
         result.sourcesByKey[source.key] = source

--- a/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
+++ b/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
@@ -1,0 +1,318 @@
+--[[
+    CooldownCompanion - Config/CooldownManagerPanels
+    Read-only Cooldown Manager starter panel helpers.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local ipairs = ipairs
+local math_floor = math.floor
+local math_max = math.max
+local tonumber = tonumber
+
+local IsConcreteSpellID = ST.IsConcreteSpellID
+local ResolveCDMAuraSpellID = ST.ResolveCDMAuraSpellID
+local bit_band = bit and bit.band
+
+local CDM_PANEL_SOURCES = {
+    {
+        key = "trackedBuffs",
+        categoryKey = "TrackedBuff",
+        panelName = "CDM | Tracked Buffs",
+        displayMode = "icons",
+        entryKind = "aura",
+        layoutKind = "trackedBuffs",
+    },
+    {
+        key = "essential",
+        categoryKey = "Essential",
+        panelName = "CDM | Essential Cooldowns",
+        displayMode = "icons",
+        entryKind = "spell",
+        layoutKind = "essential",
+    },
+    {
+        key = "utility",
+        categoryKey = "Utility",
+        panelName = "CDM | Utility Cooldowns",
+        displayMode = "icons",
+        entryKind = "spell",
+        layoutKind = "utility",
+    },
+    {
+        key = "trackedBars",
+        categoryKey = "TrackedBar",
+        panelName = "CDM | Tracked Bars",
+        displayMode = "bars",
+        entryKind = "aura",
+        layoutKind = "trackedBars",
+    },
+}
+
+local CDM_PANEL_SOURCE_BY_KEY = {}
+for _, source in ipairs(CDM_PANEL_SOURCES) do
+    CDM_PANEL_SOURCE_BY_KEY[source.key] = source
+end
+
+local function IsKnownSourceKey(sourceKey)
+    return CDM_PANEL_SOURCE_BY_KEY[sourceKey] ~= nil
+end
+
+local function CheckCooldownViewerAvailable()
+    if not (C_CooldownViewer
+        and C_CooldownViewer.GetCooldownViewerCategorySet
+        and C_CooldownViewer.GetCooldownViewerCooldownInfo
+        and Enum
+        and Enum.CooldownViewerCategory) then
+        return false, "Cooldown Manager API is unavailable."
+    end
+
+    if C_CooldownViewer.IsCooldownViewerAvailable then
+        local available, failureReason = C_CooldownViewer.IsCooldownViewerAvailable()
+        if available ~= true then
+            if type(failureReason) == "string" and failureReason ~= "" then
+                return false, failureReason
+            end
+            return false, "Unknown reason"
+        end
+    end
+
+    return true, nil
+end
+
+local function GetCooldownCategory(source)
+    local categories = Enum and Enum.CooldownViewerCategory
+    return categories and categories[source.categoryKey] or nil
+end
+
+local function HasCooldownFlag(cooldownInfo, flag)
+    if not (cooldownInfo and type(flag) == "number" and bit_band) then
+        return false
+    end
+    local flags = cooldownInfo.flags
+    if type(flags) ~= "number" then
+        return false
+    end
+    return bit_band(flags, flag) ~= 0
+end
+
+local function ShouldIncludeAuraCooldownInfo(cooldownInfo)
+    if type(cooldownInfo) ~= "table" then
+        return false
+    end
+
+    local flagsEnum = Enum and Enum.CooldownSetSpellFlags
+    if flagsEnum and HasCooldownFlag(cooldownInfo, flagsEnum.HideAura) then
+        return false
+    end
+
+    return true
+end
+
+local function ResolveSpellName(spellID)
+    if not (C_Spell and IsConcreteSpellID and IsConcreteSpellID(spellID)) then
+        return nil
+    end
+
+    if C_Spell.GetSpellInfo then
+        local spellInfo = C_Spell.GetSpellInfo(spellID)
+        if spellInfo and spellInfo.name then
+            return spellInfo.name
+        end
+    end
+
+    if C_Spell.GetSpellName then
+        return C_Spell.GetSpellName(spellID)
+    end
+
+    return nil
+end
+
+local function ResolveEntrySpellID(source, cooldownInfo)
+    if source.entryKind == "aura" then
+        return ResolveCDMAuraSpellID and ResolveCDMAuraSpellID(cooldownInfo) or nil
+    end
+
+    return cooldownInfo and cooldownInfo.spellID or nil
+end
+
+local function BuildSourceEntries(source)
+    local entries = {}
+    local category = GetCooldownCategory(source)
+    if category == nil then
+        return entries
+    end
+
+    local cooldownIDs = C_CooldownViewer.GetCooldownViewerCategorySet(category, false)
+    if type(cooldownIDs) ~= "table" then
+        return entries
+    end
+
+    local seen = {}
+    for _, cooldownID in ipairs(cooldownIDs) do
+        if type(cooldownID) == "number" then
+            local cooldownInfo = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
+            if type(cooldownInfo) == "table"
+                and cooldownInfo.isKnown ~= false
+                and (source.entryKind ~= "aura" or ShouldIncludeAuraCooldownInfo(cooldownInfo)) then
+                local spellID = ResolveEntrySpellID(source, cooldownInfo)
+                if IsConcreteSpellID and IsConcreteSpellID(spellID) and not seen[spellID] then
+                    local name = ResolveSpellName(spellID)
+                    if type(name) == "string" and name ~= "" then
+                        seen[spellID] = true
+                        entries[#entries + 1] = {
+                            id = spellID,
+                            name = name,
+                            sourceKey = source.key,
+                            cooldownID = cooldownID,
+                            forceAura = source.entryKind == "aura" and true or false,
+                            isPassive = source.entryKind == "aura" and true or nil,
+                        }
+                    end
+                end
+            end
+        end
+    end
+
+    return entries
+end
+
+local function CopySourceSpec(source)
+    return {
+        key = source.key,
+        categoryKey = source.categoryKey,
+        panelName = source.panelName,
+        displayMode = source.displayMode,
+        entryKind = source.entryKind,
+        layoutKind = source.layoutKind,
+    }
+end
+
+local function BuildCDMPanelSourceData()
+    local available, failureReason = CheckCooldownViewerAvailable()
+    local result = {
+        available = available == true,
+        failureReason = failureReason,
+        sources = {},
+        sourcesByKey = {},
+        totalEntries = 0,
+    }
+
+    if not result.available then
+        return result
+    end
+
+    for _, sourceSpec in ipairs(CDM_PANEL_SOURCES) do
+        local source = CopySourceSpec(sourceSpec)
+        source.entries = BuildSourceEntries(sourceSpec)
+        result.totalEntries = result.totalEntries + #source.entries
+        result.sources[#result.sources + 1] = source
+        result.sourcesByKey[source.key] = source
+    end
+
+    return result
+end
+
+local function GetSourceData(sourceData, sourceKey)
+    if not (sourceData and sourceKey) then
+        return nil
+    end
+    return sourceData.sourcesByKey and sourceData.sourcesByKey[sourceKey] or nil
+end
+
+local function PopulateCDMPanelFromSource(panelId, sourceData)
+    local group = CooldownCompanion
+        and CooldownCompanion.db
+        and CooldownCompanion.db.profile
+        and CooldownCompanion.db.profile.groups
+        and CooldownCompanion.db.profile.groups[panelId]
+        or nil
+    if not group then
+        return 0
+    end
+
+    group.buttons = {}
+
+    local added = 0
+    for _, entry in ipairs(sourceData and sourceData.entries or {}) do
+        local index = CooldownCompanion:AddButtonToGroup(
+            panelId,
+            "spell",
+            entry.id,
+            entry.name,
+            nil,
+            entry.isPassive,
+            entry.forceAura
+        )
+        if index then
+            added = added + 1
+        end
+    end
+
+    if added == 0 and CooldownCompanion.RefreshGroupFrame then
+        CooldownCompanion:RefreshGroupFrame(panelId)
+    end
+
+    return added
+end
+
+local function SetPanelAnchor(group, containerId, x, y)
+    if not group then
+        return
+    end
+    group.anchor = {
+        point = "CENTER",
+        relativeTo = "CooldownCompanionContainer" .. tostring(containerId),
+        relativePoint = "CENTER",
+        x = x,
+        y = y,
+    }
+end
+
+local function ScaleIconPanel(style, scale, floorSize)
+    local baseSize = tonumber(style.buttonSize) or ST.BUTTON_SIZE or 36
+    style.buttonSize = math_max(floorSize, math_floor((baseSize * scale) + 0.5))
+    style.maintainAspectRatio = true
+    style.iconWidth = nil
+    style.iconHeight = nil
+    style.orientation = "horizontal"
+    style.growthOrigin = "TOPLEFT"
+    style.buttonsPerRow = math_max(8, tonumber(style.buttonsPerRow) or 12)
+end
+
+local function ApplyCDMStarterPanelLayout(group, sourceKey, containerId)
+    local source = CDM_PANEL_SOURCE_BY_KEY[sourceKey]
+    if not (group and source) then
+        return
+    end
+
+    group.style = group.style or {}
+    local style = group.style
+
+    if source.layoutKind == "essential" then
+        ScaleIconPanel(style, 1.3, 46)
+        SetPanelAnchor(group, containerId, -130, 30)
+    elseif source.layoutKind == "trackedBuffs" then
+        ScaleIconPanel(style, 0.95, 34)
+        SetPanelAnchor(group, containerId, -130, 95)
+    elseif source.layoutKind == "utility" then
+        ScaleIconPanel(style, 0.95, 34)
+        SetPanelAnchor(group, containerId, -130, -35)
+    elseif source.layoutKind == "trackedBars" then
+        style.orientation = "vertical"
+        style.growthOrigin = "TOPLEFT"
+        style.buttonsPerRow = 1
+        style.barLength = math_max(180, tonumber(style.barLength) or 180)
+        style.barHeight = math_max(20, tonumber(style.barHeight) or 20)
+        style.barIconSize = math_max(20, tonumber(style.barIconSize) or style.barHeight or 20)
+        SetPanelAnchor(group, containerId, 180, 30)
+    end
+end
+
+ST._BuildCDMPanelSourceData = BuildCDMPanelSourceData
+ST._GetCDMPanelSourceData = GetSourceData
+ST._PopulateCDMPanelFromSource = PopulateCDMPanelFromSource
+ST._ApplyCDMStarterPanelLayout = ApplyCDMStarterPanelLayout
+ST._IsCDMPanelSourceKey = IsKnownSourceKey
+ST._CDMPanelSources = CDM_PANEL_SOURCES

--- a/CooldownCompanion_Config/Config/ExportCodec.lua
+++ b/CooldownCompanion_Config/Config/ExportCodec.lua
@@ -17,6 +17,9 @@ local UNSUPPORTED_COMPACT_FORMATS = {
     compact1 = true,
     compact2 = true,
 }
+local LOCAL_PANEL_METADATA_KEYS = {
+    cdmPanelSource = true,
+}
 
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
     classAllowlist = "class",
@@ -173,6 +176,64 @@ local function StripCharacterEligibilityFromPayload(payload)
     if type(payload.bars) == "table" then
         for _, bar in ipairs(payload.bars) do
             stripped = stripped + StripCharacterEligibilityFromEntity(bar)
+        end
+    end
+    return stripped
+end
+
+local function StripLocalPanelMetadataFromEntity(entity)
+    if type(entity) ~= "table" then return 0 end
+    local stripped = 0
+    for key in pairs(LOCAL_PANEL_METADATA_KEYS) do
+        if entity[key] ~= nil then
+            entity[key] = nil
+            stripped = stripped + 1
+        end
+    end
+    return stripped
+end
+
+local function StripLocalPanelMetadataFromContainerEntry(entry)
+    if type(entry) ~= "table" then return 0 end
+    local stripped = 0
+    if type(entry.panels) == "table" then
+        for _, panel in ipairs(entry.panels) do
+            stripped = stripped + StripLocalPanelMetadataFromEntity(panel)
+        end
+    end
+    return stripped
+end
+
+local function StripLocalPanelMetadataFromProfile(profile)
+    if type(profile) ~= "table" then return 0 end
+    local stripped = 0
+    if type(profile.groups) == "table" then
+        for _, group in pairs(profile.groups) do
+            stripped = stripped + StripLocalPanelMetadataFromEntity(group)
+        end
+    end
+    return stripped
+end
+
+local function StripLocalPanelMetadataFromPayload(payload)
+    if type(payload) ~= "table" then return 0 end
+    local stripped = 0
+    stripped = stripped + StripLocalPanelMetadataFromProfile(payload)
+    stripped = stripped + StripLocalPanelMetadataFromProfile(payload.profile)
+    stripped = stripped + StripLocalPanelMetadataFromEntity(payload.group)
+    if type(payload.groups) == "table" then
+        for _, group in ipairs(payload.groups) do
+            stripped = stripped + StripLocalPanelMetadataFromEntity(group)
+        end
+    end
+    if type(payload.panels) == "table" then
+        for _, panel in ipairs(payload.panels) do
+            stripped = stripped + StripLocalPanelMetadataFromEntity(panel)
+        end
+    end
+    if type(payload.containers) == "table" then
+        for _, entry in ipairs(payload.containers) do
+            stripped = stripped + StripLocalPanelMetadataFromContainerEntry(entry)
         end
     end
     return stripped
@@ -711,6 +772,8 @@ local function CompactPanel(group, styleDefaults, panelContainerRef, formatVersi
             and IsPanelAnchor(group.anchor)
             and HasActivePanelAlphaSettings(group) then
             compact.inheritPanelAlpha = true
+        elseif LOCAL_PANEL_METADATA_KEYS[key] then
+            -- Local setup metadata stays in the active profile only.
         elseif panelDefaults[key] ~= nil then
             if not DeepEqual(value, panelDefaults[key]) then
                 compact[key] = CopyValue(value)
@@ -754,6 +817,7 @@ local function RehydratePanel(group, styleDefaults, panelContainerRef, formatVer
     if preserveCustomPanelAlpha then
         group.inheritPanelAlpha = false
     end
+    StripLocalPanelMetadataFromEntity(group)
 end
 
 local function CompactContainer(container, formatVersion)
@@ -1260,6 +1324,7 @@ local function EncodeSharedPayload(payload, exportKind)
     local formatVersion = CURRENT_COMPACT_FORMAT_VALUE
 
     StripAndTagCharacterEligibility(exportData)
+    StripLocalPanelMetadataFromPayload(exportData)
 
     if CooldownCompanion.StampExportPayloadCheckpoint then
         CooldownCompanion:StampExportPayloadCheckpoint(exportData, exportKind)
@@ -1317,12 +1382,16 @@ local function DecodeSharedPayload(text)
     end
 
     StripAndTagCharacterEligibility(data)
+    StripLocalPanelMetadataFromPayload(data)
 
     return true, data
 end
 
 ST._StripCharacterEligibilityFromProfile = StripCharacterEligibilityFromProfile
 ST._StripCharacterEligibilityFromPayload = StripCharacterEligibilityFromPayload
+ST._StripLocalPanelMetadataFromEntity = StripLocalPanelMetadataFromEntity
+ST._StripLocalPanelMetadataFromProfile = StripLocalPanelMetadataFromProfile
+ST._StripLocalPanelMetadataFromPayload = StripLocalPanelMetadataFromPayload
 ST._EncodeSharedPayload = EncodeSharedPayload
 ST._DecodeSharedPayload = DecodeSharedPayload
 ST._PrepareSharedImportText = PrepareSharedImportText

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -17,6 +17,8 @@ local ClearConfigPanelMultiSelection = ST._ClearConfigPanelMultiSelection
 local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local StripCharacterEligibilityFromPayload = ST._StripCharacterEligibilityFromPayload
+local StripLocalPanelMetadataFromEntity = ST._StripLocalPanelMetadataFromEntity
+local StripLocalPanelMetadataFromPayload = ST._StripLocalPanelMetadataFromPayload
 
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
     classAllowlist = "class",
@@ -431,6 +433,21 @@ StaticPopupDialogs["CDC_DELETE_PANEL"] = {
             CS.addingToPanelId = nil
         end
         CooldownCompanion:RefreshConfigPanel()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+StaticPopupDialogs["CDC_DELETE_EMPTY_CDM_PANEL"] = {
+    text = "Cooldown Manager section for '%s' is empty. Delete this panel?",
+    button1 = "Delete",
+    button2 = "Cancel",
+    OnAccept = function(self, data)
+        if ST._DeleteEmptyCDMPanel then
+            ST._DeleteEmptyCDMPanel(data)
+        end
     end,
     timeout = 0,
     whileDead = true,
@@ -966,6 +983,9 @@ end
 
 local function BuildGroupExportData(group)
     local data = CopyTable(group)
+    if StripLocalPanelMetadataFromEntity then
+        StripLocalPanelMetadataFromEntity(data)
+    end
     data.createdBy = nil
     data.order = nil
     data.folderId = nil
@@ -1122,6 +1142,7 @@ local function CreateImportedPanel(db, containerId, panelIndex, srcPanel, import
 
     local panel = srcPanel and CopyTable(srcPanel) or BuildDefaultImportedPanel(containerId)
     panel._originalGroupId = nil
+    panel.cdmPanelSource = nil
     panel.parentContainerId = containerId
     panel.order = panelIndex
     if not panel.anchor then
@@ -1355,6 +1376,9 @@ local function ApplyGroupImportData(data)
     activeGroupImportPayloads[data] = nil
     if RejectUnsupportedImportPayload(data, "group import") then
         return false
+    end
+    if StripLocalPanelMetadataFromPayload then
+        StripLocalPanelMetadataFromPayload(data)
     end
 
     if not data.type then

--- a/CooldownCompanion_Config/Config/Popups.lua
+++ b/CooldownCompanion_Config/Config/Popups.lua
@@ -18,6 +18,7 @@ local ClearConfigCustomBarSelection = ST._ClearConfigCustomBarSelection
 local EncodeSharedPayload = ST._EncodeSharedPayload
 local StripCharacterEligibilityFromPayload = ST._StripCharacterEligibilityFromPayload
 local StripLocalPanelMetadataFromEntity = ST._StripLocalPanelMetadataFromEntity
+local StripLocalPanelMetadataFromProfile = ST._StripLocalPanelMetadataFromProfile
 local StripLocalPanelMetadataFromPayload = ST._StripLocalPanelMetadataFromPayload
 
 local LOAD_CONDITION_ALLOWLIST_KEYS = {
@@ -700,6 +701,9 @@ StaticPopupDialogs["CDC_DUPLICATE_PROFILE"] = {
             CooldownCompanion._suppressOwnershipRestamp = true
             db:SetProfile(newName)
             db:CopyProfile(data.source)
+            if StripLocalPanelMetadataFromProfile then
+                StripLocalPanelMetadataFromProfile(db.profile)
+            end
             CooldownCompanion._suppressOwnershipRestamp = nil
             ResetConfigSelection(true)
             CooldownCompanion:RefreshConfigPanel()

--- a/CooldownCompanion_Config/Config/ProfileImport.lua
+++ b/CooldownCompanion_Config/Config/ProfileImport.lua
@@ -8,6 +8,7 @@ local CooldownCompanion = ST.Addon
 
 local ResetConfigSelection = ST._ResetConfigSelection
 local StripCharacterEligibilityFromProfile = ST._StripCharacterEligibilityFromProfile
+local StripLocalPanelMetadataFromProfile = ST._StripLocalPanelMetadataFromProfile
 
 local PROFILE_IMPORT_METADATA_KEYS = {
     _exporterCharKey = true,
@@ -541,6 +542,9 @@ function CooldownCompanion:ApplyFullProfileImport(data, options)
 
     local strippedCharacterEligibility = tonumber(data._cdcCharacterEligibilityStripped) or 0
     CopyProfileDataIntoActiveProfile(db.profile, data)
+    if StripLocalPanelMetadataFromProfile then
+        StripLocalPanelMetadataFromProfile(db.profile)
+    end
     strippedCharacterEligibility = strippedCharacterEligibility + (StripCharacterEligibilityFromProfile
         and StripCharacterEligibilityFromProfile(db.profile)
         or 0)

--- a/CooldownCompanion_Config/CooldownCompanion_Config.toc
+++ b/CooldownCompanion_Config/CooldownCompanion_Config.toc
@@ -28,6 +28,7 @@ Config\Pickers.lua
 Config\TalentPicker.lua
 Config\SpellItemAdd.lua
 Config\AutoImport.lua
+Config\CooldownManagerPanels.lua
 Config\DragReorderTargets.lua
 Config\DragReorderPreview.lua
 Config\DragReorderLifecycle.lua


### PR DESCRIPTION
## What Players Will Notice
- New groups with no panels now offer a `Build from Cooldown Manager` action that creates editable Cooldown Companion panels from the player’s displayed Blizzard Cooldown Manager sections.
- Existing groups can use `Add Missing CDM Panels` from the panel menu to add only missing CDM-sourced panels without duplicating ones already created.
- Starter panels are named for their CDM source, use separate icon panels for tracked buffs, essential cooldowns, and utility cooldowns, and place tracked bars in a vertical bar panel instead of stacking everything on top of itself.
- Entries in Cooldown Manager’s Not Displayed section are ignored. Spell cooldown panels add spell entries with aura tracking disabled, while tracked buff/bar sections add aura entries with aura tracking enabled.
- CDM-created panels show a refresh badge that replaces entries from the linked CDM section while keeping the panel’s name, layout, order, selection behavior, and visual settings. If the linked section is empty, the refresh flow asks before deleting that panel.

## Why This Changed
- Brand new users had to manually recreate information they had already organized in Blizzard’s Cooldown Manager before Cooldown Companion became useful.
- Blizzard’s raw CDM category sets can include entries that the settings UI places under Not Displayed, so the starter flow now reads the displayed settings sections instead of the raw category membership list.

## What Changed
- Added read-only CDM starter-panel helpers that build source entries from Blizzard’s Cooldown Viewer settings data provider.
- Added Column 2 empty-state and Add Panel menu actions for creating CDM-sourced panels.
- Added a local `cdmPanelSource` marker for setup-created panels plus per-panel refresh behavior.
- Stripped `cdmPanelSource` from duplicated panels and import/export payloads so copied or shared panels become normal editable panels.

## Validation
- `lua tests/cdm-starter-panels.lua`
- `lua tests/eligibility-import-export.lua`
- `luac -p` on all tracked Lua files
- `git diff --check origin/dev...HEAD`
- In-game smoke testing has not been run yet; combat/restricted-content behavior has not been verified.