### PR TITLE
Remove dead Button helper exports

### DIFF
--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -390,7 +390,6 @@ local function IsDurationTextBindingSupported()
         and type(C_StringUtil.CreateNumericRuleFormatter) == "function"
         or false
 end
-CooldownCompanion.IsDurationTextBindingSupported = IsDurationTextBindingSupported
 
 local function UnbindDurationText(fontString, clearText)
     if not fontString then return end
@@ -595,7 +594,6 @@ CooldownCompanion.HasCastCountText = HasCastCountText
 local function HasConditionalCastCountText(buttonData)
     return GetConditionalCastCountFamily(buttonData) ~= nil
 end
-CooldownCompanion.HasConditionalCastCountText = HasConditionalCastCountText
 
 local function GetCastCountSpellID(buttonData, currentSpellID)
     local family = GetCastCountFamily(buttonData)
@@ -686,7 +684,6 @@ local function GetItemAvailableQuantity(itemID, forceChargeCount)
     end
     return stackCount, "stacks"
 end
-CooldownCompanion.GetItemAvailableQuantity = GetItemAvailableQuantity
 
 local function HasItemFallbacks(buttonData)
     return buttonData
@@ -787,7 +784,6 @@ local function NormalizeItemFallbackVisibilitySettings(buttonData, hasFallbacks,
 
     return changed
 end
-CooldownCompanion.NormalizeItemFallbackVisibilitySettings = NormalizeItemFallbackVisibilitySettings
 
 local function NormalizeItemFallbacks(buttonData)
     if not (buttonData and type(buttonData.itemFallbacks) == "table") then
@@ -849,7 +845,6 @@ local function ResolveItemFallback(buttonData)
 
     return primaryID, primaryQuantity, primaryKind
 end
-CooldownCompanion.ResolveItemFallback = ResolveItemFallback
 
 -- Position a region in the icon area of a bar button.
 -- inset=0 for backgrounds/bounds, inset=borderSize for the icon texture itself.


### PR DESCRIPTION
## What Changed
- Removed five stale `CooldownCompanion.*` export assignments from `CooldownCompanion/ButtonFrame/Helpers.lua` while leaving the live local helper functions in place.

## Why This Changed
- These helpers are only used inside `ButtonFrame/Helpers.lua`; exporting them made them look like cross-module contracts even though no production or test consumer reads those addon-table names.

## Developer Impact
- Duration text support checks, conditional cast-count detection, item quantity lookup, fallback visibility normalization, and fallback item resolution now have a smaller internal surface to maintain.

## Validation
- `rg` scan for the removed `CooldownCompanion.*` / `ST.Addon.*` helper exports returned no matches across `CooldownCompanion`, `CooldownCompanion_Config`, and `tests`.
- `luac -p CooldownCompanion\ButtonFrame\Helpers.lua` passed.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed, with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only export cleanup with no intended runtime behavior change.