### PR TITLE
Aura-tracking entries no longer react to spell castability

### DIFF
--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -189,6 +189,14 @@ local function IsUnusableVisualActive(button, buttonData)
     if buttonData.isPassive or buttonData.isPassiveCooldown then
         return false
     end
+    -- Entries added to track an aura (buff/debuff) display aura state, not spell
+    -- castability, so the "dim when unusable" visual never applies to them -- only
+    -- to entries added as a spell/cooldown. Mirrors the isPassive exemption above.
+    -- (auraTracking can auto-enable on a spell/cooldown entry, so key off the
+    -- immutable add-intent label, not the runtime aura-tracking flag.)
+    if buttonData.addedAs == "aura" then
+        return false
+    end
     if button._conditionalUnusablePreview then
         return true, "unusable-preview"
     end

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -186,7 +186,8 @@ local function IsUnusableVisualActive(button, buttonData)
     if buttonData and buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
         return false
     end
-    if buttonData.isPassive or buttonData.isPassiveCooldown then
+    -- aura entries (by add-intent, not the runtime auraTracking flag) show aura state, not castability
+    if buttonData.isPassive or buttonData.isPassiveCooldown or buttonData.addedAs == "aura" then
         return false
     end
     if button._conditionalUnusablePreview then

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -190,14 +190,6 @@ local function IsUnusableVisualActive(button, buttonData)
     if buttonData.isPassive or buttonData.isPassiveCooldown or buttonData.addedAs == "aura" then
         return false
     end
-    -- Entries added to track an aura (buff/debuff) display aura state, not spell
-    -- castability, so the "dim when unusable" visual never applies to them -- only
-    -- to entries added as a spell/cooldown. Mirrors the isPassive exemption above.
-    -- (auraTracking can auto-enable on a spell/cooldown entry, so key off the
-    -- immutable add-intent label, not the runtime aura-tracking flag.)
-    if buttonData.addedAs == "aura" then
-        return false
-    end
     if button._conditionalUnusablePreview then
         return true, "unusable-preview"
     end


### PR DESCRIPTION
## What Players Will Notice
- An entry added to **track a buff/debuff (an aura tracker)** now reflects only whether that aura is active. It no longer picks up an extra dimmed/desaturated look just because the underlying spell isn't castable at that moment — e.g. a Feral Druid's Rip aura tracker no longer reacts to being at 0 combo points or out of Cat Form while the DoT is still ticking.
- In practice this was mostly invisible; it was most likely to show when the "unusable" cue is set to desaturation and the aura was up while the spell was momentarily uncastable.

## Why This Changed
- The default-on "dim when unusable" visual ran a spell-castability check (`IsSpellUsable`) on **every** non-passive spell entry — including aura trackers. An aura tracker's job is to answer "is the buff/debuff up," not "can I cast this spell," so layering a castability cue on it was incorrect and produced a confusing double-signal. The check already skipped passive entries but had never skipped aura-tracking ones.

## What Changed
- One added condition on the existing exemption guard in `IsUnusableVisualActive` (the shared resolver both the icon-tint and desaturation paths call): entries added as an aura (`addedAs == "aura"`) now skip the unusable visual, right alongside the existing passive exemption.
- Keyed off the immutable add-intent (`addedAs`), **not** the runtime `auraTracking` flag — that flag can auto-enable on a spell/cooldown entry that happens to expose an aura, and those stay classified as spell entries and keep the cue.
- Scope is the automatic `showUnusable` dim/desaturation only. An aura tracker's own aura-driven desaturation is unchanged, and explicitly configured usability features (the `{unusable}` text token, hide-while-unusable, trigger/texture conditions) are left working.

## Validation
- `luac -p` clean; `git diff --check` clean.
- In-game (owner, Feral Druid, out of combat): confirmed the Rip aura tracker shows no visual regression — its aura cue is intact and it no longer reacts to castability.
- Display-only guard with no combat-specific path; combat / restricted-content was not separately exercised for this change.
