### PR TITLE
Reduce aura event allocations by reusing instance ID sets

### DIFF
--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -36,16 +36,22 @@ local COOLDOWN_VIEWER_ASSOCIATION_CATEGORIES = {
     Enum.CooldownViewerCategory.TrackedBar,
 }
 
-local function BuildAuraInstanceIDSet(auraInstanceIDs)
+-- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
+-- value within the same synchronous event dispatch; contents are stale between
+-- calls (the nil-return path skips the wipe). Never read directly or retain.
+local removedAuraIDSetScratch = {}
+local updatedAuraIDSetScratch = {}
+
+local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
     if not (auraInstanceIDs and auraInstanceIDs[1]) then
         return nil
     end
 
-    local auraInstanceIDSet = {}
+    wipe(scratch)
     for _, auraInstanceID in ipairs(auraInstanceIDs) do
-        auraInstanceIDSet[auraInstanceID] = true
+        scratch[auraInstanceID] = true
     end
-    return auraInstanceIDSet
+    return scratch
 end
 
 local function IsBuffViewerChild(frame)
@@ -485,8 +491,8 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- work correctly — the update path re-checks _auraInstanceID after removals.
     local removedIDs = updateInfo.removedAuraInstanceIDs
     local updatedIDs = updateInfo.updatedAuraInstanceIDs
-    local removedIDSet = BuildAuraInstanceIDSet(removedIDs)
-    local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
+    local removedIDSet = FillAuraInstanceIDSet(removedAuraIDSetScratch, removedIDs)
+    local updatedIDSet = FillAuraInstanceIDSet(updatedAuraIDSetScratch, updatedIDs)
     local isTarget = (unit == "target")
     if removedIDs or updatedIDs or isTarget then
         self:ForEachButton(function(button)

--- a/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
@@ -8,8 +8,28 @@ local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
 
 local math_abs = math.abs
+local ipairs = ipairs
+local wipe = wipe
 
 local RB = ST._RB
+
+-- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
+-- value within the same synchronous event dispatch; contents are stale between
+-- calls (the nil-return path skips the wipe). Never read directly or retain.
+local removedAuraIDSetScratch = {}
+local updatedAuraIDSetScratch = {}
+
+local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
+    if not (auraInstanceIDs and auraInstanceIDs[1]) then
+        return nil
+    end
+
+    wipe(scratch)
+    for _, auraInstanceID in ipairs(auraInstanceIDs) do
+        scratch[auraInstanceID] = true
+    end
+    return scratch
+end
 
 function RB.CreateResourceBarLifecycleModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -28,18 +48,6 @@ function RB.CreateResourceBarLifecycleModule(deps)
     local pendingTalentResourceRefreshToken = 0
     local lifecycleEventsEnabled = false
     local InstallHooks
-
-    local function BuildAuraInstanceIDSet(auraInstanceIDs)
-        if not (auraInstanceIDs and auraInstanceIDs[1]) then
-            return nil
-        end
-
-        local auraInstanceIDSet = {}
-        for _, auraInstanceID in ipairs(auraInstanceIDs) do
-            auraInstanceIDSet[auraInstanceID] = true
-        end
-        return auraInstanceIDSet
-    end
 
     local function IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
         if not (barInfo and cabConfig) then return false end
@@ -172,8 +180,8 @@ function RB.CreateResourceBarLifecycleModule(deps)
 
                     local removedIDs = updateInfo.removedAuraInstanceIDs
                     local updatedIDs = updateInfo.updatedAuraInstanceIDs
-                    local removedIDSet = BuildAuraInstanceIDSet(removedIDs)
-                    local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
+                    local removedIDSet = FillAuraInstanceIDSet(removedAuraIDSetScratch, removedIDs)
+                    local updatedIDSet = FillAuraInstanceIDSet(updatedAuraIDSetScratch, updatedIDs)
                     local hasAuraChange = updateInfo.isFullUpdate or updateInfo.addedAuras or removedIDs or updatedIDs
                     local targetSwitchDataReceived = false
 


### PR DESCRIPTION
## What Changed
- The UNIT_AURA handlers in `Core/Aura.lua` (button tracking) and `OtherBars/ResourceBarLifecycle.lua` (custom aura bars) no longer build throwaway removed/updated aura-instance-ID lookup tables on every event. Each file now wipes and refills its own pair of module-level scratch sets.
- The fill helper preserves the exact nil-when-empty return contract the downstream code branches on, so all consumer logic is untouched.
- Per review: the scratch declarations carry invariant comments matching the convention from #498, and `ResourceBarLifecycle.lua` now localizes `wipe`/`ipairs` so both copies of the helper resolve globals identically on the hot path.

## Why This Changed
- Sub-change 3b of the CPU-performance series (audit finding 3): per-event throwaway tables accumulate garbage that triggers periodic GC stutters in combat. UNIT_AURA fires constantly in raid combat and feeds both the button walk and custom aura bars, making these two allocation sites recurring garbage producers.

## Developer Impact
- Fewer allocations per UNIT_AURA event with no intended behavior change; display accuracy is unaffected by design (same data, same contract, reused storage).
- Extends the scratch-table reuse pattern established in #498 (3a); the remaining table types are covered by planned sub-changes 3c and 3d.

## Validation
- `luac -p` syntax check passed on both files.
- Multi-angle code review (8 finder angles + independent verification): zero correctness findings. Lifetime traces confirmed both consumers finish synchronously within the event dispatch, nothing retains the sets, no reentrancy path exists, and the two files use fully separate scratch pairs.
- In-game validation NOT yet performed. Pending targeted sweep before leaving draft: DoT refresh mid-duration (remove + add in the same event), natural aura expiry, pandemic dirty-marking on aura updates, target swap with target-aura tracking active, and the same aura checks on custom aura bars. Combat behavior unverified until that sweep.