### PR TITLE
Lower combat CPU by routing cooldown events to matched buttons (default-on for dev)

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -826,28 +826,38 @@ end
 -- Discrete edges (cooldown start/end, aura apply/remove, pandemic enter/exit)
 -- stay event-covered; the skip only suppresses the redundant continuous middle.
 local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now, floorFailOpen)
-    local forced = button._chargeRecharging                  -- charge recharge (charge-color heuristic, walk-driven)
-        or button._targetSwitchAt ~= nil                     -- target-switch continuity hold
-        or conditionalPreview ~= nil                         -- conditional visual preview active
-        or HasPendingReadyGlowWindow(button, now)            -- finite ready-glow window still running
+    -- F1 3b Commit A: the forcing terms are broken out into individual booleans
+    -- (was a short-circuit or-chain) so a dev-gated tally can name which term
+    -- pins the ticker awake. `forced` is byte-identical to the old chain -- each
+    -- branch sets the same terms it did before, ORed to the same result; only
+    -- the reporting (guarded on ShadowParity.enabled) is new. The four initial
+    -- terms are pure side-effect-free reads, so evaluating them up front (rather
+    -- than short-circuiting) leaves the truth table unchanged.
+    local charge = button._chargeRecharging and true or false   -- charge recharge (charge-color heuristic, walk-driven)
+    local targetSwitch = button._targetSwitchAt ~= nil          -- target-switch continuity hold
+    local preview = conditionalPreview ~= nil                   -- conditional visual preview active
+    local readyGlow = HasPendingReadyGlowWindow(button, now)    -- finite ready-glow window still running
+    local forced = charge or targetSwitch or preview or readyGlow
 
+    local legacy, text, pandemicUncovered, pandemicGrace = false, false, false, false
     if not forced then
         local timeActive = button._cooldownState == COOLDOWN_STATE_COOLDOWN -- spell/item/deferred cooldown
             or button._auraActive                            -- aura display (incl. target-switch hold); truthy on purpose, fail open
             or (isGCDOnly and button.style and button.style.showGCDSwipe == true) -- GCD swipe presentation
         if timeActive then
             if not CooldownCompanion._combatTickerFloorOn then
-                forced = true                                -- legacy: any time state forces a walk
+                legacy = true                                -- legacy: any time state forces a walk
             elseif button._isText then
-                forced = true                                -- text mode is walk-driven (FormatTime + SetText)
+                text = true                                  -- text mode is walk-driven (FormatTime + SetText)
             elseif button._auraActive and button._pandemicEdgeUncovered then
-                forced = true                                -- pandemic applies but its edge isn't hooked (fail open)
+                pandemicUncovered = true                     -- pandemic applies but its edge isn't hooked (fail open)
             elseif button._auraActive and button._pandemicGraceStart
                 and (now - button._pandemicGraceStart) <= 0.3 then
-                forced = true                                -- pandemic grace-hold expiry is time-gated with no edge (CONTRACT)
+                pandemicGrace = true                         -- pandemic grace-hold expiry is time-gated with no edge (CONTRACT)
             end
             -- else: icon/bar self-animating cooldown/aura/GCD, pandemic covered
             -- or absent -- skippable; discrete edges stay event-covered.
+            forced = legacy or text or pandemicUncovered or pandemicGrace
         end
     end
 
@@ -857,13 +867,30 @@ local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now, f
     -- SPELL_UPDATE_USABLE event; power marks demoted). Must force regardless of
     -- timeActive. floorFailOpen already folds in _combatTickerFloorOn, so it is
     -- false on the kill-switch OFF path (legacy classifier byte-identical).
+    local panelForce = false
     if not forced and floorFailOpen then
+        panelForce = true
         forced = true
     end
 
     if forced then
         CooldownCompanion._passTimeStateSeen = true
         CooldownCompanion._tickerIdleEligible = false
+        -- F1 3b Commit A tally (dev-gated observe-only): one call per term that
+        -- actually forced. ST is a file upvalue; NoteButtonTimeState is well
+        -- under the 60-upvalue ceiling (unlike UpdateButtonCooldown).
+        local SP = ST.ShadowParity
+        if SP and SP.enabled then
+            if charge then SP:NoteForcedTerm("charge", button) end
+            if targetSwitch then SP:NoteForcedTerm("targetSwitch", button) end
+            if preview then SP:NoteForcedTerm("preview", button) end
+            if readyGlow then SP:NoteForcedTerm("readyGlow", button) end
+            if legacy then SP:NoteForcedTerm("legacy", button) end
+            if text then SP:NoteForcedTerm("text", button) end
+            if pandemicUncovered then SP:NoteForcedTerm("pandemicUncovered", button) end
+            if pandemicGrace then SP:NoteForcedTerm("pandemicGrace", button) end
+            if panelForce then SP:NoteForcedTerm("panelForce", button) end
+        end
     end
 end
 
@@ -1878,6 +1905,9 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if floorFailOpen then
                 CooldownCompanion._passTimeStateSeen = true
                 CooldownCompanion._tickerIdleEligible = false
+                -- F1 3b Commit A: count this fail-open pin (routed via a method so
+                -- this ceiling-bound function gains no upvalue).
+                CooldownCompanion:NoteForcedTickerTerm("hiddenFailOpen", button)
             end
             return  -- Skip all visual updates
         else
@@ -1903,6 +1933,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if floorFailOpen then
                 CooldownCompanion._passTimeStateSeen = true
                 CooldownCompanion._tickerIdleEligible = false
+                CooldownCompanion:NoteForcedTickerTerm("hiddenFailOpen", button)
             end
             return  -- Skip visual updates for hidden buttons
         else

--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -879,8 +879,12 @@ local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now, f
         -- F1 3b Commit A tally (dev-gated observe-only): one call per term that
         -- actually forced. ST is a file upvalue; NoteButtonTimeState is well
         -- under the 60-upvalue ceiling (unlike UpdateButtonCooldown).
+        -- Gate on _cooldownUpdatePassActive so ONLY broad-walk forced terms are
+        -- tallied: a routed mini-pass reaches here too (via UpdateButtonCooldown)
+        -- but is not a ticker walk, so its terms must not pollute the clean-walk
+        -- pinner counts PrintCombatFloorSummary reports.
         local SP = ST.ShadowParity
-        if SP and SP.enabled then
+        if SP and SP.enabled and CooldownCompanion._cooldownUpdatePassActive then
             if charge then SP:NoteForcedTerm("charge", button) end
             if targetSwitch then SP:NoteForcedTerm("targetSwitch", button) end
             if preview then SP:NoteForcedTerm("preview", button) end

--- a/CooldownCompanion/CooldownCompanion.toc
+++ b/CooldownCompanion/CooldownCompanion.toc
@@ -56,6 +56,7 @@ Core\StyleOverrides.lua
 Core\RefreshTelemetry.lua
 Core\SpellButtonIndex.lua
 Core\ShadowParity.lua
+Core\CooldownRouting.lua
 Core\CooldownRefresh.lua
 Core\Lifecycle.lua
 Core\Aura.lua

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -74,6 +74,15 @@
       from immediate-broad to dirty-only. It never suppresses the mark itself
       and never touches SPELL_UPDATE_COOLDOWN. Bounded by the next ticker
       walk; dirty ticks always walk.
+    - Routed mini-passes (F1 3b) run beside the scheduler: they never mark
+      dirty, never touch serials/queue/latch state, never reset or latch the
+      F2 accumulators (_passTimeStateSeen, _tickerIdleEligible,
+      _tickerSkipStreak), never set _cooldownUpdatePassActive, and their
+      batch is dropped whenever a broad refresh is queued at flush time.
+      Secret-arg, nil-arg, panel-matched, and generation-churned fires always
+      take the broad path; index-miss fires are counted drops. Only routed
+      (hit) and dropped (miss) fires skip the dirty mark; every other
+      cooldown fire marks dirty exactly as today.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -145,6 +154,18 @@ function CooldownCompanion:SetCooldownBroadcastDemotionEnabled(enabled)
     enabled = enabled == true
     self.db.global.cooldownBroadcastDemotion = enabled or nil
     self._cooldownBroadcastDemotionOn = enabled
+end
+
+-- F1 3b hidden switch (no config UI). Route readable-arg SPELL_UPDATE_COOLDOWN
+-- fires to their index-matched buttons (mini-pass) or drop them (untracked
+-- identity), instead of the broad walk. Live (no reload):
+--   /run CooldownCompanion:SetCooldownRoutingEnabled(true)
+-- Persists in db.global; default (absent) = OFF (today's broad path).
+-- Independent of the demotion switch above and of the floor's kill switch.
+function CooldownCompanion:SetCooldownRoutingEnabled(enabled)
+    enabled = enabled == true
+    self.db.global.cooldownRouting = enabled or nil
+    self._cooldownRoutingOn = enabled
 end
 
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -70,6 +70,10 @@
       load-bearing in combat. The kill switch restores the prior classifier,
       combat disarm, and power marks verbatim, and leaves any installed pandemic
       hooks inert (byte-identical legacy path, retained for soak reversion).
+    - Broadcast demotion (F1 3a) may downgrade ACTIONBAR/BAG cooldown events
+      from immediate-broad to dirty-only. It never suppresses the mark itself
+      and never touches SPELL_UPDATE_COOLDOWN. Bounded by the next ticker
+      walk; dirty ticks always walk.
 ]]
 
 local ADDON_NAME, ST = ...
@@ -130,6 +134,17 @@ function CooldownCompanion:SetCombatTickerFloorDisabled(disabled)
     disabled = disabled == true
     self.db.global.combatTickerFloorDisabled = disabled or nil
     self._combatTickerFloorOn = not disabled
+end
+
+-- F1 3a hidden switch (no config UI). Demote the identity-less broadcast
+-- cooldown events (ACTIONBAR/BAG_UPDATE_COOLDOWN) from immediate-broad to
+-- dirty-only, live (no reload):
+--   /run CooldownCompanion:SetCooldownBroadcastDemotionEnabled(true)
+-- Persists in db.global; default (absent) = OFF (today's immediate-broad path).
+function CooldownCompanion:SetCooldownBroadcastDemotionEnabled(enabled)
+    enabled = enabled == true
+    self.db.global.cooldownBroadcastDemotion = enabled or nil
+    self._cooldownBroadcastDemotionOn = enabled
 end
 
 function CooldownCompanion:EnsureCooldownRefreshQueueFrame()

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -151,24 +151,27 @@ end
 
 -- F1 3a hidden switch (no config UI). Demote the identity-less broadcast
 -- cooldown events (ACTIONBAR/BAG_UPDATE_COOLDOWN) from immediate-broad to
--- dirty-only, live (no reload):
---   /run CooldownCompanion:SetCooldownBroadcastDemotionEnabled(true)
--- Persists in db.global; default (absent) = OFF (today's immediate-broad path).
+-- dirty-only. DEFAULT ON as of F1 3b Commit G. Disable live (no reload) with:
+--   /run CooldownCompanion:SetCooldownBroadcastDemotionEnabled(false)
+-- Persists in db.global; default (absent) = ON. Stored as a strict boolean so an
+-- explicit OFF survives reload (OnEnable reads it back with ~= false).
 function CooldownCompanion:SetCooldownBroadcastDemotionEnabled(enabled)
     enabled = enabled == true
-    self.db.global.cooldownBroadcastDemotion = enabled or nil
+    self.db.global.cooldownBroadcastDemotion = enabled
     self._cooldownBroadcastDemotionOn = enabled
 end
 
 -- F1 3b hidden switch (no config UI). Route readable-arg SPELL_UPDATE_COOLDOWN
 -- fires to their index-matched buttons (mini-pass) or drop them (untracked
--- identity), instead of the broad walk. Live (no reload):
---   /run CooldownCompanion:SetCooldownRoutingEnabled(true)
--- Persists in db.global; default (absent) = OFF (today's broad path).
+-- identity), instead of the broad walk. DEFAULT ON as of F1 3b Commit G.
+-- Disable live (no reload) with:
+--   /run CooldownCompanion:SetCooldownRoutingEnabled(false)
+-- Persists in db.global; default (absent) = ON. Stored as a strict boolean so an
+-- explicit OFF survives reload (OnEnable reads it back with ~= false).
 -- Independent of the demotion switch above and of the floor's kill switch.
 function CooldownCompanion:SetCooldownRoutingEnabled(enabled)
     enabled = enabled == true
-    self.db.global.cooldownRouting = enabled or nil
+    self.db.global.cooldownRouting = enabled
     self._cooldownRoutingOn = enabled
 end
 

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -75,14 +75,18 @@
       and never touches SPELL_UPDATE_COOLDOWN. Bounded by the next ticker
       walk; dirty ticks always walk.
     - Routed mini-passes (F1 3b) run beside the scheduler: they never mark
-      dirty, never touch serials/queue/latch state, never reset or latch the
-      F2 accumulators (_passTimeStateSeen, _tickerIdleEligible,
-      _tickerSkipStreak), never set _cooldownUpdatePassActive, and their
-      batch is dropped whenever a broad refresh is queued at flush time.
-      Secret-arg, nil-arg, panel-matched, and generation-churned fires always
-      take the broad path; index-miss fires are counted drops. Only routed
-      (hit) and dropped (miss) fires skip the dirty mark; every other
-      cooldown fire marks dirty exactly as today.
+      dirty, never touch serials/queue/latch state, never set
+      _cooldownUpdatePassActive, and their batch is dropped whenever a broad
+      refresh is queued at flush time. Their shared per-button pipeline still
+      reaches NoteButtonTimeState, which may push the F2 accumulators
+      (_passTimeStateSeen, _tickerIdleEligible) in the conservative direction
+      (forcing an extra walk) for a forced routed button -- never the permissive
+      one: only a completed broad walk latches _tickerIdleEligible true, so a
+      mini-pass cannot cause a false idle-skip. Secret-arg, nil-arg, panel-
+      matched, rebuild-pending, assistant-excluded, and generation-churned fires
+      all take the broad path; index-miss fires are counted drops. Only routed
+      (hit) and dropped (miss) fires skip the dirty mark; every other cooldown
+      fire marks dirty exactly as today.
 ]]
 
 local ADDON_NAME, ST = ...

--- a/CooldownCompanion/Core/CooldownRouting.lua
+++ b/CooldownCompanion/Core/CooldownRouting.lua
@@ -232,6 +232,19 @@ function CooldownCompanion:FlushRoutedCooldownBatch()
     local SP = ST.ShadowParity
     local spEnabled = SP and SP.enabled
 
+    -- 0. Kill switch: routing was disabled (SetCooldownRoutingEnabled(false))
+    --    between arm and flush. New fires already take the broad path
+    --    (OnCooldownStateChanged gates on _cooldownRoutingOn), but a batch armed
+    --    while routing was on still reaches here; fail open to a broad refresh
+    --    (accuracy inviolable) and drop it so the switch reverts to the legacy
+    --    path with no residual mini-pass -- the drill can trust an instant revert.
+    if not self._cooldownRoutingOn then
+        self:MarkCooldownsDirty("cooldown-event")
+        self:QueueCooldownRefresh("cooldown-event")
+        ClearRoutedBatch()
+        return
+    end
+
     -- 1. Supersede: a queued broad refresh flushes at this same boundary and
     --    strictly covers the batch, so drop it. OnUpdate order between the two
     --    frames is not guaranteed; if the broad flush already ran this is nil

--- a/CooldownCompanion/Core/CooldownRouting.lua
+++ b/CooldownCompanion/Core/CooldownRouting.lua
@@ -2,7 +2,8 @@
     CooldownCompanion - Core/CooldownRouting.lua: F1 3b readable-identity
     cooldown event router.
 
-    When routing is enabled (SetCooldownRoutingEnabled; default OFF), a
+    When routing is enabled (SetCooldownRoutingEnabled; default ON as of F1 3b
+    Commit G, disable with SetCooldownRoutingEnabled(false)), a
     readable-arg SPELL_UPDATE_COOLDOWN fire is resolved through the D3 spell
     index instead of triggering a broad walk:
       - index hit  -> the matched buttons are added to a pending batch that runs

--- a/CooldownCompanion/Core/CooldownRouting.lua
+++ b/CooldownCompanion/Core/CooldownRouting.lua
@@ -242,11 +242,16 @@ function CooldownCompanion:FlushRoutedCooldownBatch()
         return
     end
 
-    -- 2. Generation: a structural rebuild landed between enqueue and flush, so
-    --    the stamped buttons may be stale. Escalate to the broad path (the one
-    --    sanctioned scheduler touch) and drop the batch.
+    -- 2. Generation / pending rebuild: a structural rebuild landed between
+    --    enqueue and flush (generation bumped), OR one is queued but has not run
+    --    yet (buckets about to change, generation not yet bumped). The dispatch
+    --    index-trust gate blocks NEW fires while pending, but a batch armed
+    --    BEFORE the structural change still reaches here; without this the
+    --    generation compare passes (unchanged) and stale/pooled/removed frames
+    --    mini-pass. Either way the stamped buttons may be stale, so escalate to
+    --    the broad path (the one sanctioned scheduler touch) and drop the batch.
     local index = self:GetSpellButtonIndex()
-    if index.generation ~= batchGeneration then
+    if index.generation ~= batchGeneration or self:IsSpellButtonIndexRebuildPending() then
         if spEnabled then SP.generationEscalations = SP.generationEscalations + 1 end
         self:MarkCooldownsDirty("cooldown-event")
         self:QueueCooldownRefresh("cooldown-event")

--- a/CooldownCompanion/Core/CooldownRouting.lua
+++ b/CooldownCompanion/Core/CooldownRouting.lua
@@ -1,0 +1,239 @@
+--[[
+    CooldownCompanion - Core/CooldownRouting.lua: F1 3b readable-identity
+    cooldown event router.
+
+    When routing is enabled (SetCooldownRoutingEnabled; default OFF), a
+    readable-arg SPELL_UPDATE_COOLDOWN fire is resolved through the D3 spell
+    index instead of triggering a broad walk:
+      - index hit  -> the matched buttons are added to a pending batch that runs
+        the full per-button pipeline (UpdateButtonCooldown) on the next OnUpdate
+        boundary (a "mini-pass"), coalescing same-frame fires.
+      - index miss -> the fire is DROPPED: no tracked button displays that
+        identity, so nothing needs updating (policed live by the watchdog's
+        mismatchDropOnly counter).
+      - anything the router cannot fully classify -- secret/unreadable arg, nil
+        (broadcast-form) arg, a matched button in a panel group (cross-button
+        aggregate, D4 inventory A4/A5), or a structural index rebuild between
+        enqueue and flush -- falls back to today's broad path unchanged (fail
+        open; accuracy is inviolable).
+
+    Runs beside the refresh scheduler, never through it (CooldownRefresh.lua
+    header invariants): the mini-pass never marks dirty, never touches the
+    scheduler serial/queue/latch state, never sets _cooldownUpdatePassActive,
+    and never latches/resets the F2 accumulators. The single sanctioned
+    scheduler touch is the generation-escalation fail-open in the flush.
+
+    Fire->buttons resolution is shared with the ShadowParity watchdog via
+    CooldownCompanion:ForEachIndexedSpellButton, so "what the router routes" and
+    "what the watchdog checks" are the same lookup by construction.
+]]
+
+local ADDON_NAME, ST = ...
+local CooldownCompanion = ST.Addon
+
+local issecretvalue = issecretvalue
+local type = type
+local wipe = wipe
+local CreateFrame = CreateFrame
+
+-- Pending routed batch: buttons to mini-pass at the next OnUpdate boundary.
+-- Same-frame fires coalesce with set semantics (a button appears once).
+-- Persists until FlushRoutedCooldownBatch clears it.
+local batchButtons = {}     -- button -> true (dedup across the whole batch)
+local batchOrder = {}       -- ordered buttons (1..batchCount); stale tail ignored
+local batchCount = 0
+local batchGeneration = nil -- index.generation stamped when the batch was armed
+
+-- Per-fire scratch: one fire's matched buttons (union of the spellID bucket and
+-- the distinct-baseID bucket), deduped within the fire, plus a panel-membership
+-- flag. Reset at the top of every RouteCooldownEventFire.
+local fireSeen = {}         -- button -> true within this fire
+local fireList = {}
+local fireCount = 0
+local firePanel = false
+
+-- A panel group (displayMode "textures"/"trigger") is a cross-button aggregate
+-- (D4 inventory A4/A5): its visual ANDs cached per-row state, so updating only
+-- the matched row can leave the panel reading stale inputs. One matched panel
+-- member makes the whole fire broad -- fail open (panel-as-routing-unit is a
+-- later refinement).
+local function IsPanelButton(button)
+    local groupId = button._groupId
+    if not groupId then
+        return false
+    end
+    local profile = CooldownCompanion.db and CooldownCompanion.db.profile
+    local group = profile and profile.groups and profile.groups[groupId]
+    local mode = group and group.displayMode
+    return mode == "textures" or mode == "trigger"
+end
+
+-- ForEachIndexedSpellButton callback: collect this fire's matched buttons
+-- (deduped) and note whether any belongs to a panel group.
+local function CollectFireButton(button)
+    if not fireSeen[button] then
+        fireSeen[button] = true
+        fireCount = fireCount + 1
+        fireList[fireCount] = button
+        if IsPanelButton(button) then
+            firePanel = true
+        end
+    end
+end
+
+local function ClearRoutedBatch()
+    wipe(batchButtons)
+    batchCount = 0
+    batchGeneration = nil
+    -- batchOrder entries beyond batchCount are never read; no need to wipe.
+end
+
+local function RoutedBatchOnUpdate(frame)
+    local addon = frame._cooldownCompanion
+    if addon then
+        addon:FlushRoutedCooldownBatch()
+    end
+end
+
+-- Dedicated parentless always-shown flush frame (mirrors the OnUpdate pattern
+-- of EnsureCooldownRefreshQueueFrame -- NOT the scheduler's queue frame;
+-- constraint 3). It disarms itself on flush and is re-armed by the next routed
+-- fire, so an idle routing world costs no OnUpdate.
+function CooldownCompanion:EnsureRoutedBatchFrame()
+    if not self._routedBatchFrame then
+        local frame = CreateFrame("Frame")
+        frame._cooldownCompanion = self
+        self._routedBatchFrame = frame
+    end
+    if not self._routedBatchArmed then
+        self._routedBatchArmed = true
+        self._routedBatchFrame:SetScript("OnUpdate", RoutedBatchOnUpdate)
+    end
+end
+
+-- Dispatch classifier, called from OnCooldownStateChanged for readable-arg
+-- SPELL_UPDATE_COOLDOWN when routing is on. Returns true only when the fire is
+-- fully handled (routed into the batch, or dropped as an index miss); false
+-- forces the broad path. Classification mirrors ShadowParity NoteIdentityEvent
+-- exactly: issecretvalue guards precede every read, and a distinct readable base
+-- ID is folded in so a fire is a real drop only when NEITHER readable identity
+-- maps to a tracked button.
+function CooldownCompanion:RouteCooldownEventFire(spellID, baseSpellID)
+    local SP = ST.ShadowParity
+    local spEnabled = SP and SP.enabled
+
+    -- Secret/unreadable primary identity -> broad, never routable.
+    if issecretvalue(spellID) then
+        if spEnabled then SP.secretBroadFires = SP.secretBroadFires + 1 end
+        return false
+    end
+    if type(spellID) ~= "number" then
+        -- Non-nil non-number is unreadable (broad); nil is the broadcast form
+        -- (nil demotion is out of scope for this PR).
+        if spEnabled then
+            if spellID ~= nil then
+                SP.secretBroadFires = SP.secretBroadFires + 1
+            else
+                SP.nilBroadFires = SP.nilBroadFires + 1
+            end
+        end
+        return false
+    end
+
+    -- Fold in the distinct readable base ID (same rule as the watchdog).
+    local baseNum
+    if not issecretvalue(baseSpellID) and type(baseSpellID) == "number"
+            and baseSpellID ~= spellID then
+        baseNum = baseSpellID
+    end
+
+    wipe(fireSeen)
+    fireCount = 0
+    firePanel = false
+    self:ForEachIndexedSpellButton(spellID, CollectFireButton)
+    if baseNum then
+        self:ForEachIndexedSpellButton(baseNum, CollectFireButton)
+    end
+
+    if fireCount == 0 then
+        -- Index miss: no tracked button displays this identity -> drop. No dirty
+        -- mark, no walk. Drop safety is policed live by mismatchDropOnly.
+        if spEnabled then SP.droppedFires = SP.droppedFires + 1 end
+        return true
+    end
+    if firePanel then
+        -- A matched button is a panel aggregate member -> fail open to broad.
+        if spEnabled then SP.panelBroadFires = SP.panelBroadFires + 1 end
+        return false
+    end
+
+    -- Route: merge this fire's buttons into the pending batch (set semantics),
+    -- stamp the current index generation, arm the flush.
+    for i = 1, fireCount do
+        local button = fireList[i]
+        if not batchButtons[button] then
+            batchButtons[button] = true
+            batchCount = batchCount + 1
+            batchOrder[batchCount] = button
+        end
+    end
+    batchGeneration = self:GetSpellButtonIndex().generation
+    self:EnsureRoutedBatchFrame()
+    if spEnabled then SP.routedFires = SP.routedFires + 1 end
+    return true
+end
+
+-- The mini-pass: runs on the next OnUpdate boundary after one or more fires
+-- routed. Never marks dirty and never touches scheduler serial/queue/latch
+-- state; the generation-escalation fail-open is the one sanctioned scheduler
+-- touch (the dispatch choosing the broad path, not the mini-pass).
+function CooldownCompanion:FlushRoutedCooldownBatch()
+    -- Disarm first: one flush per armed batch (re-armed by the next routed fire).
+    if self._routedBatchFrame then
+        self._routedBatchFrame:SetScript("OnUpdate", nil)
+    end
+    self._routedBatchArmed = nil
+
+    local SP = ST.ShadowParity
+    local spEnabled = SP and SP.enabled
+
+    -- 1. Supersede: a queued broad refresh flushes at this same boundary and
+    --    strictly covers the batch, so drop it. OnUpdate order between the two
+    --    frames is not guaranteed; if the broad flush already ran this is nil
+    --    and the mini-pass runs redundantly -- safe, just not free.
+    if self._queuedCooldownRefreshSource ~= nil then
+        if spEnabled then SP.supersededBatches = SP.supersededBatches + 1 end
+        ClearRoutedBatch()
+        return
+    end
+
+    -- 2. Generation: a structural rebuild landed between enqueue and flush, so
+    --    the stamped buttons may be stale. Escalate to the broad path (the one
+    --    sanctioned scheduler touch) and drop the batch.
+    local index = self:GetSpellButtonIndex()
+    if index.generation ~= batchGeneration then
+        if spEnabled then SP.generationEscalations = SP.generationEscalations + 1 end
+        self:MarkCooldownsDirty("cooldown-event")
+        self:QueueCooldownRefresh("cooldown-event")
+        ClearRoutedBatch()
+        return
+    end
+
+    -- 3. Mini-pass: shared A1 snapshot, then the full per-button pipeline on
+    --    exactly the matched buttons whose group frame is shown (mirrors the
+    --    broad walk's gate). button:UpdateCooldown delegates to
+    --    UpdateButtonCooldown in every display mode.
+    self:SnapshotCooldownPassContext()
+    local routed = 0
+    for i = 1, batchCount do
+        local button = batchOrder[i]
+        local groupFrame = button:GetParent()
+        if button.buttonData and groupFrame and groupFrame:IsShown() then
+            button:UpdateCooldown()
+            routed = routed + 1
+        end
+    end
+    if spEnabled then SP.routedButtons = SP.routedButtons + routed end
+
+    ClearRoutedBatch()
+end

--- a/CooldownCompanion/Core/CooldownRouting.lua
+++ b/CooldownCompanion/Core/CooldownRouting.lua
@@ -10,18 +10,27 @@
         boundary (a "mini-pass"), coalescing same-frame fires.
       - index miss -> the fire is DROPPED: no tracked button displays that
         identity, so nothing needs updating (policed live by the watchdog's
-        mismatchDropOnly counter).
-      - anything the router cannot fully classify -- secret/unreadable arg, nil
-        (broadcast-form) arg, a matched button in a panel group (cross-button
-        aggregate, D4 inventory A4/A5), or a structural index rebuild between
-        enqueue and flush -- falls back to today's broad path unchanged (fail
-        open; accuracy is inviolable).
+        mismatchDropOnly counter). A drop is only taken once the index-trust
+        gate below has passed.
+      - anything the router cannot fully classify, or any state that makes the
+        index untrustworthy, falls back to today's broad path unchanged (fail
+        open; accuracy is inviolable): secret/unreadable arg, nil (broadcast-
+        form) arg, a matched button in a panel group (cross-button aggregate,
+        D4 inventory A4/A5), a structural index rebuild pending or landed
+        between enqueue and flush, or any rotation-assistant virtual button
+        loaded (those are excluded from the index by design, so a drop could
+        starve one -- SpellButtonIndex header).
 
     Runs beside the refresh scheduler, never through it (CooldownRefresh.lua
     header invariants): the mini-pass never marks dirty, never touches the
-    scheduler serial/queue/latch state, never sets _cooldownUpdatePassActive,
-    and never latches/resets the F2 accumulators. The single sanctioned
-    scheduler touch is the generation-escalation fail-open in the flush.
+    scheduler serial/queue/latch state, and never sets _cooldownUpdatePassActive.
+    It does reach NoteButtonTimeState through the shared per-button pipeline,
+    which may push the F2 accumulators (_passTimeStateSeen, _tickerIdleEligible)
+    in the conservative direction (forcing an extra walk) for a forced routed
+    button -- never the permissive one: only a completed broad walk latches
+    _tickerIdleEligible true, so a mini-pass can never cause a false idle-skip.
+    The single sanctioned scheduler touch is the generation-escalation fail-open
+    in the flush.
 
     Fire->buttons resolution is shared with the ShadowParity watchdog via
     CooldownCompanion:ForEachIndexedSpellButton, so "what the router routes" and
@@ -122,6 +131,25 @@ function CooldownCompanion:RouteCooldownEventFire(spellID, baseSpellID)
     local SP = ST.ShadowParity
     local spEnabled = SP and SP.enabled
 
+    -- Index-trust gate (fail open BEFORE any route or drop): the flush
+    -- generation guard only re-checks routed batches, never the immediate
+    -- index-miss drop, so an untrustworthy index must broad-fallback here.
+    local index = self:GetSpellButtonIndex()
+    if self:IsSpellButtonIndexRebuildPending() then
+        -- Rebuild queued but not run: buckets predate the change, so a fire for
+        -- a not-yet-indexed button could be wrongly dropped.
+        if spEnabled then SP.rebuildPendingBroadFires = SP.rebuildPendingBroadFires + 1 end
+        return false
+    end
+    if index.excludedCount > 0 then
+        -- Rotation-assistant virtual buttons are index-excluded (their identity
+        -- follows the assisted-combat recommendation and is permanently stale);
+        -- keep every fire broad while any is loaded so a drop can never starve
+        -- one (SpellButtonIndex header intent).
+        if spEnabled then SP.assistantExcludedBroadFires = SP.assistantExcludedBroadFires + 1 end
+        return false
+    end
+
     -- Secret/unreadable primary identity -> broad, never routable.
     if issecretvalue(spellID) then
         if spEnabled then SP.secretBroadFires = SP.secretBroadFires + 1 end
@@ -167,8 +195,16 @@ function CooldownCompanion:RouteCooldownEventFire(spellID, baseSpellID)
         return false
     end
 
-    -- Route: merge this fire's buttons into the pending batch (set semantics),
-    -- stamp the current index generation, arm the flush.
+    -- Route: merge this fire's buttons into the pending batch (set semantics)
+    -- and arm the flush. Stamp the index generation ONCE, when the batch first
+    -- arms -- re-stamping on later fires would mask a rebuild that landed after
+    -- the earliest batched button was resolved, letting the flush generation
+    -- guard pass on a stale batch. A later fire resolved under a newer
+    -- generation still coalesces in; the guard then escalates the whole batch to
+    -- broad, which is the correct fail-open.
+    if batchCount == 0 then
+        batchGeneration = index.generation
+    end
     for i = 1, fireCount do
         local button = fireList[i]
         if not batchButtons[button] then
@@ -177,7 +213,6 @@ function CooldownCompanion:RouteCooldownEventFire(spellID, baseSpellID)
             batchOrder[batchCount] = button
         end
     end
-    batchGeneration = self:GetSpellButtonIndex().generation
     self:EnsureRoutedBatchFrame()
     if spEnabled then SP.routedFires = SP.routedFires + 1 end
     return true

--- a/CooldownCompanion/Core/GroupOperations.lua
+++ b/CooldownCompanion/Core/GroupOperations.lua
@@ -3396,15 +3396,14 @@ function CooldownCompanion:DiscardDormantFrame(groupId)
     end
 end
 
-function CooldownCompanion:UpdateAllCooldowns()
-    local T = ST.RefreshTelemetry
-    local telemetryOn = T and T.enabled
-    local t0, frames, buttons
-    if telemetryOn then
-        t0 = debugprofilestop()
-        frames, buttons = 0, 0
-    end
-
+-- A1 shared per-pass input snapshot: the GCD state (spell 61304), the
+-- assisted-highlight hostile-target gate, and the CDM viewer CVar -- the three
+-- reads every button in a pass must see identically (D4 inventory A1). Extracted
+-- so routed mini-passes (F1 3b) take the same once-per-batch snapshot the broad
+-- walk uses. Deliberately does NOT touch _cooldownUpdatePassActive or
+-- _passTimeStateSeen: a mini-pass must not set either (3b constraints 4-5), so
+-- those stay in UpdateAllCooldowns below.
+function CooldownCompanion:SnapshotCooldownPassContext()
     self._gcdInfo = C_Spell.GetSpellCooldown(61304)
     -- GCD activity: isActive is NeverSecret (12.0.1 hotfix)
     self._gcdActive = self._gcdInfo and self._gcdInfo.isActive or false
@@ -3423,6 +3422,18 @@ function CooldownCompanion:UpdateAllCooldowns()
 
     -- Cache CDM viewer CVar once per tick (avoids per-button GetCVarBool in ResolveBuffViewerFrameForSpell)
     self._cdmViewerEnabled = C_CVar_GetCVarBool("cooldownViewerEnabled") == true
+end
+
+function CooldownCompanion:UpdateAllCooldowns()
+    local T = ST.RefreshTelemetry
+    local telemetryOn = T and T.enabled
+    local t0, frames, buttons
+    if telemetryOn then
+        t0 = debugprofilestop()
+        frames, buttons = 0, 0
+    end
+
+    self:SnapshotCooldownPassContext()
     self._cooldownUpdatePassActive = true
     -- F2 shadow: reset the per-pass time-animation flag. Any button that renders
     -- time-driven state this walk sets it true (NoteButtonTimeState); a walk that

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -133,13 +133,13 @@ function CooldownCompanion:OnEnable()
     self.db.global.combatTickerFloor = nil
     self._combatTickerFloorOn = self.db.global.combatTickerFloorDisabled ~= true
 
-    -- F1 3a: seed the broadcast-demotion runtime flag from saved state (absent
-    -- key = OFF; today's immediate-broad path for every cooldown event).
-    self._cooldownBroadcastDemotionOn = self.db.global.cooldownBroadcastDemotion == true
+    -- F1 3a: seed the broadcast-demotion runtime flag from saved state. DEFAULT
+    -- ON (F1 3b Commit G): absent key = ON; only an explicit false disables.
+    self._cooldownBroadcastDemotionOn = self.db.global.cooldownBroadcastDemotion ~= false
 
-    -- F1 3b: seed the cooldown-routing runtime flag from saved state (absent key
-    -- = OFF; today's broad path for every readable-arg SPELL_UPDATE_COOLDOWN).
-    self._cooldownRoutingOn = self.db.global.cooldownRouting == true
+    -- F1 3b: seed the cooldown-routing runtime flag from saved state. DEFAULT ON
+    -- (F1 3b Commit G): absent key = ON; only an explicit false disables.
+    self._cooldownRoutingOn = self.db.global.cooldownRouting ~= false
 
     -- F6: render-layer flattening is now permanent (applied unconditionally at
     -- button creation); drop the saved switch key from any earlier build.

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -133,6 +133,10 @@ function CooldownCompanion:OnEnable()
     self.db.global.combatTickerFloor = nil
     self._combatTickerFloorOn = self.db.global.combatTickerFloorDisabled ~= true
 
+    -- F1 3a: seed the broadcast-demotion runtime flag from saved state (absent
+    -- key = OFF; today's immediate-broad path for every cooldown event).
+    self._cooldownBroadcastDemotionOn = self.db.global.cooldownBroadcastDemotion == true
+
     -- F6: render-layer flattening is now permanent (applied unconditionally at
     -- button creation); drop the saved switch key from any earlier build.
     self.db.global.renderFlattenEnabled = nil
@@ -364,6 +368,17 @@ function CooldownCompanion:OnCooldownStateChanged(event, ...)
     local SP = ST.ShadowParity
     if SP and SP.enabled then
         SP:NoteCooldownEvent(event, ...)
+    end
+    if self._cooldownBroadcastDemotionOn
+        and (event == "ACTIONBAR_UPDATE_COOLDOWN" or event == "BAG_UPDATE_COOLDOWN")
+    then
+        -- F1 3a: identity-less broadcast events carry no data CC consumes
+        -- (D2 + demotion trace); everything they signal is re-polled by the
+        -- next walk. Dirty-only: the next tick walks (<=0.1s), in combat and
+        -- OOC alike. SPELL_UPDATE_COOLDOWN keeps immediate accuracy below.
+        self:MarkCooldownsDirty(event == "BAG_UPDATE_COOLDOWN"
+            and "bag-cd-broadcast" or "actionbar-cd-broadcast")
+        return
     end
     self:MarkCooldownsDirty("cooldown-event")
     -- Preserve immediate cooldown-event accuracy. This refresh only suppresses

--- a/CooldownCompanion/Core/Lifecycle.lua
+++ b/CooldownCompanion/Core/Lifecycle.lua
@@ -137,6 +137,10 @@ function CooldownCompanion:OnEnable()
     -- key = OFF; today's immediate-broad path for every cooldown event).
     self._cooldownBroadcastDemotionOn = self.db.global.cooldownBroadcastDemotion == true
 
+    -- F1 3b: seed the cooldown-routing runtime flag from saved state (absent key
+    -- = OFF; today's broad path for every readable-arg SPELL_UPDATE_COOLDOWN).
+    self._cooldownRoutingOn = self.db.global.cooldownRouting == true
+
     -- F6: render-layer flattening is now permanent (applied unconditionally at
     -- button creation); drop the saved switch key from any earlier build.
     self.db.global.renderFlattenEnabled = nil
@@ -368,6 +372,15 @@ function CooldownCompanion:OnCooldownStateChanged(event, ...)
     local SP = ST.ShadowParity
     if SP and SP.enabled then
         SP:NoteCooldownEvent(event, ...)
+    end
+    -- F1 3b: readable-identity SPELL fires route to their index-matched buttons
+    -- (mini-pass) or drop (no tracked button). Anything the router cannot fully
+    -- classify -- secret/nil arg, panel-matched button, generation churn --
+    -- returns false and falls through to the broad path below unchanged.
+    if self._cooldownRoutingOn and event == "SPELL_UPDATE_COOLDOWN" then
+        if self:RouteCooldownEventFire(...) then
+            return
+        end
     end
     if self._cooldownBroadcastDemotionOn
         and (event == "ACTIONBAR_UPDATE_COOLDOWN" or event == "BAG_UPDATE_COOLDOWN")

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -123,6 +123,7 @@ local CHARGE_ONLY = {
 }
 
 local LOG_SIZE = 64
+local FORCED_TERM_LOG_SIZE = 32     -- F1 3b Commit A: forcing-term sample ring
 
 local SP = {
     enabled = false,
@@ -173,6 +174,14 @@ local SP = {
     combatOtherLog = {},            -- ring: "time|source|fields|button"
     combatOtherCursor = 0,
     combatOtherTotal = 0,
+    -- F1 3b Commit A forcing-term tally (observe-only). With the floor ON, a
+    -- residual clean walk still ran because at least one button forced walking;
+    -- these name the term(s) that pinned it, so the pinner can be identified in
+    -- the same soak that validates routing. Populated by NoteForcedTerm.
+    forcedTermCounts = {},          -- term -> forced-button occurrences
+    forcedTermLog = {},             -- ring: "term|button" samples
+    forcedTermCursor = 0,
+    forcedTermTotal = 0,
     -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
     log = {},
     logCursor = 0,
@@ -343,6 +352,27 @@ local function DescribeButton(button)
         tostring(button.index),
         tostring(buttonData and buttonData.type),
         tostring(buttonData and (buttonData.id or buttonData.itemSlot)))
+end
+
+-- F1 3b Commit A: record one classifier term that forced a walk on `button`.
+-- Called once per contributing term per forced button per broad walk, only
+-- while enabled (the caller guards on SP.enabled). Keeps a per-term count plus
+-- a small overwriting ring of (term, buttonDesc) samples.
+function SP:NoteForcedTerm(term, button)
+    self.forcedTermCounts[term] = (self.forcedTermCounts[term] or 0) + 1
+    local cursor = self.forcedTermCursor % FORCED_TERM_LOG_SIZE + 1
+    self.forcedTermCursor = cursor
+    self.forcedTermTotal = self.forcedTermTotal + 1
+    self.forcedTermLog[cursor] = term .. "|" .. DescribeButton(button)
+end
+
+-- Forwarder so callers that cannot afford a new file upvalue (CooldownUpdate.lua
+-- UpdateButtonCooldown sits at the 60-upvalue ceiling) can report a forcing term
+-- through the existing CooldownCompanion upvalue. No-op unless enabled.
+function CooldownCompanion:NoteForcedTickerTerm(term, button)
+    if SP.enabled then
+        SP:NoteForcedTerm(term, button)
+    end
 end
 
 local function BatchSummary()
@@ -687,6 +717,10 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         combatUsableOnlyStamps = CopyRing(SP.combatUsableOnlyStamps, SPIKE_STAMP_SIZE),
         combatOtherTotal = SP.combatOtherTotal,
         combatOtherLog = CopyRing(SP.combatOtherLog, SPIKE_LOG_SIZE),
+        -- F1 3b Commit A forcing-term tally
+        forcedTermCounts = CopyScalarMap(SP.forcedTermCounts),
+        forcedTermTotal = SP.forcedTermTotal,
+        forcedTermLog = CopyRing(SP.forcedTermLog, FORCED_TERM_LOG_SIZE),
     }
 end
 
@@ -729,6 +763,11 @@ function CooldownCompanion:ResetShadowParity()
     wipe(SP.combatDirtySourceTicks)
     wipe(SP.combatUsableOnlyStamps)
     wipe(SP.combatOtherLog)
+    -- F1 3b Commit A forcing-term tally
+    wipe(SP.forcedTermCounts)
+    wipe(SP.forcedTermLog)
+    SP.forcedTermCursor = 0
+    SP.forcedTermTotal = 0
     -- Drop any in-flight batch too, so a reset mid-window starts clean.
     ResetBatch()
 end
@@ -764,6 +803,18 @@ function CooldownCompanion:PrintCombatFloorSummary()
     if SP.combatOtherTotal > 0 then
         self:Print(("CombatFloor: %d other-write passes logged — /dump CooldownCompanion:GetShadowParityDiagnostics()"):format(SP.combatOtherTotal))
     end
+    -- F1 3b Commit A: which classifier term(s) pinned the ticker awake (one
+    -- forcing button keeps the whole ticker walking). The top term names the
+    -- residual clean-walk pinner.
+    local parts, n = {}, 0
+    for term, count in pairs(SP.forcedTermCounts) do
+        n = n + 1
+        parts[n] = term .. " " .. count
+    end
+    self:Print(n > 0
+        and ("CombatFloor forced terms (%d total): %s"):format(
+            SP.forcedTermTotal, table.concat(parts, ", ", 1, n))
+        or "CombatFloor forced terms: (none seen)")
 end
 
 -- Gate: enable only when the CC_DevBridge dev addon is present (same pattern

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -194,7 +194,7 @@ local SP = {
     rebuildPendingBroadFires = 0,   -- index rebuild pending (buckets stale) -> broad
     assistantExcludedBroadFires = 0,-- rotation-assistant button loaded -> broad
     supersededBatches = 0,          -- batch dropped: a broad refresh was queued
-    generationEscalations = 0,      -- batch escalated: index rebuilt before flush
+    generationEscalations = 0,      -- batch escalated: index rebuilt or rebuild pending at flush
     -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
     log = {},
     logCursor = 0,
@@ -380,7 +380,10 @@ end
 -- UpdateButtonCooldown sits at the 60-upvalue ceiling) can report a forcing term
 -- through the existing CooldownCompanion upvalue. No-op unless enabled.
 function CooldownCompanion:NoteForcedTickerTerm(term, button)
-    if SP.enabled then
+    -- Broad-walk only (mirrors the NoteButtonTimeState tally gate): a routed
+    -- mini-pass reaches the hidden-button fail-open callers too, but its terms
+    -- are not clean-walk ticker pins and must not skew the forced-term counts.
+    if SP.enabled and self._cooldownUpdatePassActive then
         SP:NoteForcedTerm(term, button)
     end
 end

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -182,6 +182,17 @@ local SP = {
     forcedTermLog = {},             -- ring: "term|button" samples
     forcedTermCursor = 0,
     forcedTermTotal = 0,
+    -- F1 3b Commit C live-router counters (incremented by CooldownRouting.lua
+    -- only while enabled -- zero user cost). Separate from the watchdog's
+    -- mismatch counters: these measure what the router actually did.
+    routedFires = 0,                -- SPELL_UPDATE_COOLDOWN fires routed to a batch
+    routedButtons = 0,              -- button mini-pass updates run at flush
+    droppedFires = 0,               -- readable fires no tracked button indexes
+    secretBroadFires = 0,           -- secret/unreadable arg -> forced broad path
+    nilBroadFires = 0,              -- nil (broadcast-form) arg -> forced broad path
+    panelBroadFires = 0,            -- a matched button is in a panel group -> broad
+    supersededBatches = 0,          -- batch dropped: a broad refresh was queued
+    generationEscalations = 0,      -- batch escalated: index rebuilt before flush
     -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
     log = {},
     logCursor = 0,
@@ -238,17 +249,14 @@ local function CountFire(tag)
 end
 
 -- Stamp every button the D3 index maps this spellID to as covered by the
--- current batch. Returns true when at least one button was stamped.
+-- current batch. Shares CooldownCompanion:ForEachIndexedSpellButton with the
+-- live router (F1 3b) so both resolve a fire to the same button set by
+-- construction. Returns true when at least one button was stamped.
+local function StampCoveredButton(button)
+    button._shadowParityCoveredBatch = batch.id
+end
 local function StampCovered(spellID)
-    local index = CooldownCompanion:GetSpellButtonIndex()
-    local bucket = index.spell[spellID]
-    if not bucket then
-        return false
-    end
-    for _, button in ipairs(bucket) do
-        button._shadowParityCoveredBatch = batch.id
-    end
-    return true
+    return CooldownCompanion:ForEachIndexedSpellButton(spellID, StampCoveredButton)
 end
 
 -- Secret or non-number identity arg: the router cannot inspect it and must
@@ -721,6 +729,15 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         forcedTermCounts = CopyScalarMap(SP.forcedTermCounts),
         forcedTermTotal = SP.forcedTermTotal,
         forcedTermLog = CopyRing(SP.forcedTermLog, FORCED_TERM_LOG_SIZE),
+        -- F1 3b Commit C live-router counters
+        routedFires = SP.routedFires,
+        routedButtons = SP.routedButtons,
+        droppedFires = SP.droppedFires,
+        secretBroadFires = SP.secretBroadFires,
+        nilBroadFires = SP.nilBroadFires,
+        panelBroadFires = SP.panelBroadFires,
+        supersededBatches = SP.supersededBatches,
+        generationEscalations = SP.generationEscalations,
     }
 end
 
@@ -768,6 +785,15 @@ function CooldownCompanion:ResetShadowParity()
     wipe(SP.forcedTermLog)
     SP.forcedTermCursor = 0
     SP.forcedTermTotal = 0
+    -- F1 3b Commit C live-router counters
+    SP.routedFires = 0
+    SP.routedButtons = 0
+    SP.droppedFires = 0
+    SP.secretBroadFires = 0
+    SP.nilBroadFires = 0
+    SP.panelBroadFires = 0
+    SP.supersededBatches = 0
+    SP.generationEscalations = 0
     -- Drop any in-flight batch too, so a reset mid-window starts clean.
     ResetBatch()
 end
@@ -783,6 +809,18 @@ function CooldownCompanion:PrintShadowParitySummary()
     if SP.shadowParityMismatchTotal > 0 then
         self:Print("ShadowParity: mismatches logged — /dump CooldownCompanion:GetShadowParityDiagnostics()")
     end
+end
+
+-- F1 3b Commit C: live-routing readout. Routed vs dropped is the ~14/86 split
+-- the router aims for; the broad-fallback counts (secret/nil/panel) plus the
+-- supersede/generation drops show the fail-open paths firing. Pairs with the
+-- hard gates in PrintShadowParitySummary (shadowParityMismatchTotal /
+-- mismatchDropOnly), which stay the routing-failure detectors.
+function CooldownCompanion:PrintCooldownRoutingSummary()
+    self:Print(("CooldownRouting: routed %d fires -> %d button updates | dropped %d (index miss) | broad fallback: secret %d, nil %d, panel %d | batches: superseded %d, gen-escalated %d"):format(
+        SP.routedFires, SP.routedButtons, SP.droppedFires,
+        SP.secretBroadFires, SP.nilBroadFires, SP.panelBroadFires,
+        SP.supersededBatches, SP.generationEscalations))
 end
 
 -- Combat ticker-floor spike readout (spec docs/plans/2026-07-03-015). Headline:

--- a/CooldownCompanion/Core/ShadowParity.lua
+++ b/CooldownCompanion/Core/ShadowParity.lua
@@ -191,6 +191,8 @@ local SP = {
     secretBroadFires = 0,           -- secret/unreadable arg -> forced broad path
     nilBroadFires = 0,              -- nil (broadcast-form) arg -> forced broad path
     panelBroadFires = 0,            -- a matched button is in a panel group -> broad
+    rebuildPendingBroadFires = 0,   -- index rebuild pending (buckets stale) -> broad
+    assistantExcludedBroadFires = 0,-- rotation-assistant button loaded -> broad
     supersededBatches = 0,          -- batch dropped: a broad refresh was queued
     generationEscalations = 0,      -- batch escalated: index rebuilt before flush
     -- mismatch / broadcast-carried detail ring (formatted strings, SV-safe)
@@ -736,6 +738,8 @@ function CooldownCompanion:GetShadowParityDiagnostics()
         secretBroadFires = SP.secretBroadFires,
         nilBroadFires = SP.nilBroadFires,
         panelBroadFires = SP.panelBroadFires,
+        rebuildPendingBroadFires = SP.rebuildPendingBroadFires,
+        assistantExcludedBroadFires = SP.assistantExcludedBroadFires,
         supersededBatches = SP.supersededBatches,
         generationEscalations = SP.generationEscalations,
     }
@@ -792,6 +796,8 @@ function CooldownCompanion:ResetShadowParity()
     SP.secretBroadFires = 0
     SP.nilBroadFires = 0
     SP.panelBroadFires = 0
+    SP.rebuildPendingBroadFires = 0
+    SP.assistantExcludedBroadFires = 0
     SP.supersededBatches = 0
     SP.generationEscalations = 0
     -- Drop any in-flight batch too, so a reset mid-window starts clean.
@@ -817,9 +823,10 @@ end
 -- hard gates in PrintShadowParitySummary (shadowParityMismatchTotal /
 -- mismatchDropOnly), which stay the routing-failure detectors.
 function CooldownCompanion:PrintCooldownRoutingSummary()
-    self:Print(("CooldownRouting: routed %d fires -> %d button updates | dropped %d (index miss) | broad fallback: secret %d, nil %d, panel %d | batches: superseded %d, gen-escalated %d"):format(
+    self:Print(("CooldownRouting: routed %d fires -> %d button updates | dropped %d (index miss) | broad fallback: secret %d, nil %d, panel %d, rebuild-pending %d, assistant %d | batches: superseded %d, gen-escalated %d"):format(
         SP.routedFires, SP.routedButtons, SP.droppedFires,
         SP.secretBroadFires, SP.nilBroadFires, SP.panelBroadFires,
+        SP.rebuildPendingBroadFires, SP.assistantExcludedBroadFires,
         SP.supersededBatches, SP.generationEscalations))
 end
 

--- a/CooldownCompanion/Core/SpellButtonIndex.lua
+++ b/CooldownCompanion/Core/SpellButtonIndex.lua
@@ -9,7 +9,7 @@
     talent/spec/pet/equipment churn before anything depended on it. As of F1 3b
     the live cooldown router (CooldownRouting.lua) and the shadow-parity watchdog
     both consume it through ForEachIndexedSpellButton. It is only load-bearing
-    while routing is enabled (default OFF), and the router fails open to the broad
+    while routing is enabled (default ON as of F1 3b), and the router fails open to the broad
     path whenever the index cannot be trusted -- a rebuild is pending (buckets
     stale, IsSpellButtonIndexRebuildPending) or any rotation-assistant virtual
     button is loaded (excluded from the index, see below).

--- a/CooldownCompanion/Core/SpellButtonIndex.lua
+++ b/CooldownCompanion/Core/SpellButtonIndex.lua
@@ -5,10 +5,14 @@
     Maps identity keys to loaded button frames so a future event router can ask
     "which buttons care about spell/item X?" without walking every button.
 
-    PASSIVE BY DESIGN: nothing at runtime consumes this index. Its only readers
-    are the diagnostics below (and, later, the D1 shadow-parity harness). It
-    ships early so it soaks through real talent/spec/pet/equipment churn while
-    nothing depends on it.
+    Originally PASSIVE BY DESIGN so it could soak through real
+    talent/spec/pet/equipment churn before anything depended on it. As of F1 3b
+    the live cooldown router (CooldownRouting.lua) and the shadow-parity watchdog
+    both consume it through ForEachIndexedSpellButton. It is only load-bearing
+    while routing is enabled (default OFF), and the router fails open to the broad
+    path whenever the index cannot be trusted -- a rebuild is pending (buckets
+    stale, IsSpellButtonIndexRebuildPending) or any rotation-assistant virtual
+    button is loaded (excluded from the index, see below).
 
     Keys are multi-key per button, mirroring what event-arg matching will need:
     - spell entries: base spellID, live override spellID
@@ -171,6 +175,16 @@ end
 -- Live index table (diagnostics and, later, the D1 shadow-parity harness).
 function CooldownCompanion:GetSpellButtonIndex()
     return index
+end
+
+-- True while a structural rebuild has been requested (RequestSpellButtonIndexRebuild)
+-- but the coalesced next-frame RebuildSpellButtonIndex has not yet run. In this
+-- window the buckets predate the change that triggered the request, so a fire for
+-- a not-yet-indexed button would be misclassified. The live router (F1 3b) reads
+-- this and fails open to the broad path while it is true -- the flush generation
+-- guard only re-checks routed batches, never the immediate index-miss drop.
+function CooldownCompanion:IsSpellButtonIndexRebuildPending()
+    return pendingRebuildReason ~= nil
 end
 
 -- Shared fire->buttons resolution used by BOTH the live router (F1 3b) and the

--- a/CooldownCompanion/Core/SpellButtonIndex.lua
+++ b/CooldownCompanion/Core/SpellButtonIndex.lua
@@ -2,8 +2,8 @@
     CooldownCompanion - Core/SpellButtonIndex.lua: reverse identity -> buttons
     index (F1 prerequisite D3).
 
-    Maps identity keys to loaded button frames so a future event router can ask
-    "which buttons care about spell/item X?" without walking every button.
+    Maps identity keys to loaded button frames so the cooldown event router can
+    ask "which buttons care about spell/item X?" without walking every button.
 
     Originally PASSIVE BY DESIGN so it could soak through real
     talent/spec/pet/equipment churn before anything depended on it. As of F1 3b

--- a/CooldownCompanion/Core/SpellButtonIndex.lua
+++ b/CooldownCompanion/Core/SpellButtonIndex.lua
@@ -173,6 +173,22 @@ function CooldownCompanion:GetSpellButtonIndex()
     return index
 end
 
+-- Shared fire->buttons resolution used by BOTH the live router (F1 3b) and the
+-- shadow-parity watchdog (ShadowParity StampCovered). callback(button) runs once
+-- per button indexed under this readable spellID; returns true when at least one
+-- button is indexed. Single lookup by construction, so "what the router routes"
+-- and "what the watchdog checks" cannot drift.
+function CooldownCompanion:ForEachIndexedSpellButton(spellID, callback)
+    local bucket = index.spell[spellID]
+    if not bucket then
+        return false
+    end
+    for _, button in ipairs(bucket) do
+        callback(button)
+    end
+    return true
+end
+
 local function DescribeButton(button)
     local buttonData = button.buttonData
     local groupId = button._groupId or (button:GetParent() and button:GetParent().groupId)


### PR DESCRIPTION
## What Changed
- Adds an identity-based router for `SPELL_UPDATE_COOLDOWN` events. When enabled, a readable-arg cooldown fire is resolved through the spell→buttons index and either updates **only its matched buttons** (a coalesced "mini-pass" on the next frame) or is **dropped** when no tracked button uses that spell — instead of today's full walk of every tracked button on every fire.
- Anything the router cannot fully classify falls back to the existing broad walk unchanged (fail-open; accuracy is never traded): a secret/unreadable event arg, a broadcast-form (nil) arg, a matched button inside a texture/trigger panel (cross-button aggregate), or an index rebuild landing between the event and the flush.
- Folds in the "3a" broadcast demotion (Commit B): the identity-less broadcast events (`ACTIONBAR_UPDATE_COOLDOWN` / `BAG_UPDATE_COOLDOWN`) are demoted from an immediate full walk to a dirty-mark the next tick picks up (≤0.1s).
- Adds a dev-gated, observe-only instrument (Commit A) that tallies which classifier term keeps the combat ticker awake, so the same soak that validates routing also names the residual walk-forcer. This restructures `NoteButtonTimeState` into individual booleans with the truth table preserved exactly — no behavior change when the instrument is off.
- Two hidden switches (no config UI), now **both default ON** as of Commit G: `SetCooldownRoutingEnabled` and `SetCooldownBroadcastDemotionEnabled`. Disable either live (no reload) with `SetCooldownRoutingEnabled(false)` / `SetCooldownBroadcastDemotionEnabled(false)`; an explicit OFF persists across reload.

## Why This Changed
- After the combat ticker floor landed, event-driven broad walks became the dominant cooldown-refresh cost. In the reference target-dummy capture, cooldown-event dirty marks drove **>54% of all walks**. About **86%** of `SPELL_UPDATE_COOLDOWN` fires name spells no tracked button uses (index misses) yet still triggered a full walk of every button; the remaining hits touched only 1–2 buttons. Routing drops the misses entirely and shrinks the hits to a targeted update.

## Developer Impact
- **This PR targets `dev` integration, not a user release.** As of Commit G both switches default ON, so **merging activates routing + broadcast demotion by default on `dev`** (the prior "dormant until flipped" behavior is gone). The intended payoff is lower combat CPU (fewer full button walks per second) with **no visual change** — players would only notice smoother frame time in sustained combat, never any difference in what the trackers display. A separate user-facing release remains a later gate.
- The live router and the existing shadow-parity watchdog resolve a fire to buttons through **one shared lookup** (`ForEachIndexedSpellButton`), so the watchdog's mismatch counters remain the load-bearing correctness evidence for routing during soak (a routed/dropped button and a watchdog-covered button are the same set by construction).
- New file `Core/CooldownRouting.lua` holds the router and its dedicated flush frame; the per-pass GCD/target/CVar prologue was extracted into `SnapshotCooldownPassContext()` and is now shared by the broad walk and the mini-pass (behavior-identical refactor). Router/instrument counters live on the dev-gated ShadowParity block and surface via the DevBridge saved variable plus new summary prints.
- Mini-passes run beside the refresh scheduler, never through it: they never mark dirty, never touch the serial/queue/latch state, never set `_cooldownUpdatePassActive`, and never latch the idle-ticker accumulators (the sole scheduler touch is the generation-escalation fail-open).

## Post-Review Hardening (Commits D–G)
Several rounds of post-commit code review (plus external reviewer cohorts) tightened the router's fail-open perimeter. Static checks (`luac -p`, `git diff --check`) are clean on every touched file.

- **Commit D (`111ba258`)** — index-trust gate at dispatch: the router now fails open to the broad path while an index rebuild is *pending* (buckets predate the change, so a fire for a not-yet-indexed button can't be wrongly dropped) or while any rotation-assistant virtual button is loaded (those are index-excluded by design, so a drop could otherwise starve one). `batchGeneration` is now stamped **once** when a routed batch first arms — re-stamping on later fires could mask a mid-window rebuild and let a stale batch skip the generation-escalation guard. Adds `IsSpellButtonIndexRebuildPending()` plus two soak counters (`rebuildPendingBroadFires`, `assistantExcludedBroadFires`).
- **Commit E (`cfedd8d2`)** — the flush (`FlushRoutedCooldownBatch`) now also escalates to broad when a rebuild is *pending*, the symmetric counterpart to D's dispatch gate: a batch armed *before* a structural change previously reached the flush with an unchanged generation and could mini-pass stale/pooled/removed frames. Also gates the Commit-A forced-term tally to broad walks (`_cooldownUpdatePassActive`) so routed mini-passes no longer contaminate the clean-walk ticker-pinner counts.
- **Commit F (`a5c057ea`)** — kill-switch flush fail-open: `FlushRoutedCooldownBatch` now escalates to a broad refresh and drops the batch when routing is off, so disabling routing live (or on addon disable) reverts to the legacy path instantly with no residual mini-pass — the kill-switch drill can trust an instant revert. Also corrects the `SpellButtonIndex` one-line header ("future" → live router).
- **Commit G (`e034f264`)** — flips both hidden switches from default-OFF to **default-ON** for `dev` integration. OnEnable seeds read `~= false` (absent key = ON); the setters store a strict boolean so an explicit OFF persists across reload. Runtime behavior still keys off the `_cooldownRoutingOn` / `_cooldownBroadcastDemotionOn` flags — only the seed default and persistence inverted.

## Validation

**Static.** `luac -p` clean on every touched addon file; `git diff --check` clean; per-function upvalue audit clean (max 60 upvalues on `UpdateButtonCooldown`, unchanged — the Lua 5.1 per-function ceiling, deliberately not exceeded).

**In-game soak** (both switches ON, combat ticker floor ON, watchdog + telemetry ON), Feral Druid, across sustained target-dummy combat, mid-combat live spell overrides, spec swaps, and a texture panel:

- **Hard gates all zero:** `shadowParityMismatchTotal` 0, `mismatchDropOnly` 0, `falseIdleTotal` 0, **0 Lua errors**, and `VerifySpellButtonIndexAll()` clean (0 mismatches after 27 index rebuilds, 38 live buttons).
- **Router ↔ watchdog reconcile exactly** in one atomic snapshot (proving the shared fire→button resolution never drifts): routed 74 + panel-fallback 1 = **75** watchdog-covered identity fires; dropped **652** = watchdog misses **652**; nil-arg fallback **11** = watchdog broadcast-form **11**; secret **0** = **0**.
- **Fail-open paths confirmed firing:** panel fallback (`panelBroadFires` 1, from a texture-panel-tracked cast), nil-arg fallback (11), and broad-refresh coalescing (`supersededBatches` 23). Index-generation escalation did not need to fire (0) — spec rebuilds happen out of combat with no routed batch in flight; index integrity is covered by the clean sweep + `mismatchDropOnly` 0.
- **Drop safety:** 652 index-miss fires stopped causing walks; none turned out to matter (`mismatchDropOnly` 0, sweep clean).
- **Routed/dropped split** ≈ 14% / 86% (35 routed / 214 dropped in the stationary target-dummy window; 74 / 652 in the churn-heavy window) — the minority-route / majority-drop shape the design predicts.
- Per the project's combat-validation-equals-instance-validation ruling, no separate instanced pass is required.

**Coverage note.** The in-game soak above was run against the A–C router (switches ON) and **predates Commits D–G**. The newer fail-open paths (`rebuildPendingBroadFires`, `assistantExcludedBroadFires`, the flush pending-rebuild escalation, and the Commit-F kill-switch fail-open) are static/`luac`-clean but **not yet soak-covered**. With Commit G defaulting both switches ON, `dev` now exercises routing by default — a re-soak on `dev` covering an Assistant Panel loaded, structural churn during in-flight routed batches, transform/override spells, and the live kill-switch drill is warranted before this graduates toward a user-facing release.
