### PR TITLE
Lower combat CPU: texture and trigger panels no longer force constant refreshes

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -7,6 +7,10 @@ local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
 local EntryRuntime = ST.EntryRuntime
+-- Forcing-attribution sink (loaded before this file; dev-gated, observe-only).
+-- Referenced only by NoteButtonTimeState -- UpdateButtonCooldown is at the
+-- 60-upvalue ceiling and must reach telemetry via CooldownCompanion methods.
+local RefreshTelemetry = ST.RefreshTelemetry
 
 -- Localize frequently-used globals
 local GetTime = GetTime
@@ -851,20 +855,30 @@ local function NoteButtonTimeState(button, conditionalPreview, isGCDOnly, now, f
         end
     end
 
-    -- Combat ticker floor fail-open: display surfaces NOT covered by the
-    -- self-animating icon/bar path -- texture/trigger panels (custom standalone
-    -- render, self-animation unproven) and hideWhileUnusable visibility (no
-    -- SPELL_UPDATE_USABLE event; power marks demoted). Must force regardless of
-    -- timeActive.
-    local panelForce = false
+    -- Combat ticker floor fail-open: hideWhileUnusable visibility is not covered
+    -- by the self-animating icon/bar path (no SPELL_UPDATE_USABLE event; power
+    -- marks demoted), so it must force regardless of timeActive.
+    local floorForce = false
     if not forced and floorFailOpen then
-        panelForce = true
+        floorForce = true
         forced = true
     end
 
     if forced then
         CooldownCompanion._passTimeStateSeen = true
         CooldownCompanion._tickerIdleEligible = false
+        -- Forcing attribution (dev-gated, observe-only): name the term(s) that
+        -- pinned this walk. Inert without the CC_DevBridge dev addon.
+        if RefreshTelemetry and RefreshTelemetry.enabled then
+            if charge then RefreshTelemetry:CountForce("charge") end
+            if targetSwitch then RefreshTelemetry:CountForce("target-switch") end
+            if preview then RefreshTelemetry:CountForce("preview") end
+            if readyGlow then RefreshTelemetry:CountForce("ready-glow") end
+            if text then RefreshTelemetry:CountForce("text") end
+            if pandemicUncovered then RefreshTelemetry:CountForce("pandemic-uncovered") end
+            if pandemicGrace then RefreshTelemetry:CountForce("pandemic-grace") end
+            if floorForce then RefreshTelemetry:CountForce(floorFailOpen) end
+        end
     end
 end
 
@@ -889,13 +903,21 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     local buttonGroup = button._groupId and CooldownCompanion.db and CooldownCompanion.db.profile
         and CooldownCompanion.db.profile.groups and CooldownCompanion.db.profile.groups[button._groupId] or nil
     local buttonDisplayMode = buttonGroup and (buttonGroup.displayMode or "icons") or "icons"
-    -- Combat ticker floor fail-open gate. Panel modes and hideWhileUnusable must
-    -- keep the ticker walking whether the button is shown or hidden: hidden
-    -- buttons early-return before NoteButtonTimeState, so this is also applied
-    -- in the visibility-hidden branch below.
-    local floorFailOpen = buttonDisplayMode == "textures" or buttonDisplayMode == "trigger"
-        or (buttonData.hideWhileUnusable == true
-            and not buttonData.isPassive and not buttonData.isPassiveCooldown)
+    -- Combat ticker floor fail-open gate ("hide-unusable" / nil; any truthy
+    -- value forces). hideWhileUnusable must keep the ticker walking whether the
+    -- button is shown or hidden (visibility re-show is walk-driven; usability
+    -- has no event): hidden buttons early-return before NoteButtonTimeState, so
+    -- this is also applied in the visibility-hidden branch below. The string
+    -- doubles as the term name for the dev-gated forcing attribution.
+    -- Texture/trigger panels do NOT force: every panel input is event-covered,
+    -- self-animating, or in the owner-approved <=1s walk-cadence class, so
+    -- panels ride dirty ticks + the safety walk like icon visuals (disposition
+    -- doc 2026-07-04-023; forcing-attribution captures showed the old blanket
+    -- force cost ~25 ms/s in combat and defeated the idle skip entirely).
+    local floorFailOpen = (buttonData.hideWhileUnusable == true
+            and not buttonData.isPassive and not buttonData.isPassiveCooldown
+            and "hide-unusable")
+        or nil
     ClearConditionalVisualPreviewFields(button)
 
     if buttonData._rotationAssistantVirtual == true and buttonData._rotationAssistantMissing == true then
@@ -1275,6 +1297,10 @@ function CooldownCompanion:UpdateButtonCooldown(button)
     end
 
     -- Probe spell CD during aura override (shared by secondary CD and sound alerts).
+    -- Accepted residual: expiry mid-override has no widget signal (OnCooldownDone
+    -- rides button.cooldown, which the aura owns), so a buff outlasting its spell's
+    -- cooldown shows the ready transition up to ~1s late while the ticker skips.
+    -- Owner-approved 2026-07-04 (CooldownRefresh.lua header, accepted residuals).
     if auraOwnsPrimarySwipe and not barAuraStackDisplay and buttonData.type == "spell" and not buttonData.isPassive then
         auraProbeInfo = C_Spell.GetSpellCooldown(cooldownSpellId)
         if auraProbeInfo and auraProbeInfo.isActive then
@@ -1873,11 +1899,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
                 CooldownCompanion:RefreshButtonVisualStateSnapshot(button, visualStateContext, "hidden")
             end
             -- Combat ticker floor fail-open: hidden buttons skip NoteButtonTimeState, so
-            -- pin the ticker here for trigger panels (walk-driven standalone texture) and
-            -- hideWhileUnusable (the walk is what re-shows the button when usability flips).
+            -- pin the ticker here for hideWhileUnusable (the walk is what re-shows the
+            -- button when usability flips).
             if floorFailOpen then
                 CooldownCompanion._passTimeStateSeen = true
                 CooldownCompanion._tickerIdleEligible = false
+                CooldownCompanion:CountTickerForce(floorFailOpen)
             end
             return  -- Skip all visual updates
         else
@@ -1903,6 +1930,7 @@ function CooldownCompanion:UpdateButtonCooldown(button)
             if floorFailOpen then
                 CooldownCompanion._passTimeStateSeen = true
                 CooldownCompanion._tickerIdleEligible = false
+                CooldownCompanion:CountTickerForce(floorFailOpen)
             end
             return  -- Skip visual updates for hidden buttons
         else

--- a/CooldownCompanion/Core/CooldownRefresh.lua
+++ b/CooldownCompanion/Core/CooldownRefresh.lua
@@ -44,6 +44,12 @@
     - Accepted residual: no-event fallback probes that ride the clean walk
       (e.g. the 0.25s icon texture staleness probe in CooldownUpdate.lua) run
       at safety-walk cadence (~1s) while skipping. Owner-approved (PR #505).
+    - Accepted residual: during aura override the real spell cooldown has no
+      expiry signal (OnCooldownDone rides button.cooldown, which the aura owns;
+      the walk-time probe in CooldownUpdate.lua re-checks it). For a buff that
+      outlasts its spell's cooldown, the ready transition (desat clear, ready
+      glow) can lag up to the ~1s safety walk while skipping.
+      Owner-approved (2026-07-04).
     - cd-done marks come from ST.OnButtonCooldownDone (ButtonFrame/Helpers.lua)
       and are ordinary MarkCooldownsDirty calls.
     - The combat ticker floor extends the idle skip into combat for

--- a/CooldownCompanion/Core/RefreshTelemetry.lua
+++ b/CooldownCompanion/Core/RefreshTelemetry.lua
@@ -11,6 +11,10 @@
     - F2 (observe-only): would-skip count under the live-skip predicate and
       false-idle count (a time-render canary that fired during a pass that
       began clean and idle-eligible)
+    - forcing attribution (observe-only): which classifier term(s) pinned each
+      broad walk (per-term button counts in forcingCounts, per-walk term
+      combinations in passForceCombos, and a "force" field on passLog entries)
+      -- names what keeps the idle skip from engaging
     Read via CooldownCompanion:GetRefreshTelemetry(); reset via
     CooldownCompanion:ResetRefreshTelemetry(). Never alters refresh behavior.
 ]]
@@ -43,6 +47,13 @@ local T = {
     -- (fires) to gauge the edge-hook. The pool is small and reused across DoTs,
     -- so this is a handful, not one-per-DoT.
     pandemicEdgeHooks = 0,
+    -- Forcing attribution (observe-only): which NoteButtonTimeState term(s)
+    -- forced walking. forcingCounts = term -> per-button occurrences across all
+    -- broad walks; passForceCombos = sorted "term(+term)" combo -> walks pinned
+    -- by exactly that set; passForceTerms = per-walk scratch (wiped each pass).
+    forcingCounts = {},
+    passForceCombos = {},
+    passForceTerms = {},
     passLog = {},               -- ring buffer of reused entry tables
     passCursor = 0,             -- last written index (1..RING_SIZE)
     passTotal = 0,              -- total passes recorded since reset
@@ -91,6 +102,24 @@ function T:CountPandemicEdgeHook()
     self.pandemicEdgeHooks = self.pandemicEdgeHooks + 1
 end
 
+-- Forcing attribution: a classifier term forced this button to keep the ticker
+-- walking. Only broad walks are relevant to idle-skip pinning (mirrors
+-- NoteTimeRender), so ignore routed mini-pass renders.
+function T:CountForce(term)
+    if not CooldownCompanion._cooldownUpdatePassActive then return end
+    self.forcingCounts[term] = (self.forcingCounts[term] or 0) + 1
+    self.passForceTerms[term] = true
+end
+
+-- Enabled-gated wrapper for call sites inside UpdateButtonCooldown, which sits
+-- at the Lua 5.1 60-upvalue ceiling and cannot capture a new file-local; it
+-- reaches this through the CooldownCompanion upvalue it already holds.
+function CooldownCompanion:CountTickerForce(term)
+    if T.enabled then
+        T:CountForce(term)
+    end
+end
+
 -- F2 canary: a time-driven remaining render happened. Only renders that occur
 -- during a broad UpdateAllCooldowns walk are relevant to skip safety -- the
 -- idle skip suppresses that walk, not the OnUpdate self-animation that runs
@@ -135,6 +164,19 @@ function T:RecordPass(frames, buttons, ms)
     local source = self.pendingSource or "direct-untagged"
     self.passCounts[source] = (self.passCounts[source] or 0) + 1
     self.passTotal = self.passTotal + 1
+    -- Forcing attribution: fold this walk's distinct forcing terms into a
+    -- stable sorted combo key (nil when nothing forced -- an idle-eligible walk).
+    local force
+    if next(self.passForceTerms) then
+        local terms = {}
+        for term in pairs(self.passForceTerms) do
+            terms[#terms + 1] = term
+        end
+        table.sort(terms)
+        force = table.concat(terms, "+")
+        self.passForceCombos[force] = (self.passForceCombos[force] or 0) + 1
+        wipe(self.passForceTerms)
+    end
     local cursor = self.passCursor % RING_SIZE + 1
     self.passCursor = cursor
     local entry = self.passLog[cursor]
@@ -143,6 +185,7 @@ function T:RecordPass(frames, buttons, ms)
         self.passLog[cursor] = entry
     end
     entry.t = GetTime()
+    entry.force = force
     entry.src = source
     entry.detail = self.pendingDetail
     entry.hist = self.pendingHist
@@ -175,6 +218,9 @@ function CooldownCompanion:ResetRefreshTelemetry()
     wipe(T.dirtyCounts)
     wipe(T.queueCounts)
     wipe(T.passCounts)
+    wipe(T.forcingCounts)
+    wipe(T.passForceCombos)
+    wipe(T.passForceTerms)
     T.tickerSkips = 0
     T.wouldSkipTotal = 0
     T.falseIdleTotal = 0


### PR DESCRIPTION
## What Players Will Notice
- Anyone using a texture panel or trigger panel: the addon roughly halves its combat CPU cost while a panel is on screen, and stops burning CPU entirely while idle with a panel visible. Measured on the author profile: refresh work dropped from ~56 ms/s to ~25 ms/s in combat with panels shown.
- Panel behavior is unchanged: every condition (auras, procs, pandemic, cooldown ready, usability, charges, range) updates exactly as before. The only theoretical change is a usability-only flip during a complete casting lull, which can now take up to ~1 second - the same already-accepted worst case as the icon unusable dim.
- No panels in your layout? No change.

## Why This Changed
- The combat ticker floor (#512) shipped with a blanket safety rule: any visible texture/trigger panel forced a full refresh of every button in the layout, 10x per second, because panel inputs had not been individually proven safe to skip. Forcing-attribution captures showed this one rule was the single remaining source of refresh waste: one visible panel pinned the entire layout into constant full refreshes, combat and idle alike.

## What Changed
- A disposition pass classified every input a texture/trigger panel can display: each is event-covered (aura/proc/pandemic/cooldown/charges/range/combat events all mark the scheduler dirty), self-animating (pulse/shrink/bounce run on the game animation engine), or rides the ~1s walk cadence already approved for the icon unusable dim (live usability and item-range reads, which have no events). Panels therefore no longer force walks; they re-evaluate on the same dirty ticks and ~1s safety walk as icon visuals.
- The hideWhileUnusable force term and the cooldown router panel fail-open (mini-pass consistency guard) are deliberately unchanged.
- RefreshTelemetry gains permanent forcing attribution (per-term counts, per-walk term combinations, a force field on pass-log entries) so any future "what is pinning the ticker?" question is answered by one capture. Dev-gated; inert without the CC_DevBridge dev addon.
- Documents one accepted residual (owner-approved): during aura override the spell cooldown has no expiry signal, so a buff outlasting its spell cooldown can show the ready transition up to ~1s late while skipping.

## Validation
- Three DevBridge captures on the author Feral profile bracket the change: combat with a visible panel before = 12.5 walks/s, every walk pinned by the "panel" term; same setup after = 6.2 walks/s, "panel" absent from the forcing counter, skipping engaged with panels visible; zero Lua errors in all captures.
- Owner in-game validation in combat: panel condition flips (aura, proc, pandemic, ready, usability), trigger sound, and the standard visual checklist (swipes, charges, text countdowns, pandemic glow, target switch) all correct. Combat validation satisfies instance validation per owner ruling.
- luac -p clean on all changed files.