### PR TITLE
Keep Custom Bar tab helpers private

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsCustomBars.lua
@@ -2341,12 +2341,12 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
     end
 
     if activeTab == "soundalerts" then
-        ST._BuildCustomBarSoundAlertsTab(container, cab, infoButtons)
+        BuildCustomBarSoundAlertsTab(container, cab, infoButtons)
         return
     end
 
     if activeTab == "loadconditions" then
-        ST._BuildCustomBarLoadConditionsTab(container, cab, infoButtons)
+        BuildCustomBarLoadConditionsTab(container, cab, infoButtons)
         return
     end
 
@@ -2818,8 +2818,6 @@ local function BuildCustomAuraBarPanel(container, customBarId, activeTab)
 
 end
 
--- Expose for ButtonSettings.lua and Config.lua
+-- Expose panel builders used by the config columns
 ST._BuildCustomBarsListPanel = BuildCustomBarsListPanel
 ST._BuildCustomAuraBarPanel = BuildCustomAuraBarPanel
-ST._BuildCustomBarSoundAlertsTab = BuildCustomBarSoundAlertsTab
-ST._BuildCustomBarLoadConditionsTab = BuildCustomBarLoadConditionsTab


### PR DESCRIPTION
## What Changed
- Custom Bars sound-alert and load-condition tab builders now stay as file-local helpers.
- `BuildCustomAuraBarPanel` calls those helpers directly instead of routing through `ST` exports.
- The remaining export comment now describes the two panel builders that are still shared with the config columns.

## Why This Changed
- Exact tracked and hidden-file scans showed `ST._BuildCustomBarSoundAlertsTab` and `ST._BuildCustomBarLoadConditionsTab` had no external consumers.
- Keeping same-file helpers on the shared `ST` table made the Custom Bars config surface look larger than it is.

## Developer Impact
- Future config maintenance has two fewer shared helper names to audit or preserve.
- The live Custom Bars Sound Alerts and Load Conditions tabs still use the same local builders through direct calls.

## Validation
- `rg --hidden --glob '!.git/**' --glob '!*.png' --glob '!*.jpg' --glob '!*.tga' --glob '!*.blp' -n "_BuildCustomBarSoundAlertsTab|_BuildCustomBarLoadConditionsTab|BuildCustomBarSoundAlertsTab|BuildCustomBarLoadConditionsTab" .`
- `rg -n "BuildCustomBar(SoundAlertsTab|LoadConditionsTab)" CooldownCompanion_Config\ConfigSettings\ResourceBarPanelsCustomBars.lua`
- `luac -p CooldownCompanion_Config\ConfigSettings\ResourceBarPanelsCustomBars.lua`
- `luac -p` across all 96 tracked Lua files
- `git diff --check HEAD^ HEAD`
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only helper-surface cleanup with no intended behavior change.