### PR TITLE
Open bar settings from Layout & Order previews

### DIFF
--- a/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
+++ b/CooldownCompanion_Config/ConfigSettings/ResourceBarLayoutOrderPreview.lua
@@ -207,6 +207,7 @@ local function FinalizePreviewState(preview)
             frame:ClearAllPoints()
             frame:SetParent(preview.root)
             frame:SetScript("OnMouseDown", nil)
+            frame:SetScript("OnMouseUp", nil)
             frame:SetScript("OnEnter", nil)
             frame:SetScript("OnLeave", nil)
         end
@@ -1544,6 +1545,27 @@ local function BuildStableLaneSlots(lane, draggedSlotId)
     return laneScale, slotRects
 end
 
+local function SelectPreviewSlot(slot)
+    if type(slot) ~= "table" then
+        return false
+    end
+
+    if slot.kind == "resource" and slot.powerType ~= nil and ST._SelectConfigResource then
+        ST._SelectConfigResource(slot.powerType, { toggle = true })
+        return true
+    end
+
+    if slot.kind == "custom" and slot.customBarId ~= nil and ST._SelectConfigCustomBar then
+        ST._SelectConfigCustomBar(slot.customBarId, {
+            clearPreview = true,
+            toggle = true,
+        })
+        return true
+    end
+
+    return false
+end
+
 local function BuildLane(preview, parent, layoutDrag, title, width, height, axis, side, reversed, slotModels, slotWidth, slotHeight, acceptedCategory)
     local laneFrame = AcquireContainer(preview, parent)
     laneFrame:SetSize(width, height)
@@ -1584,6 +1606,26 @@ local function BuildLane(preview, parent, layoutDrag, title, width, height, axis
                 slotData = slotModel,
             }
             StartDragTracking()
+        end)
+        slotFrame:SetScript("OnMouseUp", function(self, button)
+            local state = CS.dragState
+            if button ~= "LeftButton"
+                or not state
+                or state.kind ~= LAYOUT_PREVIEW_DRAG_KIND
+                or state.phase ~= "pending"
+                or state.widget ~= self then
+                return
+            end
+
+            if CancelDrag then
+                CancelDrag()
+            else
+                CS.dragState = nil
+            end
+
+            if SelectPreviewSlot(slotModel) then
+                CooldownCompanion:RefreshConfigPanel()
+            end
         end)
         slotFrame:SetScript("OnEnter", function(self)
             if self.hoverHighlight then


### PR DESCRIPTION
## What Players Will Notice
- In Bars & Frames config, clicking a Resource or Custom Bar preview in Layout & Order now opens that bar's settings, matching the Custom Bars & Resources list.
- Dragging preview bars to reorder still works, and Cast Bar previews remain drag-only.

## Why This Changed
- Layout & Order already shows the bars players are arranging, but opening a bar's settings still required selecting it from the Custom Bars & Resources column.
- This makes the visual preview behave like the rest of the resource/custom-bar settings UI.

## What Changed
- Added a Layout & Order preview click path that routes resource previews through the existing resource settings selector and custom bar previews through the existing custom bar selector.
- Guarded the click behavior behind the existing pending drag state so a real drag-to-reorder action does not open settings.
- Cleared recycled preview slot mouse-up handlers so reused preview frames do not keep stale click behavior.

## Validation
- `luac -p` passed for all 99 tracked Lua files.
- `git diff --check origin/main...HEAD` passed.
- `parallel-review-recommendations` completed one five-reviewer static review cohort with no actionable findings.
- In-game config UI validation is still pending: click resource/custom preview slots, drag them past the reorder threshold, click the selected slot again to confirm toggle behavior, and confirm Cast Bar previews remain drag-only.
- Combat/restricted-content validation was not performed and is not expected for this config-only interaction.