### PR TITLE
Add dev-gated watchdog that verifies event routing would never stale the display

### DIFF
--- a/CooldownCompanion/CooldownCompanion.toc
+++ b/CooldownCompanion/CooldownCompanion.toc
@@ -55,6 +55,7 @@ Core\SoundAlerts.lua
 Core\StyleOverrides.lua
 Core\RefreshTelemetry.lua
 Core\SpellButtonIndex.lua
+Core\ShadowParity.lua
 Core\CooldownRefresh.lua
 Core\Lifecycle.lua
 Core\Aura.lua

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -844,6 +844,11 @@ local function ClearReusableButtonRuntime(button)
     button._textModeSecretArgs = nil
     button._textModeSecretParts = nil
     button._savedOnUpdate = nil
+    -- D1 shadow-parity per-button caches: drop them on reuse so a recycled
+    -- frame is not diffed against the previous logical button's baseline/stamps.
+    button._shadowParityState = nil
+    button._shadowParitySigGen = nil
+    button._shadowParityCoveredBatch = nil
     button._inPandemic = nil
     if EntryRuntime and EntryRuntime.ClearAuraPandemicRuntimeState then
         EntryRuntime.ClearAuraPandemicRuntimeState(button)

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -3450,6 +3450,12 @@ function CooldownCompanion:UpdateAllCooldowns()
     -- TICKER_MAX_CONSECUTIVE_SKIPS). Covers every walk path, not just the ticker.
     self._tickerSkipStreak = 0
     if telemetryOn then
+        -- D1 shadow-parity: diff button visual signatures against the pending
+        -- event batch before RecordPass clears the pass attribution.
+        local SP = ST.ShadowParity
+        if SP and SP.enabled then
+            SP:NotePassEnd(T.pendingSource, T.pendingDetail)
+        end
         T:RecordPass(frames, buttons, debugprofilestop() - t0)
     end
 end

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -3450,13 +3450,16 @@ function CooldownCompanion:UpdateAllCooldowns()
     -- TICKER_MAX_CONSECUTIVE_SKIPS). Covers every walk path, not just the ticker.
     self._tickerSkipStreak = 0
     if telemetryOn then
+        -- Measure the broad pass alone: capture elapsed before the shadow-parity
+        -- scan so its diagnostic overhead never lands in the recorded pass time.
+        local elapsed = debugprofilestop() - t0
         -- D1 shadow-parity: diff button visual signatures against the pending
         -- event batch before RecordPass clears the pass attribution.
         local SP = ST.ShadowParity
         if SP and SP.enabled then
             SP:NotePassEnd(T.pendingSource, T.pendingDetail)
         end
-        T:RecordPass(frames, buttons, debugprofilestop() - t0)
+        T:RecordPass(frames, buttons, elapsed)
     end
 end
 

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -341,7 +341,13 @@ function CooldownCompanion:OnEnable()
     self:FinalizeContainerAnchorsToScreenOffsets()
 end
 
-function CooldownCompanion:OnCooldownStateChanged()
+function CooldownCompanion:OnCooldownStateChanged(event, ...)
+    -- D1 shadow-parity tap (dev-gated, observe-only). Event args pass through
+    -- unread here; the harness issecretvalue-checks before any read.
+    local SP = ST.ShadowParity
+    if SP and SP.enabled then
+        SP:NoteCooldownEvent(event, ...)
+    end
     self:MarkCooldownsDirty("cooldown-event")
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses
     -- the next ticker walk when no other dirty state appears afterward.
@@ -407,6 +413,11 @@ function CooldownCompanion:OnDisable()
 end
 
 function CooldownCompanion:OnChargesChanged(event, spellID, baseSpellID)
+    -- D1 shadow-parity tap (dev-gated, observe-only).
+    local SP = ST.ShadowParity
+    if SP and SP.enabled then
+        SP:NoteChargesEvent(event, spellID, baseSpellID)
+    end
     if event == "SPELL_UPDATE_USES" and spellID then
         local matchesConditionalCastCountEvent = CooldownCompanion.MatchesConditionalCastCountEvent
         local matchedCastCountButton = false

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -69,9 +69,8 @@ local STATE_GCD = CooldownLogic.STATE_GCD
 local pairs = pairs
 local ipairs = ipairs
 local type = type
-local select = select
 local floor = math.floor
-local issecretvalue = issecretvalue or function() return false end
+local issecretvalue = issecretvalue
 
 local SECRET = "\1secret"   -- placeholder for secret-typed field values
 
@@ -178,6 +177,23 @@ local BATCH_SPELL_CAP = 8
 
 local changedKeys = {}          -- per-pass scratch, reused
 
+-- Clear the pending batch and advance batch.id so any coverage stamps still
+-- sitting on buttons (button._shadowParityCoveredBatch) from the previous batch
+-- can no longer match. Called from the tail of every evaluated pass and from a
+-- manual reset, so a reset landing between an event tap and the next pass end
+-- cannot carry stale fires or stamps into the fresh window.
+local function ResetBatch()
+    batch.id = batch.id + 1
+    batch.fireCount = 0
+    batch.identityFires = 0
+    batch.broadcastFires = 0
+    batch.missFires = 0
+    batch.secretFires = 0
+    wipe(batch.events)
+    wipe(batch.idSpells)
+    wipe(batch.missSpells)
+end
+
 local function CountFire(tag)
     batch.fireCount = batch.fireCount + 1
     batch.events[tag] = (batch.events[tag] or 0) + 1
@@ -253,17 +269,32 @@ local function NoteBroadcast(event)
     CountFire(event .. ":bc")
 end
 
+-- Shared identity handling for the cooldown/charge taps. Both carry the same
+-- (spellID, baseSpellID) identity shape. NoteIdentityArg makes the primary
+-- decision (secret/unreadable -> broad-fallback, plain number -> stamp or miss,
+-- nil -> broadcast). The differing plain base is stamped as supplementary
+-- coverage ONLY when the primary was itself a readable plain number: a secret
+-- primary forces the whole fire broad with no partial coverage credit. Every
+-- read is issecretvalue-guarded before any type/compare touches the arg.
+local function NoteIdentityEvent(event, spellID, baseSpellID)
+    if not NoteIdentityArg(event, spellID) then
+        NoteBroadcast(event)
+        return
+    end
+    if not issecretvalue(spellID) and type(spellID) == "number"
+            and not issecretvalue(baseSpellID) and type(baseSpellID) == "number"
+            and baseSpellID ~= spellID then
+        StampCovered(baseSpellID)
+    end
+end
+
 -- Tap for OnCooldownStateChanged (SPELL/BAG/ACTIONBAR_UPDATE_COOLDOWN).
--- Args pass through untouched; issecretvalue is checked before any read.
+-- SPELL_UPDATE_COOLDOWN payload: spellID, baseSpellID, category,
+-- startRecoveryCategory. issecretvalue is checked before any read.
 function SP:NoteCooldownEvent(event, ...)
     if event == "SPELL_UPDATE_COOLDOWN" then
-        local spellID
-        if select("#", ...) > 0 then
-            spellID = select(1, ...)
-        end
-        if not NoteIdentityArg(event, spellID) then
-            NoteBroadcast(event)
-        end
+        local spellID, baseSpellID = ...
+        NoteIdentityEvent(event, spellID, baseSpellID)
     else
         NoteBroadcast(event)
     end
@@ -272,15 +303,7 @@ end
 -- Tap for OnChargesChanged (SPELL_UPDATE_CHARGES / SPELL_UPDATE_USES).
 function SP:NoteChargesEvent(event, spellID, baseSpellID)
     if event == "SPELL_UPDATE_USES" then
-        if not NoteIdentityArg(event, spellID) then
-            NoteBroadcast(event)
-        end
-        -- Also cover the base spell when it differs. Never compare against
-        -- spellID unless both are known non-secret plain values.
-        if not issecretvalue(baseSpellID) and type(baseSpellID) == "number"
-                and (issecretvalue(spellID) or baseSpellID ~= spellID) then
-            StampCovered(baseSpellID)
-        end
+        NoteIdentityEvent(event, spellID, baseSpellID)
     else
         NoteBroadcast(event)
     end
@@ -488,15 +511,7 @@ function SP:NotePassEnd(passSource, passDetail)
                 self.broadcastSilentPasses = self.broadcastSilentPasses + 1
             end
         end
-        batch.id = batch.id + 1
-        batch.fireCount = 0
-        batch.identityFires = 0
-        batch.broadcastFires = 0
-        batch.missFires = 0
-        batch.secretFires = 0
-        wipe(batch.events)
-        wipe(batch.idSpells)
-        wipe(batch.missSpells)
+        ResetBatch()
     end
 end
 
@@ -572,6 +587,8 @@ function CooldownCompanion:ResetShadowParity()
     SP.logTotal = 0
     wipe(SP.log)
     wipe(SP.fireCounts)
+    -- Drop any in-flight batch too, so a reset mid-window starts clean.
+    ResetBatch()
 end
 
 function CooldownCompanion:PrintShadowParitySummary()

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -40,12 +40,19 @@
     (shadowParityMismatchTotal, per-family) — the number Gate 2 requires to
     be zero across the D7 matrix.
 
+    Index-miss identity fires (spells no button tracks — most of the
+    spellbook fires SPELL_UPDATE_COOLDOWN) are what the intended router
+    DROPS. Batches of identity + miss fires get their own mismatch counter
+    (mismatchDropOnly): a core change there means a dropped fire may have
+    mattered, i.e. the index was stale for a tracked identity. Secret or
+    unreadable args instead force the broad path (never mismatch-eligible).
+
     Broadcast demotion evidence (the Gate 1 question): batches containing
     broadcast fires (ACTIONBAR/BAG_UPDATE_COOLDOWN, no-arg
-    SPELL_UPDATE_COOLDOWN, SPELL_UPDATE_CHARGES) are not mismatch-eligible —
-    Phase 3 keeps broadcasts on the broad path — but are measured instead:
-    did the broad pass change any uncovered cooldown-core state
-    (broadcastCarriedChanges) or not (broadcastSilentPasses)?
+    SPELL_UPDATE_COOLDOWN, SPELL_UPDATE_CHARGES) or secret args are not
+    mismatch-eligible — Phase 3 keeps those on the broad path — but are
+    measured instead: did the broad pass change any uncovered cooldown-core
+    state (broadcastCarriedChanges) or not (broadcastSilentPasses)?
 
     Owner-runnable:
       /run CooldownCompanion:PrintShadowParitySummary()
@@ -120,14 +127,17 @@ local SP = {
     -- pass counters
     passTotal = 0,              -- every completed broad pass (signature refresh)
     passesEvaluated = 0,        -- passes that consumed a non-empty event batch
-    passesIdentityOnly = 0,
-    passesWithBroadcast = 0,
-    -- event fire counters (lifetime, by "EVENT:id|bc|fb" tag)
+    passesIdentityOnly = 0,     -- batch was pure tracked-identity fires
+    passesDropOnly = 0,         -- identity + index-miss fires only (router
+                                -- would route the hits and drop the misses)
+    passesWithBroadcast = 0,    -- batch forces the broad path (broadcast or
+                                -- secret/unreadable arg)
+    -- event fire counters (lifetime, by "EVENT:id|bc|miss|secret" tag)
     fireCounts = {},
     identityFireTotal = 0,
     broadcastFireTotal = 0,
-    fallbackFireTotal = 0,      -- identity events routing could not route
-                                -- (secret arg or index miss -> broad fallback)
+    missFireTotal = 0,          -- identity fires for untracked spells (dropped)
+    secretFireTotal = 0,        -- secret/unreadable args (broad fallback)
     -- per-button change classifications on evaluated passes
     routedCoveredChanges = 0,   -- changed AND covered: routing caught it
     crossFamilyChanges = 0,
@@ -137,6 +147,9 @@ local SP = {
     shadowParityMismatchTotal = 0,
     mismatchCooldown = 0,
     mismatchCharges = 0,
+    mismatchDropOnly = 0,       -- core change in an identity+miss batch: a
+                                -- dropped fire may have mattered (drop-safety
+                                -- evidence, kept separate from the pure counter)
     -- Gate 1 broadcast-demotion evidence
     broadcastCarriedChanges = 0,
     broadcastSilentPasses = 0,
@@ -154,7 +167,8 @@ local batch = {
     fireCount = 0,
     identityFires = 0,
     broadcastFires = 0,
-    fallbackFires = 0,
+    missFires = 0,
+    secretFires = 0,
     events = {},                -- tag -> count for the current batch
 }
 
@@ -180,18 +194,30 @@ local function StampCovered(spellID)
     return true
 end
 
-local function CountFallback(event)
-    batch.fallbackFires = batch.fallbackFires + 1
-    SP.fallbackFireTotal = SP.fallbackFireTotal + 1
-    CountFire(event .. ":fb")
+-- Secret or non-number identity arg: the router cannot inspect it and must
+-- broad-fallback. Batches containing these are never mismatch-eligible.
+local function CountSecret(event)
+    batch.secretFires = batch.secretFires + 1
+    SP.secretFireTotal = SP.secretFireTotal + 1
+    CountFire(event .. ":secret")
 end
 
--- Identity-arg fire: stamp coverage, or degrade to a broad-fallback fire when
--- the router could not have routed it (secret arg, non-number, index miss).
--- issecretvalue runs before any other operation touches the arg.
+-- Identity fire naming a spell no button tracks (index miss). The intended
+-- router DROPS these — most SPELL_UPDATE_COOLDOWN fires name untracked
+-- spellbook spells. Whether dropping is safe is exactly what the drop-batch
+-- mismatch counter (mismatchDropOnly) tests: a stale-index miss on a spell a
+-- button DOES track would surface there.
+local function CountMiss(event)
+    batch.missFires = batch.missFires + 1
+    SP.missFireTotal = SP.missFireTotal + 1
+    CountFire(event .. ":miss")
+end
+
+-- Identity-arg fire. issecretvalue runs before any other operation touches
+-- the arg.
 local function NoteIdentityArg(event, spellID)
     if issecretvalue(spellID) then
-        CountFallback(event)
+        CountSecret(event)
         return true
     end
     if type(spellID) == "number" then
@@ -200,12 +226,12 @@ local function NoteIdentityArg(event, spellID)
             SP.identityFireTotal = SP.identityFireTotal + 1
             CountFire(event .. ":id")
         else
-            CountFallback(event)
+            CountMiss(event)
         end
         return true
     end
     if spellID ~= nil then
-        CountFallback(event)
+        CountSecret(event)
         return true
     end
     return false
@@ -361,9 +387,9 @@ function SP:NotePassEnd(passSource, passDetail)
     self.passTotal = self.passTotal + 1
 
     local evaluate = batch.fireCount > 0
-    local identityOnly = evaluate
-        and batch.broadcastFires == 0
-        and batch.fallbackFires == 0
+    local broadRequired = batch.broadcastFires > 0 or batch.secretFires > 0
+    local identityOnly = evaluate and not broadRequired and batch.missFires == 0
+    local dropOnly = evaluate and not broadRequired and not identityOnly
     local uncoveredCoreChanges = 0
     local source = passDetail or passSource
 
@@ -397,6 +423,10 @@ function SP:NotePassEnd(passSource, passDetail)
                                 end
                                 uncoveredCoreChanges = uncoveredCoreChanges + 1
                                 LogChange("MISMATCH", source, button, changedCount)
+                            elseif dropOnly then
+                                self.mismatchDropOnly = self.mismatchDropOnly + 1
+                                uncoveredCoreChanges = uncoveredCoreChanges + 1
+                                LogChange("DROPMISS", source, button, changedCount)
                             else
                                 -- broadcasts stay on the broad path in Phase 3;
                                 -- this is demotion evidence, not a mismatch
@@ -415,6 +445,8 @@ function SP:NotePassEnd(passSource, passDetail)
         self.passesEvaluated = self.passesEvaluated + 1
         if identityOnly then
             self.passesIdentityOnly = self.passesIdentityOnly + 1
+        elseif dropOnly then
+            self.passesDropOnly = self.passesDropOnly + 1
         else
             self.passesWithBroadcast = self.passesWithBroadcast + 1
             if uncoveredCoreChanges == 0 then
@@ -425,7 +457,8 @@ function SP:NotePassEnd(passSource, passDetail)
         batch.fireCount = 0
         batch.identityFires = 0
         batch.broadcastFires = 0
-        batch.fallbackFires = 0
+        batch.missFires = 0
+        batch.secretFires = 0
         wipe(batch.events)
     end
 end
@@ -451,10 +484,12 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         passTotal = SP.passTotal,
         passesEvaluated = SP.passesEvaluated,
         passesIdentityOnly = SP.passesIdentityOnly,
+        passesDropOnly = SP.passesDropOnly,
         passesWithBroadcast = SP.passesWithBroadcast,
         identityFireTotal = SP.identityFireTotal,
         broadcastFireTotal = SP.broadcastFireTotal,
-        fallbackFireTotal = SP.fallbackFireTotal,
+        missFireTotal = SP.missFireTotal,
+        secretFireTotal = SP.secretFireTotal,
         routedCoveredChanges = SP.routedCoveredChanges,
         crossFamilyChanges = SP.crossFamilyChanges,
         usabilityChanges = SP.usabilityChanges,
@@ -463,6 +498,7 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         shadowParityMismatchTotal = SP.shadowParityMismatchTotal,
         mismatchCooldown = SP.mismatchCooldown,
         mismatchCharges = SP.mismatchCharges,
+        mismatchDropOnly = SP.mismatchDropOnly,
         broadcastCarriedChanges = SP.broadcastCarriedChanges,
         broadcastSilentPasses = SP.broadcastSilentPasses,
         secretFieldSeen = SP.secretFieldSeen,
@@ -477,10 +513,12 @@ function CooldownCompanion:ResetShadowParity()
     SP.passTotal = 0
     SP.passesEvaluated = 0
     SP.passesIdentityOnly = 0
+    SP.passesDropOnly = 0
     SP.passesWithBroadcast = 0
     SP.identityFireTotal = 0
     SP.broadcastFireTotal = 0
-    SP.fallbackFireTotal = 0
+    SP.missFireTotal = 0
+    SP.secretFireTotal = 0
     SP.routedCoveredChanges = 0
     SP.crossFamilyChanges = 0
     SP.usabilityChanges = 0
@@ -489,6 +527,7 @@ function CooldownCompanion:ResetShadowParity()
     SP.shadowParityMismatchTotal = 0
     SP.mismatchCooldown = 0
     SP.mismatchCharges = 0
+    SP.mismatchDropOnly = 0
     SP.broadcastCarriedChanges = 0
     SP.broadcastSilentPasses = 0
     SP.secretFieldSeen = 0
@@ -499,13 +538,13 @@ function CooldownCompanion:ResetShadowParity()
 end
 
 function CooldownCompanion:PrintShadowParitySummary()
-    self:Print(("ShadowParity: %d passes, %d evaluated (%d identity-only, %d w/broadcast) | MISMATCH %d (cd %d, ch %d) | noise: gcd %d, expiry %d, cross %d, usab %d | covered %d | bcast carried %d, silent %d | fires id %d, bc %d, fb %d"):format(
-        SP.passTotal, SP.passesEvaluated, SP.passesIdentityOnly, SP.passesWithBroadcast,
-        SP.shadowParityMismatchTotal, SP.mismatchCooldown, SP.mismatchCharges,
+    self:Print(("ShadowParity: %d passes, %d evaluated (%d pure-id, %d id+miss, %d broad) | MISMATCH %d (cd %d, ch %d) dropMISM %d | noise: gcd %d, expiry %d, cross %d, usab %d | covered %d | bcast carried %d, silent %d | fires id %d, miss %d, bc %d, secret %d"):format(
+        SP.passTotal, SP.passesEvaluated, SP.passesIdentityOnly, SP.passesDropOnly, SP.passesWithBroadcast,
+        SP.shadowParityMismatchTotal, SP.mismatchCooldown, SP.mismatchCharges, SP.mismatchDropOnly,
         SP.gcdSettleChanges, SP.expirySettleChanges, SP.crossFamilyChanges, SP.usabilityChanges,
         SP.routedCoveredChanges,
         SP.broadcastCarriedChanges, SP.broadcastSilentPasses,
-        SP.identityFireTotal, SP.broadcastFireTotal, SP.fallbackFireTotal))
+        SP.identityFireTotal, SP.missFireTotal, SP.broadcastFireTotal, SP.secretFireTotal))
     if SP.shadowParityMismatchTotal > 0 then
         self:Print("ShadowParity: mismatches logged — /dump CooldownCompanion:GetShadowParityDiagnostics()")
     end

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -349,6 +349,7 @@ end
 local function Classify(changedCount, oldCd, newCd)
     local coreCount = 0
     local onlyTint = true
+    local onlyGsup = true
     local cdChanged = false
     local gcdOk, expiryOk, chargeOnly = true, true, true
     for i = 1, changedCount do
@@ -357,6 +358,7 @@ local function Classify(changedCount, oldCd, newCd)
             coreCount = coreCount + 1
             if key == "cd" then cdChanged = true end
             if key ~= "tint" then onlyTint = false end
+            if key ~= "gsup" then onlyGsup = false end
             if not GCD_SHAPE[key] then gcdOk = false end
             if not EXPIRY_SHAPE[key] then expiryOk = false end
             if not CHARGE_ONLY[key] then chargeOnly = false end
@@ -367,6 +369,12 @@ local function Classify(changedCount, oldCd, newCd)
     end
     if onlyTint then
         return "usability"
+    end
+    if onlyGsup then
+        -- _barGCDSuppressed flips only with GCD activity (A1 shared
+        -- snapshot); a gsup-only change is GCD settle even when the
+        -- cooldown state itself did not change this pass.
+        return "gcd"
     end
     if cdChanged and gcdOk and (oldCd == STATE_GCD or newCd == STATE_GCD) then
         return "gcd"

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -1,0 +1,516 @@
+--[[
+    CooldownCompanion - Core/ShadowParity.lua: D1 shadow-parity harness
+    (F1 program Phase 2). Observe-only; never alters refresh behavior.
+
+    Question it answers: if identity-carrying cooldown/charge events were
+    routed through the SpellButtonIndex (updating only matching buttons)
+    instead of triggering today's broad walk, would any button's visuals have
+    been left stale? Every routable event stamps the buttons routing WOULD
+    have updated; the broad pass then runs unchanged; after the pass, any
+    uncovered button whose visual state changed is classified.
+
+    Dev-gated like RefreshTelemetry: enabled at PLAYER_LOGIN only when the
+    CC_DevBridge dev addon is loaded. Inert otherwise (one table lookup and
+    branch per tapped event/pass).
+
+    Signature fields are the always-maintained per-button state caches — the
+    same fields VisualStateDiagnostics compares as authoritative. The
+    intent/applied sidecar tables are NOT used here: they are only stored
+    while visual-state snapshot capture is on, so they cannot back an
+    every-pass diff. No time-varying numbers are included (remaining-time
+    animation happens in OnUpdate self-animation, not these fields);
+    visibility alpha is quantized to hundredths.
+
+    Expected-noise classes (counted separately so the hard mismatch counter
+    can meaningfully reach and hold zero, mirroring falseIdleTotal):
+    - cross-family: only proc/aura-glow/pandemic/visibility fields changed.
+      Those families are not being routed (aura/target is last-or-never);
+      the broad pass applied their pending state opportunistically.
+    - usability: only the unusable tint changed. Usability is polled per
+      pass with no identity event; the in-combat ticker re-applies it within
+      ~0.1s in a routed world. Latency-only, never lost state.
+    - gcd-settle: a cooldown-state transition into/out of STATE_GCD with only
+      GCD-shaped fields changed. GCD display is the per-pass shared snapshot
+      (D4 inventory A1); routed mini-passes snapshot it per batch and the
+      ticker settles the rest.
+    - expiry-settle: a cooldown-state transition to STATE_READY with only
+      expiry-shaped fields changed. Cooldown expiry is event-covered by F3's
+      OnCooldownDone signal independent of broadcasts.
+    Anything else on an uncovered button is a HARD MISMATCH
+    (shadowParityMismatchTotal, per-family) — the number Gate 2 requires to
+    be zero across the D7 matrix.
+
+    Broadcast demotion evidence (the Gate 1 question): batches containing
+    broadcast fires (ACTIONBAR/BAG_UPDATE_COOLDOWN, no-arg
+    SPELL_UPDATE_COOLDOWN, SPELL_UPDATE_CHARGES) are not mismatch-eligible —
+    Phase 3 keeps broadcasts on the broad path — but are measured instead:
+    did the broad pass change any uncovered cooldown-core state
+    (broadcastCarriedChanges) or not (broadcastSilentPasses)?
+
+    Owner-runnable:
+      /run CooldownCompanion:PrintShadowParitySummary()
+      /run CooldownCompanion:ResetShadowParity()
+      /dump CooldownCompanion:GetShadowParityDiagnostics()
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+local CooldownLogic = ST.CooldownLogic or {}
+local STATE_READY = CooldownLogic.STATE_READY
+local STATE_GCD = CooldownLogic.STATE_GCD
+
+local pairs = pairs
+local ipairs = ipairs
+local type = type
+local select = select
+local floor = math.floor
+local issecretvalue = issecretvalue or function() return false end
+
+local SECRET = "\1secret"   -- placeholder for secret-typed field values
+
+-- Signature fields: { shortKey, buttonField }. Short keys name the changed
+-- fields in log lines and drive the classification sets below.
+local FIELDS = {
+    { "cd",          "_cooldownState" },
+    { "desatCd",     "_desatCooldownActive" },
+    { "desat",       "_desaturated" },
+    { "charge",      "_chargeState" },
+    { "chargeRe",    "_chargeRecharging" },
+    { "chargeSpent", "_chargesSpent" },
+    { "nocd",        "_noCooldown" },
+    { "tint",        "_unusableTintActive" },
+    { "fill",        "_iconFillActive" },
+    { "fillMode",    "_iconFillMode" },
+    { "fillAura",    "_iconFillAuraActive" },
+    { "fillUpd",     "_iconFillOnUpdateInstalled" },
+    { "proc",        "_procGlowActive" },
+    { "aglow",       "_auraGlowActive" },
+    { "pand",        "_auraGlowPandemic" },
+    { "ready",       "_readyGlowActive" },
+    { "hid",         "_visibilityHidden" },
+    { "alpha",       "_visibilityAlphaOverride" },
+    { "vmode",       "_visibilityFinalMode" },
+    { "gsup",        "_barGCDSuppressed" },
+}
+local FIELD_COUNT = #FIELDS
+
+-- Fields owned by families this program is not routing (aura/proc/visibility).
+local CROSS_FAMILY = {
+    proc = true, aglow = true, pand = true, fillAura = true,
+    hid = true, alpha = true, vmode = true,
+}
+-- Fields a GCD start/end legitimately flips across all buttons (A1 aggregate).
+local GCD_SHAPE = {
+    cd = true, desatCd = true, desat = true, gsup = true,
+    fill = true, fillMode = true, fillUpd = true, ready = true, tint = true,
+}
+-- Fields a cooldown/charge expiry legitimately flips (F3-covered).
+local EXPIRY_SHAPE = {
+    cd = true, desatCd = true, desat = true, ready = true,
+    fill = true, fillMode = true, fillUpd = true,
+    charge = true, chargeRe = true, chargeSpent = true, nocd = true, tint = true,
+}
+local CHARGE_ONLY = { charge = true, chargeRe = true, chargeSpent = true }
+
+local LOG_SIZE = 64
+
+local SP = {
+    enabled = false,
+    passGen = 0,
+    -- pass counters
+    passTotal = 0,              -- every completed broad pass (signature refresh)
+    passesEvaluated = 0,        -- passes that consumed a non-empty event batch
+    passesIdentityOnly = 0,
+    passesWithBroadcast = 0,
+    -- event fire counters (lifetime, by "EVENT:id|bc|fb" tag)
+    fireCounts = {},
+    identityFireTotal = 0,
+    broadcastFireTotal = 0,
+    fallbackFireTotal = 0,      -- identity events routing could not route
+                                -- (secret arg or index miss -> broad fallback)
+    -- per-button change classifications on evaluated passes
+    routedCoveredChanges = 0,   -- changed AND covered: routing caught it
+    crossFamilyChanges = 0,
+    usabilityChanges = 0,
+    gcdSettleChanges = 0,
+    expirySettleChanges = 0,
+    shadowParityMismatchTotal = 0,
+    mismatchCooldown = 0,
+    mismatchCharges = 0,
+    -- Gate 1 broadcast-demotion evidence
+    broadcastCarriedChanges = 0,
+    broadcastSilentPasses = 0,
+    secretFieldSeen = 0,
+    -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
+    log = {},
+    logCursor = 0,
+    logTotal = 0,
+}
+ST.ShadowParity = SP
+
+-- Pending event batch: everything fired since the last completed broad pass.
+local batch = {
+    id = 1,
+    fireCount = 0,
+    identityFires = 0,
+    broadcastFires = 0,
+    fallbackFires = 0,
+    events = {},                -- tag -> count for the current batch
+}
+
+local changedKeys = {}          -- per-pass scratch, reused
+
+local function CountFire(tag)
+    batch.fireCount = batch.fireCount + 1
+    batch.events[tag] = (batch.events[tag] or 0) + 1
+    SP.fireCounts[tag] = (SP.fireCounts[tag] or 0) + 1
+end
+
+-- Stamp every button the D3 index maps this spellID to as covered by the
+-- current batch. Returns true when at least one button was stamped.
+local function StampCovered(spellID)
+    local index = CooldownCompanion:GetSpellButtonIndex()
+    local bucket = index.spell[spellID]
+    if not bucket then
+        return false
+    end
+    for _, button in ipairs(bucket) do
+        button._shadowParityCoveredBatch = batch.id
+    end
+    return true
+end
+
+-- Identity-arg fire: stamp coverage, or degrade to a broad-fallback fire when
+-- the router could not have routed it (secret arg, non-number, index miss).
+local function NoteIdentityArg(event, spellID)
+    if spellID ~= nil and not issecretvalue(spellID)
+            and type(spellID) == "number" then
+        if StampCovered(spellID) then
+            batch.identityFires = batch.identityFires + 1
+            SP.identityFireTotal = SP.identityFireTotal + 1
+            CountFire(event .. ":id")
+        else
+            batch.fallbackFires = batch.fallbackFires + 1
+            SP.fallbackFireTotal = SP.fallbackFireTotal + 1
+            CountFire(event .. ":fb")
+        end
+        return true
+    end
+    if spellID ~= nil then
+        -- secret or non-number arg: router must broad-fallback
+        batch.fallbackFires = batch.fallbackFires + 1
+        SP.fallbackFireTotal = SP.fallbackFireTotal + 1
+        CountFire(event .. ":fb")
+        return true
+    end
+    return false
+end
+
+local function NoteBroadcast(event)
+    batch.broadcastFires = batch.broadcastFires + 1
+    SP.broadcastFireTotal = SP.broadcastFireTotal + 1
+    CountFire(event .. ":bc")
+end
+
+-- Tap for OnCooldownStateChanged (SPELL/BAG/ACTIONBAR_UPDATE_COOLDOWN).
+-- Args pass through untouched; issecretvalue is checked before any read.
+function SP:NoteCooldownEvent(event, ...)
+    if event == "SPELL_UPDATE_COOLDOWN" then
+        local spellID
+        if select("#", ...) > 0 then
+            spellID = select(1, ...)
+        end
+        if not NoteIdentityArg(event, spellID) then
+            NoteBroadcast(event)
+        end
+    else
+        NoteBroadcast(event)
+    end
+end
+
+-- Tap for OnChargesChanged (SPELL_UPDATE_CHARGES / SPELL_UPDATE_USES).
+function SP:NoteChargesEvent(event, spellID, baseSpellID)
+    if event == "SPELL_UPDATE_USES" then
+        if not NoteIdentityArg(event, spellID) then
+            NoteBroadcast(event)
+        elseif baseSpellID ~= nil and not issecretvalue(baseSpellID)
+                and type(baseSpellID) == "number" and baseSpellID ~= spellID then
+            StampCovered(baseSpellID)
+        end
+    else
+        NoteBroadcast(event)
+    end
+end
+
+local function DescribeButton(button)
+    local buttonData = button.buttonData
+    local groupId = button._groupId or (button:GetParent() and button:GetParent().groupId)
+    return ("%s#%s:%s:%s"):format(
+        tostring(groupId),
+        tostring(button.index),
+        tostring(buttonData and buttonData.type),
+        tostring(buttonData and (buttonData.id or buttonData.itemSlot)))
+end
+
+local function BatchSummary()
+    local parts, n = {}, 0
+    for tag, count in pairs(batch.events) do
+        n = n + 1
+        parts[n] = tag .. "x" .. count
+    end
+    return table.concat(parts, ",", 1, n)
+end
+
+local function LogChange(kind, passSource, button, changedCount)
+    local cursor = SP.logCursor % LOG_SIZE + 1
+    SP.logCursor = cursor
+    SP.logTotal = SP.logTotal + 1
+    SP.log[cursor] = ("%.1f|%s|%s|%s|%s|%s"):format(
+        GetTime(), kind, tostring(passSource),
+        BatchSummary(), DescribeButton(button),
+        table.concat(changedKeys, ",", 1, changedCount))
+end
+
+-- Read the signature fields into the button's reusable state table and
+-- collect changed short keys into the shared scratch. When suppress is true
+-- (first observation, or the button was not observed in the immediately
+-- previous pass — new button, frame re-shown) the baseline is refreshed
+-- without reporting changes.
+local function ObserveButton(button, suppress)
+    local st = button._shadowParityState
+    if not st then
+        st = {}
+        button._shadowParityState = st
+        suppress = true
+    end
+    local changedCount = 0
+    local oldCd, newCd
+    for i = 1, FIELD_COUNT do
+        local field = FIELDS[i]
+        local key = field[1]
+        local value = button[field[2]]
+        if issecretvalue(value) then
+            SP.secretFieldSeen = SP.secretFieldSeen + 1
+            value = SECRET
+        elseif key == "alpha" and type(value) == "number" then
+            value = floor(value * 100 + 0.5)
+        end
+        if key == "cd" then
+            oldCd = st.cd
+            newCd = value
+        end
+        if st[key] ~= value then
+            if not suppress then
+                changedCount = changedCount + 1
+                changedKeys[changedCount] = key
+            end
+            st[key] = value
+        end
+    end
+    return changedCount, oldCd, newCd
+end
+
+-- Classify an uncovered button's change set. Returns "cross", "usability",
+-- "gcd", "expiry", or "core" (+ family "cooldown"/"charges" for "core").
+local function Classify(changedCount, oldCd, newCd)
+    local coreCount = 0
+    local onlyTint = true
+    local cdChanged = false
+    local gcdOk, expiryOk, chargeOnly = true, true, true
+    for i = 1, changedCount do
+        local key = changedKeys[i]
+        if not CROSS_FAMILY[key] then
+            coreCount = coreCount + 1
+            if key == "cd" then cdChanged = true end
+            if key ~= "tint" then onlyTint = false end
+            if not GCD_SHAPE[key] then gcdOk = false end
+            if not EXPIRY_SHAPE[key] then expiryOk = false end
+            if not CHARGE_ONLY[key] then chargeOnly = false end
+        end
+    end
+    if coreCount == 0 then
+        return "cross"
+    end
+    if onlyTint then
+        return "usability"
+    end
+    if cdChanged and gcdOk and (oldCd == STATE_GCD or newCd == STATE_GCD) then
+        return "gcd"
+    end
+    if cdChanged and expiryOk and newCd == STATE_READY then
+        return "expiry"
+    end
+    return "core", chargeOnly and "charges" or "cooldown"
+end
+
+-- Called from the tail of every UpdateAllCooldowns pass (before telemetry's
+-- RecordPass clears its pending attribution). Refreshes every visible
+-- button's signature; when the pass consumed a pending event batch, changed
+-- uncovered buttons are classified and counted.
+function SP:NotePassEnd(passSource, passDetail)
+    local passGen = self.passGen + 1
+    self.passGen = passGen
+    self.passTotal = self.passTotal + 1
+
+    local evaluate = batch.fireCount > 0
+    local identityOnly = evaluate
+        and batch.broadcastFires == 0
+        and batch.fallbackFires == 0
+    local uncoveredCoreChanges = 0
+    local source = passDetail or passSource
+
+    for _, frame in pairs(CooldownCompanion.groupFrames) do
+        if frame and frame.UpdateCooldowns and frame.buttons and frame:IsShown() then
+            for _, button in ipairs(frame.buttons) do
+                local buttonData = button.buttonData
+                if buttonData and buttonData._rotationAssistantVirtual ~= true then
+                    local suppress = button._shadowParitySigGen ~= passGen - 1
+                    local changedCount, oldCd, newCd = ObserveButton(button, suppress)
+                    button._shadowParitySigGen = passGen
+                    if evaluate and changedCount > 0 then
+                        if button._shadowParityCoveredBatch == batch.id then
+                            self.routedCoveredChanges = self.routedCoveredChanges + 1
+                        else
+                            local class, family = Classify(changedCount, oldCd, newCd)
+                            if class == "cross" then
+                                self.crossFamilyChanges = self.crossFamilyChanges + 1
+                            elseif class == "usability" then
+                                self.usabilityChanges = self.usabilityChanges + 1
+                            elseif class == "gcd" then
+                                self.gcdSettleChanges = self.gcdSettleChanges + 1
+                            elseif class == "expiry" then
+                                self.expirySettleChanges = self.expirySettleChanges + 1
+                            elseif identityOnly then
+                                self.shadowParityMismatchTotal = self.shadowParityMismatchTotal + 1
+                                if family == "charges" then
+                                    self.mismatchCharges = self.mismatchCharges + 1
+                                else
+                                    self.mismatchCooldown = self.mismatchCooldown + 1
+                                end
+                                uncoveredCoreChanges = uncoveredCoreChanges + 1
+                                LogChange("MISMATCH", source, button, changedCount)
+                            else
+                                -- broadcasts stay on the broad path in Phase 3;
+                                -- this is demotion evidence, not a mismatch
+                                self.broadcastCarriedChanges = self.broadcastCarriedChanges + 1
+                                uncoveredCoreChanges = uncoveredCoreChanges + 1
+                                LogChange("BCARRY", source, button, changedCount)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    if evaluate then
+        self.passesEvaluated = self.passesEvaluated + 1
+        if identityOnly then
+            self.passesIdentityOnly = self.passesIdentityOnly + 1
+        else
+            self.passesWithBroadcast = self.passesWithBroadcast + 1
+            if uncoveredCoreChanges == 0 then
+                self.broadcastSilentPasses = self.broadcastSilentPasses + 1
+            end
+        end
+        batch.id = batch.id + 1
+        batch.fireCount = 0
+        batch.identityFires = 0
+        batch.broadcastFires = 0
+        batch.fallbackFires = 0
+        wipe(batch.events)
+    end
+end
+
+function CooldownCompanion:GetShadowParity()
+    return SP
+end
+
+-- SV-safe copy (scalars + string tables only; no frame references).
+function CooldownCompanion:GetShadowParityDiagnostics()
+    local fires = {}
+    for tag, count in pairs(SP.fireCounts) do
+        fires[tag] = count
+    end
+    local log = {}
+    for i = 1, LOG_SIZE do
+        if SP.log[i] then
+            log[#log + 1] = SP.log[i]
+        end
+    end
+    return {
+        enabled = SP.enabled,
+        passTotal = SP.passTotal,
+        passesEvaluated = SP.passesEvaluated,
+        passesIdentityOnly = SP.passesIdentityOnly,
+        passesWithBroadcast = SP.passesWithBroadcast,
+        identityFireTotal = SP.identityFireTotal,
+        broadcastFireTotal = SP.broadcastFireTotal,
+        fallbackFireTotal = SP.fallbackFireTotal,
+        routedCoveredChanges = SP.routedCoveredChanges,
+        crossFamilyChanges = SP.crossFamilyChanges,
+        usabilityChanges = SP.usabilityChanges,
+        gcdSettleChanges = SP.gcdSettleChanges,
+        expirySettleChanges = SP.expirySettleChanges,
+        shadowParityMismatchTotal = SP.shadowParityMismatchTotal,
+        mismatchCooldown = SP.mismatchCooldown,
+        mismatchCharges = SP.mismatchCharges,
+        broadcastCarriedChanges = SP.broadcastCarriedChanges,
+        broadcastSilentPasses = SP.broadcastSilentPasses,
+        secretFieldSeen = SP.secretFieldSeen,
+        logTotal = SP.logTotal,
+        fireCounts = fires,
+        log = log,
+    }
+end
+
+function CooldownCompanion:ResetShadowParity()
+    -- passGen keeps running (baseline continuity survives a reset)
+    SP.passTotal = 0
+    SP.passesEvaluated = 0
+    SP.passesIdentityOnly = 0
+    SP.passesWithBroadcast = 0
+    SP.identityFireTotal = 0
+    SP.broadcastFireTotal = 0
+    SP.fallbackFireTotal = 0
+    SP.routedCoveredChanges = 0
+    SP.crossFamilyChanges = 0
+    SP.usabilityChanges = 0
+    SP.gcdSettleChanges = 0
+    SP.expirySettleChanges = 0
+    SP.shadowParityMismatchTotal = 0
+    SP.mismatchCooldown = 0
+    SP.mismatchCharges = 0
+    SP.broadcastCarriedChanges = 0
+    SP.broadcastSilentPasses = 0
+    SP.secretFieldSeen = 0
+    SP.logCursor = 0
+    SP.logTotal = 0
+    wipe(SP.log)
+    wipe(SP.fireCounts)
+end
+
+function CooldownCompanion:PrintShadowParitySummary()
+    self:Print(("ShadowParity: %d passes, %d evaluated (%d identity-only, %d w/broadcast) | MISMATCH %d (cd %d, ch %d) | noise: gcd %d, expiry %d, cross %d, usab %d | covered %d | bcast carried %d, silent %d | fires id %d, bc %d, fb %d"):format(
+        SP.passTotal, SP.passesEvaluated, SP.passesIdentityOnly, SP.passesWithBroadcast,
+        SP.shadowParityMismatchTotal, SP.mismatchCooldown, SP.mismatchCharges,
+        SP.gcdSettleChanges, SP.expirySettleChanges, SP.crossFamilyChanges, SP.usabilityChanges,
+        SP.routedCoveredChanges,
+        SP.broadcastCarriedChanges, SP.broadcastSilentPasses,
+        SP.identityFireTotal, SP.broadcastFireTotal, SP.fallbackFireTotal))
+    if SP.shadowParityMismatchTotal > 0 then
+        self:Print("ShadowParity: mismatches logged — /dump CooldownCompanion:GetShadowParityDiagnostics()")
+    end
+end
+
+-- Gate: enable only when the CC_DevBridge dev addon is present (same pattern
+-- and reason as RefreshTelemetry).
+local gateFrame = CreateFrame("Frame")
+gateFrame:RegisterEvent("PLAYER_LOGIN")
+gateFrame:SetScript("OnEvent", function(frame)
+    frame:UnregisterAllEvents()
+    local _, loaded = C_AddOns.IsAddOnLoaded("CC_DevBridge")
+    if loaded then
+        SP.enabled = true
+    end
+end)

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -180,27 +180,32 @@ local function StampCovered(spellID)
     return true
 end
 
+local function CountFallback(event)
+    batch.fallbackFires = batch.fallbackFires + 1
+    SP.fallbackFireTotal = SP.fallbackFireTotal + 1
+    CountFire(event .. ":fb")
+end
+
 -- Identity-arg fire: stamp coverage, or degrade to a broad-fallback fire when
 -- the router could not have routed it (secret arg, non-number, index miss).
+-- issecretvalue runs before any other operation touches the arg.
 local function NoteIdentityArg(event, spellID)
-    if spellID ~= nil and not issecretvalue(spellID)
-            and type(spellID) == "number" then
+    if issecretvalue(spellID) then
+        CountFallback(event)
+        return true
+    end
+    if type(spellID) == "number" then
         if StampCovered(spellID) then
             batch.identityFires = batch.identityFires + 1
             SP.identityFireTotal = SP.identityFireTotal + 1
             CountFire(event .. ":id")
         else
-            batch.fallbackFires = batch.fallbackFires + 1
-            SP.fallbackFireTotal = SP.fallbackFireTotal + 1
-            CountFire(event .. ":fb")
+            CountFallback(event)
         end
         return true
     end
     if spellID ~= nil then
-        -- secret or non-number arg: router must broad-fallback
-        batch.fallbackFires = batch.fallbackFires + 1
-        SP.fallbackFireTotal = SP.fallbackFireTotal + 1
-        CountFire(event .. ":fb")
+        CountFallback(event)
         return true
     end
     return false
@@ -233,8 +238,11 @@ function SP:NoteChargesEvent(event, spellID, baseSpellID)
     if event == "SPELL_UPDATE_USES" then
         if not NoteIdentityArg(event, spellID) then
             NoteBroadcast(event)
-        elseif baseSpellID ~= nil and not issecretvalue(baseSpellID)
-                and type(baseSpellID) == "number" and baseSpellID ~= spellID then
+        end
+        -- Also cover the base spell when it differs. Never compare against
+        -- spellID unless both are known non-secret plain values.
+        if not issecretvalue(baseSpellID) and type(baseSpellID) == "number"
+                and (issecretvalue(spellID) or baseSpellID ~= spellID) then
             StampCovered(baseSpellID)
         end
     else

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -170,7 +170,11 @@ local batch = {
     missFires = 0,
     secretFires = 0,
     events = {},                -- tag -> count for the current batch
+    idSpells = {},              -- identity spellIDs this batch (capped, for logs)
+    missSpells = {},            -- index-miss spellIDs this batch (capped)
 }
+
+local BATCH_SPELL_CAP = 8
 
 local changedKeys = {}          -- per-pass scratch, reused
 
@@ -225,8 +229,14 @@ local function NoteIdentityArg(event, spellID)
             batch.identityFires = batch.identityFires + 1
             SP.identityFireTotal = SP.identityFireTotal + 1
             CountFire(event .. ":id")
+            if #batch.idSpells < BATCH_SPELL_CAP then
+                batch.idSpells[#batch.idSpells + 1] = spellID
+            end
         else
             CountMiss(event)
+            if #batch.missSpells < BATCH_SPELL_CAP then
+                batch.missSpells[#batch.missSpells + 1] = spellID
+            end
         end
         return true
     end
@@ -292,6 +302,14 @@ local function BatchSummary()
         n = n + 1
         parts[n] = tag .. "x" .. count
     end
+    if #batch.idSpells > 0 then
+        n = n + 1
+        parts[n] = "id[" .. table.concat(batch.idSpells, " ") .. "]"
+    end
+    if #batch.missSpells > 0 then
+        n = n + 1
+        parts[n] = "miss[" .. table.concat(batch.missSpells, " ") .. "]"
+    end
     return table.concat(parts, ",", 1, n)
 end
 
@@ -351,12 +369,21 @@ local function Classify(changedCount, oldCd, newCd)
     local onlyTint = true
     local onlyGsup = true
     local cdChanged = false
+    local desatCdChanged = false
     local gcdOk, expiryOk, chargeOnly = true, true, true
     for i = 1, changedCount do
         local key = changedKeys[i]
-        if not CROSS_FAMILY[key] then
+        if CROSS_FAMILY[key] then
+            -- aura/proc/visibility families: never cooldown/charges evidence
+        elseif key == "desat" and not (cdChanged or desatCdChanged) then
+            -- Applied desaturation moved while the cooldown state and the
+            -- cooldown-desat intent both stayed put (FIELDS orders cd/desatCd
+            -- before desat, so both flags are already decided here): that is
+            -- aura-tracking / hold-driven desaturation, not cooldown evidence.
+        else
             coreCount = coreCount + 1
             if key == "cd" then cdChanged = true end
+            if key == "desatCd" then desatCdChanged = true end
             if key ~= "tint" then onlyTint = false end
             if key ~= "gsup" then onlyGsup = false end
             if not GCD_SHAPE[key] then gcdOk = false end
@@ -468,6 +495,8 @@ function SP:NotePassEnd(passSource, passDetail)
         batch.missFires = 0
         batch.secretFires = 0
         wipe(batch.events)
+        wipe(batch.idSpells)
+        wipe(batch.missSpells)
     end
 end
 

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -83,6 +83,7 @@ local FIELDS = {
     { "charge",      "_chargeState" },
     { "chargeRe",    "_chargeRecharging" },
     { "chargeSpent", "_chargesSpent" },
+    { "chargeN",     "_currentReadableCharges" },
     { "nocd",        "_noCooldown" },
     { "tint",        "_unusableTintActive" },
     { "fill",        "_iconFillActive" },
@@ -114,9 +115,12 @@ local GCD_SHAPE = {
 local EXPIRY_SHAPE = {
     cd = true, desatCd = true, desat = true, ready = true,
     fill = true, fillMode = true, fillUpd = true,
-    charge = true, chargeRe = true, chargeSpent = true, nocd = true, tint = true,
+    charge = true, chargeRe = true, chargeSpent = true, chargeN = true,
+    nocd = true, tint = true,
 }
-local CHARGE_ONLY = { charge = true, chargeRe = true, chargeSpent = true }
+local CHARGE_ONLY = {
+    charge = true, chargeRe = true, chargeSpent = true, chargeN = true,
+}
 
 local LOG_SIZE = 64
 
@@ -233,36 +237,6 @@ local function CountMiss(event)
     CountFire(event .. ":miss")
 end
 
--- Identity-arg fire. issecretvalue runs before any other operation touches
--- the arg.
-local function NoteIdentityArg(event, spellID)
-    if issecretvalue(spellID) then
-        CountSecret(event)
-        return true
-    end
-    if type(spellID) == "number" then
-        if StampCovered(spellID) then
-            batch.identityFires = batch.identityFires + 1
-            SP.identityFireTotal = SP.identityFireTotal + 1
-            CountFire(event .. ":id")
-            if #batch.idSpells < BATCH_SPELL_CAP then
-                batch.idSpells[#batch.idSpells + 1] = spellID
-            end
-        else
-            CountMiss(event)
-            if #batch.missSpells < BATCH_SPELL_CAP then
-                batch.missSpells[#batch.missSpells + 1] = spellID
-            end
-        end
-        return true
-    end
-    if spellID ~= nil then
-        CountSecret(event)
-        return true
-    end
-    return false
-end
-
 local function NoteBroadcast(event)
     batch.broadcastFires = batch.broadcastFires + 1
     SP.broadcastFireTotal = SP.broadcastFireTotal + 1
@@ -270,21 +244,49 @@ local function NoteBroadcast(event)
 end
 
 -- Shared identity handling for the cooldown/charge taps. Both carry the same
--- (spellID, baseSpellID) identity shape. NoteIdentityArg makes the primary
--- decision (secret/unreadable -> broad-fallback, plain number -> stamp or miss,
--- nil -> broadcast). The differing plain base is stamped as supplementary
--- coverage ONLY when the primary was itself a readable plain number: a secret
--- primary forces the whole fire broad with no partial coverage credit. Every
--- read is issecretvalue-guarded before any type/compare touches the arg.
+-- (spellID, baseSpellID) identity shape, and the D3 index keys buttons under
+-- base, override, and display IDs alike -- so a fire is a real drop only when
+-- NEITHER readable identity maps to a tracked button. A secret/unreadable
+-- primary still forces the broad path with no partial coverage credit (a routed
+-- world could not key on it). issecretvalue guards precede every type/compare.
 local function NoteIdentityEvent(event, spellID, baseSpellID)
-    if not NoteIdentityArg(event, spellID) then
-        NoteBroadcast(event)
+    -- Secret/unreadable primary identity -> broad, never mismatch-eligible.
+    if issecretvalue(spellID) then
+        CountSecret(event)
         return
     end
-    if not issecretvalue(spellID) and type(spellID) == "number"
-            and not issecretvalue(baseSpellID) and type(baseSpellID) == "number"
+    if type(spellID) ~= "number" then
+        -- Non-nil non-number is unreadable (broad); nil is the broadcast form.
+        if spellID ~= nil then
+            CountSecret(event)
+        else
+            NoteBroadcast(event)
+        end
+        return
+    end
+    -- Primary is a readable number. Fold in the distinct readable base ID: stamp
+    -- both, and treat the fire as covered when EITHER maps to a tracked button.
+    local baseNum
+    if not issecretvalue(baseSpellID) and type(baseSpellID) == "number"
             and baseSpellID ~= spellID then
-        StampCovered(baseSpellID)
+        baseNum = baseSpellID
+    end
+    local covered = StampCovered(spellID)
+    if baseNum and StampCovered(baseNum) then
+        covered = true
+    end
+    if covered then
+        batch.identityFires = batch.identityFires + 1
+        SP.identityFireTotal = SP.identityFireTotal + 1
+        CountFire(event .. ":id")
+        if #batch.idSpells < BATCH_SPELL_CAP then
+            batch.idSpells[#batch.idSpells + 1] = spellID
+        end
+    else
+        CountMiss(event)
+        if #batch.missSpells < BATCH_SPELL_CAP then
+            batch.missSpells[#batch.missSpells + 1] = spellID
+        end
     end
 end
 


### PR DESCRIPTION
## What Changed
- New `Core/ShadowParity.lua`: an observe-only harness that answers, from live play, "if cooldown/charge events were routed to only their matching buttons (via the spell/item index from #508) instead of refreshing everything, would anything on screen have gone stale?" Identity-carrying events stamp the buttons routing would have updated; the normal broad refresh then runs completely unchanged; afterwards the harness diffs a compact per-button visual signature and classifies any change routing would have skipped.
- Classification separates expected noise from real evidence so the hard counters can meaningfully hold zero: cross-family changes (aura/proc/visibility — families not being routed, including aura-driven desaturation), usability tint (re-polled every pass), GCD-settle shapes, and cooldown-expiry shapes (covered by the OnCooldownDone signal from #504). What remains lands in `shadowParityMismatchTotal` (per family) or `mismatchDropOnly` (identity fires for untracked spells, which a router would drop), each with a detail ring log naming the event batch, spell IDs, button, and changed fields.
- Broadcast fires (ACTIONBAR/BAG_UPDATE_COOLDOWN, no-arg SPELL_UPDATE_COOLDOWN, SPELL_UPDATE_CHARGES) are measured for the demotion question instead: per batch, did the broad pass change anything routing hadn't covered (`broadcastCarriedChanges`) or not (`broadcastSilentPasses`)?
- Three small taps feed it: the cooldown/charges event handlers in `Lifecycle.lua` (args pass through unread; `issecretvalue` is checked before any read or comparison) and the tail of `UpdateAllCooldowns` in `GroupOperations.lua`.

## Why This Changed
- The F1 event-routing program requires proof, not review confidence, that routing cannot compromise display accuracy — and hard numbers on whether the ~13/sec identity-less broadcast events actually carry anything the identity events don't. This harness is that instrument; routing ships only after its mismatch counters hold zero across the scenario matrix.

## Developer Impact
- **Zero behavior change and zero cost for users.** The harness is enabled only when the CC_DevBridge dev addon is loaded (checked at PLAYER_LOGIN, same gate as the refresh telemetry); without it the taps are one table lookup and branch. It never alters scheduling, marks nothing dirty, and writes only its own diagnostic fields.
- Owner tools: `/run CooldownCompanion:PrintShadowParitySummary()`, `ResetShadowParity()`, and an SV-safe `GetShadowParityDiagnostics()` for DevBridge snapshots.

## Validation
- `luac -p` static parse and `git diff --check` clean on all touched files.
- Live-soaked in-game on the developer profile during this session (three capture rounds, Feral, world combat): the first four mismatches it reported were diagnosed from its own ring log as aura-family classification gaps, fixed by evidence (commits on this branch), after which the counters held **MISMATCH 0 / dropMISM 0 across 389 evaluated passes** with broadcasts 99% silent.
- Sustained instanced-combat soak (dungeon/raid) and alt-spec coverage are the remaining soak work; that accumulation is the point of merging — the harness collects Gate 1 evidence during all normal play on dev.