### PR TITLE
Make cooldown expiry an event signal instead of polling for it (no visible change)

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1717,6 +1717,7 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button.cooldown:SetHideCountdownNumbers(true)
     button.cooldown:Hide()
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    button.cooldown:SetScript("OnCooldownDone", ST.OnButtonCooldownDone)
 
     -- Suppress bling (cooldown-end flash) on all bar buttons
     button.cooldown:SetDrawBling(false)

--- a/CooldownCompanion/ButtonFrame/Helpers.lua
+++ b/CooldownCompanion/ButtonFrame/Helpers.lua
@@ -1144,6 +1144,16 @@ local function FitHighlightFrame(frame, button, overhangPct)
     end
 end
 
+-- F3: native cooldown-expiry signal. One shared handler for every button's
+-- primary Cooldown widget; marks the scheduler dirty so expiry is a signal
+-- rather than something the clean ticker polls for. Reads no game or widget
+-- state at fire time, so it is safe to run re-entrantly mid-pass. Kill switch:
+-- CooldownCompanion:SetCooldownDoneSignalDisabled().
+function ST.OnButtonCooldownDone(cooldown)
+    if CooldownCompanion._cooldownDoneSignalOff then return end
+    CooldownCompanion:MarkCooldownsDirty("cd-done")
+end
+
 -- Exports
 ST._DEFAULT_BAR_AURA_COLOR = DEFAULT_BAR_AURA_COLOR
 ST._DEFAULT_BAR_PANDEMIC_COLOR = DEFAULT_BAR_PANDEMIC_COLOR

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -723,6 +723,7 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     -- Recursively disable mouse on cooldown and all its children (CooldownFrameTemplate has children)
     -- Always fully non-interactive: disable both clicks and motion
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    button.cooldown:SetScript("OnCooldownDone", ST.OnButtonCooldownDone)
 
     -- Loss of control cooldown frame (red swipe showing lockout duration)
     button.locCooldown = CreateFrame("Cooldown", button:GetName() .. "LocCooldown", button, "CooldownFrameTemplate")

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -1007,6 +1007,7 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button.cooldown:SetHideCountdownNumbers(true)
     button.cooldown:Hide()
     SetFrameClickThroughRecursive(button.cooldown, true, true)
+    button.cooldown:SetScript("OnCooldownDone", ST.OnButtonCooldownDone)
 
     -- Charge/item count overlay (hidden, but UpdateChargeTracking writes to button.count)
     button.overlayFrame = CreateFrame("Frame", nil, button)

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -27,6 +27,9 @@
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
     - Refresh telemetry fields are observe-only and never change scheduling.
+    - cd-done marks come from ST.OnButtonCooldownDone (ButtonFrame/Helpers.lua)
+      and are ordinary MarkCooldownsDirty calls; the hidden kill switch only
+      stops the marks, never adds skips.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -50,6 +53,16 @@ end
 
 function CooldownCompanion:ClearCooldownsDirty()
     self._cooldownsDirty = false
+end
+
+-- F3 hidden kill switch (no config UI). Disable the cooldown-expiry signal
+-- live (no reload) with:
+--   /run CooldownCompanion:SetCooldownDoneSignalDisabled(true)
+-- Persists in db.global; default (absent) = signal enabled.
+function CooldownCompanion:SetCooldownDoneSignalDisabled(disabled)
+    disabled = disabled == true
+    self.db.global.cooldownDoneSignalDisabled = disabled or nil
+    self._cooldownDoneSignalOff = disabled
 end
 
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -114,6 +114,10 @@ function CooldownCompanion:EnsureRuntimeInitialized()
 end
 
 function CooldownCompanion:OnEnable()
+    -- F3: seed the cooldown-done kill-switch runtime flag from saved state
+    -- (absent key = signal enabled).
+    self._cooldownDoneSignalOff = self.db.global.cooldownDoneSignalDisabled == true
+
     -- Cooldown events can expose very short ready windows, so refresh them
     -- immediately instead of waiting for the ticker.
     for _, evt in ipairs({


### PR DESCRIPTION
## What Changed
- Each button's primary cooldown widget (icon, bar, and text modes) now hooks WoW's native `OnCooldownDone` script. When a tracked cooldown finishes, a single shared handler marks the cooldown scheduler dirty (source `"cd-done"`), so expiry arrives as an event instead of being discovered by the clean 10&nbsp;Hz polling ticker.
- The handler is deliberately minimal: it reads no game or widget state, allocates nothing, and only calls the existing `MarkCooldownsDirty`. By construction it can never skip or delay a refresh — it only ever *adds* a dirty mark.
- Ships enabled by default with a hidden live kill switch (no config UI): `/run CooldownCompanion:SetCooldownDoneSignalDisabled(true)` disables it with no reload; the flag persists in `db.global` and defaults to enabled.

## Why This Changed
- The clean ticker's main remaining justification was catching "just came off cooldown" moments that had no backing event. Making expiry a real signal removes that justification and is the prerequisite for a later change that lets the ticker skip work when nothing is dirty.
- Event-driven was chosen over polling because it is uniform across all three display modes and all cooldown families (spell / item / charge), needs no shadow frames, and adds no per-frame cost.

## Developer Impact
- No behavior change today: the ticker still runs every 100&nbsp;ms, so displays are byte-for-byte identical. The value is the new reliable expiry signal (visible in dev telemetry as `dirtyCounts["cd-done"]`) that a follow-up dirty-gated ticker can depend on.
- Inputs recorded for that follow-up: natural expiry can produce a bounded 1–2 marks (an event-driven refresh and the widget's own expiry can straddle the boundary); ready-state `SetCooldown(0,0)` re-clears are **silent** (no done→dirty→re-clear→done feedback loop); the game's cooldown API can still read "not ready" for ~50&nbsp;ms after the callback fires.

## Validation
- **Syntax:** `luac -p` passes on all six touched files.
- **In-game** (retail 12.0.x live, dev telemetry bridge loaded), on two classes/specs — Guardian Druid and Devastation Evoker:
  - Fires at natural expiry in all three modes (icon visible swipe; bar/text hidden widgets confirmed firing).
  - No re-feed fire storm and no ready-state feedback loop — session mark totals stayed sparse where a polling storm would be ~10×/s per active cooldown.
  - Charge spells confirmed mid-recharge and cooldown-reduction cases behaving correctly.
  - Zero Lua errors across sessions (dev error buffer = 0), including active combat.
  - Kill switch verified live and across `/reload` (persists disabled, then re-enables), with displays unchanged.
- **Player-facing:** intentionally invisible — owner confirmed the trackers look identical throughout (idle, target-switch, ability-press).
- **Restricted content:** the handler reads no game state, so it cannot touch secret cooldown values; open-world combat exercises the identical code path. A later scheduler change that *does* touch timing will still need its own instanced verification.
