### PR TITLE
Fix GCD now works with the cooldown swipe off

### DIFF
--- a/CooldownCompanion/ButtonFrame/IconMode.lua
+++ b/CooldownCompanion/ButtonFrame/IconMode.lua
@@ -1267,6 +1267,42 @@ local function UpdateIconModeVisuals(button, buttonData, style, fetchOk, isOnGCD
     UpdateIconFill(button, buttonData, style)
     UpdateBlizzardAuraSwipe(button, style)
 
+    -- Independent GCD swipe. Runs AFTER UpdateIconFill and UpdateBlizzardAuraSwipe
+    -- because both also write button.cooldown's swipe flags -- being the final owner
+    -- for the pass is what keeps the latch honest. Bar mode draws its GCD radial from
+    -- a dedicated frame, so Show GCD Swipe works there even with the main swipe off;
+    -- icon mode shares button.cooldown, whose flags ApplyDefaultCooldownSwipeStyle
+    -- gates on showCooldownSwipe, so a GCD-only radial drew nothing when the main
+    -- swipe was off. Only in that case, draw it ourselves, mirroring bar mode (sweep
+    -- on, edge per showCooldownSwipeEdge). Latched to avoid per-tick writes; the
+    -- falling edge restores default styling and runs unconditionally, so a fetchOk
+    -- false tick can't strand the latch. Defers to real cooldown (isGCDOnly excludes
+    -- it), aura/icon-fill owners, charge-visual, hideCooldownWithCharges, and previews.
+    local gcdOnlyRadialActive = fetchOk
+        and not buttonData.isPassive
+        and isGCDOnly
+        and style.showGCDSwipe == true
+        and style.showCooldownSwipe == false
+        and button._auraPrimarySwipeActive ~= true
+        and button._auraBlizzardSwipeActive ~= true
+        and button._iconFillActive ~= true
+        and button._chargeCooldownVisualActive ~= true
+        and button._hideCooldownChargesActive ~= true
+        and button._conditionalPreviewDomain ~= "cooldown"
+        and button._conditionalAuraDurationTextPreview ~= true
+
+    if gcdOnlyRadialActive then
+        if button._gcdSwipeDrawActive ~= true then
+            button._gcdSwipeDrawActive = true
+            button.cooldown:SetDrawSwipe(true)
+            button.cooldown:SetDrawEdge(style.showCooldownSwipeEdge ~= false)
+            button.cooldown:SetReverse(style.cooldownSwipeReverse or false)
+        end
+    elseif button._gcdSwipeDrawActive == true then
+        button._gcdSwipeDrawActive = nil
+        ApplyDefaultCooldownSwipeStyle(button, style)
+    end
+
     -- When separate text positions: move primary text to aura anchor during aura, cooldown anchor otherwise
     if button._secondaryCdTextRegion and button._cdTextRegion then
         local wantAuraPos = button._auraPrimarySwipeActive == true or button._conditionalAuraDurationTextPreview == true
@@ -1480,6 +1516,7 @@ function CooldownCompanion:UpdateButtonStyle(button, style)
     button._chargeCountReadable = nil
     button._zeroChargesConfirmed = nil
     button._hideCooldownChargesActive = nil
+    button._gcdSwipeDrawActive = nil
     button._nilConfirmPending = nil
     button._procGlowActive = nil
     button._auraGlowActive = nil

--- a/CooldownCompanion/Core/GroupFrame.lua
+++ b/CooldownCompanion/Core/GroupFrame.lua
@@ -757,6 +757,7 @@ local function ClearReusableButtonRuntime(button)
     button._zeroChargesConfirmed = nil
     button._nilConfirmPending = nil
     button._hideCooldownChargesActive = nil
+    button._gcdSwipeDrawActive = nil
     button._displayCountZeroUsabilityFallback = nil
     button._itemCount = nil
     button._auraSpellID = nil


### PR DESCRIPTION
## What Players Will Notice

- On **icon panels**, **Show GCD Swipe** now draws the global-cooldown sweep even when **Show Cooldown/Duration Swipe** is turned off. Previously that exact combination showed nothing, so the toggle looked like it did nothing.
- Nothing changes for defaults (cooldown swipe on, GCD swipe off) or any other combination — only the previously-dead "cooldown swipe off + GCD swipe on" case starts working. Bar panels already behaved this way; icon panels now match them.

## Why This Changed

- Icon panels reuse a single cooldown frame for both the real-cooldown radial and the GCD radial, and that frame's swipe draw flags were gated on the main cooldown-swipe setting. So with the main swipe off, the GCD radial was never actually drawn — a papercut where "Show GCD Swipe" didn't do what its label promised.

## What Changed

- Icon mode now draws the GCD-only radial itself, mirroring how bar panels already do it (sweep on, edge following the swipe-edge setting), but **only** in the specific case where the main cooldown swipe is off.
- The GCD draw runs as the **final** cooldown-frame writer of the icon update pass (after the icon-fill and Blizzard aura-swipe steps, which also touch that frame), and defers to those owners plus real cooldowns, charge visuals, hide-with-charges, and previews — so it never fights another visual.
- The draw is latched to avoid per-tick writes; the restore path runs unconditionally so the latch can't get stranded, and the latch is cleared in both button reset paths.

## Validation

- **Syntax:** `luac -p` clean on both changed files.
- **API:** `SetDrawSwipe` / `SetDrawEdge` / `SetReverse` confirmed against the current WoW API.
- **Static reasoning:** confirmed the idle-skip classifier already treats GCD-swipe presentation as a walk-forcing state independent of the main swipe, and the GCD cooldown timing was already fed to the frame — so this is a draw-flag-only change with no new plumbing.
- **In-game: NOT yet performed.** Combat and instanced-content verification is still pending, including the two targeted edge cases — a Blizzard aura-swipe ending into a GCD window, and Icon Fill Timer combined with GCD swipe. **Do not merge until that passes.**
