### PR TITLE
Lower combat CPU by skipping redundant cooldown refreshes

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -814,15 +814,41 @@ end
 -- -- including pending time-gated transitions that look static right now (e.g.
 -- a running ready-glow duration window) -- must have a term here, or the idle
 -- skip will starve it until the ~1s safety walk.
+--
+-- Combat ticker floor (switch-gated): the cooldown swipe/numbers, aura swipe, and
+-- GCD swipe self-animate in icon/bar mode (Blizzard CooldownFrameTemplate /
+-- BarModeOnUpdate) -- they do NOT need a walk to keep drawing. So while the floor
+-- is on, those states stop forcing walks EXCEPT in text mode (redrawn from
+-- GetTime() each walk) or when an active aura's pandemic glow applies but its
+-- edge-hook is not yet covering it. Everything else (charge-color heuristic,
+-- target-switch hold, preview, ready-glow window) stays walk-forcing in every
+-- mode. Switch OFF reproduces the legacy all-terms-force classifier exactly.
+-- Discrete edges (cooldown start/end, aura apply/remove, pandemic enter/exit)
+-- stay event-covered; the skip only suppresses the redundant continuous middle.
 local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now)
-    if button._cooldownState == COOLDOWN_STATE_COOLDOWN     -- spell/item/deferred cooldown
-        or button._chargeRecharging                          -- charge recharge in progress
-        or button._auraActive                                -- aura display (incl. target-switch hold); truthy on purpose, fail open
+    local forced = button._chargeRecharging                  -- charge recharge (charge-color heuristic, walk-driven)
         or button._targetSwitchAt ~= nil                     -- target-switch continuity hold
         or conditionalPreview ~= nil                         -- conditional visual preview active
-        or (isGCDOnly and button.style and button.style.showGCDSwipe == true) -- GCD swipe presentation
         or HasPendingReadyGlowWindow(button, now)            -- finite ready-glow window still running
-    then
+
+    if not forced then
+        local timeActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN -- spell/item/deferred cooldown
+            or button._auraActive                            -- aura display (incl. target-switch hold); truthy on purpose, fail open
+            or (isGCDOnly and button.style and button.style.showGCDSwipe == true) -- GCD swipe presentation
+        if timeActive then
+            if not CooldownCompanion._combatTickerFloorOn then
+                forced = true                                -- legacy: any time state forces a walk
+            elseif button._isText then
+                forced = true                                -- text mode is walk-driven (FormatTime + SetText)
+            elseif button._auraActive and button._pandemicEdgeUncovered then
+                forced = true                                -- pandemic applies but its edge isn't hooked (fail open)
+            end
+            -- else: icon/bar self-animating cooldown/aura/GCD, pandemic covered
+            -- or absent -- skippable; discrete edges stay event-covered.
+        end
+    end
+
+    if forced then
         CooldownCompanion._passTimeStateSeen = true
         CooldownCompanion._tickerIdleEligible = false
     end

--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -403,7 +403,10 @@ local function SetIconFillFromCooldownWidget(button)
 
     -- F2 canary: cooldown-widget icon fill draws remaining this walk (covered by
     -- the _cooldownState == COOLDOWN / _auraActive classifier terms, guarded above).
-    if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
+    -- Under the combat ticker floor this fill self-animates (its own OnUpdate,
+    -- usesOnUpdate), so the walk-time render is redundant -- do not count it, or it
+    -- would falsely trip falseIdleTotal against the now-skippable icon.
+    if not CooldownCompanion._combatTickerFloorOn and RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
     button.iconFill:SetValue(value)
     return true
 end
@@ -432,8 +435,10 @@ local function SetIconFillValue(button)
 
         if button._auraCooldownStart and button._auraCooldownDuration and button._auraCooldownDuration > 0 then
             -- F2 canary: aura-cooldown icon fill draws remaining this walk
-            -- (covered by the _auraActive classifier term).
-            if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
+            -- (covered by the _auraActive classifier term). Skipped under the
+            -- combat ticker floor -- this fill self-animates (own OnUpdate), so
+            -- counting it would falsely trip falseIdleTotal against a skippable icon.
+            if not CooldownCompanion._combatTickerFloorOn and RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
             local elapsed = GetTime() - button._auraCooldownStart
             if elapsed < 0 then elapsed = 0 end
             if elapsed > button._auraCooldownDuration then elapsed = button._auraCooldownDuration end
@@ -462,8 +467,10 @@ local function SetIconFillValue(button)
         local durationSeconds = button._itemCdDuration or 0
         if durationSeconds > 0 then
             -- F2 canary: item cooldown icon fill draws remaining this walk
-            -- (covered by the _cooldownState == COOLDOWN classifier term).
-            if RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
+            -- (covered by the _cooldownState == COOLDOWN classifier term). Skipped
+            -- under the combat ticker floor -- this fill self-animates (own
+            -- OnUpdate), so counting it would falsely trip falseIdleTotal.
+            if not CooldownCompanion._combatTickerFloorOn and RefreshTelemetry and RefreshTelemetry.enabled then RefreshTelemetry:NoteTimeRender() end
             local elapsed = GetTime() - (button._itemCdStart or 0)
             if elapsed < 0 then elapsed = 0 end
             local value = elapsed / durationSeconds

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -47,10 +47,10 @@
     - cd-done marks come from ST.OnButtonCooldownDone (ButtonFrame/Helpers.lua)
       and are ordinary MarkCooldownsDirty calls; the hidden kill switch only
       stops the marks, never adds skips.
-    - The combat ticker floor (hidden switch SetCombatTickerFloorEnabled,
-      db.global.combatTickerFloor, default OFF) extends the idle skip into combat
-      for self-animating display modes only, via three coupled changes on the one
-      switch:
+    - The combat ticker floor (ON by default; hidden kill switch
+      SetCombatTickerFloorDisabled, db.global.combatTickerFloorDisabled, for
+      soak reversion only) extends the idle skip into combat for self-animating
+      display modes only, via three coupled changes gated on _combatTickerFloorOn:
         1. Mode-aware classifier (NoteButtonTimeState): an active cooldown/aura/
            GCD swipe on an icon or bar button no longer forces a walk (the swipe,
            numbers, and iconFill self-animate). Text mode, charge recharge,
@@ -67,9 +67,9 @@
            walk ~1s worst case).
       Discrete edges stay event-covered (cooldown start/end, aura apply/remove,
       pandemic enter/exit). The safety walk (TICKER_MAX_CONSECUTIVE_SKIPS) is now
-      load-bearing in combat. Switch OFF restores the prior classifier, combat
-      disarm, and power marks verbatim, and leaves any installed pandemic hooks
-      inert (byte-identical behavior).
+      load-bearing in combat. The kill switch restores the prior classifier,
+      combat disarm, and power marks verbatim, and leaves any installed pandemic
+      hooks inert (byte-identical legacy path, retained for soak reversion).
 ]]
 
 local ADDON_NAME, ST = ...
@@ -120,17 +120,16 @@ function CooldownCompanion:SetCooldownDoneSignalDisabled(disabled)
     self._cooldownDoneSignalOff = disabled
 end
 
--- Combat ticker floor hidden switch (no config UI). Extends the idle skip into
--- combat for self-animating display modes; default OFF. Currently wires the
--- pandemic edge-hook (the crossing is secret in combat); the classifier
--- refinement and power-mark demotion land on this same switch later. Toggle
--- live (no reload) with:
---   /run CooldownCompanion:SetCombatTickerFloorEnabled(true)
--- Persists in db.global; default (absent) = OFF (today's behavior).
-function CooldownCompanion:SetCombatTickerFloorEnabled(enabled)
-    enabled = enabled == true
-    self.db.global.combatTickerFloor = enabled or nil
-    self._combatTickerFloorOn = enabled
+-- Combat ticker floor: ON by default (the shipped behavior -- extends the idle
+-- skip into combat for self-animating display modes). Hidden kill switch (no
+-- config UI, F3 pattern) to force the legacy always-walk path during soak, live
+-- (no reload):
+--   /run CooldownCompanion:SetCombatTickerFloorDisabled(true)
+-- Persists in db.global; default (absent) = enabled.
+function CooldownCompanion:SetCombatTickerFloorDisabled(disabled)
+    disabled = disabled == true
+    self.db.global.combatTickerFloorDisabled = disabled or nil
+    self._combatTickerFloorOn = not disabled
 end
 
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -48,15 +48,28 @@
       and are ordinary MarkCooldownsDirty calls; the hidden kill switch only
       stops the marks, never adds skips.
     - The combat ticker floor (hidden switch SetCombatTickerFloorEnabled,
-      db.global.combatTickerFloor, default OFF) is landing in stages. Stage 1
-      (this change) wires only the pandemic edge-hook: while the switch is on,
-      the CDM's pooled pandemic FX frames' OnShow/OnHide (hooked per viewer via
-      pandemicIconPool) mark cooldowns dirty ("pandemic-edge"), covering the
-      secret-in-combat pandemic crossing as an event (<=1 tick) instead of the
-      per-walk IsVisible() poll. It only ever adds walks, so it cannot stale the
-      display. The classifier refinement and power-mark
-      demotion -- the parts that actually skip walks in combat -- land later on
-      this same switch. Switch OFF leaves any installed hooks inert.
+      db.global.combatTickerFloor, default OFF) extends the idle skip into combat
+      for self-animating display modes only, via three coupled changes on the one
+      switch:
+        1. Mode-aware classifier (NoteButtonTimeState): an active cooldown/aura/
+           GCD swipe on an icon or bar button no longer forces a walk (the swipe,
+           numbers, and iconFill self-animate). Text mode, charge recharge,
+           target-switch holds, ready-glow windows, previews, and any
+           secret/unproven state still force walks.
+        2. Pandemic edge-hook: the crossing is secret in combat, so the CDM's
+           pooled pandemic FX frames' OnShow/OnHide (hooked per viewer via
+           pandemicIconPool) mark dirty ("pandemic-edge") -- a one-tick
+           event-covered edge, not a poll. An aura button is skippable only once
+           its viewer's pandemic pool is hooked (_pandemicEdgeUncovered nil);
+           until then it forces (fail open).
+        3. Power-mark demotion: UNIT_POWER_FREQUENT stops marking dirty while the
+           switch is on; the castability tint then rides walk cadence (safety
+           walk ~1s worst case).
+      Discrete edges stay event-covered (cooldown start/end, aura apply/remove,
+      pandemic enter/exit). The safety walk (TICKER_MAX_CONSECUTIVE_SKIPS) is now
+      load-bearing in combat. Switch OFF restores the prior classifier, combat
+      disarm, and power marks verbatim, and leaves any installed pandemic hooks
+      inert (byte-identical behavior).
 ]]
 
 local ADDON_NAME, ST = ...
@@ -204,7 +217,12 @@ function CooldownCompanion:IsIdleTickerSkipEligible()
     return not self._cooldownsDirty
         and not self._queuedCooldownRefreshSource
         and self._tickerIdleEligible == true
-        and not self._inCombatForTicker
+        -- The idle skip is out-of-combat only, UNLESS the combat ticker floor is
+        -- on: it extends the skip into combat, relying on the mode-aware
+        -- classifier (self-animating icon/bar buttons no longer force walks) and
+        -- the pandemic edge-hook. The classifier + safety walk still bound
+        -- staleness; a walk-forcing button in combat still keeps the ticker awake.
+        and (not self._inCombatForTicker or self._combatTickerFloorOn)
         and not self._cooldownDoneSignalOff
 end
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -47,6 +47,15 @@
     - cd-done marks come from ST.OnButtonCooldownDone (ButtonFrame/Helpers.lua)
       and are ordinary MarkCooldownsDirty calls; the hidden kill switch only
       stops the marks, never adds skips.
+    - The combat ticker floor (hidden switch SetCombatTickerFloorEnabled,
+      db.global.combatTickerFloor, default OFF) is landing in stages. Stage 1
+      (this change) wires only the pandemic edge-hook: while the switch is on,
+      the CDM PandemicIcon's OnShow/OnHide mark cooldowns dirty ("pandemic-edge"),
+      covering the secret-in-combat pandemic crossing as an event (<=1 tick)
+      instead of the per-walk IsVisible() poll. It only ever adds walks, so it
+      cannot stale the display. The classifier refinement and power-mark
+      demotion -- the parts that actually skip walks in combat -- land later on
+      this same switch. Switch OFF leaves any installed hooks inert.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -95,6 +104,19 @@ function CooldownCompanion:SetCooldownDoneSignalDisabled(disabled)
     disabled = disabled == true
     self.db.global.cooldownDoneSignalDisabled = disabled or nil
     self._cooldownDoneSignalOff = disabled
+end
+
+-- Combat ticker floor hidden switch (no config UI). Extends the idle skip into
+-- combat for self-animating display modes; default OFF. Currently wires the
+-- pandemic edge-hook (the crossing is secret in combat); the classifier
+-- refinement and power-mark demotion land on this same switch later. Toggle
+-- live (no reload) with:
+--   /run CooldownCompanion:SetCombatTickerFloorEnabled(true)
+-- Persists in db.global; default (absent) = OFF (today's behavior).
+function CooldownCompanion:SetCombatTickerFloorEnabled(enabled)
+    enabled = enabled == true
+    self.db.global.combatTickerFloor = enabled or nil
+    self._combatTickerFloorOn = enabled
 end
 
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -50,10 +50,11 @@
     - The combat ticker floor (hidden switch SetCombatTickerFloorEnabled,
       db.global.combatTickerFloor, default OFF) is landing in stages. Stage 1
       (this change) wires only the pandemic edge-hook: while the switch is on,
-      the CDM PandemicIcon's OnShow/OnHide mark cooldowns dirty ("pandemic-edge"),
-      covering the secret-in-combat pandemic crossing as an event (<=1 tick)
-      instead of the per-walk IsVisible() poll. It only ever adds walks, so it
-      cannot stale the display. The classifier refinement and power-mark
+      the CDM's pooled pandemic FX frames' OnShow/OnHide (hooked per viewer via
+      pandemicIconPool) mark cooldowns dirty ("pandemic-edge"), covering the
+      secret-in-combat pandemic crossing as an event (<=1 tick) instead of the
+      per-walk IsVisible() poll. It only ever adds walks, so it cannot stale the
+      display. The classifier refinement and power-mark
       demotion -- the parts that actually skip walks in combat -- land later on
       this same switch. Switch OFF leaves any installed hooks inert.
 ]]

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -703,40 +703,71 @@ function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
     owner._auraUnit = unit or "target"
 end
 
--- Shared hook body for the pandemic edge (OnShow/OnHide). Marks dirty only while
--- the combat ticker floor switch is on, so installed hooks are inert when OFF
--- (one shared function object -- no per-icon closure allocation).
+-- Shared hook body for the pandemic edge (a pooled CDM FX frame's OnShow/OnHide,
+-- which fire only on real pandemic enter/exit transitions -- Show() on an
+-- already-shown frame is a no-op, so these do NOT fire per update). Marks dirty
+-- only while the switch is on, so installed hooks are inert when OFF (one shared
+-- function object -- no per-frame closure allocation).
 local function OnPandemicEdge()
     if CooldownCompanion._combatTickerFloorOn then
         CooldownCompanion:MarkCooldownsDirty("pandemic-edge")
     end
 end
 
--- Combat ticker floor (switch-gated): the pandemic threshold is a secret value
--- in combat (Phase 0: 0 readable of 8401 Feral resolves), so the crossing time
--- cannot be computed and scheduled. The CDM PandemicIcon's OnShow/OnHide fire on
--- the real transition, so hook them to MarkCooldownsDirty -- turning the crossing
--- into an event-covered edge (<=1 tick, at least as accurate as today's per-walk
--- IsVisible() poll, which CC already trusts as the combat signal).
---
--- Idempotent per icon (guard flag on the frame). Hooks are additive and touch
--- only CC state (a dirty mark) -- no protected calls, no taint. owner.
--- _pandemicEdgeHooked records coverage so the classifier can gate its
--- skip-exemption on it (fail open when unhooked/absent).
-local function InstallPandemicEdgeHook(owner, viewerFrame)
-    local icon = viewerFrame.PandemicIcon
-    if not (icon and icon.HookScript) then
-        owner._pandemicEdgeHooked = nil
-        return
-    end
-    if not icon._ccPandemicEdgeHooked then
-        icon._ccPandemicEdgeHooked = true
-        icon:HookScript("OnShow", OnPandemicEdge)
-        icon:HookScript("OnHide", OnPandemicEdge)
+-- Hook one pooled pandemic FX frame's OnShow/OnHide once (guard on the frame).
+local function HookPandemicFrame(frame)
+    if frame and not frame._ccPandemicEdgeHooked and frame.HookScript then
+        frame._ccPandemicEdgeHooked = true
+        frame:HookScript("OnShow", OnPandemicEdge)
+        frame:HookScript("OnHide", OnPandemicEdge)
         local RT = ST.RefreshTelemetry
         if RT and RT.enabled then
             RT:CountPandemicEdgeHook()
         end
+    end
+end
+
+-- Hook every active frame in the pool. Also used as the post-hook on the pool's
+-- Acquire, which runs inside SetupPandemicStateFrameForItem BEFORE the item's
+-- PandemicIcon:Show(), so a newly grown pool frame is hooked before its first
+-- OnShow -- no missed first transition.
+local function HookPandemicPoolActive(pool)
+    for frame in pool:EnumerateActive() do
+        HookPandemicFrame(frame)
+    end
+end
+
+-- Combat ticker floor (switch-gated): the pandemic threshold is a secret value
+-- in combat (Phase 0: 0 readable of 8401 Feral resolves), so the crossing time
+-- cannot be computed and scheduled. The CDM shows a pooled pandemic FX frame on
+-- the real transition -- Blizzard CooldownViewerItem Show/HidePandemicStateFrame
+-- acquire/release it from viewer.pandemicIconPool -- so hooking that pool's
+-- frames' OnShow/OnHide to MarkCooldownsDirty turns the crossing into an
+-- event-covered edge (<=1 tick, at least as accurate as today's per-walk
+-- IsVisible() poll, which CC already trusts as the combat signal).
+--
+-- Hooks the POOL, not per-item PandemicIcon: HidePandemicStateFrame releases the
+-- frame and nils item.PandemicIcon on exit, and the small pool is reused across
+-- all DoTs -- so a per-item hook could neither guarantee coverage before a DoT
+-- enters pandemic (its frame isn't assigned yet) nor catch a pool-growth frame's
+-- first Show. Hooking the pool once per viewer (enumerate current + hooksecurefunc
+-- Acquire) covers every DoT on it, including future frames, before their Show.
+-- Idempotent (per-frame + per-viewer guards); hooks are additive post-hooks
+-- touching only CC state (a dirty mark) -- no protected calls, no taint. owner.
+-- _pandemicEdgeHooked records coverage (stable, per viewer) so the classifier can
+-- gate its skip-exemption on it (fail open when the viewer/pool is unavailable).
+local function InstallPandemicEdgeHook(owner, viewerFrame)
+    local getViewer = viewerFrame.GetViewerFrame
+    local viewer = getViewer and getViewer(viewerFrame)
+    local pool = viewer and viewer.pandemicIconPool
+    if not (pool and pool.EnumerateActive) then
+        owner._pandemicEdgeHooked = nil
+        return
+    end
+    if not viewer._ccPandemicPoolHooked then
+        viewer._ccPandemicPoolHooked = true
+        HookPandemicPoolActive(pool)
+        hooksecurefunc(pool, "Acquire", HookPandemicPoolActive)
     end
     owner._pandemicEdgeHooked = true
 end
@@ -757,8 +788,8 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
     end
 
     -- Combat ticker floor (switch-gated): make the secret-in-combat pandemic
-    -- crossing an event-covered edge by hooking this viewer's PandemicIcon.
-    -- Inert unless the switch is on; installs once per icon.
+    -- crossing an event-covered edge by hooking this viewer's pandemic FX pool.
+    -- Inert unless the switch is on; installs once per viewer.
     if CooldownCompanion._combatTickerFloorOn then
         InstallPandemicEdgeHook(owner, viewerFrame)
     end

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -722,6 +722,13 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
     local auraUnit, auraInstanceID = GetPandemicAuraIdentity(owner, options)
     local pandemicStartTime, pandemicEndTime, hasReadableRange = GetReadablePandemicRange(viewerFrame)
     local hasDirtyUpdate = HasMatchingPandemicDirtyState(owner, auraUnit, auraInstanceID)
+    -- Spike 016: observe-only pandemic-secrecy instrument (dev-gated, combat).
+    -- Answers whether the ticker-floor pandemic crossing is schedulable (readable
+    -- range) or secret (must poll PandemicIcon). Zero behavior change.
+    local shadowParity = ST.ShadowParity
+    if shadowParity and shadowParity.enabled and CooldownCompanion._inCombatForTicker then
+        shadowParity:NotePandemicResolve(hasReadableRange, viewerFrame)
+    end
     if hasReadableRange and viewerFrame.IsInPandemicTime then
         local semanticResult = viewerFrame:IsInPandemicTime(now)
         if not issecretvalue(semanticResult) then

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -703,6 +703,44 @@ function EntryRuntime.StartTrackedAuraTargetSwitch(owner, now, unit)
     owner._auraUnit = unit or "target"
 end
 
+-- Shared hook body for the pandemic edge (OnShow/OnHide). Marks dirty only while
+-- the combat ticker floor switch is on, so installed hooks are inert when OFF
+-- (one shared function object -- no per-icon closure allocation).
+local function OnPandemicEdge()
+    if CooldownCompanion._combatTickerFloorOn then
+        CooldownCompanion:MarkCooldownsDirty("pandemic-edge")
+    end
+end
+
+-- Combat ticker floor (switch-gated): the pandemic threshold is a secret value
+-- in combat (Phase 0: 0 readable of 8401 Feral resolves), so the crossing time
+-- cannot be computed and scheduled. The CDM PandemicIcon's OnShow/OnHide fire on
+-- the real transition, so hook them to MarkCooldownsDirty -- turning the crossing
+-- into an event-covered edge (<=1 tick, at least as accurate as today's per-walk
+-- IsVisible() poll, which CC already trusts as the combat signal).
+--
+-- Idempotent per icon (guard flag on the frame). Hooks are additive and touch
+-- only CC state (a dirty mark) -- no protected calls, no taint. owner.
+-- _pandemicEdgeHooked records coverage so the classifier can gate its
+-- skip-exemption on it (fail open when unhooked/absent).
+local function InstallPandemicEdgeHook(owner, viewerFrame)
+    local icon = viewerFrame.PandemicIcon
+    if not (icon and icon.HookScript) then
+        owner._pandemicEdgeHooked = nil
+        return
+    end
+    if not icon._ccPandemicEdgeHooked then
+        icon._ccPandemicEdgeHooked = true
+        icon:HookScript("OnShow", OnPandemicEdge)
+        icon:HookScript("OnHide", OnPandemicEdge)
+        local RT = ST.RefreshTelemetry
+        if RT and RT.enabled then
+            RT:CountPandemicEdgeHook()
+        end
+    end
+    owner._pandemicEdgeHooked = true
+end
+
 function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
     if not owner then return false end
     options = options or {}
@@ -716,6 +754,13 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
             ClearAuraPandemicRuntimeState(owner)
         end
         return false
+    end
+
+    -- Combat ticker floor (switch-gated): make the secret-in-combat pandemic
+    -- crossing an event-covered edge by hooking this viewer's PandemicIcon.
+    -- Inert unless the switch is on; installs once per icon.
+    if CooldownCompanion._combatTickerFloorOn then
+        InstallPandemicEdgeHook(owner, viewerFrame)
     end
 
     local now = options.now or GetTime()

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -753,15 +753,17 @@ end
 -- first Show. Hooking the pool once per viewer (enumerate current + hooksecurefunc
 -- Acquire) covers every DoT on it, including future frames, before their Show.
 -- Idempotent (per-frame + per-viewer guards); hooks are additive post-hooks
--- touching only CC state (a dirty mark) -- no protected calls, no taint. owner.
--- _pandemicEdgeHooked records coverage (stable, per viewer) so the classifier can
--- gate its skip-exemption on it (fail open when the viewer/pool is unavailable).
+-- touching only CC state (a dirty mark) -- no protected calls, no taint.
+-- Records `owner._pandemicEdgeUncovered` (stable, per viewer) for the classifier:
+-- true = pandemic applies but its edge is NOT covered (pool unavailable → the
+-- button must keep forcing walks, fail open); nil = covered (the pool is hooked,
+-- so the crossing wakes the ticker → the button is skippable on the pandemic axis).
 local function InstallPandemicEdgeHook(owner, viewerFrame)
     local getViewer = viewerFrame.GetViewerFrame
     local viewer = getViewer and getViewer(viewerFrame)
     local pool = viewer and viewer.pandemicIconPool
     if not (pool and pool.EnumerateActive) then
-        owner._pandemicEdgeHooked = nil
+        owner._pandemicEdgeUncovered = true
         return
     end
     if not viewer._ccPandemicPoolHooked then
@@ -769,7 +771,7 @@ local function InstallPandemicEdgeHook(owner, viewerFrame)
         HookPandemicPoolActive(pool)
         hooksecurefunc(pool, "Acquire", HookPandemicPoolActive)
     end
-    owner._pandemicEdgeHooked = true
+    owner._pandemicEdgeUncovered = nil
 end
 
 function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
@@ -781,6 +783,9 @@ function EntryRuntime.ResolveAuraPandemicState(owner, viewerFrame, options)
     end
 
     if not (options.enabled and viewerFrame) then
+        -- Pandemic glow does not apply to this button/pass -- nothing for the
+        -- classifier to keep walk-forcing on the pandemic axis.
+        owner._pandemicEdgeUncovered = nil
         if options.clearWhenDisabled then
             ClearAuraPandemicRuntimeState(owner)
         end

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -171,7 +171,16 @@ function CooldownCompanion:OnEnable()
         self._unitEventFrame = CreateFrame("Frame")
         self._unitEventFrame:SetScript("OnEvent", function(_, event, ...)
             if event == "UNIT_POWER_FREQUENT" then
-                self:MarkCooldownsDirty("power")
+                -- Combat ticker floor: power updates (~14/sec in combat) are the
+                -- ticker's dirty floor and their only consumer is the castability
+                -- tint. While the floor is on, stop marking dirty here so the
+                -- ticker can idle-skip; the tint then rides walk cadence (safety
+                -- walk ~1s worst case -- the owner-signed-off latency trade).
+                -- Switch OFF restores the immediate mark verbatim. The power
+                -- dirtyCount dropping toward 0 is the telemetry signal.
+                if not self._combatTickerFloorOn then
+                    self:MarkCooldownsDirty("power")
+                end
             elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
                 self:OnSpellCast(event, ...)
             elseif event == "UNIT_AURA" then

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -125,6 +125,12 @@ function CooldownCompanion:OnEnable()
     -- (absent key = signal enabled).
     self._cooldownDoneSignalOff = self.db.global.cooldownDoneSignalDisabled == true
 
+    -- Combat ticker floor: seed the hidden switch flag from saved state (absent
+    -- key = OFF). Gates the pandemic edge-hook install/fire; the classifier
+    -- refinement and power-mark demotion land on this same flag later.
+    -- Maintained by SetCombatTickerFloorEnabled.
+    self._combatTickerFloorOn = self.db.global.combatTickerFloor == true
+
     -- F6: render-layer flattening is now permanent (applied unconditionally at
     -- button creation); drop the saved switch key from any earlier build.
     self.db.global.renderFlattenEnabled = nil

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -125,11 +125,13 @@ function CooldownCompanion:OnEnable()
     -- (absent key = signal enabled).
     self._cooldownDoneSignalOff = self.db.global.cooldownDoneSignalDisabled == true
 
-    -- Combat ticker floor: seed the hidden switch flag from saved state (absent
-    -- key = OFF). Gates the pandemic edge-hook install/fire; the classifier
-    -- refinement and power-mark demotion land on this same flag later.
-    -- Maintained by SetCombatTickerFloorEnabled.
-    self._combatTickerFloorOn = self.db.global.combatTickerFloor == true
+    -- Combat ticker floor: ON by default (the shipped behavior). Seeds enabled
+    -- unless the hidden kill switch (SetCombatTickerFloorDisabled) has forced the
+    -- legacy path; absent key = ON. Gates the mode-aware classifier, the pandemic
+    -- edge-hook, and the power-mark demotion. Drop the earlier default-OFF opt-in
+    -- key from any prior build.
+    self.db.global.combatTickerFloor = nil
+    self._combatTickerFloorOn = self.db.global.combatTickerFloorDisabled ~= true
 
     -- F6: render-layer flattening is now permanent (applied unconditionally at
     -- button creation); drop the saved switch key from any earlier build.

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -38,6 +38,10 @@ local T = {
     -- F2 live skip: clean idle ticks actually suppressed. The "safety-tick"
     -- pass source counts the forced ~1/s walks while skipping.
     tickerIdleSkips = 0,
+    -- Combat ticker floor: count of CDM PandemicIcon frames the edge-hook has
+    -- installed on (coverage). Pairs with the "pandemic-edge" dirtyCounts entry
+    -- (fires) to gauge whether the edge-hook covers every tracked DoT.
+    pandemicEdgeHooks = 0,
     passLog = {},               -- ring buffer of reused entry tables
     passCursor = 0,             -- last written index (1..RING_SIZE)
     passTotal = 0,              -- total passes recorded since reset
@@ -79,6 +83,11 @@ end
 -- F2 live skip: a clean idle tick was actually suppressed (early return).
 function T:CountIdleSkip()
     self.tickerIdleSkips = self.tickerIdleSkips + 1
+end
+
+-- Combat ticker floor: an edge-hook was installed on a CDM PandemicIcon frame.
+function T:CountPandemicEdgeHook()
+    self.pandemicEdgeHooks = self.pandemicEdgeHooks + 1
 end
 
 -- F2 canary: a time-driven remaining render happened. Only renders that occur

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -38,9 +38,10 @@ local T = {
     -- F2 live skip: clean idle ticks actually suppressed. The "safety-tick"
     -- pass source counts the forced ~1/s walks while skipping.
     tickerIdleSkips = 0,
-    -- Combat ticker floor: count of CDM PandemicIcon frames the edge-hook has
+    -- Combat ticker floor: count of pooled pandemic FX frames the edge-hook has
     -- installed on (coverage). Pairs with the "pandemic-edge" dirtyCounts entry
-    -- (fires) to gauge whether the edge-hook covers every tracked DoT.
+    -- (fires) to gauge the edge-hook. The pool is small and reused across DoTs,
+    -- so this is a handful, not one-per-DoT.
     pandemicEdgeHooks = 0,
     passLog = {},               -- ring buffer of reused entry tables
     passCursor = 0,             -- last written index (1..RING_SIZE)
@@ -85,7 +86,7 @@ function T:CountIdleSkip()
     self.tickerIdleSkips = self.tickerIdleSkips + 1
 end
 
--- Combat ticker floor: an edge-hook was installed on a CDM PandemicIcon frame.
+-- Combat ticker floor: an edge-hook was installed on a pooled pandemic FX frame.
 function T:CountPandemicEdgeHook()
     self.pandemicEdgeHooks = self.pandemicEdgeHooks + 1
 end

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -157,6 +157,22 @@ local SP = {
     broadcastCarriedChanges = 0,
     broadcastSilentPasses = 0,
     secretFieldSeen = 0,
+    -- Combat ticker-floor feasibility spike counters (observe-only). Per broad
+    -- pass IN COMBAT, classified by signature-diff outcome to measure what the
+    -- power-driven floor walk actually writes -- independent of the event batch
+    -- (floor passes carry no cooldown-family event, so the classifiers above
+    -- never see them).
+    combatPassZeroWrite = 0,        -- no button's signature changed
+    combatPassUsabilityOnly = 0,    -- only the unusable tint (castability) changed
+    combatPassOtherWrite = 0,       -- something else changed
+    combatPassUnclassified = 0,     -- a button was re-baselined this pass
+    combatOtherWriteBySource = {},  -- passSource -> other-write pass count
+    combatDirtySourceTicks = {},    -- dirty source -> ticker ticks it preceded
+    combatUsableOnlyStamps = {},    -- ring of usability-only pass times (USABLE corr.)
+    combatUsableOnlyCursor = 0,
+    combatOtherLog = {},            -- ring: "time|source|fields|button"
+    combatOtherCursor = 0,
+    combatOtherTotal = 0,
     -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
     log = {},
     logCursor = 0,
@@ -180,6 +196,14 @@ local batch = {
 local BATCH_SPELL_CAP = 8
 
 local changedKeys = {}          -- per-pass scratch, reused
+
+-- Combat ticker-floor feasibility spike (spec docs/plans/2026-07-03-015),
+-- observe-only. Scratch + running state for the per-pass write classification.
+local SPIKE_LOG_SIZE = 32       -- other-write detail ring
+local SPIKE_STAMP_SIZE = 64     -- usability-only pass timestamp ring
+local spikeFams = {}            -- per-pass set of non-usability changed keys
+local spikeFamList = {}         -- per-pass ordered scratch for the log string
+local dirtyPrev = {}            -- running RefreshTelemetry.dirtyCounts snapshot
 
 -- Clear the pending batch and advance batch.id so any coverage stamps still
 -- sitting on buttons (button._shadowParityCoveredBatch) from the previous batch
@@ -348,6 +372,15 @@ local function LogChange(kind, passSource, button, changedCount)
         table.concat(changedKeys, ",", 1, changedCount))
 end
 
+-- Combat-floor spike other-write ring entry: which fields the floor walk wrote.
+local function LogCombatOther(passSource, famsStr, button)
+    local cursor = SP.combatOtherCursor % SPIKE_LOG_SIZE + 1
+    SP.combatOtherCursor = cursor
+    SP.combatOtherTotal = SP.combatOtherTotal + 1
+    SP.combatOtherLog[cursor] = ("%.1f|%s|%s|%s"):format(
+        GetTime(), tostring(passSource), famsStr, DescribeButton(button))
+end
+
 -- Read the signature fields into the button's reusable state table and
 -- collect changed short keys into the shared scratch. When suppress is true
 -- (first observation, or the button was not observed in the immediately
@@ -453,6 +486,13 @@ function SP:NotePassEnd(passSource, passDetail)
     local uncoveredCoreChanges = 0
     local source = passDetail or passSource
 
+    -- Combat ticker-floor spike accumulators (observe-only). Classify this pass
+    -- by what it wrote, in combat only, independent of the event batch above.
+    local inCombat = CooldownCompanion._inCombatForTicker and true or false
+    local spikeChanged, spikeNonUsability, spikeSuppressed = false, false, false
+    local spikeRingButton
+    if inCombat then wipe(spikeFams) end
+
     for _, frame in pairs(CooldownCompanion.groupFrames) do
         if frame and frame.UpdateCooldowns and frame.buttons and frame:IsShown() then
             for _, button in ipairs(frame.buttons) do
@@ -461,6 +501,26 @@ function SP:NotePassEnd(passSource, passDetail)
                     local suppress = button._shadowParitySigGen ~= passGen - 1
                     local changedCount, oldCd, newCd = ObserveButton(button, suppress)
                     button._shadowParitySigGen = passGen
+                    if inCombat then
+                        if suppress then
+                            spikeSuppressed = true
+                        elseif changedCount > 0 then
+                            spikeChanged = true
+                            local buttonOther = false
+                            for i = 1, changedCount do
+                                if changedKeys[i] ~= "tint" then
+                                    buttonOther = true
+                                    spikeFams[changedKeys[i]] = true
+                                end
+                            end
+                            if buttonOther then
+                                spikeNonUsability = true
+                                if not spikeRingButton then
+                                    spikeRingButton = button
+                                end
+                            end
+                        end
+                    end
                     if evaluate and changedCount > 0 then
                         if button._shadowParityCoveredBatch == batch.id then
                             self.routedCoveredChanges = self.routedCoveredChanges + 1
@@ -501,6 +561,47 @@ function SP:NotePassEnd(passSource, passDetail)
         end
     end
 
+    -- Combat-floor spike: fold this pass's write-outcome and the dirty sources
+    -- that preceded it (ticker ticks only -- the floor) into the counters. The
+    -- dirty snapshot updates every pass so "since last walk" always holds.
+    local T = ST.RefreshTelemetry
+    if T and T.enabled then
+        local countThis = inCombat
+            and (passSource == "ticker-dirty" or passSource == "ticker-clean"
+                or passSource == "safety-tick")
+        for src, count in pairs(T.dirtyCounts) do
+            if countThis and count > (dirtyPrev[src] or 0) then
+                self.combatDirtySourceTicks[src] =
+                    (self.combatDirtySourceTicks[src] or 0) + 1
+            end
+            dirtyPrev[src] = count
+        end
+    end
+    if inCombat then
+        if spikeSuppressed then
+            self.combatPassUnclassified = self.combatPassUnclassified + 1
+        elseif not spikeChanged then
+            self.combatPassZeroWrite = self.combatPassZeroWrite + 1
+        elseif not spikeNonUsability then
+            self.combatPassUsabilityOnly = self.combatPassUsabilityOnly + 1
+            local cursor = self.combatUsableOnlyCursor % SPIKE_STAMP_SIZE + 1
+            self.combatUsableOnlyCursor = cursor
+            self.combatUsableOnlyStamps[cursor] = floor(GetTime() * 10 + 0.5) / 10
+        else
+            self.combatPassOtherWrite = self.combatPassOtherWrite + 1
+            local srcKey = passSource or "untagged"
+            self.combatOtherWriteBySource[srcKey] =
+                (self.combatOtherWriteBySource[srcKey] or 0) + 1
+            local n = 0
+            for key in pairs(spikeFams) do
+                n = n + 1
+                spikeFamList[n] = key
+            end
+            LogCombatOther(srcKey, table.concat(spikeFamList, ",", 1, n),
+                spikeRingButton)
+        end
+    end
+
     if evaluate then
         self.passesEvaluated = self.passesEvaluated + 1
         if identityOnly then
@@ -515,6 +616,21 @@ function SP:NotePassEnd(passSource, passDetail)
         end
         ResetBatch()
     end
+end
+
+-- SV-safe copy helpers for the spike diagnostics (scalars/strings only).
+local function CopyScalarMap(src)
+    local out = {}
+    for k, v in pairs(src) do out[k] = v end
+    return out
+end
+
+local function CopyRing(src, size)
+    local out = {}
+    for i = 1, size do
+        if src[i] ~= nil then out[#out + 1] = src[i] end
+    end
+    return out
 end
 
 function CooldownCompanion:GetShadowParity()
@@ -559,6 +675,16 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         logTotal = SP.logTotal,
         fireCounts = fires,
         log = log,
+        -- Combat ticker-floor spike
+        combatPassZeroWrite = SP.combatPassZeroWrite,
+        combatPassUsabilityOnly = SP.combatPassUsabilityOnly,
+        combatPassOtherWrite = SP.combatPassOtherWrite,
+        combatPassUnclassified = SP.combatPassUnclassified,
+        combatOtherWriteBySource = CopyScalarMap(SP.combatOtherWriteBySource),
+        combatDirtySourceTicks = CopyScalarMap(SP.combatDirtySourceTicks),
+        combatUsableOnlyStamps = CopyRing(SP.combatUsableOnlyStamps, SPIKE_STAMP_SIZE),
+        combatOtherTotal = SP.combatOtherTotal,
+        combatOtherLog = CopyRing(SP.combatOtherLog, SPIKE_LOG_SIZE),
     }
 end
 
@@ -589,6 +715,18 @@ function CooldownCompanion:ResetShadowParity()
     SP.logTotal = 0
     wipe(SP.log)
     wipe(SP.fireCounts)
+    -- Combat ticker-floor spike counters (dirtyPrev is a running snapshot, kept)
+    SP.combatPassZeroWrite = 0
+    SP.combatPassUsabilityOnly = 0
+    SP.combatPassOtherWrite = 0
+    SP.combatPassUnclassified = 0
+    SP.combatUsableOnlyCursor = 0
+    SP.combatOtherCursor = 0
+    SP.combatOtherTotal = 0
+    wipe(SP.combatOtherWriteBySource)
+    wipe(SP.combatDirtySourceTicks)
+    wipe(SP.combatUsableOnlyStamps)
+    wipe(SP.combatOtherLog)
     -- Drop any in-flight batch too, so a reset mid-window starts clean.
     ResetBatch()
 end
@@ -603,6 +741,26 @@ function CooldownCompanion:PrintShadowParitySummary()
         SP.identityFireTotal, SP.missFireTotal, SP.broadcastFireTotal, SP.secretFireTotal))
     if SP.shadowParityMismatchTotal > 0 then
         self:Print("ShadowParity: mismatches logged — /dump CooldownCompanion:GetShadowParityDiagnostics()")
+    end
+end
+
+-- Combat ticker-floor spike readout (spec docs/plans/2026-07-03-015). Headline:
+-- what share of in-combat walks wrote nothing or only the castability tint
+-- (skippable if usability can be event-signaled), and how many ticker ticks
+-- power vs cooldown-event marks preceded.
+function CooldownCompanion:PrintCombatFloorSummary()
+    local zero = SP.combatPassZeroWrite
+    local usab = SP.combatPassUsabilityOnly
+    local other = SP.combatPassOtherWrite
+    local classified = zero + usab + other
+    local pct = classified > 0 and ((zero + usab) / classified * 100) or 0
+    self:Print(("CombatFloor: %d classified combat walks — zero-write %d, usability-only %d, other-write %d (+%d unclassified) | skippable %.0f%% | ticker ticks: power %d, cd-event %d, aura-player %d"):format(
+        classified, zero, usab, other, SP.combatPassUnclassified, pct,
+        SP.combatDirtySourceTicks.power or 0,
+        SP.combatDirtySourceTicks["cooldown-event"] or 0,
+        SP.combatDirtySourceTicks["aura-player"] or 0))
+    if SP.combatOtherTotal > 0 then
+        self:Print(("CombatFloor: %d other-write passes logged — /dump CooldownCompanion:GetShadowParityDiagnostics()"):format(SP.combatOtherTotal))
     end
 end
 

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -173,6 +173,15 @@ local SP = {
     combatOtherLog = {},            -- ring: "time|source|fields|button"
     combatOtherCursor = 0,
     combatOtherTotal = 0,
+    -- Spike 016 pandemic-secrecy probe: is the combat pandemic crossing
+    -- schedulable (readable range) or secret (must poll PandemicIcon)? And do the
+    -- CDM PandemicIcon OnShow/OnHide scripts fire (edge-hook pivot test)?
+    pandemicResolvesCombat = 0,
+    pandemicRangeReadable = 0,
+    pandemicRangeSecret = 0,
+    pandemicIconsHooked = 0,
+    pandemicIconShowFires = 0,
+    pandemicIconHideFires = 0,
     -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
     log = {},
     logCursor = 0,
@@ -618,6 +627,32 @@ function SP:NotePassEnd(passSource, passDetail)
     end
 end
 
+-- Spike 016 pandemic-secrecy probe (observe-only, dev-gated, combat only).
+-- Records whether the pandemic crossing is schedulable (readable range) vs must
+-- poll PandemicIcon (secret), and lazily hooks each viewer's PandemicIcon
+-- OnShow/OnHide to test an edge-hook pivot. Hooks only bump counters -- no
+-- protected calls, no taint; never runs for users (SP.enabled gates on
+-- CC_DevBridge).
+function SP:NotePandemicResolve(hasReadableRange, viewerFrame)
+    self.pandemicResolvesCombat = self.pandemicResolvesCombat + 1
+    if hasReadableRange then
+        self.pandemicRangeReadable = self.pandemicRangeReadable + 1
+    else
+        self.pandemicRangeSecret = self.pandemicRangeSecret + 1
+    end
+    local icon = viewerFrame and viewerFrame.PandemicIcon
+    if icon and icon.HookScript and not icon._ccSpikePandemicHooked then
+        icon._ccSpikePandemicHooked = true
+        self.pandemicIconsHooked = self.pandemicIconsHooked + 1
+        icon:HookScript("OnShow", function()
+            SP.pandemicIconShowFires = SP.pandemicIconShowFires + 1
+        end)
+        icon:HookScript("OnHide", function()
+            SP.pandemicIconHideFires = SP.pandemicIconHideFires + 1
+        end)
+    end
+end
+
 -- SV-safe copy helpers for the spike diagnostics (scalars/strings only).
 local function CopyScalarMap(src)
     local out = {}
@@ -685,6 +720,13 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         combatUsableOnlyStamps = CopyRing(SP.combatUsableOnlyStamps, SPIKE_STAMP_SIZE),
         combatOtherTotal = SP.combatOtherTotal,
         combatOtherLog = CopyRing(SP.combatOtherLog, SPIKE_LOG_SIZE),
+        -- Spike 016 pandemic-secrecy probe
+        pandemicResolvesCombat = SP.pandemicResolvesCombat,
+        pandemicRangeReadable = SP.pandemicRangeReadable,
+        pandemicRangeSecret = SP.pandemicRangeSecret,
+        pandemicIconsHooked = SP.pandemicIconsHooked,
+        pandemicIconShowFires = SP.pandemicIconShowFires,
+        pandemicIconHideFires = SP.pandemicIconHideFires,
     }
 end
 
@@ -727,6 +769,13 @@ function CooldownCompanion:ResetShadowParity()
     wipe(SP.combatDirtySourceTicks)
     wipe(SP.combatUsableOnlyStamps)
     wipe(SP.combatOtherLog)
+    -- Spike 016 pandemic-secrecy window metrics (pandemicIconsHooked is a
+    -- structural count of installed hooks -- kept across resets).
+    SP.pandemicResolvesCombat = 0
+    SP.pandemicRangeReadable = 0
+    SP.pandemicRangeSecret = 0
+    SP.pandemicIconShowFires = 0
+    SP.pandemicIconHideFires = 0
     -- Drop any in-flight batch too, so a reset mid-window starts clean.
     ResetBatch()
 end
@@ -762,6 +811,18 @@ function CooldownCompanion:PrintCombatFloorSummary()
     if SP.combatOtherTotal > 0 then
         self:Print(("CombatFloor: %d other-write passes logged — /dump CooldownCompanion:GetShadowParityDiagnostics()"):format(SP.combatOtherTotal))
     end
+end
+
+-- Spike 016 pandemic-secrecy readout: the decisive gate for the floor phase.
+-- High "secret" share = the pandemic crossing is NOT schedulable in combat
+-- (must poll PandemicIcon) = the Feral risk. OnShow/OnHide fires gauge whether
+-- an edge-hook pivot is available (0 hooked = PandemicIcon absent or not a frame).
+function CooldownCompanion:PrintPandemicSecrecy()
+    local total = SP.pandemicResolvesCombat
+    local secretPct = total > 0 and (SP.pandemicRangeSecret / total * 100) or 0
+    self:Print(("PandemicSecrecy: %d combat resolves — readable %d, secret %d (%.0f%% secret) | PandemicIcon hooked %d, OnShow %d, OnHide %d"):format(
+        total, SP.pandemicRangeReadable, SP.pandemicRangeSecret, secretPct,
+        SP.pandemicIconsHooked, SP.pandemicIconShowFires, SP.pandemicIconHideFires))
 end
 
 -- Gate: enable only when the CC_DevBridge dev addon is present (same pattern


### PR DESCRIPTION
## What Players Will Notice

- **Lower CPU during combat.** The addon no longer re-scans all tracked cooldowns ~10x/sec when nothing is actually changing — it stops the redundant per-tick work while icon and bar displays animate themselves. This is **on by default** for everyone. Cooldown swipes, DoT timers, pandemic glows, and unusable/greyed-out states keep displaying accurately. The effect is largest during combat lulls/downtime.
- One trade: a spell's "can't afford it yet" grey-out (e.g. low energy) can take up to ~1s to clear during a stretch with **no casting**, instead of near-instant. During active casting it stays fresh. This was reviewed and accepted.

## Why This Changed

- In combat, the 10Hz refresh ticker re-walked all ~37 tracked buttons on nearly every tick — driven mostly by ~14/sec energy/power updates — even though icon and bar displays animate themselves (Blizzard's cooldown swipe/countdown, bar OnUpdate) and rarely needed that walk. That per-tick rescan was largely redundant CPU.

## What Changed

Extends the existing out-of-combat idle-skip into combat, via three coupled changes (all gated on the internal `_combatTickerFloorOn` flag):

- **Mode-aware refresh classifier** — an active cooldown / aura / GCD on a self-animating icon or bar button no longer forces a refresh walk. Text mode, charge-recharge coloring, target-switch holds, ready-glow windows, previews, and any secret/unproven state still force walks (fail open).
- **Pandemic edge-hook** — the pandemic threshold is a secret value in combat, so it can't be scheduled. Instead the CDM's pooled pandemic FX frames are hooked per viewer (via `pandemicIconPool`, before their first show) so a pandemic enter/exit wakes the ticker within one tick, rather than being polled on every walk. Covers all DoTs through the shared pooled frames.
- **Power-mark demotion** — energy/power updates stop forcing refreshes; the castability tint then rides the ~1s safety-walk cadence (the trade noted above).

Discrete edges stay event-covered (cooldown start/end, aura apply/remove, pandemic enter/exit); only the redundant continuous middle is skipped.

**On by default.** A hidden kill switch (`SetCombatTickerFloorDisabled(true)`) can force the byte-identical legacy always-walk path — it is an emergency revert for the soak period, not an opt-in. Full removal of that switch is the last step once the feature has soaked. Also ships dev-gated, observe-only telemetry/watchdog instruments (active only when the separate CC_DevBridge dev addon is present) as soak tooling — inert for players.

## Validation

- In-combat tested on Feral (target dummy), multiple ~60s captures: watchdog `shadowParityMismatchTotal` = **0**, zero Lua errors, display stayed accurate while skipping. The power-driven refresh floor was eliminated (power dirty-marks ~300 → 0). The pandemic edge fired 1:1 with glow transitions (24 marks == 11 shows + 13 hides).
- `luac -p` clean on all changed files. The legacy path (kill switch on) is byte-identical to prior behavior.
- **Ships on by default, but not yet soaked in a dungeon/raid or on a second spec.** If soak surfaces an issue, the kill switch reverts instantly without a code change. (Per owner ruling, combat is treated as equivalent to restricted content, but broader instanced and second-spec soak is still pending.)

## Honest scope note

This targets the per-tick ticker/idle refresh floor and the energy/power-driven refreshes. It does **not** touch the event-driven refresh walks (fast casting → cooldown/aura events → broad walks), which are the larger remaining cost and are addressed by separate event-routing work. Expect a real but partial CPU reduction, concentrated in combat downtime.
