### PR TITLE
Lower idle CPU use by skipping redundant cooldown-refresh ticker passes

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -34,6 +34,10 @@ local buttonAuraPandemicStateOpts = {}
 
 -- Silent-transform icon staleness probe interval (seconds). Event-driven icon
 -- refresh paths are unaffected; this only paces the no-event fallback probe.
+-- F2 accepted residual: while the idle ticker skip is active, this probe rides
+-- the ~1s safety walk instead of every clean 0.1s tick, so a silent texture
+-- change while fully idle can take up to ~1s (instead of ~0.25s) to appear.
+-- Owner-approved trade (PR #505 review).
 local TEXTURE_STALENESS_INTERVAL = 0.25
 
 -- APIs for text-mode conditional tokens
@@ -782,6 +786,22 @@ local function UpdateResolvedItemState(button, buttonData)
     return changed
 end
 
+-- F2: a finite ready-glow window (readyGlowDuration > 0) is a pending
+-- time-gated transition: the glow's OFF edge ((now - start) <= dur, see
+-- ResolveIconGlowIntent) is only re-evaluated by the walk, so a running window
+-- must keep the ticker walking. In-window check only -- the start timestamps
+-- stay set after the window expires (until the next cooldown / uncap), so a
+-- bare nil check would keep the ticker awake on every ready button forever.
+local function HasPendingReadyGlowWindow(button, now)
+    local style = button.style
+    local dur = style and style.readyGlowDuration or 0
+    if dur <= 0 then return false end
+    local startTime = button._readyGlowStartTime
+    if startTime and (now - startTime) <= dur then return true end
+    startTime = button._readyGlowMaxChargesStartTime
+    return (startTime and (now - startTime) <= dur) or false
+end
+
 -- F2 shadow: report whether this button is in any time-animated state the clean
 -- ticker must keep re-rendering, so a walk that draws nothing time-driven can
 -- latch idle-eligible. ORs only; never clears the pass flag to a false negative.
@@ -790,13 +810,18 @@ end
 -- direct frame:UpdateCooldowns() callers outside a broad pass conservative for
 -- free. Called only for buttons that reach the render dispatch (hidden buttons
 -- early-return above and correctly draw nothing).
-local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly)
+-- CONTRACT: every state that needs a walk re-render before the next dirty mark
+-- -- including pending time-gated transitions that look static right now (e.g.
+-- a running ready-glow duration window) -- must have a term here, or the idle
+-- skip will starve it until the ~1s safety walk.
+local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now)
     if button._cooldownState == COOLDOWN_STATE_COOLDOWN     -- spell/item/deferred cooldown
         or button._chargeRecharging                          -- charge recharge in progress
-        or button._auraActive == true                        -- aura display (incl. target-switch hold)
+        or button._auraActive                                -- aura display (incl. target-switch hold); truthy on purpose, fail open
         or button._targetSwitchAt ~= nil                     -- target-switch continuity hold
         or conditionalPreview ~= nil                         -- conditional visual preview active
         or (isGCDOnly and button.style and button.style.showGCDSwipe == true) -- GCD swipe presentation
+        or HasPendingReadyGlowWindow(button, now)            -- finite ready-glow window still running
     then
         CooldownCompanion._passTimeStateSeen = true
         CooldownCompanion._tickerIdleEligible = false
@@ -1890,5 +1915,5 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end
-    NoteButtonTimeState(button, conditionalPreview, isGCDOnly)
+    NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now)
 end

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -782,6 +782,27 @@ local function UpdateResolvedItemState(button, buttonData)
     return changed
 end
 
+-- F2 shadow: report whether this button is in any time-animated state the clean
+-- ticker must keep re-rendering, so a walk that draws nothing time-driven can
+-- latch idle-eligible. ORs only; never clears the pass flag to a false negative.
+-- Fail open -- any unclear or ambiguous state counts as active. Setting
+-- _tickerIdleEligible false directly (not only the pass-scoped flag) also keeps
+-- direct frame:UpdateCooldowns() callers outside a broad pass conservative for
+-- free. Called only for buttons that reach the render dispatch (hidden buttons
+-- early-return above and correctly draw nothing).
+local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly)
+    if button._cooldownState == COOLDOWN_STATE_COOLDOWN     -- spell/item/deferred cooldown
+        or button._chargeRecharging                          -- charge recharge in progress
+        or button._auraActive == true                        -- aura display (incl. target-switch hold)
+        or button._targetSwitchAt ~= nil                     -- target-switch continuity hold
+        or conditionalPreview ~= nil                         -- conditional visual preview active
+        or (isGCDOnly and button.style and button.style.showGCDSwipe == true) -- GCD swipe presentation
+    then
+        CooldownCompanion._passTimeStateSeen = true
+        CooldownCompanion._tickerIdleEligible = false
+    end
+end
+
 function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonData = button.buttonData
     local style = button.style
@@ -1869,4 +1890,5 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     if shouldCaptureVisualState then
         CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "post-dispatch")
     end
+    NoteButtonTimeState(button, conditionalPreview, isGCDOnly)
 end

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -7,6 +7,8 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local EntryRuntime = ST.EntryRuntime
+-- F2 canary sink (loaded before this file; dev-gated, observe-only).
+local RefreshTelemetry = ST.RefreshTelemetry
 local COOLDOWN_STATE_COOLDOWN = CooldownLogic.STATE_COOLDOWN
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
@@ -355,6 +357,9 @@ local function ResolveIconFillPreviewRemaining(button)
         return nil, nil
     end
 
+    -- F2 canary: past the guard, an icon-fill conditional-preview remaining is
+    -- computed this walk (covered by the conditionalPreview classifier term).
+    if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
     local remaining
     if button._conditionalPreviewLoop
         and button._conditionalPreviewLoopStartTime
@@ -396,6 +401,9 @@ local function SetIconFillFromCooldownWidget(button)
 
     local value = ResolveIconFillTimerValue(button, elapsed / durMs)
 
+    -- F2 canary: cooldown-widget icon fill draws remaining this walk (covered by
+    -- the _cooldownState == COOLDOWN / _auraActive classifier terms, guarded above).
+    if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
     button.iconFill:SetValue(value)
     return true
 end
@@ -423,6 +431,9 @@ local function SetIconFillValue(button)
         end
 
         if button._auraCooldownStart and button._auraCooldownDuration and button._auraCooldownDuration > 0 then
+            -- F2 canary: aura-cooldown icon fill draws remaining this walk
+            -- (covered by the _auraActive classifier term).
+            if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
             local elapsed = GetTime() - button._auraCooldownStart
             if elapsed < 0 then elapsed = 0 end
             if elapsed > button._auraCooldownDuration then elapsed = button._auraCooldownDuration end
@@ -450,6 +461,9 @@ local function SetIconFillValue(button)
     if button._iconFillMode == "cooldown" and IsEntryItemLike(button.buttonData) then
         local durationSeconds = button._itemCdDuration or 0
         if durationSeconds > 0 then
+            -- F2 canary: item cooldown icon fill draws remaining this walk
+            -- (covered by the _cooldownState == COOLDOWN classifier term).
+            if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
             local elapsed = GetTime() - (button._itemCdStart or 0)
             if elapsed < 0 then elapsed = 0 end
             local value = elapsed / durationSeconds

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1399,7 +1399,16 @@ local function UpdateIconModeGlows(button, buttonData, style, procOverlayActive)
 
     -- Ready glow (glow while off cooldown)
     if button.readyGlow then
-        local showReady = glowIntent and glowIntent.ready and glowIntent.ready.active == true
+        local readyIntent = glowIntent and glowIntent.ready
+        local showReady = readyIntent and readyIntent.active == true
+        -- F2 canary: a finite ready-glow duration window is lit this walk; its
+        -- OFF edge is walk-evaluated (covered by the ready-glow window
+        -- classifier term). durationWindow is reset on every resolve, so this
+        -- cannot read a stale flag.
+        if showReady and readyIntent.durationWindow == true
+            and RefreshTelemetry and RefreshTelemetry.enabled then
+            RefreshTelemetry:NoteTimeRender()
+        end
         SetReadyGlow(button, showReady)
     end
 end

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -6,6 +6,8 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+-- F2 canary sink (loaded before this file; dev-gated, observe-only).
+local RefreshTelemetry = ST.RefreshTelemetry
 local CHARGE_STATE_FULL = CooldownLogic.CHARGE_STATE_FULL
 local CHARGE_STATE_MISSING = CooldownLogic.CHARGE_STATE_MISSING
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
@@ -467,6 +469,9 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
             durationRemaining = rem
         end
     elseif not auraActive and button._itemCdStart and button._itemCdDuration and button._itemCdDuration > 0 then
+        -- F2 canary: item cooldown text remaining is drawn this walk (covered by
+        -- the _cooldownState == COOLDOWN classifier term).
+        if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
         local now = GetTime()
         local elapsed = now - button._itemCdStart
         local rem = button._itemCdDuration - elapsed

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -466,6 +466,11 @@ local function SubstituteTokens(button, segments, style, effectState, secretName
             durationIsSecret = true
             durationRemaining = rem
         elseif rem and rem > 0 then
+            -- F2 canary: spell-cooldown / aura remaining text is drawn from the
+            -- duration object this walk (covered by the _cooldownState ==
+            -- COOLDOWN / _auraActive classifier terms). Secret branch above is
+            -- combat-only, where the idle skip is disarmed.
+            if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
             durationRemaining = rem
         end
     elseif not auraActive and button._itemCdStart and button._itemCdDuration and button._itemCdDuration > 0 then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -17,6 +17,12 @@
     - _cooldownRefreshQueueFrame/_cooldownRefreshQueueArmed: parentless helper
       frame and arm flag used to flush queued work on the next OnUpdate
       boundary. The frame must stay shown; hidden frames do not receive OnUpdate.
+    - _tickerIdleEligible (set in GroupOperations.UpdateAllCooldowns): true after
+      a completed walk that saw no time-animated button. Read by
+      IsIdleTickerSkipEligible; it gates the idle ticker skip
+      (CanSkipIdleTickerRefresh) and the observe-only would-skip count.
+    - _tickerSkipStreak: consecutive idle skips since the last walk; forces a 1s
+      safety walk (TICKER_MAX_CONSECUTIVE_SKIPS). Reset by every walk.
 
     Invariants:
     - Only cooldown-event requests write _cooldownRefreshSatisfiedSerial.
@@ -27,6 +33,14 @@
       instead of skipping. That is intentionally conservative: displays can only
       be fresher, never staler.
     - Refresh telemetry fields are observe-only and never change scheduling.
+    - The idle ticker skip (PR F2) can only suppress the ticker's clean broad
+      walk. It never suppresses dirty ticks, queued flushes, immediate
+      refreshes, or direct passes, and never touches serials or queue state.
+    - _tickerIdleEligible is latched true only by a completed
+      UpdateAllCooldowns walk that saw no time-animated button; every other
+      writer may only clear it. Eligibility is never older than the last walk.
+    - The skip fails open: combat, config, a disabled cd-done signal, or any
+      unclassified state forces walking. A 1s safety walk runs while skipping.
     - cd-done marks come from ST.OnButtonCooldownDone (ButtonFrame/Helpers.lua)
       and are ordinary MarkCooldownsDirty calls; the hidden kill switch only
       stops the marks, never adds skips.
@@ -34,6 +48,21 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+
+-- F2: while the idle skip is active, force a full walk at least once per this
+-- many ticks (1.0s at the 0.1s ticker) so nothing can go stale longer than the
+-- safety window even if the predicate ever mis-latched. Skip at most this many
+-- ticks in a row; the next tick walks.
+local TICKER_MAX_CONSECUTIVE_SKIPS = 9
+
+-- F2: authoritative "config UI is open" check (read-only, nil-safe; the same
+-- indicator used elsewhere, e.g. AuraTexturesDisplay). Conditional previews are
+-- the only time-animated config surface, so an open config forces walking.
+local function IsConfigWindowOpen()
+    local cs = ST._configState
+    return cs and cs.configFrame and cs.configFrame.frame
+        and cs.configFrame.frame:IsShown() and true or false
+end
 
 local function CooldownRefreshQueueOnUpdate(frame)
     local addon = frame._cooldownCompanion
@@ -141,6 +170,26 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
+-- F2 idle-skip eligibility (inner predicate, shared by the PR-A observe-only
+-- would-skip counter and, later, the PR-B live skip, so the two can never
+-- drift). This is everything except the user switch. It latches on
+-- _tickerIdleEligible, which a completed walk sets true only when it saw no
+-- time-animated button. Fail open: any term unclear forces a walk.
+function CooldownCompanion:IsIdleTickerSkipEligible()
+    return not self._cooldownsDirty
+        and not self._queuedCooldownRefreshSource
+        and self._tickerIdleEligible == true
+        and not self._inCombatForTicker
+        and not self._cooldownDoneSignalOff
+end
+
+-- F2 live-skip predicate: the shared inner eligibility plus the config-open
+-- interlock. Fail open on every term (any false forces a walk).
+function CooldownCompanion:CanSkipIdleTickerRefresh()
+    return self:IsIdleTickerSkipEligible()
+        and not IsConfigWindowOpen()
+end
+
 function CooldownCompanion:TickCooldownRefresh()
     local T = ST.RefreshTelemetry
     local telemetryOn = T and T.enabled
@@ -154,6 +203,28 @@ function CooldownCompanion:TickCooldownRefresh()
     end
     if self:CanSkipTickerCooldownRefresh() then
         if telemetryOn then T:CountSkip() end
+        return true
+    end
+    -- F2 shadow: keep counting would-skips even with the live skip on, so the
+    -- soak can cross-check tickerIdleSkips (+ safety-tick walks) against it.
+    if telemetryOn and self:IsIdleTickerSkipEligible() then
+        T:CountWouldSkip()
+    end
+    -- F2 live skip: early-return a clean idle tick when the switch is on and the
+    -- predicate holds, except after TICKER_MAX_CONSECUTIVE_SKIPS skips in a row,
+    -- where the next tick walks anyway (safety-tick) so nothing goes stale
+    -- longer than ~1s. This only ever suppresses the clean broad walk; queued
+    -- flushes and dirty ticks were already handled above.
+    if self:CanSkipIdleTickerRefresh() then
+        if (self._tickerSkipStreak or 0) >= TICKER_MAX_CONSECUTIVE_SKIPS then
+            if telemetryOn then
+                T:SetPending("safety-tick", nil, nil, false)
+            end
+            self:UpdateAllCooldowns()   -- resets _tickerSkipStreak
+            return false
+        end
+        self._tickerSkipStreak = (self._tickerSkipStreak or 0) + 1
+        if telemetryOn then T:CountIdleSkip() end
         return true
     end
     if telemetryOn then

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -20,7 +20,7 @@
     - _tickerIdleEligible (set in GroupOperations.UpdateAllCooldowns): true after
       a completed walk that saw no time-animated button. Read by
       IsIdleTickerSkipEligible; it gates the idle ticker skip
-      (CanSkipIdleTickerRefresh) and the observe-only would-skip count.
+      (CanSkipIdleTickerRefresh) and its observe-only would-skip cross-check.
     - _tickerSkipStreak: consecutive idle skips since the last walk; forces a 1s
       safety walk (TICKER_MAX_CONSECUTIVE_SKIPS). Reset by every walk.
 
@@ -41,6 +41,9 @@
       writer may only clear it. Eligibility is never older than the last walk.
     - The skip fails open: combat, config, a disabled cd-done signal, or any
       unclassified state forces walking. A 1s safety walk runs while skipping.
+    - Accepted residual: no-event fallback probes that ride the clean walk
+      (e.g. the 0.25s icon texture staleness probe in CooldownUpdate.lua) run
+      at safety-walk cadence (~1s) while skipping. Owner-approved (PR #505).
     - cd-done marks come from ST.OnButtonCooldownDone (ButtonFrame/Helpers.lua)
       and are ordinary MarkCooldownsDirty calls; the hidden kill switch only
       stops the marks, never adds skips.
@@ -170,11 +173,10 @@ function CooldownCompanion:CanSkipTickerCooldownRefresh()
         and self._cooldownRefreshSatisfiedSerial == (self._cooldownDirtySerial or 0)
 end
 
--- F2 idle-skip eligibility (inner predicate, shared by the PR-A observe-only
--- would-skip counter and, later, the PR-B live skip, so the two can never
--- drift). This is everything except the user switch. It latches on
--- _tickerIdleEligible, which a completed walk sets true only when it saw no
--- time-animated button. Fail open: any term unclear forces a walk.
+-- F2 idle-skip eligibility (inner predicate of CanSkipIdleTickerRefresh; every
+-- term except the config-open interlock). It latches on _tickerIdleEligible,
+-- which a completed walk sets true only when it saw no time-animated button.
+-- Fail open: any term unclear forces a walk.
 function CooldownCompanion:IsIdleTickerSkipEligible()
     return not self._cooldownsDirty
         and not self._queuedCooldownRefreshSource
@@ -205,17 +207,19 @@ function CooldownCompanion:TickCooldownRefresh()
         if telemetryOn then T:CountSkip() end
         return true
     end
-    -- F2 shadow: keep counting would-skips even with the live skip on, so the
-    -- soak can cross-check tickerIdleSkips (+ safety-tick walks) against it.
-    if telemetryOn and self:IsIdleTickerSkipEligible() then
+    -- F2 cross-check: count every tick the live-skip predicate accepts, whether
+    -- it then skips or walks as a safety tick. Soak invariant: wouldSkipTotal ==
+    -- tickerIdleSkips + "safety-tick" pass count.
+    local canSkipIdle = self:CanSkipIdleTickerRefresh()
+    if telemetryOn and canSkipIdle then
         T:CountWouldSkip()
     end
-    -- F2 live skip: early-return a clean idle tick when the switch is on and the
-    -- predicate holds, except after TICKER_MAX_CONSECUTIVE_SKIPS skips in a row,
-    -- where the next tick walks anyway (safety-tick) so nothing goes stale
-    -- longer than ~1s. This only ever suppresses the clean broad walk; queued
-    -- flushes and dirty ticks were already handled above.
-    if self:CanSkipIdleTickerRefresh() then
+    -- F2 live skip: early-return a clean idle tick when the predicate holds,
+    -- except after TICKER_MAX_CONSECUTIVE_SKIPS skips in a row, where the next
+    -- tick walks anyway (safety-tick) so nothing goes stale longer than ~1s.
+    -- This only ever suppresses the clean broad walk; queued flushes and dirty
+    -- ticks were already handled above.
+    if canSkipIdle then
         if (self._tickerSkipStreak or 0) >= TICKER_MAX_CONSECUTIVE_SKIPS then
             if telemetryOn then
                 T:SetPending("safety-tick", nil, nil, false)

--- a/CooldownCompanion/Core/EventHandlers.lua
+++ b/CooldownCompanion/Core/EventHandlers.lua
@@ -194,13 +194,22 @@ function CooldownCompanion:OnSpellsChanged()
 end
 
 function CooldownCompanion:OnSpellUpdateIcon()
+    local anyDeferred = false
     self:ForEachButton(function(button, bd)
         if bd.cdmChildSlot then
             button._iconDirty = true
+            anyDeferred = true
         else
             self:UpdateButtonIcon(button)
         end
     end)
+    -- A skipped idle tick doesn't walk, so a deferred cdmChildSlot icon refresh
+    -- (_iconDirty, consumed in UpdateButtonCooldown) must mark dirty to force a
+    -- walk; otherwise it waits for the ~1s idle-skip safety walk. Conservative:
+    -- only ever adds a walk. Mirrors the assisted-spell dirty-mark in Lifecycle.
+    if anyDeferred then
+        self:MarkCooldownsDirty("icon")
+    end
 end
 
 local function GetRangeCheckSpellID(buttonData)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -3414,6 +3414,10 @@ function CooldownCompanion:UpdateAllCooldowns()
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
     self._cooldownUpdatePassActive = true
+    -- F2 shadow: reset the per-pass time-animation flag. Any button that renders
+    -- time-driven state this walk sets it true (NoteButtonTimeState); a walk that
+    -- ends with it still false latches idle-eligible below. Fail open.
+    self._passTimeStateSeen = false
 
     for groupId, frame in pairs(self.groupFrames) do
         if frame and frame.UpdateCooldowns and frame:IsShown() then
@@ -3426,6 +3430,15 @@ function CooldownCompanion:UpdateAllCooldowns()
     end
 
     self._cooldownUpdatePassActive = nil
+    -- F2 shadow eligibility: a completed full walk that saw no time-animated
+    -- button latches idle-eligible. Only this line may latch it true; every
+    -- other writer (NoteButtonTimeState) may only clear it to false. It is thus
+    -- never older than the last completed walk. Maintained unconditionally (not
+    -- gated on telemetry) so the PR-B predicate can read it live. Fail open.
+    self._tickerIdleEligible = not self._passTimeStateSeen
+    -- F2: any completed walk restarts the idle-skip safety clock (see
+    -- TICKER_MAX_CONSECUTIVE_SKIPS). Covers every walk path, not just the ticker.
+    self._tickerSkipStreak = 0
     if telemetryOn then
         T:RecordPass(frames, buttons, debugprofilestop() - t0)
     end

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -142,8 +142,11 @@ function CooldownCompanion:OnEnable()
     end
 
     -- Broader state changes can wait for the regular ticker pass.
+    -- PLAYER_SOFT_ENEMY_CHANGED refreshes the assisted-highlight hostile gate
+    -- when there is no hard target and the softenemy fallback changes.
     for _, evt in ipairs({
         "LOSS_OF_CONTROL_ADDED", "LOSS_OF_CONTROL_UPDATE", "ITEM_COUNT_CHANGED",
+        "PLAYER_SOFT_ENEMY_CHANGED",
     }) do
         self:RegisterEvent(evt, "MarkCooldownsDirty")
     end

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -99,9 +99,16 @@ function CooldownCompanion:EnsureRuntimeInitialized()
 
     if not self.updateTicker then
         self.updateTicker = C_Timer.NewTicker(0.1, function()
-            -- Read assisted combat recommended spell (plain table field, no API call)
+            -- Read assisted combat recommended spell (plain table field, no API
+            -- call). A skipped tick doesn't walk, so a changed recommendation
+            -- must mark dirty to force a walk. Conservative: a new dirty source
+            -- only ever adds walks, never removes them.
             if AssistedCombatManager then
-                self.assistedSpellID = AssistedCombatManager.lastNextCastSpellID
+                local nextCast = AssistedCombatManager.lastNextCastSpellID
+                if nextCast ~= self.assistedSpellID then
+                    self.assistedSpellID = nextCast
+                    self:MarkCooldownsDirty("assisted")
+                end
             end
 
             self:TickCooldownRefresh()
@@ -117,6 +124,14 @@ function CooldownCompanion:OnEnable()
     -- F3: seed the cooldown-done kill-switch runtime flag from saved state
     -- (absent key = signal enabled).
     self._cooldownDoneSignalOff = self.db.global.cooldownDoneSignalDisabled == true
+
+    -- F2: seed the combat flag read by the idle-skip predicate (the skip is
+    -- out-of-combat only). Maintained by OnCombatStart/OnCombatEnd; one
+    -- InCombatLockdown() read here covers /reload-in-combat. No per-tick probe.
+    self._inCombatForTicker = InCombatLockdown() and true or false
+
+    -- F2: reset the idle-skip safety-walk streak.
+    self._tickerSkipStreak = 0
 
     -- Cooldown events can expose very short ready windows, so refresh them
     -- immediately instead of waiting for the ticker.
@@ -448,6 +463,7 @@ end
 
 
 function CooldownCompanion:OnCombatStart()
+    self._inCombatForTicker = true  -- F2: disarms the idle ticker skip in combat
     self:BeginCombatForcedLock()
     self:QueueCooldownRefresh("combat-event")
     -- Close spellbook during combat to avoid Blizzard secret value errors
@@ -467,6 +483,7 @@ function CooldownCompanion:OnCombatStart()
 end
 
 function CooldownCompanion:OnCombatEnd()
+    self._inCombatForTicker = false  -- F2: re-arms idle ticker skip eligibility
     local combatLockSnapshot = self:EndCombatForcedLock()
     self:QueueCooldownRefresh("combat-event")
     self:ApplyCdmAlpha()

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -5,8 +5,12 @@
     - dirty-mark counts by source
     - queue request counts by source, plus per-flush source history
     - every UpdateAllCooldowns pass: time, source, detail, queue history,
-      dirty-at-start (ticker passes), frames/buttons walked, duration (ms)
+      dirty-at-start (ticker passes), frames/buttons walked, duration (ms),
+      idle-eligibility at pass start and whether a time-render canary fired
     - ticker skips (satisfied cooldown-event serial)
+    - F2 shadow (observe-only): would-skip count under the PR-B idle predicate
+      and false-idle count (a time-render canary that fired during a pass that
+      began clean and idle-eligible)
     Read via CooldownCompanion:GetRefreshTelemetry(); reset via
     CooldownCompanion:ResetRefreshTelemetry(). Never alters refresh behavior.
 ]]
@@ -23,6 +27,15 @@ local T = {
     queueCounts = {},           -- source -> count
     passCounts = {},            -- source -> count
     tickerSkips = 0,
+    -- F2 shadow (observe-only): clean ticker passes that the PR-B idle predicate
+    -- would have skipped, and times a time-render canary fired during a pass
+    -- that began clean + idle-eligible (a proven-wrong "false idle"; the PR-B
+    -- soak gate requires this to stay 0). Neither ever changes scheduling.
+    wouldSkipTotal = 0,
+    falseIdleTotal = 0,
+    -- F2 live skip (PR B): clean idle ticks actually suppressed (switch on).
+    -- The "safety-tick" pass source counts the forced ~1/s walks while skipping.
+    tickerIdleSkips = 0,
     passLog = {},               -- ring buffer of reused entry tables
     passCursor = 0,             -- last written index (1..RING_SIZE)
     passTotal = 0,              -- total passes recorded since reset
@@ -33,6 +46,9 @@ local T = {
     pendingDetail = nil,
     pendingHist = nil,
     pendingDirtyAtStart = nil,
+    -- F2: eligibility snapshot at pass start, and whether a canary fired.
+    pendingIdleEligible = nil,
+    pendingRenderedTime = nil,
 }
 ST.RefreshTelemetry = T
 
@@ -52,6 +68,31 @@ function T:CountSkip()
     self.tickerSkips = self.tickerSkips + 1
 end
 
+-- F2 shadow: a clean ticker pass that the PR-B idle predicate would have
+-- skipped. Observe-only -- the pass still walks in PR A.
+function T:CountWouldSkip()
+    self.wouldSkipTotal = self.wouldSkipTotal + 1
+end
+
+-- F2 live skip (PR B): a clean idle tick was actually suppressed (early return).
+function T:CountIdleSkip()
+    self.tickerIdleSkips = self.tickerIdleSkips + 1
+end
+
+-- F2 canary: a time-driven remaining render happened. Only renders that occur
+-- during a broad UpdateAllCooldowns walk are relevant to skip safety -- the
+-- idle skip suppresses that walk, not the OnUpdate self-animation that runs
+-- between passes -- so ignore anything fired outside a pass. A render during a
+-- pass that began clean and idle-eligible is a proven false idle: the predicate
+-- said "nothing time-animated" yet something drew remaining time.
+function T:NoteTimeRender()
+    if not CooldownCompanion._cooldownUpdatePassActive then return end
+    self.pendingRenderedTime = true
+    if self.pendingIdleEligible and self.pendingDirtyAtStart == false then
+        self.falseIdleTotal = self.falseIdleTotal + 1
+    end
+end
+
 -- Consume and clear the accumulated queue-source history (called at flush).
 function T:TakeQueueHistory()
     if self.queueHistoryLen == 0 then return nil end
@@ -69,6 +110,12 @@ function T:SetPending(source, detail, hist, dirtyAtStart)
     self.pendingDetail = detail
     self.pendingHist = hist
     self.pendingDirtyAtStart = dirtyAtStart
+    -- F2: snapshot the eligibility latched by the previous completed walk, so a
+    -- canary firing during this pass is judged against the state the PR-B skip
+    -- decision would have used (eligibility always lags one walk). Reset the
+    -- per-pass canary flag.
+    self.pendingIdleEligible = CooldownCompanion._tickerIdleEligible == true
+    self.pendingRenderedTime = nil
 end
 
 -- Called from the end of UpdateAllCooldowns when enabled.
@@ -88,6 +135,8 @@ function T:RecordPass(frames, buttons, ms)
     entry.detail = self.pendingDetail
     entry.hist = self.pendingHist
     entry.dirtyAtStart = self.pendingDirtyAtStart
+    entry.idleEligible = self.pendingIdleEligible
+    entry.renderedTime = self.pendingRenderedTime
     entry.frames = frames
     entry.buttons = buttons
     entry.ms = ms
@@ -95,6 +144,8 @@ function T:RecordPass(frames, buttons, ms)
     self.pendingDetail = nil
     self.pendingHist = nil
     self.pendingDirtyAtStart = nil
+    self.pendingIdleEligible = nil
+    self.pendingRenderedTime = nil
 end
 
 -- One-line tag helper for direct UpdateAllCooldowns callsites.
@@ -113,6 +164,9 @@ function CooldownCompanion:ResetRefreshTelemetry()
     wipe(T.queueCounts)
     wipe(T.passCounts)
     T.tickerSkips = 0
+    T.wouldSkipTotal = 0
+    T.falseIdleTotal = 0
+    T.tickerIdleSkips = 0
     T.passCursor = 0
     T.passTotal = 0
     T.queueHistoryLen = 0
@@ -120,6 +174,8 @@ function CooldownCompanion:ResetRefreshTelemetry()
     T.pendingDetail = nil
     T.pendingHist = nil
     T.pendingDirtyAtStart = nil
+    T.pendingIdleEligible = nil
+    T.pendingRenderedTime = nil
     -- Entry tables in passLog are reused; stale entries beyond passTotal are
     -- ignored by readers (passTotal + passCursor define the valid window).
 end

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -8,8 +8,8 @@
       dirty-at-start (ticker passes), frames/buttons walked, duration (ms),
       idle-eligibility at pass start and whether a time-render canary fired
     - ticker skips (satisfied cooldown-event serial)
-    - F2 shadow (observe-only): would-skip count under the PR-B idle predicate
-      and false-idle count (a time-render canary that fired during a pass that
+    - F2 (observe-only): would-skip count under the live-skip predicate and
+      false-idle count (a time-render canary that fired during a pass that
       began clean and idle-eligible)
     Read via CooldownCompanion:GetRefreshTelemetry(); reset via
     CooldownCompanion:ResetRefreshTelemetry(). Never alters refresh behavior.
@@ -27,14 +27,16 @@ local T = {
     queueCounts = {},           -- source -> count
     passCounts = {},            -- source -> count
     tickerSkips = 0,
-    -- F2 shadow (observe-only): clean ticker passes that the PR-B idle predicate
-    -- would have skipped, and times a time-render canary fired during a pass
-    -- that began clean + idle-eligible (a proven-wrong "false idle"; the PR-B
-    -- soak gate requires this to stay 0). Neither ever changes scheduling.
+    -- F2 (observe-only): ticks the live-skip predicate accepted, whether then
+    -- skipped or walked as a safety tick (soak invariant: wouldSkipTotal ==
+    -- tickerIdleSkips + "safety-tick" pass count), and times a time-render
+    -- canary fired during a pass that began clean + idle-eligible (a
+    -- proven-wrong "false idle"; the soak gate requires this to stay 0).
+    -- Neither ever changes scheduling.
     wouldSkipTotal = 0,
     falseIdleTotal = 0,
-    -- F2 live skip (PR B): clean idle ticks actually suppressed (switch on).
-    -- The "safety-tick" pass source counts the forced ~1/s walks while skipping.
+    -- F2 live skip: clean idle ticks actually suppressed. The "safety-tick"
+    -- pass source counts the forced ~1/s walks while skipping.
     tickerIdleSkips = 0,
     passLog = {},               -- ring buffer of reused entry tables
     passCursor = 0,             -- last written index (1..RING_SIZE)
@@ -68,13 +70,13 @@ function T:CountSkip()
     self.tickerSkips = self.tickerSkips + 1
 end
 
--- F2 shadow: a clean ticker pass that the PR-B idle predicate would have
--- skipped. Observe-only -- the pass still walks in PR A.
+-- F2 cross-check: a clean tick the live-skip predicate accepted (then either
+-- skipped or walked as a safety tick). Observe-only.
 function T:CountWouldSkip()
     self.wouldSkipTotal = self.wouldSkipTotal + 1
 end
 
--- F2 live skip (PR B): a clean idle tick was actually suppressed (early return).
+-- F2 live skip: a clean idle tick was actually suppressed (early return).
 function T:CountIdleSkip()
     self.tickerIdleSkips = self.tickerIdleSkips + 1
 end
@@ -111,7 +113,7 @@ function T:SetPending(source, detail, hist, dirtyAtStart)
     self.pendingHist = hist
     self.pendingDirtyAtStart = dirtyAtStart
     -- F2: snapshot the eligibility latched by the previous completed walk, so a
-    -- canary firing during this pass is judged against the state the PR-B skip
+    -- canary firing during this pass is judged against the state the live skip
     -- decision would have used (eligibility always lags one walk). Reset the
     -- per-pass canary flag.
     self.pendingIdleEligible = CooldownCompanion._tickerIdleEligible == true


### PR DESCRIPTION
## What Players Will Notice
- Lower CPU use while idle / out of combat — the addon stops doing redundant background work each second when nothing is changing. The benefit grows with the number of tracked spells and items.
- **No visible difference and nothing to configure.** Cooldowns, auras, charges, ready glows, and previews look and update exactly as before; it's automatic.

## Why This Changed
- The cooldown-refresh ticker re-walked every shown button 10 times a second, forever — even while standing idle with nothing on cooldown. Telemetry measured **~89% of idle ticker passes were pure redundant walks** (~2.8 ms each) doing no useful work.

## What Changed
- When the addon is provably idle — out of combat with no active cooldowns, recharges, tracked auras, target-switch holds, running ready-glow duration windows, or conditional previews — the 0.1s ticker now early-returns instead of walking every button.
- Eligibility is derived from pass output: a completed walk that renders nothing time-animated latches "idle-eligible"; any dirty mark or game event forces a walk and re-evaluates it, so the decision is never based on state older than the last walk.
- **Fails open, with a safety net.** A full walk still runs at least once per second while skipping, and combat, an open config window, the cooldown-done kill switch, any pending refresh, or any unclassified button state all force a normal walk.
- Bar-mode fill/countdown already self-animates on its own OnUpdate and is unaffected; icon/text/charge/aura/preview/glow time renders are covered by a per-button active-state classifier.
- Adds dev-only refresh telemetry (active only when the CC_DevBridge dev addon is loaded) — would-skip / false-idle counters and per-button time-render canaries — used to prove the skip never suppressed a live display update. Inert for normal players (one nil-check per render).

### Review fixes (second commit)
A multi-angle code review of the first commit found and fixed:
- **Finite ready-glow duration windows** (`readyGlowDuration > 0`, non-default) were not classified as time-animated, so the glow could linger up to ~1s past its configured duration out of combat. The classifier now keeps the ticker walking while a glow window is running (in-window check; the max-charges variant too).
- **Telemetry alignment:** the observe-only would-skip counter now uses the same predicate as the live skip, restoring a checkable soak invariant (`wouldSkipTotal == tickerIdleSkips + safety-tick passes`). Stale comments describing the removed rollout switch were scrubbed.
- **Canary coverage:** added time-render canaries to the two walk-driven render paths that had none (ready-glow window, text-mode spell/aura remaining), so the `falseIdleTotal` gate can actually observe this class of miss. Bar mode is deliberately uninstrumented — its renders are OnUpdate-driven, not walk-driven.
- **Accepted residual (documented in code):** the 0.25s silent icon-texture staleness probe rides the ~1s safety walk while skipping, so a silent texture change while fully idle can take up to ~1s to appear instead of ~0.25s. Owner-approved trade; event-driven icon refreshes are unaffected.

## Validation
- `luac -p` clean on all changed files (both commits); `git diff --check` clean.
- In-game (Devastation Evoker, retail 12.0.x), **first commit**: displays looked identical with the skip active; idle telemetry showed skips occurring (`tickerIdleSkips` climbing) with `falseIdleTotal == 0` and zero Lua errors, across out-of-combat, target-dummy combat, and instanced content; cooldown-expiry, aura, charge, target-switch, and proc-from-idle transitions rendered on time. Scope caveat: the canaries in that build did not cover the ready-glow or text duration-object paths, so that soak could not have caught the ready-glow finding — hence the review fixes.
- **Second commit (review fixes): in-game re-soak pending.** Checklist: skips still occurring with `falseIdleTotal == 0` under the widened canaries; `wouldSkipTotal == tickerIdleSkips + safety-tick passes`; ready-glow with a set duration expires on time out of combat; a `hideWhileOnCooldown` button reappears promptly at cooldown end (open review question: whether a hidden Cooldown widget fires `OnCooldownDone`); assisted-combat highlight active in combat with zero errors.
- Landing on `dev` for continued multi-spec soak before release. The skip's failure mode is inherently visual (a stale/late display); none has been observed.
