### PR TITLE
Remove unused entry move helper export

### DIFF
--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -3069,5 +3069,4 @@ end
 ------------------------------------------------------------------------
 -- ST._ exports
 ------------------------------------------------------------------------
-ST._BuildEntryMoveDestinationSections = BuildEntryMoveDestinationSections
 ST._RefreshColumn2 = RefreshColumn2


### PR DESCRIPTION
## What Changed
- Removed the unused `ST._BuildEntryMoveDestinationSections` private export from `CooldownCompanion_Config/Config/Column2.lua`.

## Why This Changed
- The entry move destination helper still has direct local callers, but its `ST._` bridge had no tracked source, test, or local harness consumers.

## Developer Impact
- Keeps the config module's private export surface smaller and makes future maintenance less likely to treat an unused bridge as a supported cross-module contract.

## Validation
- `git grep -n -F "ST._BuildEntryMoveDestinationSections" -- .` returned no matches after removal.
- `git grep -n -F "BuildEntryMoveDestinationSections" -- .` shows only the local helper definition and its direct local caller.
- `luac -p CooldownCompanion_Config\Config\Column2.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended runtime behavior change.