### PR TITLE
Remove unused resource aura visual exports

### DIFF
--- a/CooldownCompanion/OtherBars/ResourceBarVisuals.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarVisuals.lua
@@ -1499,16 +1499,11 @@ end
 -- Add all visual functions to ST._RB
 ------------------------------------------------------------------------
 
-RB.GetResourceAuraEntry = GetResourceAuraEntry
-RB.GetLegacyResourceAuraEntry = GetLegacyResourceAuraEntry
 RB.GetActiveResourceAuraEntry = GetActiveResourceAuraEntry
-RB.GetResourceAuraTrackingMode = GetResourceAuraTrackingMode
 RB.GetResourceAuraConfiguredMaxStacks = GetResourceAuraConfiguredMaxStacks
 RB.IsResourceAuraOverlayEnabled = IsResourceAuraOverlayEnabled
 RB.GetResourceAuraState = GetResourceAuraState
 RB.HideResourceAuraStackSegments = HideResourceAuraStackSegments
-RB.LayoutResourceAuraStackSegments = LayoutResourceAuraStackSegments
-RB.EnsureResourceAuraStackSegments = EnsureResourceAuraStackSegments
 RB.ApplyResourceAuraStackSegments = ApplyResourceAuraStackSegments
 RB.ClearResourceAuraVisuals = ClearResourceAuraVisuals
 RB.UpdateContinuousTickMarker = UpdateContinuousTickMarker


### PR DESCRIPTION
## What Changed
- Removed five stale `ST._RB` bridge exports from `ResourceBarVisuals.lua` for resource-aura helper functions that no tracked production, config, or test code calls through the shared bridge.

## Why This Changed
- These helpers still have direct local callers inside `ResourceBarVisuals.lua`, but their exported aliases had become dead surface area. Keeping unused bridge exports makes the resource-bar visual API harder to audit.

## Developer Impact
- The resource-bar visual bridge now exposes fewer unused internals, making future resource-aura maintenance and exact-symbol sweeps simpler.

## Validation
- Exact tracked-source scan confirmed no remaining `ST._RB`/`RB` callers for the removed export names.
- `luac -p CooldownCompanion\OtherBars\ResourceBarVisuals.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check cleanup..HEAD`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.