### PR TITLE
Reduce redundant cooldown group lookups

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -480,7 +480,7 @@ local function ShouldUseActiveAuraIcon(buttonData)
             or buttonData.isPassive == true)
 end
 
-local function DispatchStandaloneTextureVisual(button)
+local function DispatchStandaloneTextureVisual(button, group)
     if not button then
         return
     end
@@ -488,8 +488,10 @@ local function DispatchStandaloneTextureVisual(button)
         return
     end
 
-    local group = button._groupId and CooldownCompanion.db and CooldownCompanion.db.profile
-        and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
+    if group == nil then
+        group = button._groupId and CooldownCompanion.db and CooldownCompanion.db.profile
+            and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
+    end
     if group and group.displayMode == "trigger" then
         local frame = button:GetParent()
         local runtimeButtons = frame and frame.buttons
@@ -1691,7 +1693,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._rawVisibilityReasonBits = button._visibilityReasonBits
     button._rawVisibilityReasonMode = button._visibilityReasonMode
 
-    local group = button._groupId and CooldownCompanion.db.profile.groups[button._groupId]
+    local group = buttonGroup
     local isTriggerPanel = group and group.displayMode == "trigger"
     local forceVisibleByUnlockPreview = group
         and group.parentContainerId
@@ -1764,7 +1766,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button:SetAlpha(0)
                 button._lastVisAlpha = 0
             end
-            DispatchStandaloneTextureVisual(button)
+            DispatchStandaloneTextureVisual(button, group)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
@@ -1784,7 +1786,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and icon mode force-show both read stale true on next tick.
             button.cooldown:Hide()
             HideIconFillForHiddenButton(button)
-            DispatchStandaloneTextureVisual(button)
+            DispatchStandaloneTextureVisual(button, group)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
@@ -1849,11 +1851,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
     elseif button._isBar then
         UpdateBarDisplay(button)
-        DispatchStandaloneTextureVisual(button)
+        DispatchStandaloneTextureVisual(button, group)
     else
         UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
-        DispatchStandaloneTextureVisual(button)
+        DispatchStandaloneTextureVisual(button, group)
     end
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")


### PR DESCRIPTION
## What Changed
- Reuses the already-resolved button group inside `UpdateButtonCooldown` instead of chasing `CooldownCompanion.db.profile.groups[button._groupId]` again later in the same walk.
- Lets `DispatchStandaloneTextureVisual` accept that group from `UpdateButtonCooldown`, while preserving its original guarded fallback for the rotation-assistant missing-state path that has no group in scope.

## Why This Changed
- The cooldown walk can run many times per second across many buttons, and the previous code repeated the same group-table lookup within a single button update.
- This keeps the behavior the same while removing redundant table lookups from the hot visibility/texture-dispatch tail.

## Developer Impact
- Reduces duplicate per-walk group lookup work in `CooldownCompanion/ButtonFrame/CooldownUpdate.lua` without adding new state, changing group semantics, or touching adjacent cooldown logic.
- Keeps the cold rotation-assistant fallback path unchanged so callers without a resolved group still behave as before.

## Validation
- `rg "groups\\[button\\._groupId\\]" CooldownCompanion/ButtonFrame/CooldownUpdate.lua` returns exactly two matches: the canonical lookup and dispatcher fallback.
- Verified one unchanged dispatcher call for the rotation-assistant path and four `UpdateButtonCooldown` dispatcher calls passing `group`.
- `luac -p CooldownCompanion/ButtonFrame/CooldownUpdate.lua`
- Full tracked Lua syntax sweep with `luac -p`
- `git diff --check origin/dev...HEAD`
- `$parallel-review-recommendations` against `origin/dev` completed one five-reviewer cohort with `Findings: NO ACTIONABLE FINDINGS`.
- In-game/runtime validation has not been performed yet; trigger panels, compact layout hide/show, container unlock preview, hidden-button restore, rotation-assistant missing-state fallback, and combat sanity still need the planned `dev` QA pass.