### PR TITLE
Buttons render their stacked layers in one pass for lower rendering cost

### DIFF
--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1550,6 +1550,11 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._isBar = true
     button._isVertical = isVertical
 
+    -- F6 (hidden switch, default OFF): flatten this bar's render layers.
+    if CooldownCompanion._renderFlattenOn then
+        button:SetFlattensRenderLayers(true)
+    end
+
     -- Background — covers bar area only when icon is shown (icon has its own iconBg)
     local bgColor = style.barBgColor or {0.1, 0.1, 0.1, 0.8}
     button.bg = button:CreateTexture(nil, "BACKGROUND")

--- a/CooldownCompanion/ButtonFrame/BarMode.lua
+++ b/CooldownCompanion/ButtonFrame/BarMode.lua
@@ -1550,10 +1550,9 @@ function CooldownCompanion:CreateBarFrame(parent, index, buttonData, style)
     button._isBar = true
     button._isVertical = isVertical
 
-    -- F6 (hidden switch, default OFF): flatten this bar's render layers.
-    if CooldownCompanion._renderFlattenOn then
-        button:SetFlattensRenderLayers(true)
-    end
+    -- F6: flatten this bar's render layers into one render pass
+    -- (owner-validated V1-V10: no visual difference).
+    button:SetFlattensRenderLayers(true)
 
     -- Background — covers bar area only when icon is shown (icon has its own iconBg)
     local bgColor = style.barBgColor or {0.1, 0.1, 0.1, 0.8}

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -672,10 +672,9 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     local button = CreateFrame("Frame", parent:GetName() .. "Button" .. index, parent)
     button:SetSize(width, height)
 
-    -- F6 (hidden switch, default OFF): flatten this button's render layers.
-    if CooldownCompanion._renderFlattenOn then
-        button:SetFlattensRenderLayers(true)
-    end
+    -- F6: flatten this button's render layers into one render pass
+    -- (owner-validated V1-V10: no visual difference).
+    button:SetFlattensRenderLayers(true)
 
     -- Background
     button.bg = button:CreateTexture(nil, "BACKGROUND")

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -672,6 +672,11 @@ function CooldownCompanion:CreateButtonFrame(parent, index, buttonData, style)
     local button = CreateFrame("Frame", parent:GetName() .. "Button" .. index, parent)
     button:SetSize(width, height)
 
+    -- F6 (hidden switch, default OFF): flatten this button's render layers.
+    if CooldownCompanion._renderFlattenOn then
+        button:SetFlattensRenderLayers(true)
+    end
+
     -- Background
     button.bg = button:CreateTexture(nil, "BACKGROUND")
     button.bg:SetAllPoints()

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -956,6 +956,11 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button:SetSize(w, h)
     button._isText = true
 
+    -- F6 (hidden switch, default OFF): flatten this text frame's render layers.
+    if CooldownCompanion._renderFlattenOn then
+        button:SetFlattensRenderLayers(true)
+    end
+
     -- Background (sublayer 0)
     local bgColor = style.textBgColor or {0, 0, 0, 0}
     button.bg = button:CreateTexture(nil, "BACKGROUND", nil, 0)

--- a/CooldownCompanion/ButtonFrame/TextMode.lua
+++ b/CooldownCompanion/ButtonFrame/TextMode.lua
@@ -956,10 +956,9 @@ function CooldownCompanion:CreateTextFrame(parent, index, buttonData, style)
     button:SetSize(w, h)
     button._isText = true
 
-    -- F6 (hidden switch, default OFF): flatten this text frame's render layers.
-    if CooldownCompanion._renderFlattenOn then
-        button:SetFlattensRenderLayers(true)
-    end
+    -- F6: flatten this text frame's render layers into one render pass
+    -- (owner-validated V1-V10: no visual difference).
+    button:SetFlattensRenderLayers(true)
 
     -- Background (sublayer 0)
     local bgColor = style.textBgColor or {0, 0, 0, 0}

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -97,6 +97,33 @@ function CooldownCompanion:SetCooldownDoneSignalDisabled(disabled)
     self._cooldownDoneSignalOff = disabled
 end
 
+-- F6 hidden switch (no config UI, default OFF). Render-layer flattening collapses
+-- each button's stacked regions (icon, cooldown swipe, overlays, texts, bars) into
+-- one render pass via Frame:SetFlattensRenderLayers. Visual-risk change (overlapping
+-- semi-transparent regions can composite differently), so it ships behind a switch.
+-- Enable live (no reload) with:
+--   /run CooldownCompanion:SetRenderFlattenEnabled(true)
+-- Persists in db.global; default (absent) = disabled. Applies to existing and
+-- future button roots; disabling reverts every live button the same way.
+function CooldownCompanion:SetRenderFlattenEnabled(enabled)
+    enabled = enabled == true
+    self.db.global.renderFlattenEnabled = enabled or nil
+    self._renderFlattenOn = enabled
+    self:ApplyRenderFlattenToAllButtons()
+end
+
+-- Apply the current render-flatten state to every live button root frame. Both
+-- directions work live (enable AND disable without reload). Button roots only --
+-- never group/container/panel/bar-frame wrappers (see the creation-site guards).
+function CooldownCompanion:ApplyRenderFlattenToAllButtons()
+    local enabled = self._renderFlattenOn == true
+    self:ForEachButton(function(button)
+        if button.SetFlattensRenderLayers then
+            button:SetFlattensRenderLayers(enabled)
+        end
+    end)
+end
+
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
     if not self._cooldownRefreshQueueFrame then
         local frame = CreateFrame("Frame")

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -97,33 +97,6 @@ function CooldownCompanion:SetCooldownDoneSignalDisabled(disabled)
     self._cooldownDoneSignalOff = disabled
 end
 
--- F6 hidden switch (no config UI, default OFF). Render-layer flattening collapses
--- each button's stacked regions (icon, cooldown swipe, overlays, texts, bars) into
--- one render pass via Frame:SetFlattensRenderLayers. Visual-risk change (overlapping
--- semi-transparent regions can composite differently), so it ships behind a switch.
--- Enable live (no reload) with:
---   /run CooldownCompanion:SetRenderFlattenEnabled(true)
--- Persists in db.global; default (absent) = disabled. Applies to existing and
--- future button roots; disabling reverts every live button the same way.
-function CooldownCompanion:SetRenderFlattenEnabled(enabled)
-    enabled = enabled == true
-    self.db.global.renderFlattenEnabled = enabled or nil
-    self._renderFlattenOn = enabled
-    self:ApplyRenderFlattenToAllButtons()
-end
-
--- Apply the current render-flatten state to every live button root frame. Both
--- directions work live (enable AND disable without reload). Button roots only --
--- never group/container/panel/bar-frame wrappers (see the creation-site guards).
-function CooldownCompanion:ApplyRenderFlattenToAllButtons()
-    local enabled = self._renderFlattenOn == true
-    self:ForEachButton(function(button)
-        if button.SetFlattensRenderLayers then
-            button:SetFlattensRenderLayers(enabled)
-        end
-    end)
-end
-
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()
     if not self._cooldownRefreshQueueFrame then
         local frame = CreateFrame("Frame")

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -125,10 +125,9 @@ function CooldownCompanion:OnEnable()
     -- (absent key = signal enabled).
     self._cooldownDoneSignalOff = self.db.global.cooldownDoneSignalDisabled == true
 
-    -- F6: seed the render-flatten switch from saved state (absent key = OFF).
-    -- Future button roots read it at creation; SetRenderFlattenEnabled applies
-    -- it to existing buttons live.
-    self._renderFlattenOn = self.db.global.renderFlattenEnabled == true
+    -- F6: render-layer flattening is now permanent (applied unconditionally at
+    -- button creation); drop the saved switch key from any earlier build.
+    self.db.global.renderFlattenEnabled = nil
 
     -- F2: seed the combat flag read by the idle-skip predicate (the skip is
     -- out-of-combat only). Maintained by OnCombatStart/OnCombatEnd; one

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -125,6 +125,11 @@ function CooldownCompanion:OnEnable()
     -- (absent key = signal enabled).
     self._cooldownDoneSignalOff = self.db.global.cooldownDoneSignalDisabled == true
 
+    -- F6: seed the render-flatten switch from saved state (absent key = OFF).
+    -- Future button roots read it at creation; SetRenderFlattenEnabled applies
+    -- it to existing buttons live.
+    self._renderFlattenOn = self.db.global.renderFlattenEnabled == true
+
     -- F2: seed the combat flag read by the idle-skip predicate (the skip is
     -- out-of-combat only). Maintained by OnCombatStart/OnCombatEnd; one
     -- InCombatLockdown() read here covers /reload-in-combat. No per-tick probe.


### PR DESCRIPTION
## What Players Will Notice
- Nothing visually — buttons look identical. Each tracker button now renders its stacked layers (icon, cooldown swipe, overlays, texts, bars) in a single render pass, which reduces per-frame rendering cost, especially with many buttons on screen.

## Why This Changed
- Part of a rendering-cost investigation: a button is a stack of overlapping regions, and the client can composite that stack in one pass via `Frame:SetFlattensRenderLayers`. The only risk is visual (overlapping semi-transparent regions can composite differently), so it was first built behind a hidden default-off switch and put through a full side-by-side visual comparison before being made permanent.

## What Changed
- The three button root frames (icon mode, bar mode, text mode) call `SetFlattensRenderLayers(true)` unconditionally at creation. The flag inherits down each button's subtree; group/container/panel frames, cast/resource bars, and config frames are untouched.
- The interim hidden switch (`SetRenderFlattenEnabled` and its plumbing) is removed — flattening is permanent, matching how the earlier idle-ticker-skip change was landed after validation. Startup clears the stale saved switch key from test builds.

## Validation
- `luac -p` clean (all 5 files); `git diff --check` clean.
- API confirmed against the game API: `Frame:SetFlattensRenderLayers(boolean)`.
- **Owner-run V1–V10 side-by-side visual matrix (switch OFF vs ON, live toggle, same scene): no visible differences** — covering icon/bar/text modes with cooldowns running, proc-overlay glow, unusable dim + desaturation (partial-alpha tint, the highest-risk compositing case), loss-of-control, bar fill/spark/text, text-mode effects, alpha fade, pandemic glow + aura textures, and target-switch hold.
- Combat/instanced smoke with flattening active is still pending as part of the owner's normal soak; flattening is C-side (no new Lua paths at runtime), so Lua-error risk is minimal.
- Render/FPS impact is owner-observed only; no performance numbers are claimed here.
