### PR TITLE
Keep disabled resource label helper private

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -1594,7 +1594,6 @@ local function AddResourceBarsDisabledLabel(container, text)
     label:SetFullWidth(true)
     container:AddChild(label)
 end
-ST._AddResourceBarsDisabledLabel = AddResourceBarsDisabledLabel
 
 ST._AddResourceSettingsListSection = function(container, settings)
     local resources = settings and RBP.GetConfigEditableResources and RBP.GetConfigEditableResources(settings) or {}
@@ -1654,7 +1653,7 @@ local function BuildCustomBarsListPanel(container)
     local settings = CooldownCompanion:GetResourceBarSettings()
     if not (settings and settings.enabled) then
         ST._AddResourceSettingsListSection(container, nil)
-        ST._AddResourceBarsDisabledLabel(container, "Enable Resource Bars to configure Custom Bars and Resources.")
+        AddResourceBarsDisabledLabel(container, "Enable Resource Bars to configure Custom Bars and Resources.")
         return
     end
 


### PR DESCRIPTION
## What Changed
- Removed the stale `ST._AddResourceBarsDisabledLabel` shared helper export.
- Changed the only shared-table call in `ResourceBarPanelsCustomBars.lua` to call the file-local `AddResourceBarsDisabledLabel` helper directly.

## Why This Changed
- The disabled Resource Bars label helper is only used inside `ResourceBarPanelsCustomBars.lua`; exporting it made the config helper surface look broader than it is.

## Developer Impact
- Resource/custom bar settings have one fewer dead `ST` helper contract to reason about.
- No player-facing behavior is intended to change.

## Validation
- `rg -n "ST\\._AddResourceBarsDisabledLabel|_AddResourceBarsDisabledLabel|AddResourceBarsDisabledLabel" CooldownCompanion CooldownCompanion_Config tests`
- `luac -p CooldownCompanion_Config\\ConfigSettings\\ResourceBarPanelsCustomBars.lua`
- All tracked Lua syntax sweep: `luac -p` across 96 files
- `git diff --check` passed with only the repo's usual LF-to-CRLF working-copy warning
- In-game, DevBridge, combat, and restricted-content validation were not run; this is a static-only config helper cleanup with no intended runtime behavior change.