### PR TITLE
Remove dead config state exports

### DIFF
--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -238,9 +238,7 @@ local function OpenProfileWideBarTextureWindow()
 end
 
 CS.CloseProfileWideFontWindow = CloseProfileWideFontWindow
-CS.OpenProfileWideFontWindow = OpenProfileWideFontWindow
 CS.CloseProfileWideBarTextureWindow = CloseProfileWideBarTextureWindow
-CS.OpenProfileWideBarTextureWindow = OpenProfileWideBarTextureWindow
 
 if not AceGUI:GetLayout(MANUAL_COLUMN_LAYOUT) then
     -- These columns are positioned and sized manually, so their layout should

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -327,7 +327,6 @@ ST._configState = {
     -- CS.* function forward declarations (set by later files)
     IsStrataOrderComplete = nil,
     InitPendingStrataOrder = nil,
-    SetConfigPrimaryMode = nil,
     StartPickFrame = nil,
     StartPickCDM = nil,
     ShowPopupAboveConfig = nil,
@@ -3246,7 +3245,6 @@ end
 ------------------------------------------------------------------------
 -- ST._ exports (consumed by later Config/ files at load time)
 ------------------------------------------------------------------------
-CS.SetConfigPrimaryMode = SetConfigPrimaryMode
 ST._CompactUntitledInlineGroupConfig = CompactUntitledInlineGroupConfig
 ST._CleanRecycledEntry = CleanRecycledEntry
 ST._ApplyConfigRowIcon = ApplyConfigRowIcon


### PR DESCRIPTION
## What Changed
- Removed unused `CS.OpenProfileWideFontWindow` and `CS.OpenProfileWideBarTextureWindow` assignments from the config panel; the panel still calls the local open helpers directly.
- Removed the unused `CS.SetConfigPrimaryMode` forward declaration/export from config state; mode switching still goes through the existing `ST._SetConfigPrimaryMode` wrapper and `ST._SetConfigPrimaryModeImpl` implementation.

## Why This Changed
- Exact reference scans showed these `CS` properties had no consumers, leaving stale config-state surface around live local helpers and the stable `ST._SetConfigPrimaryMode` bridge.

## Developer Impact
- Keeps the shared config-state table closer to the contracts that are actually consumed, reducing false leads for future config maintenance.

## Validation
- `rg -n "CS\.OpenProfileWideFontWindow|ST\._configState\.OpenProfileWideFontWindow|CS\.OpenProfileWideBarTextureWindow|ST\._configState\.OpenProfileWideBarTextureWindow|CS\.SetConfigPrimaryMode|ST\._configState\.SetConfigPrimaryMode|SetConfigPrimaryMode = nil" CooldownCompanion CooldownCompanion_Config tests` returned no matches.
- `luac -p CooldownCompanion_Config\Config\Panel.lua CooldownCompanion_Config\Config\State.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check cleanup..HEAD` passed.
- `lua tests\config-loader.lua` was attempted but failed at `/cdc should toggle native config after load`; that harness does not load either changed file, so it was not used as passing validation for this static cleanup.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended player-facing behavior change.