### PR TITLE
Remove dead entry settings helper

### DIFF
--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -64,14 +64,6 @@ local function GetEntryStableKey(buttonData)
 end
 CooldownCompanion.GetEntryStableKey = GetEntryStableKey
 
-local function GetEntrySettingsKind(buttonData)
-    if IsEquipmentSlotEntry(buttonData) then
-        return EQUIPMENT_SLOT_TYPE
-    end
-    return buttonData and buttonData.type or nil
-end
-CooldownCompanion.GetEntrySettingsKind = GetEntrySettingsKind
-
 local function IsEntryItemLike(buttonData)
     return buttonData and (buttonData.type == "item" or IsEquipmentSlotEntry(buttonData))
 end


### PR DESCRIPTION
## What Changed
- Removed the unused `GetEntrySettingsKind` local helper and stale `CooldownCompanion.GetEntrySettingsKind` export from `CooldownCompanion/ButtonFrame/Helpers.lua`.

## Why This Changed
- Exact tracked-source scans showed the symbol was only declared and exported; no production or test code read it.

## Developer Impact
- Keeps the button helper API surface smaller and avoids maintaining an entry-kind helper that no code can call.

## Validation
- `git grep -n -F "GetEntrySettingsKind" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `luac -p CooldownCompanion/ButtonFrame/Helpers.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed, with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.