### PR TITLE
Prefer namespaced specialization info calls

### DIFF
--- a/CooldownCompanion/Core/GroupManagement.lua
+++ b/CooldownCompanion/Core/GroupManagement.lua
@@ -1876,7 +1876,15 @@ local function FindDisplaySpell(matcher)
     if not classID then return nil end
     local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID)
     for specIndex = 1, numSpecs do
-        local specID = GetSpecializationInfoForClassID(classID, specIndex)
+        local specID = C_SpecializationInfo.GetSpecializationInfo(
+            specIndex,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
         if specID then
             local ids = C_SpecializationInfo.GetSpellsDisplay(specID)
             if ids then

--- a/CooldownCompanion/Core/ScopedSettings.lua
+++ b/CooldownCompanion/Core/ScopedSettings.lua
@@ -506,7 +506,15 @@ local function GetClassSpecInfo(classKey)
     end
 
     for i = 1, numSpecs do
-        local specID = GetSpecializationInfoForClassID(classID, i)
+        local specID = C_SpecializationInfo.GetSpecializationInfo(
+            i,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
         if specID then
             specIDs[specID] = true
         end
@@ -2149,7 +2157,15 @@ function CooldownCompanion:GetResourceBarSpecCopyOptions()
     local order = {}
     local numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classID) or 0
     for i = 1, numSpecs do
-        local specID, specName = GetSpecializationInfoForClassID(classID, i)
+        local specID, specName = C_SpecializationInfo.GetSpecializationInfo(
+            i,
+            false,
+            false,
+            nil,
+            nil,
+            nil,
+            classID
+        )
         if specID then
             if specID ~= currentSpecID then
                 values[specID] = specName or ("Spec " .. tostring(specID))

--- a/CooldownCompanion_Config/Config/TalentPicker.lua
+++ b/CooldownCompanion_Config/Config/TalentPicker.lua
@@ -555,7 +555,7 @@ local function BuildSpecDropdownOptions(group)
     local order = {}
 
     for i = 1, (GetNumSpecializations() or 0) do
-        local specID, name = GetSpecializationInfo(i)
+        local specID, name = C_SpecializationInfo.GetSpecializationInfo(i)
         if specID and name and (not hasSpecFilter or effectiveSpecs[specID]) then
             values[specID] = name
             order[#order + 1] = specID


### PR DESCRIPTION
## What Changed
- Replaced the remaining legacy specialization-info reads in the talent picker, display-spell scan, and resource-bar class/spec copy helpers with `C_SpecializationInfo.GetSpecializationInfo`.
- Used the repo's existing class-ID lookup pattern for class-scoped specialization data.

## Why This Changed
- Project guidance prefers current `C_` APIs over legacy globals, and `wow-api` marks `GetSpecializationInfo` deprecated in favor of `C_SpecializationInfo.GetSpecializationInfo`.
- `C_SpecializationInfo.GetSpecializationInfo` now accepts `classID`, which lets the class-scoped paths avoid `GetSpecializationInfoForClassID` while preserving the existing lookup intent.

## Developer Impact
- Keeps specialization lookups on one current API surface, making future API audits and Midnight compatibility checks simpler.
- No intended player-facing behavior change.

## Validation
- `wow-api validate_source` returned `Status: valid`.
- `wow-api lookup_api GetSpecializationInfo`, `wow-api get_namespace C_SpecializationInfo`, and Warcraft Wiki lookup for `C_SpecializationInfo.GetSpecializationInfo` verified the replacement signature and `classID` argument.
- Exact legacy call scan found no remaining `GetSpecializationInfoForClassID` or bare `GetSpecializationInfo(...)` production calls.
- `luac -p CooldownCompanion/Core/GroupManagement.lua CooldownCompanion/Core/ScopedSettings.lua CooldownCompanion_Config/Config/TalentPicker.lua` passed.
- `luac -p` across all tracked Lua files passed.
- `git diff --check` passed; Git only reported the usual LF-to-CRLF working-copy warnings.
- `lua tests/eligibility-load-conditions.lua` and `lua tests/character-eligibility-choices.lua` passed.
- `lua tests/resource-bars-class-scope.lua` fails unchanged because the ignored local harness stubs `C_SpecializationInfo.GetSpecializationInfo` without the verified `classID` argument; an in-memory rerun with only that stub adjusted to the verified signature passed.
- No in-game, DevBridge, combat, or restricted-content validation was performed; this is a static API maintenance cleanup.