### PR TITLE
Remove dead resource panel helper functions

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua
@@ -896,13 +896,6 @@ end
 -- Identical to GetSafeRGBConfig; alias kept for call-site clarity (RGB vs RGBA intent)
 local GetSafeRGBAConfig = GetSafeRGBConfig
 
-local function CopyRGBConfig(color)
-    if type(color) ~= "table" or color[1] == nil or color[2] == nil or color[3] == nil then
-        return nil
-    end
-    return { color[1], color[2], color[3] }
-end
-
 local function GetSegmentedThresholdValueConfig(resource)
     local value = tonumber(resource and resource.segThresholdValue)
     if not value then
@@ -952,14 +945,6 @@ end
 ------------------------------------------------------------------------
 -- Autocomplete handlers
 ------------------------------------------------------------------------
-
-local function AttachAuraAutocompleteHandlers(editBoxWidget, onAuraSelect)
-    editBoxWidget:SetCallback("OnTextChanged", function(widget, event, text)
-        ShowAuraBarAutocompleteResults(text, widget, onAuraSelect)
-    end)
-
-    CS.SetupAutocompleteKeyHandler(editBoxWidget)
-end
 
 ------------------------------------------------------------------------
 -- Aura overlay UI builders
@@ -1243,35 +1228,6 @@ local function ClearLegacyResourceAuraFieldsConfig(resource)
     resource.auraUnit = nil
     resource.auraUnitExplicit = nil
 end
-
-local function ClearResourceAuraEntryConfig(powerType, resource, specID)
-    if type(resource.auraOverlayEntries) ~= "table" then
-        return
-    end
-
-    resource.auraOverlayEntries[specID] = nil
-    resource.auraOverlayEntries[tostring(specID)] = nil
-    if not next(resource.auraOverlayEntries) then
-        resource.auraOverlayEntries = nil
-    end
-    if type(resource.specOverrides) == "table" then
-        local specData = resource.specOverrides[specID] or resource.specOverrides[tostring(specID)]
-        if type(specData) == "table" then
-            specData.auraOverlayEnabled = nil
-            if not next(specData) then
-                resource.specOverrides[specID] = nil
-                resource.specOverrides[tostring(specID)] = nil
-                if not next(resource.specOverrides) then
-                    resource.specOverrides = nil
-                end
-            end
-        end
-    end
-
-    CooldownCompanion:ApplyResourceBars()
-    CooldownCompanion:RefreshConfigPanel()
-end
-
 
 local function AddResourceAuraOverrideControls(container, settings, powerType, resourceName, auraAdvButtons, opts)
     if not settings.resources[powerType] then


### PR DESCRIPTION
## What Changed
- Removed three orphaned local helper functions from `CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua`: `CopyRGBConfig`, `AttachAuraAutocompleteHandlers`, and `ClearResourceAuraEntryConfig`.

## Why This Changed
- Exact tracked-source/test scans showed these helpers had no remaining callers or exported bridge consumers after the live resource-aura panel path moved to direct autocomplete callbacks and the current legacy-field clearing helper.

## Developer Impact
- Keeps the Resource Bar panel helper module focused on live helper paths and removes stale aura-overlay code that could mislead future maintenance.

## Validation
- `git grep -n -F "CopyRGBConfig" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `git grep -n -F "AttachAuraAutocompleteHandlers" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `git grep -n -F "ClearResourceAuraEntryConfig" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- Exact declaration-only local scan found no remaining declaration-only locals in `ResourceBarPanelsHelpers.lua`.
- `luac -p CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua`
- `luac -p` passed for all 96 tracked Lua files.
- `git diff --check`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.
