### PR TITLE
Remove dead CDM display icon export

### DIFF
--- a/CooldownCompanion_Config/Config/Panel.lua
+++ b/CooldownCompanion_Config/Config/Panel.lua
@@ -1146,7 +1146,6 @@ local function CreateConfigPanel()
         cdmDisplayBtn:GetHighlightTexture():SetAlpha(0.3)
     end
     UpdateCdmDisplayIcon()
-    CS.UpdateCdmDisplayIcon = UpdateCdmDisplayIcon
 
     cdmDisplayBtn:SetScript("OnClick", function()
         CooldownCompanion.db.profile.cdmHidden = not CooldownCompanion.db.profile.cdmHidden


### PR DESCRIPTION
## What Changed
- Removed the unused `CS.UpdateCdmDisplayIcon` assignment from the config panel setup.

## Why This Changed
- The CDM display icon refresh helper is only used inside `CreateConfigPanel`; exporting it through the shared config state left a stale maintenance surface with no consumers.

## Developer Impact
- Keeps the config shared state smaller and makes the CDM display toggle easier to reason about without changing player-facing behavior.

## Validation
- `git grep -n -F "UpdateCdmDisplayIcon" -- .` now shows only the local helper and its two local call sites.
- `luac -p CooldownCompanion_Config\Config\Panel.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning before commit.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.