### PR TITLE
Reduce aura tracking allocations by reusing per-owner state tables

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -45,8 +45,8 @@ local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_BAR_COLOR = {0.2, 0.6, 1.0, 1.0}
 local DEFAULT_READY_TEXT_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -26,14 +26,13 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
--- Reusable scratch opts — single call site each; assign EVERY field
--- unconditionally before each call (a conditional write leaves a stale value
--- from the previous call that silently overrides owner/auraState data).
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
+-- Reusable scratch opts — single call site each; filled immediately before
+-- their call and wiped right after it, so they are always empty between walks
+-- and never pin values from a previous walk.
 local evaluateButtonAuraStateOpts = {}
 local buttonAuraPandemicStateOpts = {}
-local auraProbeGCDOnlyOpts = {}
 
 -- Silent-transform icon staleness probe interval (seconds). Event-driven icon
 -- refresh paths are unaffected; this only paces the no-event fallback probe.
@@ -350,11 +349,19 @@ local function GetViewerNameFontString(viewerFrame)
     return bar and bar.Name or nil
 end
 
+-- Reusable per-button scratch -- only valid within the current cooldown walk.
+-- Never retain or read directly between calls.
 local function CreateAuraDisplayNameState(button)
-    return {
-        priorReadableName = button and button._auraDisplayName or nil,
-        priorSecretTextActive = button and button._isText and button._textSecretNameActive == true or false,
-    }
+    local state = button._auraDisplayNameStateScratch
+    if state then
+        wipe(state)
+    else
+        state = {}
+        button._auraDisplayNameStateScratch = state
+    end
+    state.priorReadableName = button._auraDisplayName
+    state.priorSecretTextActive = button._isText and button._textSecretNameActive == true or false
+    return state
 end
 
 local function RecordAuraDisplayName(state, auraData)
@@ -1002,7 +1009,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._auraSpellID,
             evaluateButtonAuraStateOpts
         )
-        evaluateButtonAuraStateOpts.previousAuraDurationObj = nil -- don't pin the duration object between walks
+        wipe(evaluateButtonAuraStateOpts)
         local viewerFrame = auraState.viewerFrame
         auraTrackingReady = auraState.auraTrackingReady == true
         auraOverrideActive = auraState.auraPresent == true
@@ -1125,7 +1132,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         buttonAuraPandemicStateOpts.clearWhenDisabled = true
         buttonAuraPandemicStateOpts.auraState = auraState
         button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, buttonAuraPandemicStateOpts)
-        buttonAuraPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between walks
+        wipe(buttonAuraPandemicStateOpts)
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1185,13 +1192,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
             auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
-        if auraProbeInfo then
-            auraProbeGCDOnlyOpts.normalCooldownShown = auraProbeNormalCooldownShown
-            auraProbeGCDOnlyOpts.realCooldownShown = auraProbeRealCooldownShown
-            auraProbeIsGCDOnly = CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeGCDOnlyOpts) or false
-        else
-            auraProbeIsGCDOnly = false
-        end
+        auraProbeIsGCDOnly = CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeNormalCooldownShown, auraProbeRealCooldownShown)
     end
 
     -- Secondary cooldown text display during aura override

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -1026,6 +1026,10 @@ local function ResolveEffectiveItem(buttonData, opts)
 end
 CooldownCompanion.ResolveEffectiveItem = ResolveEffectiveItem
 
+-- Immutable shared opts for ResolveEffectiveItem callers that want async item
+-- loads requested. Shared across files and calls — never write to this table.
+CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+
 -- Apply configurable strata (frame level) ordering to button sub-elements.
 -- order: array of 6 keys or nil for default.
 -- Index 1 = lowest layer (baseLevel+1), index 6 = highest (baseLevel+6).

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -75,8 +75,8 @@ local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCoo
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -52,8 +52,8 @@ local DEFAULT_READY_COLOR = {0.2, 1.0, 0.2, 1}
 local DEFAULT_AURA_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_CUSTOM_COLOR = {1, 0.82, 0, 1}
 local DEFAULT_TEXT_FORMAT = "{name}  {status}"
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 
 local function IsAuraOnlyEntry(buttonData)
     return buttonData

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -42,6 +42,9 @@ local removedAuraIDSetScratch = {}
 local updatedAuraIDSetScratch = {}
 local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
 
+-- Immutable — shared across calls; never write to this table.
+local CLEAR_TRACKED_AURA_FALSE_STATE_OPTS = { useFalseState = true }
+
 local function IsBuffViewerChild(frame)
     if not frame then return false end
     local parent = frame:GetParent()
@@ -528,7 +531,7 @@ function CooldownCompanion:ClearAuraUnit(unitToken)
                 shouldClear = true
             end
             if shouldClear then
-                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, { useFalseState = true })
+                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, CLEAR_TRACKED_AURA_FALSE_STATE_OPTS)
                 button._auraPrimarySwipeActive = nil
             end
         end

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -36,23 +36,11 @@ local COOLDOWN_VIEWER_ASSOCIATION_CATEGORIES = {
     Enum.CooldownViewerCategory.TrackedBar,
 }
 
--- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
--- value within the same synchronous event dispatch; contents are stale between
--- calls (the nil-return path skips the wipe). Never read directly or retain.
+-- Caller-owned scratch sets for ST.FillAuraInstanceIDSet — see Utils.lua for
+-- the lifetime contract (use only the returned set, never read these directly).
 local removedAuraIDSetScratch = {}
 local updatedAuraIDSetScratch = {}
-
-local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
-    if not (auraInstanceIDs and auraInstanceIDs[1]) then
-        return nil
-    end
-
-    wipe(scratch)
-    for _, auraInstanceID in ipairs(auraInstanceIDs) do
-        scratch[auraInstanceID] = true
-    end
-    return scratch
-end
+local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
 
 local function IsBuffViewerChild(frame)
     if not frame then return false end

--- a/CooldownCompanion/Core/CooldownLogic.lua
+++ b/CooldownCompanion/Core/CooldownLogic.lua
@@ -17,13 +17,12 @@ CooldownLogic.CHARGE_STATE_FULL = "full"
 CooldownLogic.CHARGE_STATE_MISSING = "missing"
 CooldownLogic.CHARGE_STATE_ZERO = "zero"
 
-function CooldownLogic.IsSpellGCDOnly(info, options)
+function CooldownLogic.IsSpellGCDOnly(info, normalCooldownShown, realCooldownShown)
     if not info then
         return false
     end
 
-    options = options or {}
-    if options.realCooldownShown or not options.normalCooldownShown then
+    if realCooldownShown or not normalCooldownShown then
         return false
     end
 

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -25,12 +25,12 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local TARGET_SWITCH_SAFETY_CAP = 0.60
--- Reusable scratch opts — single call site each; assign EVERY field
--- unconditionally before each call (a conditional write leaves a stale value
--- from the previous call that silently overrides owner/auraState data).
+-- Reusable scratch opts — single call site each; filled immediately before
+-- their call and wiped right after it, so they are always empty between uses
+-- and never pin values from a previous call.
 local buttonSpellCooldownLaneOpts = {}
-local laneGCDOnlyOpts = {}
 local customBarSpellCooldownLaneOpts = {}
+local clearOwnerStateOpts = {}
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -813,10 +813,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
             owner._targetSwitchDataReceived = nil
         end
     else
-        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit, {
-            useFalseState = true,
-            preserveTargetSwitch = state.wasAuraActive == true,
-        })
+        clearOwnerStateOpts.useFalseState = true
+        clearOwnerStateOpts.preserveTargetSwitch = state.wasAuraActive == true
+        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit, clearOwnerStateOpts)
+        wipe(clearOwnerStateOpts)
         if owner._targetSwitchAt and not state.wasAuraActive then
             owner._targetSwitchAt = nil
             owner._targetSwitchDataReceived = nil
@@ -824,6 +824,9 @@ local function CommitTrackedAuraOwnerState(owner, state)
     end
 end
 
+-- Returns a per-owner scratch table that is wiped and refilled on this owner's
+-- next evaluation. Read it only synchronously within the current update; never
+-- retain the returned table (or store it on another object) across ticks/events.
 function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
     owner = owner or {}
     options = options or {}
@@ -1038,34 +1041,43 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     end
 
     local auraExpirationTime, auraDuration, auraTimingReadable = GetReadableAuraTiming(auraPresent and auraData or nil)
-    local state = {
-        ready = ready == true,
-        auraPresent = auraPresent == true,
-        auraTrackingReady = ready == true,
-        cdmEnabled = cdmEnabled == true,
-        auraData = auraPresent and auraData or nil,
-        auraApplications = auraPresent and auraApplications or nil,
-        auraInstanceID = auraPresent and auraInstanceID or nil,
-        auraUnit = auraPresent and auraUnit or configUnit,
-        configUnit = configUnit,
-        viewerFrame = viewerFrame,
-        viewerBar = viewerBar,
-        durationObj = auraPresent and durationObj or nil,
-        auraCooldownStart = auraPresent and auraCooldownStart or nil,
-        auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
-        auraExpirationTime = auraTimingReadable and auraExpirationTime or nil,
-        auraDuration = auraTimingReadable and auraDuration or nil,
-        auraHasTimer = auraPresent and auraHasTimer == true or false,
-        auraGraceHeld = auraGraceHeld == true,
-        activeAuraSpellID = activeAuraSpellID,
-        activeAuraSpellIDResolved = activeAuraSpellIDResolved == true,
-        activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
-        activeAuraIcon = activeAuraIcon,
-        activeAuraIconAvailable = activeAuraIconAvailable == true,
-        activeAuraIconResolved = activeAuraIconResolved == true,
-        allowDurationlessAuraInstance = allowDurationlessAuraInstance,
-        wasAuraActive = wasAuraActive,
-    }
+    -- Reusable per-owner scratch -- see the contract above the function header.
+    -- The wipe is enforcement: every field below is assigned unconditionally
+    -- today, but the wipe keeps a future conditional assignment from leaking a
+    -- stale value between evaluations.
+    local state = owner._trackedAuraStateScratch
+    if state then
+        wipe(state)
+    else
+        state = {}
+        owner._trackedAuraStateScratch = state
+    end
+    state.ready = ready == true
+    state.auraPresent = auraPresent == true
+    state.auraTrackingReady = ready == true
+    state.cdmEnabled = cdmEnabled == true
+    state.auraData = auraPresent and auraData or nil
+    state.auraApplications = auraPresent and auraApplications or nil
+    state.auraInstanceID = auraPresent and auraInstanceID or nil
+    state.auraUnit = auraPresent and auraUnit or configUnit
+    state.configUnit = configUnit
+    state.viewerFrame = viewerFrame
+    state.viewerBar = viewerBar
+    state.durationObj = auraPresent and durationObj or nil
+    state.auraCooldownStart = auraPresent and auraCooldownStart or nil
+    state.auraCooldownDuration = auraPresent and auraCooldownDuration or nil
+    state.auraExpirationTime = auraTimingReadable and auraExpirationTime or nil
+    state.auraDuration = auraTimingReadable and auraDuration or nil
+    state.auraHasTimer = auraPresent and auraHasTimer == true or false
+    state.auraGraceHeld = auraGraceHeld == true
+    state.activeAuraSpellID = activeAuraSpellID
+    state.activeAuraSpellIDResolved = activeAuraSpellIDResolved == true
+    state.activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback
+    state.activeAuraIcon = activeAuraIcon
+    state.activeAuraIconAvailable = activeAuraIconAvailable == true
+    state.activeAuraIconResolved = activeAuraIconResolved == true
+    state.allowDurationlessAuraInstance = allowDurationlessAuraInstance
+    state.wasAuraActive = wasAuraActive
 
     if mutateOwner then
         CommitTrackedAuraOwnerState(owner, state)
@@ -1263,10 +1275,6 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
-    -- Snapshot for the IsSpellGCDOnly elseif below — keep in sync if anything
-    -- mutates result.normalCooldownShown/realCooldownShown before that branch.
-    laneGCDOnlyOpts.normalCooldownShown = result.normalCooldownShown
-    laneGCDOnlyOpts.realCooldownShown = result.realCooldownShown
     if suppressCooldownSurface then
         if result.isOnGCD == true and CooldownCompanion._gcdDurationObj then
             result.source = "resource-gated-gcd"
@@ -1283,7 +1291,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-real-ignore-gcd"
         result.renderDurationObj = result.realDurationObj
-    elseif CooldownLogic.IsSpellGCDOnly(info, laneGCDOnlyOpts) then
+    elseif CooldownLogic.IsSpellGCDOnly(info, result.normalCooldownShown, result.realCooldownShown) then
         result.source = "spell-gcd"
         result.presentationState = COOLDOWN_STATE_GCD
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
@@ -1326,7 +1334,9 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     buttonSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
     buttonSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
     buttonSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
+    local result = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
+    wipe(buttonSpellCooldownLaneOpts)
+    return result
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
@@ -1669,6 +1679,7 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     customBarSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
     customBarSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, customBarSpellCooldownLaneOpts)
+    wipe(customBarSpellCooldownLaneOpts)
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
     result.noCooldown = noCooldown or nil

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -30,7 +30,9 @@ local TARGET_SWITCH_SAFETY_CAP = 0.60
 -- and never pin values from a previous call.
 local buttonSpellCooldownLaneOpts = {}
 local customBarSpellCooldownLaneOpts = {}
-local clearOwnerStateOpts = {}
+-- Immutable — shared across calls; never write to these tables.
+local CLEAR_OWNER_FALSE_STATE_OPTS = { useFalseState = true }
+local CLEAR_OWNER_FALSE_STATE_KEEP_SWITCH_OPTS = { useFalseState = true, preserveTargetSwitch = true }
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -680,6 +682,17 @@ function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
     end
 end
 
+-- Releases the per-owner evaluation scratches: the tracked-aura state table
+-- filled by EvaluateTrackedAuraState and the aura display-name scratch filled
+-- by ButtonFrame/CooldownUpdate. Both are recreated lazily on the next
+-- evaluation. Call only from teardown/dormancy paths, never while an
+-- evaluation's returned state is still being read.
+function EntryRuntime.ReleaseTrackedAuraScratch(owner)
+    if not owner then return end
+    owner._trackedAuraStateScratch = nil
+    owner._auraDisplayNameStateScratch = nil
+end
+
 function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
     if not owner then return end
     owner._auraInstanceID = nil
@@ -813,10 +826,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
             owner._targetSwitchDataReceived = nil
         end
     else
-        clearOwnerStateOpts.useFalseState = true
-        clearOwnerStateOpts.preserveTargetSwitch = state.wasAuraActive == true
-        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit, clearOwnerStateOpts)
-        wipe(clearOwnerStateOpts)
+        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit,
+            state.wasAuraActive == true
+                and CLEAR_OWNER_FALSE_STATE_KEEP_SWITCH_OPTS
+                or CLEAR_OWNER_FALSE_STATE_OPTS)
         if owner._targetSwitchAt and not state.wasAuraActive then
             owner._targetSwitchAt = nil
             owner._targetSwitchDataReceived = nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -782,6 +782,14 @@ local function ClearReusableButtonRuntime(button)
     button._auraStackText = nil
     button._auraHasTimer = nil
     button._textSecretNameActive = nil
+    -- Release refs pinned by per-button evaluation scratches (aura data,
+    -- duration objects, viewer frames, secret aura names).
+    if button._trackedAuraStateScratch then
+        wipe(button._trackedAuraStateScratch)
+    end
+    if button._auraDisplayNameStateScratch then
+        wipe(button._auraDisplayNameStateScratch)
+    end
     button._bindingKeyInfos = nil
     button._keyPressHighlightActive = nil
     button._visibilityHidden = false
@@ -866,7 +874,7 @@ end
 local function ResolveReusableButtonEntryState(button, buttonData)
     if CooldownCompanion.IsEntryItemLike and CooldownCompanion.IsEntryItemLike(buttonData) then
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true })
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS)
             or nil
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -782,14 +782,7 @@ local function ClearReusableButtonRuntime(button)
     button._auraStackText = nil
     button._auraHasTimer = nil
     button._textSecretNameActive = nil
-    -- Release refs pinned by per-button evaluation scratches (aura data,
-    -- duration objects, viewer frames, secret aura names).
-    if button._trackedAuraStateScratch then
-        wipe(button._trackedAuraStateScratch)
-    end
-    if button._auraDisplayNameStateScratch then
-        wipe(button._auraDisplayNameStateScratch)
-    end
+    EntryRuntime.ReleaseTrackedAuraScratch(button)
     button._bindingKeyInfos = nil
     button._keyPressHighlightActive = nil
     button._visibilityHidden = false

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2732,6 +2732,9 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
 
         return true
     elseif CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        -- RESOLVE_ITEM_REQUEST_LOAD_OPTS must be read at call time here: this
+        -- file loads before ButtonFrame/Helpers.lua defines it (TOC order), so
+        -- a file-scope local would capture nil and silently drop requestLoad.
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
             and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS) or nil
         return effectiveItem and effectiveItem.trackable == true
@@ -3287,6 +3290,9 @@ function CooldownCompanion:UnloadGroup(groupId)
                 button._savedOnUpdate = onUpdate
                 button:SetScript("OnUpdate", nil)
             end
+            -- Dormant buttons stop being evaluated; release their scratches so
+            -- they don't pin aura data or secret names while parked.
+            ST.EntryRuntime.ReleaseTrackedAuraScratch(button)
         end
     end
 

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2733,7 +2733,7 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
         return true
     elseif CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS) or nil
         return effectiveItem and effectiveItem.trackable == true
     elseif buttonData.type == "item" then
         if buttonData.hasCharges then return true end

--- a/CooldownCompanion/Core/Utils.lua
+++ b/CooldownCompanion/Core/Utils.lua
@@ -8,6 +8,7 @@ local ADDON_NAME, ST = ...
 local InCombatLockdown = InCombatLockdown
 local string_format = string.format
 local ipairs = ipairs
+local wipe = wipe
 local pairs = pairs
 local tonumber = tonumber
 local type = type
@@ -39,6 +40,27 @@ ST.EDGE_ANCHOR_SPEC = {
     {"TOPLEFT", "TOPLEFT",     "BOTTOMRIGHT", "BOTTOMLEFT",   0, -1,  1,  1}, -- Left   (inset to avoid corner overlap)
     {"TOPLEFT", "TOPRIGHT",    "BOTTOMRIGHT", "BOTTOMRIGHT", -1, -1,  0,  1}, -- Right  (inset to avoid corner overlap)
 }
+
+--------------------------------------------------------------------------------
+-- Aura Instance ID Sets
+--------------------------------------------------------------------------------
+
+-- Fills a caller-owned scratch set from a UNIT_AURA instance-ID array and
+-- returns it, or returns nil when the array is empty/absent (the nil path
+-- deliberately skips the wipe, so scratch contents are stale between calls).
+-- Use only the returned set, only within the same synchronous event dispatch;
+-- never read the scratch directly or retain the set.
+function ST.FillAuraInstanceIDSet(scratch, auraInstanceIDs)
+    if not (auraInstanceIDs and auraInstanceIDs[1]) then
+        return nil
+    end
+
+    wipe(scratch)
+    for _, auraInstanceID in ipairs(auraInstanceIDs) do
+        scratch[auraInstanceID] = true
+    end
+    return scratch
+end
 
 --------------------------------------------------------------------------------
 -- StatusBar Motion Helpers

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -431,6 +431,11 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     frame._cdcIndependentAlphaTarget = nil
     frame._cdcIndependentLastAlpha = nil
     EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, { clearCustomAuraStacks = true })
+    -- Release refs pinned by the per-owner evaluation scratch (aura data,
+    -- duration objects, viewer frames).
+    if frame._trackedAuraStateScratch then
+        wipe(frame._trackedAuraStateScratch)
+    end
     frame._parsedAuraIDs = nil
     frame._parsedAuraIDsRaw = nil
     frame._parsedAuraIDsButtonID = nil

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -39,6 +39,9 @@ local function UnbindFrameDurationText(frame)
     end
 end
 
+-- Immutable — shared across calls; never write to this table.
+local CLEAR_CUSTOM_AURA_STACKS_OPTS = { clearCustomAuraStacks = true }
+
 ------------------------------------------------------------------------
 -- Imports from ResourceBarConstants / ResourceBarHelpers / ResourceBarVisuals
 ------------------------------------------------------------------------
@@ -223,7 +226,7 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     local bar = barInfo and barInfo.frame
     if not bar then return end
 
-    EntryRuntime.ClearTrackedAuraOwnerState(bar, nil, { clearCustomAuraStacks = true })
+    EntryRuntime.ClearTrackedAuraOwnerState(bar, nil, CLEAR_CUSTOM_AURA_STACKS_OPTS)
 
     ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
 end
@@ -430,12 +433,8 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     end
     frame._cdcIndependentAlphaTarget = nil
     frame._cdcIndependentLastAlpha = nil
-    EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, { clearCustomAuraStacks = true })
-    -- Release refs pinned by the per-owner evaluation scratch (aura data,
-    -- duration objects, viewer frames).
-    if frame._trackedAuraStateScratch then
-        wipe(frame._trackedAuraStateScratch)
-    end
+    EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, CLEAR_CUSTOM_AURA_STACKS_OPTS)
+    EntryRuntime.ReleaseTrackedAuraScratch(frame)
     frame._parsedAuraIDs = nil
     frame._parsedAuraIDsRaw = nil
     frame._parsedAuraIDsButtonID = nil

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -97,9 +97,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
-    -- Reusable scratch opts — single call site each; assign EVERY field
-    -- unconditionally before each call (a conditional write leaves a stale value
-    -- from the previous call that silently overrides owner/auraState data).
+    -- Reusable scratch opts — single call site each; filled immediately before
+    -- their call and wiped right after it, so they are always empty between
+    -- updates and never pin values from a previous update.
     local spellCustomBarAuraStateOpts = {}
     local customAuraBarAuraStateOpts = {}
     local customAuraBarPandemicStateOpts = {}
@@ -185,7 +185,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         spellCustomBarAuraStateOpts.allowDurationlessAuraInstance = true
         spellCustomBarAuraStateOpts.useButtonAuraViewerFallback = true
         spellCustomBarAuraStateOpts.validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell
-        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
+        local auraState = EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
+        wipe(spellCustomBarAuraStateOpts)
+        return auraState
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -224,6 +226,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 customAuraBarAuraStateOpts.allowDurationlessAuraInstance = true
                 customAuraBarAuraStateOpts.allowPlayerAuraFallbackWithoutReady = true
                 auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, customAuraBarAuraStateOpts)
+                wipe(customAuraBarAuraStateOpts)
                 viewerFrame = auraState and auraState.viewerFrame or nil
             end
         end
@@ -295,7 +298,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customAuraBarPandemicStateOpts.auraUnit = auraUnit
         customAuraBarPandemicStateOpts.auraInstanceID = instId
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, customAuraBarPandemicStateOpts)
-        customAuraBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
+        wipe(customAuraBarPandemicStateOpts)
 
         if isActive and bar then
             if auraPresent then
@@ -590,7 +593,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customCooldownBarPandemicStateOpts.clearWhenDisabled = true
         customCooldownBarPandemicStateOpts.auraState = auraState
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, customCooldownBarPandemicStateOpts)
-        customCooldownBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
+        wipe(customCooldownBarPandemicStateOpts)
 
         if auraState
             and auraState.ready == true

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -144,6 +144,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end)
     end
 
+    -- Reusable scratch buttonData -- returned to callers but only consumed
+    -- synchronously within the same bar update; never retain between updates
+    -- and never assign to a button.buttonData field (style caches key on
+    -- buttonData table identity). The wipe is enforcement so no field can
+    -- leak between fills.
+    local customBarAuraButtonDataScratch = {}
+
     local function BuildCustomBarAuraButtonData(cabConfig, addedAsAura)
         local spellID = tonumber(cabConfig and cabConfig.spellID)
         if not spellID then
@@ -158,16 +165,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return nil, nil
         end
 
-        local buttonData = {
-            type = "spell",
-            id = spellID,
-            auraSpellID = cabConfig.auraSpellID,
-            auraTracking = true,
-            auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID),
-        }
-        if addedAsAura then
-            buttonData.addedAs = "aura"
-        end
+        local buttonData = customBarAuraButtonDataScratch
+        wipe(buttonData)
+        buttonData.type = "spell"
+        buttonData.id = spellID
+        buttonData.auraSpellID = cabConfig.auraSpellID
+        buttonData.auraTracking = true
+        buttonData.auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
+        buttonData.addedAs = addedAsAura and "aura" or nil
         return buttonData, spellID
     end
 
@@ -1167,6 +1172,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 ClearCustomAuraBarIndicatorState(barInfo, true)
                 ClearResourceAuraVisuals(barInfo.frame)
                 ClearMaxStacksIndicator(barInfo)
+                -- The old frame is abandoned (frames are never destroyed);
+                -- release its evaluation scratch so it stops pinning aura refs.
+                EntryRuntime.ReleaseTrackedAuraScratch(barInfo.frame)
                 barInfo.frame:Hide()
             end
             if mode == "continuous" then

--- a/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
@@ -18,6 +18,9 @@ local removedAuraIDSetScratch = {}
 local updatedAuraIDSetScratch = {}
 local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
 
+-- Immutable — shared across calls; never write to this table.
+local CLEAR_CUSTOM_BAR_AURA_OPTS = { useFalseState = true, clearCustomAuraStacks = true }
+
 function RB.CreateResourceBarLifecycleModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
     local GetResourceBarSettings = deps.GetResourceBarSettings or RB.GetResourceBarSettings
@@ -46,10 +49,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
     end
 
     local function ClearCustomBarAuraRuntime(bar, configUnit)
-        EntryRuntime.ClearTrackedAuraOwnerState(bar, configUnit, {
-            useFalseState = true,
-            clearCustomAuraStacks = true,
-        })
+        EntryRuntime.ClearTrackedAuraOwnerState(bar, configUnit, CLEAR_CUSTOM_BAR_AURA_OPTS)
     end
 
     local function RebuildResourceBarTalentEligibilityCache()

--- a/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
@@ -9,27 +9,14 @@ local EntryRuntime = ST.EntryRuntime
 
 local math_abs = math.abs
 local ipairs = ipairs
-local wipe = wipe
 
 local RB = ST._RB
 
--- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
--- value within the same synchronous event dispatch; contents are stale between
--- calls (the nil-return path skips the wipe). Never read directly or retain.
+-- Caller-owned scratch sets for ST.FillAuraInstanceIDSet — see Utils.lua for
+-- the lifetime contract (use only the returned set, never read these directly).
 local removedAuraIDSetScratch = {}
 local updatedAuraIDSetScratch = {}
-
-local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
-    if not (auraInstanceIDs and auraInstanceIDs[1]) then
-        return nil
-    end
-
-    wipe(scratch)
-    for _, auraInstanceID in ipairs(auraInstanceIDs) do
-        scratch[auraInstanceID] = true
-    end
-    return scratch
-end
+local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
 
 function RB.CreateResourceBarLifecycleModule(deps)
     local resourceBarFrames = deps.resourceBarFrames


### PR DESCRIPTION
## What Changed
- The tracked-aura state table that `EvaluateTrackedAuraState` builds every update is now a reusable per-owner scratch table (wiped and refilled in place) instead of a fresh table per call, and the per-button aura display-name state uses the same pattern. These were the two largest remaining per-tick table allocations in the aura tracking path.
- All shared scratch opts tables now follow one mechanical discipline: filled immediately before their single call and wiped right after it, replacing the previous comment-enforced "assign every field" convention and the ad-hoc per-field nil-outs. This also releases object references (aura data, duration objects, aura instance IDs) that a few opts tables previously kept pinned between updates.
- Scratch release is owned by a single new `EntryRuntime.ReleaseTrackedAuraScratch(owner)` export, called from every path where an owner stops being evaluated: button recycle (`ClearReusableButtonRuntime`), bar recycle (`ClearStaleRecycledBarRuntimeState`), custom-bar recreate (`PrepareCustomAuraBar` — abandoned frames previously kept pinning aura refs on every aura on/off bar-type flip), and group unload (`UnloadGroup` — dormant buttons previously kept their last aura data and secret aura names while parked).
- `CooldownLogic.IsSpellGCDOnly` takes its two booleans as plain parameters instead of an options table, deleting two scratch tables and a fragile early snapshot whose freshness was guarded only by a comment.
- Constant option tables are shared immutably instead of allocated per call: the clear-owner options in `CommitTrackedAuraOwnerState` (the steady-state aura-absent path), the `ClearTrackedAuraOwnerState` literals in `ClearAuraUnit` / `ClearCustomBarAuraRuntime` / resource-bar teardown, and the custom-bar aura `buttonData` built per bar update (now a module scratch).
- Deduplicated `FillAuraInstanceIDSet` into a single shared helper in `Core/Utils.lua` (was copied verbatim in `Core/Aura.lua` and `OtherBars/ResourceBarLifecycle.lua`), and moved the shared immutable `{ requestLoad = true }` opts table into `ButtonFrame/Helpers.lua` (was declared identically in four files); the TOC load-order constraint that forces `GroupOperations.lua` to read it at call time is now documented at that call site.

## Why This Changed
- Third branch in the allocation-reduction series (after #498 option tables and #499 aura instance ID sets). Profiling flagged the aura-state result tables as the dominant remaining per-tick garbage source: one fresh ~26-field table per aura-tracked button or custom bar per cooldown walk.
- Two multi-agent review passes shaped the final form: the first surfaced retention and fragility issues in the initial scratch approach (folded into the first commit); the second confirmed the fixes held and found the remaining release-coverage gaps (orphaned recreate frames, dormant groups) and constant-hoist opportunities closed by the follow-up commit.

## Developer Impact
- Less garbage generated per cooldown walk means less GC pressure during combat on aura-heavy layouts; cumulative with #498/#499.
- Scratch-table rules are mechanical rather than comment-enforced: opts tables are provably empty between uses, the returned state scratch documents its never-retain contract at the function header, and scratch field names live in one module behind the release export (a rename can no longer silently disable teardown release).
- Known follow-up (intentionally out of scope): `EvaluateSpellCooldownLane` still allocates its result table per call; converting it needs its own retention audit because that table escapes to callers.

## Validation
- `luac 5.1 -p` parse check passed on every changed file in both commits.
- Two full multi-agent static reviews (8 finder angles + per-finding verification each): no correctness regressions found in either pass; all verified findings were addressed in these two commits or explicitly deferred (the lane-result follow-up above). Second-pass verification also confirmed the `IsSpellGCDOnly` migration, TOC load order, wipe placements, and scratch lifetimes are correct.
- Static tracing confirmed every scratch table is consumed synchronously by its callee and that no caller retains the returned state table across updates.
- Not yet validated in-game. Combat and restricted-content behavior (aura-tracked buttons including secret names in text mode, custom aura/cooldown bars including bar-type flips on aura transitions, pandemic glow, target switching, group load-condition swaps, item/equipment-slot entries) still needs an in-game pass before merge.
