### PR TITLE
Keep active aura-tracked spells from showing spell range and usability states

### DIFF
--- a/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
+++ b/CooldownCompanion/ButtonFrame/CooldownUpdate.lua
@@ -1959,8 +1959,12 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         if buttonData.isPassive or buttonData.isPassiveCooldown then
             button._isUnusable = false
         elseif buttonData.type == "spell" then
-            local spellID = button._displaySpellId or buttonData.id
-            button._isUnusable = not C_Spell_IsSpellUsable(spellID)
+            if EntryRuntime.ShouldSuppressSpellUnusableVisual(button, buttonData) then
+                button._isUnusable = false
+            else
+                local spellID = button._displaySpellId or buttonData.id
+                button._isUnusable = not C_Spell_IsSpellUsable(spellID)
+            end
         elseif IsEntryItemLike(buttonData) or buttonData.type == "equipitem" then
             local itemID = button._resolvedItemId or buttonData.id
             local usable = itemID and IsUsableItem(itemID)
@@ -1970,7 +1974,11 @@ function CooldownCompanion:UpdateButtonCooldown(button)
         end
 
         if buttonData.type == "spell" and not buttonData.isPassiveCooldown then
-            button._isOutOfRange = button._spellOutOfRange or false
+            if EntryRuntime.ShouldSuppressSpellRangeVisual(button, buttonData) then
+                button._isOutOfRange = false
+            else
+                button._isOutOfRange = button._spellOutOfRange or false
+            end
         elseif IsEntryItemLike(buttonData) or buttonData.type == "equipitem" then
             -- C_Item.IsItemInRange is protected in combat for non-enemy targets (10.2.0)
             local itemID = button._resolvedItemId or buttonData.id

--- a/CooldownCompanion/ButtonFrame/Tracking.lua
+++ b/CooldownCompanion/ButtonFrame/Tracking.lua
@@ -6,6 +6,7 @@
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
 local CooldownLogic = ST.CooldownLogic
+local EntryRuntime = ST.EntryRuntime
 local CHARGE_STATE_ZERO = CooldownLogic.CHARGE_STATE_ZERO
 
 -- Localize frequently-used globals
@@ -194,6 +195,9 @@ local function IsUnusableVisualActive(button, buttonData)
         return true, "unusable-preview"
     end
     if buttonData.type == "spell" then
+        if EntryRuntime.ShouldSuppressSpellUnusableVisual(button, buttonData) then
+            return false
+        end
         local spellID = button._displaySpellId or buttonData.id
         if not C_Spell_IsSpellUsable(spellID) then
             return true, "unusable"
@@ -244,7 +248,8 @@ local function ResolveIconTintIntent(button, buttonData, style, target)
             r, g, b = 1, 0.2, 0.2
             reason = "out-of-range-preview"
             stateOverride = true
-        elseif buttonData.type == "spell" then
+        elseif buttonData.type == "spell"
+                and not EntryRuntime.ShouldSuppressSpellRangeVisual(button, buttonData) then
             if button._spellOutOfRange then
                 r, g, b = 1, 0.2, 0.2
                 reason = "out-of-range"

--- a/CooldownCompanion/Core/AuraTexturesEffects.lua
+++ b/CooldownCompanion/Core/AuraTexturesEffects.lua
@@ -5,6 +5,7 @@
 
 local ADDON_NAME, ST = ...
 local CooldownCompanion = ST.Addon
+local EntryRuntime = ST.EntryRuntime
 local AT = ST._AT
 
 local C_Item_IsItemInRange = C_Item.IsItemInRange
@@ -621,6 +622,9 @@ local function ResolveTextureIndicatorSectionState(button, sectionKey, config, t
             return FinishTextureIndicatorSectionState(target, false, reason, nil, effectType)
         end
         if buttonData.type == "spell" then
+            if EntryRuntime.ShouldSuppressSpellUnusableVisual(button, buttonData) then
+                return FinishTextureIndicatorSectionState(target, false, "aura-active", nil, effectType)
+            end
             local spellID = button._displaySpellId or buttonData.id
             local active = not C_Spell_IsSpellUsable(spellID)
             return FinishTextureIndicatorSectionState(target, active, active and "unusable" or "usable", nil, effectType)
@@ -660,6 +664,9 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
         end
 
         if buttonData.type == "spell" then
+            if EntryRuntime.ShouldSuppressSpellRangeVisual(button, buttonData) then
+                return nil
+            end
             if button._spellOutOfRange == nil then
                 return nil
             end
@@ -687,6 +694,9 @@ local function EvaluateTriggerRowCondition(button, conditionKey)
             return false
         end
         if buttonData.type == "spell" then
+            if EntryRuntime.ShouldSuppressSpellUnusableVisual(button, buttonData) then
+                return nil
+            end
             local spellID = button._displaySpellId or buttonData.id
             return C_Spell_IsSpellUsable(spellID)
         end

--- a/CooldownCompanion/Core/EntryRuntime.lua
+++ b/CooldownCompanion/Core/EntryRuntime.lua
@@ -37,6 +37,22 @@ local CLEAR_OWNER_FALSE_STATE_KEEP_SWITCH_OPTS = { useFalseState = true, preserv
 local EntryRuntime = ST.EntryRuntime or {}
 ST.EntryRuntime = EntryRuntime
 
+function EntryRuntime.ShouldSuppressSpellRangeVisual(button, buttonData)
+    return type(buttonData) == "table"
+        and buttonData.type == "spell"
+        and buttonData.auraTracking == true
+        and button
+        and button._auraActive == true
+end
+
+function EntryRuntime.ShouldSuppressSpellUnusableVisual(button, buttonData)
+    return type(buttonData) == "table"
+        and buttonData.type == "spell"
+        and buttonData.auraTracking == true
+        and button
+        and button._auraActive == true
+end
+
 -- Hidden scratch CooldownFrame for probing DurationObject activity.
 -- DurationObject:IsZero() returns a secret boolean in tainted contexts;
 -- feeding the object to a Cooldown widget and checking IsShown() yields a


### PR DESCRIPTION
## What Players Will Notice
- Spell entries that are showing an active tracked aura no longer turn red for range or dim/desaturate for spell usability while that aura is active.
- Once the tracked aura fades, normal spell range and usability visuals return.

## Why This Changed
- Aura displays were inheriting spell-only visual states. Auras do not have spell range or castability, so an active aura could look out of range or unusable even though the entry was currently representing the aura.

## What Changed
- Added shared runtime helpers for suppressing spell range and spell unusable visuals while an aura-tracked spell entry has an active aura.
- Applied the suppression to icon/bar icon tinting, text-mode `{oor}` and `{unusable}` conditionals, trigger-panel range/usable conditions, and unusable texture effects.
- Left the underlying spell range/usability state and range-check registrations intact so visuals resume as soon as the aura stops owning the display.

## Validation
- `luac -p CooldownCompanion\Core\EntryRuntime.lua CooldownCompanion\ButtonFrame\Tracking.lua CooldownCompanion\ButtonFrame\CooldownUpdate.lua CooldownCompanion\Core\AuraTexturesEffects.lua`
- `git diff --check origin/main...HEAD`
- In-game validation pending: needs confirmation that an aura-tracked spell suppresses range/unusable visuals while active and restores them after the aura fades.