### PR TITLE
Add dev-only refresh telemetry to measure cooldown scheduler cost

### DIFF
--- a/CooldownCompanion/CooldownCompanion.toc
+++ b/CooldownCompanion/CooldownCompanion.toc
@@ -53,6 +53,7 @@ Core\ScopedSettings.lua
 Core\BarsAndFramesRuntime.lua
 Core\SoundAlerts.lua
 Core\StyleOverrides.lua
+Core\RefreshTelemetry.lua
 Core\CooldownRefresh.lua
 Core\Lifecycle.lua
 Core\Aura.lua

--- a/CooldownCompanion/Core/Aura.lua
+++ b/CooldownCompanion/Core/Aura.lua
@@ -465,7 +465,7 @@ local function ForEachAuraLayoutInfo(callback)
 end
 
 function CooldownCompanion:OnUnitAura(event, unit, updateInfo)
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty(unit == "player" and "aura-player" or "aura-other")
     if unit == "player" and self._isDracthyr then
         self:InvalidateMountAlphaCache()
     end
@@ -531,7 +531,7 @@ function CooldownCompanion:ClearAuraUnit(unitToken)
             end
         end
     end)
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty("aura-clear")
 end
 
 function CooldownCompanion:OnTargetChanged()
@@ -559,6 +559,7 @@ function CooldownCompanion:OnTargetChanged()
     -- been processed by the time PLAYER_TARGET_CHANGED fires, the CDM children
     -- will have fresh auraInstanceID data.  Probing immediately lets the
     -- primary path clear _targetSwitchAt in the same frame — zero hold.
+    ST.TagRefreshPass("target-probe")
     self:UpdateAllCooldowns()
 end
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -104,11 +104,14 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
         cooldownEventSerial = self._cooldownDirtySerial or 0
     end
 
+    local T = ST.RefreshTelemetry
+    if self._queuedCooldownRefreshSource and T and T.enabled then
+        T:ClearQueueHistory()
+    end
     self._queuedCooldownRefreshSource = nil
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
-    local T = ST.RefreshTelemetry
     if T and T.enabled then
         T:SetPending("immediate", source, nil, nil)
     end

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -26,6 +26,7 @@
       If another dirty mark lands before the flush, the later ticker walks
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
+    - Refresh telemetry fields are observe-only and never change scheduling.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -38,9 +39,13 @@ local function CooldownRefreshQueueOnUpdate(frame)
     end
 end
 
-function CooldownCompanion:MarkCooldownsDirty()
+function CooldownCompanion:MarkCooldownsDirty(source)
     self._cooldownsDirty = true
     self._cooldownDirtySerial = (self._cooldownDirtySerial or 0) + 1
+    local T = ST.RefreshTelemetry
+    if T and T.enabled then
+        T:CountDirty(source or "unspecified")
+    end
 end
 
 function CooldownCompanion:ClearCooldownsDirty()
@@ -65,6 +70,10 @@ function CooldownCompanion:FlushQueuedCooldownRefresh()
     self:ResetCooldownRefreshState()
 
     if queuedSource then
+        local T = ST.RefreshTelemetry
+        if T and T.enabled then
+            T:SetPending("queue-flush", queuedSource, T:TakeQueueHistory(), nil)
+        end
         self:UpdateAllCooldowns()
         if cooldownEventSerial then
             self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
@@ -76,6 +85,10 @@ function CooldownCompanion:QueueCooldownRefresh(source)
     self._queuedCooldownRefreshSource = source or "event"
     if source == "cooldown-event" then
         self._queuedCooldownRefreshCooldownEventSerial = self._cooldownDirtySerial or 0
+    end
+    local T = ST.RefreshTelemetry
+    if T and T.enabled then
+        T:CountQueue(source or "event")
     end
     self:EnsureCooldownRefreshQueueFrame()
 end
@@ -95,6 +108,10 @@ function CooldownCompanion:RunImmediateCooldownRefresh(source)
     self._queuedCooldownRefreshCooldownEventSerial = nil
     self._cooldownImmediateRefreshThisFrame = true
     self:EnsureCooldownRefreshQueueFrame()
+    local T = ST.RefreshTelemetry
+    if T and T.enabled then
+        T:SetPending("immediate", source, nil, nil)
+    end
     self:UpdateAllCooldowns()
     if cooldownEventSerial then
         self._cooldownRefreshSatisfiedSerial = cooldownEventSerial
@@ -109,12 +126,23 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
 end
 
 function CooldownCompanion:TickCooldownRefresh()
+    local T = ST.RefreshTelemetry
+    local telemetryOn = T and T.enabled
+    local dirtyAtStart
+    if telemetryOn then
+        dirtyAtStart = self._cooldownsDirty and true or false
+    end
     if self._queuedCooldownRefreshSource then
         self:FlushQueuedCooldownRefresh()
         return false
     end
     if self:CanSkipTickerCooldownRefresh() then
+        if telemetryOn then T:CountSkip() end
         return true
+    end
+    if telemetryOn then
+        T:SetPending(dirtyAtStart and "ticker-dirty" or "ticker-clean",
+            nil, nil, dirtyAtStart)
     end
     self:UpdateAllCooldowns()
     return false

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -56,7 +56,7 @@ local function GroupHasEquipmentSlotEntries(group)
 end
 
 function CooldownCompanion:RefreshEquipmentSlotEntries(reason, itemID)
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty("equipment-slots")
     if self.db and self.db.profile and self.db.profile.groups then
         for groupId, group in pairs(self.db.profile.groups) do
             if GroupHasEquipmentSlotEntries(group) then
@@ -73,7 +73,7 @@ function CooldownCompanion:OnEquipmentChanged(event, equipmentSlot)
     if equipmentSlot == trinket1 or equipmentSlot == trinket2 then
         self:RefreshEquipmentSlotEntries("equipment", nil)
     else
-        self:MarkCooldownsDirty()
+        self:MarkCooldownsDirty("equipment-changed")
     end
 end
 
@@ -257,12 +257,12 @@ function CooldownCompanion:OnSpellRangeCheckUpdate(event, spellIdentifier, isInR
         end
     end)
     if changed then
-        self:MarkCooldownsDirty()
+        self:MarkCooldownsDirty("range-check")
     end
 end
 
 function CooldownCompanion:OnBagChanged()
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty("bag-changed")
     self:RefreshChargeFlags("item")
     self:RefreshConfigPanel()
 end
@@ -569,7 +569,7 @@ function CooldownCompanion:OnPlayerEnteringWorld(event, isInitialLogin, isReload
                     end
                 end
             end)
-            self:MarkCooldownsDirty()
+            self:MarkCooldownsDirty("player-entering-world")
         end)
     end
 end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -2865,7 +2865,7 @@ function CooldownCompanion:ResetSpellAvailabilityButtonRuntime()
         end
     end
 
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty("availability-rebuild")
 end
 
 function CooldownCompanion:RefreshAllGroupsForSpellAvailability()
@@ -2878,6 +2878,7 @@ function CooldownCompanion:RefreshAllGroupsForSpellAvailability()
         self:RefreshAllGroupsVisibilityOnly()
     end
 
+    ST.TagRefreshPass("availability-rebuild")
     self:UpdateAllCooldowns()
 end
 
@@ -3386,6 +3387,14 @@ function CooldownCompanion:DiscardDormantFrame(groupId)
 end
 
 function CooldownCompanion:UpdateAllCooldowns()
+    local T = ST.RefreshTelemetry
+    local telemetryOn = T and T.enabled
+    local t0, frames, buttons
+    if telemetryOn then
+        t0 = debugprofilestop()
+        frames, buttons = 0, 0
+    end
+
     self._gcdInfo = C_Spell.GetSpellCooldown(61304)
     -- GCD activity: isActive is NeverSecret (12.0.1 hotfix)
     self._gcdActive = self._gcdInfo and self._gcdInfo.isActive or false
@@ -3409,10 +3418,17 @@ function CooldownCompanion:UpdateAllCooldowns()
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
             frame:UpdateCooldowns()
+            if telemetryOn then
+                frames = frames + 1
+                buttons = buttons + (frame.buttons and #frame.buttons or 0)
+            end
         end
     end
 
     self._cooldownUpdatePassActive = nil
+    if telemetryOn then
+        T:RecordPass(frames, buttons, debugprofilestop() - t0)
+    end
 end
 
 function CooldownCompanion:UpdateAllGroupLayouts()

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -139,7 +139,7 @@ function CooldownCompanion:OnEnable()
         self._unitEventFrame = CreateFrame("Frame")
         self._unitEventFrame:SetScript("OnEvent", function(_, event, ...)
             if event == "UNIT_POWER_FREQUENT" then
-                self:MarkCooldownsDirty()
+                self:MarkCooldownsDirty("power")
             elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
                 self:OnSpellCast(event, ...)
             elseif event == "UNIT_AURA" then
@@ -219,7 +219,8 @@ function CooldownCompanion:OnEnable()
             if ST._QueueInheritedUnitFrameAlphaResync then
                 ST._QueueInheritedUnitFrameAlphaResync()
             end
-            self:MarkCooldownsDirty()
+            self:MarkCooldownsDirty("unit-target")
+            ST.TagRefreshPass("unit-target-direct")
             self:UpdateAllCooldowns()
         end)
     end
@@ -315,7 +316,7 @@ function CooldownCompanion:OnEnable()
 end
 
 function CooldownCompanion:OnCooldownStateChanged()
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty("cooldown-event")
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
     self:RunImmediateCooldownRefresh("cooldown-event")
@@ -409,7 +410,7 @@ end
 
 function CooldownCompanion:OnProcGlowHide(event, spellID)
     self.procOverlaySpells[spellID] = nil
-    self:MarkCooldownsDirty()
+    self:MarkCooldownsDirty("proc-hide")
     self:QueueCooldownRefresh("proc-event")
 end
 

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -349,6 +349,10 @@ function CooldownCompanion:OnDisable()
         self._alphaFrame = nil
     end
 
+    local T = ST.RefreshTelemetry
+    if self._queuedCooldownRefreshSource and T and T.enabled then
+        T:ClearQueueHistory()
+    end
     self:ResetCooldownRefreshState()
 
     -- Disable all range check registrations

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -60,6 +60,10 @@ function T:TakeQueueHistory()
     return hist
 end
 
+function T:ClearQueueHistory()
+    self.queueHistoryLen = 0
+end
+
 function T:SetPending(source, detail, hist, dirtyAtStart)
     self.pendingSource = source
     self.pendingDetail = detail
@@ -126,7 +130,8 @@ local gateFrame = CreateFrame("Frame")
 gateFrame:RegisterEvent("PLAYER_LOGIN")
 gateFrame:SetScript("OnEvent", function(frame)
     frame:UnregisterAllEvents()
-    if C_AddOns.IsAddOnLoaded("CC_DevBridge") then
+    local _, loaded = C_AddOns.IsAddOnLoaded("CC_DevBridge")
+    if loaded then
         T.enabled = true
     end
 end)

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -1,0 +1,132 @@
+--[[
+    CooldownCompanion - Core/RefreshTelemetry.lua: dev-gated, observe-only
+    telemetry for the cooldown refresh scheduler. Active only when the
+    CC_DevBridge dev addon is loaded (checked at PLAYER_LOGIN). Records:
+    - dirty-mark counts by source
+    - queue request counts by source, plus per-flush source history
+    - every UpdateAllCooldowns pass: time, source, detail, queue history,
+      dirty-at-start (ticker passes), frames/buttons walked, duration (ms)
+    - ticker skips (satisfied cooldown-event serial)
+    Read via CooldownCompanion:GetRefreshTelemetry(); reset via
+    CooldownCompanion:ResetRefreshTelemetry(). Never alters refresh behavior.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local RING_SIZE = 2000          -- pass log entries (field-reuse ring)
+local QUEUE_HISTORY_CAP = 16    -- max sources remembered per queue flush
+
+local T = {
+    enabled = false,
+    dirtyCounts = {},           -- source -> count
+    queueCounts = {},           -- source -> count
+    passCounts = {},            -- source -> count
+    tickerSkips = 0,
+    passLog = {},               -- ring buffer of reused entry tables
+    passCursor = 0,             -- last written index (1..RING_SIZE)
+    passTotal = 0,              -- total passes recorded since reset
+    queueHistory = {},          -- pending sources for the next flush
+    queueHistoryLen = 0,
+    -- pending attribution for the next UpdateAllCooldowns call
+    pendingSource = nil,
+    pendingDetail = nil,
+    pendingHist = nil,
+    pendingDirtyAtStart = nil,
+}
+ST.RefreshTelemetry = T
+
+function T:CountDirty(source)
+    self.dirtyCounts[source] = (self.dirtyCounts[source] or 0) + 1
+end
+
+function T:CountQueue(source)
+    self.queueCounts[source] = (self.queueCounts[source] or 0) + 1
+    if self.queueHistoryLen < QUEUE_HISTORY_CAP then
+        self.queueHistoryLen = self.queueHistoryLen + 1
+        self.queueHistory[self.queueHistoryLen] = source
+    end
+end
+
+function T:CountSkip()
+    self.tickerSkips = self.tickerSkips + 1
+end
+
+-- Consume and clear the accumulated queue-source history (called at flush).
+function T:TakeQueueHistory()
+    if self.queueHistoryLen == 0 then return nil end
+    local hist = table.concat(self.queueHistory, ",", 1, self.queueHistoryLen)
+    self.queueHistoryLen = 0
+    return hist
+end
+
+function T:SetPending(source, detail, hist, dirtyAtStart)
+    self.pendingSource = source
+    self.pendingDetail = detail
+    self.pendingHist = hist
+    self.pendingDirtyAtStart = dirtyAtStart
+end
+
+-- Called from the end of UpdateAllCooldowns when enabled.
+function T:RecordPass(frames, buttons, ms)
+    local source = self.pendingSource or "direct-untagged"
+    self.passCounts[source] = (self.passCounts[source] or 0) + 1
+    self.passTotal = self.passTotal + 1
+    local cursor = self.passCursor % RING_SIZE + 1
+    self.passCursor = cursor
+    local entry = self.passLog[cursor]
+    if not entry then
+        entry = {}
+        self.passLog[cursor] = entry
+    end
+    entry.t = GetTime()
+    entry.src = source
+    entry.detail = self.pendingDetail
+    entry.hist = self.pendingHist
+    entry.dirtyAtStart = self.pendingDirtyAtStart
+    entry.frames = frames
+    entry.buttons = buttons
+    entry.ms = ms
+    self.pendingSource = nil
+    self.pendingDetail = nil
+    self.pendingHist = nil
+    self.pendingDirtyAtStart = nil
+end
+
+-- One-line tag helper for direct UpdateAllCooldowns callsites.
+function ST.TagRefreshPass(source, detail)
+    if T.enabled then
+        T:SetPending(source, detail, nil, nil)
+    end
+end
+
+function CooldownCompanion:GetRefreshTelemetry()
+    return T
+end
+
+function CooldownCompanion:ResetRefreshTelemetry()
+    wipe(T.dirtyCounts)
+    wipe(T.queueCounts)
+    wipe(T.passCounts)
+    T.tickerSkips = 0
+    T.passCursor = 0
+    T.passTotal = 0
+    T.queueHistoryLen = 0
+    T.pendingSource = nil
+    T.pendingDetail = nil
+    T.pendingHist = nil
+    T.pendingDirtyAtStart = nil
+    -- Entry tables in passLog are reused; stale entries beyond passTotal are
+    -- ignored by readers (passTotal + passCursor define the valid window).
+end
+
+-- Gate: enable only when the CC_DevBridge dev addon is present. Checked at
+-- PLAYER_LOGIN because addon load order is not guaranteed at file-load time.
+local gateFrame = CreateFrame("Frame")
+gateFrame:RegisterEvent("PLAYER_LOGIN")
+gateFrame:SetScript("OnEvent", function(frame)
+    frame:UnregisterAllEvents()
+    if C_AddOns.IsAddOnLoaded("CC_DevBridge") then
+        T.enabled = true
+    end
+end)


### PR DESCRIPTION
## What Changed
- Adds a new dev-only telemetry layer (`Core/RefreshTelemetry.lua`) that records what drives CDC's cooldown refresh scheduler: how many broad `UpdateAllCooldowns` passes run, what triggered each, how many frames/buttons each walked, and how long each took (ms).
- Tags every refresh source with a stable label: `MarkCooldownsDirty` gained an optional `source` argument, and each call site now names itself (`power`, `aura-player`/`aura-other`, `cooldown-event`, `range-check`, `bag-changed`, `availability-rebuild`, `target-probe`, `unit-target`, etc.). Direct `UpdateAllCooldowns` call sites are tagged via a small `ST.TagRefreshPass` helper.
- Records per-pass detail into a fixed 2000-entry ring buffer, plus per-source counters for dirty marks, queue requests, passes, and ticker skips. Exposed via `CooldownCompanion:GetRefreshTelemetry()` / `:ResetRefreshTelemetry()`, readable through the CC_DevBridge SavedVariables after `/reload`.
- Gated so it is completely inert for normal users: a `PLAYER_LOGIN` check enables telemetry only when the `CC_DevBridge` dev addon is loaded.

## Why This Changed
- The performance roadmap (competitor study findings F1/F2/F5) depends on knowing where CDC's refresh work actually goes — especially how much of the 10Hz ticker's broad passes are wasted when nothing changed. Prior planning relied on the static refresh-source inventory rather than measured numbers.
- This is finding F7: build the measurement engine first, so later optimizations (dirty-gated ticker, event routing) can be justified and validated with real before/after data instead of guesswork.

## Developer Impact
- Provides per-source attribution and pass timing for the refresh scheduler, surfaced through DevBridge. First hard evidence for the F2 (dirty-gated ticker) case: idle ticker-clean pass volume is now directly countable.
- Scope is deliberately PR 1 of F7 — source/decision metadata only. Per-handler CPU attribution (the `GetFunctionCPUUsage` family restored in 12.0.7) is intentionally left for a later PR.
- No change to refresh behavior: the enabled path only reads scheduler state and writes to its own tables; it never calls a scheduling function or mutates scheduler fields. Disabled cost is a couple of table reads per pass.

## Validation
- Static review at extra-high effort: no correctness findings. Verified the observe-only invariant (telemetry cannot alter scheduling), load order (`Init.lua` sets `ST.Addon` before the new file; all consumers load after it), `ST` bindings in every touched file, ring-buffer wrap math, and that reused ring entries fully overwrite all fields.
- A prior second-opinion review flagged two issues, both fixed in commit `bda33e6d`: stale queue-source history when an immediate refresh discards queued work (now cleared in both `RunImmediateCooldownRefresh` and `OnDisable`, without corrupting the legitimate flush path), and the addon-loaded gate now reads the `loaded` return of `C_AddOns.IsAddOnLoaded` rather than `loadedOrLoading`.
- Not yet done: in-game validation. The DevBridge capture scenarios from the spec (idle baseline, target switch, ability press, combat/instance smoke) have not been run/confirmed in this session. Combat and restricted-content behavior is unverified. Since the code is dev-gated and observe-only, there is no player-facing runtime risk, but the telemetry numbers themselves should be sanity-checked in-game before relying on them for F2.