### PR TITLE
Reduce cooldown update allocations by reusing option tables

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -45,6 +45,8 @@ local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_BAR_COLOR = {0.2, 0.6, 1.0, 1.0}
 local DEFAULT_READY_TEXT_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -1785,7 +1787,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraNameOverrideActive = nil
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -26,6 +26,11 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+local evaluateButtonAuraStateOpts = {}
+local buttonAuraPandemicStateOpts = {}
+local auraProbeGCDOnlyOpts = {}
 
 -- Silent-transform icon staleness probe interval (seconds). Event-driven icon
 -- refresh paths are unaffected; this only paces the no-event fallback probe.
@@ -736,7 +741,7 @@ local function UpdateResolvedItemState(button, buttonData)
         return false
     end
 
-    local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+    local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
     if IsEquipmentSlotEntry(buttonData) and not (effectiveItem and effectiveItem.trackable) then
         if InCombatLockdown() and button._resolvedItemId then
             return false
@@ -984,16 +989,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
+        evaluateButtonAuraStateOpts.now = now
+        evaluateButtonAuraStateOpts.allowDurationlessAuraInstance = barAuraStackConfigured
+        evaluateButtonAuraStateOpts.previousAuraDurationObj = prevAuraDurationObj
+        evaluateButtonAuraStateOpts.wasAuraActive = wasAuraActive
         local auraState = EntryRuntime.EvaluateTrackedAuraState(
             button,
             buttonData,
             button._auraSpellID,
-            {
-                now = now,
-                allowDurationlessAuraInstance = barAuraStackConfigured,
-                previousAuraDurationObj = prevAuraDurationObj,
-                wasAuraActive = wasAuraActive,
-            }
+            evaluateButtonAuraStateOpts
         )
         local viewerFrame = auraState.viewerFrame
         auraTrackingReady = auraState.auraTrackingReady == true
@@ -1111,13 +1115,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         end
 
-        button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, {
-            now = now,
-            enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic),
-            previewActive = button._pandemicPreview == true,
-            clearWhenDisabled = true,
-            auraState = auraState,
-        })
+        buttonAuraPandemicStateOpts.now = now
+        buttonAuraPandemicStateOpts.enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic)
+        buttonAuraPandemicStateOpts.previewActive = button._pandemicPreview == true
+        buttonAuraPandemicStateOpts.clearWhenDisabled = true
+        buttonAuraPandemicStateOpts.auraState = auraState
+        button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, buttonAuraPandemicStateOpts)
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1177,10 +1180,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
             auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
-        auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, {
-            normalCooldownShown = auraProbeNormalCooldownShown,
-            realCooldownShown = auraProbeRealCooldownShown,
-        }) or false
+        auraProbeGCDOnlyOpts.normalCooldownShown = auraProbeNormalCooldownShown
+        auraProbeGCDOnlyOpts.realCooldownShown = auraProbeRealCooldownShown
+        auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeGCDOnlyOpts) or false
     end
 
     -- Secondary cooldown text display during aura override

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -28,6 +28,9 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 local DEFAULT_WHITE = {1, 1, 1, 1}
 -- Immutable — shared across calls; never write to this table.
 local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Reusable scratch opts — single call site each; assign EVERY field
+-- unconditionally before each call (a conditional write leaves a stale value
+-- from the previous call that silently overrides owner/auraState data).
 local evaluateButtonAuraStateOpts = {}
 local buttonAuraPandemicStateOpts = {}
 local auraProbeGCDOnlyOpts = {}
@@ -999,6 +1002,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._auraSpellID,
             evaluateButtonAuraStateOpts
         )
+        evaluateButtonAuraStateOpts.previousAuraDurationObj = nil -- don't pin the duration object between walks
         local viewerFrame = auraState.viewerFrame
         auraTrackingReady = auraState.auraTrackingReady == true
         auraOverrideActive = auraState.auraPresent == true
@@ -1121,6 +1125,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         buttonAuraPandemicStateOpts.clearWhenDisabled = true
         buttonAuraPandemicStateOpts.auraState = auraState
         button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, buttonAuraPandemicStateOpts)
+        buttonAuraPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between walks
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1180,9 +1185,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
             auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
-        auraProbeGCDOnlyOpts.normalCooldownShown = auraProbeNormalCooldownShown
-        auraProbeGCDOnlyOpts.realCooldownShown = auraProbeRealCooldownShown
-        auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeGCDOnlyOpts) or false
+        if auraProbeInfo then
+            auraProbeGCDOnlyOpts.normalCooldownShown = auraProbeNormalCooldownShown
+            auraProbeGCDOnlyOpts.realCooldownShown = auraProbeRealCooldownShown
+            auraProbeIsGCDOnly = CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeGCDOnlyOpts) or false
+        else
+            auraProbeIsGCDOnly = false
+        end
     end
 
     -- Secondary cooldown text display during aura override

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -75,6 +75,8 @@ local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCoo
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1
@@ -810,7 +812,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.buttonData = buttonData
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -52,6 +52,8 @@ local DEFAULT_READY_COLOR = {0.2, 1.0, 0.2, 1}
 local DEFAULT_AURA_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_CUSTOM_COLOR = {1, 0.82, 0, 1}
 local DEFAULT_TEXT_FORMAT = "{name}  {status}"
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 
 local function IsAuraOnlyEntry(buttonData)
     return buttonData
@@ -1056,7 +1058,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._textSecretNameActive = nil
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -25,6 +25,9 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local TARGET_SWITCH_SAFETY_CAP = 0.60
+local buttonSpellCooldownLaneOpts = {}
+local laneGCDOnlyOpts = {}
+local customBarSpellCooldownLaneOpts = {}
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -1257,6 +1260,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
+    laneGCDOnlyOpts.normalCooldownShown = result.normalCooldownShown
+    laneGCDOnlyOpts.realCooldownShown = result.realCooldownShown
     if suppressCooldownSurface then
         if result.isOnGCD == true and CooldownCompanion._gcdDurationObj then
             result.source = "resource-gated-gcd"
@@ -1273,10 +1278,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-real-ignore-gcd"
         result.renderDurationObj = result.realDurationObj
-    elseif CooldownLogic.IsSpellGCDOnly(info, {
-        normalCooldownShown = result.normalCooldownShown,
-        realCooldownShown = result.realCooldownShown,
-    }) then
+    elseif CooldownLogic.IsSpellGCDOnly(info, laneGCDOnlyOpts) then
         result.source = "spell-gcd"
         result.presentationState = COOLDOWN_STATE_GCD
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
@@ -1316,11 +1318,10 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     local allowActionSlotReadyFallback = allowActionSlotRealFallback
         and cooldownSpellId ~= buttonData.id
 
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
-        allowActionSlotRealFallback = allowActionSlotRealFallback,
-        allowActionSlotReadyFallback = allowActionSlotReadyFallback,
-        suppressCooldownSurface = resourceGatedNoCooldown == true,
-    })
+    buttonSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
+    buttonSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
+    buttonSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
@@ -1659,11 +1660,10 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local allowActionSlotReadyFallback = allowActionSlotRealFallback
         and cooldownSpellID ~= spellID
 
-    local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
-        allowActionSlotRealFallback = allowActionSlotRealFallback,
-        allowActionSlotReadyFallback = allowActionSlotReadyFallback,
-        suppressCooldownSurface = resourceGatedNoCooldown == true,
-    })
+    customBarSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
+    customBarSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
+    customBarSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
+    local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, customBarSpellCooldownLaneOpts)
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
     result.noCooldown = noCooldown or nil

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -25,6 +25,9 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local TARGET_SWITCH_SAFETY_CAP = 0.60
+-- Reusable scratch opts — single call site each; assign EVERY field
+-- unconditionally before each call (a conditional write leaves a stale value
+-- from the previous call that silently overrides owner/auraState data).
 local buttonSpellCooldownLaneOpts = {}
 local laneGCDOnlyOpts = {}
 local customBarSpellCooldownLaneOpts = {}
@@ -1260,6 +1263,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
+    -- Snapshot for the IsSpellGCDOnly elseif below — keep in sync if anything
+    -- mutates result.normalCooldownShown/realCooldownShown before that branch.
     laneGCDOnlyOpts.normalCooldownShown = result.normalCooldownShown
     laneGCDOnlyOpts.realCooldownShown = result.realCooldownShown
     if suppressCooldownSurface then

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -88,6 +88,10 @@ end
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
+    local spellCustomBarAuraStateOpts = {}
+    local customAuraBarAuraStateOpts = {}
+    local customAuraBarPandemicStateOpts = {}
+    local customCooldownBarPandemicStateOpts = {}
     local GetPreviewActive = deps.GetPreviewActive
     local MarkLayoutDirty = deps.MarkLayoutDirty
     local RelayoutResourceStack = deps.RelayoutResourceStack
@@ -174,12 +178,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = buttonData.auraUnit or "player"
         local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
-        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, {
-            configUnit = configUnit,
-            allowDurationlessAuraInstance = true,
-            useButtonAuraViewerFallback = true,
-            validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell,
-        })
+        spellCustomBarAuraStateOpts.configUnit = configUnit
+        spellCustomBarAuraStateOpts.allowDurationlessAuraInstance = true
+        spellCustomBarAuraStateOpts.useButtonAuraViewerFallback = true
+        spellCustomBarAuraStateOpts.validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell
+        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -214,11 +217,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, true)
             if buttonData and spellID then
                 configUnit = buttonData.auraUnit or configUnit
-                auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, {
-                    configUnit = configUnit,
-                    allowDurationlessAuraInstance = true,
-                    allowPlayerAuraFallbackWithoutReady = true,
-                })
+                customAuraBarAuraStateOpts.configUnit = configUnit
+                customAuraBarAuraStateOpts.allowDurationlessAuraInstance = true
+                customAuraBarAuraStateOpts.allowPlayerAuraFallbackWithoutReady = true
+                auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, customAuraBarAuraStateOpts)
                 viewerFrame = auraState and auraState.viewerFrame or nil
             end
         end
@@ -283,14 +285,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         local pandemicStateFrame = barInfo.frame
-        local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, {
-            enabled = configUnit == "target" and auraPresent,
-            previewActive = pandemicPreview == true,
-            clearWhenDisabled = true,
-            auraState = auraState,
-            auraUnit = auraUnit,
-            auraInstanceID = instId,
-        })
+        customAuraBarPandemicStateOpts.enabled = configUnit == "target" and auraPresent
+        customAuraBarPandemicStateOpts.previewActive = pandemicPreview == true
+        customAuraBarPandemicStateOpts.clearWhenDisabled = true
+        customAuraBarPandemicStateOpts.auraState = auraState
+        customAuraBarPandemicStateOpts.auraUnit = auraUnit
+        customAuraBarPandemicStateOpts.auraInstanceID = instId
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, customAuraBarPandemicStateOpts)
 
         if isActive and bar then
             if auraPresent then
@@ -580,12 +581,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = (auraState and auraState.configUnit)
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
-        local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, {
-            enabled = configUnit == "target" and auraPresent,
-            previewActive = pandemicPreview == true,
-            clearWhenDisabled = true,
-            auraState = auraState,
-        })
+        customCooldownBarPandemicStateOpts.enabled = configUnit == "target" and auraPresent
+        customCooldownBarPandemicStateOpts.previewActive = pandemicPreview == true
+        customCooldownBarPandemicStateOpts.clearWhenDisabled = true
+        customCooldownBarPandemicStateOpts.auraState = auraState
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, customCooldownBarPandemicStateOpts)
 
         if auraState
             and auraState.ready == true

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -88,10 +88,6 @@ end
 
 function RB.CreateResourceBarCustomBarsModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
-    local spellCustomBarAuraStateOpts = {}
-    local customAuraBarAuraStateOpts = {}
-    local customAuraBarPandemicStateOpts = {}
-    local customCooldownBarPandemicStateOpts = {}
     local GetPreviewActive = deps.GetPreviewActive
     local MarkLayoutDirty = deps.MarkLayoutDirty
     local RelayoutResourceStack = deps.RelayoutResourceStack
@@ -101,6 +97,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
+    -- Reusable scratch opts — single call site each; assign EVERY field
+    -- unconditionally before each call (a conditional write leaves a stale value
+    -- from the previous call that silently overrides owner/auraState data).
+    local spellCustomBarAuraStateOpts = {}
+    local customAuraBarAuraStateOpts = {}
+    local customAuraBarPandemicStateOpts = {}
+    local customCooldownBarPandemicStateOpts = {}
     local customAuraWakeRetryQueue = {}
     local customAuraWakeRetryPending = {}
     local customAuraWakeRetryScheduled = false
@@ -292,6 +295,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customAuraBarPandemicStateOpts.auraUnit = auraUnit
         customAuraBarPandemicStateOpts.auraInstanceID = instId
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, customAuraBarPandemicStateOpts)
+        customAuraBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
 
         if isActive and bar then
             if auraPresent then
@@ -586,6 +590,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customCooldownBarPandemicStateOpts.clearWhenDisabled = true
         customCooldownBarPandemicStateOpts.auraState = auraState
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, customCooldownBarPandemicStateOpts)
+        customCooldownBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
 
         if auraState
             and auraState.ready == true


### PR DESCRIPTION
## What Changed
- Eleven hot call sites in the cooldown, aura, and pandemic evaluation paths no longer build a throwaway Lua options table on every update pass. Each site now reuses one pre-allocated table, overwriting every field on every call (nil assignments included, so conditionally-absent fields behave exactly as before).
- Four files (\`CooldownUpdate\`, \`TextMode\`, \`BarMode\`, \`IconMode\`) hoist the constant \`{ requestLoad = true }\` item-resolution options into a single immutable module-level table each, marked read-only by comment.
- Two identical literals on cold rebuild-only paths (\`GroupOperations\`, \`GroupFrame\`) were deliberately left unchanged — no per-update payoff there.
- No logic, ordering, or timing changes anywhere: every callee receives the same field values it received before, on the same code paths.

## Why This Changed
- These tables were allocated per spell button per cooldown walk and per custom bar per update tick — in dense combat that is thousands of short-lived tables per second, all immediately discarded.
- That allocation churn forces Lua's garbage collector to run more often, and GC steps are a classic cause of periodic frame hitches that per-call CPU profiling doesn't surface.
- This is the first of a planned series of allocation-reduction changes (options tables → aura-event ID sets → aura state table → cooldown lane results); the payoff is cumulative across the series.

## Developer Impact
- Establishes the reuse pattern (one scratch table per call site, all fields written every call, constants immutable) that the follow-up allocation work builds on.
- Every converted callee was audited to confirm it only reads fields from its options argument and never retains the table — the safety precondition for reuse.

## Validation
- Implemented from a pre-verified spec with a per-site inventory; the implementing agent's pre-flight grep re-verification halted a first attempt on an inventory gap, the spec was corrected (two additional sites found and included), and the second pass matched cleanly.
- Diff reviewed against the spec's acceptance criteria: one table per call site, no cross-site sharing, every field assigned on every call, cold-path literals untouched.
- Lifetime self-audit completed for each converted site: all callees read fields only; none stores the options table.
- **In-game validation is pending**: the mixed-content sweep (charge spells, resource-gated spells, item and equipment-slot buttons, aura-tracked buttons with pandemic glow, custom aura/cooldown/stack bars) has not yet been run, and combat behavior is not yet verified. This PR should stay in draft until that sweep passes.