### PR TITLE
Reduce memory churn in cooldown and aura updates for smoother combat performance

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -45,6 +45,8 @@ local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_BAR_COLOR = {0.2, 0.6, 1.0, 1.0}
 local DEFAULT_READY_TEXT_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -1785,7 +1787,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraNameOverrideActive = nil
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -45,8 +45,8 @@ local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_BAR_COLOR = {0.2, 0.6, 1.0, 1.0}
 local DEFAULT_READY_TEXT_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer

--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -45,8 +45,6 @@ local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_BAR_COLOR = {0.2, 0.6, 1.0, 1.0}
 local DEFAULT_READY_TEXT_COLOR = {0.2, 1.0, 0.2, 1.0}
 local DEFAULT_CUSTOM_AURA_MAX_COLOR = {1, 0.84, 0, 1}
--- Immutable shared opts owned by Helpers.lua; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 
 -- Imports from Glows
 local CreateGlowContainer = ST._CreateGlowContainer
@@ -1787,7 +1785,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._auraNameOverrideActive = nil
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
+        local effectiveItem = ResolveEffectiveItem(buttonData, true)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -26,11 +26,9 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
--- Immutable shared opts owned by Helpers.lua; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
--- Reusable scratch opts — single call site each; filled immediately before
--- their call and wiped right after it, so they are always empty between walks
--- and never pin values from a previous walk.
+-- Reusable scratch opts — single call site each; wiped immediately before
+-- each fill, so a previous walk can never leak values into the next call
+-- even if an error aborts a walk mid-call.
 local evaluateButtonAuraStateOpts = {}
 local buttonAuraPandemicStateOpts = {}
 
@@ -751,7 +749,7 @@ local function UpdateResolvedItemState(button, buttonData)
         return false
     end
 
-    local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
+    local effectiveItem = ResolveEffectiveItem(buttonData, true)
     if IsEquipmentSlotEntry(buttonData) and not (effectiveItem and effectiveItem.trackable) then
         if InCombatLockdown() and button._resolvedItemId then
             return false
@@ -999,6 +997,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
+        wipe(evaluateButtonAuraStateOpts)
         evaluateButtonAuraStateOpts.now = now
         evaluateButtonAuraStateOpts.allowDurationlessAuraInstance = barAuraStackConfigured
         evaluateButtonAuraStateOpts.previousAuraDurationObj = prevAuraDurationObj
@@ -1009,7 +1008,6 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._auraSpellID,
             evaluateButtonAuraStateOpts
         )
-        wipe(evaluateButtonAuraStateOpts)
         local viewerFrame = auraState.viewerFrame
         auraTrackingReady = auraState.auraTrackingReady == true
         auraOverrideActive = auraState.auraPresent == true
@@ -1126,13 +1124,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         end
 
+        wipe(buttonAuraPandemicStateOpts)
         buttonAuraPandemicStateOpts.now = now
         buttonAuraPandemicStateOpts.enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic)
         buttonAuraPandemicStateOpts.previewActive = button._pandemicPreview == true
         buttonAuraPandemicStateOpts.clearWhenDisabled = true
         buttonAuraPandemicStateOpts.auraState = auraState
         button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, buttonAuraPandemicStateOpts)
-        wipe(buttonAuraPandemicStateOpts)
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1451,13 +1449,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and duration > 0).  It can report true during per-cast lockouts
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
-            local probeShown = spellCooldownResult and spellCooldownResult.slotProbeShown
-            local probeRealShown = spellCooldownResult and spellCooldownResult.slotProbeRealShown
-            if probeShown == nil then
-                local slotProbe = EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-                probeShown = slotProbe.shown
-                probeRealShown = slotProbe.realShown
-            end
+            local probeShown, probeRealShown = EntryRuntime.ResolveSlotProbeShown(spellCooldownResult, buttonData.id, cooldownSpellId)
             if probeShown ~= nil then
                 button._mainCDShown = probeRealShown == true
             elseif not auraOwnsPrimarySwipe then

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1451,10 +1451,15 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             -- and duration > 0).  It can report true during per-cast lockouts
             -- and recharge, so the _chargesSpent heuristic below guards both
             -- this path and the isActive fallback.
-            local slotProbe = spellCooldownResult and spellCooldownResult.slotProbe
-                or EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
-            if slotProbe.shown ~= nil then
-                button._mainCDShown = slotProbe.realShown == true
+            local probeShown = spellCooldownResult and spellCooldownResult.slotProbeShown
+            local probeRealShown = spellCooldownResult and spellCooldownResult.slotProbeRealShown
+            if probeShown == nil then
+                local slotProbe = EntryRuntime.ProbeActionSlotCooldownForSpell(buttonData.id, cooldownSpellId)
+                probeShown = slotProbe.shown
+                probeRealShown = slotProbe.realShown
+            end
+            if probeShown ~= nil then
+                button._mainCDShown = probeRealShown == true
             elseif not auraOwnsPrimarySwipe then
                 -- No action bar slot found; use the ignoreGCD-backed real cooldown state.
                 if spellCooldownResult and spellCooldownResult.fetchOk then

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -26,6 +26,14 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Reusable scratch opts — single call site each; assign EVERY field
+-- unconditionally before each call (a conditional write leaves a stale value
+-- from the previous call that silently overrides owner/auraState data).
+local evaluateButtonAuraStateOpts = {}
+local buttonAuraPandemicStateOpts = {}
+local auraProbeGCDOnlyOpts = {}
 
 -- Silent-transform icon staleness probe interval (seconds). Event-driven icon
 -- refresh paths are unaffected; this only paces the no-event fallback probe.
@@ -736,7 +744,7 @@ local function UpdateResolvedItemState(button, buttonData)
         return false
     end
 
-    local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+    local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
     if IsEquipmentSlotEntry(buttonData) and not (effectiveItem and effectiveItem.trackable) then
         if InCombatLockdown() and button._resolvedItemId then
             return false
@@ -984,17 +992,17 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if buttonData.auraTracking and button._auraSpellID then
         auraDisplayNameState = CreateAuraDisplayNameState(button)
         button._auraDisplayName = nil
+        evaluateButtonAuraStateOpts.now = now
+        evaluateButtonAuraStateOpts.allowDurationlessAuraInstance = barAuraStackConfigured
+        evaluateButtonAuraStateOpts.previousAuraDurationObj = prevAuraDurationObj
+        evaluateButtonAuraStateOpts.wasAuraActive = wasAuraActive
         local auraState = EntryRuntime.EvaluateTrackedAuraState(
             button,
             buttonData,
             button._auraSpellID,
-            {
-                now = now,
-                allowDurationlessAuraInstance = barAuraStackConfigured,
-                previousAuraDurationObj = prevAuraDurationObj,
-                wasAuraActive = wasAuraActive,
-            }
+            evaluateButtonAuraStateOpts
         )
+        evaluateButtonAuraStateOpts.previousAuraDurationObj = nil -- don't pin the duration object between walks
         local viewerFrame = auraState.viewerFrame
         auraTrackingReady = auraState.auraTrackingReady == true
         auraOverrideActive = auraState.auraPresent == true
@@ -1111,13 +1119,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             end
         end
 
-        button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, {
-            now = now,
-            enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic),
-            previewActive = button._pandemicPreview == true,
-            clearWhenDisabled = true,
-            auraState = auraState,
-        })
+        buttonAuraPandemicStateOpts.now = now
+        buttonAuraPandemicStateOpts.enabled = auraOverrideActive and (style.showPandemicGlow ~= false or buttonData.hideAuraActiveExceptPandemic)
+        buttonAuraPandemicStateOpts.previewActive = button._pandemicPreview == true
+        buttonAuraPandemicStateOpts.clearWhenDisabled = true
+        buttonAuraPandemicStateOpts.auraState = auraState
+        button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, buttonAuraPandemicStateOpts)
+        buttonAuraPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between walks
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1177,10 +1185,13 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
             auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
-        auraProbeIsGCDOnly = auraProbeInfo and CooldownLogic.IsSpellGCDOnly(auraProbeInfo, {
-            normalCooldownShown = auraProbeNormalCooldownShown,
-            realCooldownShown = auraProbeRealCooldownShown,
-        }) or false
+        if auraProbeInfo then
+            auraProbeGCDOnlyOpts.normalCooldownShown = auraProbeNormalCooldownShown
+            auraProbeGCDOnlyOpts.realCooldownShown = auraProbeRealCooldownShown
+            auraProbeIsGCDOnly = CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeGCDOnlyOpts) or false
+        else
+            auraProbeIsGCDOnly = false
+        end
     end
 
     -- Secondary cooldown text display during aura override

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -26,14 +26,13 @@ local EvaluateButtonVisibility = ST._EvaluateButtonVisibility
 -- Pre-defined color constant tables to avoid per-tick allocation.
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
--- Reusable scratch opts — single call site each; assign EVERY field
--- unconditionally before each call (a conditional write leaves a stale value
--- from the previous call that silently overrides owner/auraState data).
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
+-- Reusable scratch opts — single call site each; filled immediately before
+-- their call and wiped right after it, so they are always empty between walks
+-- and never pin values from a previous walk.
 local evaluateButtonAuraStateOpts = {}
 local buttonAuraPandemicStateOpts = {}
-local auraProbeGCDOnlyOpts = {}
 
 -- Silent-transform icon staleness probe interval (seconds). Event-driven icon
 -- refresh paths are unaffected; this only paces the no-event fallback probe.
@@ -350,11 +349,19 @@ local function GetViewerNameFontString(viewerFrame)
     return bar and bar.Name or nil
 end
 
+-- Reusable per-button scratch -- only valid within the current cooldown walk.
+-- Never retain or read directly between calls.
 local function CreateAuraDisplayNameState(button)
-    return {
-        priorReadableName = button and button._auraDisplayName or nil,
-        priorSecretTextActive = button and button._isText and button._textSecretNameActive == true or false,
-    }
+    local state = button._auraDisplayNameStateScratch
+    if state then
+        wipe(state)
+    else
+        state = {}
+        button._auraDisplayNameStateScratch = state
+    end
+    state.priorReadableName = button._auraDisplayName
+    state.priorSecretTextActive = button._isText and button._textSecretNameActive == true or false
+    return state
 end
 
 local function RecordAuraDisplayName(state, auraData)
@@ -1002,7 +1009,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             button._auraSpellID,
             evaluateButtonAuraStateOpts
         )
-        evaluateButtonAuraStateOpts.previousAuraDurationObj = nil -- don't pin the duration object between walks
+        wipe(evaluateButtonAuraStateOpts)
         local viewerFrame = auraState.viewerFrame
         auraTrackingReady = auraState.auraTrackingReady == true
         auraOverrideActive = auraState.auraPresent == true
@@ -1125,7 +1132,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         buttonAuraPandemicStateOpts.clearWhenDisabled = true
         buttonAuraPandemicStateOpts.auraState = auraState
         button._inPandemic = EntryRuntime.ResolveAuraPandemicState(button, viewerFrame, buttonAuraPandemicStateOpts)
-        buttonAuraPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between walks
+        wipe(buttonAuraPandemicStateOpts)
 
         -- Pass through aura display names while keeping icon writes owned by UpdateButtonIcon.
         CommitAuraDisplayName(button, buttonData, viewerFrame, auraOverrideActive, auraDisplayNameState)
@@ -1185,13 +1192,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             auraProbeDuration = C_Spell.GetSpellCooldownDuration(cooldownSpellId, true)
             auraProbeRealCooldownShown = EntryRuntime.DurationObjectShowsCooldown(auraProbeDuration)
         end
-        if auraProbeInfo then
-            auraProbeGCDOnlyOpts.normalCooldownShown = auraProbeNormalCooldownShown
-            auraProbeGCDOnlyOpts.realCooldownShown = auraProbeRealCooldownShown
-            auraProbeIsGCDOnly = CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeGCDOnlyOpts) or false
-        else
-            auraProbeIsGCDOnly = false
-        end
+        auraProbeIsGCDOnly = CooldownLogic.IsSpellGCDOnly(auraProbeInfo, auraProbeNormalCooldownShown, auraProbeRealCooldownShown)
     end
 
     -- Secondary cooldown text display during aura override

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -1026,6 +1026,10 @@ local function ResolveEffectiveItem(buttonData, opts)
 end
 CooldownCompanion.ResolveEffectiveItem = ResolveEffectiveItem
 
+-- Immutable shared opts for ResolveEffectiveItem callers that want async item
+-- loads requested. Shared across files and calls — never write to this table.
+CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+
 -- Apply configurable strata (frame level) ordering to button sub-elements.
 -- order: array of 6 keys or nil for default.
 -- Index 1 = lowest layer (baseLevel+1), index 6 = highest (baseLevel+6).

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -938,7 +938,7 @@ local function RequestEquipmentSlotItemData(itemLocation, itemID)
     end
 end
 
-local function ResolveEquipmentSlotItem(buttonData, opts)
+local function ResolveEquipmentSlotItem(buttonData, requestLoad)
     local result = {
         isEquipmentSlot = true,
         itemSlot = buttonData and buttonData.itemSlot or nil,
@@ -966,7 +966,7 @@ local function ResolveEquipmentSlotItem(buttonData, opts)
     result.itemID = itemID
     if not itemID then
         result.reason = "loading"
-        if opts and opts.requestLoad then
+        if requestLoad then
             RequestEquipmentSlotItemData(itemLocation)
         end
         return result
@@ -978,7 +978,7 @@ local function ResolveEquipmentSlotItem(buttonData, opts)
 
     if C_Item.IsItemDataCached(itemLocation) == false or C_Item.IsItemDataCachedByID(itemID) == false then
         result.reason = "loading"
-        if opts and opts.requestLoad then
+        if requestLoad then
             RequestEquipmentSlotItemData(itemLocation, itemID)
         end
         return result
@@ -1004,9 +1004,9 @@ local function ResolveEquipmentSlotItem(buttonData, opts)
     return result
 end
 
-local function ResolveEffectiveItem(buttonData, opts)
+local function ResolveEffectiveItem(buttonData, requestLoad)
     if IsEquipmentSlotEntry(buttonData) then
-        return ResolveEquipmentSlotItem(buttonData, opts)
+        return ResolveEquipmentSlotItem(buttonData, requestLoad)
     end
     if not (buttonData and buttonData.type == "item") then
         return nil
@@ -1025,10 +1025,6 @@ local function ResolveEffectiveItem(buttonData, opts)
     }
 end
 CooldownCompanion.ResolveEffectiveItem = ResolveEffectiveItem
-
--- Immutable shared opts for ResolveEffectiveItem callers that want async item
--- loads requested. Shared across files and calls — never write to this table.
-CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 
 -- Apply configurable strata (frame level) ordering to button sub-elements.
 -- order: array of 6 keys or nil for default.

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -75,8 +75,8 @@ local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCoo
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -75,8 +75,6 @@ local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCoo
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
--- Immutable shared opts owned by Helpers.lua; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1
@@ -812,7 +810,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.buttonData = buttonData
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
+        local effectiveItem = ResolveEffectiveItem(buttonData, true)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -75,6 +75,8 @@ local ApplyDurationFormatToCooldown = CooldownCompanion.ApplyDurationFormatToCoo
 -- IMPORTANT: These tables are read-only — never write to their indices.
 local DEFAULT_WHITE = {1, 1, 1, 1}
 local DEFAULT_AURA_TEXT_COLOR = {0, 0.925, 1, 1}
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 local ICON_FILL_TEXTURE = "Interface\\Buttons\\WHITE8x8"
 local BLIZZARD_AURA_SWIPE_TEXTURE = "Interface\\HUD\\UI-HUD-CoolDownManager-Icon-Swipe"
 local BLIZZARD_AURA_SWIPE_R = 1
@@ -810,7 +812,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     button.buttonData = buttonData
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -52,6 +52,8 @@ local DEFAULT_READY_COLOR = {0.2, 1.0, 0.2, 1}
 local DEFAULT_AURA_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_CUSTOM_COLOR = {1, 0.82, 0, 1}
 local DEFAULT_TEXT_FORMAT = "{name}  {status}"
+-- Immutable — shared across calls; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
 
 local function IsAuraOnlyEntry(buttonData)
     return buttonData
@@ -1056,7 +1058,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._textSecretNameActive = nil
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, { requestLoad = true })
+        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -52,8 +52,6 @@ local DEFAULT_READY_COLOR = {0.2, 1.0, 0.2, 1}
 local DEFAULT_AURA_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_CUSTOM_COLOR = {1, 0.82, 0, 1}
 local DEFAULT_TEXT_FORMAT = "{name}  {status}"
--- Immutable shared opts owned by Helpers.lua; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 
 local function IsAuraOnlyEntry(buttonData)
     return buttonData
@@ -1058,7 +1056,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button._textSecretNameActive = nil
 
     if IsEntryItemLike(buttonData) then
-        local effectiveItem = ResolveEffectiveItem(buttonData, RESOLVE_ITEM_REQUEST_LOAD_OPTS)
+        local effectiveItem = ResolveEffectiveItem(buttonData, true)
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0
         button._resolvedItemQuantityKind = effectiveItem and effectiveItem.quantityKind or "stacks"

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -52,8 +52,8 @@ local DEFAULT_READY_COLOR = {0.2, 1.0, 0.2, 1}
 local DEFAULT_AURA_COLOR = {0, 0.925, 1, 1}
 local DEFAULT_CUSTOM_COLOR = {1, 0.82, 0, 1}
 local DEFAULT_TEXT_FORMAT = "{name}  {status}"
--- Immutable — shared across calls; never write to this table.
-local RESOLVE_ITEM_REQUEST_LOAD_OPTS = { requestLoad = true }
+-- Immutable shared opts owned by Helpers.lua; never write to this table.
+local RESOLVE_ITEM_REQUEST_LOAD_OPTS = CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS
 
 local function IsAuraOnlyEntry(buttonData)
     return buttonData

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -36,16 +36,22 @@ local COOLDOWN_VIEWER_ASSOCIATION_CATEGORIES = {
     Enum.CooldownViewerCategory.TrackedBar,
 }
 
-local function BuildAuraInstanceIDSet(auraInstanceIDs)
+-- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
+-- value within the same synchronous event dispatch; contents are stale between
+-- calls (the nil-return path skips the wipe). Never read directly or retain.
+local removedAuraIDSetScratch = {}
+local updatedAuraIDSetScratch = {}
+
+local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
     if not (auraInstanceIDs and auraInstanceIDs[1]) then
         return nil
     end
 
-    local auraInstanceIDSet = {}
+    wipe(scratch)
     for _, auraInstanceID in ipairs(auraInstanceIDs) do
-        auraInstanceIDSet[auraInstanceID] = true
+        scratch[auraInstanceID] = true
     end
-    return auraInstanceIDSet
+    return scratch
 end
 
 local function IsBuffViewerChild(frame)
@@ -485,8 +491,8 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- work correctly — the update path re-checks _auraInstanceID after removals.
     local removedIDs = updateInfo.removedAuraInstanceIDs
     local updatedIDs = updateInfo.updatedAuraInstanceIDs
-    local removedIDSet = BuildAuraInstanceIDSet(removedIDs)
-    local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
+    local removedIDSet = FillAuraInstanceIDSet(removedAuraIDSetScratch, removedIDs)
+    local updatedIDSet = FillAuraInstanceIDSet(updatedAuraIDSetScratch, updatedIDs)
     local isTarget = (unit == "target")
     if removedIDs or updatedIDs or isTarget then
         self:ForEachButton(function(button)

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -36,11 +36,7 @@ local COOLDOWN_VIEWER_ASSOCIATION_CATEGORIES = {
     Enum.CooldownViewerCategory.TrackedBar,
 }
 
--- Caller-owned scratch sets for ST.FillAuraInstanceIDSet — see Utils.lua for
--- the lifetime contract (use only the returned set, never read these directly).
-local removedAuraIDSetScratch = {}
-local updatedAuraIDSetScratch = {}
-local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
+local GetAuraInstanceIDSets = ST.GetAuraInstanceIDSets
 
 -- Immutable — shared across calls; never write to this table.
 local CLEAR_TRACKED_AURA_FALSE_STATE_OPTS = { useFalseState = true }
@@ -482,8 +478,7 @@ function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
     -- work correctly — the update path re-checks _auraInstanceID after removals.
     local removedIDs = updateInfo.removedAuraInstanceIDs
     local updatedIDs = updateInfo.updatedAuraInstanceIDs
-    local removedIDSet = FillAuraInstanceIDSet(removedAuraIDSetScratch, removedIDs)
-    local updatedIDSet = FillAuraInstanceIDSet(updatedAuraIDSetScratch, updatedIDs)
+    local removedIDSet, updatedIDSet = GetAuraInstanceIDSets(updateInfo)
     local isTarget = (unit == "target")
     if removedIDs or updatedIDs or isTarget then
         self:ForEachButton(function(button)

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -36,23 +36,14 @@ local COOLDOWN_VIEWER_ASSOCIATION_CATEGORIES = {
     Enum.CooldownViewerCategory.TrackedBar,
 }
 
--- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
--- value within the same synchronous event dispatch; contents are stale between
--- calls (the nil-return path skips the wipe). Never read directly or retain.
+-- Caller-owned scratch sets for ST.FillAuraInstanceIDSet — see Utils.lua for
+-- the lifetime contract (use only the returned set, never read these directly).
 local removedAuraIDSetScratch = {}
 local updatedAuraIDSetScratch = {}
+local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
 
-local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
-    if not (auraInstanceIDs and auraInstanceIDs[1]) then
-        return nil
-    end
-
-    wipe(scratch)
-    for _, auraInstanceID in ipairs(auraInstanceIDs) do
-        scratch[auraInstanceID] = true
-    end
-    return scratch
-end
+-- Immutable — shared across calls; never write to this table.
+local CLEAR_TRACKED_AURA_FALSE_STATE_OPTS = { useFalseState = true }
 
 local function IsBuffViewerChild(frame)
     if not frame then return false end
@@ -540,7 +531,7 @@ function CooldownCompanion:ClearAuraUnit(unitToken)
                 shouldClear = true
             end
             if shouldClear then
-                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, { useFalseState = true })
+                EntryRuntime.ClearTrackedAuraOwnerState(button, configUnit, CLEAR_TRACKED_AURA_FALSE_STATE_OPTS)
                 button._auraPrimarySwipeActive = nil
             end
         end

--- a/CooldownCompanion/Core/CooldownLogic.lua
+++ b/CooldownCompanion/Core/CooldownLogic.lua
@@ -17,13 +17,12 @@ CooldownLogic.CHARGE_STATE_FULL = "full"
 CooldownLogic.CHARGE_STATE_MISSING = "missing"
 CooldownLogic.CHARGE_STATE_ZERO = "zero"
 
-function CooldownLogic.IsSpellGCDOnly(info, options)
+function CooldownLogic.IsSpellGCDOnly(info, normalCooldownShown, realCooldownShown)
     if not info then
         return false
     end
 
-    options = options or {}
-    if options.realCooldownShown or not options.normalCooldownShown then
+    if realCooldownShown or not normalCooldownShown then
         return false
     end
 

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -1125,6 +1125,15 @@ local function IsSpellCooldownDeferred(info)
 end
 
 local actionSlotSeenScratch = {}
+-- Reusable probe/lane scratch tables, wiped at the start of every fill; each
+-- keeps its previous fill's contents (including Blizzard info/duration/charge
+-- references) until then. The two probe scratches must stay separate tables:
+-- ProbeActionSlotCooldownForSpell fills actionSlotCooldownProbeScratch while
+-- MergeActionSlotProbe reads from actionSlotProbeScratch, so sharing one
+-- table would wipe the merged result mid-probe.
+local actionSlotProbeScratch = {}
+local actionSlotCooldownProbeScratch = {}
+local spellCooldownLaneResultScratch = {}
 
 local function MergeActionSlotProbe(result, probe)
     if probe.sawAnySlot then result.sawAnySlot = true end
@@ -1147,13 +1156,11 @@ local function MergeActionSlotProbe(result, probe)
     return false
 end
 
+-- Returns a module-local scratch table. Read it only synchronously in the
+-- current probe/merge path; never retain it across calls.
 local function ProbeActionSlotsForSpellID(spellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
+    local result = actionSlotProbeScratch
+    wipe(result)
 
     if not spellID then return result end
 
@@ -1198,13 +1205,11 @@ local function ProbeActionSlotsForSpellID(spellID)
 
     return result
 end
+-- Returns a module-local scratch table. Read it only synchronously in the
+-- current update/probe path; never retain it across ticks/events.
 local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
-    local result = {
-        shown = nil,
-        realShown = nil,
-        sawAnySlot = false,
-        sawUnknown = false,
-    }
+    local result = actionSlotCooldownProbeScratch
+    wipe(result)
 
     if not baseSpellID then return result end
 
@@ -1227,19 +1232,24 @@ local function ProbeActionSlotCooldownForSpell(baseSpellID, displaySpellID)
 
     return result
 end
+-- Public alias: external callers receive the same scratch table on every
+-- call, so two calls never yield independent results -- consume synchronously,
+-- never retain.
 EntryRuntime.ProbeActionSlotCooldownForSpell = ProbeActionSlotCooldownForSpell
 
+-- Returns a module-local scratch table. Read it only synchronously within the
+-- current button/custom-bar update; never retain it across ticks/events.
 local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
-    local result = {
-        spellID = spellID,
-        fetchOk = false,
-        state = COOLDOWN_STATE_READY,
-        source = "ready",
-        realCooldownShown = false,
-        isOnGCD = false,
-        deferred = false,
-        resourceGatedNoCooldown = false,
-    }
+    local result = spellCooldownLaneResultScratch
+    wipe(result)
+    result.spellID = spellID
+    result.fetchOk = false
+    result.state = COOLDOWN_STATE_READY
+    result.source = "ready"
+    result.realCooldownShown = false
+    result.isOnGCD = false
+    result.deferred = false
+    result.resourceGatedNoCooldown = false
 
     if not spellID then
         return result
@@ -1260,7 +1270,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
                 result.realCooldownShown = slotProbe.realShown == true
                 result.durationObj = slotProbe.durationObj
                 result.realDurationObj = slotProbe.realDurationObj
-                result.slotProbe = slotProbe
+                result.slotProbeShown = slotProbe.shown
+                result.slotProbeRealShown = slotProbe.realShown
                 if result.realCooldownShown and slotProbe.realDurationObj then
                     result.state = COOLDOWN_STATE_COOLDOWN
                     result.source = "action-slot-real-no-spell-info"
@@ -1319,7 +1330,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         and options.allowActionSlotRealFallback then
         local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID or spellID, spellID)
         if slotProbe.realShown == true and slotProbe.realDurationObj then
-            result.slotProbe = slotProbe
+            result.slotProbeShown = slotProbe.shown
+            result.slotProbeRealShown = slotProbe.realShown
             result.normalCooldownShown = slotProbe.shown == true or result.normalCooldownShown
             result.realCooldownShown = true
             result.durationObj = slotProbe.durationObj or result.durationObj
@@ -1332,6 +1344,8 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
 
     return result
 end
+-- Returns the spell cooldown lane scratch; read only synchronously in the
+-- current button update and never retain across ticks/events.
 local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldown, resourceGateCost, baseNoCooldown, baseResourceGateCost)
     local resourceGatedNoCooldown = noCooldown == true
         and (resourceGateCost == true
@@ -1517,10 +1531,15 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
     if currentCharges ~= nil then
         mainCDShown = currentCharges <= 0
     else
-        local slotProbe = result.slotProbe or ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
-        result.chargeSlotProbe = slotProbe
-        if slotProbe.shown ~= nil then
-            mainCDShown = slotProbe.realShown == true
+        local probeShown = result.slotProbeShown
+        local probeRealShown = result.slotProbeRealShown
+        if probeShown == nil then
+            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
+            probeShown = slotProbe.shown
+            probeRealShown = slotProbe.realShown
+        end
+        if probeShown ~= nil then
+            mainCDShown = probeRealShown == true
         elseif result.fetchOk then
             mainCDShown = result.state == COOLDOWN_STATE_COOLDOWN
         end
@@ -1646,6 +1665,8 @@ function EntryRuntime.ApplyBarAuraStackState(
     return barAuraSecretStackValue, preserveBarAuraStackText
 end
 
+-- Returns the spell cooldown lane scratch; read only synchronously in the
+-- current custom-bar update and never retain across ticks/events.
 function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local spellID = tonumber(customBar and customBar.spellID)
     if not spellID then

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -25,9 +25,9 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local TARGET_SWITCH_SAFETY_CAP = 0.60
--- Reusable scratch opts — single call site each; filled immediately before
--- their call and wiped right after it, so they are always empty between uses
--- and never pin values from a previous call.
+-- Reusable scratch opts — single call site each; wiped immediately before
+-- each fill, so a previous call can never leak values into the next one
+-- even if an error aborts an update mid-call.
 local buttonSpellCooldownLaneOpts = {}
 local customBarSpellCooldownLaneOpts = {}
 -- Immutable — shared across calls; never write to these tables.
@@ -1237,6 +1237,21 @@ end
 -- never retain.
 EntryRuntime.ProbeActionSlotCooldownForSpell = ProbeActionSlotCooldownForSpell
 
+-- Resolve the action-slot probe state cached on a lane result, re-probing when
+-- the lane stored none (nil slotProbeShown means "not probed"). Returns
+-- shown, realShown; both nil when no action slot matches the spell.
+local function ResolveSlotProbeShown(result, baseSpellID, cooldownSpellID)
+    local probeShown = result and result.slotProbeShown
+    local probeRealShown = result and result.slotProbeRealShown
+    if probeShown == nil then
+        local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
+        probeShown = slotProbe.shown
+        probeRealShown = slotProbe.realShown
+    end
+    return probeShown, probeRealShown
+end
+EntryRuntime.ResolveSlotProbeShown = ResolveSlotProbeShown
+
 -- Returns a module-local scratch table. Read it only synchronously within the
 -- current button/custom-bar update; never retain it across ticks/events.
 local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
@@ -1358,12 +1373,11 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     local allowActionSlotReadyFallback = allowActionSlotRealFallback
         and cooldownSpellId ~= buttonData.id
 
+    wipe(buttonSpellCooldownLaneOpts)
     buttonSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
     buttonSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
     buttonSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
-    local result = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
-    wipe(buttonSpellCooldownLaneOpts)
-    return result
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
@@ -1531,13 +1545,7 @@ local function ApplyCustomBarChargeState(owner, result, baseSpellID, cooldownSpe
     if currentCharges ~= nil then
         mainCDShown = currentCharges <= 0
     else
-        local probeShown = result.slotProbeShown
-        local probeRealShown = result.slotProbeRealShown
-        if probeShown == nil then
-            local slotProbe = ProbeActionSlotCooldownForSpell(baseSpellID, cooldownSpellID)
-            probeShown = slotProbe.shown
-            probeRealShown = slotProbe.realShown
-        end
+        local probeShown, probeRealShown = ResolveSlotProbeShown(result, baseSpellID, cooldownSpellID)
         if probeShown ~= nil then
             mainCDShown = probeRealShown == true
         elseif result.fetchOk then
@@ -1709,11 +1717,11 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local allowActionSlotReadyFallback = allowActionSlotRealFallback
         and cooldownSpellID ~= spellID
 
+    wipe(customBarSpellCooldownLaneOpts)
     customBarSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
     customBarSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
     customBarSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, customBarSpellCooldownLaneOpts)
-    wipe(customBarSpellCooldownLaneOpts)
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
     result.noCooldown = noCooldown or nil

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -25,12 +25,14 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local TARGET_SWITCH_SAFETY_CAP = 0.60
--- Reusable scratch opts — single call site each; assign EVERY field
--- unconditionally before each call (a conditional write leaves a stale value
--- from the previous call that silently overrides owner/auraState data).
+-- Reusable scratch opts — single call site each; filled immediately before
+-- their call and wiped right after it, so they are always empty between uses
+-- and never pin values from a previous call.
 local buttonSpellCooldownLaneOpts = {}
-local laneGCDOnlyOpts = {}
 local customBarSpellCooldownLaneOpts = {}
+-- Immutable — shared across calls; never write to these tables.
+local CLEAR_OWNER_FALSE_STATE_OPTS = { useFalseState = true }
+local CLEAR_OWNER_FALSE_STATE_KEEP_SWITCH_OPTS = { useFalseState = true, preserveTargetSwitch = true }
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -680,6 +682,17 @@ function EntryRuntime.ClearTrackedAuraOwnerState(owner, configUnit, options)
     end
 end
 
+-- Releases the per-owner evaluation scratches: the tracked-aura state table
+-- filled by EvaluateTrackedAuraState and the aura display-name scratch filled
+-- by ButtonFrame/CooldownUpdate. Both are recreated lazily on the next
+-- evaluation. Call only from teardown/dormancy paths, never while an
+-- evaluation's returned state is still being read.
+function EntryRuntime.ReleaseTrackedAuraScratch(owner)
+    if not owner then return end
+    owner._trackedAuraStateScratch = nil
+    owner._auraDisplayNameStateScratch = nil
+end
+
 function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
     if not owner then return end
     owner._auraInstanceID = nil
@@ -813,10 +826,10 @@ local function CommitTrackedAuraOwnerState(owner, state)
             owner._targetSwitchDataReceived = nil
         end
     else
-        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit, {
-            useFalseState = true,
-            preserveTargetSwitch = state.wasAuraActive == true,
-        })
+        EntryRuntime.ClearTrackedAuraOwnerState(owner, state.configUnit,
+            state.wasAuraActive == true
+                and CLEAR_OWNER_FALSE_STATE_KEEP_SWITCH_OPTS
+                or CLEAR_OWNER_FALSE_STATE_OPTS)
         if owner._targetSwitchAt and not state.wasAuraActive then
             owner._targetSwitchAt = nil
             owner._targetSwitchDataReceived = nil
@@ -824,6 +837,9 @@ local function CommitTrackedAuraOwnerState(owner, state)
     end
 end
 
+-- Returns a per-owner scratch table that is wiped and refilled on this owner's
+-- next evaluation. Read it only synchronously within the current update; never
+-- retain the returned table (or store it on another object) across ticks/events.
 function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, options)
     owner = owner or {}
     options = options or {}
@@ -1038,34 +1054,43 @@ function EntryRuntime.EvaluateTrackedAuraState(owner, buttonData, auraSpellID, o
     end
 
     local auraExpirationTime, auraDuration, auraTimingReadable = GetReadableAuraTiming(auraPresent and auraData or nil)
-    local state = {
-        ready = ready == true,
-        auraPresent = auraPresent == true,
-        auraTrackingReady = ready == true,
-        cdmEnabled = cdmEnabled == true,
-        auraData = auraPresent and auraData or nil,
-        auraApplications = auraPresent and auraApplications or nil,
-        auraInstanceID = auraPresent and auraInstanceID or nil,
-        auraUnit = auraPresent and auraUnit or configUnit,
-        configUnit = configUnit,
-        viewerFrame = viewerFrame,
-        viewerBar = viewerBar,
-        durationObj = auraPresent and durationObj or nil,
-        auraCooldownStart = auraPresent and auraCooldownStart or nil,
-        auraCooldownDuration = auraPresent and auraCooldownDuration or nil,
-        auraExpirationTime = auraTimingReadable and auraExpirationTime or nil,
-        auraDuration = auraTimingReadable and auraDuration or nil,
-        auraHasTimer = auraPresent and auraHasTimer == true or false,
-        auraGraceHeld = auraGraceHeld == true,
-        activeAuraSpellID = activeAuraSpellID,
-        activeAuraSpellIDResolved = activeAuraSpellIDResolved == true,
-        activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback,
-        activeAuraIcon = activeAuraIcon,
-        activeAuraIconAvailable = activeAuraIconAvailable == true,
-        activeAuraIconResolved = activeAuraIconResolved == true,
-        allowDurationlessAuraInstance = allowDurationlessAuraInstance,
-        wasAuraActive = wasAuraActive,
-    }
+    -- Reusable per-owner scratch -- see the contract above the function header.
+    -- The wipe is enforcement: every field below is assigned unconditionally
+    -- today, but the wipe keeps a future conditional assignment from leaking a
+    -- stale value between evaluations.
+    local state = owner._trackedAuraStateScratch
+    if state then
+        wipe(state)
+    else
+        state = {}
+        owner._trackedAuraStateScratch = state
+    end
+    state.ready = ready == true
+    state.auraPresent = auraPresent == true
+    state.auraTrackingReady = ready == true
+    state.cdmEnabled = cdmEnabled == true
+    state.auraData = auraPresent and auraData or nil
+    state.auraApplications = auraPresent and auraApplications or nil
+    state.auraInstanceID = auraPresent and auraInstanceID or nil
+    state.auraUnit = auraPresent and auraUnit or configUnit
+    state.configUnit = configUnit
+    state.viewerFrame = viewerFrame
+    state.viewerBar = viewerBar
+    state.durationObj = auraPresent and durationObj or nil
+    state.auraCooldownStart = auraPresent and auraCooldownStart or nil
+    state.auraCooldownDuration = auraPresent and auraCooldownDuration or nil
+    state.auraExpirationTime = auraTimingReadable and auraExpirationTime or nil
+    state.auraDuration = auraTimingReadable and auraDuration or nil
+    state.auraHasTimer = auraPresent and auraHasTimer == true or false
+    state.auraGraceHeld = auraGraceHeld == true
+    state.activeAuraSpellID = activeAuraSpellID
+    state.activeAuraSpellIDResolved = activeAuraSpellIDResolved == true
+    state.activeAuraSpellIDFromFallback = activeAuraSpellIDFromFallback
+    state.activeAuraIcon = activeAuraIcon
+    state.activeAuraIconAvailable = activeAuraIconAvailable == true
+    state.activeAuraIconResolved = activeAuraIconResolved == true
+    state.allowDurationlessAuraInstance = allowDurationlessAuraInstance
+    state.wasAuraActive = wasAuraActive
 
     if mutateOwner then
         CommitTrackedAuraOwnerState(owner, state)
@@ -1263,10 +1288,6 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
-    -- Snapshot for the IsSpellGCDOnly elseif below — keep in sync if anything
-    -- mutates result.normalCooldownShown/realCooldownShown before that branch.
-    laneGCDOnlyOpts.normalCooldownShown = result.normalCooldownShown
-    laneGCDOnlyOpts.realCooldownShown = result.realCooldownShown
     if suppressCooldownSurface then
         if result.isOnGCD == true and CooldownCompanion._gcdDurationObj then
             result.source = "resource-gated-gcd"
@@ -1283,7 +1304,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-real-ignore-gcd"
         result.renderDurationObj = result.realDurationObj
-    elseif CooldownLogic.IsSpellGCDOnly(info, laneGCDOnlyOpts) then
+    elseif CooldownLogic.IsSpellGCDOnly(info, result.normalCooldownShown, result.realCooldownShown) then
         result.source = "spell-gcd"
         result.presentationState = COOLDOWN_STATE_GCD
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
@@ -1326,7 +1347,9 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     buttonSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
     buttonSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
     buttonSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
+    local result = EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
+    wipe(buttonSpellCooldownLaneOpts)
+    return result
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
@@ -1669,6 +1692,7 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     customBarSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
     customBarSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
     local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, customBarSpellCooldownLaneOpts)
+    wipe(customBarSpellCooldownLaneOpts)
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
     result.noCooldown = noCooldown or nil

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -25,6 +25,12 @@ local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 local TARGET_SWITCH_SAFETY_CAP = 0.60
+-- Reusable scratch opts — single call site each; assign EVERY field
+-- unconditionally before each call (a conditional write leaves a stale value
+-- from the previous call that silently overrides owner/auraState data).
+local buttonSpellCooldownLaneOpts = {}
+local laneGCDOnlyOpts = {}
+local customBarSpellCooldownLaneOpts = {}
 
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
@@ -1257,6 +1263,10 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.realCooldownShown = DurationObjectShowsCooldown(result.realDurationObj)
     end
 
+    -- Snapshot for the IsSpellGCDOnly elseif below — keep in sync if anything
+    -- mutates result.normalCooldownShown/realCooldownShown before that branch.
+    laneGCDOnlyOpts.normalCooldownShown = result.normalCooldownShown
+    laneGCDOnlyOpts.realCooldownShown = result.realCooldownShown
     if suppressCooldownSurface then
         if result.isOnGCD == true and CooldownCompanion._gcdDurationObj then
             result.source = "resource-gated-gcd"
@@ -1273,10 +1283,7 @@ local function EvaluateSpellCooldownLane(spellID, secrecy, baseSpellID, options)
         result.state = COOLDOWN_STATE_COOLDOWN
         result.source = "spell-real-ignore-gcd"
         result.renderDurationObj = result.realDurationObj
-    elseif CooldownLogic.IsSpellGCDOnly(info, {
-        normalCooldownShown = result.normalCooldownShown,
-        realCooldownShown = result.realCooldownShown,
-    }) then
+    elseif CooldownLogic.IsSpellGCDOnly(info, laneGCDOnlyOpts) then
         result.source = "spell-gcd"
         result.presentationState = COOLDOWN_STATE_GCD
         result.renderDurationObj = result.durationObj or CooldownCompanion._gcdDurationObj
@@ -1316,11 +1323,10 @@ local function EvaluateButtonSpellCooldown(buttonData, cooldownSpellId, noCooldo
     local allowActionSlotReadyFallback = allowActionSlotRealFallback
         and cooldownSpellId ~= buttonData.id
 
-    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, {
-        allowActionSlotRealFallback = allowActionSlotRealFallback,
-        allowActionSlotReadyFallback = allowActionSlotReadyFallback,
-        suppressCooldownSurface = resourceGatedNoCooldown == true,
-    })
+    buttonSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
+    buttonSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
+    buttonSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
+    return EvaluateSpellCooldownLane(cooldownSpellId, buttonData._cooldownSecrecy, buttonData.id, buttonSpellCooldownLaneOpts)
 end
 EntryRuntime.EvaluateButtonSpellCooldown = EvaluateButtonSpellCooldown
 
@@ -1659,11 +1665,10 @@ function EntryRuntime.EvaluateSpellCooldownStateForCustomBar(customBar, owner)
     local allowActionSlotReadyFallback = allowActionSlotRealFallback
         and cooldownSpellID ~= spellID
 
-    local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, {
-        allowActionSlotRealFallback = allowActionSlotRealFallback,
-        allowActionSlotReadyFallback = allowActionSlotReadyFallback,
-        suppressCooldownSurface = resourceGatedNoCooldown == true,
-    })
+    customBarSpellCooldownLaneOpts.allowActionSlotRealFallback = allowActionSlotRealFallback
+    customBarSpellCooldownLaneOpts.allowActionSlotReadyFallback = allowActionSlotReadyFallback
+    customBarSpellCooldownLaneOpts.suppressCooldownSurface = resourceGatedNoCooldown == true
+    local result = EvaluateSpellCooldownLane(cooldownSpellID, secrecy, spellID, customBarSpellCooldownLaneOpts)
     result.baseSpellID = spellID
     result.cooldownSpellID = cooldownSpellID
     result.noCooldown = noCooldown or nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -782,6 +782,7 @@ local function ClearReusableButtonRuntime(button)
     button._auraStackText = nil
     button._auraHasTimer = nil
     button._textSecretNameActive = nil
+    EntryRuntime.ReleaseTrackedAuraScratch(button)
     button._bindingKeyInfos = nil
     button._keyPressHighlightActive = nil
     button._visibilityHidden = false
@@ -866,7 +867,7 @@ end
 local function ResolveReusableButtonEntryState(button, buttonData)
     if CooldownCompanion.IsEntryItemLike and CooldownCompanion.IsEntryItemLike(buttonData) then
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true })
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS)
             or nil
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -867,7 +867,7 @@ end
 local function ResolveReusableButtonEntryState(button, buttonData)
     if CooldownCompanion.IsEntryItemLike and CooldownCompanion.IsEntryItemLike(buttonData) then
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS)
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, true)
             or nil
         button._resolvedItemId = effectiveItem and effectiveItem.itemID or buttonData.id
         button._resolvedItemAvailableQuantity = effectiveItem and effectiveItem.availableQuantity or 0

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2732,11 +2732,8 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
 
         return true
     elseif CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
-        -- RESOLVE_ITEM_REQUEST_LOAD_OPTS must be read at call time here: this
-        -- file loads before ButtonFrame/Helpers.lua defines it (TOC order), so
-        -- a file-scope local would capture nil and silently drop requestLoad.
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS) or nil
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, true) or nil
         return effectiveItem and effectiveItem.trackable == true
     elseif buttonData.type == "item" then
         if buttonData.hasCharges then return true end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2732,8 +2732,11 @@ function CooldownCompanion:IsButtonUsable(buttonData, group, opts)
 
         return true
     elseif CooldownCompanion.IsEquipmentSlotEntry and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
+        -- RESOLVE_ITEM_REQUEST_LOAD_OPTS must be read at call time here: this
+        -- file loads before ButtonFrame/Helpers.lua defines it (TOC order), so
+        -- a file-scope local would capture nil and silently drop requestLoad.
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, CooldownCompanion.RESOLVE_ITEM_REQUEST_LOAD_OPTS) or nil
         return effectiveItem and effectiveItem.trackable == true
     elseif buttonData.type == "item" then
         if buttonData.hasCharges then return true end
@@ -3287,6 +3290,9 @@ function CooldownCompanion:UnloadGroup(groupId)
                 button._savedOnUpdate = onUpdate
                 button:SetScript("OnUpdate", nil)
             end
+            -- Dormant buttons stop being evaluated; release their scratches so
+            -- they don't pin aura data or secret names while parked.
+            ST.EntryRuntime.ReleaseTrackedAuraScratch(button)
         end
     end
 

--- a/CooldownCompanion/Core/SoundAlerts.lua
+++ b/CooldownCompanion/Core/SoundAlerts.lua
@@ -941,6 +941,8 @@ local function UpdateCooldownSoundAlertTransitions(state, enabledEvents, opts)
     end
 end
 
+-- cooldownResult is a reused evaluation scratch: copy scalar fields only and
+-- never store the table or read it after this call returns.
 function CooldownCompanion:UpdateCustomBarSoundAlerts(barInfo, auraActive, cooldownActive, cooldownResult)
     local customBar = barInfo and barInfo.cabConfig
     local enabledEvents = self:GetEnabledSoundAlertEventsForCustomBar(customBar)

--- a/CooldownCompanion/Core/Utils.lua
+++ b/CooldownCompanion/Core/Utils.lua
@@ -8,6 +8,7 @@ local ADDON_NAME, ST = ...
 local InCombatLockdown = InCombatLockdown
 local string_format = string.format
 local ipairs = ipairs
+local wipe = wipe
 local pairs = pairs
 local tonumber = tonumber
 local type = type
@@ -39,6 +40,27 @@ ST.EDGE_ANCHOR_SPEC = {
     {"TOPLEFT", "TOPLEFT",     "BOTTOMRIGHT", "BOTTOMLEFT",   0, -1,  1,  1}, -- Left   (inset to avoid corner overlap)
     {"TOPLEFT", "TOPRIGHT",    "BOTTOMRIGHT", "BOTTOMRIGHT", -1, -1,  0,  1}, -- Right  (inset to avoid corner overlap)
 }
+
+--------------------------------------------------------------------------------
+-- Aura Instance ID Sets
+--------------------------------------------------------------------------------
+
+-- Fills a caller-owned scratch set from a UNIT_AURA instance-ID array and
+-- returns it, or returns nil when the array is empty/absent (the nil path
+-- deliberately skips the wipe, so scratch contents are stale between calls).
+-- Use only the returned set, only within the same synchronous event dispatch;
+-- never read the scratch directly or retain the set.
+function ST.FillAuraInstanceIDSet(scratch, auraInstanceIDs)
+    if not (auraInstanceIDs and auraInstanceIDs[1]) then
+        return nil
+    end
+
+    wipe(scratch)
+    for _, auraInstanceID in ipairs(auraInstanceIDs) do
+        scratch[auraInstanceID] = true
+    end
+    return scratch
+end
 
 --------------------------------------------------------------------------------
 -- StatusBar Motion Helpers

--- a/CooldownCompanion/Core/Utils.lua
+++ b/CooldownCompanion/Core/Utils.lua
@@ -45,12 +45,15 @@ ST.EDGE_ANCHOR_SPEC = {
 -- Aura Instance ID Sets
 --------------------------------------------------------------------------------
 
--- Fills a caller-owned scratch set from a UNIT_AURA instance-ID array and
--- returns it, or returns nil when the array is empty/absent (the nil path
--- deliberately skips the wipe, so scratch contents are stale between calls).
--- Use only the returned set, only within the same synchronous event dispatch;
--- never read the scratch directly or retain the set.
-function ST.FillAuraInstanceIDSet(scratch, auraInstanceIDs)
+-- Module-owned scratch sets for GetAuraInstanceIDSets. Only the getter below
+-- may touch these; callers use only the returned sets.
+local removedAuraIDSetScratch = {}
+local updatedAuraIDSetScratch = {}
+
+-- Fills a scratch set from a UNIT_AURA instance-ID array and returns it, or
+-- returns nil when the array is empty/absent (the nil path deliberately skips
+-- the wipe, so scratch contents are stale between calls).
+local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
     if not (auraInstanceIDs and auraInstanceIDs[1]) then
         return nil
     end
@@ -60,6 +63,15 @@ function ST.FillAuraInstanceIDSet(scratch, auraInstanceIDs)
         scratch[auraInstanceID] = true
     end
     return scratch
+end
+
+-- Returns removedIDSet, updatedIDSet lookup sets for a UNIT_AURA updateInfo;
+-- either may be nil when its instance-ID array is empty/absent. Both are
+-- shared scratch sets: use them only within the same synchronous event
+-- dispatch and never retain them.
+function ST.GetAuraInstanceIDSets(updateInfo)
+    return FillAuraInstanceIDSet(removedAuraIDSetScratch, updateInfo and updateInfo.removedAuraInstanceIDs),
+        FillAuraInstanceIDSet(updatedAuraIDSetScratch, updateInfo and updateInfo.updatedAuraInstanceIDs)
 end
 
 --------------------------------------------------------------------------------

--- a/CooldownCompanion/OtherBars/ResourceBar.lua
+++ b/CooldownCompanion/OtherBars/ResourceBar.lua
@@ -39,6 +39,9 @@ local function UnbindFrameDurationText(frame)
     end
 end
 
+-- Immutable — shared across calls; never write to this table.
+local CLEAR_CUSTOM_AURA_STACKS_OPTS = { clearCustomAuraStacks = true }
+
 ------------------------------------------------------------------------
 -- Imports from ResourceBarConstants / ResourceBarHelpers / ResourceBarVisuals
 ------------------------------------------------------------------------
@@ -223,7 +226,7 @@ local function ClearCustomAuraBarIndicatorState(barInfo, clearPreviewFlags)
     local bar = barInfo and barInfo.frame
     if not bar then return end
 
-    EntryRuntime.ClearTrackedAuraOwnerState(bar, nil, { clearCustomAuraStacks = true })
+    EntryRuntime.ClearTrackedAuraOwnerState(bar, nil, CLEAR_CUSTOM_AURA_STACKS_OPTS)
 
     ClearCustomAuraBarIndicatorVisualState(barInfo, clearPreviewFlags)
 end
@@ -430,7 +433,8 @@ local function ClearStaleRecycledBarRuntimeState(frame)
     end
     frame._cdcIndependentAlphaTarget = nil
     frame._cdcIndependentLastAlpha = nil
-    EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, { clearCustomAuraStacks = true })
+    EntryRuntime.ClearTrackedAuraOwnerState(frame, nil, CLEAR_CUSTOM_AURA_STACKS_OPTS)
+    EntryRuntime.ReleaseTrackedAuraScratch(frame)
     frame._parsedAuraIDs = nil
     frame._parsedAuraIDsRaw = nil
     frame._parsedAuraIDsButtonID = nil

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -97,9 +97,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
-    -- Reusable scratch opts — single call site each; filled immediately before
-    -- their call and wiped right after it, so they are always empty between
-    -- updates and never pin values from a previous update.
+    -- Reusable scratch opts — single call site each; wiped immediately before
+    -- each fill, so a previous update can never leak values into the next one
+    -- even if an error aborts an update mid-call.
     local spellCustomBarAuraStateOpts = {}
     local customAuraBarAuraStateOpts = {}
     local customAuraBarPandemicStateOpts = {}
@@ -186,13 +186,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = buttonData.auraUnit or "player"
         local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
+        wipe(spellCustomBarAuraStateOpts)
         spellCustomBarAuraStateOpts.configUnit = configUnit
         spellCustomBarAuraStateOpts.allowDurationlessAuraInstance = true
         spellCustomBarAuraStateOpts.useButtonAuraViewerFallback = true
         spellCustomBarAuraStateOpts.validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell
-        local auraState = EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
-        wipe(spellCustomBarAuraStateOpts)
-        return auraState
+        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -227,11 +226,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, true)
             if buttonData and spellID then
                 configUnit = buttonData.auraUnit or configUnit
+                wipe(customAuraBarAuraStateOpts)
                 customAuraBarAuraStateOpts.configUnit = configUnit
                 customAuraBarAuraStateOpts.allowDurationlessAuraInstance = true
                 customAuraBarAuraStateOpts.allowPlayerAuraFallbackWithoutReady = true
                 auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, customAuraBarAuraStateOpts)
-                wipe(customAuraBarAuraStateOpts)
                 viewerFrame = auraState and auraState.viewerFrame or nil
             end
         end
@@ -296,6 +295,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         local pandemicStateFrame = barInfo.frame
+        wipe(customAuraBarPandemicStateOpts)
         customAuraBarPandemicStateOpts.enabled = configUnit == "target" and auraPresent
         customAuraBarPandemicStateOpts.previewActive = pandemicPreview == true
         customAuraBarPandemicStateOpts.clearWhenDisabled = true
@@ -303,7 +303,6 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customAuraBarPandemicStateOpts.auraUnit = auraUnit
         customAuraBarPandemicStateOpts.auraInstanceID = instId
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, customAuraBarPandemicStateOpts)
-        wipe(customAuraBarPandemicStateOpts)
 
         if isActive and bar then
             if auraPresent then
@@ -593,12 +592,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = (auraState and auraState.configUnit)
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
+        wipe(customCooldownBarPandemicStateOpts)
         customCooldownBarPandemicStateOpts.enabled = configUnit == "target" and auraPresent
         customCooldownBarPandemicStateOpts.previewActive = pandemicPreview == true
         customCooldownBarPandemicStateOpts.clearWhenDisabled = true
         customCooldownBarPandemicStateOpts.auraState = auraState
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, customCooldownBarPandemicStateOpts)
-        wipe(customCooldownBarPandemicStateOpts)
 
         if auraState
             and auraState.ready == true

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -97,9 +97,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
-    -- Reusable scratch opts — single call site each; assign EVERY field
-    -- unconditionally before each call (a conditional write leaves a stale value
-    -- from the previous call that silently overrides owner/auraState data).
+    -- Reusable scratch opts — single call site each; filled immediately before
+    -- their call and wiped right after it, so they are always empty between
+    -- updates and never pin values from a previous update.
     local spellCustomBarAuraStateOpts = {}
     local customAuraBarAuraStateOpts = {}
     local customAuraBarPandemicStateOpts = {}
@@ -144,6 +144,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end)
     end
 
+    -- Reusable scratch buttonData -- returned to callers but only consumed
+    -- synchronously within the same bar update; never retain between updates
+    -- and never assign to a button.buttonData field (style caches key on
+    -- buttonData table identity). The wipe is enforcement so no field can
+    -- leak between fills.
+    local customBarAuraButtonDataScratch = {}
+
     local function BuildCustomBarAuraButtonData(cabConfig, addedAsAura)
         local spellID = tonumber(cabConfig and cabConfig.spellID)
         if not spellID then
@@ -158,16 +165,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             return nil, nil
         end
 
-        local buttonData = {
-            type = "spell",
-            id = spellID,
-            auraSpellID = cabConfig.auraSpellID,
-            auraTracking = true,
-            auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID),
-        }
-        if addedAsAura then
-            buttonData.addedAs = "aura"
-        end
+        local buttonData = customBarAuraButtonDataScratch
+        wipe(buttonData)
+        buttonData.type = "spell"
+        buttonData.id = spellID
+        buttonData.auraSpellID = cabConfig.auraSpellID
+        buttonData.auraTracking = true
+        buttonData.auraUnit = GetResolvedCustomAuraBarAuraUnit(cabConfig, spellID)
+        buttonData.addedAs = addedAsAura and "aura" or nil
         return buttonData, spellID
     end
 
@@ -185,7 +190,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         spellCustomBarAuraStateOpts.allowDurationlessAuraInstance = true
         spellCustomBarAuraStateOpts.useButtonAuraViewerFallback = true
         spellCustomBarAuraStateOpts.validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell
-        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
+        local auraState = EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
+        wipe(spellCustomBarAuraStateOpts)
+        return auraState
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -224,6 +231,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 customAuraBarAuraStateOpts.allowDurationlessAuraInstance = true
                 customAuraBarAuraStateOpts.allowPlayerAuraFallbackWithoutReady = true
                 auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, customAuraBarAuraStateOpts)
+                wipe(customAuraBarAuraStateOpts)
                 viewerFrame = auraState and auraState.viewerFrame or nil
             end
         end
@@ -295,7 +303,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customAuraBarPandemicStateOpts.auraUnit = auraUnit
         customAuraBarPandemicStateOpts.auraInstanceID = instId
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, customAuraBarPandemicStateOpts)
-        customAuraBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
+        wipe(customAuraBarPandemicStateOpts)
 
         if isActive and bar then
             if auraPresent then
@@ -590,7 +598,7 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         customCooldownBarPandemicStateOpts.clearWhenDisabled = true
         customCooldownBarPandemicStateOpts.auraState = auraState
         local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, customCooldownBarPandemicStateOpts)
-        customCooldownBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
+        wipe(customCooldownBarPandemicStateOpts)
 
         if auraState
             and auraState.ready == true
@@ -1164,6 +1172,9 @@ function RB.CreateResourceBarCustomBarsModule(deps)
                 ClearCustomAuraBarIndicatorState(barInfo, true)
                 ClearResourceAuraVisuals(barInfo.frame)
                 ClearMaxStacksIndicator(barInfo)
+                -- The old frame is abandoned (frames are never destroyed);
+                -- release its evaluation scratch so it stops pinning aura refs.
+                EntryRuntime.ReleaseTrackedAuraScratch(barInfo.frame)
                 barInfo.frame:Hide()
             end
             if mode == "continuous" then

--- a/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarCustomBars.lua
@@ -97,6 +97,13 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         or ClearCustomAuraBarIndicatorState
     local UpdateCustomAuraBarIndicatorVisuals = deps.UpdateCustomAuraBarIndicatorVisuals
     local ApplyCustomAuraBarPreviewState = deps.ApplyCustomAuraBarPreviewState
+    -- Reusable scratch opts — single call site each; assign EVERY field
+    -- unconditionally before each call (a conditional write leaves a stale value
+    -- from the previous call that silently overrides owner/auraState data).
+    local spellCustomBarAuraStateOpts = {}
+    local customAuraBarAuraStateOpts = {}
+    local customAuraBarPandemicStateOpts = {}
+    local customCooldownBarPandemicStateOpts = {}
     local customAuraWakeRetryQueue = {}
     local customAuraWakeRetryPending = {}
     local customAuraWakeRetryScheduled = false
@@ -174,12 +181,11 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = buttonData.auraUnit or "player"
         local resolvedAuraSpellID = CooldownCompanion:ResolveAuraSpellID(buttonData)
-        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, {
-            configUnit = configUnit,
-            allowDurationlessAuraInstance = true,
-            useButtonAuraViewerFallback = true,
-            validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell,
-        })
+        spellCustomBarAuraStateOpts.configUnit = configUnit
+        spellCustomBarAuraStateOpts.allowDurationlessAuraInstance = true
+        spellCustomBarAuraStateOpts.useButtonAuraViewerFallback = true
+        spellCustomBarAuraStateOpts.validateCachedAuraData = EntryRuntime.AuraDataMatchesTrackedSpell
+        return EntryRuntime.EvaluateTrackedAuraState(bar, buttonData, resolvedAuraSpellID, spellCustomBarAuraStateOpts)
     end
 
     local function UpdateCustomAuraBar(barInfo)
@@ -214,11 +220,10 @@ function RB.CreateResourceBarCustomBarsModule(deps)
             local buttonData, spellID = BuildCustomBarAuraButtonData(cabConfig, true)
             if buttonData and spellID then
                 configUnit = buttonData.auraUnit or configUnit
-                auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, {
-                    configUnit = configUnit,
-                    allowDurationlessAuraInstance = true,
-                    allowPlayerAuraFallbackWithoutReady = true,
-                })
+                customAuraBarAuraStateOpts.configUnit = configUnit
+                customAuraBarAuraStateOpts.allowDurationlessAuraInstance = true
+                customAuraBarAuraStateOpts.allowPlayerAuraFallbackWithoutReady = true
+                auraState = EntryRuntime.EvaluateTrackedAuraState(barInfo.frame, buttonData, spellID, customAuraBarAuraStateOpts)
                 viewerFrame = auraState and auraState.viewerFrame or nil
             end
         end
@@ -283,14 +288,14 @@ function RB.CreateResourceBarCustomBarsModule(deps)
         end
 
         local pandemicStateFrame = barInfo.frame
-        local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, {
-            enabled = configUnit == "target" and auraPresent,
-            previewActive = pandemicPreview == true,
-            clearWhenDisabled = true,
-            auraState = auraState,
-            auraUnit = auraUnit,
-            auraInstanceID = instId,
-        })
+        customAuraBarPandemicStateOpts.enabled = configUnit == "target" and auraPresent
+        customAuraBarPandemicStateOpts.previewActive = pandemicPreview == true
+        customAuraBarPandemicStateOpts.clearWhenDisabled = true
+        customAuraBarPandemicStateOpts.auraState = auraState
+        customAuraBarPandemicStateOpts.auraUnit = auraUnit
+        customAuraBarPandemicStateOpts.auraInstanceID = instId
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(pandemicStateFrame, viewerFrame, customAuraBarPandemicStateOpts)
+        customAuraBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
 
         if isActive and bar then
             if auraPresent then
@@ -580,12 +585,12 @@ function RB.CreateResourceBarCustomBarsModule(deps)
 
         local configUnit = (auraState and auraState.configUnit)
             or GetResolvedCustomAuraBarAuraUnit(cabConfig, cabConfig.spellID)
-        local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, {
-            enabled = configUnit == "target" and auraPresent,
-            previewActive = pandemicPreview == true,
-            clearWhenDisabled = true,
-            auraState = auraState,
-        })
+        customCooldownBarPandemicStateOpts.enabled = configUnit == "target" and auraPresent
+        customCooldownBarPandemicStateOpts.previewActive = pandemicPreview == true
+        customCooldownBarPandemicStateOpts.clearWhenDisabled = true
+        customCooldownBarPandemicStateOpts.auraState = auraState
+        local inPandemic = EntryRuntime.ResolveAuraPandemicState(bar, auraState and auraState.viewerFrame, customCooldownBarPandemicStateOpts)
+        customCooldownBarPandemicStateOpts.auraState = nil -- don't pin the aura-state chain between updates
 
         if auraState
             and auraState.ready == true

--- a/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
@@ -9,27 +9,17 @@ local EntryRuntime = ST.EntryRuntime
 
 local math_abs = math.abs
 local ipairs = ipairs
-local wipe = wipe
 
 local RB = ST._RB
 
--- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
--- value within the same synchronous event dispatch; contents are stale between
--- calls (the nil-return path skips the wipe). Never read directly or retain.
+-- Caller-owned scratch sets for ST.FillAuraInstanceIDSet — see Utils.lua for
+-- the lifetime contract (use only the returned set, never read these directly).
 local removedAuraIDSetScratch = {}
 local updatedAuraIDSetScratch = {}
+local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
 
-local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
-    if not (auraInstanceIDs and auraInstanceIDs[1]) then
-        return nil
-    end
-
-    wipe(scratch)
-    for _, auraInstanceID in ipairs(auraInstanceIDs) do
-        scratch[auraInstanceID] = true
-    end
-    return scratch
-end
+-- Immutable — shared across calls; never write to this table.
+local CLEAR_CUSTOM_BAR_AURA_OPTS = { useFalseState = true, clearCustomAuraStacks = true }
 
 function RB.CreateResourceBarLifecycleModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -59,10 +49,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
     end
 
     local function ClearCustomBarAuraRuntime(bar, configUnit)
-        EntryRuntime.ClearTrackedAuraOwnerState(bar, configUnit, {
-            useFalseState = true,
-            clearCustomAuraStacks = true,
-        })
+        EntryRuntime.ClearTrackedAuraOwnerState(bar, configUnit, CLEAR_CUSTOM_BAR_AURA_OPTS)
     end
 
     local function RebuildResourceBarTalentEligibilityCache()

--- a/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
@@ -12,11 +12,7 @@ local ipairs = ipairs
 
 local RB = ST._RB
 
--- Caller-owned scratch sets for ST.FillAuraInstanceIDSet — see Utils.lua for
--- the lifetime contract (use only the returned set, never read these directly).
-local removedAuraIDSetScratch = {}
-local updatedAuraIDSetScratch = {}
-local FillAuraInstanceIDSet = ST.FillAuraInstanceIDSet
+local GetAuraInstanceIDSets = ST.GetAuraInstanceIDSets
 
 -- Immutable — shared across calls; never write to this table.
 local CLEAR_CUSTOM_BAR_AURA_OPTS = { useFalseState = true, clearCustomAuraStacks = true }
@@ -167,8 +163,7 @@ function RB.CreateResourceBarLifecycleModule(deps)
 
                     local removedIDs = updateInfo.removedAuraInstanceIDs
                     local updatedIDs = updateInfo.updatedAuraInstanceIDs
-                    local removedIDSet = FillAuraInstanceIDSet(removedAuraIDSetScratch, removedIDs)
-                    local updatedIDSet = FillAuraInstanceIDSet(updatedAuraIDSetScratch, updatedIDs)
+                    local removedIDSet, updatedIDSet = GetAuraInstanceIDSets(updateInfo)
                     local hasAuraChange = updateInfo.isFullUpdate or updateInfo.addedAuras or removedIDs or updatedIDs
                     local targetSwitchDataReceived = false
 

--- a/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
+++ b/CooldownCompanion/OtherBars/ResourceBarLifecycle.lua
@@ -8,8 +8,28 @@ local CooldownCompanion = ST.Addon
 local EntryRuntime = ST.EntryRuntime
 
 local math_abs = math.abs
+local ipairs = ipairs
+local wipe = wipe
 
 local RB = ST._RB
+
+-- Reusable scratch sets — only valid through FillAuraInstanceIDSet's return
+-- value within the same synchronous event dispatch; contents are stale between
+-- calls (the nil-return path skips the wipe). Never read directly or retain.
+local removedAuraIDSetScratch = {}
+local updatedAuraIDSetScratch = {}
+
+local function FillAuraInstanceIDSet(scratch, auraInstanceIDs)
+    if not (auraInstanceIDs and auraInstanceIDs[1]) then
+        return nil
+    end
+
+    wipe(scratch)
+    for _, auraInstanceID in ipairs(auraInstanceIDs) do
+        scratch[auraInstanceID] = true
+    end
+    return scratch
+end
 
 function RB.CreateResourceBarLifecycleModule(deps)
     local resourceBarFrames = deps.resourceBarFrames
@@ -28,18 +48,6 @@ function RB.CreateResourceBarLifecycleModule(deps)
     local pendingTalentResourceRefreshToken = 0
     local lifecycleEventsEnabled = false
     local InstallHooks
-
-    local function BuildAuraInstanceIDSet(auraInstanceIDs)
-        if not (auraInstanceIDs and auraInstanceIDs[1]) then
-            return nil
-        end
-
-        local auraInstanceIDSet = {}
-        for _, auraInstanceID in ipairs(auraInstanceIDs) do
-            auraInstanceIDSet[auraInstanceID] = true
-        end
-        return auraInstanceIDSet
-    end
 
     local function IsCustomBarAuraRuntimeTracked(barInfo, cabConfig)
         if not (barInfo and cabConfig) then return false end
@@ -172,8 +180,8 @@ function RB.CreateResourceBarLifecycleModule(deps)
 
                     local removedIDs = updateInfo.removedAuraInstanceIDs
                     local updatedIDs = updateInfo.updatedAuraInstanceIDs
-                    local removedIDSet = BuildAuraInstanceIDSet(removedIDs)
-                    local updatedIDSet = BuildAuraInstanceIDSet(updatedIDs)
+                    local removedIDSet = FillAuraInstanceIDSet(removedAuraIDSetScratch, removedIDs)
+                    local updatedIDSet = FillAuraInstanceIDSet(updatedAuraIDSetScratch, updatedIDs)
                     local hasAuraChange = updateInfo.isFullUpdate or updateInfo.addedAuras or removedIDs or updatedIDs
                     local targetSwitchDataReceived = false
 

--- a/CooldownCompanion_Config/Config/Column2.lua
+++ b/CooldownCompanion_Config/Config/Column2.lua
@@ -2746,7 +2746,7 @@ local function RefreshColumn2()
                     elseif CooldownCompanion.IsEquipmentSlotEntry
                         and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
                         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-                            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+                            and CooldownCompanion.ResolveEffectiveItem(buttonData, true) or nil
                         if effectiveItem and effectiveItem.trackable and effectiveItem.itemID then
                             BindConfigShiftTooltip(entry, "item", effectiveItem.itemID, entry.frame, "ANCHOR_RIGHT")
                         end

--- a/CooldownCompanion_Config/Config/State.lua
+++ b/CooldownCompanion_Config/Config/State.lua
@@ -402,7 +402,7 @@ local function GetButtonIcon(buttonData)
     elseif CooldownCompanion.IsEquipmentSlotEntry
         and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, true) or nil
         if effectiveItem and effectiveItem.trackable and effectiveItem.icon then
             return effectiveItem.icon
         end

--- a/CooldownCompanion_Config/ConfigSettings/FormatEditor.lua
+++ b/CooldownCompanion_Config/ConfigSettings/FormatEditor.lua
@@ -501,7 +501,7 @@ local function GetPreviewIcon()
             elseif CooldownCompanion.IsEquipmentSlotEntry
                 and CooldownCompanion.IsEquipmentSlotEntry(bd) then
                 local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-                    and CooldownCompanion.ResolveEffectiveItem(bd, { requestLoad = true }) or nil
+                    and CooldownCompanion.ResolveEffectiveItem(bd, true) or nil
                 if effectiveItem and effectiveItem.trackable and effectiveItem.icon then
                     return effectiveItem.icon
                 end

--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -469,7 +469,7 @@ GetLayoutPreviewIcon = function(buttonData)
     elseif CooldownCompanion.IsEquipmentSlotEntry
         and CooldownCompanion.IsEquipmentSlotEntry(buttonData) then
         local effectiveItem = CooldownCompanion.ResolveEffectiveItem
-            and CooldownCompanion.ResolveEffectiveItem(buttonData, { requestLoad = true }) or nil
+            and CooldownCompanion.ResolveEffectiveItem(buttonData, true) or nil
         if effectiveItem and effectiveItem.trackable then
             icon = effectiveItem.icon
         end


### PR DESCRIPTION
## What Players Will Notice
- No change to what trackers display — icons, bars, charges, auras, and pandemic glows behave exactly as before.
- Less background memory garbage during combat. The update loop that refreshes every tracked button and custom bar ten times per second no longer creates throwaway tables on each pass, which reduces garbage-collector pressure and the frame-time spikes it can cause in busy fights with many trackers.

## Why This Changed
- The per-tick cooldown and aura update paths allocated fresh short-lived tables on every pass — option tables, per-owner aura state, cooldown lane results, and aura instance-ID sets. Multiplied by button count at ~10 updates per second, this produced constant allocation churn for data that is immediately discarded.
- Display accuracy is a hard constraint for this addon, so the fix reuses tables without deferring or approximating any tracker state.

## What Changed
- Option tables, per-owner aura state tables, spell cooldown lane results, and aura instance-ID scratch sets are now module- or owner-scoped reusable tables that are wiped and refilled instead of reallocated (the four commits previously reviewed as #498, #499, #500, and #501).
- A follow-up hardening commit from a full-branch review:
  - Reusable opts tables are now wiped immediately before each fill rather than after the call, so an error mid-update can never leave a previous owner''s references pinned; the redundant post-call wipes are gone.
  - `ResolveEffectiveItem` takes a plain `requestLoad` boolean instead of a shared options table, removing a file-load-order hazard and the last per-call opts allocations in the config addon.
  - The duplicated cached action-slot probe fallback now lives in one shared helper (`EntryRuntime.ResolveSlotProbeShown`).
  - UNIT_AURA removed/updated instance-ID sets are centralized behind `ST.GetAuraInstanceIDSets`, deleting duplicated per-module scratch pairs.

## Validation
- Each allocation commit was reviewed and merged individually on dev (PRs #498-#501).
- The combined branch received a multi-agent recall-focused code review (eight independent finder angles, one verifier per candidate); all confirmed findings worth fixing before merge are addressed by the hardening commit. Static call-site tracing confirmed no consumer retains any reused table across updates.
- All edited files pass Lua 5.1 syntax checking (`luac -p`).
- In-game verification of the combined branch, including combat and instanced content, has not yet been performed and should happen before merge.