### PR TITLE
Show charge spells only at zero charges

### DIFF
--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -134,6 +134,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
 
     -- Phase 1: Evaluate each hide condition and accumulate active reasons as bits.
     local hideReasons = 0
+    local zeroOnlyChargeSpellHide = false
     local auraTrackingReady = button._auraTrackingReady == true
     local barAuraStackDisplay = button._barAuraStackDisplay == true
     local itemUsesResolvedCooldownState = IsEntryItemLike(buttonData)
@@ -175,6 +176,7 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 if button._chargeState == CHARGE_STATE_FULL
                         or button._chargeState == CHARGE_STATE_MISSING then
                     hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
+                    zeroOnlyChargeSpellHide = true
                 end
             elseif button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
@@ -256,7 +258,10 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
     -- which is equivalent to "this is the only active hide reason."
     if hideReasons ~= 0 then
         for _, entry in ipairs(BASELINE_FALLBACKS) do
-            if bit_band(hideReasons, entry.bit) ~= 0 and buttonData[entry.key] then
+            local suppressFallback = zeroOnlyChargeSpellHide and entry.bit == HIDE_NOT_ON_COOLDOWN
+            if not suppressFallback
+                    and bit_band(hideReasons, entry.bit) ~= 0
+                    and buttonData[entry.key] then
                 if hideReasons == entry.bit then
                     local groupId = button._groupId
                     local group = groupId and CooldownCompanion.db.profile.groups[groupId]

--- a/CooldownCompanion/ButtonFrame/Visibility.lua
+++ b/CooldownCompanion/ButtonFrame/Visibility.lua
@@ -169,7 +169,14 @@ local function EvaluateButtonVisibility(button, buttonData, auraOverrideActive, 
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif UsesChargeBehavior(buttonData) then
-            if button._chargeState == CHARGE_STATE_FULL then
+            if buttonData.type == "spell"
+                    and buttonData.hasCharges == true
+                    and buttonData.showOnlyAtZeroCharges then
+                if button._chargeState == CHARGE_STATE_FULL
+                        or button._chargeState == CHARGE_STATE_MISSING then
+                    hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
+                end
+            elseif button._chargeState == CHARGE_STATE_FULL then
                 hideReasons = bit_bor(hideReasons, HIDE_NOT_ON_COOLDOWN)
             end
         elseif IsEntryItemLike(buttonData) then

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -2004,6 +2004,19 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         end
     end
 
+    local function ApplyToChargeSpellNotOnCooldownOnly(field, value)
+        if isBatch then
+            for idx in pairs(CS.selectedButtons) do
+                local bd = group.buttons[idx]
+                if bd and FilterChargeSpellNotOnCooldown(bd) then
+                    bd[field] = value
+                end
+            end
+        elseif FilterChargeSpellNotOnCooldown(buttonData) then
+            buttonData[field] = value
+        end
+    end
+
     -- Filtered apply: only write to equippable items (equip toggles).
     -- When clearing, write to ALL selected to clean stale data.
     local function ApplyToEquippable(field, value)
@@ -2248,8 +2261,9 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         WrapBatchCallback(showOnlyAtZeroCb, function(widget, event, val)
             ApplyToChargeSpellNotOnCooldown("showOnlyAtZeroCharges", val or nil)
             if val then
-                ApplyToChargeSpellNotOnCooldown("hideWhileZeroCharges", nil)
-                ApplyToChargeSpellNotOnCooldown("useBaselineAlphaFallbackZeroCharges", nil)
+                ApplyToChargeSpellNotOnCooldownOnly("useBaselineAlphaFallbackNotOnCooldown", nil)
+                ApplyToChargeSpellNotOnCooldownOnly("hideWhileZeroCharges", nil)
+                ApplyToChargeSpellNotOnCooldownOnly("useBaselineAlphaFallbackZeroCharges", nil)
             end
             CooldownCompanion:RefreshConfigPanel()
         end)
@@ -2268,6 +2282,10 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         ApplyCheckboxIndent(fallbackNotOnCDCb, 20)
         WrapBatchCallback(fallbackNotOnCDCb, function(widget, event, val)
             ApplyToSelected("useBaselineAlphaFallbackNotOnCooldown", val or nil)
+            if val then
+                ApplyToChargeSpellNotOnCooldownOnly("showOnlyAtZeroCharges", nil)
+            end
+            CooldownCompanion:RefreshConfigPanel()
         end)
         scroll:AddChild(fallbackNotOnCDCb)
 

--- a/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ButtonConditions.lua
@@ -1631,6 +1631,13 @@ local function FilterChargeCapable(bd)
     if bd.type == "item" and not CooldownCompanion.IsItemEquippable(bd) then return true end
     return false
 end
+local function FilterChargeSpell(bd)
+    if HasItemFallbacks(bd) then return false end
+    return bd.type == "spell" and bd.hasCharges == true and UsesChargeBehavior(bd)
+end
+local function FilterChargeSpellNotOnCooldown(bd)
+    return FilterChargeSpell(bd) and bd.hideWhileNotOnCooldown == true
+end
 
 -- Returns true if any selected button has field truthy
 local function AnySelectedHas(group, field)
@@ -1963,6 +1970,40 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         end
     end
 
+    -- Filtered apply: only write to charge-based spell buttons.
+    -- When clearing (value is falsy), write to ALL selected to clean stale data.
+    local function ApplyToChargeSpell(field, value)
+        if isBatch then
+            for idx in pairs(CS.selectedButtons) do
+                local bd = group.buttons[idx]
+                if bd then
+                    if not value or FilterChargeSpell(bd) then
+                        bd[field] = value
+                    end
+                end
+            end
+        else
+            buttonData[field] = value
+        end
+    end
+
+    -- Filtered apply for the nested "Hide While Not On Cooldown" charge-spell option.
+    -- When clearing, write to ALL selected to remove stale child values.
+    local function ApplyToChargeSpellNotOnCooldown(field, value)
+        if isBatch then
+            for idx in pairs(CS.selectedButtons) do
+                local bd = group.buttons[idx]
+                if bd then
+                    if not value or FilterChargeSpellNotOnCooldown(bd) then
+                        bd[field] = value
+                    end
+                end
+            end
+        else
+            buttonData[field] = value
+        end
+    end
+
     -- Filtered apply: only write to equippable items (equip toggles).
     -- When clearing, write to ALL selected to clean stale data.
     local function ApplyToEquippable(field, value)
@@ -2144,6 +2185,7 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
         if val then
             ApplyToSelected("hideWhileNotOnCooldown", nil)
             ApplyToSelected("useBaselineAlphaFallbackNotOnCooldown", nil)
+            ApplyToChargeSpell("showOnlyAtZeroCharges", nil)
         else
             ApplyToSelected("useBaselineAlphaFallbackOnCooldown", nil)
         end
@@ -2184,10 +2226,35 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
             ApplyToSelected("useBaselineAlphaFallbackOnCooldown", nil)
         else
             ApplyToSelected("useBaselineAlphaFallbackNotOnCooldown", nil)
+            ApplyToChargeSpell("showOnlyAtZeroCharges", nil)
         end
         CooldownCompanion:RefreshConfigPanel()
     end)
     scroll:AddChild(hideNotCDCb)
+
+    local showOnlyAtZeroCharges
+    if isBatch then
+        showOnlyAtZeroCharges = AnySelectedMatch(FilterChargeSpellNotOnCooldown)
+    else
+        showOnlyAtZeroCharges = buttonData.hideWhileNotOnCooldown
+            and FilterChargeSpell(buttonData)
+    end
+    if showOnlyAtZeroCharges then
+        local showOnlyAtZeroCb = AceGUI:Create("CheckBox")
+        showOnlyAtZeroCb:SetLabel("Only Show At Zero Charges")
+        SetCheckboxValue(showOnlyAtZeroCb, "showOnlyAtZeroCharges", FilterChargeSpellNotOnCooldown)
+        showOnlyAtZeroCb:SetFullWidth(true)
+        ApplyCheckboxIndent(showOnlyAtZeroCb, 20)
+        WrapBatchCallback(showOnlyAtZeroCb, function(widget, event, val)
+            ApplyToChargeSpellNotOnCooldown("showOnlyAtZeroCharges", val or nil)
+            if val then
+                ApplyToChargeSpellNotOnCooldown("hideWhileZeroCharges", nil)
+                ApplyToChargeSpellNotOnCooldown("useBaselineAlphaFallbackZeroCharges", nil)
+            end
+            CooldownCompanion:RefreshConfigPanel()
+        end)
+        scroll:AddChild(showOnlyAtZeroCb)
+    end
 
     -- Baseline Alpha Fallback (nested under hideWhileNotOnCooldown)
     local showFallbackNotOnCooldown
@@ -2324,6 +2391,7 @@ local function BuildVisibilitySettings(scroll, buttonData, infoButtons, batchCon
             ApplyToChargeCapable("hideWhileZeroCharges", val or nil)
             if val then
                 ApplyToChargeCapable("desaturateWhileZeroCharges", nil)
+                ApplyToChargeSpell("showOnlyAtZeroCharges", nil)
             else
                 ApplyToChargeCapable("useBaselineAlphaFallbackZeroCharges", nil)
             end


### PR DESCRIPTION
## What Players Will Notice
- Charge-based spell buttons can now be set to appear only when all charges are spent.
- For spells like Monk Roll, the button can stay hidden at full or partial charges, show at zero charges, and hide again as soon as one charge returns.

## Why This Changed
- `Hide While Not On Cooldown` previously treated charge spells as visible once any charge was missing, which made it impossible to use the button as a true “all charges spent” warning.
- The new behavior is opt-in so existing charge spell setups keep their current visibility behavior.

## What Changed
- Added a charge-spell-only `showOnlyAtZeroCharges` button setting behind a nested `Only Show At Zero Charges` checkbox under `Hide While Not On Cooldown`.
- Updated visibility evaluation so opted-in charge spells hide at full and partial charges, show at zero charges, and do not dim instead of hiding when the not-on-cooldown baseline fallback is also present.
- Kept charged item behavior unchanged and continued using the already-resolved charge state instead of adding new `C_Spell` reads in visibility code.
- Added config cleanup for conflicting charge visibility toggles in single-button and batch editing flows.

## Validation
- `luac -p CooldownCompanion\ButtonFrame\Visibility.lua CooldownCompanion_Config\ConfigSettings\ButtonConditions.lua`
- `luac -p` across all tracked Lua files
- `git diff --check origin/main...HEAD`
- Focused Lua visibility matrix for default charge behavior, zero-only charge behavior, fallback suppression, charged items, and normal non-charge spells
- Focused batch-clear matrix confirming unrelated charged item settings are preserved
- One five-reviewer `parallel-review-recommendations` pass after the follow-up fixes reported `Findings: NO ACTIONABLE FINDINGS`
- In-game Monk Roll validation has not been performed yet; combat/restricted-context validation and DevBridge/Lua error checks are still pending.