### PR TITLE
Keep resource panel helpers private

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -163,10 +163,6 @@ local function ReadDisplaySetting(baseSettings, specSettings, key, fallback)
     return fallback
 end
 
-CS._GetCurrentConfigSpecID = GetCurrentConfigSpecID
-CS._GetSpecResourceDisplayProfile = RB.GetSpecResourceDisplayProfile
-CS._ResourceTextDisplayKeys = RB.RESOURCE_TEXT_DISPLAY_KEYS
-
 local HealthResource = { ID = RB.RESOURCE_HEALTH }
 
 function HealthResource.GetEffectTextureOptions()
@@ -344,7 +340,7 @@ local function BuildResourceTextControls(container, settings, powerType, display
         EnsureResourceSettings(settings, capturedPt)
     end
     local baseSettings = settings.resources[capturedPt]
-    local resSettings = SeedSpecResourceDisplaySettings(settings, capturedPt, displaySpecID, CS._ResourceTextDisplayKeys) or baseSettings
+    local resSettings = SeedSpecResourceDisplaySettings(settings, capturedPt, displaySpecID, RB.RESOURCE_TEXT_DISPLAY_KEYS) or baseSettings
     local name = POWER_NAMES[capturedPt] or ("Power " .. capturedPt)
 
     local showTextValue = ReadDisplaySetting(baseSettings, resSettings, "showText", nil)
@@ -1934,8 +1930,8 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
         local hasContinuousTick = resourceSettingsPowerType ~= 101 and resourceSettingsPowerType ~= healthResourceID
         showThresholdsTicks = hasSegmentedThreshold or hasContinuousTick
     end
-    local displaySpecID = opts and tonumber(opts.specID) or CS._GetCurrentConfigSpecID()
-    local displayProfile = displaySpecID and CS._GetSpecResourceDisplayProfile(settings, displaySpecID) or nil
+    local displaySpecID = opts and tonumber(opts.specID) or GetCurrentConfigSpecID()
+    local displayProfile = displaySpecID and RB.GetSpecResourceDisplayProfile(settings, displaySpecID) or nil
     if not displaySpecID or not displayProfile then
         local label = AceGUI:Create("Label")
         ST._ConfigureWrappedHelperLabel(label)


### PR DESCRIPTION
## What Changed
- Removed three private resource-panel helper aliases from the shared `CS` config-state table.
- Updated the only same-file call sites to use the existing local helper and `RB` resource-bar helper table directly.

## Why This Changed
- Exact tracked-source/test scans showed `_GetCurrentConfigSpecID`, `_GetSpecResourceDisplayProfile`, and `_ResourceTextDisplayKeys` were only written to `CS` and read back inside `ResourceBarPanelsResource.lua`.
- Keeping these private helpers off shared state makes the resource panel module's real cross-file surface smaller and easier to audit.

## Developer Impact
- Future cleanup/export scans no longer need to treat these implementation details as possible cross-module contracts.
- No player-facing behavior is intended to change.

## Validation
- `git grep -n -F "_GetCurrentConfigSpecID" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `git grep -n -F "_GetSpecResourceDisplayProfile" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `git grep -n -F "_ResourceTextDisplayKeys" -- CooldownCompanion CooldownCompanion_Config tests` returned no matches after removal.
- `luac -p CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the existing LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only config-module cleanup with no intended runtime behavior change.