### PR TITLE
Keep visual snapshot flag private

### DIFF
--- a/CooldownCompanion/ButtonFrame/VisualState.lua
+++ b/CooldownCompanion/ButtonFrame/VisualState.lua
@@ -525,14 +525,14 @@ local function ResolveIconFillIntent(button, buttonData, style, target)
     return SetIconFillIntent(target, true, false, "inactive")
 end
 
-ST._buttonVisualStateSnapshotsEnabled = ST._buttonVisualStateSnapshotsEnabled == true
+local buttonVisualStateSnapshotsEnabled = false
 
 local function SetButtonVisualStateSnapshotsEnabled(enabled)
-    ST._buttonVisualStateSnapshotsEnabled = enabled == true
+    buttonVisualStateSnapshotsEnabled = enabled == true
 end
 
 local function AreButtonVisualStateSnapshotsEnabled()
-    return ST._buttonVisualStateSnapshotsEnabled == true
+    return buttonVisualStateSnapshotsEnabled == true
 end
 
 local function CopyTextVisualState(button, text, context)


### PR DESCRIPTION
## What Changed
- Kept the button visual-state snapshot enable flag as a file-local boolean in `ButtonFrame/VisualState.lua`.
- Left the existing exported setter/getter functions in place for diagnostics, Bar Mode, Text Mode, and cooldown update callers.

## Why This Changed
- Exact-symbol scans showed the backing `ST._buttonVisualStateSnapshotsEnabled` key was never read outside `VisualState.lua`; only the accessor functions are part of the cross-file contract.
- Keeping the backing flag local removes a private mutable state key from the shared addon table.

## Developer Impact
- Narrows the shared `ST` surface for visual-state diagnostics without changing the caller API or player-facing behavior.

## Validation
- `rg -n "_buttonVisualStateSnapshotsEnabled|buttonVisualStateSnapshotsEnabled" --hidden --glob '!/.git/**'`
- `luac -p CooldownCompanion\ButtonFrame\VisualState.lua`
- `luac -p` across all tracked Lua files
- `git diff --check` passed with the usual LF-to-CRLF working-copy warning from Git
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static-only internal cleanup.