### PR TITLE
Remove unused CDM starter source export

### DIFF
--- a/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
+++ b/CooldownCompanion_Config/Config/CooldownManagerPanels.lua
@@ -380,4 +380,3 @@ ST._PopulateCDMPanelFromSource = PopulateCDMPanelFromSource
 ST._ApplyCDMStarterPanelLayout = ApplyCDMStarterPanelLayout
 ST._IsCDMPanelSourceKey = IsKnownSourceKey
 ST._GetCDMPanelSourceDisplayMode = GetSourceDisplayMode
-ST._CDMPanelSources = CDM_PANEL_SOURCES


### PR DESCRIPTION
## What Changed
- Removed the unused `ST._CDMPanelSources` private export from the Cooldown Manager starter panel helper module.

## Why This Changed
- The source table is only consumed inside `CooldownManagerPanels.lua`; an exact source-and-test scan showed the exported `ST._CDMPanelSources` symbol had no consumers.

## Developer Impact
- Keeps the starter-panel helper surface smaller and avoids implying an unused private contract exists for other config modules.

## Validation
- `rg --line-number --fixed-strings "ST._CDMPanelSources" CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `luac -p CooldownCompanion_Config\Config\CooldownManagerPanels.lua`
- `lua tests\cdm-starter-panels.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning for the touched Lua file.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only private export cleanup with no intended runtime behavior change.