### PR TITLE
Keep health resource color helpers private

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -908,8 +908,6 @@ function HealthResource.BuildColorControls(container, settings, applyBars)
     end
 end
 
-CS.healthResourceUI = HealthResource
-
 local function AddResourceSpecCopyButton(enableCb)
     local _, initialSpecOrder, currentSpecID = CooldownCompanion:GetResourceBarSpecCopyOptions()
     if not currentSpecID or #initialSpecOrder == 0 then
@@ -2054,7 +2052,7 @@ local function BuildResourceBarStylingPanel(container, sectionMode, opts)
     if showHealthColors then
         local health = settings.resources and settings.resources[healthResourceID]
         if health and health.enabled == true then
-            CS.healthResourceUI.BuildColorControls(container, settings, applyBars)
+            HealthResource.BuildColorControls(container, settings, applyBars)
         elseif mode == "health" then
             local label = AceGUI:Create("Label")
             ST._ConfigureWrappedHelperLabel(label)


### PR DESCRIPTION
## What Changed
- Removed the stale `CS.healthResourceUI` shared-state alias from the resource bar settings panel.
- Changed the one same-file health color call site to use the existing local `HealthResource` helper table directly.

## Why This Changed
- The alias was not a real cross-module contract: exact production and test scans showed no external `CS.healthResourceUI` consumers.
- Keeping the helper private reduces misleading config-state surface area while preserving the existing health color UI behavior.

## Developer Impact
- Future resource panel work has one fewer shared `CS` field to reason about.
- The health resource color controls stay anchored to their local implementation instead of appearing to be exported state.

## Validation
- `rg -n -F "CS.healthResourceUI" CooldownCompanion CooldownCompanion_Config tests` returned no matches after the change.
- `rg -n -F "healthResourceUI" .` returned no matches after the change.
- `luac -p CooldownCompanion_Config\ConfigSettings\ResourceBarPanelsResource.lua`
- `luac -p` across all 96 tracked Lua files.
- `git diff --check` passed; Git only reported the usual LF-to-CRLF working-copy warning before commit.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only config helper cleanup with no intended behavior change.