### PR TITLE
Reduce cooldown update allocations by reusing spell cooldown lane result tables

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1451,10 +1451,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and duration > 0).  It can report true during per-cast lockouts
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
-            local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
-                or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-            if slotProbe.shown ~= nil then
-                button._mainCDShown = slotProbe.realShown == true
+            local probeShown = spellCooldownResult and spellCooldownResult.slotProbeShown
+            local probeRealShown = spellCooldownResult and spellCooldownResult.slotProbeRealShown
+            if probeShown == nil then
+                local slotProbe = EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+                probeShown = slotProbe.shown
+                probeRealShown = slotProbe.realShown
+            end
+            if probeShown ~= nil then
+                button._mainCDShown = probeRealShown == true
             elseif not auraOwnsPrimarySwipe then
                 -- No action bar slot found; use the ignoreGCD-backed real cooldown state.
                 if spellCooldownResult and spellCooldownResult.fetchOk then

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1125,6 +1125,9 @@ local function IsSpellCooldownDeferred(info)
 end
 
 local actionSlotSeenScratch = {}
+local actionSlotProbeScratch = {}
+local actionSlotCooldownProbeScratch = {}
+local spellCooldownLaneResultScratch = {}
 
 local function MergeActionSlotProbe(result, probe)
     if probe.sawAnySlot then result.sawAnySlot = true end
@@ -1147,13 +1150,13 @@ local function MergeActionSlotProbe(result, probe)
     return false
 end
 
+-- Returns a module-local scratch table. Read it only synchronously in the
+-- current probe/merge path; never retain it across calls.
 local function ProbeActionSlotsForSpellID(spellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
+    local result = actionSlotProbeScratch
+    wipe(result)
+    result.sawAnySlot = false
+    result.sawUnknown = false
 
     if not spellID then return result end
 
@@ -1198,13 +1201,13 @@ local function ProbeActionSlotsForSpellID(spellID)
 
     return result
 end
+-- Returns a module-local scratch table. Read it only synchronously in the
+-- current update/probe path; never retain it across ticks/events.
 local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
+    local result = actionSlotCooldownProbeScratch
+    wipe(result)
+    result.sawAnySlot = false
+    result.sawUnknown = false
 
     if not baseSpellID then return result end
 
@@ -1229,17 +1232,19 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
 end
 EntryRuntime.ProbeActionSlotCooldownForSpell = ProbeActionSlotCooldownForSpell
 
+-- Returns a module-local scratch table. Read it only synchronously within the
+-- current button/custom-bar update; never retain it across ticks/events.
 local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
-    local result = {
-        spellID = spellID,
-        fetchOk = false,
-        state = COOLDOWN_STATE_READY,
-        source = "ready",
-        realCooldownShown = false,
-        isOnGCD = false,
-        deferred = false,
-        resourceGatedNoCooldown = false,
-    }
+    local result = spellCooldownLaneResultScratch
+    wipe(result)
+    result.spellID = spellID
+    result.fetchOk = false
+    result.state = COOLDOWN_STATE_READY
+    result.source = "ready"
+    result.realCooldownShown = false
+    result.isOnGCD = false
+    result.deferred = false
+    result.resourceGatedNoCooldown = false
 
     if not spellID then
         return result
@@ -1332,6 +1337,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 
     return result
 end
+-- Returns the spell cooldown lane scratch; read only synchronously in the
+-- current button update and never retain across ticks/events.
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown, resourceGateCost, baseNoCooldown, baseResourceGateCost)
     local resourceGatedNoCooldown = noCooldown == true
         and (resourceGateCost == true
@@ -1646,6 +1653,8 @@ function EntryRuntime.ApplyBarAuraStackState(
     return barAuraSecretStackValue, preserveBarAuraStackText
 end
 
+-- Returns the spell cooldown lane scratch; read only synchronously in the
+-- current custom-bar update and never retain across ticks/events.
 function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local spellID = tonumber(customBar and customBar.spellID)
     if not spellID then

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1125,6 +1125,12 @@ local function IsSpellCooldownDeferred(info)
 end
 
 local actionSlotSeenScratch = {}
+-- Reusable probe/lane scratch tables, wiped at the start of every fill; each
+-- keeps its previous fill's contents (including Blizzard info/duration/charge
+-- references) until then. The two probe scratches must stay separate tables:
+-- ProbeActionSlotCooldownForSpell fills actionSlotCooldownProbeScratch while
+-- MergeActionSlotProbe reads from actionSlotProbeScratch, so sharing one
+-- table would wipe the merged result mid-probe.
 local actionSlotProbeScratch = {}
 local actionSlotCooldownProbeScratch = {}
 local spellCooldownLaneResultScratch = {}
@@ -1155,8 +1161,6 @@ end
 local function ProbeActionSlotsForSpellID(spellID)
     local result = actionSlotProbeScratch
     wipe(result)
-    result.sawAnySlot = false
-    result.sawUnknown = false
 
     if not spellID then return result end
 
@@ -1206,8 +1210,6 @@ end
 local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
     local result = actionSlotCooldownProbeScratch
     wipe(result)
-    result.sawAnySlot = false
-    result.sawUnknown = false
 
     if not baseSpellID then return result end
 
@@ -1230,6 +1232,9 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
 
     return result
 end
+-- Public alias: external callers receive the same scratch table on every
+-- call, so two calls never yield independent results -- consume synchronously,
+-- never retain.
 EntryRuntime.ProbeActionSlotCooldownForSpell = ProbeActionSlotCooldownForSpell
 
 -- Returns a module-local scratch table. Read it only synchronously within the
@@ -1265,7 +1270,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
                 result.realCooldownShown = slotProbe.realShown == true
                 result.durationObj = slotProbe.durationObj
                 result.realDurationObj = slotProbe.realDurationObj
-                result.slotProbe = slotProbe
+                result.slotProbeShown = slotProbe.shown
+                result.slotProbeRealShown = slotProbe.realShown
                 if result.realCooldownShown and slotProbe.realDurationObj then
                     result.state = COOLDOWN_STATE_COOLDOWN
                     result.source = "action-slot-real-no-spell-info"
@@ -1324,7 +1330,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         and options.allowActionSlotRealFallback then
         local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
         if slotProbe.realShown == true and slotProbe.realDurationObj then
-            result.slotProbe = slotProbe
+            result.slotProbeShown = slotProbe.shown
+            result.slotProbeRealShown = slotProbe.realShown
             result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
             result.realCooldownShown = true
             result.durationObj = slotProbe.durationObj or result.durationObj
@@ -1524,10 +1531,15 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
     if currentCharges ~= nil then
         mainCDShown = currentCharges <= 0
     else
-        local slotProbe = result.slotProbe or ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
-        result.chargeSlotProbe = slotProbe
-        if slotProbe.shown ~= nil then
-            mainCDShown = slotProbe.realShown == true
+        local probeShown = result.slotProbeShown
+        local probeRealShown = result.slotProbeRealShown
+        if probeShown == nil then
+            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
+            probeShown = slotProbe.shown
+            probeRealShown = slotProbe.realShown
+        end
+        if probeShown ~= nil then
+            mainCDShown = probeRealShown == true
         elseif result.fetchOk then
             mainCDShown = result.state == COOLDOWN_STATE_COOLDOWN
         end

--- a/CooldownCompanion/Core/SoundAlerts.lua
+++ b/CooldownCompanion/Core/SoundAlerts.lua
@@ -941,6 +941,8 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
     end
 end
 
+-- cooldownResult is a reused evaluation scratch: copy scalar fields only and
+-- never store the table or read it after this call returns.
 function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, cooldownActive, cooldownResult)
     local customBar = barInfo and barInfo.cabConfig
     local enabledEvents = self:GetEnabledSoundAlertEventsForCustomBar(customBar)


### PR DESCRIPTION
## What Changed
- `EvaluateSpellCooldownLane` in Core/EntryRuntime.lua now fills a module-local scratch table instead of allocating a new result table on every call. This function runs once per tracked spell button and once per custom cooldown bar on every update tick, so it was the last remaining steady-state table allocation in the cooldown evaluation path (finding 3 of the allocation-reduction series, following #498, #499, and #500).
- The two action-slot probe helpers (`ProbeActionSlotCooldownForSpell` and `ProbeActionSlotsForSpellID`) each reuse their own module-local scratch as well. They use separate tables because the outer probe merges the inner probe's fields while both are live — now documented at the declarations.
- All three scratches follow the series conventions: wiped at the top of every fill so no field can leak between fills, and documented with a header contract — the returned table may only be read synchronously within the current update and must never be retained across ticks or events.
- **Review follow-up (second commit):** a full multi-agent review found no correctness bugs and eight hardening/cleanup findings, applied as follows. The lane result no longer stores a reference to the probe scratch table (`result.slotProbe`); it copies the two scalar fields consumers actually read (`slotProbeShown`/`slotProbeRealShown`), removing the cross-scratch aliasing class entirely, and both consumers (button zero-charge classification and custom-bar charge state) were updated to match. The write-only `chargeSlotProbe` field was deleted. The scratch declarations, the public probe export, and the sound-alert `cooldownResult` parameter now carry the reuse contract in comments, and redundant post-wipe `false` initializers were removed.

## Why This Changed
- Each cooldown evaluation tick was creating several short-lived tables per button and per custom bar, generating constant garbage-collector pressure during combat for tables whose contents are always consumed immediately and never kept.

## Developer Impact
- No behavior change intended; this is allocation reuse only. Consumers were audited twice (implementation and review): the button update and custom-bar update both read the result within the same synchronous call, sound alerts copy only scalar fields into their persistent options, and only separately allocated Blizzard duration objects escape onto frames.
- After the review follow-up, no scratch table is ever nested inside another scratch, so a future probe call can no longer silently rewrite data an earlier result still points at.
- Known accepted trade-off from review: the module-local scratches keep their last fill's small Blizzard object references between ticks (negligible size, no growth); a pre-existing dead `sawUnknown` probe field was flagged for separate cleanup outside this PR.

## Validation
- `luac -p` passes on all edited files; a repo-wide grep confirms the removed `slotProbe`/`chargeSlotProbe` table references have no remaining readers and the new scalar fields are read only at the two intended sites.
- Multi-agent code review (8 finder angles, 11 verified candidates): zero correctness bugs; all confirmed findings applied in the follow-up commit.
- Not yet verified in game. Before merge, the following needs an in-game pass, including in combat: spell buttons on and off cooldown (including GCD-only presses), charge spells at zero, partial, and full charges, spells kept off the action bars (exercises the action-slot probe fallback — especially important now that the probe result crosses to consumers as two scalar fields), custom cooldown bars including charge text and sound alerts, and base/override spell pairs.
