### PR TITLE
Remove stale custom bar scroll state

### DIFF
--- a/CooldownCompanion_Config/Config/Column4.lua
+++ b/CooldownCompanion_Config/Config/Column4.lua
@@ -469,7 +469,6 @@ local function RefreshColumn4(container)
                             scroll:SetLayout("List")
                             widget:AddChild(scroll)
                             container.customBarsDetailScroll = scroll
-                            CS.customBarSettingsScroll = scroll
                             container._customBarDetailScrollKey = GetCustomBarDetailScrollKey()
                             ST._BuildCustomAuraBarPanel(scroll, CS.selectedCustomBarId, CS.customBarSettingsTab)
                         end)


### PR DESCRIPTION
## What Changed
- Removed the stale `CS.customBarSettingsScroll` assignment from the Custom Bars detail tab rebuild path in `CooldownCompanion_Config/Config/Column4.lua`.

## Why This Changed
- Exact tracked-source scans showed `CS.customBarSettingsScroll` was only written and never read. The live detail scroll is already tracked on `container.customBarsDetailScroll`, which is the state used for scroll preservation.

## Developer Impact
- The config state surface has one fewer unused scroll handle, reducing confusion around the Custom Bars panel lifecycle.

## Validation
- `git grep -n -F "customBarSettingsScroll" -- .` returned no matches after removal.
- `luac -p CooldownCompanion_Config\Config\Column4.lua`
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.