### PR TITLE
Keep Custom Bars resource list helper private

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -1595,7 +1595,7 @@ local function AddResourceBarsDisabledLabel(container, text)
     container:AddChild(label)
 end
 
-ST._AddResourceSettingsListSection = function(container, settings)
+local function AddResourceSettingsListSection(container, settings)
     local resources = settings and RBP.GetConfigEditableResources and RBP.GetConfigEditableResources(settings) or {}
     local editableResourceSet = {}
     for _, powerType in ipairs(resources or {}) do
@@ -1652,7 +1652,7 @@ local function BuildCustomBarsListPanel(container)
 
     local settings = CooldownCompanion:GetResourceBarSettings()
     if not (settings and settings.enabled) then
-        ST._AddResourceSettingsListSection(container, nil)
+        AddResourceSettingsListSection(container, nil)
         AddResourceBarsDisabledLabel(container, "Enable Resource Bars to configure Custom Bars and Resources.")
         return
     end
@@ -1885,7 +1885,7 @@ local function BuildCustomBarsListPanel(container)
     local renderedListBlock = false
     for index, item in ipairs(customBarRows) do
         if item.resources then
-            renderedListBlock = ST._AddResourceSettingsListSection(container, settings) or renderedListBlock
+            renderedListBlock = AddResourceSettingsListSection(container, settings) or renderedListBlock
         elseif item.heading then
             renderedListBlock = true
             local listHeading = AceGUI:Create("Heading")


### PR DESCRIPTION
## What Changed
- Kept the Custom Bars resource list builder file-local instead of exporting it through `ST._AddResourceSettingsListSection`.
- Updated the two same-file call sites to use the local helper directly.

## Why This Changed
- Exact-symbol scans showed `ST._AddResourceSettingsListSection` was only defined and consumed inside `ResourceBarPanelsCustomBars.lua`, so the shared-table export was stale internal glue.

## Developer Impact
- The Custom Bars settings file now has one less private `ST._...` surface to reason about, which keeps ownership of this helper local to the file that uses it.

## Validation
- `rg -n -F "ST._AddResourceSettingsListSection" CooldownCompanion CooldownCompanion_Config tests` returned no matches after the change.
- `rg -n -F "AddResourceSettingsListSection" CooldownCompanion CooldownCompanion_Config tests` shows only the local helper plus its two same-file calls.
- `luac -p CooldownCompanion_Config\ConfigSettings\ResourceBarPanelsCustomBars.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warning.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only cleanup with no intended behavior change.
