### PR TITLE
Remove dead Advanced Settings window state

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua
+++ b/CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua
@@ -248,7 +248,6 @@ local function CleanupWindow(widget)
     widget:ReleaseChildren()
     AceGUI:Release(widget)
     advancedWindow = nil
-    CS.advancedSettingsPanelWindow = nil
     activeDescriptor = nil
     if CS.SetActiveAdvancedSettingsToggleButton then
         CS.SetActiveAdvancedSettingsToggleButton(nil)
@@ -309,7 +308,6 @@ local function OpenAdvancedSettingsPanel(opts)
         window:EnableResize(false)
         window:SetCallback("OnClose", CleanupWindow)
         advancedWindow = window
-        CS.advancedSettingsPanelWindow = window
         if CS.RegisterConfigDragAlphaFrame then
             CS.RegisterConfigDragAlphaFrame(window.frame)
         end


### PR DESCRIPTION
## What Changed
- Removed the stale `CS.advancedSettingsPanelWindow` shared-state writes from the Advanced Settings panel lifecycle.

## Why This Changed
- The panel already uses the file-local `advancedWindow` handle for open, close, refresh, and cleanup behavior, and exact tracked-source scans showed no remaining consumers of `CS.advancedSettingsPanelWindow`.

## Developer Impact
- Keeps the config shared-state table from advertising a dead window handle that future config work could accidentally treat as a supported integration point.

## Validation
- `git grep -n -F "advancedSettingsPanelWindow" -- .` returned no matches after removal.
- `luac -p CooldownCompanion_Config/ConfigSettings/AdvancedSettingsPanel.lua`
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.