### PR TITLE
Keep resource bar height builder private

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua
@@ -97,6 +97,7 @@ local resourceSpecCopyButton
 local resourceSpecCopyMenu
 local thresholdTickDraftRows = {}
 local thresholdTickEditorErrors = {}
+local BuildBarHeightControls
 
 -- Imports from ResourceBarPanelsHelpers
 local RBP = ST._RBP
@@ -1240,7 +1241,7 @@ local function BuildResourceBarPositioningPanel(container)
     container:AddChild(segGapSlider)
 
     -- Bar Height + Custom Heights
-    ST._BuildBarHeightControls(container, settings, layout)
+    BuildBarHeightControls(container, settings, layout)
 
     -- ============ Anchor Settings (independent mode only) ============
     if isIndependentStack then
@@ -1376,7 +1377,7 @@ local function GetResourceBarTextureOptions()
 end
 
 -- Extracted to its own function to keep upvalue counts manageable in the caller.
-local function BuildBarHeightControls(container, settings, layout)
+BuildBarHeightControls = function(container, settings, layout)
     layout = layout or settings
     local thicknessField, thicknessLabel, customThicknessLabel = GetResourceThicknessFieldConfig(settings, layout)
     local customHeightsAdvKey = "customResourceBarHeights"
@@ -1492,8 +1493,6 @@ local function BuildBarHeightControls(container, settings, layout)
         {"When enabled, each resource can have its own bar size. Open advanced settings here to configure all resource sizes together.", 1, 1, 1, true},
     }, customHeightsCb)
 end
-
-ST._BuildBarHeightControls = BuildBarHeightControls
 
 local function AddResourceColorDescriptor(descriptors, key, label, defaultColor, hasAlpha)
     descriptors[#descriptors + 1] = {


### PR DESCRIPTION
## What Changed
- Resource bar positioning now calls the bar-height/custom-height builder through a file-local forward declaration.
- Removed the unused `ST._BuildBarHeightControls` shared-table export.

## Why This Changed
- The builder was only exported to bridge declaration order inside `ResourceBarPanelsResource.lua`, with no production or test consumers outside that file.

## Developer Impact
- Keeps the resource bar settings helper surface smaller and makes future dead-export scans easier to trust.

## Validation
- `git grep -n -F "ST._BuildBarHeightControls" -- .` returned no matches after removal.
- `git grep -n -F "BuildBarHeightControls" -- CooldownCompanion CooldownCompanion_Config tests` now shows only the file-local forward declaration, call, and assignment.
- `luac -p CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsResource.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check` passed with only the existing LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only helper-surface cleanup with no intended behavior change.