### PR TITLE
Reduce silent icon texture refresh overhead

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -480,7 +480,7 @@ local function ShouldUseActiveAuraIcon(buttonData)
             or buttonData.isPassive == true)
 end
 
-local function DispatchStandaloneTextureVisual(button)
+local function DispatchStandaloneTextureVisual(button, group)
     if not button then
         return
     end
@@ -488,8 +488,10 @@ local function DispatchStandaloneTextureVisual(button)
         return
     end
 
-    local group = button._groupId and CooldownCompanion.db and CooldownCompanion.db.profile
-        and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
+    if group == nil then
+        group = button._groupId and CooldownCompanion.db and CooldownCompanion.db.profile
+            and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
+    end
     if group and group.displayMode == "trigger" then
         local frame = button:GetParent()
         local runtimeButtons = frame and frame.buttons
@@ -1691,7 +1693,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     button._rawVisibilityReasonBits = button._visibilityReasonBits
     button._rawVisibilityReasonMode = button._visibilityReasonMode
 
-    local group = button._groupId and CooldownCompanion.db.profile.groups[button._groupId]
+    local group = buttonGroup
     local isTriggerPanel = group and group.displayMode == "trigger"
     local forceVisibleByUnlockPreview = group
         and group.parentContainerId
@@ -1764,7 +1766,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 button:SetAlpha(0)
                 button._lastVisAlpha = 0
             end
-            DispatchStandaloneTextureVisual(button)
+            DispatchStandaloneTextureVisual(button, group)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
@@ -1784,7 +1786,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and icon mode force-show both read stale true on next tick.
             button.cooldown:Hide()
             HideIconFillForHiddenButton(button)
-            DispatchStandaloneTextureVisual(button)
+            DispatchStandaloneTextureVisual(button, group)
             if shouldCaptureVisualState then
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
@@ -1849,11 +1851,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
     elseif button._isBar then
         UpdateBarDisplay(button)
-        DispatchStandaloneTextureVisual(button)
+        DispatchStandaloneTextureVisual(button, group)
     else
         UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD, isGCDOnly)
         UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
-        DispatchStandaloneTextureVisual(button)
+        DispatchStandaloneTextureVisual(button, group)
     end
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -27,6 +27,10 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 
+-- Silent-transform icon staleness probe interval (seconds). Event-driven icon
+-- refresh paths are unaffected; this only paces the no-event fallback probe.
+local TEXTURE_STALENESS_INTERVAL = 0.25
+
 -- APIs for text-mode conditional tokens
 local C_Spell_IsSpellUsable = C_Spell.IsSpellUsable
 local IsUsableItem = C_Item.IsUsableItem
@@ -832,13 +836,21 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             refreshIcon = true
         end
 
-        -- Per-tick icon staleness detection for silent transforms (e.g. Tiger's
+        -- Icon staleness detection for silent transforms (e.g. Tiger's
         -- Fury changing Rake/Rip icons). GetSpellTexture dynamically resolves
-        -- the current visual, but no event fires for these transforms.
-        local freshIcon = C_Spell.GetSpellTexture(buttonData.id)
-        if freshIcon and freshIcon ~= button._lastSpellTexture then
-            button._lastSpellTexture = freshIcon
-            refreshIcon = true
+        -- the current visual, but no event fires for these transforms, so a
+        -- paced probe is the fallback. Also re-probe whenever an icon refresh
+        -- is already pending, so the stored baseline stays in sync with what
+        -- UpdateButtonIcon is about to display.
+        if refreshIcon
+            or button._lastTextureCheckAt == nil
+            or (now - button._lastTextureCheckAt) >= TEXTURE_STALENESS_INTERVAL then
+            button._lastTextureCheckAt = now
+            local freshIcon = C_Spell.GetSpellTexture(buttonData.id)
+            if freshIcon and freshIcon ~= button._lastSpellTexture then
+                button._lastSpellTexture = freshIcon
+                refreshIcon = true
+            end
         end
 
         if refreshIcon then

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -874,6 +874,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
 
     button._auraInstanceID = nil
@@ -1461,6 +1462,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._activeAuraIconAvailable = nil
     button._lastViewerTexId = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
 
     button._auraInstanceID = nil

--- a/CooldownCompanion/Core/Defaults.lua
+++ b/CooldownCompanion/Core/Defaults.lua
@@ -766,6 +766,7 @@ function CooldownCompanion:ClearRotationAssistantButtonRuntime(button)
     button._displaySpellId = nil
     button._liveOverrideSpellId = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
     button._baseNoCooldown = nil
     button._baseNoCooldownSpellId = nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -728,6 +728,7 @@ local function ClearReusableButtonRuntime(button)
     button._liveOverrideSpellId = nil
     button._spellOutOfRange = nil
     button._lastSpellTexture = nil
+    button._lastTextureCheckAt = nil
     button._spellTexBaseline = nil
     button._noCooldown = nil
     button._noCooldownSpellId = nil

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2827,6 +2827,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
                 button._displaySpellId = nil
                 button._liveOverrideSpellId = nil
                 button._lastSpellTexture = nil
+                button._lastTextureCheckAt = nil
                 button._iconDirty = true
                 button._cooldownDeferred = nil
                 button._durationObj = nil


### PR DESCRIPTION
## What Players Will Notice
- Spell icons that change silently, such as transformed Feral abilities, still refresh, but Cooldown Companion now checks for those no-event texture changes on a paced fallback instead of every cooldown update.
- Standalone texture visuals continue to update from the same resolved group context during cooldown refreshes.

## Why This Changed
- The silent texture fallback was calling `C_Spell.GetSpellTexture` every update for spell buttons to catch icon changes that do not fire events, which was more work than needed on idle or unchanged buttons.
- Standalone texture dispatch also re-read the button's group from profile data in cooldown paths where the update loop had already resolved that group.

## What Changed
- Added a 0.25s spell texture staleness interval for the silent-transform fallback, while still re-probing immediately whenever an icon refresh is already pending so the stored baseline stays current.
- Reset the texture probe timestamp anywhere button runtime/style state clears spell texture baselines.
- Passed the current group into standalone texture dispatch and kept the profile lookup as a fallback for callers that do not already have group context.

## Validation
- `git diff --check origin/main...HEAD`
- `luac -p` on the five changed Lua files
- `lua tests/group-style-update-fast-path.lua`
- `lua tests/group-button-frame-pooling.lua`
- Attempted nearby broader harnesses: `lua tests/cooldown-refresh-queue.lua` failed in `CooldownRefresh.lua` behavior outside this diff; `lua tests/actionbar-cooldown-policy.lua` failed because `CooldownCompanion/Core/RefreshScope.lua` is not present locally; `lua tests/power-event-focused-visual.lua` failed on an existing nil `ApplyPowerIconUsabilityVisualMaintenance` path; `lua tests/aura-texture-generated-output.lua` requires a missing local `.tmp/texture-harvester/aura-texture-generated-output.lua` artifact.
- No in-game, DevBridge, combat, or restricted-content validation was run for this publish-only closeout.