### PR TITLE
Prefer namespaced CVar checks for cooldown viewer state

### DIFF
--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -1265,7 +1265,7 @@ end
 
 function CooldownCompanion:ResolveBuffViewerFrameForSpell(spellID)
     local enabled = self._cdmViewerEnabled
-    if enabled == nil then enabled = GetCVarBool("cooldownViewerEnabled") end
+    if enabled == nil then enabled = C_CVar.GetCVarBool("cooldownViewerEnabled") end
     if not spellID or spellID == 0 or not enabled then
         return nil
     end

--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1744,7 +1744,7 @@ function CooldownCompanion:AddButtonToGroup(groupId, buttonType, id, name, isPet
                 end
             end
             local hasViewerFrame = false
-            if viewerFrame and GetCVarBool("cooldownViewerEnabled") then
+            if viewerFrame and C_CVar.GetCVarBool("cooldownViewerEnabled") then
                 local parent = viewerFrame:GetParent()
                 local parentName = parent and parent:GetName()
                 hasViewerFrame = parentName == "BuffIconCooldownViewer" or parentName == "BuffBarCooldownViewer"

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -2060,7 +2060,7 @@ local function RefreshColumn2()
             return
         end
 
-        local cdmEnabled = GetCVarBool("cooldownViewerEnabled")
+        local cdmEnabled = C_CVar.GetCVarBool("cooldownViewerEnabled")
 
         -- Metadata for cross-panel drag detection
         local col2RenderedRows = {}


### PR DESCRIPTION
## What Changed
- Replaced the remaining production direct `GetCVarBool("cooldownViewerEnabled")` calls with `C_CVar.GetCVarBool("cooldownViewerEnabled")` in aura viewer resolution, Column 2 CDM metadata, and add-button aura tracking detection.
- Left the existing `ResourceBarPanelsHelpers.lua` fallback alone because it already prefers `C_CVar.GetCVarBool` and only falls back to the global when the namespace is unavailable.

## Why This Changed
- Cooldown Companion already uses the namespaced `C_CVar.GetCVarBool` API throughout most cooldown-viewer checks, and AGENTS.md prefers current namespaced WoW APIs over legacy globals.
- Root cause: a few older call sites still referenced the legacy global directly after nearby code had moved to namespaced CVar access.

## Developer Impact
- Keeps cooldown-viewer CVar reads consistent with the verified current WoW API surface.
- Reduces future maintenance confusion by leaving only the intentional compatibility fallback as a bare `GetCVarBool` reference.

## Validation
- `wow-api validate_source` reported the loaded API source as valid.
- `wow-api search_api GetCVarBool` and `wow-api get_namespace C_CVar` verified `C_CVar.GetCVarBool(name: CVar) -> boolean?` for Mainline.
- `wow-api list_deprecated GetCVarBool` found no deprecation entry blocking the change.
- Exact scan for bare `GetCVarBool(` now reports only the intentional fallback in `CooldownCompanion_Config/ConfigSettings/ResourceBarPanelsHelpers.lua`.
- `luac -p` passed for the three changed files.
- `luac -p` passed across all 96 tracked Lua files.
- `git diff --check` passed with only the usual LF-to-CRLF working-copy warnings.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is an API-name consistency cleanup with no intended behavior change.