### PR TITLE
Reduce CPU from silent spell icon checks

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -27,6 +27,10 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 
+-- Silent-transform icon staleness probe interval (seconds). Event-driven icon
+-- refresh paths are unaffected; this only paces the no-event fallback probe.
+local TEXTURE_STALENESS_INTERVAL = 0.25
+
 -- APIs for text-mode conditional tokens
 local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
 local IsUsableItem = C_Item.IsUsableItem
@@ -832,13 +836,21 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             refreshIcon = true
         end
 
-        -- Per-tick icon staleness detection for silent transforms (e.g. Tiger's
+        -- Icon staleness detection for silent transforms (e.g. Tiger's
         -- Fury changing Rake/Rip icons). GetSpellTexture dynamically resolves
-        -- the current visual, but no event fires for these transforms.
-        local freshIcon = C_Spell.GetSpellTexture(buttonData.id)
-        if freshIcon and freshIcon ~= button._lastSpellTexture then
-            button._lastSpellTexture = freshIcon
-            refreshIcon = true
+        -- the current visual, but no event fires for these transforms, so a
+        -- paced probe is the fallback. Also re-probe whenever an icon refresh
+        -- is already pending, so the stored baseline stays in sync with what
+        -- UpdateButtonIcon is about to display.
+        if refreshIcon
+            or button._lastTextureCheckAt == nil
+            or (now - button._lastTextureCheckAt) >= TEXTURE_STALENESS_INTERVAL then
+            button._lastTextureCheckAt = now
+            local freshIcon = C_Spell.GetSpellTexture(buttonData.id)
+            if freshIcon and freshIcon ~= button._lastSpellTexture then
+                button._lastSpellTexture = freshIcon
+                refreshIcon = true
+            end
         end
 
         if refreshIcon then

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -874,6 +874,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
 
     button._auraInstanceID = nil
@@ -1461,6 +1462,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
 
     button._auraInstanceID = nil

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -766,6 +766,7 @@ function CooldownCompanion:ClearRotationAssistantButtonRuntime(button)
     button._displaySpellId = nil
     button._liveOverrideSpellId = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -728,6 +728,7 @@ local function ClearReusableButtonRuntime(button)
     button._liveOverrideSpellId = nil
     button._spellOutOfRange = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2827,6 +2827,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil
+                button._lastTextureCheckAt = nil
                 button._iconDirty = true
                 button._cooldownDeferred = nil
                 button._durationObj = nil


### PR DESCRIPTION
## What Players Will Notice
- Spell button icons should keep the same immediate updates for normal icon events and override-based spell transforms.
- In busy combat, Cooldown Companion does less repeated spell texture polling for rare silent artwork swaps. Truly silent icon-only changes may now settle within 250 ms, which should be visually indistinguishable.

## Why This Changed
- Every non-CDM spell button was calling `C_Spell.GetSpellTexture` on every cooldown walk just to catch silent icon artwork transforms.
- In event-dense combat, that fallback probe could become many repeated C API calls per second for artwork that changes rarely.

## What Changed
- Added a 0.25 second per-button throttle for the silent-transform texture staleness probe in `CooldownUpdate.lua`.
- Kept override detection unthrottled and ahead of the texture probe, so transformed spell cooldown lanes still update immediately.
- Kept event-driven icon refresh paths untouched and re-probes whenever an icon refresh is already pending.
- Reset the new texture-check timestamp wherever the existing spell-texture baseline is reset, so rebuilt or reused buttons probe immediately on their next walk.

## Validation
- Verified `C_Spell.GetSpellTexture` with `wow-api`: current/non-deprecated, and may return nil for missing spells.
- `luac -p` passed for the five touched Lua files.
- `git diff --check origin/dev...origin/texture-cleanup` passed.
- Focused local harnesses passed: `tests\durationless-aura-cooldown-swipe.lua` and `tests\surging-totem-override-cooldown.lua`.
- `parallel-review-recommendations` ran one five-reviewer static pass: 0 actionable findings, 5 reviewers with none.
- In-game validation is still pending: silent transform timing, override transforms, event-driven icon changes, spec swaps, CDM child buttons, and combat sanity have not been verified in a live WoW session yet.